### PR TITLE
DYT-258: Parameterize entity extraction API

### DIFF
--- a/src/khora/engines/graphrag/engine.py
+++ b/src/khora/engines/graphrag/engine.py
@@ -223,6 +223,8 @@ class GraphRAGEngine:
         source: str = "",
         metadata: dict[str, Any] | None = None,
         skill_name: str = "general_entities",
+        entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -287,6 +289,8 @@ class GraphRAGEngine:
             skill_name=skill_name,
             embedding_model=self._config.llm.embedding_model,
             extraction_model=self._config.llm.extraction_model or self._config.llm.model,
+            entity_types=entity_types,
+            relationship_types=relationship_types,
         )
         timings["pipeline_ms"] = (time.perf_counter() - start) * 1000
         timings["total_ms"] = (time.perf_counter() - total_start) * 1000
@@ -389,6 +393,8 @@ class GraphRAGEngine:
         deduplicate: bool = True,
         infer_relationships: bool = True,
         on_progress: Callable[[int, int], None] | None = None,
+        entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
     ) -> BatchResult:
         """Store multiple documents with automatic optimization.
 
@@ -461,6 +467,8 @@ class GraphRAGEngine:
             shared_embedder=shared_embedder,
             shared_entity_index=shared_entity_index,
             enable_expansion=infer_relationships,
+            entity_types=entity_types,
+            relationship_types=relationship_types,
         )
         timings["ingest_pipeline_ms"] = (time.perf_counter() - start) * 1000
         timings["total_ms"] = (time.perf_counter() - total_start) * 1000

--- a/src/khora/engines/protocol.py
+++ b/src/khora/engines/protocol.py
@@ -54,6 +54,8 @@ class MemoryEngineProtocol(Protocol):
         source: str = "",
         metadata: dict[str, Any] | None = None,
         skill_name: str = "general_entities",
+        entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -64,6 +66,8 @@ class MemoryEngineProtocol(Protocol):
             source: Optional source identifier
             metadata: Optional metadata
             skill_name: Extraction skill to use
+            entity_types: Optional entity types to extract (overrides defaults)
+            relationship_types: Optional relationship types to extract (overrides defaults)
 
         Returns:
             RememberResult with details
@@ -119,6 +123,8 @@ class MemoryEngineProtocol(Protocol):
         deduplicate: bool = True,
         infer_relationships: bool = True,
         on_progress: Callable[[int, int], None] | None = None,
+        entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
     ) -> BatchResult:
         """Store multiple documents with automatic optimization.
 
@@ -130,6 +136,8 @@ class MemoryEngineProtocol(Protocol):
             deduplicate: Deduplicate entities across documents
             infer_relationships: Infer relationships after ingestion
             on_progress: Callback(processed_count, total_count) for progress updates
+            entity_types: Optional entity types to extract (overrides defaults)
+            relationship_types: Optional relationship types to extract (overrides defaults)
 
         Returns:
             BatchResult with aggregated statistics

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -214,6 +214,8 @@ class SkeletonConstructionEngine:
         metadata: dict[str, Any] | None = None,
         skill_name: str = "general_entities",
         occurred_at: datetime | None = None,
+        entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -581,6 +583,8 @@ class SkeletonConstructionEngine:
         deduplicate: bool = True,
         infer_relationships: bool = False,  # Not used in Skeleton Construction engine
         on_progress: Callable[[int, int], None] | None = None,
+        entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
     ) -> BatchResult:
         """Store multiple documents with automatic optimization.
 

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -456,6 +456,8 @@ class VectorCypherEngine:
         expertise: ExpertiseConfig | str | None = None,
         extraction_model: str | None = None,
         occurred_at: datetime | None = None,
+        entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -512,6 +514,8 @@ class VectorCypherEngine:
             expertise=expertise,
             extraction_model=extraction_model,
             occurred_at=occurred_at or datetime.now(UTC),
+            entity_types=entity_types,
+            relationship_types=relationship_types,
         )
 
         return RememberResult(
@@ -530,6 +534,8 @@ class VectorCypherEngine:
         expertise: ExpertiseConfig | str | None = None,
         extraction_model: str | None = None,
         occurred_at: datetime,
+        entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
     ) -> tuple[int, int, int]:
         """Process a document into chunks with skeleton-based entity extraction.
 
@@ -624,6 +630,8 @@ class VectorCypherEngine:
                     skill_name=skill_name,
                     expertise=expertise,
                     extraction_model=extraction_model,
+                    entity_types=entity_types,
+                    relationship_types=relationship_types,
                 )
 
             # Update document status
@@ -648,6 +656,8 @@ class VectorCypherEngine:
         skill_name: str = "general_entities",
         expertise: ExpertiseConfig | str | None = None,
         extraction_model: str | None = None,
+        entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
     ) -> tuple[int, int]:
         """Run skeleton-based entity extraction on core chunks only.
 
@@ -713,6 +723,8 @@ class VectorCypherEngine:
                 expertise=expertise,
                 model=model,
                 max_concurrent=self._vc_config.max_concurrent_extractions,
+                entity_types=entity_types,
+                relationship_types=relationship_types,
             )
 
             if not entities:
@@ -775,6 +787,8 @@ class VectorCypherEngine:
         skill_name: str = "general_entities",
         expertise: ExpertiseConfig | str | None = None,
         extraction_model: str | None = None,
+        entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
     ) -> tuple[list[Entity], list[Relationship], list[EntityChunkLink]]:
         """Run skeleton extraction but return results instead of storing.
 
@@ -829,6 +843,8 @@ class VectorCypherEngine:
             expertise=expertise,
             model=model,
             max_concurrent=self._vc_config.max_concurrent_extractions,
+            entity_types=entity_types,
+            relationship_types=relationship_types,
         )
 
         if not entities:
@@ -864,6 +880,8 @@ class VectorCypherEngine:
         extraction_model: str | None = None,
         occurred_at: datetime,
         embedding_text_override: str | None = None,
