### PR TITLE
DYT-226: Fix Alembic migrations failing on fresh database

### DIFF
--- a/alembic/versions/003_flexible_type_columns.py
+++ b/alembic/versions/003_flexible_type_columns.py
@@ -26,6 +26,11 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    # Drop column defaults that reference the enum types before converting,
+    # otherwise PostgreSQL refuses to DROP TYPE due to dependent defaults.
+    op.execute("ALTER TABLE entities ALTER COLUMN entity_type DROP DEFAULT")
+    op.execute("ALTER TABLE relationships ALTER COLUMN relationship_type DROP DEFAULT")
+
     # Convert entity_type from enum to varchar
     op.execute("""
         ALTER TABLE entities

--- a/alembic/versions/005_index_improvements.py
+++ b/alembic/versions/005_index_improvements.py
@@ -12,6 +12,7 @@ Adds:
 
 from collections.abc import Sequence
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -22,21 +23,35 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    # GIN index on tags for array containment queries (@>, &&)
-    op.execute("CREATE INDEX IF NOT EXISTS ix_khora_chunks_tags_gin " "ON khora_chunks USING GIN (tags)")
-
-    # Composite index for temporal filtering within namespace
-    op.execute("CREATE INDEX IF NOT EXISTS ix_khora_chunks_ns_occurred " "ON khora_chunks (namespace_id, occurred_at)")
-
-    # Rebuild HNSW index with higher ef_construction for better recall.
-    # ef_construction=128 (up from default 64) improves recall at build time
-    # with negligible query-time cost.
-    op.execute("DROP INDEX IF EXISTS ix_khora_chunks_embedding_hnsw")
-    op.execute(
-        "CREATE INDEX ix_khora_chunks_embedding_hnsw "
-        "ON khora_chunks USING hnsw (embedding vector_cosine_ops) "
-        "WITH (m = 16, ef_construction = 128)"
+    # khora_chunks is created at runtime by the skeleton engine, not by migrations.
+    # Only create indexes if the table already exists.
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT EXISTS ("
+            "  SELECT FROM information_schema.tables"
+            "  WHERE table_name = 'khora_chunks'"
+            ")"
+        )
     )
+    has_khora_chunks = result.scalar()
+
+    if has_khora_chunks:
+        # GIN index on tags for array containment queries (@>, &&)
+        op.execute("CREATE INDEX IF NOT EXISTS ix_khora_chunks_tags_gin " "ON khora_chunks USING GIN (tags)")
+
+        # Composite index for temporal filtering within namespace
+        op.execute("CREATE INDEX IF NOT EXISTS ix_khora_chunks_ns_occurred " "ON khora_chunks (namespace_id, occurred_at)")
+
+        # Rebuild HNSW index with higher ef_construction for better recall.
+        # ef_construction=128 (up from default 64) improves recall at build time
+        # with negligible query-time cost.
+        op.execute("DROP INDEX IF EXISTS ix_khora_chunks_embedding_hnsw")
+        op.execute(
+            "CREATE INDEX ix_khora_chunks_embedding_hnsw "
+            "ON khora_chunks USING hnsw (embedding vector_cosine_ops) "
+            "WITH (m = 16, ef_construction = 128)"
+        )
 
 
 def downgrade() -> None:

--- a/alembic/versions/005_index_improvements.py
+++ b/alembic/versions/005_index_improvements.py
@@ -13,6 +13,7 @@ Adds:
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -27,12 +28,7 @@ def upgrade() -> None:
     # Only create indexes if the table already exists.
     conn = op.get_bind()
     result = conn.execute(
-        sa.text(
-            "SELECT EXISTS ("
-            "  SELECT FROM information_schema.tables"
-            "  WHERE table_name = 'khora_chunks'"
-            ")"
-        )
+        sa.text("SELECT EXISTS (" "  SELECT FROM information_schema.tables" "  WHERE table_name = 'khora_chunks'" ")")
     )
     has_khora_chunks = result.scalar()
 
@@ -41,7 +37,9 @@ def upgrade() -> None:
         op.execute("CREATE INDEX IF NOT EXISTS ix_khora_chunks_tags_gin " "ON khora_chunks USING GIN (tags)")
 
         # Composite index for temporal filtering within namespace
-        op.execute("CREATE INDEX IF NOT EXISTS ix_khora_chunks_ns_occurred " "ON khora_chunks (namespace_id, occurred_at)")
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS ix_khora_chunks_ns_occurred " "ON khora_chunks (namespace_id, occurred_at)"
+        )
 
         # Rebuild HNSW index with higher ef_construction for better recall.
         # ef_construction=128 (up from default 64) improves recall at build time

--- a/alembic/versions/007_hnsw_parameter_tuning.py
+++ b/alembic/versions/007_hnsw_parameter_tuning.py
@@ -69,21 +69,27 @@ def upgrade() -> None:
         op.execute(text("ALTER INDEX IF EXISTS ix_entities_embedding_hnsw_v2 RENAME TO ix_entities_embedding_hnsw"))
 
     # --- khora_chunks HNSW index (skeleton engine backend) ---
+    # khora_chunks is created at runtime by the skeleton engine; skip if absent.
     # ef_construction was already 128 from migration 005; only m changes 16 -> 24.
-    with op.get_context().autocommit_block():
-        op.execute(
-            text(
-                "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_khora_chunks_embedding_hnsw_v2 "
-                "ON khora_chunks USING hnsw (embedding vector_cosine_ops) "
-                "WITH (m = 24, ef_construction = 128)"
+    conn = op.get_bind()
+    has_khora_chunks = conn.execute(
+        text("SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'khora_chunks')")
+    ).scalar()
+    if has_khora_chunks:
+        with op.get_context().autocommit_block():
+            op.execute(
+                text(
+                    "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_khora_chunks_embedding_hnsw_v2 "
+                    "ON khora_chunks USING hnsw (embedding vector_cosine_ops) "
+                    "WITH (m = 24, ef_construction = 128)"
+                )
             )
-        )
-    with op.get_context().autocommit_block():
-        op.execute(text("DROP INDEX CONCURRENTLY IF EXISTS ix_khora_chunks_embedding_hnsw"))
-    with op.get_context().autocommit_block():
-        op.execute(
-            text("ALTER INDEX IF EXISTS ix_khora_chunks_embedding_hnsw_v2 " "RENAME TO ix_khora_chunks_embedding_hnsw")
-        )
+        with op.get_context().autocommit_block():
+            op.execute(text("DROP INDEX CONCURRENTLY IF EXISTS ix_khora_chunks_embedding_hnsw"))
+        with op.get_context().autocommit_block():
+            op.execute(
+                text("ALTER INDEX IF EXISTS ix_khora_chunks_embedding_hnsw_v2 RENAME TO ix_khora_chunks_embedding_hnsw")
+            )
 
 
 def downgrade() -> None:

--- a/alembic/versions/008_entity_dedup_and_indexes.py
+++ b/alembic/versions/008_entity_dedup_and_indexes.py
@@ -161,7 +161,9 @@ def upgrade() -> None:
         text("SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'khora_chunks')")
     ).scalar()
     if has_khora_chunks:
-        op.execute(text("CREATE INDEX IF NOT EXISTS ix_khora_chunks_ns_doc " "ON khora_chunks (namespace_id, document_id)"))
+        op.execute(
+            text("CREATE INDEX IF NOT EXISTS ix_khora_chunks_ns_doc " "ON khora_chunks (namespace_id, document_id)")
+        )
 
     # =========================================================================
     # 5.5: Entity temporal partial indexes

--- a/alembic/versions/008_entity_dedup_and_indexes.py
+++ b/alembic/versions/008_entity_dedup_and_indexes.py
@@ -156,7 +156,12 @@ def upgrade() -> None:
     # =========================================================================
     # 5.3: khora_chunks composite index
     # =========================================================================
-    op.execute(text("CREATE INDEX IF NOT EXISTS ix_khora_chunks_ns_doc " "ON khora_chunks (namespace_id, document_id)"))
+    conn = op.get_bind()
+    has_khora_chunks = conn.execute(
+        text("SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'khora_chunks')")
+    ).scalar()
+    if has_khora_chunks:
+        op.execute(text("CREATE INDEX IF NOT EXISTS ix_khora_chunks_ns_doc " "ON khora_chunks (namespace_id, document_id)"))
 
     # =========================================================================
     # 5.5: Entity temporal partial indexes


### PR DESCRIPTION
## Summary

- **Migration 003:** Added `DROP DEFAULT` before enum-to-varchar conversion to fix `cannot drop type entity_type` error
- **Migrations 005, 007, 008:** Wrapped `khora_chunks` index operations in table existence guards since the table is created at runtime by the skeleton engine, not by migrations

## Verification

All migrations (000–009) run successfully on a clean database.

## Test plan

- [ ] Drop and recreate the database, run `alembic upgrade head` — all 10 migrations pass
- [ ] Run against an existing database with `khora_chunks` present — indexes are still created

Closes DYT-226

🤖 Generated with [Claude Code](https://claude.com/claude-code)