### PR TITLE
DYT-220: Flatten multi-tenancy to namespace-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ MemoryLake (facade) → Engine (graphrag | skeleton | vectorcypher) → StorageC
 - **Engines are pluggable** — implement `MemoryEngineProtocol` in `engines/protocol.py`
 - **Graph backends are interchangeable** — all implement `GraphBackend` in `storage/backends/base.py`
 - **Extraction skills are YAML-defined** — see `extraction/skills/builtin/`
-- **Multi-tenancy:** Organization → Workspace → MemoryNamespace
+- **Multi-tenancy:** MemoryNamespace (sole isolation boundary)
 - **Config via env vars** — prefix `KHORA_`, use `__` for nesting (e.g., `KHORA_QUERY__ENABLE_HYDE=true`)
 
 ## Key Entry Points

--- a/alembic/versions/010_flatten_namespace_hierarchy.py
+++ b/alembic/versions/010_flatten_namespace_hierarchy.py
@@ -1,0 +1,235 @@
+"""Flatten multi-tenancy to namespace-only (DYT-220).
+
+Revision ID: 010_flatten_namespace_hierarchy
+Revises: 009_temporal_search_indexes
+Create Date: 2026-03-05
+
+Removes the Organization -> Workspace -> Namespace hierarchy.
+Namespace becomes the sole data isolation boundary with globally unique slugs.
+
+Steps:
+1. Pre-check for duplicate slugs across workspaces
+2. Delete orphaned permission rows referencing org/workspace
+3. Drop inherited_from columns from permissions
+4. Drop old indexes on memory_namespaces that reference workspace_id
+5. Remove workspace_id FK and column from memory_namespaces
+6. Add tenancy_mode column to memory_namespaces
+7. Add new unique constraint UNIQUE(slug, version)
+8. Add new partial index idx_namespace_slug_active
+9. Drop workspaces table
+10. Drop organizations table
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy import text
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "010_flatten_namespace_hierarchy"
+down_revision: str | Sequence[str] | None = "009_temporal_search_indexes"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # =========================================================================
+    # Step 1: Pre-check for duplicate slugs across workspaces
+    # =========================================================================
+    conn = op.get_bind()
+    result = conn.execute(text("""
+        SELECT slug, version, count(*) AS cnt
+        FROM memory_namespaces
+        GROUP BY slug, version
+        HAVING count(*) > 1
+    """))
+    duplicates = result.fetchall()
+    if duplicates:
+        lines = [f"  slug={row[0]!r}, version={row[1]}, count={row[2]}" for row in duplicates]
+        raise RuntimeError(
+            "Cannot flatten namespace hierarchy: duplicate (slug, version) pairs found.\n"
+            "Resolve these manually before re-running the migration:\n" + "\n".join(lines)
+        )
+
+    # =========================================================================
+    # Step 2: Delete orphaned permission rows
+    # =========================================================================
+    op.execute(text("DELETE FROM permissions WHERE resource_type IN ('organization', 'workspace')"))
+    op.execute(text("DELETE FROM permissions WHERE inherited_from_type IN ('organization', 'workspace')"))
+
+    # =========================================================================
+    # Step 3: Drop inherited_from columns from permissions
+    # =========================================================================
+    op.drop_column("permissions", "inherited_from_type")
+    op.drop_column("permissions", "inherited_from_id")
+
+    # =========================================================================
+    # Step 4: Drop old indexes on memory_namespaces that reference workspace_id
+    # =========================================================================
+    # Partial index: idx_namespace_active ON (workspace_id, slug) WHERE is_active
+    op.drop_index("idx_namespace_active", table_name="memory_namespaces")
+    # Unique constraint: uq_namespace_workspace_slug_version ON (workspace_id, slug, version)
+    op.drop_constraint("uq_namespace_workspace_slug_version", "memory_namespaces", type_="unique")
+    # Auto-created index on workspace_id column
+    op.drop_index("ix_memory_namespaces_workspace_id", table_name="memory_namespaces")
+
+    # =========================================================================
+    # Step 5: Remove workspace_id FK and column from memory_namespaces
+    # =========================================================================
+    op.drop_constraint("memory_namespaces_workspace_id_fkey", "memory_namespaces", type_="foreignkey")
+    op.drop_column("memory_namespaces", "workspace_id")
+
+    # =========================================================================
+    # Step 6: Add tenancy_mode column
+    # =========================================================================
+    op.add_column(
+        "memory_namespaces",
+        sa.Column(
+            "tenancy_mode",
+            sa.String(20),
+            server_default="shared",
+            nullable=False,
+        ),
+    )
+
+    # =========================================================================
+    # Step 7: Add new unique constraint UNIQUE(slug, version)
+    # =========================================================================
+    op.create_unique_constraint("uq_namespace_slug_version", "memory_namespaces", ["slug", "version"])
+
+    # =========================================================================
+    # Step 8: Add new partial index
+    # =========================================================================
+    op.create_index(
+        "idx_namespace_slug_active",
+        "memory_namespaces",
+        ["slug", "version"],
+        postgresql_where=sa.text("is_active = true"),
+    )
+
+    # =========================================================================
+    # Step 9: Drop workspaces table
+    # =========================================================================
+    op.drop_table("workspaces")
+
+    # =========================================================================
+    # Step 10: Drop organizations table
+    # =========================================================================
+    op.drop_table("organizations")
+
+
+def downgrade() -> None:
+    # Reverse step 10: Recreate organizations table
+    op.create_table(
+        "organizations",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("slug", sa.String(255), nullable=False, unique=True, index=True),
+        sa.Column(
+            "tenancy_mode",
+            postgresql.ENUM("shared", "isolated", name="tenancy_mode", create_type=False),
+            server_default="shared",
+        ),
+        sa.Column("metadata", postgresql.JSONB, server_default="{}"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+    # Reverse step 9: Recreate workspaces table
+    op.create_table(
+        "workspaces",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "organization_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("organizations.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("slug", sa.String(255), nullable=False, index=True),
+        sa.Column("description", sa.Text, server_default=""),
+        sa.Column("metadata", postgresql.JSONB, server_default="{}"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.UniqueConstraint("organization_id", "slug", name="uq_workspace_org_slug"),
+    )
+
+    # Reverse step 8: Drop new partial index
+    op.drop_index("idx_namespace_slug_active", table_name="memory_namespaces")
+
+    # Reverse step 7: Drop new unique constraint
+    op.drop_constraint("uq_namespace_slug_version", "memory_namespaces", type_="unique")
+
+    # Reverse step 6: Drop tenancy_mode column
+    op.drop_column("memory_namespaces", "tenancy_mode")
+
+    # Reverse step 5: Re-add workspace_id column with FK
+    # Create a default org and workspace to satisfy FK constraints
+    op.execute(text("""
+        INSERT INTO organizations (id, name, slug)
+        VALUES ('00000000-0000-0000-0000-000000000001', 'Default Organization', 'default')
+        ON CONFLICT DO NOTHING
+    """))
+    op.execute(text("""
+        INSERT INTO workspaces (id, organization_id, name, slug)
+        VALUES (
+            '00000000-0000-0000-0000-000000000002',
+            '00000000-0000-0000-0000-000000000001',
+            'Default Workspace',
+            'default'
+        )
+        ON CONFLICT DO NOTHING
+    """))
+
+    op.add_column(
+        "memory_namespaces",
+        sa.Column(
+            "workspace_id",
+            postgresql.UUID(as_uuid=False),
+            nullable=True,
+        ),
+    )
+    # Point all existing namespaces to the default workspace
+    op.execute(text("UPDATE memory_namespaces SET workspace_id = '00000000-0000-0000-0000-000000000002'"))
+    op.alter_column("memory_namespaces", "workspace_id", nullable=False)
+    op.create_foreign_key(
+        "memory_namespaces_workspace_id_fkey",
+        "memory_namespaces",
+        "workspaces",
+        ["workspace_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # Reverse step 4: Restore old indexes
+    op.create_index(
+        "ix_memory_namespaces_workspace_id",
+        "memory_namespaces",
+        ["workspace_id"],
+    )
+    op.create_unique_constraint(
+        "uq_namespace_workspace_slug_version",
+        "memory_namespaces",
+        ["workspace_id", "slug", "version"],
+    )
+    op.create_index(
+        "idx_namespace_active",
+        "memory_namespaces",
+        ["workspace_id", "slug"],
+        postgresql_where=sa.text("is_active = true"),
+    )
+
+    # Reverse step 3: Re-add inherited_from columns to permissions
+    op.add_column(
+        "permissions",
+        sa.Column("inherited_from_type", sa.String(64), nullable=True),
+    )
+    op.add_column(
+        "permissions",
+        sa.Column("inherited_from_id", postgresql.UUID(as_uuid=False), nullable=True),
+    )
+
+    # Reverse steps 2 & 1: No action needed — deleted rows cannot be restored

--- a/alembic/versions/010_flatten_namespace_hierarchy.py
+++ b/alembic/versions/010_flatten_namespace_hierarchy.py
@@ -88,7 +88,7 @@ def upgrade() -> None:
         "memory_namespaces",
         sa.Column(
             "tenancy_mode",
-            sa.String(20),
+            postgresql.ENUM("shared", "isolated", name="tenancy_mode", create_type=False),
             server_default="shared",
             nullable=False,
         ),
@@ -105,7 +105,7 @@ def upgrade() -> None:
     op.create_index(
         "idx_namespace_slug_active",
         "memory_namespaces",
-        ["slug", "version"],
+        ["slug"],
         postgresql_where=sa.text("is_active = true"),
     )
 
@@ -121,6 +121,11 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # WARNING: This downgrade is intended for one-time emergency recovery only.
+    # Repeated downgrade->upgrade cycles may produce inconsistent state because
+    # the upgrade deletes org/workspace permission rows and drops the tables,
+    # and the downgrade creates synthetic defaults that won't match original data.
+
     # Reverse step 10: Recreate organizations table
     op.create_table(
         "organizations",

--- a/docs/prds/DYT-220-flatten-namespace-hierarchy.md
+++ b/docs/prds/DYT-220-flatten-namespace-hierarchy.md
@@ -1,0 +1,417 @@
+# DYT-220: Flatten Multi-Tenancy to Namespace-Only
+
+**Status:** Reviewed
+**Author:** Filip
+**Date:** 2026-03-05
+**Linear Ticket:** DYT-220
+
+---
+
+## Problem Statement
+
+Khora's multi-tenancy model uses a 3-level hierarchy: Organization → Workspace → Namespace. In practice, **namespace is the only meaningful isolation boundary** — all data (documents, chunks, entities, relationships, episodes) is scoped to `namespace_id`. Organization and Workspace exist as structural overhead that:
+
+1. **Adds friction to the API** — creating a namespace requires a workspace, which requires an organization. The `ensure_namespace()` method auto-creates "default" org and workspace to hide this from callers.
+2. **Complicates downstream consumers** — genesis, peras, and khora-benchmarks all interact with namespaces. None meaningfully needs the org/workspace hierarchy going forward.
+3. **Creates dead code** — `TenancyMode.ISOLATED` (per-org database separation) is defined but not implemented. Organization/Workspace CRUD operations exist in the storage layer but serve only to satisfy FK constraints.
+4. **Inflates the schema** — 2 tables (`organizations`, `workspaces`), ~15 columns, multiple indexes, and cascade chains exist solely to support a hierarchy nobody uses.
+
+### Downstream Consumers
+
+| Consumer | Current Usage | Impact |
+|----------|--------------|--------|
+| **genesis** | Uses `lake.storage` API for full org/workspace/namespace hierarchy — CLI navigates orgs, lists workspaces, browses namespaces | Must rewrite navigation UX to namespace-only; remove all org/workspace creation and lookup calls |
+| **peras** | Uses `MemoryLake` facade + accesses `lake.storage` directly for `get_sync_checkpoint()`, `set_sync_checkpoint()`, `get_document()` | Must remove any org/workspace references; storage API changes affect sync checkpoint calls |
+| **khora-benchmarks** | Creates test namespaces | Must update setup code to remove `workspace_id` |
+
+---
+
+## Goals
+
+- Namespace becomes the **sole** data isolation boundary — no parent references required
+- Public API (`MemoryLake`) requires **zero breaking changes** for callers using `namespace: str | UUID | None`
+- Storage layer API removes org/workspace CRUD methods
+- Database migration safely drops `organizations` and `workspaces` tables
+- ACL system simplified to namespace-only permissions
+- ConfigResolver reduced to 2-tier: global defaults → namespace overrides
+- `TenancyMode` moves from Organization to Namespace
+- All downstream consumers updated with a clean version bump (no deprecation period)
+
+---
+
+## Non-Goals
+
+- Introducing a new grouping/tagging mechanism for namespaces (future work)
+- Changing how `namespace_id` is used in data tables (documents, chunks, entities, etc.) — these stay as-is
+- Modifying namespace versioning (`version`, `is_active`, `previous_version_id`) — orthogonal to this change
+- Changing the graph backend namespace isolation model
+- Adding namespace-level billing or quotas
+- Implementing `TenancyMode.ISOLATED` — it moves to namespace but remains unimplemented
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+#### FR-1: Remove Organization Model and Table
+
+Remove `Organization` dataclass (`core/models/tenancy.py`), `OrganizationModel` ORM class (`db/models.py`), and the `organizations` database table. Remove all CRUD operations: `create_organization()`, `get_organization()`, `get_organization_by_slug()` from `StorageCoordinator`, backend protocol, and PostgreSQL backend.
+
+**Files affected:**
+- `src/khora/core/models/tenancy.py` — delete `Organization` class
+- `src/khora/db/models.py` — delete `OrganizationModel`
+- `src/khora/core/__init__.py`, `src/khora/core/models/__init__.py` — remove re-exports
+- `src/khora/db/__init__.py` — remove re-export
+- `src/khora/storage/backends/base.py` — remove protocol methods
+- `src/khora/storage/backends/postgresql.py` — remove implementations
+- `src/khora/storage/coordinator.py` — remove delegations
+
+#### FR-2: Remove Workspace Model and Table
+
+Remove `Workspace` dataclass, `WorkspaceModel` ORM class, and the `workspaces` database table. Remove all CRUD operations: `create_workspace()`, `get_workspace()`, `list_workspaces()`, `get_workspace_by_slug()`.
+
+**Files affected:** Same set as FR-1.
+
+#### FR-3: Update MemoryNamespace — Remove `workspace_id`, Add `tenancy_mode`
+
+The `MemoryNamespace` dataclass and `MemoryNamespaceModel` lose the `workspace_id` FK and gain a `tenancy_mode` field (default: `SHARED`).
+
+**Before:**
+```python
+@dataclass
+class MemoryNamespace:
+    id: UUID
+    workspace_id: UUID  # FK to workspaces
+    name: str
+    slug: str
+    ...
+```
+
+**After:**
+```python
+@dataclass
+class MemoryNamespace:
+    id: UUID
+    name: str
+    slug: str
+    tenancy_mode: TenancyMode = TenancyMode.SHARED
+    ...
+```
+
+**Database constraint change:**
+- Old: `UNIQUE(workspace_id, slug, version)`
+- New: `UNIQUE(slug, version)` — slugs become globally unique
+
+**Files affected:**
+- `src/khora/core/models/tenancy.py` — remove `workspace_id` field, add `tenancy_mode`
+- `src/khora/db/models.py` — update `MemoryNamespaceModel`, drop FK, update constraints
+- Alembic migration (new)
+
+#### FR-4: Update `create_namespace()` and `create_namespace_version()` APIs
+
+Remove `workspace_id` parameter from `MemoryLake.create_namespace()`, `create_namespace_version()`, and the engine protocol.
+
+**Before:**
+```python
+async def create_namespace(self, name: str, workspace_id: UUID, ...) -> MemoryNamespace
+async def create_namespace_version(self, workspace_id: UUID, slug: str, ...) -> MemoryNamespace
+```
+
+**After:**
+```python
+async def create_namespace(self, name: str, ...) -> MemoryNamespace
+async def create_namespace_version(self, slug: str, ...) -> MemoryNamespace
+```
+
+**Files affected:**
+- `src/khora/memory_lake.py`
+- `src/khora/engines/protocol.py`
+- `src/khora/engines/graphrag/engine.py`
+- `src/khora/engines/skeleton/engine.py`
+- `src/khora/engines/vectorcypher/engine.py`
+- `src/khora/storage/coordinator.py` — `create_namespace_version()` (line 344)
+- `src/khora/storage/backends/postgresql.py` — `create_namespace_version()` (line 333)
+
+#### FR-5: Simplify `ensure_namespace()` and `get_or_create_default_namespace()`
+
+These methods currently auto-create a "default" Organization and Workspace before creating the namespace. After this change, they create the namespace directly.
+
+**Files affected:**
+- `src/khora/memory_lake.py`
+- All engine implementations
+
+#### FR-6: Simplify `_resolve_namespace()` Slug Lookup
+
+Currently resolves slugs by looking up the default workspace, then finding the namespace within that workspace. After this change, slugs are globally unique — look up directly by slug.
+
+**Before:**
+```python
+ns = await storage.get_namespace_by_slug(default_ns.workspace_id, namespace)
+```
+
+**After:**
+```python
+ns = await storage.get_namespace_by_slug(namespace)
+```
+
+**Files affected:**
+- `src/khora/memory_lake.py` — `_resolve_namespace()`
+- `src/khora/storage/backends/base.py` — update protocol signature
+- `src/khora/storage/backends/postgresql.py` — remove `workspace_id` from query
+
+#### FR-7: Simplify ACL to Namespace-Only
+
+Remove `workspace_id` and `organization_id` from `ACLContext`. Remove the `parent_ids` property. Remove all org/workspace-related methods and constants:
+
+- `ACLEnforcer.check_workspace_read()` (enforcer.py:152)
+- `ACLEnforcer.check_workspace_admin()` (enforcer.py:155)
+- `ACLEnforcer.check_organization_read()` (enforcer.py:160)
+- `ACLEnforcer.check_organization_admin()` (enforcer.py:164)
+- `ACLChecker.HIERARCHY` dict entries for "organization" and "workspace" (checker.py:87-92)
+- `ACLChecker.check()` parent walk-up logic that uses `parent_ids`
+
+Update `PermissionModel` resource_type to only allow "namespace".
+
+**Files affected:**
+- `src/khora/acl/enforcer.py` — simplify `ACLContext`, remove 4 methods, remove `parent_ids`
+- `src/khora/acl/checker.py` — remove `HIERARCHY` org/workspace entries, remove parent walk-up logic
+- `src/khora/db/models.py` — update `PermissionModel` resource_type options
+
+#### FR-8: Simplify ConfigResolver to 2-Tier
+
+Reduce config resolution from 4-tier (global → org → workspace → namespace) to 2-tier (global → namespace). Remove all workspace/organization-related code — no backward compatibility.
+
+**Before:** `resolve_for_namespace()` fetches namespace → workspace → organization and merges all configs.
+**After:** `resolve_for_namespace()` fetches namespace only and merges with global defaults.
+
+`resolve_immediate()` loses its `organization_config` and `workspace_config` parameters entirely (no no-ops).
+
+**Files affected:**
+- `src/khora/config/resolver.py` — remove workspace/org fetch (lines 84-89), remove merge steps, remove `resolve_immediate()` org/workspace params
+
+#### FR-9: Remove `full_path` Property
+
+Remove `MemoryNamespace.full_path` property entirely. Callers should use `slug` directly.
+
+**Files affected:**
+- `src/khora/core/models/tenancy.py` — delete `full_path` property (lines 106-109)
+
+#### FR-10: Database Migration
+
+Create an Alembic migration with the following steps **in this exact order**:
+
+1. **Pre-check:** Query for duplicate slugs across workspaces. If collisions exist, **fail fast** with a clear error listing the conflicting slugs. Require manual resolution before re-running. No auto-renaming.
+2. **Delete orphaned permission rows:** `DELETE FROM permissions WHERE resource_type IN ('organization', 'workspace')` and `DELETE FROM permissions WHERE inherited_from_type IN ('organization', 'workspace')`
+3. **Drop `inherited_from_type` and `inherited_from_id` columns** from `permissions` table (no hierarchy = no inheritance tracking)
+4. **Drop old indexes** on `memory_namespaces` that reference `workspace_id` (including `idx_namespace_active`)
+5. **Remove `workspace_id` FK and column** from `memory_namespaces`
+6. **Add `tenancy_mode` column** to `memory_namespaces` (default: `'shared'`)
+7. **Add new unique constraint** `UNIQUE(slug, version)`
+8. **Add new index** `idx_namespace_slug_active ON memory_namespaces (slug, version) WHERE is_active = true`
+9. **Drop `workspaces` table** (FK to organizations is safe to drop since no other table references workspaces after step 5)
+10. **Drop `organizations` table**
+
+**Migration must be reversible** with a downgrade path that recreates the tables with default data.
+
+**Slug collision risk:** <50 namespaces exist in production — global uniqueness is highly likely. The pre-check query in step 1 ensures the migration fails safely if collisions exist.
+
+#### FR-11: Update Engine Implementations
+
+All three engines (graphrag, skeleton, vectorcypher) import and use Organization/Workspace types in their namespace management code. Update all to remove these references.
+
+**Files affected:**
+- `src/khora/engines/graphrag/engine.py`
+- `src/khora/engines/skeleton/engine.py`
+- `src/khora/engines/vectorcypher/engine.py`
+
+#### FR-12: Update `list_namespaces()` Signature
+
+Replace workspace-scoped listing with paginated global listing.
+
+**Before:**
+```python
+async def list_namespaces(self, workspace_id: UUID, *, active_only: bool = True) -> list[MemoryNamespace]
+```
+
+**After:**
+```python
+async def list_namespaces(self, *, active_only: bool = True, limit: int = 100, offset: int = 0) -> list[MemoryNamespace]
+```
+
+Results ordered by `id` always. No workspace filter.
+
+**Files affected:**
+- `src/khora/storage/backends/base.py` — update protocol
+- `src/khora/storage/backends/postgresql.py` — update query
+- `src/khora/storage/coordinator.py` — update delegation
+- `src/khora/engines/graphrag/engine.py` — update call sites
+- `src/khora/engines/skeleton/engine.py` — update call sites
+- `src/khora/engines/vectorcypher/engine.py` — update call sites
+
+### Non-Functional Requirements
+
+1. **NFR-1:** Zero data loss — all existing documents, chunks, entities, and relationships must survive the migration
+2. **NFR-2:** Migration pre-check must detect slug collisions and fail fast with actionable error
+3. **NFR-3:** Test coverage must remain ≥30% after changes
+4. **NFR-4:** `make lint` and `ty check src/` must pass clean after changes
+5. **NFR-5:** Public `remember()`/`recall()`/`forget()` signatures remain unchanged — callers using `namespace: str | UUID | None` see no breaking change
+
+---
+
+## User Stories
+
+- As a **library consumer** (genesis/peras), I want to create namespaces without needing to set up organizations and workspaces, so that I can start storing data with a single call.
+- As a **library maintainer**, I want fewer tenancy concepts so that the codebase is simpler to understand and maintain.
+- As a **downstream developer**, I want namespace slugs to be globally unique so that I can reference namespaces by name without workspace context.
+- As a **library consumer**, I want per-namespace config overrides with global defaults so that I can customize behavior without organizational hierarchy.
+
+---
+
+## Technical Approach
+
+### Migration Strategy
+
+1. **Phase 1 — Code changes** (no migration yet):
+   - Update all models, remove org/workspace from domain layer
+   - Update storage backends, coordinator, engines
+   - Update ACL, ConfigResolver
+   - Update tests
+
+2. **Phase 2 — Migration**:
+   - Write Alembic migration with slug collision pre-check (fail fast, no auto-rename)
+   - Drop FKs, add column, update constraints and indexes, drop tables
+
+3. **Phase 3 — Downstream coordination (clean break, no deprecation)**:
+   - Update genesis: rewrite namespace navigation to namespace-only
+   - Update peras: remove any org/workspace storage API calls
+   - Update khora-benchmarks: update setup code
+   - All downstream updates happen simultaneously with khora version bump
+
+### Breaking Changes Summary
+
+| Change | Who It Breaks | Migration Path |
+|--------|--------------|----------------|
+| `create_namespace()` loses `workspace_id` param | Direct callers of this method | Remove the argument |
+| `create_namespace_version()` loses `workspace_id` param | Direct callers | Remove the argument |
+| `get_namespace_by_slug()` loses `workspace_id` param | Direct callers | Remove the argument |
+| `list_namespaces()` loses `workspace_id`, gains `limit`/`offset` | Direct callers | Remove workspace_id, add pagination params |
+| `Organization` class removed | Importers of `khora.core.models.Organization` | Delete imports |
+| `Workspace` class removed | Importers of `khora.core.models.Workspace` | Delete imports |
+| `create_organization()`/`create_workspace()` removed | Storage layer callers (genesis, peras) | Delete calls |
+| `get_organization()`/`get_workspace()`/`list_workspaces()` removed | Storage layer callers (genesis) | Delete calls |
+| `MemoryNamespace.workspace_id` removed | Code accessing this field | Delete references |
+| `MemoryNamespace.full_path` removed | Code using `namespace.full_path` | Use `namespace.slug` |
+| ACL `check_workspace_*`/`check_organization_*` removed | ACL consumers | Use `check_namespace_*` |
+| `ConfigResolver.resolve_immediate()` loses org/workspace params | `resolve_immediate()` callers | Remove those params |
+| `PermissionModel.inherited_from_type/id` columns dropped | Direct SQL queries on permissions | Update queries |
+| DB schema: `organizations`/`workspaces` tables dropped | Direct SQL queries against these tables | Update queries |
+
+---
+
+## Risks and Reasons NOT to Remove
+
+These were considered and the decision was made to proceed:
+
+1. **Future multi-tenancy needs**: If a consumer later needs org-level grouping (e.g., billing boundary, team separation), we'd need to re-introduce some hierarchy. **Mitigation:** Namespace metadata can hold arbitrary grouping tags. A lightweight "label" or "group" field can be added later without full org/workspace overhead.
+
+2. **Slug collision on migration**: Two namespaces in different workspaces could have the same slug. **Mitigation:** <50 namespaces exist — global uniqueness is highly likely. Migration includes a pre-check that fails fast with a clear error if collisions exist, requiring manual resolution. No auto-renaming.
+
+3. **Config inheritance loss**: Organizations/workspaces provided config inheritance (set a model once, all child namespaces inherit). After this change, each namespace must be configured individually or rely on global defaults. **Mitigation:** 2-tier (global + namespace) is accepted as sufficient. For bulk config, consumers set `config_overrides` programmatically. No bulk config API is planned.
+
+4. **Permission inheritance loss**: Org-admin granting workspace/namespace access in one grant is no longer possible. **Mitigation:** ACL is not wired into production paths. Namespace-only permissions are simpler and sufficient.
+
+5. **Downstream breakage**: genesis, peras, khora-benchmarks all need updates. Genesis impact is significant (navigation UX rewrite). **Mitigation:** Clean break with simultaneous version bump across all consumers. No deprecation period.
+
+---
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Tables removed | 2 (`organizations`, `workspaces`) | Schema inspection |
+| Columns removed from `memory_namespaces` | 1 (`workspace_id`) | Schema inspection |
+| Lines of code removed (net) | 200+ | `git diff --stat` |
+| Public API breakage (`remember`/`recall`/`forget`) | 0 | Existing tests pass |
+| Test coverage | ≥30% | `make test` |
+| ConfigResolver DB queries per call | 1 (down from 3) | Code inspection |
+
+---
+
+## Timeline
+
+| Phase | Milestone | Scope |
+|-------|-----------|-------|
+| 1 | Code changes | Remove org/workspace from models, storage, engines, ACL, config |
+| 2 | Migration | Alembic migration with collision pre-check |
+| 3 | Tests | Update all tests, verify coverage |
+| 4 | Downstream | Simultaneously update genesis, peras, khora-benchmarks |
+
+---
+
+## Review Findings (2026-03-05)
+
+**Overall Assessment: REQUEST CHANGES → APPROVED WITH REVISIONS**
+
+Reviewers: Security, Performance, Correctness, Test, Docs, Devil's Advocate (6 reviewers, all findings addressed below).
+
+### HIGH Findings
+
+**H1: Genesis actively uses full org/workspace hierarchy.** The devil's advocate found that genesis isn't just "creating namespaces" — its CLI navigates orgs, lists workspaces, and browses namespaces within workspaces. The original PRD understated this as "must update namespace creation calls."
+**Resolution:** Accepted scope. Genesis will be rewritten to use namespace-only navigation. Downstream impact table updated to reflect the full scope. No migration shim — clean break.
+
+**H2: Slug collision migration algorithm was unspecified.** Five of six reviewers flagged this. The original PRD said "append workspace slug as suffix" with no algorithm or test.
+**Resolution:** No auto-renaming. <50 namespaces exist; global uniqueness is highly likely. Migration includes a pre-check query that fails fast with a clear error listing collisions, requiring manual resolution. FR-10 updated with exact step ordering.
+
+**H3: Migration FK ordering was ambiguous.** Must remove `workspace_id` FK from `memory_namespaces` before dropping `workspaces` table.
+**Resolution:** FR-10 rewritten with explicit 10-step ordering. FK removal (step 5) precedes table drops (steps 9-10).
+
+**H4: Orphaned permission rows.** `PermissionModel` has no FK to org/workspace tables. Dropping those tables leaves rows with `resource_type='organization'/'workspace'` as orphans.
+**Resolution:** FR-10 step 2 now explicitly deletes these rows. Step 3 drops the `inherited_from_type` and `inherited_from_id` columns entirely.
+
+**H5: `list_namespaces()` becomes unbounded.** Currently filtered by `workspace_id` (indexed). After removal, returns all namespaces with no pagination.
+**Resolution:** New FR-12 added. Signature becomes `list_namespaces(*, active_only=True, limit=100, offset=0)`, ordered by `id`.
+
+**H6: ConfigResolver missing from affected files.** `resolve_for_namespace()` calls `storage.get_workspace()` and `storage.get_organization()` — would break at runtime.
+**Resolution:** FR-8 updated to include `src/khora/config/resolver.py` and specifies removing all org/workspace code with no backward compatibility.
+
+**H7: Missing index on `(slug, version)`.** Current index `idx_namespace_active` has `workspace_id` as leading column. After migration, slug lookups won't use it.
+**Resolution:** FR-10 step 4 drops old indexes, step 8 creates `idx_namespace_slug_active ON memory_namespaces (slug, version) WHERE is_active = true`.
+
+### MEDIUM Findings
+
+**M1: Peras accesses `.storage` API directly.** Uses `get_sync_checkpoint()`, `set_sync_checkpoint()`, `get_document()` — more coupling than originally documented.
+**Resolution:** Downstream impact table updated. Peras will be updated as part of the clean break.
+
+**M2: TenancyMode.ISOLATED — remove or move?** Devil's advocate argued against moving an unimplemented feature.
+**Resolution:** Move it to namespace. It stays as a placeholder for future implementation. Added to Non-Goals that implementing ISOLATED is out of scope.
+
+**M3: Config inheritance loss understated.** No bulk config API for 50-namespace scenarios.
+**Resolution:** Accepted trade-off. 2-tier (global + namespace) is sufficient. Documented honestly in Risks section.
+
+**M4: No deprecation timeline.** No communication plan for downstream consumers.
+**Resolution:** Clean break with simultaneous version bump. All downstream consumers (genesis, peras, khora-benchmarks) updated in the same release cycle. No deprecation period.
+
+**M5: `create_namespace_version()` still requires `workspace_id`.** Not addressed in original PRD.
+**Resolution:** Added to FR-4. Both `create_namespace()` and `create_namespace_version()` lose `workspace_id`.
+
+**M6: ACL HIERARCHY dict and enforcer methods not explicitly listed.** FR-7 was vague about what to remove.
+**Resolution:** FR-7 expanded with explicit list of 4 methods, HIERARCHY dict entries, and parent walk-up logic to remove.
+
+**M7: FR-9 `full_path` was undecided.** Two options listed, no decision.
+**Resolution:** Remove entirely. Callers use `slug` directly.
+
+**M8: `PermissionModel.inherited_from_type/id` columns unclear.** Should they be dropped?
+**Resolution:** Yes. FR-10 step 3 drops both columns. No hierarchy means no inheritance tracking.
+
+### LOW Findings
+
+**L1: Open questions lacked deadlines.** All three open questions have been resolved during review and removed from the Open Questions section.
+
+**L2: Missing observability section.** No version compatibility matrix.
+**Resolution:** Accepted as out of scope for this PRD. Version bump communicates the break.
+
+**L3: ConfigResolver 3→1 query reduction.** Positive performance finding — every `remember()`/`recall()` call saves 2 DB roundtrips. Added to Success Metrics.
+
+**L4: Test coverage impact minimal.** 15 tests affected (8 delete, 7 update). Coverage stays at ~52%, well above 30% threshold.
+**Resolution:** No action needed. Migration test should be added as part of Phase 3.

--- a/src/khora/acl/checker.py
+++ b/src/khora/acl/checker.py
@@ -70,24 +70,17 @@ class PermissionGrant:
     """A permission grant for a principal on a resource."""
 
     principal: Principal
-    resource_type: str  # organization, workspace, namespace
+    resource_type: str  # namespace
     resource_id: UUID
     permission: Permission
     inherited_from: tuple[str, UUID] | None = None  # (resource_type, resource_id) if inherited
 
 
 class ACLChecker:
-    """ACL checker with permission inheritance.
+    """ACL checker for namespace-only permissions."""
 