+        entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
     ) -> tuple[int, list[Entity], list[Relationship], list[EntityChunkLink]]:
         """Process a document, returning entities for deferred batch storage.
 
@@ -952,6 +970,8 @@ class VectorCypherEngine:
                 skill_name=skill_name,
                 expertise=expertise,
                 extraction_model=extraction_model,
+                entity_types=entity_types,
+                relationship_types=relationship_types,
             )
 
         return len(stored_chunks), entities, relationships, entity_chunk_links
@@ -1170,6 +1190,8 @@ class VectorCypherEngine:
         deduplicate: bool = True,
         infer_relationships: bool = True,
         on_progress: Callable[[int, int], None] | None = None,
+        entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
     ) -> BatchResult:
         """Store multiple documents with automatic optimization.
 
@@ -1315,6 +1337,8 @@ class VectorCypherEngine:
                             extraction_model=extraction_model,
                             occurred_at=occurred_at or datetime.now(UTC),
                             embedding_text_override=context_by_orig.get(doc_index),
+                            entity_types=entity_types,
+                            relationship_types=relationship_types,
                         )
 
                         # Accumulate entities for batch storage
@@ -1345,6 +1369,8 @@ class VectorCypherEngine:
                             expertise=expertise,
                             extraction_model=extraction_model,
                             occurred_at=occurred_at,
+                            entity_types=entity_types,
+                            relationship_types=relationship_types,
                         )
 
                         async with results_lock:

--- a/src/khora/extraction/extractors/base.py
+++ b/src/khora/extraction/extractors/base.py
@@ -90,6 +90,7 @@ class EntityExtractor(ABC):
         text: str,
         *,
         entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
         expertise: ExpertiseConfig | None = None,
         context: dict[str, Any] | None = None,
     ) -> ExtractionResult:
@@ -98,6 +99,7 @@ class EntityExtractor(ABC):
         Args:
             text: Text to extract from
             entity_types: Optional list of entity types to extract
+            relationship_types: Optional list of relationship types to extract
             expertise: Optional ExpertiseConfig for domain-specific extraction
             context: Optional context dict for prompt template rendering
 
@@ -112,6 +114,7 @@ class EntityExtractor(ABC):
         texts: list[str],
         *,
         entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
         expertise: ExpertiseConfig | None = None,
         context: dict[str, Any] | None = None,
     ) -> list[ExtractionResult]:
@@ -120,6 +123,7 @@ class EntityExtractor(ABC):
         Args:
             texts: List of texts to extract from
             entity_types: Optional list of entity types to extract
+            relationship_types: Optional list of relationship types to extract
             expertise: Optional ExpertiseConfig for domain-specific extraction
             context: Optional context dict for prompt template rendering
 

--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -611,6 +611,7 @@ class LLMEntityExtractor(EntityExtractor):
         text: str,
         *,
         entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
         expertise: ExpertiseConfig | None = None,
         context: dict[str, Any] | None = None,
     ) -> ExtractionResult:  # type: ignore[invalid-return-type]
@@ -619,6 +620,7 @@ class LLMEntityExtractor(EntityExtractor):
         Args:
             text: Text to extract from
             entity_types: Optional list of entity types to extract
+            relationship_types: Optional list of relationship types to extract
             expertise: Optional ExpertiseConfig for domain-specific extraction
             context: Optional context dict for prompt template rendering
 
@@ -628,11 +630,25 @@ class LLMEntityExtractor(EntityExtractor):
         if not text.strip():
             return ExtractionResult()
 
-        # Determine entity types from expertise or fallback
-        if expertise:
+        # Normalize empty lists to None (use defaults)
+        entity_types = entity_types or None
+        relationship_types = relationship_types or None
+
+        # Resolve entity types: explicit param > expertise > default
+        if entity_types is not None:
+            pass  # use as-is
+        elif expertise:
             entity_types = expertise.get_entity_type_names() or DEFAULT_ENTITY_TYPES
         else:
-            entity_types = entity_types or DEFAULT_ENTITY_TYPES
+            entity_types = DEFAULT_ENTITY_TYPES
+
+        # Resolve relationship types: explicit param > expertise > default
+        if relationship_types is not None:
+            pass  # use as-is
+        elif expertise:
+            relationship_types = expertise.get_relationship_type_names() or DEFAULT_RELATIONSHIP_TYPES
+        else:
+            relationship_types = DEFAULT_RELATIONSHIP_TYPES
 
         try:
             import litellm
@@ -641,7 +657,9 @@ class LLMEntityExtractor(EntityExtractor):
 
         # Render prompts based on expertise
         system_prompt = self._render_system_prompt(expertise, context)
