### PR TITLE
DYT-209: Support document updates in ingestion pipeline

### DIFF
--- a/alembic/versions/010_document_source_index.py
+++ b/alembic/versions/010_document_source_index.py
@@ -1,0 +1,33 @@
+"""Add partial composite index on documents(namespace_id, source).
+
+Revision ID: 010_document_source_index
+Revises: 009_temporal_search_indexes
+Create Date: 2026-03-03
+
+Supports source-based document update detection: when a document is
+re-ingested with the same source but different content, the old data is
+cleaned up and replaced. The partial index (WHERE source != '') avoids
+indexing documents without a source, which cannot be auto-updated.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "010_document_source_index"
+down_revision: str | Sequence[str] | None = "009_temporal_search_indexes"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_documents_namespace_source",
+        "documents",
+        ["namespace_id", "source"],
+        postgresql_where="source != ''",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_documents_namespace_source", table_name="documents")

--- a/docs/design/document-update-identity.md
+++ b/docs/design/document-update-identity.md
@@ -31,6 +31,7 @@ Use the existing `source` field (URL, file path, etc.) as an **optional update k
 - If a doc is first ingested without source, then later re-ingested with a source and different content → creates a second document (no retroactive identity assignment).
 - Concurrent updates to the same source race; **last writer wins** (no locking in v1).
 - On update: old chunks are deleted, entity/relationship `source_document_ids` are pruned, orphaned entities/relationships (sole source was this doc) are deleted.
+- Cross-backend cleanup (Neo4j + pgvector) is best-effort; if one backend fails mid-cleanup, stale references may persist until the next update of the same source.
 - The document UUID is **reused** on update so external consumers referencing doc IDs see continuity.
 
 ## Future Considerations
@@ -38,3 +39,4 @@ Use the existing `source` field (URL, file path, etc.) as an **optional update k
 - A dedicated `external_id` column could be added if `source` proves insufficient as an identity key.
 - Backfill support (`update_document_source()`) could be added to retroactively assign sources.
 - `SELECT ... FOR UPDATE` could be added if concurrent update races become problematic.
+- Error handling and retry logic for partial cleanup failures across backends.

--- a/docs/design/document-update-identity.md
+++ b/docs/design/document-update-identity.md
@@ -1,0 +1,40 @@
+# ADR: Document Update Identity
+
+## Status
+
+Accepted
+
+## Context
+
+Khora's ingestion pipeline treats every `remember()` call as a new document. The only dedup is checksum-based: identical content is skipped. When a document's content changes (same source URL, different text), the old chunks, entities, and relationships remain alongside the new ones, causing stale/contradictory query results.
+
+We need a mechanism to detect when a re-ingested document is an update of an existing one, clean up the old data, and replace it.
+
+Two competing approaches were considered:
+
+- **(A) Consumer-supplied stable ID:** Consumers pass an explicit `external_id`; Khora is fully agnostic about identity.
+- **(B) Auto-detect from existing metadata:** Khora uses an existing field (`source`) to detect updates without requiring new consumer-side changes.
+
+## Decision
+
+Use the existing `source` field (URL, file path, etc.) as an **optional update key** for v1.
+
+- When `source` is **non-empty** and a document with the same `(namespace_id, source)` exists but has a **different checksum** → treat as an update.
+- When `source` is **empty** → always create a new document (current behavior).
+- An `allow_update: bool = True` parameter allows consumers to opt out.
+- Checksum dedup runs **first** — if content is identical, skip regardless of source.
+
+## Implications
+
+- Documents ingested **without** `source` can never be auto-updated (no identity key).
+- Same content re-ingested under a different source URL is **skipped** by checksum dedup (not treated as a new doc for the new source).
+- If a doc is first ingested without source, then later re-ingested with a source and different content → creates a second document (no retroactive identity assignment).
+- Concurrent updates to the same source race; **last writer wins** (no locking in v1).
+- On update: old chunks are deleted, entity/relationship `source_document_ids` are pruned, orphaned entities/relationships (sole source was this doc) are deleted.
+- The document UUID is **reused** on update so external consumers referencing doc IDs see continuity.
+
+## Future Considerations
+
+- A dedicated `external_id` column could be added if `source` proves insufficient as an identity key.
+- Backfill support (`update_document_source()`) could be added to retroactively assign sources.
+- `SELECT ... FOR UPDATE` could be added if concurrent update races become problematic.

--- a/src/khora/db/models.py
+++ b/src/khora/db/models.py
@@ -215,6 +215,12 @@ class DocumentModel(Base):
     __table_args__ = (
         Index("ix_documents_namespace_checksum", "namespace_id", "checksum"),
         Index("ix_documents_namespace_source_type", "namespace_id", "source_type"),
+        Index(
+            "ix_documents_namespace_source",
+            "namespace_id",
+            "source",
+            postgresql_where="source != ''",
+        ),
     )
 
     def __repr__(self) -> str:

--- a/src/khora/engines/graphrag/engine.py
+++ b/src/khora/engines/graphrag/engine.py
@@ -20,6 +20,7 @@ from loguru import logger
 
 from khora.config import KhoraConfig, LiteLLMConfig
 from khora.core.models import Document, DocumentMetadata, Entity, MemoryNamespace, Organization, Workspace
+from khora.core.models.document import DocumentStatus
 from khora.extraction.embedders import LiteLLMEmbedder
 from khora.memory_lake import BatchResult, RecallResult, RememberResult, Stats
 from khora.query import HybridQueryEngine, QueryConfig, SearchMode
@@ -223,6 +224,7 @@ class GraphRAGEngine:
         source: str = "",
         metadata: dict[str, Any] | None = None,
         skill_name: str = "general_entities",
+        allow_update: bool = True,
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -234,6 +236,7 @@ class GraphRAGEngine:
         """
         timings: dict[str, float] = {}
         total_start = time.perf_counter()
+        is_update = False
 
         # Compute checksum
         start = time.perf_counter()
@@ -259,23 +262,58 @@ class GraphRAGEngine:
                 metadata={"duplicate": True, "status": str(existing.status), "timings": timings},
             )
 
-        # Create document
-        start = time.perf_counter()
-        doc_metadata = DocumentMetadata(
-            title=title,
-            source=source,
-            source_type="api",
-            checksum=checksum,
-            size_bytes=len(content.encode("utf-8")),
-            custom=metadata or {},
-        )
-        document = Document(
-            namespace_id=namespace_id,
-            content=content,
-            metadata=doc_metadata,
-        )
-        document = await storage.create_document(document)
-        timings["document_create_ms"] = (time.perf_counter() - start) * 1000
+        # Source-based update detection: same source, different content
+        document: Document | None = None
+        if allow_update and source:
+            start = time.perf_counter()
+            existing_by_source = await storage.get_document_by_source(namespace_id, source)
+            timings["source_check_ms"] = (time.perf_counter() - start) * 1000
+
+            if existing_by_source:
+                # Clean up old data
+                start = time.perf_counter()
+                cleanup_stats = await storage.cleanup_document_references(existing_by_source.id, namespace_id)
+                timings["cleanup_ms"] = (time.perf_counter() - start) * 1000
+
+                # Update existing document record with new content
+                start = time.perf_counter()
+                existing_by_source.content = content
+                existing_by_source.metadata = DocumentMetadata(
+                    title=title,
+                    source=source,
+                    source_type="api",
+                    checksum=checksum,
+                    size_bytes=len(content.encode("utf-8")),
+                    custom=metadata or {},
+                )
+                existing_by_source.status = DocumentStatus.PENDING
+                existing_by_source.chunk_count = 0
+                existing_by_source.entity_count = 0
+                existing_by_source.error_message = None
+                existing_by_source.processed_at = None
+                document = await storage.update_document(existing_by_source)
+                timings["document_update_ms"] = (time.perf_counter() - start) * 1000
+                is_update = True
+                logger.info(f"Updating document {document.id} (source={source!r}, " f"cleanup: {cleanup_stats})")
+
+        # Create new document if not an update
+        if document is None:
+            start = time.perf_counter()
+            doc_metadata = DocumentMetadata(
+                title=title,
+                source=source,
+                source_type="api",
+                checksum=checksum,
+                size_bytes=len(content.encode("utf-8")),
+                custom=metadata or {},
+            )
+            document = Document(
+                namespace_id=namespace_id,
+                content=content,
+                metadata=doc_metadata,
+            )
+            document = await storage.create_document(document)
+            timings["document_create_ms"] = (time.perf_counter() - start) * 1000
 
         # Process through pipeline (handles chunking, embedding, extraction in parallel)
         from khora.pipelines.flows.ingest import process_document
@@ -316,6 +354,7 @@ class GraphRAGEngine:
             chunks_created=result["chunks"],
             entities_extracted=result["entities"],
             relationships_created=result["relationships"],