-    Supports hierarchical permissions:
-    - Organization -> Workspace -> Namespace
-    - Permissions at higher levels cascade down
-    """
-
-    # Resource type hierarchy (parent -> child)
+    # Resource type hierarchy (namespace is the sole boundary)
     HIERARCHY = {
-        "organization": "workspace",
-        "workspace": "namespace",
         "namespace": None,
     }
 
@@ -168,19 +161,14 @@ class ACLChecker:
         resource_type: str,
         resource_id: UUID,
         required_permission: Permission,
-        *,
-        parent_ids: dict[str, UUID] | None = None,
     ) -> bool:
         """Check if a principal has a permission on a resource.
-
-        Checks both direct grants and inherited permissions from parent resources.
 
         Args:
             principal: Principal to check
             resource_type: Type of resource
             resource_id: ID of resource
             required_permission: Permission required
-            parent_ids: Optional dict of parent resource IDs for inheritance
 
         Returns:
             True if permission is granted
@@ -190,16 +178,7 @@ class ACLChecker:
             return True
 
         # Check direct grant
-        if self._has_direct_grant(principal, resource_type, resource_id, required_permission):
-            return True
-
-        # Check inherited permissions from parent resources
-        if parent_ids:
-            for parent_type, parent_id in self._get_parent_chain(resource_type, parent_ids):
-                if self._has_direct_grant(principal, parent_type, parent_id, required_permission):
-                    return True
-
-        return False
+        return self._has_direct_grant(principal, resource_type, resource_id, required_permission)
 
     def _has_direct_grant(
         self,
@@ -220,47 +199,24 @@ class ACLChecker:
                 return True
         return False
 
-    def _get_parent_chain(
-        self,
-        resource_type: str,
-        parent_ids: dict[str, UUID],
-    ) -> list[tuple[str, UUID]]:
-        """Get the chain of parent resources for inheritance."""
-        chain = []
-        current_type = resource_type
-
-        # Walk up the hierarchy
-        for parent_type, child_type in self.HIERARCHY.items():
-            if child_type == current_type and parent_type in parent_ids:
-                chain.append((parent_type, parent_ids[parent_type]))
-                current_type = parent_type
-
-        return chain
-
     def get_effective_permissions(
         self,
         principal: Principal,
         resource_type: str,
         resource_id: UUID,
-        *,
-        parent_ids: dict[str, UUID] | None = None,
     ) -> list[PermissionGrant]:
         """Get all effective permissions for a principal on a resource.
-
-        Includes both direct and inherited permissions.
 
         Args:
             principal: Principal to check
             resource_type: Type of resource
             resource_id: ID of resource
-            parent_ids: Optional dict of parent resource IDs
 
         Returns:
             List of effective PermissionGrant objects
         """
         effective = []
 
-        # Direct grants
         for grant in self._grants:
             if (
                 grant.principal.principal_type == principal.principal_type
@@ -269,26 +225,6 @@ class ACLChecker:
                 and grant.resource_id == resource_id
             ):
                 effective.append(grant)
-
-        # Inherited grants
-        if parent_ids:
-            for parent_type, parent_id in self._get_parent_chain(resource_type, parent_ids):
-                for grant in self._grants:
-                    if (
-                        grant.principal.principal_type == principal.principal_type
-                        and grant.principal.principal_id == principal.principal_id
-                        and grant.resource_type == parent_type
-                        and grant.resource_id == parent_id
-                    ):
-                        # Mark as inherited
-                        inherited_grant = PermissionGrant(
-                            principal=grant.principal,
-                            resource_type=resource_type,
-                            resource_id=resource_id,
-                            permission=grant.permission,
-                            inherited_from=(parent_type, parent_id),
-                        )
-                        effective.append(inherited_grant)
 
         return effective
 

--- a/src/khora/acl/checker.py
+++ b/src/khora/acl/checker.py
@@ -73,7 +73,6 @@ class PermissionGrant:
     resource_type: str  # namespace
     resource_id: UUID
     permission: Permission
-    inherited_from: tuple[str, UUID] | None = None  # (resource_type, resource_id) if inherited
 
 
 class ACLChecker:

--- a/src/khora/acl/enforcer.py
+++ b/src/khora/acl/enforcer.py
@@ -43,18 +43,6 @@ class ACLContext:
 
     principal: Principal
     namespace_id: UUID | None = None
-    workspace_id: UUID | None = None
-    organization_id: UUID | None = None
-
-    @property
-    def parent_ids(self) -> dict[str, UUID]:
-        """Get parent IDs for permission inheritance."""
-        ids = {}
-        if self.workspace_id:
-            ids["workspace"] = self.workspace_id
-        if self.organization_id:
-            ids["organization"] = self.organization_id
-        return ids
 
 
 class ACLEnforcer:
@@ -122,7 +110,6 @@ class ACLEnforcer:
             resource_type,
             resource_id,
             required_permission,
-            parent_ids=context.parent_ids,
         )
 
         if not has_permission:
