### PR TITLE
DYT-232: Fix tenacity before_sleep_log crash with loguru

### DIFF
--- a/src/khora/extraction/embedders/litellm.py
+++ b/src/khora/extraction/embedders/litellm.py
@@ -9,7 +9,7 @@ from hashlib import sha256
 from typing import TYPE_CHECKING
 
 from loguru import logger
-from tenacity import AsyncRetrying, before_sleep_log, stop_after_attempt, wait_exponential
+from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential
 
 from .base import Embedder
 
@@ -264,7 +264,11 @@ class LiteLLMEmbedder(Embedder):
         async for attempt in AsyncRetrying(
             stop=stop_after_attempt(self._max_retries),
             wait=wait_exponential(multiplier=self._retry_wait, min=self._retry_wait, max=10),
-            before_sleep=before_sleep_log(logger, "WARNING"),
+            before_sleep=lambda retry_state: logger.opt(depth=1).warning(
+                "Retrying embedding (attempt {}) after {!s}",
+                retry_state.attempt_number,
+                retry_state.outcome.exception() if retry_state.outcome and retry_state.outcome.failed else "unknown",
+            ),
             reraise=True,
         ):
             with attempt:

--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -8,7 +8,7 @@ import re
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
-from tenacity import AsyncRetrying, before_sleep_log, stop_after_attempt, wait_exponential
+from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential
 
 from .base import (
     EntityExtractor,
@@ -647,7 +647,15 @@ class LLMEntityExtractor(EntityExtractor):
             async for attempt in AsyncRetrying(
                 stop=stop_after_attempt(self._max_retries),
                 wait=wait_exponential(multiplier=self._retry_wait, min=self._retry_wait, max=10),
-                before_sleep=before_sleep_log(logger, "WARNING"),
+                before_sleep=lambda retry_state: logger.warning(
+                    "Retrying LLM call (attempt {}) after {!s}",
+                    retry_state.attempt_number,
+                    (
+                        retry_state.outcome.exception()
+                        if retry_state.outcome and retry_state.outcome.failed
+                        else "unknown"
+                    ),
+                ),
                 reraise=True,
             ):
                 with attempt:
@@ -1340,7 +1348,15 @@ Return ONLY valid JSON, no other text."""
             async for attempt in AsyncRetrying(
                 stop=stop_after_attempt(self._max_retries),
                 wait=wait_exponential(multiplier=self._retry_wait, min=self._retry_wait, max=10),
-                before_sleep=before_sleep_log(logger, "WARNING"),
+                before_sleep=lambda retry_state: logger.warning(
+                    "Retrying LLM call (attempt {}) after {!s}",
+                    retry_state.attempt_number,
+                    (
+                        retry_state.outcome.exception()
+                        if retry_state.outcome and retry_state.outcome.failed
+                        else "unknown"
+                    ),
+                ),
                 reraise=True,
             ):
                 with attempt:

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -13,7 +13,7 @@ from uuid import UUID
 from loguru import logger
 from sqlalchemy import delete, func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
-from tenacity import AsyncRetrying, before_sleep_log, retry_if_exception, stop_after_attempt, wait_exponential
+from tenacity import AsyncRetrying, retry_if_exception, stop_after_attempt, wait_exponential
 
 from khora.core.models import Chunk, ChunkMetadata
 from khora.db.models import Base, ChunkModel, EntityModel
@@ -39,7 +39,11 @@ async def _retry_on_deadlock(coro_fn, *args, **kwargs):
         stop=stop_after_attempt(_DEADLOCK_MAX_RETRIES),
         wait=wait_exponential(multiplier=0.1, min=0.1, max=0.4),
         retry=retry_if_exception(lambda e: "deadlock" in str(e).lower()),
-        before_sleep=before_sleep_log(logger, "WARNING"),
+        before_sleep=lambda retry_state: logger.warning(
+            "Retrying after deadlock (attempt {}): {!s}",
+            retry_state.attempt_number,
+            retry_state.outcome.exception() if retry_state.outcome and retry_state.outcome.failed else "unknown",
+        ),
         reraise=True,
     ):
         with attempt:


### PR DESCRIPTION
## Summary
- Replace all `before_sleep_log(logger, "WARNING")` calls with inline lambdas that use loguru's `{!s}` formatting
- Fixes `KeyError: "'error'"` crash when API errors contain curly braces (e.g. JSON responses)
- Affected: embedder retries, LLM extraction retries, pgvector deadlock retries

Linear: https://linear.app/deyta/issue/DYT-232/fix-tenacity-before-sleep-log-crash-with-loguru

## Problem
tenacity's `before_sleep_log` passes exception messages through `str.format()`, and loguru's `logger.log()` does the same. When error responses contain `{...}` (common in JSON API errors), the double-formatting causes a `KeyError` that masks the real error.

## Test plan
- [ ] Run TUI search with missing/invalid `OPENAI_API_KEY` — should show actual API error, not `KeyError: "'error'"`
- [ ] Verify embedding retries log properly on transient failures
- [ ] Verify LLM extraction retries log properly on transient failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)