### PR TITLE
fix: return Chunk/Entity models instead of dicts in VectorCypher and Skeleton recall

### DIFF
--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -19,7 +19,16 @@ from uuid import UUID
 from loguru import logger
 
 from khora.config import KhoraConfig, LiteLLMConfig
-from khora.core.models import Document, DocumentMetadata, Entity, MemoryNamespace, Organization, Workspace
+from khora.core.models import (
+    Chunk,
+    ChunkMetadata,
+    Document,
+    DocumentMetadata,
+    Entity,
+    MemoryNamespace,
+    Organization,
+    Workspace,
+)
 from khora.extraction.embedders import LiteLLMEmbedder
 from khora.memory_lake import BatchResult, RecallResult, RememberResult, Stats
 from khora.query import SearchMode
@@ -419,18 +428,23 @@ class SkeletonConstructionEngine:
 
         # Build context text
         context_parts = []
-        chunks_with_scores = []
+        chunks_with_scores: list[tuple[Chunk, float]] = []
         for result in results:
             context_parts.append(result.chunk.content)
-            # Convert TemporalChunk to a simple dict for RecallResult
-            chunk_dict = {
-                "id": result.chunk.id,
-                "content": result.chunk.content,
-                "document_id": result.chunk.document_id,
-                "occurred_at": result.chunk.occurred_at.isoformat() if result.chunk.occurred_at else None,
-                "metadata": result.chunk.metadata,
-            }
-            chunks_with_scores.append((chunk_dict, result.combined_score or result.similarity))
+            chunk = Chunk(
+                id=result.chunk.id,
+                namespace_id=result.chunk.namespace_id,
+                document_id=result.chunk.document_id,
+                content=result.chunk.content,
+                metadata=ChunkMetadata(
+                    custom={
+                        "occurred_at": result.chunk.occurred_at.isoformat() if result.chunk.occurred_at else None,
+                        **(result.chunk.metadata or {}),
+                    }
+                ),
+                created_at=result.chunk.created_at or result.chunk.occurred_at,
+            )
+            chunks_with_scores.append((chunk, result.combined_score or result.similarity))
 
         context_text = "\n\n---\n\n".join(context_parts[:limit])
 

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -826,53 +826,49 @@ class VectorCypherEngine:
 
     def _validate_recall_results(
         self,
-        chunks: list[tuple[dict[str, Any], float]],
+        chunks: list[tuple[Chunk, float]],
         query: str,
         *,
         min_content_length: int = 10,
-    ) -> list[tuple[dict[str, Any], float]]:
+    ) -> list[tuple[Chunk, float]]:
         """Validate and filter retrieval results.
 
         Removes duplicates, filters out empty content, ensures scores are normalized,
         and logs quality warnings.
 
         Args:
-            chunks: List of (chunk_dict, score) tuples
+            chunks: List of (chunk, score) tuples
             query: Original query text for logging context
             min_content_length: Minimum content length to accept
 
         Returns:
-            Validated and filtered list of (chunk_dict, score) tuples
+            Validated and filtered list of (chunk, score) tuples
         """
-        validated: list[tuple[dict[str, Any], float]] = []
-        seen_ids: set[str] = set()
+        validated: list[tuple[Chunk, float]] = []
+        seen_ids: set[UUID] = set()
         empty_count = 0
         duplicate_count = 0
 
-        for chunk_dict, score in chunks:
-            if not isinstance(chunk_dict, dict):
-                logger.warning(f"Skipping non-dict chunk result: {type(chunk_dict)}")
+        for chunk, score in chunks:
+            if not isinstance(chunk, Chunk):
+                logger.warning(f"Skipping non-Chunk result: {type(chunk)}")
                 continue
-
-            chunk_id = chunk_dict.get("id", "")
 
             # Skip duplicates
-            if chunk_id and chunk_id in seen_ids:
+            if chunk.id in seen_ids:
                 duplicate_count += 1
                 continue
-            if chunk_id:
-                seen_ids.add(chunk_id)
+            seen_ids.add(chunk.id)
 
             # Skip empty content