@@ -148,22 +135,6 @@ class ACLEnforcer:
     def check_namespace_admin(self, context: ACLContext, namespace_id: UUID) -> bool:
         """Check admin permission on a namespace."""
         return self.check_permission(context, "namespace", namespace_id, Permission.ADMIN)
-
-    def check_workspace_read(self, context: ACLContext, workspace_id: UUID) -> bool:
-        """Check read permission on a workspace."""
-        return self.check_permission(context, "workspace", workspace_id, Permission.READ)
-
-    def check_workspace_admin(self, context: ACLContext, workspace_id: UUID) -> bool:
-        """Check admin permission on a workspace."""
-        return self.check_permission(context, "workspace", workspace_id, Permission.ADMIN)
-
-    def check_organization_read(self, context: ACLContext, organization_id: UUID) -> bool:
-        """Check read permission on an organization."""
-        return self.check_permission(context, "organization", organization_id, Permission.READ)
-
-    def check_organization_admin(self, context: ACLContext, organization_id: UUID) -> bool:
-        """Check admin permission on an organization."""
-        return self.check_permission(context, "organization", organization_id, Permission.ADMIN)
 
     def require(
         self,

--- a/src/khora/config/resolver.py
+++ b/src/khora/config/resolver.py
@@ -1,6 +1,6 @@
-"""Hierarchical configuration resolver for Khora Memory Lake.
+"""Configuration resolver for Khora Memory Lake.
 
-Resolves configuration values with inheritance from namespace -> workspace -> organization -> global.
+Resolves configuration values with 2-tier inheritance: global defaults -> namespace overrides.
 """
 
 from __future__ import annotations
@@ -12,7 +12,7 @@ from uuid import UUID
 from loguru import logger
 
 if TYPE_CHECKING:
-    from khora.core.models import MemoryNamespace, Organization, Workspace
+    from khora.core.models import MemoryNamespace
     from khora.storage import StorageCoordinator
 
 
@@ -33,13 +33,11 @@ class ResolvedConfig:
 
 
 class ConfigResolver:
-    """Resolves configuration with hierarchical inheritance.
+    """Resolves configuration with 2-tier inheritance.
 
     Configuration inheritance order (highest to lowest priority):
     1. Namespace config_overrides
-    2. Workspace metadata config
-    3. Organization metadata config
-    4. Global application config
+    2. Global application config
     """
 
     def __init__(
@@ -50,7 +48,7 @@ class ConfigResolver:
         """Initialize the config resolver.
 
         Args:
-            storage: StorageCoordinator for fetching hierarchy
+            storage: StorageCoordinator for fetching namespace
             global_config: Global application configuration
         """
         self._storage = storage
@@ -80,29 +78,17 @@ class ConfigResolver:
             logger.warning(f"Namespace {namespace_id} not found")
             return ResolvedConfig(values=dict(self._global_config), sources={k: "global" for k in self._global_config})
 
-        # Fetch workspace
-        workspace = await self._storage.get_workspace(namespace.workspace_id)
-
-        # Fetch organization if workspace exists
-        organization = None
-        if workspace:
-            organization = await self._storage.get_organization(workspace.organization_id)
-
         return self._merge_configs(
             namespace=namespace,
-            workspace=workspace,
-            organization=organization,
             keys=keys,
         )
 
     def _merge_configs(
         self,
         namespace: MemoryNamespace | None,
-        workspace: Workspace | None,
-        organization: Organization | None,
         keys: list[str] | None,
     ) -> ResolvedConfig:
-        """Merge configurations from all levels."""
+        """Merge configurations from global and namespace levels."""
         result = ResolvedConfig()
 
         # Start with global config
@@ -110,22 +96,6 @@ class ConfigResolver:
             if keys is None or key in keys:
                 result.values[key] = value
                 result.sources[key] = "global"
-
-        # Apply organization config
-        if organization and organization.metadata:
-            config = organization.metadata.get("config", {})
-            for key, value in config.items():
-                if keys is None or key in keys:
-                    result.values[key] = value
-                    result.sources[key] = "organization"
-
-        # Apply workspace config
-        if workspace and workspace.metadata:
-            config = workspace.metadata.get("config", {})
-            for key, value in config.items():
-                if keys is None or key in keys:
-                    result.values[key] = value
-                    result.sources[key] = "workspace"
 
         # Apply namespace config (highest priority)
         if namespace and namespace.config_overrides:
@@ -139,8 +109,6 @@ class ConfigResolver:
     def resolve_immediate(
         self,
         global_config: dict[str, Any] | None = None,
-        organization_config: dict[str, Any] | None = None,
-        workspace_config: dict[str, Any] | None = None,
         namespace_config: dict[str, Any] | None = None,
     ) -> ResolvedConfig:
         """Resolve configuration from provided values (no storage lookup).
@@ -149,8 +117,6 @@ class ConfigResolver:
 
         Args:
             global_config: Global configuration
-            organization_config: Organization-level config
-            workspace_config: Workspace-level config
             namespace_config: Namespace-level config
 
         Returns:
@@ -161,8 +127,6 @@ class ConfigResolver:
         # Apply in order of priority (lowest to highest)
         for config, source in [
             (global_config or self._global_config, "global"),
-            (organization_config or {}, "organization"),
-            (workspace_config or {}, "workspace"),
             (namespace_config or {}, "namespace"),
         ]:
             for key, value in config.items():

--- a/src/khora/core/__init__.py
+++ b/src/khora/core/__init__.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 from .models.document import Chunk, ChunkMetadata, Document, DocumentMetadata
 from .models.entity import Entity, EntityType, Episode, Relationship, RelationshipType
 from .models.event import EventType, MemoryEvent
-from .models.tenancy import MemoryNamespace, Organization, TenancyMode, Workspace
+from .models.tenancy import MemoryNamespace, TenancyMode
 
 __all__ = [
     # Tenancy
-    "Organization",
-    "Workspace",
     "MemoryNamespace",
     "TenancyMode",
     # Document

--- a/src/khora/core/models/__init__.py
+++ b/src/khora/core/models/__init__.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 from .document import Chunk, ChunkMetadata, Document, DocumentMetadata
 from .entity import Entity, EntityType, Episode, Relationship, RelationshipType
 from .event import EventType, MemoryEvent
-from .tenancy import MemoryNamespace, Organization, TenancyMode, Workspace
+from .tenancy import MemoryNamespace, TenancyMode
 
 __all__ = [
     # Tenancy
-    "Organization",
-    "Workspace",
     "MemoryNamespace",
     "TenancyMode",
     # Document

--- a/src/khora/core/models/tenancy.py
+++ b/src/khora/core/models/tenancy.py
@@ -1,8 +1,7 @@
 """Multi-tenancy models for Khora Memory Lake.
 
-Supports two modes:
-- Shared: namespace_id filtering with row-level security
-- Isolated: Separate database instances per tenant
+Namespace is the sole data isolation boundary. All memories, entities,
+and relationships are scoped to a namespace_id.
 """
 
 from __future__ import annotations
@@ -22,49 +21,6 @@ class TenancyMode(str, Enum):
 
 
 @dataclass
-class Organization:
-    """Top-level tenant organization.
-
-    An organization can have multiple workspaces and represents the billing
-    and administrative boundary for tenants.
-    """
-
-    id: UUID = field(default_factory=uuid4)
-    name: str = ""
-    slug: str = ""  # URL-friendly identifier
-    tenancy_mode: TenancyMode = TenancyMode.SHARED
-    metadata: dict[str, Any] = field(default_factory=dict)
-    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
-    updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
-
-    def __post_init__(self) -> None:
-        if not self.slug and self.name:
-            self.slug = self.name.lower().replace(" ", "-")
-
-
-@dataclass
-class Workspace:
-    """Workspace within an organization.
-
-    Workspaces provide logical separation of projects or teams within
-    an organization. Each workspace can have multiple memory namespaces.
-    """
-
-    id: UUID = field(default_factory=uuid4)
-    organization_id: UUID = field(default_factory=uuid4)
-    name: str = ""
-    slug: str = ""
-    description: str = ""
-    metadata: dict[str, Any] = field(default_factory=dict)
-    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
-    updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
-
-    def __post_init__(self) -> None:
-        if not self.slug and self.name:
-            self.slug = self.name.lower().replace(" ", "-")
-
-
-@dataclass
 class MemoryNamespace:
     """Memory namespace for isolating memories.
 
@@ -79,10 +35,10 @@ class MemoryNamespace:
     """
 
     id: UUID = field(default_factory=uuid4)
-    workspace_id: UUID = field(default_factory=uuid4)
     name: str = ""
     slug: str = ""
     description: str = ""
+    tenancy_mode: TenancyMode = TenancyMode.SHARED
 
     # Versioning fields
     version: int = 1
@@ -102,8 +58,3 @@ class MemoryNamespace:
     def __post_init__(self) -> None:
         if not self.slug and self.name:
             self.slug = self.name.lower().replace(" ", "-")
-
-    @property
-    def full_path(self) -> str:
-        """Get the full path identifier for this namespace."""
-        return f"{self.workspace_id}/{self.slug}"

--- a/src/khora/db/__init__.py
+++ b/src/khora/db/__init__.py
@@ -11,11 +11,9 @@ from .models import (
     EpisodeModel,
     MemoryEventModel,
     MemoryNamespaceModel,
-    OrganizationModel,
     PermissionModel,
     RelationshipModel,
     SyncCheckpointModel,
-    WorkspaceModel,
 )
 from .session import close_db, get_db, get_engine, init_db, run_migrations
 
@@ -23,8 +21,6 @@ __all__ = [
     # Base
     "Base",
     # Models
-    "OrganizationModel",
-    "WorkspaceModel",
     "MemoryNamespaceModel",
     "DocumentModel",
     "ChunkModel",

--- a/src/khora/db/models.py
+++ b/src/khora/db/models.py
@@ -1,7 +1,7 @@
 """SQLAlchemy models for Khora Memory Lake.
 
 This module defines the complete database schema including:
-- Multi-tenancy (organizations, workspaces, namespaces)
+- Multi-tenancy (namespaces)
 - Documents and chunks with vector embeddings
 - Entities, relationships, and episodes
 - Event sourcing log
@@ -51,61 +51,10 @@ class Base(DeclarativeBase):
 # =============================================================================
 
 
-class OrganizationModel(Base):
-    """Organization - top-level tenant."""
-
-    __tablename__ = "organizations"
-
-    id: Mapped[UUIDType] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
-    name: Mapped[str] = mapped_column(String(255), nullable=False)
-    slug: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
-    tenancy_mode: Mapped[str] = mapped_column(
-        Enum(TenancyMode, name="tenancy_mode", create_constraint=True, values_callable=lambda e: [m.value for m in e]),
-        default=TenancyMode.SHARED,
-    )
-    metadata_: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB, default=dict)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC)
-    )
-
-    # Relationships
-    workspaces: Mapped[list[WorkspaceModel]] = relationship("WorkspaceModel", back_populates="organization")
-
-    def __repr__(self) -> str:
-        return f"<Organization(id={self.id!r}, name={self.name!r})>"
-
-
-class WorkspaceModel(Base):
-    """Workspace within an organization."""
-
-    __tablename__ = "workspaces"
-
-    id: Mapped[UUIDType] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
-    organization_id: Mapped[UUIDType] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True
-    )
-    name: Mapped[str] = mapped_column(String(255), nullable=False)
-    slug: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
-    description: Mapped[str] = mapped_column(Text, default="")
-    metadata_: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB, default=dict)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC)
-    )
-
-    # Relationships
-    organization: Mapped[OrganizationModel] = relationship("OrganizationModel", back_populates="workspaces")
-    namespaces: Mapped[list[MemoryNamespaceModel]] = relationship("MemoryNamespaceModel", back_populates="workspace")
-
-    __table_args__ = (UniqueConstraint("organization_id", "slug", name="uq_workspace_org_slug"),)
-
-    def __repr__(self) -> str:
-        return f"<Workspace(id={self.id!r}, name={self.name!r})>"
-
-
 class MemoryNamespaceModel(Base):
     """Memory namespace for isolating memories.
+
+    Namespace is the sole data isolation boundary.
 
     Supports versioning for data replacement workflows:
     - version: Incremental version number (starts at 1)
@@ -116,12 +65,13 @@ class MemoryNamespaceModel(Base):
     __tablename__ = "memory_namespaces"
 
     id: Mapped[UUIDType] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
-    workspace_id: Mapped[UUIDType] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False, index=True
-    )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     slug: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     description: Mapped[str] = mapped_column(Text, default="")
+    tenancy_mode: Mapped[str] = mapped_column(
+        Enum(TenancyMode, name="tenancy_mode", create_constraint=True, values_callable=lambda e: [m.value for m in e]),
+        default=TenancyMode.SHARED,
+    )
 
     # Versioning fields
     version: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
@@ -139,7 +89,6 @@ class MemoryNamespaceModel(Base):
     )
 
     # Relationships
-    workspace: Mapped[WorkspaceModel] = relationship("WorkspaceModel", back_populates="namespaces")
     documents: Mapped[list[DocumentModel]] = relationship("DocumentModel", back_populates="namespace")
     chunks: Mapped[list[ChunkModel]] = relationship("ChunkModel", back_populates="namespace")
     entities: Mapped[list[EntityModel]] = relationship("EntityModel", back_populates="namespace")
@@ -151,10 +100,10 @@ class MemoryNamespaceModel(Base):
     )
 
     __table_args__ = (
-        # Only one active namespace per workspace/slug combination
-        UniqueConstraint("workspace_id", "slug", "version", name="uq_namespace_workspace_slug_version"),
+        # Slugs are globally unique per version
+        UniqueConstraint("slug", "version", name="uq_namespace_slug_version"),
         # Partial index for efficient active namespace queries
-        Index("idx_namespace_active", "workspace_id", "slug", postgresql_where="is_active = true"),
+        Index("idx_namespace_slug_active", "slug", "version", postgresql_where="is_active = true"),
     )
 
     def __repr__(self) -> str:
@@ -516,17 +465,11 @@ class PermissionModel(Base):
     principal_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
 
     # The resource (what the permission applies to)
-    resource_type: Mapped[str] = mapped_column(
-        String(64), nullable=False, index=True
-    )  # organization, workspace, namespace
+    resource_type: Mapped[str] = mapped_column(String(64), nullable=False, index=True)  # namespace
     resource_id: Mapped[UUIDType] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
 
     # The permission level
     permission: Mapped[str] = mapped_column(String(64), nullable=False)  # read, write, admin, owner
-
-    # Inheritance
-    inherited_from_type: Mapped[str | None] = mapped_column(String(64), nullable=True)
-    inherited_from_id: Mapped[UUIDType | None] = mapped_column(UUID(as_uuid=True), nullable=True)
 
     metadata_: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB, default=dict)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))

--- a/src/khora/db/models.py
+++ b/src/khora/db/models.py
@@ -465,7 +465,8 @@ class PermissionModel(Base):
     principal_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
 
     # The resource (what the permission applies to)
-    resource_type: Mapped[str] = mapped_column(String(64), nullable=False, index=True)  # namespace
+    # Post-DYT-220: resource_type must always be 'namespace' (sole isolation boundary).
+    resource_type: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
     resource_id: Mapped[UUIDType] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
 
     # The permission level

--- a/src/khora/engines/graphrag/engine.py
+++ b/src/khora/engines/graphrag/engine.py
@@ -19,7 +19,7 @@ from uuid import UUID
 from loguru import logger
 
 from khora.config import KhoraConfig, LiteLLMConfig
-from khora.core.models import Document, DocumentMetadata, Entity, MemoryNamespace, Organization, Workspace
+from khora.core.models import Document, DocumentMetadata, Entity, MemoryNamespace
 from khora.extraction.embedders import LiteLLMEmbedder
 from khora.memory_lake import BatchResult, RecallResult, RememberResult, Stats
 from khora.query import HybridQueryEngine, QueryConfig, SearchMode
@@ -507,32 +507,13 @@ class GraphRAGEngine:
         if self._default_namespace_id:
             return self._default_namespace_id
 
-        # Try to find existing default namespace
-        # For simplicity, we'll create a default org/workspace/namespace
         storage = self._get_storage()
-        default_org = await storage.get_organization_by_slug("default")
-        if not default_org:
-            default_org = await storage.create_organization(Organization(name="Default", slug="default"))
 
-        workspaces = await storage.list_workspaces(default_org.id)
-        if workspaces:
-            default_workspace = workspaces[0]
-        else:
-            default_workspace = await storage.create_workspace(
-                Workspace(
-                    organization_id=default_org.id,
-                    name="Default",
-                    slug="default",
-                )
-            )
-
-        namespaces = await storage.list_namespaces(default_workspace.id)
-        if namespaces:
-            default_namespace = namespaces[0]
-        else:
+        # Try to find existing default namespace by slug
+        default_namespace = await storage.get_namespace_by_slug("default")
+        if not default_namespace:
             default_namespace = await storage.create_namespace(
                 MemoryNamespace(
-                    workspace_id=default_workspace.id,
                     name="Default",
                     slug="default",
                 )
@@ -544,14 +525,12 @@ class GraphRAGEngine:
     async def create_namespace(
         self,
         name: str,
-        workspace_id: UUID,
         *,
         description: str = "",
         config_overrides: dict[str, Any] | None = None,
     ) -> MemoryNamespace:
         """Create a new memory namespace."""
         namespace = MemoryNamespace(
-            workspace_id=workspace_id,
             name=name,
             description=description,
             config_overrides=config_overrides or {},
@@ -571,30 +550,15 @@ class GraphRAGEngine:
         """Get or create a namespace by name."""
         storage = self._get_storage()
 
-        # Ensure default org/workspace exists
-        await self.get_or_create_default_namespace()
-
-        # Get default workspace
-        default_org = await storage.get_organization_by_slug("default")
-        if not default_org:
-            raise RuntimeError("Default organization not found")
-
-        workspaces = await storage.list_workspaces(default_org.id)
-        if not workspaces:
-            raise RuntimeError("Default workspace not found")
-
-        default_workspace = workspaces[0]
-
         # Try to find namespace by slug
         slug = name.lower().replace(" ", "-")
-        existing_ns = await storage.get_namespace_by_slug(default_workspace.id, slug)
+        existing_ns = await storage.get_namespace_by_slug(slug)
         if existing_ns:
             return existing_ns.id
 
         # Create new namespace
         new_ns = await storage.create_namespace(
             MemoryNamespace(
-                workspace_id=default_workspace.id,
                 name=name,
                 slug=slug,
                 description=description,

--- a/src/khora/engines/protocol.py
+++ b/src/khora/engines/protocol.py
@@ -151,7 +151,6 @@ class MemoryEngineProtocol(Protocol):
     async def create_namespace(
         self,
         name: str,
-        workspace_id: UUID,
         *,
         description: str = "",
         config_overrides: dict[str, Any] | None = None,
@@ -160,7 +159,6 @@ class MemoryEngineProtocol(Protocol):
 
         Args:
             name: Namespace name
-            workspace_id: Parent workspace ID
             description: Optional description
             config_overrides: Optional configuration overrides
 
@@ -188,7 +186,7 @@ class MemoryEngineProtocol(Protocol):
     ) -> UUID:
         """Get or create a namespace by name.
 