+            updated=is_update,
             metadata={
                 "timings": timings,
                 "quality_metrics": {

--- a/src/khora/engines/graphrag/engine.py
+++ b/src/khora/engines/graphrag/engine.py
@@ -428,6 +428,7 @@ class GraphRAGEngine:
         deduplicate: bool = True,
         infer_relationships: bool = True,
         on_progress: Callable[[int, int], None] | None = None,
+        allow_update: bool = True,
     ) -> BatchResult:
         """Store multiple documents with automatic optimization.
 
@@ -500,6 +501,7 @@ class GraphRAGEngine:
             shared_embedder=shared_embedder,
             shared_entity_index=shared_entity_index,
             enable_expansion=infer_relationships,
+            allow_update=allow_update,
         )
         timings["ingest_pipeline_ms"] = (time.perf_counter() - start) * 1000
         timings["total_ms"] = (time.perf_counter() - total_start) * 1000

--- a/src/khora/engines/graphrag/engine.py
+++ b/src/khora/engines/graphrag/engine.py
@@ -262,6 +262,19 @@ class GraphRAGEngine:
                 metadata={"duplicate": True, "status": str(existing.status), "timings": timings},
             )
 
+        def _make_metadata() -> DocumentMetadata:
+            return DocumentMetadata(
+                title=title,
+                source=source,
+                source_type="api",
+                content_type="text/plain",
+                language="en",
+                author="",
+                checksum=checksum,
+                size_bytes=len(content.encode("utf-8")),
+                custom=metadata or {},
+            )
+
         # Source-based update detection: same source, different content
         document: Document | None = None
         if allow_update and source:
@@ -278,14 +291,7 @@ class GraphRAGEngine:
                 # Update existing document record with new content
                 start = time.perf_counter()
                 existing_by_source.content = content
-                existing_by_source.metadata = DocumentMetadata(
-                    title=title,
-                    source=source,
-                    source_type="api",
-                    checksum=checksum,
-                    size_bytes=len(content.encode("utf-8")),
-                    custom=metadata or {},
-                )
+                existing_by_source.metadata = _make_metadata()
                 existing_by_source.status = DocumentStatus.PENDING
                 existing_by_source.chunk_count = 0
                 existing_by_source.entity_count = 0
@@ -299,18 +305,10 @@ class GraphRAGEngine:
         # Create new document if not an update
         if document is None:
             start = time.perf_counter()
-            doc_metadata = DocumentMetadata(
-                title=title,
-                source=source,
-                source_type="api",
-                checksum=checksum,
-                size_bytes=len(content.encode("utf-8")),
-                custom=metadata or {},
-            )
             document = Document(
                 namespace_id=namespace_id,
                 content=content,
-                metadata=doc_metadata,
+                metadata=_make_metadata(),
             )
             document = await storage.create_document(document)
             timings["document_create_ms"] = (time.perf_counter() - start) * 1000
@@ -536,6 +534,7 @@ class GraphRAGEngine:
             chunks=result.get("total_chunks", 0),
             entities=result.get("total_entities", 0),
             relationships=result.get("total_relationships", 0) + result.get("total_inferred_relationships", 0),
+            updated=result.get("updated_documents", 0),
             metadata={"timings": timings},
         )
 

--- a/src/khora/engines/protocol.py
+++ b/src/khora/engines/protocol.py
@@ -123,6 +123,7 @@ class MemoryEngineProtocol(Protocol):
         deduplicate: bool = True,
         infer_relationships: bool = True,
         on_progress: Callable[[int, int], None] | None = None,
+        allow_update: bool = True,
     ) -> BatchResult:
         """Store multiple documents with automatic optimization.
 
@@ -134,6 +135,7 @@ class MemoryEngineProtocol(Protocol):
             deduplicate: Deduplicate entities across documents
             infer_relationships: Infer relationships after ingestion
             on_progress: Callback(processed_count, total_count) for progress updates
+            allow_update: When True, detect and update existing documents by source
 
         Returns:
             BatchResult with aggregated statistics

--- a/src/khora/engines/protocol.py
+++ b/src/khora/engines/protocol.py
@@ -54,6 +54,7 @@ class MemoryEngineProtocol(Protocol):
         source: str = "",
         metadata: dict[str, Any] | None = None,
         skill_name: str = "general_entities",
+        allow_update: bool = True,
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -64,6 +65,9 @@ class MemoryEngineProtocol(Protocol):
             source: Optional source identifier
             metadata: Optional metadata
             skill_name: Extraction skill to use
+            allow_update: When True and source matches an existing document with
+                different content, update the existing document instead of creating
+                a new one. When False, always create a new document.
 
         Returns:
             RememberResult with details

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -583,6 +583,7 @@ class SkeletonConstructionEngine:
         deduplicate: bool = True,
         infer_relationships: bool = False,  # Not used in Skeleton Construction engine
         on_progress: Callable[[int, int], None] | None = None,
+        allow_update: bool = True,
     ) -> BatchResult:
         """Store multiple documents with automatic optimization.
 

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -1099,6 +1099,7 @@ class VectorCypherEngine:
         deduplicate: bool = True,
         infer_relationships: bool = True,
         on_progress: Callable[[int, int], None] | None = None,
+        allow_update: bool = True,
     ) -> BatchResult:
         """Store multiple documents with automatic optimization.
 

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -352,6 +352,7 @@ class MemoryLake:
         deduplicate: bool = True,
         infer_relationships: bool = True,
         on_progress: Callable[[int, int], None] | None = None,
+        allow_update: bool = True,
     ) -> BatchResult:
         """Store multiple documents with automatic optimization.
 
@@ -377,6 +378,7 @@ class MemoryLake:
             deduplicate: Deduplicate entities across documents (default: True)
             infer_relationships: Infer relationships after ingestion (default: True)
             on_progress: Callback(processed_count, total_count) for progress updates
+            allow_update: When True, detect and update existing documents by source
 
         Returns:
             BatchResult with aggregated statistics
@@ -395,6 +397,7 @@ class MemoryLake:
                     deduplicate=deduplicate,
                     infer_relationships=infer_relationships,
                     on_progress=on_progress,
+                    allow_update=allow_update,
                 )
         finally:
             clear_trace_id()

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -36,6 +36,7 @@ class RememberResult:
     chunks_created: int
     entities_extracted: int
     relationships_created: int
+    updated: bool = False
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -50,6 +51,7 @@ class BatchResult:
     chunks: int
     entities: int
     relationships: int
+    updated: int = 0
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -294,6 +296,7 @@ class MemoryLake:
         source: str = "",
         metadata: dict[str, Any] | None = None,
         skill_name: str = "general_entities",
+        allow_update: bool = True,
     ) -> RememberResult:
         """Store content in the memory lake.
 
@@ -303,6 +306,11 @@ class MemoryLake:
         3. Generates embeddings
         4. Extracts entities and relationships
 
+        When a document with the same source already exists and content has
+        changed, the old chunks/entities/relationships are cleaned up and
+        the document is re-processed (requires non-empty ``source`` and
+        ``allow_update=True``).
+
         Args:
             content: Content to remember
             namespace: Namespace name, ID, or None for default
@@ -310,6 +318,8 @@ class MemoryLake:
             source: Optional source identifier
             metadata: Optional metadata
             skill_name: Extraction skill to use
+            allow_update: When True and source matches an existing document with
+                different content, update instead of creating new (default: True)
 
         Returns:
             RememberResult with details
@@ -327,6 +337,7 @@ class MemoryLake:
                     source=source,
                     metadata=metadata,
                     skill_name=skill_name,
+                    allow_update=allow_update,
                 )
         finally:
             clear_trace_id()

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -17,6 +17,7 @@ from uuid import UUID
 from loguru import logger
 
 from khora._accel import normalize_entity_names_batch
+from khora.core.models.document import DocumentStatus
 
 from ..registry import pipeline
 
@@ -576,10 +577,14 @@ async def stage_document(
     doc_input: dict[str, Any],
     namespace_id: UUID,
     storage: StorageCoordinator,
+    *,
+    allow_update: bool = True,
 ) -> Document | None:
     """Stage a document for processing.
 
     Checks if document already exists (by checksum) and creates it if new.
+    When allow_update is True and source matches an existing document with
+    different content, cleans up and updates the existing document.
     Uses source system timestamp for created_at when available.
 
     Returns:
@@ -598,12 +603,45 @@ async def stage_document(
         logger.debug(f"Document unchanged (checksum={checksum[:8]}..., status={existing.status})")
         return None
 
+    # Source-based update detection
+    source = doc_input.get("source", "")
+    if allow_update and source:
+        existing_by_source = await storage.get_document_by_source(namespace_id, source)
+        if existing_by_source:
+            # Clean up old data and update existing document
+            await storage.cleanup_document_references(existing_by_source.id, namespace_id)
+
+            custom_metadata = doc_input.get("metadata", {})
+            source_timestamp = _extract_source_timestamp(custom_metadata)
+
+            existing_by_source.content = content
+            existing_by_source.metadata = DocumentMetadata(
+                source=source,
+                source_type=doc_input.get("source_type", "manual"),
+                content_type=doc_input.get("content_type", "text/plain"),
+                title=doc_input.get("title", ""),
+                author=doc_input.get("author", ""),
+                language=doc_input.get("language", "en"),
+                checksum=checksum,
+                size_bytes=len(content.encode("utf-8")),
+                custom=custom_metadata,
+            )
+            existing_by_source.status = DocumentStatus.PENDING
+            existing_by_source.chunk_count = 0
+            existing_by_source.entity_count = 0
+            existing_by_source.error_message = None
+            existing_by_source.processed_at = None
+            existing_by_source.source_timestamp = source_timestamp
+
+            logger.info(f"Updating document {existing_by_source.id} (source={source!r})")
+            return await storage.update_document(existing_by_source)
+
     # Extract custom metadata
     custom_metadata = doc_input.get("metadata", {})
 
     # Create document
     metadata = DocumentMetadata(
-        source=doc_input.get("source", ""),
+        source=source,
         source_type=doc_input.get("source_type", "manual"),
         content_type=doc_input.get("content_type", "text/plain"),
         title=doc_input.get("title", ""),
@@ -634,14 +672,17 @@ async def stage_documents_batch(
     doc_inputs: list[dict[str, Any]],
     namespace_id: UUID,
     storage: StorageCoordinator,
+    *,
+    allow_update: bool = True,
 ) -> list[Document | None]:
     """Batch stage documents with single-query checksum dedup.
 
     Computes all checksums upfront and checks for existing documents
     in a single batch query instead of N individual queries.
+    When allow_update is True, detects source-based updates in batch.
 
     Returns:
