### PR TITLE
DYT-233: Fix document_status and event_type enum uppercase values

### DIFF
--- a/src/khora/db/models.py
+++ b/src/khora/db/models.py
@@ -177,7 +177,12 @@ class DocumentModel(Base):
     )
     content: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(
-        Enum(DocumentStatus, name="document_status", create_constraint=True),
+        Enum(
+            DocumentStatus,
+            name="document_status",
+            create_constraint=True,
+            values_callable=lambda e: [m.value for m in e],
+        ),
         default=DocumentStatus.PENDING,
         index=True,
     )
@@ -461,7 +466,7 @@ class MemoryEventModel(Base):
         UUID(as_uuid=True), ForeignKey("memory_namespaces.id", ondelete="CASCADE"), nullable=False, index=True
     )
     event_type: Mapped[str] = mapped_column(
-        Enum(EventType, name="event_type", create_constraint=True),
+        Enum(EventType, name="event_type", create_constraint=True, values_callable=lambda e: [m.value for m in e]),
         nullable=False,
         index=True,
     )


### PR DESCRIPTION
## Summary
- Add `values_callable` to `document_status` and `event_type` enum columns in `db/models.py`
- Same fix as DYT-231 (tenancy_mode) — SQLAlchemy sends `.name` (PENDING) instead of `.value` (pending)
- Fixes `invalid input value for enum document_status: "PENDING"` during `genesis create`

Linear: https://linear.app/deyta/issue/DYT-233/fix-document-status-and-event-type-enums-sending-uppercase-instead-of

## Test plan
- [ ] Run `genesis create` — documents should be inserted without enum errors
- [ ] Verify event_type inserts also work with lowercase values

🤖 Generated with [Claude Code](https://claude.com/claude-code)