-        Creates the default organization and workspace if they don't exist.
+        Creates the namespace if it doesn't exist.
 
         Args:
             name: Namespace name (will be slugified)

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -26,8 +26,6 @@ from khora.core.models import (
     DocumentMetadata,
     Entity,
     MemoryNamespace,
-    Organization,
-    Workspace,
 )
 from khora.extraction.embedders import LiteLLMEmbedder
 from khora.memory_lake import BatchResult, RecallResult, RememberResult, Stats
@@ -725,30 +723,11 @@ class SkeletonConstructionEngine:
 
         storage = self._get_storage()
 
-        # Try to find existing default namespace
-        default_org = await storage.get_organization_by_slug("default")
-        if not default_org:
-            default_org = await storage.create_organization(Organization(name="Default", slug="default"))
-
-        workspaces = await storage.list_workspaces(default_org.id)
-        if workspaces:
-            default_workspace = workspaces[0]
-        else:
-            default_workspace = await storage.create_workspace(
-                Workspace(
-                    organization_id=default_org.id,
-                    name="Default",
-                    slug="default",
-                )
-            )
-
-        namespaces = await storage.list_namespaces(default_workspace.id)
-        if namespaces:
-            default_namespace = namespaces[0]
-        else:
+        # Try to find existing default namespace by slug
+        default_namespace = await storage.get_namespace_by_slug("default")
+        if not default_namespace:
             default_namespace = await storage.create_namespace(
                 MemoryNamespace(
-                    workspace_id=default_workspace.id,
                     name="Default",
                     slug="default",
                 )
@@ -760,14 +739,12 @@ class SkeletonConstructionEngine:
     async def create_namespace(
         self,
         name: str,
-        workspace_id: UUID,
         *,
         description: str = "",
         config_overrides: dict[str, Any] | None = None,
     ) -> MemoryNamespace:
         """Create a new memory namespace."""
         namespace = MemoryNamespace(
-            workspace_id=workspace_id,
             name=name,
             description=description,
             config_overrides=config_overrides or {},
@@ -787,30 +764,15 @@ class SkeletonConstructionEngine:
         """Get or create a namespace by name."""
         storage = self._get_storage()
 
-        # Ensure default org/workspace exists
-        await self.get_or_create_default_namespace()
-
-        # Get default workspace
-        default_org = await storage.get_organization_by_slug("default")
-        if not default_org:
-            raise RuntimeError("Default organization not found")
-
-        workspaces = await storage.list_workspaces(default_org.id)
-        if not workspaces:
-            raise RuntimeError("Default workspace not found")
-
-        default_workspace = workspaces[0]
-
         # Try to find namespace by slug
         slug = name.lower().replace(" ", "-")
-        existing_ns = await storage.get_namespace_by_slug(default_workspace.id, slug)
+        existing_ns = await storage.get_namespace_by_slug(slug)
         if existing_ns:
             return existing_ns.id
 
         # Create new namespace
         new_ns = await storage.create_namespace(
             MemoryNamespace(
-                workspace_id=default_workspace.id,
                 name=name,
                 slug=slug,
                 description=description,

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -31,9 +31,7 @@ from khora.core.models import (
     DocumentMetadata,
     Entity,
     MemoryNamespace,
-    Organization,
     Relationship,
-    Workspace,
 )
 from khora.engines.skeleton.backends import TemporalChunk, TemporalFilter, create_temporal_store
 from khora.engines.skeleton.skeleton import SkeletonIndexer
@@ -1350,29 +1348,11 @@ class VectorCypherEngine:
 
         storage = self._get_storage()
 
-        default_org = await storage.get_organization_by_slug("default")
-        if not default_org:
-            default_org = await storage.create_organization(Organization(name="Default", slug="default"))
-
-        workspaces = await storage.list_workspaces(default_org.id)
-        if workspaces:
-            default_workspace = workspaces[0]
-        else:
-            default_workspace = await storage.create_workspace(
-                Workspace(
-                    organization_id=default_org.id,
-                    name="Default",
-                    slug="default",
-                )
-            )
-
-        namespaces = await storage.list_namespaces(default_workspace.id)
-        if namespaces:
-            default_namespace = namespaces[0]
-        else:
+        # Try to find existing default namespace by slug
+        default_namespace = await storage.get_namespace_by_slug("default")
+        if not default_namespace:
             default_namespace = await storage.create_namespace(
                 MemoryNamespace(
-                    workspace_id=default_workspace.id,
                     name="Default",
                     slug="default",
                 )
@@ -1384,14 +1364,12 @@ class VectorCypherEngine:
     async def create_namespace(
         self,
         name: str,
-        workspace_id: UUID,
         *,
         description: str = "",
         config_overrides: dict[str, Any] | None = None,
     ) -> MemoryNamespace:
         """Create a new memory namespace."""
         namespace = MemoryNamespace(
-            workspace_id=workspace_id,
             name=name,
             description=description,
             config_overrides=config_overrides or {},
@@ -1411,26 +1389,14 @@ class VectorCypherEngine:
         """Get or create a namespace by name."""
         storage = self._get_storage()
 
-        await self.get_or_create_default_namespace()
-
-        default_org = await storage.get_organization_by_slug("default")
-        if not default_org:
-            raise RuntimeError("Default organization not found")
-
-        workspaces = await storage.list_workspaces(default_org.id)
-        if not workspaces:
-            raise RuntimeError("Default workspace not found")
-
-        default_workspace = workspaces[0]
-
+        # Try to find namespace by slug
         slug = name.lower().replace(" ", "-")
-        existing_ns = await storage.get_namespace_by_slug(default_workspace.id, slug)
+        existing_ns = await storage.get_namespace_by_slug(slug)
         if existing_ns:
             return existing_ns.id
 
         new_ns = await storage.create_namespace(
             MemoryNamespace(
-                workspace_id=default_workspace.id,
                 name=name,
                 slug=slug,
                 description=description,

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -229,8 +229,8 @@ class MemoryLake:
         """Get the storage coordinator for admin/management operations.
 
         Provides direct access to the underlying storage coordinator for
-        organizational operations like creating workspaces, managing namespaces,
-        and other administrative tasks not covered by the high-level API.
+        managing namespaces and other administrative tasks not covered
+        by the high-level API.
 
         For common operations, prefer the MemoryLake convenience methods:
         - lake.get_document() for document retrieval
@@ -250,7 +250,6 @@ class MemoryLake:
     async def create_namespace(
         self,
         name: str,
-        workspace_id: UUID,
         *,
         description: str = "",
         config_overrides: dict[str, Any] | None = None,
@@ -259,7 +258,6 @@ class MemoryLake:
 
         Args:
             name: Namespace name
-            workspace_id: Parent workspace ID
             description: Optional description
             config_overrides: Optional configuration overrides
 
@@ -268,7 +266,6 @@ class MemoryLake:
         """
         return await self._get_engine().create_namespace(
             name,
-            workspace_id,
             description=description,
             config_overrides=config_overrides,
         )
@@ -585,9 +582,8 @@ class MemoryLake:
     ) -> UUID:
         """Get or create a namespace by name.
 
-        Creates the default organization and workspace if they don't exist.
         This is a convenience method for simple usage where you just want
-        a namespace by name without managing the full hierarchy.
+        a namespace by name without managing it explicitly.
 
         Args:
             name: Namespace name (will be slugified)
@@ -616,19 +612,15 @@ class MemoryLake:
         except ValueError:
             pass
 
-        # Look up by slug in default workspace
-        # Access storage through engine for namespace lookup
+        # Look up by slug (globally unique)
         engine = self._get_engine()
         if not hasattr(engine, "_storage") or engine._storage is None:
             raise RuntimeError("Engine does not support namespace lookup by slug")
 
         storage = engine._storage
-        default_ns_id = await self.get_or_create_default_namespace()
-        default_ns = await storage.get_namespace(default_ns_id)  # type: ignore[unresolved-attribute]
-        if default_ns:
-            ns = await storage.get_namespace_by_slug(default_ns.workspace_id, namespace)  # type: ignore[unresolved-attribute]
-            if ns:
-                return ns.id
+        ns = await storage.get_namespace_by_slug(namespace)  # type: ignore[unresolved-attribute]
+        if ns:
+            return ns.id
 
         raise ValueError(f"Namespace not found: {namespace}")
 

--- a/src/khora/storage/__init__.py
+++ b/src/khora/storage/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from .backends.base import (
     EventStoreProtocol,
     GraphBackendProtocol,
+    PaginatedResult,
     RelationalBackendProtocol,
     VectorBackendProtocol,
 )
@@ -28,6 +29,7 @@ from .optimize import optimize_neo4j, optimize_postgresql, optimize_storage
 
 __all__ = [
     # Protocols
+    "PaginatedResult",
     "RelationalBackendProtocol",
     "VectorBackendProtocol",
     "GraphBackendProtocol",

--- a/src/khora/storage/backends/base.py
+++ b/src/khora/storage/backends/base.py
@@ -7,9 +7,12 @@ enabling dependency injection and easy testing with mocks.
 from __future__ import annotations
 
 from abc import abstractmethod
+from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, runtime_checkable
 from uuid import UUID
+
+T = TypeVar("T")
 
 if TYPE_CHECKING:
     from khora.core.models import (
@@ -21,6 +24,16 @@ if TYPE_CHECKING:
         MemoryNamespace,
         Relationship,
     )
+
+
+@dataclass(frozen=True)
+class PaginatedResult(Generic[T]):
+    """Paginated query result with total count."""
+
+    items: list[T]
+    total: int
+    limit: int
+    offset: int
 
 
 @runtime_checkable
@@ -64,7 +77,7 @@ class RelationalBackendProtocol(Protocol):
     @abstractmethod
     async def list_namespaces(
         self, *, active_only: bool = True, limit: int = 100, offset: int = 0
-    ) -> list[MemoryNamespace]:
+    ) -> PaginatedResult[MemoryNamespace]:
         """List namespaces with pagination."""
         ...
 

--- a/src/khora/storage/backends/base.py
+++ b/src/khora/storage/backends/base.py
@@ -19,9 +19,7 @@ if TYPE_CHECKING:
         Episode,
         MemoryEvent,
         MemoryNamespace,
-        Organization,
         Relationship,
-        Workspace,
     )
 
 
@@ -47,38 +45,6 @@ class RelationalBackendProtocol(Protocol):
         """Check if the backend is healthy and connected."""
         ...
 
-    # Organization operations
-    @abstractmethod
-    async def create_organization(self, org: Organization) -> Organization:
-        """Create a new organization."""
-        ...
-
-    @abstractmethod
-    async def get_organization(self, org_id: UUID) -> Organization | None:
-        """Get an organization by ID."""
-        ...
-
-    @abstractmethod
-    async def get_organization_by_slug(self, slug: str) -> Organization | None:
-        """Get an organization by slug."""
-        ...
-
-    # Workspace operations
-    @abstractmethod
-    async def create_workspace(self, workspace: Workspace) -> Workspace:
-        """Create a new workspace."""
-        ...
-
-    @abstractmethod
-    async def get_workspace(self, workspace_id: UUID) -> Workspace | None:
-        """Get a workspace by ID."""
-        ...
-
-    @abstractmethod
-    async def list_workspaces(self, organization_id: UUID) -> list[Workspace]:
-        """List all workspaces in an organization."""
-        ...
-
     # Namespace operations
     @abstractmethod
     async def create_namespace(self, namespace: MemoryNamespace) -> MemoryNamespace:
@@ -91,13 +57,15 @@ class RelationalBackendProtocol(Protocol):
         ...
 
     @abstractmethod
-    async def get_namespace_by_slug(self, workspace_id: UUID, slug: str) -> MemoryNamespace | None:
-        """Get a namespace by workspace ID and slug."""
+    async def get_namespace_by_slug(self, slug: str, *, active_only: bool = True) -> MemoryNamespace | None:
+        """Get a namespace by slug (globally unique)."""
         ...
 
     @abstractmethod
-    async def list_namespaces(self, workspace_id: UUID) -> list[MemoryNamespace]:
-        """List all namespaces in a workspace."""
+    async def list_namespaces(
+        self, *, active_only: bool = True, limit: int = 100, offset: int = 0
+    ) -> list[MemoryNamespace]:
+        """List namespaces with pagination."""
         ...
 
     @abstractmethod
@@ -108,7 +76,6 @@ class RelationalBackendProtocol(Protocol):
     @abstractmethod
     async def create_namespace_version(
         self,
-        workspace_id: UUID,
         slug: str,
         *,
         previous_version: MemoryNamespace | None = None,
@@ -116,7 +83,6 @@ class RelationalBackendProtocol(Protocol):
         """Create a new version of a namespace.
 
         Args:
-            workspace_id: Workspace ID
             slug: Namespace slug
             previous_version: The previous version to supersede (if any)
 

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -14,15 +14,13 @@ from loguru import logger
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 
-from khora.core.models import Document, DocumentMetadata, MemoryNamespace, Organization, TenancyMode, Workspace
+from khora.core.models import Document, DocumentMetadata, MemoryNamespace, TenancyMode
 from khora.core.models.document import DocumentStatus
 from khora.db.models import (
     Base,
     DocumentModel,
     MemoryNamespaceModel,
-    OrganizationModel,
     SyncCheckpointModel,
-    WorkspaceModel,
 )
 from khora.storage.backends.mixins import AsyncSessionMixin, retry_on_deadlock
 
@@ -119,103 +117,6 @@ class PostgreSQLBackend(AsyncSessionMixin):
             await conn.run_sync(Base.metadata.create_all)
 
     # =========================================================================
-    # Organization operations
-    # =========================================================================
-
-    async def create_organization(self, org: Organization) -> Organization:
-        """Create a new organization."""
-        async with self._get_session() as session:
-            model = OrganizationModel(
-                id=org.id,
-                name=org.name,
-                slug=org.slug,
-                tenancy_mode=org.tenancy_mode,
-                metadata_=org.metadata,
-                created_at=org.created_at,
-                updated_at=org.updated_at,
-            )
-            session.add(model)
-            await session.commit()
-            await session.refresh(model)
-            return self._org_model_to_domain(model)
-
-    async def get_organization(self, org_id: UUID) -> Organization | None:
-        """Get an organization by ID."""
-        async with self._get_session() as session:
-            result = await session.execute(select(OrganizationModel).where(OrganizationModel.id == org_id))
-            model = result.scalar_one_or_none()
-            return self._org_model_to_domain(model) if model else None
-
-    async def get_organization_by_slug(self, slug: str) -> Organization | None:
-        """Get an organization by slug."""
-        async with self._get_session() as session:
-            result = await session.execute(select(OrganizationModel).where(OrganizationModel.slug == slug))
-            model = result.scalar_one_or_none()
-            return self._org_model_to_domain(model) if model else None
-
-    def _org_model_to_domain(self, model: OrganizationModel) -> Organization:
-        """Convert OrganizationModel to domain Organization."""
-        return Organization(
-            id=model.id,
-            name=model.name,
-            slug=model.slug,
-            tenancy_mode=TenancyMode(model.tenancy_mode) if isinstance(model.tenancy_mode, str) else model.tenancy_mode,
-            metadata=model.metadata_,
-            created_at=model.created_at,
-            updated_at=model.updated_at,
-        )
-
-    # =========================================================================
-    # Workspace operations
-    # =========================================================================
-
-    async def create_workspace(self, workspace: Workspace) -> Workspace:
-        """Create a new workspace."""
-        async with self._get_session() as session:
-            model = WorkspaceModel(
-                id=workspace.id,
-                organization_id=workspace.organization_id,
-                name=workspace.name,
-                slug=workspace.slug,
-                description=workspace.description,
-                metadata_=workspace.metadata,
-                created_at=workspace.created_at,
-                updated_at=workspace.updated_at,
-            )
-            session.add(model)
-            await session.commit()
-            await session.refresh(model)
-            return self._workspace_model_to_domain(model)
-
-    async def get_workspace(self, workspace_id: UUID) -> Workspace | None:
-        """Get a workspace by ID."""
-        async with self._get_session() as session:
-            result = await session.execute(select(WorkspaceModel).where(WorkspaceModel.id == workspace_id))
-            model = result.scalar_one_or_none()
-            return self._workspace_model_to_domain(model) if model else None
-
-    async def list_workspaces(self, organization_id: UUID) -> list[Workspace]:
-        """List all workspaces in an organization."""
-        async with self._get_session() as session:
-            result = await session.execute(
-                select(WorkspaceModel).where(WorkspaceModel.organization_id == organization_id)
-            )
-            return [self._workspace_model_to_domain(m) for m in result.scalars().all()]
-
-    def _workspace_model_to_domain(self, model: WorkspaceModel) -> Workspace:
-        """Convert WorkspaceModel to domain Workspace."""
-        return Workspace(
-            id=model.id,
-            organization_id=model.organization_id,
-            name=model.name,
-            slug=model.slug,
-            description=model.description,
-            metadata=model.metadata_,
-            created_at=model.created_at,
-            updated_at=model.updated_at,
-        )
-
-    # =========================================================================
     # Namespace operations
     # =========================================================================
 
@@ -224,10 +125,10 @@ class PostgreSQLBackend(AsyncSessionMixin):
         async with self._get_session() as session:
             model = MemoryNamespaceModel(
                 id=namespace.id,
-                workspace_id=namespace.workspace_id,
                 name=namespace.name,
                 slug=namespace.slug,
                 description=namespace.description,
+                tenancy_mode=namespace.tenancy_mode,
                 version=namespace.version,
                 is_active=namespace.is_active,
                 previous_version_id=namespace.previous_version_id,
@@ -249,13 +150,10 @@ class PostgreSQLBackend(AsyncSessionMixin):
             model = result.scalar_one_or_none()
             return self._namespace_model_to_domain(model) if model else None
 
-    async def get_namespace_by_slug(
-        self, workspace_id: UUID, slug: str, *, active_only: bool = True
-    ) -> MemoryNamespace | None:
-        """Get a namespace by workspace ID and slug.
+    async def get_namespace_by_slug(self, slug: str, *, active_only: bool = True) -> MemoryNamespace | None:
+        """Get a namespace by slug (globally unique).
 
         Args:
-            workspace_id: Workspace ID
             slug: Namespace slug
             active_only: If True, only return active namespace (default)
 
@@ -264,7 +162,6 @@ class PostgreSQLBackend(AsyncSessionMixin):
         """
         async with self._get_session() as session:
             query = select(MemoryNamespaceModel).where(
-                MemoryNamespaceModel.workspace_id == workspace_id,
                 MemoryNamespaceModel.slug == slug,
             )
             if active_only:
@@ -273,20 +170,24 @@ class PostgreSQLBackend(AsyncSessionMixin):
             model = result.scalar_one_or_none()
             return self._namespace_model_to_domain(model) if model else None
 
-    async def list_namespaces(self, workspace_id: UUID, *, active_only: bool = True) -> list[MemoryNamespace]:
-        """List all namespaces in a workspace.
+    async def list_namespaces(
+        self, *, active_only: bool = True, limit: int = 100, offset: int = 0
+    ) -> list[MemoryNamespace]:
+        """List namespaces with pagination.
 
         Args:
-            workspace_id: Workspace ID
             active_only: If True, only return active namespaces (default)
+            limit: Maximum namespaces to return
+            offset: Offset for pagination
 
         Returns:
             List of MemoryNamespace objects
         """
         async with self._get_session() as session:
-            query = select(MemoryNamespaceModel).where(MemoryNamespaceModel.workspace_id == workspace_id)
+            query = select(MemoryNamespaceModel)
             if active_only:
                 query = query.where(MemoryNamespaceModel.is_active == True)  # noqa: E712
+            query = query.order_by(MemoryNamespaceModel.id).limit(limit).offset(offset)
             result = await session.execute(query)
             return [self._namespace_model_to_domain(m) for m in result.scalars().all()]
 
@@ -316,10 +217,10 @@ class PostgreSQLBackend(AsyncSessionMixin):
         """Convert MemoryNamespaceModel to domain MemoryNamespace."""
         return MemoryNamespace(
             id=model.id,
-            workspace_id=model.workspace_id,
             name=model.name,
             slug=model.slug,
             description=model.description,
+            tenancy_mode=TenancyMode(model.tenancy_mode) if isinstance(model.tenancy_mode, str) else model.tenancy_mode,
             version=model.version,
             is_active=model.is_active,
             previous_version_id=model.previous_version_id,
@@ -332,7 +233,6 @@ class PostgreSQLBackend(AsyncSessionMixin):
 
     async def create_namespace_version(
         self,
-        workspace_id: UUID,
         slug: str,
         *,
         previous_version: MemoryNamespace | None = None,
@@ -343,7 +243,6 @@ class PostgreSQLBackend(AsyncSessionMixin):
         The previous version is marked as inactive.
 
         Args:
-            workspace_id: Workspace ID
             slug: Namespace slug
             previous_version: The previous version to supersede (if any)
 
@@ -364,7 +263,6 @@ class PostgreSQLBackend(AsyncSessionMixin):
         # Create new namespace with incremented version
         namespace = MemoryNamespace(
             id=uuid4(),
-            workspace_id=workspace_id,
             name=previous_version.name if previous_version else f"Namespace {slug}",
             slug=slug,
             description=previous_version.description if previous_version else "",

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 from loguru import logger
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 
 from khora.core.models import Document, DocumentMetadata, MemoryNamespace, TenancyMode
@@ -22,6 +22,7 @@ from khora.db.models import (
     MemoryNamespaceModel,
     SyncCheckpointModel,
 )
+from khora.storage.backends.base import PaginatedResult
 from khora.storage.backends.mixins import AsyncSessionMixin, retry_on_deadlock
 
 if TYPE_CHECKING:
@@ -172,7 +173,7 @@ class PostgreSQLBackend(AsyncSessionMixin):
 
     async def list_namespaces(
         self, *, active_only: bool = True, limit: int = 100, offset: int = 0
-    ) -> list[MemoryNamespace]:
+    ) -> PaginatedResult[MemoryNamespace]:
         """List namespaces with pagination.
 
         Args:
@@ -181,15 +182,23 @@ class PostgreSQLBackend(AsyncSessionMixin):
             offset: Offset for pagination
 
         Returns:
-            List of MemoryNamespace objects
+            PaginatedResult with namespace items and total count
         """
         async with self._get_session() as session:
-            query = select(MemoryNamespaceModel)
-            if active_only:
-                query = query.where(MemoryNamespaceModel.is_active == True)  # noqa: E712
-            query = query.order_by(MemoryNamespaceModel.id).limit(limit).offset(offset)
+            base_filter = MemoryNamespaceModel.is_active == True if active_only else True  # noqa: E712
+            count_query = select(func.count(MemoryNamespaceModel.id)).where(base_filter)
+            total = (await session.execute(count_query)).scalar_one()
+
+            query = (
+                select(MemoryNamespaceModel)
+                .where(base_filter)
+                .order_by(MemoryNamespaceModel.id)
+                .limit(limit)
+                .offset(offset)
+            )
             result = await session.execute(query)
-            return [self._namespace_model_to_domain(m) for m in result.scalars().all()]
+            items = [self._namespace_model_to_domain(m) for m in result.scalars().all()]
+            return PaginatedResult(items=items, total=total, limit=limit, offset=offset)
 
     async def update_namespace(self, namespace: MemoryNamespace) -> MemoryNamespace:
         """Update a namespace."""

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -27,9 +27,7 @@ from khora.core.models import (
     Episode,
     MemoryEvent,
     MemoryNamespace,
-    Organization,
     Relationship,
-    Workspace,
 )
 from khora.telemetry import get_collector, trace_span
 
@@ -275,42 +273,6 @@ class StorageCoordinator:
     # Tenancy operations (delegated to relational)
     # =========================================================================
 
-    async def create_organization(self, org: Organization) -> Organization:
-        """Create a new organization."""
-        if not self.relational:
-            raise RuntimeError("Relational backend not configured")
-        return await self.relational.create_organization(org)
-
-    async def get_organization(self, org_id: UUID) -> Organization | None:
-        """Get an organization by ID."""
-        if not self.relational:
-            raise RuntimeError("Relational backend not configured")
-        return await self.relational.get_organization(org_id)
-
-    async def get_organization_by_slug(self, slug: str) -> Organization | None:
-        """Get an organization by slug."""
-        if not self.relational:
-            raise RuntimeError("Relational backend not configured")
-        return await self.relational.get_organization_by_slug(slug)
-
-    async def create_workspace(self, workspace: Workspace) -> Workspace:
-        """Create a new workspace."""
-        if not self.relational:
-            raise RuntimeError("Relational backend not configured")
-        return await self.relational.create_workspace(workspace)
-
-    async def get_workspace(self, workspace_id: UUID) -> Workspace | None:
-        """Get a workspace by ID."""
-        if not self.relational:
-            raise RuntimeError("Relational backend not configured")
-        return await self.relational.get_workspace(workspace_id)
-
-    async def list_workspaces(self, organization_id: UUID) -> list[Workspace]:
-        """List all workspaces in an organization."""
-        if not self.relational:
-            raise RuntimeError("Relational backend not configured")
-        return await self.relational.list_workspaces(organization_id)
-
     async def create_namespace(self, namespace: MemoryNamespace) -> MemoryNamespace:
         """Create a new memory namespace."""
         if not self.relational:
@@ -323,17 +285,19 @@ class StorageCoordinator:
             raise RuntimeError("Relational backend not configured")
         return await self.relational.get_namespace(namespace_id)
 
-    async def get_namespace_by_slug(self, workspace_id: UUID, slug: str) -> MemoryNamespace | None:
-        """Get a namespace by workspace ID and slug."""
+    async def get_namespace_by_slug(self, slug: str) -> MemoryNamespace | None:
+        """Get a namespace by slug (globally unique)."""
         if not self.relational:
             raise RuntimeError("Relational backend not configured")
-        return await self.relational.get_namespace_by_slug(workspace_id, slug)
+        return await self.relational.get_namespace_by_slug(slug)
 
-    async def list_namespaces(self, workspace_id: UUID) -> list[MemoryNamespace]:
-        """List all namespaces in a workspace."""
+    async def list_namespaces(
+        self, *, active_only: bool = True, limit: int = 100, offset: int = 0
+    ) -> list[MemoryNamespace]:
+        """List namespaces with pagination."""
         if not self.relational:
             raise RuntimeError("Relational backend not configured")
-        return await self.relational.list_namespaces(workspace_id)
+        return await self.relational.list_namespaces(active_only=active_only, limit=limit, offset=offset)
 
     async def update_namespace(self, namespace: MemoryNamespace) -> MemoryNamespace:
         """Update a namespace."""
@@ -343,18 +307,13 @@ class StorageCoordinator:
 
     async def create_namespace_version(
         self,
-        workspace_id: UUID,
         slug: str,
         *,
         previous_version: MemoryNamespace | None = None,
     ) -> MemoryNamespace:
         """Create a new version of a namespace.
 
-        If previous_version is provided, increments its version number and links to it.
-        The previous version is marked as inactive.
-
         Args:
-            workspace_id: Workspace ID
             slug: Namespace slug
             previous_version: The previous version to supersede (if any)
 
@@ -363,7 +322,7 @@ class StorageCoordinator:
         """
         if not self.relational:
             raise RuntimeError("Relational backend not configured")
-        return await self.relational.create_namespace_version(workspace_id, slug, previous_version=previous_version)
+        return await self.relational.create_namespace_version(slug, previous_version=previous_version)
 
     async def deactivate_namespace(self, namespace_id: UUID) -> None:
         """Mark a namespace version as inactive.

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -29,6 +29,7 @@ from khora.core.models import (
     MemoryNamespace,
     Relationship,
 )
+from khora.storage.backends.base import PaginatedResult
 from khora.telemetry import get_collector, trace_span
 
 if TYPE_CHECKING:
@@ -293,7 +294,7 @@ class StorageCoordinator:
 
     async def list_namespaces(
         self, *, active_only: bool = True, limit: int = 100, offset: int = 0
-    ) -> list[MemoryNamespace]:
+    ) -> PaginatedResult[MemoryNamespace]:
         """List namespaces with pagination."""
         if not self.relational:
             raise RuntimeError("Relational backend not configured")

--- a/tests/unit/test_acl.py
+++ b/tests/unit/test_acl.py
@@ -1,0 +1,324 @@
+"""Tests for ACL checker and enforcer."""
+
+from uuid import uuid4
+
+import pytest
+
+from khora.acl.checker import ACLChecker, Permission, PermissionGrant, Principal
+from khora.acl.enforcer import ACLContext, ACLEnforcer, ACLError
+
+
+@pytest.mark.unit
+class TestPermissionOrdering:
+    """Permission enum supports comparison operators."""
+
+    def test_read_less_than_write(self):
+        assert Permission.READ < Permission.WRITE
+
+    def test_write_less_than_admin(self):
+        assert Permission.WRITE < Permission.ADMIN
+
+    def test_admin_less_than_owner(self):
+        assert Permission.ADMIN < Permission.OWNER
+
+    def test_owner_is_highest(self):
+        assert Permission.OWNER >= Permission.READ
+        assert Permission.OWNER >= Permission.WRITE
+        assert Permission.OWNER >= Permission.ADMIN
+
+    def test_same_permission_equal(self):
+        assert Permission.READ >= Permission.READ
+        assert Permission.READ <= Permission.READ
+        assert not (Permission.READ > Permission.READ)
+        assert not (Permission.READ < Permission.READ)
+
+
+@pytest.mark.unit
+class TestPrincipal:
+    """Principal factory methods."""
+
+    def test_user_principal(self):
+        p = Principal.user("alice")
+        assert p.principal_type == "user"
+        assert p.principal_id == "alice"
+
+    def test_role_principal(self):
+        p = Principal.role("admin")
+        assert p.principal_type == "role"
+        assert p.principal_id == "admin"
+
+    def test_api_key_principal(self):
+        p = Principal.api_key("key-123")
+        assert p.principal_type == "api_key"
+        assert p.principal_id == "key-123"
+
+    def test_system_principal(self):
+        p = Principal.system()
+        assert p.principal_type == "system"
+        assert p.principal_id == "system"
+
+
+@pytest.mark.unit
+class TestACLChecker:
+    """ACLChecker grant, revoke, and check operations."""
+
+    def test_direct_grant_allows_access(self):
+        checker = ACLChecker()
+        ns_id = uuid4()
+        user = Principal.user("alice")
+        checker.grant(user, "namespace", ns_id, Permission.READ)
+
+        assert checker.check(user, "namespace", ns_id, Permission.READ) is True
+
+    def test_no_grant_denies_access(self):
+        checker = ACLChecker()
+        ns_id = uuid4()
+        user = Principal.user("bob")
+
+        assert checker.check(user, "namespace", ns_id, Permission.READ) is False
+
+    def test_higher_grant_satisfies_lower_requirement(self):
+        checker = ACLChecker()
+        ns_id = uuid4()
+        user = Principal.user("alice")
+        checker.grant(user, "namespace", ns_id, Permission.ADMIN)
+
+        assert checker.check(user, "namespace", ns_id, Permission.READ) is True
+        assert checker.check(user, "namespace", ns_id, Permission.WRITE) is True
+
+    def test_lower_grant_does_not_satisfy_higher_requirement(self):
+        checker = ACLChecker()
+        ns_id = uuid4()
+        user = Principal.user("alice")
+        checker.grant(user, "namespace", ns_id, Permission.READ)
+
+        assert checker.check(user, "namespace", ns_id, Permission.WRITE) is False
+
+    def test_system_principal_always_has_access(self):
+        checker = ACLChecker()
+        ns_id = uuid4()
+        system = Principal.system()
+
+        assert checker.check(system, "namespace", ns_id, Permission.OWNER) is True
+
+    def test_grant_returns_permission_grant(self):
+        checker = ACLChecker()
+        ns_id = uuid4()
+        user = Principal.user("alice")
+        grant = checker.grant(user, "namespace", ns_id, Permission.WRITE)
+
+        assert isinstance(grant, PermissionGrant)
+        assert grant.permission == Permission.WRITE
+        assert grant.resource_id == ns_id
+
+    def test_revoke_removes_grant(self):
+        checker = ACLChecker()
+        ns_id = uuid4()
+        user = Principal.user("alice")
+        checker.grant(user, "namespace", ns_id, Permission.READ)
+        revoked = checker.revoke(user, "namespace", ns_id, Permission.READ)
+
+        assert revoked == 1
+        assert checker.check(user, "namespace", ns_id, Permission.READ) is False
+
+    def test_revoke_all_permissions(self):
+        checker = ACLChecker()
+        ns_id = uuid4()
+        user = Principal.user("alice")
+        checker.grant(user, "namespace", ns_id, Permission.READ)
+        checker.grant(user, "namespace", ns_id, Permission.WRITE)
+        revoked = checker.revoke(user, "namespace", ns_id)
+
+        assert revoked == 2
+        assert checker.check(user, "namespace", ns_id, Permission.READ) is False
+
+    def test_revoke_nonexistent_returns_zero(self):
+        checker = ACLChecker()
+        ns_id = uuid4()
+        user = Principal.user("nobody")
+
+        assert checker.revoke(user, "namespace", ns_id) == 0
+
+    def test_grants_scoped_to_resource(self):
+        checker = ACLChecker()
+        ns1 = uuid4()
+        ns2 = uuid4()
+        user = Principal.user("alice")
+        checker.grant(user, "namespace", ns1, Permission.READ)
+
+        assert checker.check(user, "namespace", ns1, Permission.READ) is True
+        assert checker.check(user, "namespace", ns2, Permission.READ) is False
+
+    def test_grants_scoped_to_principal(self):
+        checker = ACLChecker()
+        ns_id = uuid4()
+        alice = Principal.user("alice")
+        bob = Principal.user("bob")
+        checker.grant(alice, "namespace", ns_id, Permission.WRITE)
+
+        assert checker.check(alice, "namespace", ns_id, Permission.WRITE) is True
+        assert checker.check(bob, "namespace", ns_id, Permission.WRITE) is False
+
+    def test_get_effective_permissions(self):
+        checker = ACLChecker()
+        ns_id = uuid4()
+        user = Principal.user("alice")
+        checker.grant(user, "namespace", ns_id, Permission.READ)
+        checker.grant(user, "namespace", ns_id, Permission.WRITE)
+
+        effective = checker.get_effective_permissions(user, "namespace", ns_id)
+        assert len(effective) == 2
+        perms = {g.permission for g in effective}
+        assert perms == {Permission.READ, Permission.WRITE}
+
+    def test_list_grants_filter_by_principal(self):
+        checker = ACLChecker()
+        ns_id = uuid4()
+        alice = Principal.user("alice")
+        bob = Principal.user("bob")
+        checker.grant(alice, "namespace", ns_id, Permission.READ)
+        checker.grant(bob, "namespace", ns_id, Permission.WRITE)
+
+        grants = checker.list_grants(principal=alice)
+        assert len(grants) == 1
+        assert grants[0].principal.principal_id == "alice"
+
+    def test_list_grants_filter_by_resource_type(self):
+        checker = ACLChecker()
+        ns_id = uuid4()
+        user = Principal.user("alice")
+        checker.grant(user, "namespace", ns_id, Permission.READ)
+
+        grants = checker.list_grants(resource_type="namespace")
+        assert len(grants) == 1
+
+        grants = checker.list_grants(resource_type="other")
+        assert len(grants) == 0
+
+
+@pytest.mark.unit
+class TestACLEnforcer:
+    """ACLEnforcer permission checking and enforcement."""
+
+    def test_check_permission_granted(self):
+        enforcer = ACLEnforcer()
+        ns_id = uuid4()
+        user = Principal.user("alice")
+        enforcer.checker.grant(user, "namespace", ns_id, Permission.READ)
+        ctx = ACLContext(principal=user, namespace_id=ns_id)
+
+        assert enforcer.check_permission(ctx, "namespace", ns_id, Permission.READ) is True
+
+    def test_check_permission_denied_raises_acl_error(self):
+        enforcer = ACLEnforcer()
+        ns_id = uuid4()
+        user = Principal.user("bob")
+        ctx = ACLContext(principal=user, namespace_id=ns_id)
+
+        with pytest.raises(ACLError) as exc_info:
+            enforcer.check_permission(ctx, "namespace", ns_id, Permission.READ)
+
+        assert exc_info.value.principal == user
+        assert exc_info.value.resource_type == "namespace"
+        assert exc_info.value.resource_id == ns_id
+        assert exc_info.value.required_permission == Permission.READ
+
+    def test_disabled_enforcer_always_permits(self):
+        enforcer = ACLEnforcer()
+        enforcer.disable()
+        ns_id = uuid4()
+        user = Principal.user("nobody")
+        ctx = ACLContext(principal=user)
+
+        assert enforcer.check_permission(ctx, "namespace", ns_id, Permission.OWNER) is True
+        assert enforcer.enabled is False
+
+    def test_enable_re_enables_enforcement(self):
+        enforcer = ACLEnforcer()
+        enforcer.disable()
+        enforcer.enable()
+
+        assert enforcer.enabled is True
+
+    def test_check_namespace_read(self):
+        enforcer = ACLEnforcer()
+        ns_id = uuid4()
+        user = Principal.user("alice")
+        enforcer.checker.grant(user, "namespace", ns_id, Permission.READ)
+        ctx = ACLContext(principal=user)
+
+        assert enforcer.check_namespace_read(ctx, ns_id) is True
+
+    def test_check_namespace_write_denied(self):
+        enforcer = ACLEnforcer()
+        ns_id = uuid4()
+        user = Principal.user("alice")
+        enforcer.checker.grant(user, "namespace", ns_id, Permission.READ)
+        ctx = ACLContext(principal=user)
+
+        with pytest.raises(ACLError):
+            enforcer.check_namespace_write(ctx, ns_id)
+
+    def test_check_namespace_admin(self):
+        enforcer = ACLEnforcer()
+        ns_id = uuid4()
+        user = Principal.user("alice")
+        enforcer.checker.grant(user, "namespace", ns_id, Permission.ADMIN)
+        ctx = ACLContext(principal=user)
+
+        assert enforcer.check_namespace_admin(ctx, ns_id) is True
+
+    def test_system_principal_bypasses_enforcer(self):
+        enforcer = ACLEnforcer()
+        ns_id = uuid4()
+        system = Principal.system()
+        ctx = ACLContext(principal=system)
+
+        assert enforcer.check_permission(ctx, "namespace", ns_id, Permission.OWNER) is True
+
+    def test_custom_checker_injected(self):
+        checker = ACLChecker()
+        enforcer = ACLEnforcer(checker=checker)
+        assert enforcer.checker is checker
+
+
+@pytest.mark.unit
+class TestACLEnforcerRequireDecorator:
+    """ACLEnforcer.require() decorator."""
+
+    async def test_require_permits_authorized_call(self):
+        enforcer = ACLEnforcer()
+        ns_id = uuid4()
+        user = Principal.user("alice")
+        enforcer.checker.grant(user, "namespace", ns_id, Permission.WRITE)
+        ctx = ACLContext(principal=user)
+
+        @enforcer.require("namespace", Permission.WRITE)
+        async def create_doc(context: ACLContext, namespace_id=None):
+            return "ok"
+
+        result = await create_doc(context=ctx, namespace_id=ns_id)
+        assert result == "ok"
+
+    async def test_require_blocks_unauthorized_call(self):
+        enforcer = ACLEnforcer()
+        ns_id = uuid4()
+        user = Principal.user("bob")
+        ctx = ACLContext(principal=user)
+
+        @enforcer.require("namespace", Permission.WRITE)
+        async def create_doc(context: ACLContext, namespace_id=None):
+            return "ok"
+
+        with pytest.raises(ACLError):
+            await create_doc(context=ctx, namespace_id=ns_id)
+
+    async def test_require_raises_value_error_on_missing_params(self):
+        enforcer = ACLEnforcer()
+
+        @enforcer.require("namespace", Permission.READ)
+        async def some_func():
+            return "ok"
+
+        with pytest.raises(ValueError, match="Missing required parameter"):
+            await some_func()

--- a/tests/unit/test_config_resolver.py
+++ b/tests/unit/test_config_resolver.py
@@ -1,0 +1,199 @@
+"""Tests for ConfigResolver."""
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from khora.config.resolver import ConfigResolver, ResolvedConfig
+
+
+@dataclass
+class _FakeNamespace:
+    """Minimal namespace stub for testing."""
+
+    id: Any = None
+    name: str = "test-ns"
+    config_overrides: dict[str, Any] = field(default_factory=dict)
+
+
+@pytest.mark.unit
+class TestResolvedConfig:
+    """ResolvedConfig data access."""
+
+    def test_get_existing_key(self):
+        rc = ResolvedConfig(values={"a": 1}, sources={"a": "global"})
+        assert rc.get("a") == 1
+
+    def test_get_missing_key_returns_default(self):
+        rc = ResolvedConfig()
+        assert rc.get("missing") is None
+        assert rc.get("missing", 42) == 42
+
+    def test_get_source(self):
+        rc = ResolvedConfig(values={"a": 1}, sources={"a": "namespace"})
+        assert rc.get_source("a") == "namespace"
+        assert rc.get_source("missing") is None
+
+
+@pytest.mark.unit
+class TestConfigResolverGlobalOnly:
+    """Resolution with global config only (no storage)."""
+
+    async def test_global_config_returned_when_no_storage(self):
+        resolver = ConfigResolver(global_config={"chunk_size": 256, "model": "gpt-4o"})
+        ns_id = uuid4()
+
+        result = await resolver.resolve_for_namespace(ns_id)
+
+        assert result.get("chunk_size") == 256
+        assert result.get("model") == "gpt-4o"
+        assert result.get_source("chunk_size") == "global"
+        assert result.get_source("model") == "global"
+
+    async def test_empty_global_config(self):
+        resolver = ConfigResolver()
+        ns_id = uuid4()
+
+        result = await resolver.resolve_for_namespace(ns_id)
+
+        assert result.values == {}
+        assert result.sources == {}
+
+
+@pytest.mark.unit
+class TestConfigResolverNamespaceOverride:
+    """Resolution with namespace overrides from storage."""
+
+    async def test_namespace_overrides_global(self):
+        fake_ns = _FakeNamespace(config_overrides={"chunk_size": 1024, "custom_key": "ns_val"})
+        storage = AsyncMock()
+        storage.get_namespace = AsyncMock(return_value=fake_ns)
+        resolver = ConfigResolver(storage=storage, global_config={"chunk_size": 256, "model": "gpt-4o"})
+        ns_id = uuid4()
+
+        result = await resolver.resolve_for_namespace(ns_id)
+
+        assert result.get("chunk_size") == 1024
+        assert result.get_source("chunk_size") == "namespace"
+        assert result.get("model") == "gpt-4o"
+        assert result.get_source("model") == "global"
+        assert result.get("custom_key") == "ns_val"
+        assert result.get_source("custom_key") == "namespace"
+
+    async def test_namespace_not_found_falls_back_to_global(self):
+        storage = AsyncMock()
+        storage.get_namespace = AsyncMock(return_value=None)
+        resolver = ConfigResolver(storage=storage, global_config={"chunk_size": 256})
+        ns_id = uuid4()
+
+        result = await resolver.resolve_for_namespace(ns_id)
+
+        assert result.get("chunk_size") == 256
+        assert result.get_source("chunk_size") == "global"
+
+    async def test_namespace_with_no_overrides(self):
+        fake_ns = _FakeNamespace(config_overrides={})
+        storage = AsyncMock()
+        storage.get_namespace = AsyncMock(return_value=fake_ns)
+        resolver = ConfigResolver(storage=storage, global_config={"model": "gpt-4o"})
+        ns_id = uuid4()
+
+        result = await resolver.resolve_for_namespace(ns_id)
+
+        assert result.get("model") == "gpt-4o"
+        assert result.get_source("model") == "global"
+
+    async def test_keys_filter_limits_resolved_keys(self):
+        fake_ns = _FakeNamespace(config_overrides={"chunk_size": 1024, "model": "claude"})
+        storage = AsyncMock()
+        storage.get_namespace = AsyncMock(return_value=fake_ns)
+        resolver = ConfigResolver(storage=storage, global_config={"chunk_size": 256, "model": "gpt-4o", "extra": True})
+        ns_id = uuid4()
+
+        result = await resolver.resolve_for_namespace(ns_id, keys=["chunk_size"])
+
+        assert result.get("chunk_size") == 1024
+        assert result.get("model") is None
+        assert result.get("extra") is None
+
+
+@pytest.mark.unit
+class TestConfigResolverImmediate:
+    """resolve_immediate() without storage lookup."""
+
+    def test_global_only(self):
+        resolver = ConfigResolver(global_config={"a": 1})
+        result = resolver.resolve_immediate()
+
+        assert result.get("a") == 1
+        assert result.get_source("a") == "global"
+
+    def test_namespace_overrides_global(self):
+        resolver = ConfigResolver(global_config={"a": 1, "b": 2})
+        result = resolver.resolve_immediate(namespace_config={"a": 10, "c": 3})
+
+        assert result.get("a") == 10
+        assert result.get_source("a") == "namespace"
+        assert result.get("b") == 2
+        assert result.get_source("b") == "global"
+        assert result.get("c") == 3
+        assert result.get_source("c") == "namespace"
+
+    def test_explicit_global_overrides_init_global(self):
+        resolver = ConfigResolver(global_config={"a": 1})
+        result = resolver.resolve_immediate(global_config={"a": 99})
+
+        assert result.get("a") == 99
+
+    def test_empty_inputs(self):
+        resolver = ConfigResolver()
+        result = resolver.resolve_immediate()
+
+        assert result.values == {}
+        assert result.sources == {}
+
+
+@pytest.mark.unit
+class TestConfigResolverHelpers:
+    """get_pipeline_config() and get_llm_config() helpers."""
+
+    def test_pipeline_config_defaults(self):
+        resolver = ConfigResolver()
+        resolved = ResolvedConfig()
+        pipeline = resolver.get_pipeline_config(resolved)
+
+        assert pipeline["chunking_strategy"] == "semantic"
+        assert pipeline["chunk_size"] == 512
+        assert pipeline["chunk_overlap"] == 50
+        assert pipeline["embedding_model"] == "text-embedding-3-small"
+        assert pipeline["extraction_model"] == "gpt-4o-mini"
+        assert pipeline["extraction_skill"] == "general_entities"
+
+    def test_pipeline_config_overridden(self):
+        resolver = ConfigResolver()
+        resolved = ResolvedConfig(values={"chunk_size": 1024, "embedding_model": "custom-embed"})
+        pipeline = resolver.get_pipeline_config(resolved)
+
+        assert pipeline["chunk_size"] == 1024
+        assert pipeline["embedding_model"] == "custom-embed"
+
+    def test_llm_config_defaults(self):
+        resolver = ConfigResolver()
+        resolved = ResolvedConfig()
+        llm = resolver.get_llm_config(resolved)
+
+        assert llm["model"] == "gpt-4o-mini"
+        assert llm["temperature"] == 0.7
+        assert llm["max_tokens"] == 2000
+        assert llm["timeout"] == 30
+
+    def test_llm_config_overridden(self):
+        resolver = ConfigResolver()
+        resolved = ResolvedConfig(values={"llm_model": "claude", "llm_temperature": 0.0})
+        llm = resolver.get_llm_config(resolved)
+
+        assert llm["model"] == "claude"
+        assert llm["temperature"] == 0.0

--- a/tests/unit/test_memory_lake.py
+++ b/tests/unit/test_memory_lake.py
@@ -303,34 +303,23 @@ class TestResolveNamespace:
 
     @pytest.mark.asyncio
     async def test_slug_lookup(self) -> None:
-        """Non-UUID string looks up namespace by slug."""
+        """Non-UUID string looks up namespace by slug (globally unique)."""
         lake = _make_lake(connected=True)
-        default_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=default_id)
-
-        mock_ns = MagicMock()
-        mock_ns.workspace_id = uuid4()
 
         found_ns = MagicMock()
         found_ns.id = uuid4()
 
-        lake._engine._storage.get_namespace = AsyncMock(return_value=mock_ns)
         lake._engine._storage.get_namespace_by_slug = AsyncMock(return_value=found_ns)
 
         result = await lake._resolve_namespace("my-namespace")
         assert result == found_ns.id
+        lake._engine._storage.get_namespace_by_slug.assert_awaited_once_with("my-namespace")
 
     @pytest.mark.asyncio
     async def test_slug_not_found_raises(self) -> None:
         """Non-UUID string that doesn't exist raises ValueError."""
         lake = _make_lake(connected=True)
-        default_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=default_id)
 
-        mock_ns = MagicMock()
-        mock_ns.workspace_id = uuid4()
-
-        lake._engine._storage.get_namespace = AsyncMock(return_value=mock_ns)
         lake._engine._storage.get_namespace_by_slug = AsyncMock(return_value=None)
 
         with pytest.raises(ValueError, match="Namespace not found"):
@@ -533,14 +522,13 @@ class TestNamespaceManagement:
 
     @pytest.mark.asyncio
     async def test_create_namespace(self) -> None:
-        """create_namespace delegates to engine."""
+        """create_namespace delegates to engine without workspace_id."""
         lake = _make_lake(connected=True)
-        ws_id = uuid4()
 
         mock_ns = MagicMock()
         lake._engine.create_namespace = AsyncMock(return_value=mock_ns)
 
-        result = await lake.create_namespace("test-ns", ws_id, description="Test")
+        result = await lake.create_namespace("test-ns", description="Test")
         assert result is mock_ns
         lake._engine.create_namespace.assert_awaited_once()
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -9,7 +9,7 @@ from khora.core.models import Chunk, Document, Entity, Relationship
 from khora.core.models.document import ChunkMetadata, DocumentMetadata, DocumentStatus
 from khora.core.models.entity import EntityType, Episode, RelationshipType
 from khora.core.models.event import EventType, MemoryEvent
-from khora.core.models.tenancy import MemoryNamespace, Organization, TenancyMode, Workspace
+from khora.core.models.tenancy import MemoryNamespace, TenancyMode
 
 
 class TestDocument:
@@ -375,88 +375,53 @@ class TestMemoryEvent:
 
 
 class TestTenancyModels:
-    """Tests for tenancy models (Organization, Workspace, MemoryNamespace)."""
-
-    def test_create_organization(self) -> None:
-        """Test organization creation."""
-        org = Organization(name="Acme Inc", slug="acme")
-        assert org.name == "Acme Inc"
-        assert org.slug == "acme"
-
-    def test_organization_auto_slug(self) -> None:
-        """Test organization auto-generates slug from name."""
-        org = Organization(name="Test Organization")
-        assert org.slug == "test-organization"
-
-    def test_organization_tenancy_mode(self) -> None:
-        """Test organization tenancy mode."""
-        org = Organization(name="Test", tenancy_mode=TenancyMode.ISOLATED)
-        assert org.tenancy_mode == TenancyMode.ISOLATED
-
-    def test_organization_with_metadata(self) -> None:
-        """Test organization with metadata."""
-        org = Organization(
-            name="Test Org",
-            slug="test",
-            metadata={"feature_x": True},
-        )
-        assert org.metadata["feature_x"] is True
-
-    def test_create_workspace(self) -> None:
-        """Test workspace creation."""
-        org_id = uuid4()
-        ws = Workspace(organization_id=org_id, name="Engineering", slug="engineering")
-        assert ws.name == "Engineering"
-        assert ws.organization_id == org_id
-
-    def test_workspace_auto_slug(self) -> None:
-        """Test workspace auto-generates slug from name."""
-        ws = Workspace(organization_id=uuid4(), name="My Workspace")
-        assert ws.slug == "my-workspace"
-
-    def test_workspace_with_description(self) -> None:
-        """Test workspace with description."""
-        ws = Workspace(
-            organization_id=uuid4(),
-            name="Sales",
-            slug="sales",
-            description="Sales team workspace",
-        )
-        assert ws.description == "Sales team workspace"
+    """Tests for tenancy models (MemoryNamespace)."""
 
     def test_create_namespace(self) -> None:
-        """Test namespace creation."""
-        ws_id = uuid4()
-        ns = MemoryNamespace(workspace_id=ws_id, name="Project Alpha", slug="project-alpha")
+        """Test namespace creation without workspace_id."""
+        ns = MemoryNamespace(name="Project Alpha", slug="project-alpha")
         assert ns.name == "Project Alpha"
-        assert ns.workspace_id == ws_id
+        assert ns.slug == "project-alpha"
+        assert ns.id is not None
 
     def test_namespace_auto_slug(self) -> None:
         """Test namespace auto-generates slug from name."""
-        ns = MemoryNamespace(workspace_id=uuid4(), name="My Project")
+        ns = MemoryNamespace(name="My Project")
         assert ns.slug == "my-project"
 
     def test_namespace_with_config(self) -> None:
         """Test namespace with configuration overrides."""
         ns = MemoryNamespace(
-            workspace_id=uuid4(),
             name="Test",
             slug="test",
             config_overrides={"extraction_skill": "technical_docs"},
         )
         assert ns.config_overrides["extraction_skill"] == "technical_docs"
 
-    def test_namespace_full_path(self) -> None:
-        """Test namespace full path property."""
-        ws_id = uuid4()
-        ns = MemoryNamespace(workspace_id=ws_id, name="Test", slug="test-ns")
-        assert ns.full_path == f"{ws_id}/test-ns"
-
     def test_namespace_sync_checkpoints(self) -> None:
         """Test namespace sync checkpoints."""
         ns = MemoryNamespace(
-            workspace_id=uuid4(),
             name="Test",
             sync_checkpoints={"source1": "checkpoint123"},
         )
         assert ns.sync_checkpoints["source1"] == "checkpoint123"
+
+    def test_namespace_tenancy_mode_defaults_to_shared(self) -> None:
+        """Test that MemoryNamespace.tenancy_mode defaults to SHARED."""
+        ns = MemoryNamespace(name="Test")
+        assert ns.tenancy_mode == TenancyMode.SHARED
+
+    def test_namespace_tenancy_mode_isolated(self) -> None:
+        """Test that MemoryNamespace.tenancy_mode can be set to ISOLATED."""
+        ns = MemoryNamespace(name="Test", tenancy_mode=TenancyMode.ISOLATED)
+        assert ns.tenancy_mode == TenancyMode.ISOLATED
+
+    def test_namespace_no_workspace_id_attribute(self) -> None:
+        """Test that MemoryNamespace no longer has workspace_id."""
+        ns = MemoryNamespace(name="Test")
+        assert not hasattr(ns, "workspace_id")
+
+    def test_namespace_no_full_path_attribute(self) -> None:
+        """Test that MemoryNamespace no longer has full_path."""
+        ns = MemoryNamespace(name="Test")
+        assert not hasattr(ns, "full_path")


### PR DESCRIPTION
## Summary

Removes the Organization → Workspace → Namespace hierarchy, making namespace the sole data isolation boundary. This is a breaking change for the storage layer API.

- **Deleted** `Organization` and `Workspace` models, ORM classes, and all CRUD operations across storage backends, coordinator, and protocol
- **Updated** `MemoryNamespace`: removed `workspace_id` FK, added `tenancy_mode` field, removed `full_path` property
- **Simplified** ACL to namespace-only: removed 4 workspace/org check methods, hierarchy walk-up logic, and `parent_ids` inheritance
- **Reduced** ConfigResolver from 4-tier to 2-tier (global → namespace), saving 2 DB queries per `remember()`/`recall()` call
- **Updated** all 3 engines (graphrag, skeleton, vectorcypher) to remove org/workspace references
- **Added** pagination to `list_namespaces()` with `limit`/`offset` params (ordered by `id`)
- **Created** 10-step Alembic migration with slug collision pre-check, permission row cleanup, index rebuilds, and table drops
- **Removed** `inherited_from_type`/`inherited_from_id` from `PermissionModel` (no hierarchy = no inheritance)

**20 files changed**: 18 source + 1 migration + 1 PRD | -581 net lines of code

### Breaking changes

| Change | Migration path |
|--------|---------------|
| `create_namespace()` / `create_namespace_version()` lose `workspace_id` | Remove the argument |
| `get_namespace_by_slug()` loses `workspace_id` | Remove the argument |
| `list_namespaces()` loses `workspace_id`, gains `limit`/`offset` | Update signature |
| `Organization` / `Workspace` classes removed | Delete imports |
| `MemoryNamespace.full_path` removed | Use `.slug` |
| ACL `check_workspace_*` / `check_organization_*` removed | Use `check_namespace_*` |
| `ConfigResolver.resolve_immediate()` loses org/workspace params | Remove params |
| DB: `organizations` / `workspaces` tables dropped | Run migration |

## Test plan

- [x] Unit tests pass (1376 passed, 4 skipped)
- [x] Coverage: 52.32% (≥30% threshold)
- [x] `make lint` passes clean
- [x] `ty check src/` passes (only pre-existing optional dep warnings)
- [ ] Manual: run migration against dev database with `uv run alembic upgrade head`
- [ ] Downstream: update genesis, peras, khora-benchmarks before deploying

PRD: `docs/prds/DYT-220-flatten-namespace-hierarchy.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)