-        List parallel to doc_inputs: Document if new, None if unchanged
+        List parallel to doc_inputs: Document if new/updated, None if unchanged
     """
     from datetime import UTC, datetime
 
@@ -656,6 +697,14 @@ async def stage_documents_batch(
     # Single batch query for existing documents (replaces N individual queries)
     existing = await storage.get_documents_by_checksums(namespace_id, checksums)
 
+    # Batch source lookup for update detection
+    source_matches: dict[str, Document] = {}
+    if allow_update:
+        sources = [doc.get("source", "") for doc in doc_inputs]
+        non_deduped_sources = [s for s, cs in zip(sources, checksums) if cs not in existing and s]
+        if non_deduped_sources:
+            source_matches = await storage.get_documents_by_sources(namespace_id, non_deduped_sources)
+
     results: list[Document | None] = []
     for doc_input, checksum in zip(doc_inputs, checksums):
         if checksum in existing:
@@ -664,9 +713,41 @@ async def stage_documents_batch(
             continue
 
         content = doc_input.get("content", "")
+        source = doc_input.get("source", "")
         custom_metadata = doc_input.get("metadata", {})
+
+        # Source-based update detection
+        if allow_update and source and source in source_matches:
+            existing_doc = source_matches[source]
+            await storage.cleanup_document_references(existing_doc.id, namespace_id)
+
+            source_timestamp = _extract_source_timestamp(custom_metadata)
+            existing_doc.content = content
+            existing_doc.metadata = DocumentMetadata(
+                source=source,
+                source_type=doc_input.get("source_type", "manual"),
+                content_type=doc_input.get("content_type", "text/plain"),
+                title=doc_input.get("title", ""),
+                author=doc_input.get("author", ""),
+                language=doc_input.get("language", "en"),
+                checksum=checksum,
+                size_bytes=len(content.encode("utf-8")),
+                custom=custom_metadata,
+            )
+            existing_doc.status = DocumentStatus.PENDING
+            existing_doc.chunk_count = 0
+            existing_doc.entity_count = 0
+            existing_doc.error_message = None
+            existing_doc.processed_at = None
+            existing_doc.source_timestamp = source_timestamp
+
+            logger.info(f"Updating document {existing_doc.id} (source={source!r})")
+            doc = await storage.update_document(existing_doc)
+            results.append(doc)
+            continue
+
         metadata = DocumentMetadata(
-            source=doc_input.get("source", ""),
+            source=source,
             source_type=doc_input.get("source_type", "manual"),
             content_type=doc_input.get("content_type", "text/plain"),
             title=doc_input.get("title", ""),
@@ -1259,9 +1340,11 @@ async def ingest_documents(
             if existing_entities:
                 logger.info(f"Smart mode: pre-loaded {len(existing_entities)} existing entities into index")
 
-    # Phase 1: Batch checksum dedup + stage new documents
+    # Phase 1: Batch checksum dedup + stage new/updated documents
     # Single batch query replaces N individual get_document_by_checksum calls.
-    staged_results = await stage_documents_batch(documents, namespace_id, storage)
+    # Source-based update detection is included when allow_update is True.
+    allow_update = kwargs.get("allow_update", True)
+    staged_results = await stage_documents_batch(documents, namespace_id, storage, allow_update=allow_update)
     staged_docs = [doc for doc in staged_results if doc is not None]
 
     # Build mapping from staged doc ID to original dict for per-doc overrides

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -24,7 +24,7 @@ from ..registry import pipeline
 if TYPE_CHECKING:
     from datetime import datetime
 
-    from khora.core.models import Chunk, Document, Entity, Relationship
+    from khora.core.models import Chunk, Document, DocumentMetadata, Entity, Relationship
     from khora.engines.skeleton.backends import TemporalVectorStore
     from khora.extraction.embedders import Embedder
     from khora.extraction.expansion.entity_index import EntityIndex
@@ -573,6 +573,23 @@ def _parse_temporal_date(value: str | None) -> datetime | None:
         return None
 
 
+def _build_document_metadata(doc_input: dict[str, Any], checksum: str) -> DocumentMetadata:
+    """Build a DocumentMetadata from a document input dict and checksum."""
+    from khora.core.models import DocumentMetadata
+
+    return DocumentMetadata(
+        source=doc_input.get("source", ""),
+        source_type=doc_input.get("source_type", "manual"),
+        content_type=doc_input.get("content_type", "text/plain"),
+        title=doc_input.get("title", ""),
+        author=doc_input.get("author", ""),
+        language=doc_input.get("language", "en"),
+        checksum=checksum,
+        size_bytes=len(doc_input.get("content", "").encode("utf-8")),
+        custom=doc_input.get("metadata", {}),
+    )
+
+
 async def stage_document(
     doc_input: dict[str, Any],
     namespace_id: UUID,
@@ -592,7 +609,7 @@ async def stage_document(
     """
     from datetime import UTC, datetime
 
-    from khora.core.models import Document, DocumentMetadata
+    from khora.core.models import Document
 
     content = doc_input.get("content", "")
     checksum = compute_checksum(content)