-            content = chunk_dict.get("content", "")
-            if not content or len(content.strip()) < min_content_length:
+            if not chunk.content or len(chunk.content.strip()) < min_content_length:
                 empty_count += 1
                 continue
 
             # Normalize score to [0, 1]
             normalized_score = min(max(score, 0.0), 1.0)
 
-            validated.append((chunk_dict, normalized_score))
+            validated.append((chunk, normalized_score))
 
         # Log quality warnings
         if duplicate_count > 0:
@@ -930,9 +926,8 @@ class VectorCypherEngine:
 
         # Build context text from validated chunks
         context_parts = []
-        for chunk_dict, score in validated_chunks:
-            if isinstance(chunk_dict, dict):
-                context_parts.append(chunk_dict.get("content", ""))
+        for chunk, score in validated_chunks:
+            context_parts.append(chunk.content)
 
         context_text = "\n\n---\n\n".join(context_parts[:limit])
 

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -26,6 +26,8 @@ from uuid import UUID
 from loguru import logger
 from neo4j.exceptions import Neo4jError
 
+from khora.core.models import Chunk, ChunkMetadata, Entity
+
 from .dual_nodes import DualNodeManager
 from .fusion import (
     FusedResult,
@@ -48,8 +50,8 @@ if TYPE_CHECKING:
 class VectorCypherResult:
     """Result from VectorCypher retrieval."""
 
-    chunks: list[tuple[dict[str, Any], float]]
-    entities: list[tuple[dict[str, Any], float]]
+    chunks: list[tuple[Chunk, float]]
+    entities: list[tuple[Entity, float]]
     routing_decision: RoutingDecision
     metadata: dict[str, Any] = field(default_factory=dict)
 
@@ -371,20 +373,16 @@ class VectorCypherRetriever:
         chunk_results = [(r.item, r.rrf_score) for r in fused_results[:limit]]
 
         # Build entity results with name/type from graph neighborhoods
-        entity_results = []
+        entity_results: list[tuple[Entity, float]] = []
         for eid, score in entry_entities[: self._config.max_entities]:
             info = entity_info_map.get(str(eid), {})
-            entity_results.append(
-                (
-                    {
-                        "id": str(eid),
-                        "name": info.get("name", ""),
-                        "entity_type": info.get("entity_type", ""),
-                        "score": score,
-                    },
-                    score,
-                )
+            entity = Entity(
+                id=eid,
+                namespace_id=namespace_id,
+                name=info.get("name", ""),
+                entity_type=info.get("entity_type", ""),
             )
+            entity_results.append((entity, score))
 
         return VectorCypherResult(
             chunks=chunk_results,
@@ -452,16 +450,22 @@ class VectorCypherRetriever:
             query_text=query,
         )
 
-        chunk_results = []
+        chunk_results: list[tuple[Chunk, float]] = []
         for r in results:
-            chunk_dict = {
-                "id": str(r.chunk.id),
-                "content": r.chunk.content,
-                "document_id": str(r.chunk.document_id),
-                "occurred_at": r.chunk.occurred_at.isoformat() if r.chunk.occurred_at else None,
-                "metadata": r.chunk.metadata,
-            }
-            chunk_results.append((chunk_dict, r.combined_score or r.similarity))
+            chunk = Chunk(
+                id=r.chunk.id,
+                namespace_id=r.chunk.namespace_id,
+                document_id=r.chunk.document_id,
+                content=r.chunk.content,
+                metadata=ChunkMetadata(
+                    custom={
+                        "occurred_at": r.chunk.occurred_at.isoformat() if r.chunk.occurred_at else None,
+                        **(r.chunk.metadata or {}),
+                    }
+                ),
+                created_at=r.chunk.created_at or r.chunk.occurred_at,
+            )
+            chunk_results.append((chunk, r.combined_score or r.similarity))
 
         return VectorCypherResult(
             chunks=chunk_results,
@@ -555,7 +559,7 @@ class VectorCypherRetriever:
         namespace_id: UUID,
         temporal_filter: TemporalFilter | None,
         limit: int,
-    ) -> list[tuple[UUID, float, dict[str, Any]]]:
+    ) -> list[tuple[UUID, float, Chunk]]:
         """Fetch chunks connected to entities via MENTIONED_IN.
 
         Args:
@@ -565,7 +569,7 @@ class VectorCypherRetriever:
             limit: Maximum chunks to return
 
         Returns:
-            List of (chunk_id, score, chunk_data) tuples
+            List of (chunk_id, score, chunk) tuples
         """
         chunk_records = await self._dual_nodes.get_chunks_by_entities(
             entity_ids=entity_ids,
@@ -574,7 +578,7 @@ class VectorCypherRetriever:
             limit=limit,
         )
 
-        results = []
+        results: list[tuple[UUID, float, Chunk]] = []
         for record in chunk_records:
             chunk_id = UUID(record["chunk_id"])
             # Score based on mention count and entity coverage
@@ -582,15 +586,20 @@ class VectorCypherRetriever:
             entity_count = len(record.get("entity_ids", []))
             score = score * (1 + 0.1 * entity_count)  # Boost for multiple entity connections
 
-            chunk_data = {
-                "id": record["chunk_id"],
-                "content": record["content"],
-                "document_id": record["document_id"],
-                "occurred_at": record.get("occurred_at"),
-                "metadata": record.get("metadata", {}),
-                "connected_entities": record.get("entity_ids", []),
-            }
-            results.append((chunk_id, score, chunk_data))
+            chunk = Chunk(
+                id=chunk_id,
+                namespace_id=namespace_id,
+                document_id=UUID(record["document_id"]),
+                content=record["content"],
+                metadata=ChunkMetadata(
+                    custom={
+                        "occurred_at": record.get("occurred_at"),
+                        "connected_entities": record.get("entity_ids", []),
+                        **(record.get("metadata") or {}),
+                    }
+                ),
+            )
+            results.append((chunk_id, score, chunk))
 
         return results
 
@@ -601,7 +610,7 @@ class VectorCypherRetriever:
         temporal_filter: TemporalFilter | None,
         query_text: str,
         limit: int,
-    ) -> list[tuple[UUID, float, dict[str, Any]]]:
+    ) -> list[tuple[UUID, float, Chunk]]:
         """Direct vector search on chunks via pgvector.
 
         Args:
@@ -612,7 +621,7 @@ class VectorCypherRetriever:
             limit: Maximum results
 
         Returns:
-            List of (chunk_id, score, chunk_data) tuples
+            List of (chunk_id, score, chunk) tuples
         """
         results = await self._vector_store.search(
             namespace_id=namespace_id,
@@ -627,23 +636,29 @@ class VectorCypherRetriever:
             (
                 r.chunk.id,
                 r.combined_score or r.similarity,
-                {
-                    "id": str(r.chunk.id),
-                    "content": r.chunk.content,
-                    "document_id": str(r.chunk.document_id),
-                    "occurred_at": r.chunk.occurred_at.isoformat() if r.chunk.occurred_at else None,
-                    "metadata": r.chunk.metadata,
-                },
+                Chunk(
+                    id=r.chunk.id,
+                    namespace_id=r.chunk.namespace_id,
+                    document_id=r.chunk.document_id,
+                    content=r.chunk.content,
+                    metadata=ChunkMetadata(
+                        custom={
+                            "occurred_at": r.chunk.occurred_at.isoformat() if r.chunk.occurred_at else None,
+                            **(r.chunk.metadata or {}),
+                        }
+                    ),
+                    created_at=r.chunk.created_at or r.chunk.occurred_at,
+                ),
             )
             for r in results
         ]
 
     def _lazy_expand_chunks(
         self,
-        vector_only_chunks: list[tuple[UUID, float, dict[str, Any]]],
+        vector_only_chunks: list[tuple[UUID, float, Chunk]],
         entry_entities: list[tuple[UUID, float]],
         entity_info_map: dict[str, dict[str, str]],
-    ) -> list[tuple[UUID, float, dict[str, Any]]]:
+    ) -> list[tuple[UUID, float, Chunk]]:
         """Expand vector-only chunks by keyword matching against known entities.
 
         For chunks retrieved via vector search that have no MENTIONED_IN edges,
@@ -665,16 +680,16 @@ class VectorCypherRetriever:
         if not entity_names:
             return []
 
-        results = []
-        for chunk_id, _vec_score, chunk_data in vector_only_chunks:
+        results: list[tuple[UUID, float, Chunk]] = []
+        for chunk_id, _vec_score, chunk in vector_only_chunks:
             # Check cache first
             if chunk_id in self._expansion_cache:
                 cached_score = self._expansion_cache[chunk_id]
                 if cached_score > 0:
-                    results.append((chunk_id, cached_score, chunk_data))
+                    results.append((chunk_id, cached_score, chunk))
                 continue
 
-            content = chunk_data.get("content", "")
+            content = chunk.content
             if not content:
                 self._expansion_cache[chunk_id] = 0.0
                 continue
@@ -684,7 +699,7 @@ class VectorCypherRetriever:
             if matches:
                 # Weak signal: 0.5 per matched entity name
                 expansion_score = len(matches) * 0.5
-                results.append((chunk_id, expansion_score, chunk_data))
+                results.append((chunk_id, expansion_score, chunk))
                 self._expansion_cache[chunk_id] = expansion_score
             else:
                 self._expansion_cache[chunk_id] = 0.0
@@ -693,8 +708,8 @@ class VectorCypherRetriever:
 
     def _fuse_results(
         self,
-        vector_chunks: list[tuple[UUID, float, dict[str, Any]]],
-        graph_chunks: list[tuple[UUID, float, dict[str, Any]]],
+        vector_chunks: list[tuple[UUID, float, Chunk]],
+        graph_chunks: list[tuple[UUID, float, Chunk]],
         *,
         use_normalization: bool = False,
         routing: RoutingDecision | None = None,
@@ -755,28 +770,31 @@ class VectorCypherRetriever:
 
         for r in results:
             item = r.item
-            if isinstance(item, dict):
+            occurred_at_str = None
+            if isinstance(item, Chunk):
+                custom = item.metadata.custom if item.metadata else {}
+                occurred_at_str = custom.get("occurred_at")
+            elif isinstance(item, dict):
                 occurred_at_str = item.get("occurred_at")
-                if occurred_at_str:
-                    try:
-                        occurred_at = datetime.fromisoformat(occurred_at_str.replace("Z", "+00:00"))
-                        if occurred_at.tzinfo is None:
-                            occurred_at = occurred_at.replace(tzinfo=UTC)
-                        days_old = (now - occurred_at).days
-                        if self._config.recency_decay_type == "exponential":
-                            # Half-life semantics: score = 0.5 at decay_days
-                            half_life_lambda = math.log(2) / decay_days
-                            recency = math.exp(-half_life_lambda * days_old)
-                        else:
-                            # Linear decay with cliff at decay_days
-                            recency = max(0.0, 1.0 - (days_old / decay_days))
-                        scores[r.item_id] = recency
-                    except (ValueError, TypeError):
-                        scores[r.item_id] = 0.5  # Default for unparseable dates
-                else:
-                    scores[r.item_id] = 0.5  # Default for missing dates
+
+            if occurred_at_str:
+                try:
+                    occurred_at = datetime.fromisoformat(occurred_at_str.replace("Z", "+00:00"))
+                    if occurred_at.tzinfo is None:
+                        occurred_at = occurred_at.replace(tzinfo=UTC)
+                    days_old = (now - occurred_at).days
+                    if self._config.recency_decay_type == "exponential":
+                        # Half-life semantics: score = 0.5 at decay_days
+                        half_life_lambda = math.log(2) / decay_days
+                        recency = math.exp(-half_life_lambda * days_old)
+                    else:
+                        # Linear decay with cliff at decay_days
+                        recency = max(0.0, 1.0 - (days_old / decay_days))
+                    scores[r.item_id] = recency
+                except (ValueError, TypeError):
+                    scores[r.item_id] = 0.5  # Default for unparseable dates
             else:
-                scores[r.item_id] = 0.5
+                scores[r.item_id] = 0.5  # Default for missing dates
 
         return scores
 

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -18,7 +18,7 @@ from uuid import UUID
 from loguru import logger
 
 from khora.config import KhoraConfig, load_config
-from khora.core.models import Document, Entity, MemoryNamespace
+from khora.core.models import Chunk, Document, Entity, MemoryNamespace
 from khora.query import SearchMode
 
 if TYPE_CHECKING:
@@ -68,8 +68,8 @@ class RecallResult:
 
     query: str
     namespace_id: UUID
-    chunks: list[tuple[Any, float]]
-    entities: list[tuple[Any, float]]
+    chunks: list[tuple[Chunk, float]]
+    entities: list[tuple[Entity, float]]
     context_text: str
     metadata: dict[str, Any] = field(default_factory=dict)
 

--- a/tests/unit/engines/test_vectorcypher_engine.py
+++ b/tests/unit/engines/test_vectorcypher_engine.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 import pytest
 
+from khora.core.models import Chunk
 from khora.engines.vectorcypher.engine import (
     ExtractionQualityMetrics,
     VectorCypherConfig,
@@ -388,11 +389,20 @@ class TestVectorCypherEngineRecall:
             confidence=0.8,
             reasoning="test",
         )
+        chunk1 = Chunk(
+            id=uuid4(),
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="This is a test chunk with enough content to pass validation",
+        )
+        chunk2 = Chunk(
+            id=uuid4(),
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="Another test chunk that is also long enough to pass validation",
+        )
         retriever_result = VectorCypherResult(
-            chunks=[
-                ({"id": "c1", "content": "This is a test chunk with enough content to pass validation"}, 0.9),
-                ({"id": "c2", "content": "Another test chunk that is also long enough to pass validation"}, 0.7),
-            ],
+            chunks=[(chunk1, 0.9), (chunk2, 0.7)],
             entities=[],
             routing_decision=routing,
             metadata={"search_mode": "simple_vector"},
@@ -427,11 +437,21 @@ class TestVectorCypherEngineRecall:
             confidence=0.8,
             reasoning="test",
         )
+        dup_id = uuid4()
+        dup_chunk1 = Chunk(
+            id=dup_id,
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="Duplicate chunk content that is long enough for validation",
+        )
+        dup_chunk2 = Chunk(
+            id=dup_id,
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="Duplicate chunk content that is long enough for validation",
+        )
         retriever_result = VectorCypherResult(
-            chunks=[
-                ({"id": "c1", "content": "Duplicate chunk content that is long enough for validation"}, 0.9),
-                ({"id": "c1", "content": "Duplicate chunk content that is long enough for validation"}, 0.8),
-            ],
+            chunks=[(dup_chunk1, 0.9), (dup_chunk2, 0.8)],
             entities=[],
             routing_decision=routing,
             metadata={},
@@ -652,48 +672,66 @@ class TestVectorCypherEngineValidateRecallResults:
 
     def test_filters_empty_content(self, engine: VectorCypherEngine) -> None:
         """Test that chunks with empty content are filtered out."""
-        chunks = [
-            ({"id": "c1", "content": ""}, 0.9),
-            ({"id": "c2", "content": "Valid long enough content for testing"}, 0.8),
-        ]
+        c1 = Chunk(id=uuid4(), namespace_id=uuid4(), document_id=uuid4(), content="")
+        c2 = Chunk(
+            id=uuid4(), namespace_id=uuid4(), document_id=uuid4(), content="Valid long enough content for testing"
+        )
+        chunks = [(c1, 0.9), (c2, 0.8)]
         result = engine._validate_recall_results(chunks, "test query")
         assert len(result) == 1
-        assert result[0][0]["id"] == "c2"
+        assert result[0][0].id == c2.id
 
     def test_filters_short_content(self, engine: VectorCypherEngine) -> None:
         """Test that chunks with very short content are filtered."""
-        chunks = [
-            ({"id": "c1", "content": "short"}, 0.9),
-            ({"id": "c2", "content": "This content is long enough to pass minimum length validation"}, 0.8),
-        ]
+        c1 = Chunk(id=uuid4(), namespace_id=uuid4(), document_id=uuid4(), content="short")
+        c2 = Chunk(
+            id=uuid4(),
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="This content is long enough to pass minimum length validation",
+        )
+        chunks = [(c1, 0.9), (c2, 0.8)]
         result = engine._validate_recall_results(chunks, "test")
         assert len(result) == 1
 
     def test_removes_duplicates(self, engine: VectorCypherEngine) -> None:
         """Test that duplicate chunks are removed."""
-        chunks = [
-            ({"id": "c1", "content": "First occurrence with enough content"}, 0.9),
-            ({"id": "c1", "content": "First occurrence with enough content"}, 0.8),
-        ]
+        shared_id = uuid4()
+        c1 = Chunk(
+            id=shared_id, namespace_id=uuid4(), document_id=uuid4(), content="First occurrence with enough content"
+        )
+        c2 = Chunk(
+            id=shared_id, namespace_id=uuid4(), document_id=uuid4(), content="First occurrence with enough content"
+        )
+        chunks = [(c1, 0.9), (c2, 0.8)]
         result = engine._validate_recall_results(chunks, "test")
         assert len(result) == 1
 
     def test_normalizes_scores(self, engine: VectorCypherEngine) -> None:
         """Test that scores are clamped to [0, 1]."""
-        chunks = [
-            ({"id": "c1", "content": "Content that has a very high score value assigned to it"}, 1.5),
-            ({"id": "c2", "content": "Content that has a negative score value assigned to it"}, -0.5),
-        ]
+        c1 = Chunk(
+            id=uuid4(),
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="Content that has a very high score value assigned to it",
+        )
+        c2 = Chunk(
+            id=uuid4(),
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="Content that has a negative score value assigned to it",
+        )
+        chunks = [(c1, 1.5), (c2, -0.5)]
         result = engine._validate_recall_results(chunks, "test")
         assert result[0][1] == 1.0
         assert result[1][1] == 0.0
 
-    def test_skips_non_dict_chunks(self, engine: VectorCypherEngine) -> None:
-        """Test that non-dict chunks are skipped."""
-        chunks = [
-            ("not a dict", 0.9),
-            ({"id": "c1", "content": "Valid content that passes all checks"}, 0.8),
-        ]
+    def test_skips_non_chunk_objects(self, engine: VectorCypherEngine) -> None:
+        """Test that non-Chunk objects are skipped."""
+        c1 = Chunk(
+            id=uuid4(), namespace_id=uuid4(), document_id=uuid4(), content="Valid content that passes all checks"
+        )
+        chunks = [("not a chunk", 0.9), (c1, 0.8)]
         result = engine._validate_recall_results(chunks, "test")
         assert len(result) == 1
 

--- a/tests/unit/engines/test_vectorcypher_retriever.py
+++ b/tests/unit/engines/test_vectorcypher_retriever.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 import pytest
 
+from khora.core.models import Chunk, ChunkMetadata
 from khora.engines.vectorcypher.retriever import (
     RetrieverConfig,
     VectorCypherResult,
@@ -75,8 +76,9 @@ class TestVectorCypherResult:
             confidence=0.8,
             reasoning="test",
         )
+        chunk = Chunk(id=uuid4(), namespace_id=uuid4(), document_id=uuid4(), content="test")
         result = VectorCypherResult(
-            chunks=[({"id": "c1", "content": "test"}, 0.9)],
+            chunks=[(chunk, 0.9)],
             entities=[],
             routing_decision=routing,
             metadata={"test": True},
@@ -164,12 +166,15 @@ class TestRetrieverSimpleRetrieve:
         # Mock vector store search
         chunk_id = uuid4()
         doc_id = uuid4()
+        ns_id = uuid4()
         mock_result = MagicMock()
         mock_result.chunk = MagicMock()
         mock_result.chunk.id = chunk_id
+        mock_result.chunk.namespace_id = ns_id
         mock_result.chunk.content = "test chunk content"
         mock_result.chunk.document_id = doc_id
         mock_result.chunk.occurred_at = None
+        mock_result.chunk.created_at = None
         mock_result.chunk.metadata = {}
         mock_result.combined_score = 0.85
         mock_result.similarity = 0.85
@@ -233,11 +238,17 @@ class TestRetrieverFuseResults:
             embedder=AsyncMock(),
         )
 
+    def _make_chunk(self, content: str = "test") -> Chunk:
+        """Helper to create a Chunk with given content."""
+        return Chunk(id=uuid4(), namespace_id=uuid4(), document_id=uuid4(), content=content)
+
     def test_fuse_basic(self, retriever: VectorCypherRetriever) -> None:
         """Test basic fusion of vector and graph results."""
         id1, id2 = uuid4(), uuid4()
-        vector_chunks = [(id1, 0.9, {"content": "vec"})]
-        graph_chunks = [(id2, 0.8, {"content": "graph"})]
+        c1 = Chunk(id=id1, namespace_id=uuid4(), document_id=uuid4(), content="vec")
+        c2 = Chunk(id=id2, namespace_id=uuid4(), document_id=uuid4(), content="graph")
+        vector_chunks = [(id1, 0.9, c1)]
+        graph_chunks = [(id2, 0.8, c2)]
 
         fused = retriever._fuse_results(vector_chunks, graph_chunks)
 
@@ -246,8 +257,9 @@ class TestRetrieverFuseResults:
     def test_fuse_with_normalization(self, retriever: VectorCypherRetriever) -> None:
         """Test fusion with score normalization."""
         id1 = uuid4()
-        vector_chunks = [(id1, 0.9, {"content": "test"})]
-        graph_chunks = [(id1, 5.0, {"content": "test"})]
+        c1 = Chunk(id=id1, namespace_id=uuid4(), document_id=uuid4(), content="test")
+        vector_chunks = [(id1, 0.9, c1)]
+        graph_chunks = [(id1, 5.0, c1)]
 
         fused = retriever._fuse_results(
             vector_chunks,
@@ -260,6 +272,8 @@ class TestRetrieverFuseResults:
     def test_fuse_with_routing_simple(self, retriever: VectorCypherRetriever) -> None:
         """Test fusion uses simple weights for SIMPLE routing."""
         id1, id2 = uuid4(), uuid4()
+        c1 = Chunk(id=id1, namespace_id=uuid4(), document_id=uuid4(), content="v")
+        c2 = Chunk(id=id2, namespace_id=uuid4(), document_id=uuid4(), content="g")
         routing = RoutingDecision(
             complexity=QueryComplexity.SIMPLE,
             use_graph=False,
@@ -269,8 +283,8 @@ class TestRetrieverFuseResults:
         )
 
         fused = retriever._fuse_results(
-            [(id1, 0.9, {"content": "v"})],
-            [(id2, 0.8, {"content": "g"})],
+            [(id1, 0.9, c1)],
+            [(id2, 0.8, c2)],
             routing=routing,
         )
 
@@ -280,6 +294,8 @@ class TestRetrieverFuseResults:
     def test_fuse_with_routing_complex(self, retriever: VectorCypherRetriever) -> None:
         """Test fusion uses complex weights for COMPLEX routing."""
         id1, id2 = uuid4(), uuid4()
+        c1 = Chunk(id=id1, namespace_id=uuid4(), document_id=uuid4(), content="v")
+        c2 = Chunk(id=id2, namespace_id=uuid4(), document_id=uuid4(), content="g")
         routing = RoutingDecision(
             complexity=QueryComplexity.COMPLEX,
             use_graph=True,
@@ -289,8 +305,8 @@ class TestRetrieverFuseResults:
         )
 
         fused = retriever._fuse_results(
-            [(id1, 0.9, {"content": "v"})],
-            [(id2, 0.8, {"content": "g"})],
+            [(id1, 0.9, c1)],
+            [(id2, 0.8, c2)],
             routing=routing,
         )
 
@@ -321,17 +337,23 @@ class TestRetrieverRecencyScores:
         from khora.engines.vectorcypher.fusion import FusedResult
 
         id1, id2 = uuid4(), uuid4()
+        chunk1 = Chunk(
+            id=id1,
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="old",
+            metadata=ChunkMetadata(custom={"occurred_at": "2020-01-01T00:00:00+00:00"}),
+        )
+        chunk2 = Chunk(
+            id=id2,
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="recent",
+            metadata=ChunkMetadata(custom={"occurred_at": "2026-02-14T00:00:00+00:00"}),
+        )
         results = [
-            FusedResult(
-                item_id=id1,
-                item={"occurred_at": "2020-01-01T00:00:00+00:00"},
-                rrf_score=0.9,
-            ),
-            FusedResult(
-                item_id=id2,
-                item={"occurred_at": "2026-02-14T00:00:00+00:00"},
-                rrf_score=0.8,
-            ),
+            FusedResult(item_id=id1, item=chunk1, rrf_score=0.9),
+            FusedResult(item_id=id2, item=chunk2, rrf_score=0.8),
         ]
 
         scores = retriever._calculate_recency_scores(results)
@@ -344,18 +366,19 @@ class TestRetrieverRecencyScores:
         from khora.engines.vectorcypher.fusion import FusedResult
 
         id1 = uuid4()
-        results = [FusedResult(item_id=id1, item={"content": "no date"}, rrf_score=0.9)]
+        chunk = Chunk(id=id1, namespace_id=uuid4(), document_id=uuid4(), content="no date")
+        results = [FusedResult(item_id=id1, item=chunk, rrf_score=0.9)]
 
         scores = retriever._calculate_recency_scores(results)
 
         assert scores[id1] == 0.5  # Default for missing dates
 
-    def test_recency_scores_non_dict_item(self, retriever: VectorCypherRetriever) -> None:
-        """Test default recency score for non-dict items."""
+    def test_recency_scores_non_chunk_item(self, retriever: VectorCypherRetriever) -> None:
+        """Test default recency score for non-Chunk items."""
         from khora.engines.vectorcypher.fusion import FusedResult
 
         id1 = uuid4()
-        results = [FusedResult(item_id=id1, item="not a dict", rrf_score=0.9)]
+        results = [FusedResult(item_id=id1, item="not a chunk", rrf_score=0.9)]
 
         scores = retriever._calculate_recency_scores(results)
 


### PR DESCRIPTION
## Summary

- **VectorCypher engine** `recall()` returned chunks as `list[tuple[dict, float]]` instead of `list[tuple[Chunk, float]]`, breaking the API layer which expects attribute access (`chunk.id`, `chunk.content`)
- **Skeleton engine** had the same issue
- Updated all three retrieval paths in `VectorCypherRetriever` (`_simple_retrieve`, `_vector_search_chunks`, `_fetch_chunks_from_entities`) to construct `Chunk` model instances
- Updated entity results to return `Entity` model instances instead of dicts
- Updated `_validate_recall_results` and `_calculate_recency_scores` to work with `Chunk` objects
- Tightened `RecallResult` type annotations from `tuple[Any, float]` to `tuple[Chunk, float]` / `tuple[Entity, float]`
- All engines now consistently return proper model instances (matching GraphRAG reference)

## Test plan

- [x] `uv run pytest tests/unit/engines/test_vectorcypher_engine.py -v` — all pass
- [x] `uv run pytest tests/unit/engines/test_vectorcypher_retriever.py -v` — all pass
- [x] `uv run pytest tests/unit/ -v` — 1203 passed, 52.66% coverage
- [x] `make format` — clean
- [x] `make lint` — no new diagnostics
- [x] Pre-commit hooks — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)