-        extraction_prompt = self._render_extraction_prompt(text, entity_types, expertise, context)
+        extraction_prompt = self._render_extraction_prompt(
+            text, entity_types, expertise, context, relationship_types=relationship_types
+        )
 
         try:
             async for attempt in AsyncRetrying(
@@ -710,9 +728,6 @@ class LLMEntityExtractor(EntityExtractor):
                     # focused second pass to catch missed connections.
                     # Reference: DeepStruct (Wang et al., 2022)
                     if self._should_run_second_pass(result):
-                        relationship_types = (
-                            expertise.get_relationship_type_names() if expertise else DEFAULT_RELATIONSHIP_TYPES
-                        )
                         second_pass = await self._extract_additional_relationships(
                             result.entities,
                             text,
@@ -1011,8 +1026,22 @@ class LLMEntityExtractor(EntityExtractor):
         entity_types: list[str],
         expertise: ExpertiseConfig | None,
         context: dict[str, Any] | None,
+        *,
+        relationship_types: list[str] | None = None,
     ) -> str:
-        """Render the extraction prompt, optionally using expertise config."""
+        """Render the extraction prompt, optionally using expertise config.
+
+        Args:
+            text: Text to extract from
+            entity_types: Resolved entity types to extract
+            expertise: Optional expertise config
+            context: Optional context dict
+            relationship_types: Resolved relationship types (defaults applied if None)
+        """
+        # Ensure relationship_types is resolved
+        if not relationship_types:
+            relationship_types = DEFAULT_RELATIONSHIP_TYPES
+
         # Build tool context for SaaS-aware extraction
         tool_context = self._build_tool_context(expertise, context)
 
@@ -1026,8 +1055,6 @@ class LLMEntityExtractor(EntityExtractor):
                 from khora.extraction.skills.composer import ExpertiseComposer
 
                 composer = ExpertiseComposer()
-                # Get relationship types from expertise
-                relationship_types = expertise.get_relationship_type_names() or DEFAULT_RELATIONSHIP_TYPES
 
                 prompt_context = {
                     **(context or {}),
@@ -1046,12 +1073,6 @@ class LLMEntityExtractor(EntityExtractor):
 
         # Use default extraction prompt
         logger.debug("Using DEFAULT_EXTRACTION_PROMPT (no custom prompt in expertise)")
-        # Use default extraction prompt with optional tool context
-        # Get relationship types from expertise or defaults
-        if expertise:
-            relationship_types = expertise.get_relationship_type_names() or DEFAULT_RELATIONSHIP_TYPES
-        else:
-            relationship_types = DEFAULT_RELATIONSHIP_TYPES
 
         # Build document temporal context from the context dict
         document_context = self._build_document_context(context)
@@ -1090,6 +1111,7 @@ class LLMEntityExtractor(EntityExtractor):
         texts: list[str],
         *,
         entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
         expertise: ExpertiseConfig | None = None,
         context: dict[str, Any] | None = None,
     ) -> list[ExtractionResult]:
@@ -1102,6 +1124,7 @@ class LLMEntityExtractor(EntityExtractor):
         Args:
             texts: List of texts to extract from
             entity_types: Optional list of entity types to extract
+            relationship_types: Optional list of relationship types to extract
             expertise: Optional ExpertiseConfig for domain-specific extraction
             context: Optional context dict for prompt template rendering
 
@@ -1116,6 +1139,7 @@ class LLMEntityExtractor(EntityExtractor):
         return await self.extract_multi(
             texts,
             entity_types=entity_types,
+            relationship_types=relationship_types,
             expertise=expertise,
             context=context,
         )
@@ -1125,6 +1149,7 @@ class LLMEntityExtractor(EntityExtractor):
         texts: list[str],
         *,
         entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
         expertise: ExpertiseConfig | None = None,
         context: dict[str, Any] | None = None,
         batch_size: int = 5,
@@ -1143,6 +1168,7 @@ class LLMEntityExtractor(EntityExtractor):
         Args:
             texts: List of texts to extract from
             entity_types: Optional list of entity types to extract
+            relationship_types: Optional list of relationship types to extract
             expertise: Optional ExpertiseConfig for domain-specific extraction
             context: Optional context dict for prompt template rendering
             batch_size: Maximum number of texts per LLM call (fallback/cap)
@@ -1156,6 +1182,10 @@ class LLMEntityExtractor(EntityExtractor):
         """
         if not texts:
             return []
+
+        # Normalize empty lists to None (use defaults)
+        entity_types = entity_types or None
+        relationship_types = relationship_types or None
 
         # Tiered extraction: separate short texts for regex-only processing
         if tiered_extraction:
@@ -1179,6 +1209,7 @@ class LLMEntityExtractor(EntityExtractor):
             llm_results = await self.extract_multi(
                 llm_texts,
                 entity_types=entity_types,
+                relationship_types=relationship_types,
                 expertise=expertise,
                 context=context,
                 batch_size=batch_size,
@@ -1197,10 +1228,21 @@ class LLMEntityExtractor(EntityExtractor):
                     llm_idx += 1
             return combined
 
-        if expertise:
+        # Resolve entity types: explicit param > expertise > default
+        if entity_types is not None:
+            pass  # use as-is
+        elif expertise:
             entity_types = expertise.get_entity_type_names() or DEFAULT_ENTITY_TYPES
         else:
-            entity_types = entity_types or DEFAULT_ENTITY_TYPES
+            entity_types = DEFAULT_ENTITY_TYPES
+
+        # Resolve relationship types: explicit param > expertise > default
+        if relationship_types is not None:
+            pass  # use as-is
+        elif expertise:
+            relationship_types = expertise.get_relationship_type_names() or DEFAULT_RELATIONSHIP_TYPES
+        else:
+            relationship_types = DEFAULT_RELATIONSHIP_TYPES
 
         try:
             import litellm
@@ -1238,6 +1280,7 @@ class LLMEntityExtractor(EntityExtractor):
                 tool_context=tool_context,
                 expertise=expertise,
                 context=context,
+                relationship_types=relationship_types,
             )
 
             # Check if batch failed (all results have errors) - fallback to single extraction
@@ -1252,6 +1295,7 @@ class LLMEntityExtractor(EntityExtractor):
                     result = await self.extract(
                         text,
                         entity_types=entity_types,
+                        relationship_types=relationship_types,
                         expertise=expertise,
                         context=context,
                     )
@@ -1278,8 +1322,13 @@ class LLMEntityExtractor(EntityExtractor):
         tool_context: str | None = None,
         expertise: ExpertiseConfig | None = None,
         context: dict[str, Any] | None = None,
+        relationship_types: list[str] | None = None,
     ) -> list[ExtractionResult]:  # type: ignore[invalid-return-type]
         """Extract from a batch of texts in a single LLM call."""
+        # Ensure relationship_types is resolved
+        if not relationship_types:
+            relationship_types = DEFAULT_RELATIONSHIP_TYPES
+
         sections = "\n".join(f"=== SECTION {i + 1} ===\n{text[:4000]}" for i, text in enumerate(texts))
 
         # If expertise has custom extraction prompt, use it with multi-section adaptation
@@ -1297,9 +1346,6 @@ Return a JSON object with a "sections" array, one object per input section:
     ...
 ]}
 Each section follows the entity/relationship format from the instructions above."""
-
-            # Get relationship types from expertise
-            relationship_types = expertise.get_relationship_type_names() or DEFAULT_RELATIONSHIP_TYPES
 
             prompt_context = {
                 **(context or {}),
@@ -1321,12 +1367,6 @@ Each section follows the entity/relationship format from the instructions above.
 
         # Fallback to hardcoded prompt (existing behavior)
         if not expertise or not expertise.extraction_prompt:
-            # Get relationship types - expertise may exist but without custom extraction_prompt
-            if expertise:
-                relationship_types = expertise.get_relationship_type_names() or DEFAULT_RELATIONSHIP_TYPES
-            else:
-                relationship_types = DEFAULT_RELATIONSHIP_TYPES
-
             tool_prefix = f"{tool_context}\n\n" if tool_context else ""
             prompt = f"""{tool_prefix}Extract entities, relationships, and events from each text section below.
 

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -291,6 +291,8 @@ class MemoryLake:
         source: str = "",
         metadata: dict[str, Any] | None = None,
         skill_name: str = "general_entities",
+        entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
     ) -> RememberResult:
         """Store content in the memory lake.
 
@@ -307,6 +309,8 @@ class MemoryLake:
             source: Optional source identifier
             metadata: Optional metadata
             skill_name: Extraction skill to use
+            entity_types: Optional entity types to extract (overrides defaults)
+            relationship_types: Optional relationship types to extract (overrides defaults)
 
         Returns:
             RememberResult with details
@@ -324,6 +328,8 @@ class MemoryLake:
                     source=source,
                     metadata=metadata,
                     skill_name=skill_name,
+                    entity_types=entity_types,
+                    relationship_types=relationship_types,
                 )
         finally:
             clear_trace_id()
@@ -338,6 +344,8 @@ class MemoryLake:
         deduplicate: bool = True,
         infer_relationships: bool = True,
         on_progress: Callable[[int, int], None] | None = None,
+        entity_types: list[str] | None = None,
+        relationship_types: list[str] | None = None,
     ) -> BatchResult:
         """Store multiple documents with automatic optimization.
 
@@ -363,6 +371,8 @@ class MemoryLake:
             deduplicate: Deduplicate entities across documents (default: True)
             infer_relationships: Infer relationships after ingestion (default: True)
             on_progress: Callback(processed_count, total_count) for progress updates
+            entity_types: Optional entity types to extract (overrides defaults)
+            relationship_types: Optional relationship types to extract (overrides defaults)
 
         Returns:
             BatchResult with aggregated statistics
@@ -381,6 +391,8 @@ class MemoryLake:
                     deduplicate=deduplicate,
                     infer_relationships=infer_relationships,
                     on_progress=on_progress,
+                    entity_types=entity_types,
+                    relationship_types=relationship_types,
                 )
         finally:
             clear_trace_id()

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -179,6 +179,8 @@ async def stream_extract_and_embed_entities(
     extraction_max_tokens: int | None = None,
     skip_embedding_entity_types: list[str] | None = None,
     skip_embedding_mention_threshold: int = 1,
+    entity_types: list[str] | None = None,
+    relationship_types: list[str] | None = None,
 ) -> tuple[list[Entity], list[Relationship]]:
     """Extract entities from chunks and embed them in a streaming fashion.
 