@@ -611,21 +628,10 @@ async def stage_document(
             # Clean up old data and update existing document
             await storage.cleanup_document_references(existing_by_source.id, namespace_id)
 
-            custom_metadata = doc_input.get("metadata", {})
-            source_timestamp = _extract_source_timestamp(custom_metadata)
+            source_timestamp = _extract_source_timestamp(doc_input.get("metadata", {}))
 
             existing_by_source.content = content
-            existing_by_source.metadata = DocumentMetadata(
-                source=source,
-                source_type=doc_input.get("source_type", "manual"),
-                content_type=doc_input.get("content_type", "text/plain"),
-                title=doc_input.get("title", ""),
-                author=doc_input.get("author", ""),
-                language=doc_input.get("language", "en"),
-                checksum=checksum,
-                size_bytes=len(content.encode("utf-8")),
-                custom=custom_metadata,
-            )
+            existing_by_source.metadata = _build_document_metadata(doc_input, checksum)
             existing_by_source.status = DocumentStatus.PENDING
             existing_by_source.chunk_count = 0
             existing_by_source.entity_count = 0
@@ -636,24 +642,11 @@ async def stage_document(
             logger.info(f"Updating document {existing_by_source.id} (source={source!r})")
             return await storage.update_document(existing_by_source)
 
-    # Extract custom metadata
-    custom_metadata = doc_input.get("metadata", {})
-
     # Create document
-    metadata = DocumentMetadata(
-        source=source,
-        source_type=doc_input.get("source_type", "manual"),
-        content_type=doc_input.get("content_type", "text/plain"),
-        title=doc_input.get("title", ""),
-        author=doc_input.get("author", ""),
-        language=doc_input.get("language", "en"),
-        checksum=checksum,
-        size_bytes=len(content.encode("utf-8")),
-        custom=custom_metadata,
-    )
+    metadata = _build_document_metadata(doc_input, checksum)
 
     # Use source timestamp if available, otherwise use current time
-    source_timestamp = _extract_source_timestamp(custom_metadata)
+    source_timestamp = _extract_source_timestamp(doc_input.get("metadata", {}))
     created_at = source_timestamp or datetime.now(UTC)
 
     document = Document(
@@ -686,7 +679,7 @@ async def stage_documents_batch(
     """
     from datetime import UTC, datetime
 
-    from khora.core.models import Document, DocumentMetadata
+    from khora.core.models import Document
 
     if not doc_inputs:
         return []
@@ -723,17 +716,7 @@ async def stage_documents_batch(
 
             source_timestamp = _extract_source_timestamp(custom_metadata)
             existing_doc.content = content
-            existing_doc.metadata = DocumentMetadata(
-                source=source,
-                source_type=doc_input.get("source_type", "manual"),
-                content_type=doc_input.get("content_type", "text/plain"),
-                title=doc_input.get("title", ""),
-                author=doc_input.get("author", ""),
-                language=doc_input.get("language", "en"),
-                checksum=checksum,
-                size_bytes=len(content.encode("utf-8")),
-                custom=custom_metadata,
-            )
+            existing_doc.metadata = _build_document_metadata(doc_input, checksum)
             existing_doc.status = DocumentStatus.PENDING
             existing_doc.chunk_count = 0
             existing_doc.entity_count = 0
@@ -746,17 +729,7 @@ async def stage_documents_batch(
             results.append(doc)
             continue
 
-        metadata = DocumentMetadata(
-            source=source,
-            source_type=doc_input.get("source_type", "manual"),
-            content_type=doc_input.get("content_type", "text/plain"),
-            title=doc_input.get("title", ""),
-            author=doc_input.get("author", ""),
-            language=doc_input.get("language", "en"),
-            checksum=checksum,
-            size_bytes=len(content.encode("utf-8")),
-            custom=custom_metadata,
-        )
+        metadata = _build_document_metadata(doc_input, checksum)
 
         source_timestamp = _extract_source_timestamp(custom_metadata)
         created_at = source_timestamp or datetime.now(UTC)

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -667,7 +667,7 @@ async def stage_documents_batch(
     storage: StorageCoordinator,
     *,
     allow_update: bool = True,
-) -> list[Document | None]:
+) -> tuple[list[Document | None], int]:
     """Batch stage documents with single-query checksum dedup.
 
     Computes all checksums upfront and checks for existing documents
@@ -675,14 +675,15 @@ async def stage_documents_batch(
     When allow_update is True, detects source-based updates in batch.
 
     Returns:
-        List parallel to doc_inputs: Document if new/updated, None if unchanged
+        Tuple of (results list parallel to doc_inputs, count of updated documents).
+        Each result is Document if new/updated, None if unchanged/skipped.
     """
     from datetime import UTC, datetime
 
     from khora.core.models import Document
 
     if not doc_inputs:
-        return []
+        return [], 0
 
     # Compute all checksums upfront
     checksums = [compute_checksum(doc.get("content", "")) for doc in doc_inputs]
@@ -699,6 +700,8 @@ async def stage_documents_batch(
             source_matches = await storage.get_documents_by_sources(namespace_id, non_deduped_sources)
 
     results: list[Document | None] = []
+    updated_count = 0
+    processed_sources: set[str] = set()
     for doc_input, checksum in zip(doc_inputs, checksums):
         if checksum in existing:
             logger.debug(f"Document unchanged (checksum={checksum[:8]}..., status={existing[checksum].status})")
@@ -709,8 +712,15 @@ async def stage_documents_batch(
         source = doc_input.get("source", "")
         custom_metadata = doc_input.get("metadata", {})
 
+        # Duplicate source in same batch — skip
+        if allow_update and source and source in source_matches and source in processed_sources:
+            logger.warning(f"Duplicate source {source!r} in batch, skipping (already updated)")
+            results.append(None)
+            continue
+
         # Source-based update detection
         if allow_update and source and source in source_matches:
+            processed_sources.add(source)
             existing_doc = source_matches[source]
             await storage.cleanup_document_references(existing_doc.id, namespace_id)
 
@@ -727,6 +737,7 @@ async def stage_documents_batch(
             logger.info(f"Updating document {existing_doc.id} (source={source!r})")
             doc = await storage.update_document(existing_doc)
             results.append(doc)
+            updated_count += 1
             continue
 
         metadata = _build_document_metadata(doc_input, checksum)
@@ -746,7 +757,7 @@ async def stage_documents_batch(
         doc = await storage.create_document(document)
         results.append(doc)
 
-    return results
+    return results, updated_count
 
 
 async def process_document(
@@ -1317,7 +1328,9 @@ async def ingest_documents(
     # Single batch query replaces N individual get_document_by_checksum calls.
     # Source-based update detection is included when allow_update is True.
     allow_update = kwargs.get("allow_update", True)
-    staged_results = await stage_documents_batch(documents, namespace_id, storage, allow_update=allow_update)
+    staged_results, updated_documents = await stage_documents_batch(
+        documents, namespace_id, storage, allow_update=allow_update
+    )
     staged_docs = [doc for doc in staged_results if doc is not None]
 
     # Build mapping from staged doc ID to original dict for per-doc overrides
@@ -1334,6 +1347,7 @@ async def ingest_documents(
             "total_documents": len(documents),
             "processed_documents": 0,
             "skipped_documents": len(documents),
+            "updated_documents": 0,
             "total_chunks": 0,
             "total_entities": 0,
             "total_relationships": 0,
@@ -1425,6 +1439,7 @@ async def ingest_documents(
         "processed_documents": len(successful_results),
         "skipped_documents": len(documents) - len(staged_docs),
         "failed_documents": error_count,
+        "updated_documents": updated_documents,
         "total_chunks": total_chunks,
         "total_entities": total_entities,
         "total_relationships": total_relationships,

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -1441,3 +1441,88 @@ class Neo4jBackend(GraphBackendBase):
             )
             records = await result.data()
             return [self._record_to_entity(r["e"]) for r in records]
+
+    # =========================================================================
+    # Document update cleanup
+    # =========================================================================
+
+    async def remove_document_from_entities(
+        self, document_id: UUID, namespace_id: UUID
+    ) -> tuple[list[UUID], list[UUID]]:
+        """Remove a document ID from entity source_document_ids in Neo4j.
+
+        Entities whose source_document_ids become empty are deleted (DETACH DELETE
+        removes their relationships too).
+
+        Returns:
+            Tuple of (updated_entity_ids, deleted_entity_ids)
+        """
+        driver = self._get_driver()
+        doc_id_str = str(document_id)
+        ns_id_str = str(namespace_id)
+
+        query = """
+        MATCH (e:Entity {namespace_id: $ns})
+        WHERE $doc_id IN e.source_document_ids
+        SET e.source_document_ids = [x IN e.source_document_ids WHERE x <> $doc_id]
+        WITH e, e.id AS eid, size(e.source_document_ids) AS remaining
+        WITH e, eid, remaining,
+             CASE WHEN remaining = 0 THEN true ELSE false END AS should_delete
+        WITH collect(CASE WHEN should_delete THEN null ELSE eid END) AS updated_ids,
+             collect(CASE WHEN should_delete THEN e ELSE null END) AS to_delete,
+             collect(CASE WHEN should_delete THEN eid ELSE null END) AS deleted_ids
+        UNWIND to_delete AS d
+        WITH updated_ids, deleted_ids, d
+        WHERE d IS NOT NULL
+        DETACH DELETE d
+        RETURN
+            [x IN updated_ids WHERE x IS NOT NULL] AS updated,
+            [x IN deleted_ids WHERE x IS NOT NULL] AS deleted
+        """
+
+        async with driver.session(database=self._database) as session:
+            result = await session.run(query, ns=ns_id_str, doc_id=doc_id_str)
+            record = await result.single()
+
+            if record is None:
+                return [], []
+
+            updated = [UUID(uid) for uid in (record["updated"] or [])]
+            deleted = [UUID(did) for did in (record["deleted"] or [])]
+            return updated, deleted
+
+    async def remove_document_from_relationships(self, document_id: UUID, namespace_id: UUID) -> tuple[int, int]:
+        """Remove a document ID from relationship source_document_ids in Neo4j.
+
+        Relationships whose source_document_ids become empty are deleted.
+
+        Returns:
+            Tuple of (updated_count, deleted_count)
+        """
+        driver = self._get_driver()
+        doc_id_str = str(document_id)
+        ns_id_str = str(namespace_id)
+
+        query = """
+        MATCH ()-[r]->()
+        WHERE r.namespace_id = $ns AND $doc_id IN r.source_document_ids
+        SET r.source_document_ids = [x IN r.source_document_ids WHERE x <> $doc_id]
+        WITH r, size(r.source_document_ids) AS remaining
+        WITH collect(CASE WHEN remaining = 0 THEN r ELSE null END) AS to_delete,
+             sum(CASE WHEN remaining > 0 THEN 1 ELSE 0 END) AS updated_count,
+             sum(CASE WHEN remaining = 0 THEN 1 ELSE 0 END) AS deleted_count
+        UNWIND to_delete AS d
+        WITH updated_count, deleted_count, d
+        WHERE d IS NOT NULL
+        DELETE d
+        RETURN updated_count, deleted_count
+        """
+
+        async with driver.session(database=self._database) as session:
+            result = await session.run(query, ns=ns_id_str, doc_id=doc_id_str)
+            record = await result.single()
+
+            if record is None:
+                return 0, 0
+
+            return record["updated_count"] or 0, record["deleted_count"] or 0

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from tenacity import AsyncRetrying, before_sleep_log, retry_if_exception, stop_after_attempt, wait_exponential
 
 from khora.core.models import Chunk, ChunkMetadata
-from khora.db.models import Base, ChunkModel, EntityModel
+from khora.db.models import Base, ChunkModel, EntityModel, RelationshipModel
 from khora.storage.backends.mixins import AsyncSessionMixin
 
 if TYPE_CHECKING:
@@ -768,3 +768,79 @@ class PgVectorBackend(AsyncSessionMixin):
                 "chunk_embeddings": chunk_count.scalar_one(),
                 "entity_embeddings": entity_count.scalar_one(),
             }
+
+    # =========================================================================
+    # Document update cleanup operations
+    # =========================================================================
+
+    async def remove_document_from_entity_sources(self, document_id: UUID) -> tuple[int, int]:
+        """Remove a document ID from entity source_document_ids arrays.
+
+        Uses PostgreSQL array_remove(). Deletes entities where the array
+        becomes empty (orphaned entities).
+
+        Returns:
+            Tuple of (updated_count, deleted_count)
+        """
+        async with self._get_session() as session:
+            # Remove doc ID from all entities that reference it
+            update_result = await session.execute(
+                update(EntityModel)
+                .where(EntityModel.source_document_ids.any(document_id))
+                .values(
+                    source_document_ids=func.array_remove(EntityModel.source_document_ids, document_id),
+                    updated_at=datetime.now(UTC),
+                )
+                .returning(EntityModel.id)
+            )
+            updated_ids = [row[0] for row in update_result.all()]
+
+            # Delete entities where source_document_ids is now empty
+            deleted_count = 0
+            if updated_ids:
+                delete_result = await session.execute(
+                    delete(EntityModel).where(
+                        EntityModel.id.in_(updated_ids),
+                        func.array_length(EntityModel.source_document_ids, 1).is_(None),
+                    )
+                )
+                deleted_count = delete_result.rowcount  # type: ignore[assignment]
+
+            await session.commit()
+            return len(updated_ids), deleted_count
+
+    async def remove_document_from_relationship_sources(self, document_id: UUID) -> tuple[int, int]:
+        """Remove a document ID from relationship source_document_ids arrays.
+
+        Uses PostgreSQL array_remove(). Deletes relationships where the array
+        becomes empty (orphaned relationships).
+
+        Returns:
+            Tuple of (updated_count, deleted_count)
+        """
+        async with self._get_session() as session:
+            # Remove doc ID from all relationships that reference it
+            update_result = await session.execute(
+                update(RelationshipModel)
+                .where(RelationshipModel.source_document_ids.any(document_id))
+                .values(
+                    source_document_ids=func.array_remove(RelationshipModel.source_document_ids, document_id),
+                    updated_at=datetime.now(UTC),
+                )
+                .returning(RelationshipModel.id)
+            )
+            updated_ids = [row[0] for row in update_result.all()]
+
+            # Delete relationships where source_document_ids is now empty
+            deleted_count = 0
+            if updated_ids:
+                delete_result = await session.execute(
+                    delete(RelationshipModel).where(
+                        RelationshipModel.id.in_(updated_ids),
+                        func.array_length(RelationshipModel.source_document_ids, 1).is_(None),
+                    )
+                )
+                deleted_count = delete_result.rowcount  # type: ignore[assignment]
+
+            await session.commit()
+            return len(updated_ids), deleted_count

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -540,6 +540,47 @@ class PostgreSQLBackend(AsyncSessionMixin):
             models = result.scalars().all()
             return {m.id: self._document_model_to_domain(m) for m in models}
 
+    async def get_document_by_source(self, namespace_id: UUID, source: str) -> Document | None:
+        """Get a document by its source (for update detection).
+
+        Returns None if source is empty or no match found.
+        """
+        if not source:
+            return None
+
+        async with self._get_session() as session:
+            result = await session.execute(
+                select(DocumentModel).where(DocumentModel.namespace_id == namespace_id, DocumentModel.source == source)
+            )
+            model = result.scalars().first()
+            return self._document_model_to_domain(model) if model else None
+
+    async def get_documents_by_sources(self, namespace_id: UUID, sources: list[str]) -> dict[str, Document]:
+        """Fetch documents by source in a single query.
+
+        Used for batch update detection. Filters out empty sources.
+
+        Args:
+            namespace_id: Namespace to search in
+            sources: List of source identifiers to look up
+
+        Returns:
+            Dictionary mapping source to Document (only for existing documents)
+        """
+        non_empty = [s for s in sources if s]
+        if not non_empty:
+            return {}
+
+        async with self._get_session() as session:
+            result = await session.execute(
+                select(DocumentModel).where(
+                    DocumentModel.namespace_id == namespace_id,
+                    DocumentModel.source.in_(non_empty),
+                )
+            )
+            models = result.scalars().all()
+            return {m.source: self._document_model_to_domain(m) for m in models}
+
     async def get_documents_by_checksums(self, namespace_id: UUID, checksums: list[str]) -> dict[str, Document]:
         """Fetch documents by content checksums in a single query.
 

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -550,7 +550,9 @@ class PostgreSQLBackend(AsyncSessionMixin):
 
         async with self._get_session() as session:
             result = await session.execute(
-                select(DocumentModel).where(DocumentModel.namespace_id == namespace_id, DocumentModel.source == source)
+                select(DocumentModel)
+                .where(DocumentModel.namespace_id == namespace_id, DocumentModel.source == source)
+                .order_by(DocumentModel.updated_at.desc())
             )
             model = result.scalars().first()
             return self._document_model_to_domain(model) if model else None
@@ -573,13 +575,19 @@ class PostgreSQLBackend(AsyncSessionMixin):
 
         async with self._get_session() as session:
             result = await session.execute(
-                select(DocumentModel).where(
+                select(DocumentModel)
+                .where(
                     DocumentModel.namespace_id == namespace_id,
                     DocumentModel.source.in_(non_empty),
                 )
+                .order_by(DocumentModel.updated_at.desc())
             )
             models = result.scalars().all()
-            return {m.source: self._document_model_to_domain(m) for m in models}
+            result_dict: dict[str, Document] = {}
+            for m in models:
+                if m.source not in result_dict:  # keep first (newest due to DESC)
+                    result_dict[m.source] = self._document_model_to_domain(m)
+            return result_dict
 
     async def get_documents_by_checksums(self, namespace_id: UUID, checksums: list[str]) -> dict[str, Document]:
         """Fetch documents by content checksums in a single query.

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -422,11 +422,80 @@ class StorageCoordinator:
 
         return await self.relational.delete_document(document_id)
 
+    async def cleanup_document_references(self, document_id: UUID, namespace_id: UUID) -> dict[str, Any]:
+        """Clean up chunks, entity refs, and relationship refs for a document.
+
+        Used before re-processing an updated document. Orchestrates:
+        1. Delete old chunks (vector backend)
+        2. Remove doc from entity source_document_ids; delete orphaned entities (graph + vector)
+        3. Remove doc from relationship source_document_ids; delete orphaned relationships (graph + vector)
+
+        Returns:
+            Stats dict with cleanup counts
+        """
+        stats: dict[str, Any] = {
+            "chunks_deleted": 0,
+            "entities_updated": 0,
+            "entities_deleted": 0,
+            "relationships_updated": 0,
+            "relationships_deleted": 0,
+        }
+
+        # 1. Delete old chunks
+        if self.vector:
+            stats["chunks_deleted"] = await self.vector.delete_chunks_by_document(document_id)
+
+        # 2. Entity cleanup — graph backend
+        if self.graph and hasattr(self.graph, "remove_document_from_entities"):
+            updated_ids, deleted_ids = await self.graph.remove_document_from_entities(document_id, namespace_id)
+            stats["entities_updated"] = len(updated_ids)
+            stats["entities_deleted"] = len(deleted_ids)
+
+        # 3. Relationship cleanup — graph backend
+        if self.graph and hasattr(self.graph, "remove_document_from_relationships"):
+            rel_updated, rel_deleted = await self.graph.remove_document_from_relationships(document_id, namespace_id)
+            stats["relationships_updated"] = rel_updated
+            stats["relationships_deleted"] = rel_deleted
+
+        # 4. Entity cleanup — vector/SQL backend
+        if self.vector and hasattr(self.vector, "remove_document_from_entity_sources"):
+            vec_ent_updated, vec_ent_deleted = await self.vector.remove_document_from_entity_sources(document_id)
+            # Use max of graph/vector counts (they operate on same logical entities)
+            stats["entities_updated"] = max(stats["entities_updated"], vec_ent_updated)
+            stats["entities_deleted"] = max(stats["entities_deleted"], vec_ent_deleted)
+
+        # 5. Relationship cleanup — vector/SQL backend
+        if self.vector and hasattr(self.vector, "remove_document_from_relationship_sources"):
+            vec_rel_updated, vec_rel_deleted = await self.vector.remove_document_from_relationship_sources(document_id)
+            stats["relationships_updated"] = max(stats["relationships_updated"], vec_rel_updated)
+            stats["relationships_deleted"] = max(stats["relationships_deleted"], vec_rel_deleted)
+
+        logger.info(
+            f"Cleanup for document {document_id}: "
+            f"{stats['chunks_deleted']} chunks, "
+            f"{stats['entities_updated']} entities updated / {stats['entities_deleted']} deleted, "
+            f"{stats['relationships_updated']} rels updated / {stats['relationships_deleted']} deleted"
+        )
+
+        return stats
+
     async def get_document_by_checksum(self, namespace_id: UUID, checksum: str) -> Document | None:
         """Get a document by its content checksum."""
         if not self.relational:
             raise RuntimeError("Relational backend not configured")
         return await self.relational.get_document_by_checksum(namespace_id, checksum)
+
+    async def get_document_by_source(self, namespace_id: UUID, source: str) -> Document | None:
+        """Get a document by its source (for update detection)."""
+        if not self.relational:
+            raise RuntimeError("Relational backend not configured")
+        return await self.relational.get_document_by_source(namespace_id, source)  # type: ignore[unresolved-attribute]
+
+    async def get_documents_by_sources(self, namespace_id: UUID, sources: list[str]) -> dict[str, Document]:
+        """Fetch documents by source in a single query (batch update detection)."""
+        if not self.relational:
+            raise RuntimeError("Relational backend not configured")
+        return await self.relational.get_documents_by_sources(namespace_id, sources)  # type: ignore[unresolved-attribute]
 
     async def get_documents_by_checksums(self, namespace_id: UUID, checksums: list[str]) -> dict[str, Document]:
         """Fetch documents by content checksums in a single query.

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -430,8 +430,12 @@ class StorageCoordinator:
         2. Remove doc from entity source_document_ids; delete orphaned entities (graph + vector)
         3. Remove doc from relationship source_document_ids; delete orphaned relationships (graph + vector)
 
+        Each step is independently guarded — if one backend fails, cleanup
+        continues with remaining steps so partial progress is not lost.
+
         Returns:
-            Stats dict with cleanup counts
+            Stats dict with cleanup counts and an ``errors`` list naming
+            any steps that failed.
         """
         stats: dict[str, Any] = {
             "chunks_deleted": 0,
@@ -439,42 +443,68 @@ class StorageCoordinator:
             "entities_deleted": 0,
             "relationships_updated": 0,
             "relationships_deleted": 0,
+            "errors": [],
         }
 
         # 1. Delete old chunks
         if self.vector:
-            stats["chunks_deleted"] = await self.vector.delete_chunks_by_document(document_id)
+            try:
+                stats["chunks_deleted"] = await self.vector.delete_chunks_by_document(document_id)
+            except Exception:
+                logger.warning(f"Failed to delete chunks for document {document_id}", exc_info=True)
+                stats["errors"].append("chunks")
 
         # 2. Entity cleanup — graph backend
         if self.graph and hasattr(self.graph, "remove_document_from_entities"):
-            updated_ids, deleted_ids = await self.graph.remove_document_from_entities(document_id, namespace_id)
-            stats["entities_updated"] = len(updated_ids)
-            stats["entities_deleted"] = len(deleted_ids)
+            try:
+                updated_ids, deleted_ids = await self.graph.remove_document_from_entities(document_id, namespace_id)
+                stats["entities_updated"] = len(updated_ids)
+                stats["entities_deleted"] = len(deleted_ids)
+            except Exception:
+                logger.warning(f"Failed graph entity cleanup for document {document_id}", exc_info=True)
+                stats["errors"].append("graph_entities")
 
         # 3. Relationship cleanup — graph backend
         if self.graph and hasattr(self.graph, "remove_document_from_relationships"):
-            rel_updated, rel_deleted = await self.graph.remove_document_from_relationships(document_id, namespace_id)
-            stats["relationships_updated"] = rel_updated
-            stats["relationships_deleted"] = rel_deleted
+            try:
+                rel_updated, rel_deleted = await self.graph.remove_document_from_relationships(
+                    document_id, namespace_id
+                )
+                stats["relationships_updated"] = rel_updated
+                stats["relationships_deleted"] = rel_deleted
+            except Exception:
+                logger.warning(f"Failed graph relationship cleanup for document {document_id}", exc_info=True)
+                stats["errors"].append("graph_relationships")
 
         # 4. Entity cleanup — vector/SQL backend
         if self.vector and hasattr(self.vector, "remove_document_from_entity_sources"):
-            vec_ent_updated, vec_ent_deleted = await self.vector.remove_document_from_entity_sources(document_id)
-            # Use max of graph/vector counts (they operate on same logical entities)
-            stats["entities_updated"] = max(stats["entities_updated"], vec_ent_updated)
-            stats["entities_deleted"] = max(stats["entities_deleted"], vec_ent_deleted)
+            try:
+                vec_ent_updated, vec_ent_deleted = await self.vector.remove_document_from_entity_sources(document_id)
+                # Use max of graph/vector counts (they operate on same logical entities)
+                stats["entities_updated"] = max(stats["entities_updated"], vec_ent_updated)
+                stats["entities_deleted"] = max(stats["entities_deleted"], vec_ent_deleted)
+            except Exception:
+                logger.warning(f"Failed vector entity cleanup for document {document_id}", exc_info=True)
+                stats["errors"].append("vector_entities")
 
         # 5. Relationship cleanup — vector/SQL backend
         if self.vector and hasattr(self.vector, "remove_document_from_relationship_sources"):
-            vec_rel_updated, vec_rel_deleted = await self.vector.remove_document_from_relationship_sources(document_id)
-            stats["relationships_updated"] = max(stats["relationships_updated"], vec_rel_updated)
-            stats["relationships_deleted"] = max(stats["relationships_deleted"], vec_rel_deleted)
+            try:
+                vec_rel_updated, vec_rel_deleted = await self.vector.remove_document_from_relationship_sources(
+                    document_id
+                )
+                stats["relationships_updated"] = max(stats["relationships_updated"], vec_rel_updated)
+                stats["relationships_deleted"] = max(stats["relationships_deleted"], vec_rel_deleted)
+            except Exception:
+                logger.warning(f"Failed vector relationship cleanup for document {document_id}", exc_info=True)
+                stats["errors"].append("vector_relationships")
 
         logger.info(
             f"Cleanup for document {document_id}: "
             f"{stats['chunks_deleted']} chunks, "
             f"{stats['entities_updated']} entities updated / {stats['entities_deleted']} deleted, "
             f"{stats['relationships_updated']} rels updated / {stats['relationships_deleted']} deleted"
+            + (f" (errors: {stats['errors']})" if stats["errors"] else "")
         )
 
         return stats

--- a/tests/unit/test_document_update.py
+++ b/tests/unit/test_document_update.py
@@ -425,6 +425,37 @@ class TestCoordinatorCleanup:
 
         assert stats["chunks_deleted"] == 0
         assert stats["entities_updated"] == 0
+        assert stats["errors"] == []
+
+    @pytest.mark.asyncio
+    async def test_cleanup_partial_failure_continues(self) -> None:
+        """Cleanup continues when one backend step fails."""
+        doc_id = uuid4()
+        ns_id = uuid4()
+
+        vec = MagicMock()
+        vec.delete_chunks_by_document = AsyncMock(side_effect=RuntimeError("connection lost"))
+        vec.remove_document_from_entity_sources = AsyncMock(return_value=(2, 1))
+        vec.remove_document_from_relationship_sources = AsyncMock(return_value=(1, 0))
+
+        graph = MagicMock()
+        graph.remove_document_from_entities = AsyncMock(return_value=([uuid4()], []))
+        graph.remove_document_from_relationships = AsyncMock(side_effect=RuntimeError("graph timeout"))
+
+        coord = StorageCoordinator(vector=vec, graph=graph)
+        stats = await coord.cleanup_document_references(doc_id, ns_id)
+
+        # Chunk deletion failed
+        assert stats["chunks_deleted"] == 0
+        assert "chunks" in stats["errors"]
+
+        # Graph relationship cleanup failed
+        assert "graph_relationships" in stats["errors"]
+
+        # Vector entity cleanup still ran and max(graph=1, vector=2) = 2
+        assert stats["entities_updated"] == 2
+        vec.remove_document_from_entity_sources.assert_awaited_once()
+        vec.remove_document_from_relationship_sources.assert_awaited_once()
 
 
 # ===========================================================================
@@ -463,6 +494,168 @@ class TestCoordinatorSourceLookup:
         coord = StorageCoordinator()
         with pytest.raises(RuntimeError, match="Relational backend not configured"):
             await coord.get_document_by_source(uuid4(), "src")
+
+
+# ===========================================================================
+# PostgreSQL source lookup — duplicate handling
+# ===========================================================================
+
+
+class TestPostgresqlDuplicateSource:
+    """Tests that source lookup returns newest document when duplicates exist."""
+
+    @pytest.mark.asyncio
+    async def test_get_document_by_source_returns_newest(self) -> None:
+        """get_document_by_source returns the most recently updated document."""
+        from datetime import UTC, datetime
+
+        ns_id = uuid4()
+        source = "https://example.com/report"
+
+        # Create a document representing the newest version
+        new_doc = _make_document(namespace_id=ns_id, source=source, content="new version")
+
+        # Simulate the PostgreSQL backend by mocking the session
+        # The ORDER BY updated_at DESC + .first() should return newest
+        from khora.storage.backends.postgresql import PostgreSQLBackend
+
+        backend = PostgreSQLBackend.__new__(PostgreSQLBackend)
+
+        # Mock the session context manager and query result
+        mock_scalars = MagicMock()
+        mock_scalars.first.return_value = MagicMock(
+            id=new_doc.id,
+            namespace_id=ns_id,
+            content="new version",
+            status="completed",
+            chunk_count=3,
+            entity_count=5,
+            error_message=None,
+            processed_at=None,
+            source_timestamp=None,
+            created_at=datetime(2024, 1, 1, tzinfo=UTC),
+            updated_at=datetime(2024, 6, 1, tzinfo=UTC),
+            source=source,
+            source_type="api",
+            content_type="text/plain",
+            title="",
+            author="",
+            language="en",
+            checksum=new_doc.metadata.checksum,
+            size_bytes=len("new version".encode("utf-8")),
+            custom_metadata={},
+        )
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def mock_get_session():
+            yield mock_session
+
+        backend._get_session = mock_get_session
+
+        result = await backend.get_document_by_source(ns_id, source)
+
+        assert result is not None
+        assert result.id == new_doc.id
+        # Verify the query was executed (session.execute was called)
+        mock_session.execute.assert_awaited_once()
+        # Verify the SQL includes ORDER BY by inspecting the compiled query
+        call_args = mock_session.execute.call_args
+        query = call_args[0][0]
+        compiled = str(query.compile(compile_kwargs={"literal_binds": True}))
+        assert "ORDER BY" in compiled
+        assert "updated_at" in compiled
+
+    @pytest.mark.asyncio
+    async def test_get_documents_by_sources_keeps_newest(self) -> None:
+        """get_documents_by_sources returns newest document per source."""
+        from datetime import UTC, datetime
+
+        ns_id = uuid4()
+        source = "https://example.com/report"
+
+        new_doc = _make_document(namespace_id=ns_id, source=source, content="new")
+        old_doc = _make_document(namespace_id=ns_id, source=source, content="old")
+
+        from khora.storage.backends.postgresql import PostgreSQLBackend
+
+        backend = PostgreSQLBackend.__new__(PostgreSQLBackend)
+
+        # Mock two models returned in DESC order (newest first)
+        new_model = MagicMock(
+            id=new_doc.id,
+            namespace_id=ns_id,
+            content="new",
+            status="completed",
+            chunk_count=3,
+            entity_count=5,
+            error_message=None,
+            processed_at=None,
+            source_timestamp=None,
+            created_at=datetime(2024, 6, 1, tzinfo=UTC),
+            updated_at=datetime(2024, 6, 1, tzinfo=UTC),
+            source=source,
+            source_type="api",
+            content_type="text/plain",
+            title="",
+            author="",
+            language="en",
+            checksum=new_doc.metadata.checksum,
+            size_bytes=len("new".encode("utf-8")),
+            custom_metadata={},
+        )
+        old_model = MagicMock(
+            id=old_doc.id,
+            namespace_id=ns_id,
+            content="old",
+            status="completed",
+            chunk_count=3,
+            entity_count=5,
+            error_message=None,
+            processed_at=None,
+            source_timestamp=None,
+            created_at=datetime(2024, 1, 1, tzinfo=UTC),
+            updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+            source=source,
+            source_type="api",
+            content_type="text/plain",
+            title="",
+            author="",
+            language="en",
+            checksum=old_doc.metadata.checksum,
+            size_bytes=len("old".encode("utf-8")),
+            custom_metadata={},
+        )
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [new_model, old_model]
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def mock_get_session():
+            yield mock_session
+
+        backend._get_session = mock_get_session
+
+        result = await backend.get_documents_by_sources(ns_id, [source])
+
+        assert source in result
+        # Should keep the newest (first in DESC order)
+        assert result[source].id == new_doc.id
 
 
 # ===========================================================================

--- a/tests/unit/test_document_update.py
+++ b/tests/unit/test_document_update.py
@@ -1,0 +1,524 @@
+"""Unit tests for document update pipeline (DYT-209).
+
+Tests the source-based update detection in:
+- GraphRAGEngine.remember()
+- stage_document() / stage_documents_batch()
+- StorageCoordinator.cleanup_document_references()
+"""
+
+from __future__ import annotations
+
+import hashlib
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from khora.core.models import Document, DocumentMetadata
+from khora.core.models.document import DocumentStatus
+from khora.memory_lake import BatchResult, RememberResult
+from khora.storage.coordinator import StorageCoordinator
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_document(
+    *,
+    namespace_id=None,
+    source: str = "",
+    content: str = "test content",
+    checksum: str = "",
+) -> Document:
+    """Create a Document with sensible defaults."""
+    ns_id = namespace_id or uuid4()
+    cs = checksum or hashlib.sha256(content.encode("utf-8")).hexdigest()
+    return Document(
+        id=uuid4(),
+        namespace_id=ns_id,
+        content=content,
+        status=DocumentStatus.COMPLETED,
+        metadata=DocumentMetadata(
+            source=source,
+            source_type="api",
+            checksum=cs,
+            size_bytes=len(content.encode("utf-8")),
+        ),
+        chunk_count=3,
+        entity_count=5,
+    )
+
+
+def _make_storage_mock(
+    *,
+    checksum_doc: Document | None = None,
+    source_doc: Document | None = None,
+) -> MagicMock:
+    """Create a StorageCoordinator mock with common methods."""
+    storage = MagicMock(spec=StorageCoordinator)
+    storage.get_document_by_checksum = AsyncMock(return_value=checksum_doc)
+    storage.get_document_by_source = AsyncMock(return_value=source_doc)
+    storage.get_documents_by_sources = AsyncMock(return_value={})
+    storage.get_documents_by_checksums = AsyncMock(return_value={})
+    storage.create_document = AsyncMock(side_effect=lambda d: d)
+    storage.update_document = AsyncMock(side_effect=lambda d: d)
+    storage.cleanup_document_references = AsyncMock(
+        return_value={
+            "chunks_deleted": 3,
+            "entities_updated": 2,
+            "entities_deleted": 1,
+            "relationships_updated": 1,
+            "relationships_deleted": 0,
+        }
+    )
+    return storage
+
+
+# ===========================================================================
+# GraphRAGEngine.remember() — update detection
+# ===========================================================================
+
+
+class TestRememberUpdateDetection:
+    """Tests for update detection in GraphRAGEngine.remember()."""
+
+    @pytest.mark.asyncio
+    async def test_remember_new_doc_no_source(self) -> None:
+        """Document without source always creates new (current behavior)."""
+        ns_id = uuid4()
+        storage = _make_storage_mock()
+
+        with patch("khora.pipelines.flows.ingest.process_document", new_callable=AsyncMock) as mock_process:
+            mock_process.return_value = {"chunks": 2, "entities": 1, "relationships": 0}
+
+            from khora.engines.graphrag.engine import GraphRAGEngine
+
+            engine = GraphRAGEngine.__new__(GraphRAGEngine)
+            engine._storage = storage
+            engine._config = MagicMock()
+            engine._config.llm.embedding_model = "test-model"
+            engine._config.llm.extraction_model = "test-model"
+            engine._config.llm.model = "test-model"
+            engine._query_engine = MagicMock()
+            engine._query_engine.invalidate_caches = MagicMock()
+            engine._connected = True
+
+            result = await engine.remember("new content", ns_id, source="")
+
+            storage.create_document.assert_awaited_once()
+            storage.get_document_by_source.assert_not_awaited()
+            assert result.updated is False
+
+    @pytest.mark.asyncio
+    async def test_remember_duplicate_checksum_skips(self) -> None:
+        """Identical content (same checksum) is always skipped."""
+        ns_id = uuid4()
+        existing = _make_document(namespace_id=ns_id, content="same content")
+        storage = _make_storage_mock(checksum_doc=existing)
+
+        from khora.engines.graphrag.engine import GraphRAGEngine
+
+        engine = GraphRAGEngine.__new__(GraphRAGEngine)
+        engine._storage = storage
+        engine._config = MagicMock()
+        engine._query_engine = MagicMock()
+        engine._connected = True
+
+        result = await engine.remember("same content", ns_id)
+
+        assert result.document_id == existing.id
+        assert result.metadata.get("duplicate") is True
+        assert result.updated is False
+        storage.create_document.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_remember_same_source_different_content_updates(self) -> None:
+        """Same source + different content triggers update."""
+        ns_id = uuid4()
+        old_doc = _make_document(
+            namespace_id=ns_id,
+            source="https://example.com/doc",
+            content="old content",
+        )
+        storage = _make_storage_mock(source_doc=old_doc)
+
+        with patch("khora.pipelines.flows.ingest.process_document", new_callable=AsyncMock) as mock_process:
+            mock_process.return_value = {"chunks": 4, "entities": 2, "relationships": 1}
+
+            from khora.engines.graphrag.engine import GraphRAGEngine
+
+            engine = GraphRAGEngine.__new__(GraphRAGEngine)
+            engine._storage = storage
+            engine._config = MagicMock()
+            engine._config.llm.embedding_model = "test-model"
+            engine._config.llm.extraction_model = "test-model"
+            engine._config.llm.model = "test-model"
+            engine._query_engine = MagicMock()
+            engine._query_engine.invalidate_caches = MagicMock()
+            engine._connected = True
+
+            result = await engine.remember(
+                "new content",
+                ns_id,
+                source="https://example.com/doc",
+            )
+
+            # Should have cleaned up old doc
+            storage.cleanup_document_references.assert_awaited_once_with(old_doc.id, ns_id)
+            # Should have updated (not created) the document
+            storage.update_document.assert_awaited_once()
+            storage.create_document.assert_not_awaited()
+            assert result.updated is True
+
+    @pytest.mark.asyncio
+    async def test_remember_update_reuses_document_id(self) -> None:
+        """Updated document preserves the original UUID."""
+        ns_id = uuid4()
+        old_doc = _make_document(
+            namespace_id=ns_id,
+            source="file:///data/report.txt",
+            content="version 1",
+        )
+        storage = _make_storage_mock(source_doc=old_doc)
+
+        with patch("khora.pipelines.flows.ingest.process_document", new_callable=AsyncMock) as mock_process:
+            mock_process.return_value = {"chunks": 1, "entities": 0, "relationships": 0}
+
+            from khora.engines.graphrag.engine import GraphRAGEngine
+
+            engine = GraphRAGEngine.__new__(GraphRAGEngine)
+            engine._storage = storage
+            engine._config = MagicMock()
+            engine._config.llm.embedding_model = "test-model"
+            engine._config.llm.extraction_model = "test-model"
+            engine._config.llm.model = "test-model"
+            engine._query_engine = MagicMock()
+            engine._query_engine.invalidate_caches = MagicMock()
+            engine._connected = True
+
+            result = await engine.remember(
+                "version 2",
+                ns_id,
+                source="file:///data/report.txt",
+            )
+
+            # Document ID should be reused
+            assert result.document_id == old_doc.id
+
+    @pytest.mark.asyncio
+    async def test_remember_allow_update_false(self) -> None:
+        """When allow_update=False, always create new even with matching source."""
+        ns_id = uuid4()
+        storage = _make_storage_mock()
+
+        with patch("khora.pipelines.flows.ingest.process_document", new_callable=AsyncMock) as mock_process:
+            mock_process.return_value = {"chunks": 1, "entities": 0, "relationships": 0}
+
+            from khora.engines.graphrag.engine import GraphRAGEngine
+
+            engine = GraphRAGEngine.__new__(GraphRAGEngine)
+            engine._storage = storage
+            engine._config = MagicMock()
+            engine._config.llm.embedding_model = "test-model"
+            engine._config.llm.extraction_model = "test-model"
+            engine._config.llm.model = "test-model"
+            engine._query_engine = MagicMock()
+            engine._query_engine.invalidate_caches = MagicMock()
+            engine._connected = True
+
+            result = await engine.remember(
+                "content",
+                ns_id,
+                source="https://example.com/doc",
+                allow_update=False,
+            )
+
+            # Should NOT check for source match
+            storage.get_document_by_source.assert_not_awaited()
+            # Should create new document
+            storage.create_document.assert_awaited_once()
+            assert result.updated is False
+
+
+# ===========================================================================
+# stage_document() — update detection
+# ===========================================================================
+
+
+class TestStageDocumentUpdate:
+    """Tests for source-based update detection in stage_document()."""
+
+    @pytest.mark.asyncio
+    async def test_stage_new_document(self) -> None:
+        """New document (no checksum or source match) is created."""
+        ns_id = uuid4()
+        storage = _make_storage_mock()
+
+        from khora.pipelines.flows.ingest import stage_document
+
+        doc = await stage_document(
+            {"content": "hello world", "source": ""},
+            ns_id,
+            storage,
+        )
+
+        assert doc is not None
+        storage.create_document.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stage_unchanged_skips(self) -> None:
+        """Document with matching checksum is skipped."""
+        ns_id = uuid4()
+        existing = _make_document(namespace_id=ns_id, content="same")
+        storage = _make_storage_mock(checksum_doc=existing)
+
+        from khora.pipelines.flows.ingest import stage_document
+
+        doc = await stage_document(
+            {"content": "same", "source": "https://example.com"},
+            ns_id,
+            storage,
+        )
+
+        assert doc is None
+
+    @pytest.mark.asyncio
+    async def test_stage_source_update(self) -> None:
+        """Same source with different content triggers update."""
+        ns_id = uuid4()
+        old_doc = _make_document(
+            namespace_id=ns_id,
+            source="https://example.com/api",
+            content="v1",
+        )
+        storage = _make_storage_mock(source_doc=old_doc)
+
+        from khora.pipelines.flows.ingest import stage_document
+
+        doc = await stage_document(
+            {"content": "v2", "source": "https://example.com/api"},
+            ns_id,
+            storage,
+        )
+
+        assert doc is not None
+        storage.cleanup_document_references.assert_awaited_once()
+        storage.update_document.assert_awaited_once()
+        storage.create_document.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_stage_allow_update_false(self) -> None:
+        """allow_update=False skips source check, creates new."""
+        ns_id = uuid4()
+        storage = _make_storage_mock()
+
+        from khora.pipelines.flows.ingest import stage_document
+
+        doc = await stage_document(
+            {"content": "content", "source": "https://example.com"},
+            ns_id,
+            storage,
+            allow_update=False,
+        )
+
+        assert doc is not None
+        storage.get_document_by_source.assert_not_awaited()
+        storage.create_document.assert_awaited_once()
+
+
+# ===========================================================================
+# stage_documents_batch() — batch update detection
+# ===========================================================================
+
+
+class TestStageDocumentsBatchUpdate:
+    """Tests for batch source-based update detection."""
+
+    @pytest.mark.asyncio
+    async def test_batch_with_updates(self) -> None:
+        """Batch detects source-based updates for non-deduped docs."""
+        ns_id = uuid4()
+        old_doc = _make_document(
+            namespace_id=ns_id,
+            source="https://example.com/api",
+            content="old",
+        )
+        storage = _make_storage_mock()
+        storage.get_documents_by_sources = AsyncMock(return_value={"https://example.com/api": old_doc})
+
+        from khora.pipelines.flows.ingest import stage_documents_batch
+
+        docs = [
+            {"content": "new content", "source": "https://example.com/api"},
+            {"content": "brand new", "source": ""},
+        ]
+        results = await stage_documents_batch(docs, ns_id, storage)
+
+        assert len(results) == 2
+        # First doc should be updated (not None)
+        assert results[0] is not None
+        storage.cleanup_document_references.assert_awaited_once()
+        # Second doc should be created
+        assert results[1] is not None
+
+
+# ===========================================================================
+# StorageCoordinator.cleanup_document_references()
+# ===========================================================================
+
+
+class TestCoordinatorCleanup:
+    """Tests for StorageCoordinator.cleanup_document_references()."""
+
+    @pytest.mark.asyncio
+    async def test_cleanup_orchestrates_all_backends(self) -> None:
+        """cleanup_document_references calls all cleanup methods."""
+        doc_id = uuid4()
+        ns_id = uuid4()
+
+        vec = MagicMock()
+        vec.delete_chunks_by_document = AsyncMock(return_value=5)
+        vec.remove_document_from_entity_sources = AsyncMock(return_value=(3, 1))
+        vec.remove_document_from_relationship_sources = AsyncMock(return_value=(2, 0))
+
+        graph = MagicMock()
+        graph.remove_document_from_entities = AsyncMock(return_value=([uuid4(), uuid4()], [uuid4()]))
+        graph.remove_document_from_relationships = AsyncMock(return_value=(1, 1))
+
+        coord = StorageCoordinator(vector=vec, graph=graph)
+        stats = await coord.cleanup_document_references(doc_id, ns_id)
+
+        vec.delete_chunks_by_document.assert_awaited_once_with(doc_id)
+        graph.remove_document_from_entities.assert_awaited_once_with(doc_id, ns_id)
+        graph.remove_document_from_relationships.assert_awaited_once_with(doc_id, ns_id)
+        vec.remove_document_from_entity_sources.assert_awaited_once_with(doc_id)
+        vec.remove_document_from_relationship_sources.assert_awaited_once_with(doc_id)
+
+        assert stats["chunks_deleted"] == 5
+        assert stats["entities_updated"] >= 2
+        assert stats["entities_deleted"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_cleanup_without_graph(self) -> None:
+        """Cleanup works without graph backend (vector only)."""
+        doc_id = uuid4()
+        ns_id = uuid4()
+
+        vec = MagicMock()
+        vec.delete_chunks_by_document = AsyncMock(return_value=3)
+        vec.remove_document_from_entity_sources = AsyncMock(return_value=(2, 1))
+        vec.remove_document_from_relationship_sources = AsyncMock(return_value=(1, 0))
+
+        coord = StorageCoordinator(vector=vec)
+        stats = await coord.cleanup_document_references(doc_id, ns_id)
+
+        assert stats["chunks_deleted"] == 3
+        assert stats["entities_updated"] == 2
+        assert stats["entities_deleted"] == 1
+
+    @pytest.mark.asyncio
+    async def test_cleanup_without_any_backends(self) -> None:
+        """Cleanup is a no-op without backends."""
+        coord = StorageCoordinator()
+        stats = await coord.cleanup_document_references(uuid4(), uuid4())
+
+        assert stats["chunks_deleted"] == 0
+        assert stats["entities_updated"] == 0
+
+
+# ===========================================================================
+# StorageCoordinator delegation tests
+# ===========================================================================
+
+
+class TestCoordinatorSourceLookup:
+    """Tests for source-based lookup delegation in coordinator."""
+
+    @pytest.mark.asyncio
+    async def test_get_document_by_source(self) -> None:
+        """get_document_by_source delegates to relational backend."""
+        ns_id = uuid4()
+        rel = MagicMock()
+        rel.get_document_by_source = AsyncMock(return_value=None)
+        coord = StorageCoordinator(relational=rel)
+
+        await coord.get_document_by_source(ns_id, "https://example.com")
+        rel.get_document_by_source.assert_awaited_once_with(ns_id, "https://example.com")
+
+    @pytest.mark.asyncio
+    async def test_get_documents_by_sources(self) -> None:
+        """get_documents_by_sources delegates to relational backend."""
+        ns_id = uuid4()
+        rel = MagicMock()
+        rel.get_documents_by_sources = AsyncMock(return_value={})
+        coord = StorageCoordinator(relational=rel)
+
+        await coord.get_documents_by_sources(ns_id, ["src1", "src2"])
+        rel.get_documents_by_sources.assert_awaited_once_with(ns_id, ["src1", "src2"])
+
+    @pytest.mark.asyncio
+    async def test_get_document_by_source_missing_relational(self) -> None:
+        """get_document_by_source raises without relational backend."""
+        coord = StorageCoordinator()
+        with pytest.raises(RuntimeError, match="Relational backend not configured"):
+            await coord.get_document_by_source(uuid4(), "src")
+
+
+# ===========================================================================
+# RememberResult / BatchResult — updated field
+# ===========================================================================
+
+
+class TestResultTypes:
+    """Tests for updated field on result types."""
+
+    def test_remember_result_updated_default_false(self) -> None:
+        """RememberResult.updated defaults to False."""
+        result = RememberResult(
+            document_id=uuid4(),
+            namespace_id=uuid4(),
+            chunks_created=1,
+            entities_extracted=0,
+            relationships_created=0,
+        )
+        assert result.updated is False
+
+    def test_remember_result_updated_true(self) -> None:
+        """RememberResult.updated can be set to True."""
+        result = RememberResult(
+            document_id=uuid4(),
+            namespace_id=uuid4(),
+            chunks_created=1,
+            entities_extracted=0,
+            relationships_created=0,
+            updated=True,
+        )
+        assert result.updated is True
+
+    def test_batch_result_updated_default_zero(self) -> None:
+        """BatchResult.updated defaults to 0."""
+        result = BatchResult(
+            total=5,
+            processed=5,
+            skipped=0,
+            failed=0,
+            chunks=10,
+            entities=3,
+            relationships=1,
+        )
+        assert result.updated == 0
+
+    def test_batch_result_updated_count(self) -> None:
+        """BatchResult.updated tracks number of updated docs."""
+        result = BatchResult(
+            total=5,
+            processed=5,
+            skipped=0,
+            failed=0,
+            chunks=10,
+            entities=3,
+            relationships=1,
+            updated=2,
+        )
+        assert result.updated == 2

--- a/tests/unit/test_document_update.py
+++ b/tests/unit/test_document_update.py
@@ -353,7 +353,7 @@ class TestStageDocumentsBatchUpdate:
             {"content": "new content", "source": "https://example.com/api"},
             {"content": "brand new", "source": ""},
         ]
-        results = await stage_documents_batch(docs, ns_id, storage)
+        results, updated_count = await stage_documents_batch(docs, ns_id, storage)
 
         assert len(results) == 2
         # First doc should be updated (not None)
@@ -361,6 +361,36 @@ class TestStageDocumentsBatchUpdate:
         storage.cleanup_document_references.assert_awaited_once()
         # Second doc should be created
         assert results[1] is not None
+        assert updated_count == 1
+
+    @pytest.mark.asyncio
+    async def test_batch_duplicate_source_skips_second(self) -> None:
+        """Two docs with same source in one batch: first updates, second is skipped."""
+        ns_id = uuid4()
+        old_doc = _make_document(
+            namespace_id=ns_id,
+            source="https://example.com/dup",
+            content="old",
+        )
+        storage = _make_storage_mock()
+        storage.get_documents_by_sources = AsyncMock(return_value={"https://example.com/dup": old_doc})
+
+        from khora.pipelines.flows.ingest import stage_documents_batch
+
+        docs = [
+            {"content": "new v1", "source": "https://example.com/dup"},
+            {"content": "new v2", "source": "https://example.com/dup"},
+        ]
+        results, updated_count = await stage_documents_batch(docs, ns_id, storage)
+
+        assert len(results) == 2
+        # First doc triggers update
+        assert results[0] is not None
+        # Second doc with same source is skipped
+        assert results[1] is None
+        # Cleanup runs exactly once (not twice)
+        storage.cleanup_document_references.assert_awaited_once()
+        assert updated_count == 1
 
 
 # ===========================================================================

--- a/tests/unit/test_storage_coordinator.py
+++ b/tests/unit/test_storage_coordinator.py
@@ -371,6 +371,59 @@ class TestEventOps:
             await coord.append_event(MagicMock())
 
 
+class TestSourceLookupOps:
+    """Tests for source-based document lookup (update detection)."""
+
+    @pytest.mark.asyncio
+    async def test_get_document_by_source(self) -> None:
+        """get_document_by_source delegates to relational."""
+        ns_id = uuid4()
+        rel = MagicMock()
+        rel.get_document_by_source = AsyncMock(return_value=None)
+        coord = StorageCoordinator(relational=rel)
+        await coord.get_document_by_source(ns_id, "https://example.com/doc")
+        rel.get_document_by_source.assert_awaited_once_with(ns_id, "https://example.com/doc")
+
+    @pytest.mark.asyncio
+    async def test_get_documents_by_sources(self) -> None:
+        """get_documents_by_sources delegates to relational."""
+        ns_id = uuid4()
+        rel = MagicMock()
+        rel.get_documents_by_sources = AsyncMock(return_value={})
+        coord = StorageCoordinator(relational=rel)
+        await coord.get_documents_by_sources(ns_id, ["src1", "src2"])
+        rel.get_documents_by_sources.assert_awaited_once_with(ns_id, ["src1", "src2"])
+
+    @pytest.mark.asyncio
+    async def test_get_document_by_source_no_relational(self) -> None:
+        """get_document_by_source without relational raises RuntimeError."""
+        coord = StorageCoordinator()
+        with pytest.raises(RuntimeError, match="Relational backend not configured"):
+            await coord.get_document_by_source(uuid4(), "src")
+
+    @pytest.mark.asyncio
+    async def test_cleanup_document_references(self) -> None:
+        """cleanup_document_references orchestrates vector + graph cleanup."""
+        doc_id = uuid4()
+        ns_id = uuid4()
+
+        vec = MagicMock()
+        vec.delete_chunks_by_document = AsyncMock(return_value=5)
+        vec.remove_document_from_entity_sources = AsyncMock(return_value=(3, 1))
+        vec.remove_document_from_relationship_sources = AsyncMock(return_value=(2, 0))
+
+        graph = MagicMock()
+        graph.remove_document_from_entities = AsyncMock(return_value=([uuid4()], [uuid4()]))
+        graph.remove_document_from_relationships = AsyncMock(return_value=(1, 1))
+
+        coord = StorageCoordinator(vector=vec, graph=graph)
+        stats = await coord.cleanup_document_references(doc_id, ns_id)
+
+        vec.delete_chunks_by_document.assert_awaited_once_with(doc_id)
+        graph.remove_document_from_entities.assert_awaited_once_with(doc_id, ns_id)
+        assert stats["chunks_deleted"] == 5
+
+
 class TestBatchOps:
     """Tests for batch operations."""
 


### PR DESCRIPTION
## Summary
- When a document is re-ingested with the same `source` but different content, old chunks/entities/relationships are cleaned up and replaced — queries always return current information
- Uses `source` field as optional update key: non-empty source + different checksum = update; empty source = always create new (preserves current behavior)
- Checksum dedup runs first — identical content always skipped regardless of source
- Reuses document UUID on update (UPDATE not DELETE+INSERT) so external consumers keep stable references
- Entity/relationship cleanup removes the doc from `source_document_ids` arrays; deletes orphans where the array becomes empty; preserves shared entities referenced by other docs
- Adds `allow_update: bool = True` parameter to `remember()` for opt-out
- Adds `updated` field to `RememberResult` and `BatchResult`
- ADR: `docs/design/document-update-identity.md` documents the source-as-identity decision and trade-offs

### Files changed (13)
| Layer | Files | Change |
|-------|-------|--------|
| ADR | `docs/design/document-update-identity.md` | NEW — architectural decision record |
| Database | `alembic/versions/010_document_source_index.py`, `db/models.py` | Partial composite index on `(namespace_id, source)` |
| Storage | `postgresql.py`, `pgvector.py`, `neo4j.py`, `coordinator.py` | Source lookup, entity/relationship orphan cleanup |
| Engine | `engine.py`, `ingest.py`, `protocol.py` | Update detection in `remember()` and `stage_document()` |
| API | `memory_lake.py` | `allow_update` param, `updated` result field |
| Tests | `test_document_update.py`, `test_storage_coordinator.py` | 20 new + 4 new test cases |

## Test plan
- [x] All 1410 unit tests pass (0 failures, 4 skipped)
- [x] 20 new tests in `test_document_update.py` cover: new doc creation, checksum dedup, source-based update detection, document ID reuse, old chunk deletion, entity/relationship orphan cleanup, shared entity preservation, `allow_update=False` opt-out, batch updates, result metadata
- [x] 4 new tests in `test_storage_coordinator.py` cover: source lookup delegation, batch source lookup, cleanup orchestration
- [x] Coverage: 52.80% (threshold: 30%)
- [x] `make format` clean
- [x] `make lint` clean (only pre-existing weaviate/kuzu/logfire warnings)
- [ ] Manual verification: ingest a doc with source, re-ingest with changed content, verify old entities cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)