@@ -244,21 +246,22 @@ async def stream_extract_and_embed_entities(
 
             texts = [chunk.content for chunk in chunks]
 
-            if expertise:
-                results = await extractor.extract_multi(
-                    texts,
-                    expertise=expertise,
-                    context=extraction_context,
-                    batch_size=extraction_batch_size,
-                    max_input_tokens=None,
-                )
-            else:
-                results = await extractor.extract_multi(
-                    texts,
-                    entity_types=skill.entity_types,
-                    batch_size=extraction_batch_size,
-                    max_input_tokens=None,
-                )
+            # Resolve types: explicit param > expertise > skill > default
+            resolved_entity_types = entity_types or None
+            resolved_relationship_types = relationship_types or None
+
+            if resolved_entity_types is None and not expertise:
+                resolved_entity_types = skill.entity_types if hasattr(skill, "entity_types") and skill.entity_types else None
+
+            results = await extractor.extract_multi(
+                texts,
+                entity_types=resolved_entity_types,
+                relationship_types=resolved_relationship_types,
+                expertise=expertise,
+                context=extraction_context,
+                batch_size=extraction_batch_size,
+                max_input_tokens=None,
+            )
 
             # Process results and queue entities
             all_entities: dict[str, Entity] = {}
@@ -718,6 +721,8 @@ async def process_document(
     extraction_max_tokens: int | None = None,
     skip_embedding_entity_types: list[str] | None = None,
     skip_embedding_mention_threshold: int = 1,
+    entity_types: list[str] | None = None,
+    relationship_types: list[str] | None = None,
 ) -> dict[str, Any]:
     """Process a document through the enrichment pipeline.
 
@@ -832,6 +837,8 @@ async def process_document(
                     retry_wait=extraction_retry_wait,
                     extraction_batch_size=extraction_batch_size,
                     max_tokens=extraction_max_tokens,
+                    entity_types=entity_types,
+                    relationship_types=relationship_types,
                 )
 
         embedded_chunks, (entities, relationships) = await asyncio.gather(
@@ -1193,6 +1200,8 @@ async def ingest_documents(
     extraction_max_tokens: int | None = None,
     skip_embedding_entity_types: list[str] | None = None,
     skip_embedding_mention_threshold: int = 1,
+    entity_types: list[str] | None = None,
+    relationship_types: list[str] | None = None,
     **kwargs,
 ) -> dict[str, Any]:
     """Two-phase document ingestion flow with parallel processing.
@@ -1321,6 +1330,8 @@ async def ingest_documents(
                 extraction_max_tokens=extraction_max_tokens,
                 skip_embedding_entity_types=skip_embedding_entity_types,
                 skip_embedding_mention_threshold=skip_embedding_mention_threshold,
+                entity_types=entity_types,
+                relationship_types=relationship_types,
             )
 
     results = await asyncio.gather(

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -87,6 +87,8 @@ async def _extract_cross_chunk_relationships(
     extraction_context: dict,
     *,
     max_windows: int = 50,
+    entity_types: list[str] | None = None,
+    relationship_types: list[str] | None = None,
 ) -> list:
     """Extract relationships spanning chunk boundaries via overlapping windows.
 
@@ -138,6 +140,8 @@ async def _extract_cross_chunk_relationships(
         try:
             results = await extractor.extract_multi(
                 [combined_text],
+                entity_types=entity_types,
+                relationship_types=relationship_types,
                 batch_size=1,
                 max_input_tokens=None,
                 context=window_ctx,
@@ -420,7 +424,9 @@ async def stream_extract_and_embed_entities(
                     cid: [k.split(":")[0] for k in keys] for cid, keys in chunk_entity_keys.items()
                 }
                 cross_rels_raw = await _extract_cross_chunk_relationships(
-                    chunks, _entities_by_chunk, extractor, extraction_context
+                    chunks, _entities_by_chunk, extractor, extraction_context,
+                    entity_types=entity_types,
+                    relationship_types=relationship_types,
                 )
                 if cross_rels_raw:
                     logger.info(f"Cross-chunk extraction: found {len(cross_rels_raw)} candidate relationships")

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -255,7 +255,9 @@ async def stream_extract_and_embed_entities(
             resolved_relationship_types = relationship_types or None
 
             if resolved_entity_types is None and not expertise:
-                resolved_entity_types = skill.entity_types if hasattr(skill, "entity_types") and skill.entity_types else None
+                resolved_entity_types = (
+                    skill.entity_types if hasattr(skill, "entity_types") and skill.entity_types else None
+                )
 
             results = await extractor.extract_multi(
                 texts,
@@ -424,7 +426,10 @@ async def stream_extract_and_embed_entities(
                     cid: [k.split(":")[0] for k in keys] for cid, keys in chunk_entity_keys.items()
                 }
                 cross_rels_raw = await _extract_cross_chunk_relationships(
-                    chunks, _entities_by_chunk, extractor, extraction_context,
+                    chunks,
+                    _entities_by_chunk,
+                    extractor,
+                    extraction_context,
                     entity_types=entity_types,
                     relationship_types=relationship_types,
                 )

--- a/src/khora/pipelines/tasks/extract.py
+++ b/src/khora/pipelines/tasks/extract.py
@@ -22,6 +22,8 @@ async def extract_entities(
     retry_wait: float = 2.0,
     extraction_batch_size: int = 10,
     max_tokens: int | None = None,
+    entity_types: list[str] | None = None,
+    relationship_types: list[str] | None = None,
 ) -> tuple[list[Entity], list[Relationship]]:
     """Extract entities and relationships from chunks.
 
@@ -38,6 +40,10 @@ async def extract_entities(
         timeout: Request timeout in seconds
         max_retries: Maximum retries on failure
         retry_wait: Base wait time for exponential backoff between retries
+        extraction_batch_size: Maximum texts per extraction batch
+        max_tokens: Maximum tokens for LLM response
+        entity_types: Optional entity types to extract (overrides expertise/skill)
+        relationship_types: Optional relationship types to extract (overrides expertise/skill)
 
     Returns:
         Tuple of (entities, relationships)
@@ -91,28 +97,36 @@ async def extract_entities(
         extractor_kwargs["max_tokens"] = max_tokens
     extractor = LLMEntityExtractor(**extractor_kwargs)
 
+    # Normalize empty lists to None
+    entity_types = entity_types or None
+    relationship_types = relationship_types or None
+
     # Extract from all chunks using adaptive token-budget-based batching
     # Groups chunks into batches that fit within the model's input token budget,
     # reducing API round-trips by up to 5x while avoiding context overflow
     texts = [chunk.content for chunk in chunks]
 
+    # Resolve types: explicit param > expertise > skill > default
+    # When explicit params are provided, pass them directly to the extractor
+    # which will use them over expertise/defaults.
+    resolved_entity_types = entity_types
+    resolved_relationship_types = relationship_types
+
+    if resolved_entity_types is None and not resolved_expertise:
+        # No explicit types and no expertise — use skill types
+        resolved_entity_types = skill.entity_types if hasattr(skill, "entity_types") and skill.entity_types else None
+
     # Use adaptive batching based on token budget (auto-calculated from max_tokens)
     # batch_size=5 is the max texts per batch; actual batching respects token limits
-    if resolved_expertise:
-        results = await extractor.extract_multi(
-            texts,
-            expertise=resolved_expertise,
-            context=context,
-            batch_size=extraction_batch_size,
-            max_input_tokens=None,  # Auto-calculate from model
-        )
-    else:
-        results = await extractor.extract_multi(
-            texts,
-            entity_types=skill.entity_types,
-            batch_size=extraction_batch_size,
-            max_input_tokens=None,  # Auto-calculate from model
-        )
+    results = await extractor.extract_multi(
+        texts,
+        entity_types=resolved_entity_types,
+        relationship_types=resolved_relationship_types,
+        expertise=resolved_expertise,
+        context=context,
+        batch_size=extraction_batch_size,
+        max_input_tokens=None,  # Auto-calculate from model
+    )
 
     from khora._accel import normalize_entity_name
 

--- a/tests/unit/test_parameterized_extraction.py
+++ b/tests/unit/test_parameterized_extraction.py
@@ -7,7 +7,6 @@ threaded through the extraction pipeline: MemoryLake -> Engine -> Extractor -> P
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -20,7 +19,6 @@ from khora.extraction.extractors.llm import (
     LLMEntityExtractor,
 )
 from khora.extraction.skills.base import EntityTypeConfig, ExpertiseConfig
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/test_parameterized_extraction.py
+++ b/tests/unit/test_parameterized_extraction.py
@@ -1,0 +1,455 @@
+"""Unit tests for parameterized extraction (DYT-262).
+
+Tests that entity_types and relationship_types parameters are correctly
+threaded through the extraction pipeline: MemoryLake -> Engine -> Extractor -> Prompt.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from khora.extraction.extractors.base import ExtractionResult
+from khora.extraction.extractors.llm import (
+    DEFAULT_ENTITY_TYPES,
+    DEFAULT_RELATIONSHIP_TYPES,
+    LLMEntityExtractor,
+)
+from khora.extraction.skills.base import EntityTypeConfig, ExpertiseConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_llm_response(entities: list | None = None, relationships: list | None = None) -> MagicMock:
+    """Create a mock LLM response with valid JSON content."""
+    payload = {
+        "entities": entities or [],
+        "relationships": relationships or [],
+        "events": [],
+    }
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps(payload)
+    mock_response.choices[0].finish_reason = "stop"
+    mock_response.usage = MagicMock(prompt_tokens=10, completion_tokens=10, total_tokens=20)
+    return mock_response
+
+
+def _make_multi_response(num_sections: int) -> MagicMock:
+    """Create a mock LLM response for extract_multi with sections."""
+    sections = []
+    for _ in range(num_sections):
+        sections.append({"entities": [], "relationships": [], "events": []})
+    payload = {"sections": sections}
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps(payload)
+    mock_response.choices[0].finish_reason = "stop"
+    mock_response.usage = MagicMock(prompt_tokens=10, completion_tokens=10, total_tokens=20)
+    return mock_response
+
+
+def _mock_config() -> MagicMock:
+    """Create a mock KhoraConfig with all required methods."""
+    mock_config = MagicMock()
+    mock_config.get_postgresql_url.return_value = "postgresql://test"
+    mock_config.get_graph_config.return_value = None
+    mock_config.get_vector_config.return_value = None
+    mock_config.get_neo4j_url.return_value = None
+    mock_config.get_neo4j_user.return_value = None
+    mock_config.get_neo4j_password.return_value = None
+    mock_config.get_neo4j_database.return_value = None
+    mock_config.storage.embedding_dimension = 1536
+    mock_config.llm.model = "gpt-4o-mini"
+    mock_config.llm.embedding_model = "text-embedding-3-small"
+    mock_config.llm.embedding_dimension = 1536
+    mock_config.llm.extraction_model = None
+    mock_config.llm.timeout = 30
+    mock_config.llm.max_retries = 3
+    mock_config.telemetry_database_url = None
+    mock_config.telemetry_service_name = "khora-test"
+    return mock_config
+
+
+def _mock_engine() -> MagicMock:
+    """Create a mock engine with all required methods."""
+    mock_eng = MagicMock()
+    mock_eng._storage = MagicMock()
+    mock_eng._embedder = MagicMock()
+    mock_eng._default_namespace_id = None
+    mock_eng.connect = AsyncMock()
+    mock_eng.disconnect = AsyncMock()
+    mock_eng.health_check = AsyncMock(return_value={"status": "healthy"})
+    mock_eng.remember = AsyncMock()
+    mock_eng.recall = AsyncMock()
+    mock_eng.forget = AsyncMock()
+    mock_eng.remember_batch = AsyncMock()
+    mock_eng.get_or_create_default_namespace = AsyncMock(return_value=uuid4())
+    mock_eng.create_namespace = AsyncMock()
+    mock_eng.get_namespace = AsyncMock()
+    mock_eng.ensure_namespace = AsyncMock()
+    mock_eng.get_entity = AsyncMock()
+    mock_eng.list_entities = AsyncMock(return_value=[])
+    mock_eng.find_related_entities = AsyncMock(return_value=[])
+    mock_eng.get_document = AsyncMock()
+    mock_eng.list_documents = AsyncMock(return_value=[])
+    mock_eng.search_entities = AsyncMock(return_value=[])
+    mock_eng.stats = AsyncMock()
+    return mock_eng
+
+
+def _make_lake(*, connected: bool = False):
+    """Create a MemoryLake with mocked config, optionally pre-connected."""
+    from khora.memory_lake import MemoryLake
+
+    with patch("khora.memory_lake.load_config", return_value=_mock_config()):
+        lake = MemoryLake()
+
+    if connected:
+        lake._connected = True
+        lake._engine = _mock_engine()
+
+    return lake
+
+
+# ---------------------------------------------------------------------------
+# 1. Default types when None
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExtractDefaultTypes:
+    """Calling extract() without entity_types/relationship_types uses defaults."""
+
+    async def test_extract_default_types_when_none(self) -> None:
+        """Prompt contains DEFAULT_ENTITY_TYPES and DEFAULT_RELATIONSHIP_TYPES."""
+        extractor = LLMEntityExtractor(model="gpt-4o-mini", max_retries=1)
+        captured_messages: list = []
+
+        async def _capture_acompletion(**kwargs):
+            captured_messages.append(kwargs["messages"])
+            return _make_llm_response()
+
+        with patch("litellm.acompletion", side_effect=_capture_acompletion):
+            await extractor.extract("Alice works at Acme Corp in New York.")
+
+        assert len(captured_messages) == 1
+        user_prompt = captured_messages[0][1]["content"]
+
+        # All default entity types should appear
+        for et in DEFAULT_ENTITY_TYPES:
+            assert et in user_prompt, f"Default entity type {et!r} not found in prompt"
+
+        # All default relationship types should appear
+        for rt in DEFAULT_RELATIONSHIP_TYPES:
+            assert rt in user_prompt, f"Default relationship type {rt!r} not found in prompt"
+
+
+# ---------------------------------------------------------------------------
+# 2. Custom entity types
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExtractCustomEntityTypes:
+    """Passing explicit entity_types overrides defaults."""
+
+    async def test_extract_custom_entity_types(self) -> None:
+        """Prompt contains custom types, not defaults like PERSON."""
+        extractor = LLMEntityExtractor(model="gpt-4o-mini", max_retries=1)
+        captured_messages: list = []
+
+        async def _capture_acompletion(**kwargs):
+            captured_messages.append(kwargs["messages"])
+            return _make_llm_response()
+
+        with patch("litellm.acompletion", side_effect=_capture_acompletion):
+            await extractor.extract(
+                "BRCA1 gene is targeted by Olaparib.",
+                entity_types=["DRUG", "GENE"],
+            )
+
+        user_prompt = captured_messages[0][1]["content"]
+
+        assert "DRUG" in user_prompt
+        assert "GENE" in user_prompt
+        # Default type PERSON should NOT be in the entity types line
+        # (it may appear in the template boilerplate, so check the specific line)
+        entity_line = [line for line in user_prompt.split("\n") if "Entity types to extract:" in line]
+        assert len(entity_line) == 1
+        assert "PERSON" not in entity_line[0]
+
+
+# ---------------------------------------------------------------------------
+# 3. Custom relationship types
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExtractCustomRelationshipTypes:
+    """Passing explicit relationship_types overrides defaults."""
+
+    async def test_extract_custom_relationship_types(self) -> None:
+        """Prompt contains custom relationship types, not defaults like WORKS_FOR."""
+        extractor = LLMEntityExtractor(model="gpt-4o-mini", max_retries=1)
+        captured_messages: list = []
+
+        async def _capture_acompletion(**kwargs):
+            captured_messages.append(kwargs["messages"])
+            return _make_llm_response()
+
+        with patch("litellm.acompletion", side_effect=_capture_acompletion):
+            await extractor.extract(
+                "BRCA1 is targeted by Olaparib which inhibits PARP.",
+                relationship_types=["TARGETS", "INHIBITS"],
+            )
+
+        user_prompt = captured_messages[0][1]["content"]
+
+        assert "TARGETS" in user_prompt
+        assert "INHIBITS" in user_prompt
+        # Check the specific relationship types line
+        rel_line = [line for line in user_prompt.split("\n") if "Relationship types to use:" in line]
+        assert len(rel_line) == 1
+        assert "WORKS_FOR" not in rel_line[0]
+
+
+# ---------------------------------------------------------------------------
+# 4. Explicit overrides expertise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExtractExplicitOverridesExpertise:
+    """Explicit params take precedence over expertise config."""
+
+    async def test_extract_explicit_overrides_expertise(self) -> None:
+        """Prompt contains explicit DRUG, not expertise CONCEPT."""
+        expertise = ExpertiseConfig(
+            name="tech_expert",
+            entity_types=[
+                EntityTypeConfig(name="CONCEPT", description="A concept"),
+                EntityTypeConfig(name="TECHNOLOGY", description="A technology"),
+            ],
+        )
+
+        extractor = LLMEntityExtractor(model="gpt-4o-mini", max_retries=1)
+        captured_messages: list = []
+
+        async def _capture_acompletion(**kwargs):
+            captured_messages.append(kwargs["messages"])
+            return _make_llm_response()
+
+        with patch("litellm.acompletion", side_effect=_capture_acompletion):
+            await extractor.extract(
+                "Olaparib targets BRCA1.",
+                entity_types=["DRUG"],
+                expertise=expertise,
+            )
+
+        user_prompt = captured_messages[0][1]["content"]
+        entity_line = [line for line in user_prompt.split("\n") if "Entity types to extract:" in line]
+        assert len(entity_line) == 1
+        assert "DRUG" in entity_line[0]
+        assert "CONCEPT" not in entity_line[0]
+
+
+# ---------------------------------------------------------------------------
+# 5. Empty list normalization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExtractEmptyListNormalization:
+    """Empty lists [] are treated as None and fall back to defaults."""
+
+    async def test_extract_empty_list_uses_defaults(self) -> None:
+        """Empty entity_types=[] and relationship_types=[] use DEFAULT types."""
+        extractor = LLMEntityExtractor(model="gpt-4o-mini", max_retries=1)
+        captured_messages: list = []
+
+        async def _capture_acompletion(**kwargs):
+            captured_messages.append(kwargs["messages"])
+            return _make_llm_response()
+
+        with patch("litellm.acompletion", side_effect=_capture_acompletion):
+            await extractor.extract(
+                "Alice works at Acme.",
+                entity_types=[],
+                relationship_types=[],
+            )
+
+        user_prompt = captured_messages[0][1]["content"]
+
+        # Should contain defaults since empty lists are normalized to None
+        for et in DEFAULT_ENTITY_TYPES:
+            assert et in user_prompt, f"Default entity type {et!r} missing after empty-list normalization"
+
+        for rt in DEFAULT_RELATIONSHIP_TYPES:
+            assert rt in user_prompt, f"Default relationship type {rt!r} missing after empty-list normalization"
+
+
+# ---------------------------------------------------------------------------
+# 6. extract_multi threads custom types
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExtractMultiCustomTypes:
+    """extract_multi passes custom types to the batch prompt."""
+
+    async def test_extract_multi_custom_types(self) -> None:
+        """Batch prompt contains custom entity and relationship types."""
+        extractor = LLMEntityExtractor(model="gpt-4o-mini", max_retries=1)
+        captured_messages: list = []
+
+        async def _capture_acompletion(**kwargs):
+            captured_messages.append(kwargs["messages"])
+            return _make_multi_response(2)
+
+        with patch("litellm.acompletion", side_effect=_capture_acompletion):
+            results = await extractor.extract_multi(
+                ["Text one about drugs.", "Text two about genes."],
+                entity_types=["DRUG"],
+                relationship_types=["TARGETS"],
+            )
+
+        assert len(results) == 2
+        # At least one LLM call should have been made
+        assert len(captured_messages) >= 1
+        user_prompt = captured_messages[0][1]["content"]
+
+        assert "DRUG" in user_prompt
+        assert "TARGETS" in user_prompt
+
+
+# ---------------------------------------------------------------------------
+# 7. extract_entities task threads types
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExtractEntitiesTaskThreadsTypes:
+    """The extract_entities pipeline task passes custom types to the extractor."""
+
+    async def test_extract_entities_task_threads_types(self) -> None:
+        """extract_entities() passes entity_types to extractor.extract_multi()."""
+        from khora.pipelines.tasks.extract import extract_entities
+
+        mock_chunk = MagicMock()
+        mock_chunk.content = "Olaparib targets BRCA1 gene."
+        mock_chunk.namespace_id = uuid4()
+        mock_chunk.document_id = uuid4()
+        mock_chunk.id = uuid4()
+        mock_chunk.created_at = None
+
+        mock_result = ExtractionResult(entities=[], relationships=[], events=[])
+
+        with patch(
+            "khora.extraction.extractors.LLMEntityExtractor.extract_multi",
+            new_callable=AsyncMock,
+            return_value=[mock_result],
+        ) as mock_extract_multi:
+            await extract_entities(
+                [mock_chunk],
+                entity_types=["DRUG", "GENE"],
+                relationship_types=["TARGETS"],
+            )
+
+        mock_extract_multi.assert_awaited_once()
+        call_kwargs = mock_extract_multi.call_args
+        assert call_kwargs.kwargs["entity_types"] == ["DRUG", "GENE"]
+        assert call_kwargs.kwargs["relationship_types"] == ["TARGETS"]
+
+
+# ---------------------------------------------------------------------------
+# 8. MemoryLake.remember() threads types
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMemoryLakeRememberThreadsTypes:
+    """MemoryLake.remember() passes entity_types to the engine."""
+
+    async def test_memory_lake_remember_threads_types(self) -> None:
+        """engine.remember() is called with entity_types and relationship_types."""
+        from khora.memory_lake import RememberResult
+
+        lake = _make_lake(connected=True)
+        ns_id = uuid4()
+        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
+
+        mock_result = RememberResult(
+            document_id=uuid4(),
+            namespace_id=ns_id,
+            chunks_created=1,
+            entities_extracted=0,
+            relationships_created=0,
+        )
+        lake._engine.remember = AsyncMock(return_value=mock_result)
+
+        with (
+            patch("khora.telemetry.context.ensure_trace_id"),
+            patch("khora.telemetry.context.clear_trace_id"),
+        ):
+            await lake.remember(
+                "Olaparib targets BRCA1.",
+                entity_types=["DRUG", "GENE"],
+                relationship_types=["TARGETS"],
+            )
+
+        lake._engine.remember.assert_awaited_once()
+        call_kwargs = lake._engine.remember.call_args
+        assert call_kwargs.kwargs["entity_types"] == ["DRUG", "GENE"]
+        assert call_kwargs.kwargs["relationship_types"] == ["TARGETS"]
+
+
+# ---------------------------------------------------------------------------
+# 9. MemoryLake.remember_batch() threads types
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMemoryLakeRememberBatchThreadsTypes:
+    """MemoryLake.remember_batch() passes entity_types to the engine."""
+
+    async def test_memory_lake_remember_batch_threads_types(self) -> None:
+        """engine.remember_batch() is called with entity_types and relationship_types."""
+        from khora.memory_lake import BatchResult
+
+        lake = _make_lake(connected=True)
+        ns_id = uuid4()
+        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
+
+        mock_result = BatchResult(
+            total=1,
+            processed=1,
+            skipped=0,
+            failed=0,
+            chunks=1,
+            entities=0,
+            relationships=0,
+        )
+        lake._engine.remember_batch = AsyncMock(return_value=mock_result)
+
+        with (
+            patch("khora.telemetry.context.ensure_trace_id"),
+            patch("khora.telemetry.context.clear_trace_id"),
+        ):
+            await lake.remember_batch(
+                [{"content": "Olaparib targets BRCA1."}],
+                entity_types=["DRUG"],
+                relationship_types=["TARGETS"],
+            )
+
+        lake._engine.remember_batch.assert_awaited_once()
+        call_kwargs = lake._engine.remember_batch.call_args
+        assert call_kwargs.kwargs["entity_types"] == ["DRUG"]
+        assert call_kwargs.kwargs["relationship_types"] == ["TARGETS"]


### PR DESCRIPTION
## Summary

Make Khora's entity extraction pipeline ontology-agnostic by accepting `entity_types` and `relationship_types` as optional parameters, per [ADR-003](https://github.com/DeytaHQ/hegemon/blob/main/architecture/decisions/003-make-khora-ontology-agnostic.md).

- Add `entity_types: list[str] | None` and `relationship_types: list[str] | None` to the full extraction call chain: `MemoryLake` → engine protocol → 3 engine implementations → ingest pipeline → extract task → LLM extractor → prompt
- Fix precedence: explicit params > expertise config > skill config > defaults
- Fix `_render_extraction_prompt()` to accept pre-resolved relationship types instead of re-computing internally
- Thread params through cross-chunk relationship extraction (`_extract_cross_chunk_relationships`)
- Skeleton engine accepts params for protocol compliance (no entity extraction)
- All parameters optional with `None` defaults — fully backward compatible
- 9 new unit tests covering defaults, custom types, precedence, empty list normalization, and API threading

### Files changed (10 source + 1 test)

| Layer | Files |
|-------|-------|
| Public API | `memory_lake.py` |
| Engine protocol | `engines/protocol.py` |
| Engine impls | `engines/graphrag/engine.py`, `engines/skeleton/engine.py`, `engines/vectorcypher/engine.py` |
| Pipeline | `pipelines/flows/ingest.py`, `pipelines/tasks/extract.py` |
| Extractor | `extraction/extractors/base.py`, `extraction/extractors/llm.py` |
| Tests | `tests/unit/test_parameterized_extraction.py` |

## Test plan

- [x] Unit tests pass (1470 passed, 4 skipped)
- [x] Coverage: 53.77% (threshold: 30%)
- [x] Lint: ruff + black + isort clean
- [x] Type check: ty passes (13 pre-existing diagnostics, 0 new)
- [ ] Manual verification: call `lake.remember(content, entity_types=["DRUG", "GENE"], relationship_types=["TARGETS"])` and confirm custom types appear in extraction prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)