### PR TITLE
DYT-267: Remove extraction defaults and make ontology params required

### DIFF
--- a/docs/extraction/extractors.md
+++ b/docs/extraction/extractors.md
@@ -158,18 +158,8 @@ Return ONLY valid JSON, no other text."""
 
 ## Entity Types
 
-Default entity types:
-
-```python
-DEFAULT_ENTITY_TYPES = [
-    "PERSON",
-    "ORGANIZATION",
-    "LOCATION",
-    "CONCEPT",
-    "EVENT",
-    "TECHNOLOGY",
-]
-```
+Entity types must be provided by the caller — Khora does not define defaults.
+Pass `entity_types` and `relationship_types` explicitly to `remember()` / `remember_batch()`.
 
 Custom types can be specified via expertise configuration.
 

--- a/src/khora/engines/graphrag/engine.py
+++ b/src/khora/engines/graphrag/engine.py
@@ -223,8 +223,8 @@ class GraphRAGEngine:
         source: str = "",
         metadata: dict[str, Any] | None = None,
         skill_name: str = "general_entities",
-        entity_types: list[str] | None = None,
-        relationship_types: list[str] | None = None,
+        entity_types: list[str],
+        relationship_types: list[str],
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -393,8 +393,8 @@ class GraphRAGEngine:
         deduplicate: bool = True,
         infer_relationships: bool = True,
         on_progress: Callable[[int, int], None] | None = None,
-        entity_types: list[str] | None = None,
-        relationship_types: list[str] | None = None,
+        entity_types: list[str],
+        relationship_types: list[str],
     ) -> BatchResult:
         """Store multiple documents with automatic optimization.
 

--- a/src/khora/engines/protocol.py
+++ b/src/khora/engines/protocol.py
@@ -54,8 +54,8 @@ class MemoryEngineProtocol(Protocol):
         source: str = "",
         metadata: dict[str, Any] | None = None,
         skill_name: str = "general_entities",
-        entity_types: list[str] | None = None,
-        relationship_types: list[str] | None = None,
+        entity_types: list[str],
+        relationship_types: list[str],
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -66,8 +66,8 @@ class MemoryEngineProtocol(Protocol):
             source: Optional source identifier
             metadata: Optional metadata
             skill_name: Extraction skill to use
-            entity_types: Optional entity types to extract (overrides defaults)
-            relationship_types: Optional relationship types to extract (overrides defaults)
+            entity_types: Required entity types to extract
+            relationship_types: Required relationship types to extract
 
         Returns:
             RememberResult with details
@@ -123,8 +123,8 @@ class MemoryEngineProtocol(Protocol):
         deduplicate: bool = True,
         infer_relationships: bool = True,
         on_progress: Callable[[int, int], None] | None = None,
-        entity_types: list[str] | None = None,
-        relationship_types: list[str] | None = None,
+        entity_types: list[str],
+        relationship_types: list[str],
     ) -> BatchResult:
         """Store multiple documents with automatic optimization.
 
@@ -136,8 +136,8 @@ class MemoryEngineProtocol(Protocol):
             deduplicate: Deduplicate entities across documents
             infer_relationships: Infer relationships after ingestion
             on_progress: Callback(processed_count, total_count) for progress updates
-            entity_types: Optional entity types to extract (overrides defaults)
-            relationship_types: Optional relationship types to extract (overrides defaults)
+            entity_types: Required entity types to extract
+            relationship_types: Required relationship types to extract
 
         Returns:
             BatchResult with aggregated statistics

--- a/src/khora/engines/skeleton/__init__.py
+++ b/src/khora/engines/skeleton/__init__.py
@@ -11,7 +11,7 @@ The Skeleton Construction engine is optimized for:
 Usage:
     # Default backend (pgvector)
     async with MemoryLake(db_url, engine="skeleton") as lake:
-        await lake.remember("content", title="Doc")
+        await lake.remember("content", title="Doc", entity_types=[...], relationship_types=[...])
         results = await lake.recall("query", temporal_filter=TemporalFilter.relative_days(-1))
 
     # Weaviate backend (advanced filtering)

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -214,8 +214,8 @@ class SkeletonConstructionEngine:
         metadata: dict[str, Any] | None = None,
         skill_name: str = "general_entities",
         occurred_at: datetime | None = None,
-        entity_types: list[str] | None = None,
-        relationship_types: list[str] | None = None,
+        entity_types: list[str],
+        relationship_types: list[str],
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -583,8 +583,8 @@ class SkeletonConstructionEngine:
         deduplicate: bool = True,
         infer_relationships: bool = False,  # Not used in Skeleton Construction engine
         on_progress: Callable[[int, int], None] | None = None,
-        entity_types: list[str] | None = None,
-        relationship_types: list[str] | None = None,
+        entity_types: list[str],
+        relationship_types: list[str],
     ) -> BatchResult:
         """Store multiple documents with automatic optimization.
 

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -683,6 +683,8 @@ class SkeletonConstructionEngine:
                         metadata=doc_metadata,
                         skill_name=skill_name,
                         occurred_at=occurred_at,
+                        entity_types=entity_types,
+                        relationship_types=relationship_types,
                     )
 
                     async with results_lock:

--- a/src/khora/engines/vectorcypher/__init__.py
+++ b/src/khora/engines/vectorcypher/__init__.py
@@ -14,7 +14,7 @@ Usage:
     await engine.connect()
 
     # Store with temporal context
-    await engine.remember("Meeting notes...", namespace_id, occurred_at=datetime(...))
+    await engine.remember("Meeting notes...", namespace_id, occurred_at=datetime(...), entity_types=[...], relationship_types=[...])
 
     # Retrieve with hybrid search
     result = await engine.recall("What did we discuss?", namespace_id)

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -534,8 +534,8 @@ class VectorCypherEngine:
         expertise: ExpertiseConfig | str | None = None,
         extraction_model: str | None = None,
         occurred_at: datetime,
-        entity_types: list[str] | None = None,
-        relationship_types: list[str] | None = None,
+        entity_types: list[str],
+        relationship_types: list[str],
     ) -> tuple[int, int, int]:
         """Process a document into chunks with skeleton-based entity extraction.
 
@@ -656,8 +656,8 @@ class VectorCypherEngine:
         skill_name: str = "general_entities",
         expertise: ExpertiseConfig | str | None = None,
         extraction_model: str | None = None,
-        entity_types: list[str] | None = None,
-        relationship_types: list[str] | None = None,
+        entity_types: list[str],
+        relationship_types: list[str],
     ) -> tuple[int, int]:
         """Run skeleton-based entity extraction on core chunks only.
 
@@ -787,8 +787,8 @@ class VectorCypherEngine:
         skill_name: str = "general_entities",
         expertise: ExpertiseConfig | str | None = None,
         extraction_model: str | None = None,
-        entity_types: list[str] | None = None,
-        relationship_types: list[str] | None = None,
+        entity_types: list[str],
+        relationship_types: list[str],
     ) -> tuple[list[Entity], list[Relationship], list[EntityChunkLink]]:
         """Run skeleton extraction but return results instead of storing.
 
@@ -880,8 +880,8 @@ class VectorCypherEngine:
         extraction_model: str | None = None,
         occurred_at: datetime,
         embedding_text_override: str | None = None,
-        entity_types: list[str] | None = None,
-        relationship_types: list[str] | None = None,
+        entity_types: list[str],
+        relationship_types: list[str],
     ) -> tuple[int, list[Entity], list[Relationship], list[EntityChunkLink]]:
         """Process a document, returning entities for deferred batch storage.
 

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -456,8 +456,8 @@ class VectorCypherEngine:
         expertise: ExpertiseConfig | str | None = None,
         extraction_model: str | None = None,
         occurred_at: datetime | None = None,
-        entity_types: list[str] | None = None,
-        relationship_types: list[str] | None = None,
+        entity_types: list[str],
+        relationship_types: list[str],
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -1190,8 +1190,8 @@ class VectorCypherEngine:
         deduplicate: bool = True,
         infer_relationships: bool = True,
         on_progress: Callable[[int, int], None] | None = None,
-        entity_types: list[str] | None = None,
-        relationship_types: list[str] | None = None,
+        entity_types: list[str],
+        relationship_types: list[str],
     ) -> BatchResult:
         """Store multiple documents with automatic optimization.
 

--- a/src/khora/extraction/entity_resolution.py
+++ b/src/khora/extraction/entity_resolution.py
@@ -301,17 +301,6 @@ class EntityResolver:
     - Merge provenance tracking
     """
 
-    # Default entity types to pre-load when using with_preloaded_cache
-    DEFAULT_ENTITY_TYPES: list[str] = [
-        "PERSON",
-        "ORGANIZATION",
-        "LOCATION",
-        "CONCEPT",
-        "EVENT",
-        "PRODUCT",
-        "TECHNOLOGY",
-    ]
-
     def __init__(
         self,
         storage: StorageCoordinator,
@@ -694,7 +683,9 @@ class EntityResolver:
         if namespace_id is None:
             return resolver
 
-        types_to_load = entity_types or cls.DEFAULT_ENTITY_TYPES
+        if not entity_types:
+            return resolver
+        types_to_load = entity_types
 
         # Load entities for all types in parallel for efficiency
         import asyncio

--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -1046,7 +1046,7 @@ class LLMEntityExtractor(EntityExtractor):
 
         prompt = EXTRACTION_PROMPT.format(
             entity_types=", ".join(entity_types),
-            relationship_types=", ".join(relationship_types),
+            relationship_types=", ".join(relationship_types or []),
             text=text[:8000],  # Truncate very long texts
             document_context=document_context,
         )
@@ -1323,7 +1323,7 @@ Each section follows the entity/relationship format from the instructions above.
             prompt = f"""{tool_prefix}Extract entities, relationships, and events from each text section below.
 
 Entity types to find: {", ".join(entity_types)}
-Relationship types to use: {", ".join(relationship_types)}
+Relationship types to use: {", ".join(relationship_types or [])}
 
 {sections}
 

--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -32,23 +32,6 @@ if TYPE_CHECKING:
     from khora.config import LiteLLMConfig
     from khora.extraction.skills import ExpertiseConfig
 
-
-# Default entity types to extract
-DEFAULT_ENTITY_TYPES = ["PERSON", "ORGANIZATION", "LOCATION", "CONCEPT", "EVENT", "TECHNOLOGY"]
-
-# Default relationship types to use
-DEFAULT_RELATIONSHIP_TYPES = [
-    "WORKS_FOR",
-    "KNOWS",
-    "MANAGES",
-    "PART_OF",
-    "LOCATED_IN",
-    "DEPENDS_ON",
-    "IMPLEMENTS",
-    "RELATES_TO",
-    "ASSOCIATED_WITH",
-]
-
 # Default system prompt for extraction
 DEFAULT_SYSTEM_PROMPT = """You are an expert entity extraction system. Extract entities and relationships from text and return them as structured JSON."""
 
@@ -630,25 +613,13 @@ class LLMEntityExtractor(EntityExtractor):
         if not text.strip():
             return ExtractionResult()
 
-        # Normalize empty lists to None (use defaults)
-        entity_types = entity_types or None
-        relationship_types = relationship_types or None
+        # Resolve entity types: explicit param > expertise
+        if entity_types is None and expertise:
+            entity_types = expertise.get_entity_type_names() or None
 
-        # Resolve entity types: explicit param > expertise > default
-        if entity_types is not None:
-            pass  # use as-is
-        elif expertise:
-            entity_types = expertise.get_entity_type_names() or DEFAULT_ENTITY_TYPES
-        else:
-            entity_types = DEFAULT_ENTITY_TYPES
-
-        # Resolve relationship types: explicit param > expertise > default
-        if relationship_types is not None:
-            pass  # use as-is
-        elif expertise:
-            relationship_types = expertise.get_relationship_type_names() or DEFAULT_RELATIONSHIP_TYPES
-        else:
-            relationship_types = DEFAULT_RELATIONSHIP_TYPES
+        # Resolve relationship types: explicit param > expertise
+        if relationship_types is None and expertise:
+            relationship_types = expertise.get_relationship_type_names() or None
 
         try:
             import litellm
@@ -792,7 +763,7 @@ class LLMEntityExtractor(EntityExtractor):
             return []
 
         entity_list = "\n".join(f"- {e.name} ({e.entity_type})" for e in entities)
-        rel_types = relationship_types or DEFAULT_RELATIONSHIP_TYPES
+        rel_types = relationship_types or []
 
         prompt = RELATIONSHIP_EXTRACTION_PROMPT.format(
             entity_list=entity_list,
@@ -1038,10 +1009,6 @@ class LLMEntityExtractor(EntityExtractor):
             context: Optional context dict
             relationship_types: Resolved relationship types (defaults applied if None)
         """
-        # Ensure relationship_types is resolved
-        if not relationship_types:
-            relationship_types = DEFAULT_RELATIONSHIP_TYPES
-
         # Build tool context for SaaS-aware extraction
         tool_context = self._build_tool_context(expertise, context)
 
@@ -1228,21 +1195,13 @@ class LLMEntityExtractor(EntityExtractor):
                     llm_idx += 1
             return combined
 
-        # Resolve entity types: explicit param > expertise > default
-        if entity_types is not None:
-            pass  # use as-is
-        elif expertise:
-            entity_types = expertise.get_entity_type_names() or DEFAULT_ENTITY_TYPES
-        else:
-            entity_types = DEFAULT_ENTITY_TYPES
+        # Resolve entity types: explicit param > expertise
+        if entity_types is None and expertise:
+            entity_types = expertise.get_entity_type_names() or None
 
-        # Resolve relationship types: explicit param > expertise > default
-        if relationship_types is not None:
-            pass  # use as-is
-        elif expertise:
-            relationship_types = expertise.get_relationship_type_names() or DEFAULT_RELATIONSHIP_TYPES
-        else:
-            relationship_types = DEFAULT_RELATIONSHIP_TYPES
+        # Resolve relationship types: explicit param > expertise
+        if relationship_types is None and expertise:
+            relationship_types = expertise.get_relationship_type_names() or None
 
         try:
             import litellm
@@ -1325,9 +1284,6 @@ class LLMEntityExtractor(EntityExtractor):
         relationship_types: list[str] | None = None,
     ) -> list[ExtractionResult]:  # type: ignore[invalid-return-type]
         """Extract from a batch of texts in a single LLM call."""
-        # Ensure relationship_types is resolved
-        if not relationship_types:
-            relationship_types = DEFAULT_RELATIONSHIP_TYPES
 
         sections = "\n".join(f"=== SECTION {i + 1} ===\n{text[:4000]}" for i, text in enumerate(texts))
 

--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -1150,10 +1150,6 @@ class LLMEntityExtractor(EntityExtractor):
         if not texts:
             return []
 
-        # Normalize empty lists to None (use defaults)
-        entity_types = entity_types or None
-        relationship_types = relationship_types or None
-
         # Tiered extraction: separate short texts for regex-only processing
         if tiered_extraction:
             regex_results: dict[int, ExtractionResult] = {}

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -291,8 +291,8 @@ class MemoryLake:
         source: str = "",
         metadata: dict[str, Any] | None = None,
         skill_name: str = "general_entities",
-        entity_types: list[str] | None = None,
-        relationship_types: list[str] | None = None,
+        entity_types: list[str],
+        relationship_types: list[str],
     ) -> RememberResult:
         """Store content in the memory lake.
 
@@ -309,8 +309,8 @@ class MemoryLake:
             source: Optional source identifier
             metadata: Optional metadata
             skill_name: Extraction skill to use
-            entity_types: Optional entity types to extract (overrides defaults)
-            relationship_types: Optional relationship types to extract (overrides defaults)
+            entity_types: Required entity types to extract
+            relationship_types: Required relationship types to extract
 
         Returns:
             RememberResult with details
@@ -344,8 +344,8 @@ class MemoryLake:
         deduplicate: bool = True,
         infer_relationships: bool = True,
         on_progress: Callable[[int, int], None] | None = None,
-        entity_types: list[str] | None = None,
-        relationship_types: list[str] | None = None,
+        entity_types: list[str],
+        relationship_types: list[str],
     ) -> BatchResult:
         """Store multiple documents with automatic optimization.
 
@@ -371,8 +371,8 @@ class MemoryLake:
             deduplicate: Deduplicate entities across documents (default: True)
             infer_relationships: Infer relationships after ingestion (default: True)
             on_progress: Callback(processed_count, total_count) for progress updates
-            entity_types: Optional entity types to extract (overrides defaults)
-            relationship_types: Optional relationship types to extract (overrides defaults)
+            entity_types: Required entity types to extract
+            relationship_types: Required relationship types to extract
 
         Returns:
             BatchResult with aggregated statistics

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -91,7 +91,8 @@ class MemoryLake:
     Usage:
         # Simplest - from env vars (KHORA_DATABASE_URL)
         async with MemoryLake() as lake:
-            await lake.remember("Important fact...", namespace="my-ns")
+            await lake.remember("Important fact...", namespace="my-ns",
+                entity_types=["PERSON", "CONCEPT"], relationship_types=["RELATES_TO"])
 
         # Common - explicit database URL
         async with MemoryLake("postgresql://localhost/mydb") as lake:

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -87,8 +87,8 @@ async def _extract_cross_chunk_relationships(
     extraction_context: dict,
     *,
     max_windows: int = 50,
-    entity_types: list[str] | None = None,
-    relationship_types: list[str] | None = None,
+    entity_types: list[str],
+    relationship_types: list[str],
 ) -> list:
     """Extract relationships spanning chunk boundaries via overlapping windows.
 
@@ -183,8 +183,8 @@ async def stream_extract_and_embed_entities(
     extraction_max_tokens: int | None = None,
     skip_embedding_entity_types: list[str] | None = None,
     skip_embedding_mention_threshold: int = 1,
-    entity_types: list[str] | None = None,
-    relationship_types: list[str] | None = None,
+    entity_types: list[str],
+    relationship_types: list[str],
 ) -> tuple[list[Entity], list[Relationship]]:
     """Extract entities from chunks and embed them in a streaming fashion.
 
@@ -723,8 +723,8 @@ async def process_document(
     extraction_max_tokens: int | None = None,
     skip_embedding_entity_types: list[str] | None = None,
     skip_embedding_mention_threshold: int = 1,
-    entity_types: list[str] | None = None,
-    relationship_types: list[str] | None = None,
+    entity_types: list[str],
+    relationship_types: list[str],
 ) -> dict[str, Any]:
     """Process a document through the enrichment pipeline.
 
@@ -1202,8 +1202,8 @@ async def ingest_documents(
     extraction_max_tokens: int | None = None,
     skip_embedding_entity_types: list[str] | None = None,
     skip_embedding_mention_threshold: int = 1,
-    entity_types: list[str] | None = None,
-    relationship_types: list[str] | None = None,
+    entity_types: list[str],
+    relationship_types: list[str],
     **kwargs,
 ) -> dict[str, Any]:
     """Two-phase document ingestion flow with parallel processing.

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -250,19 +250,10 @@ async def stream_extract_and_embed_entities(
 
             texts = [chunk.content for chunk in chunks]
 
-            # Resolve types: explicit param > expertise > skill > default
-            resolved_entity_types = entity_types or None
-            resolved_relationship_types = relationship_types or None
-
-            if resolved_entity_types is None and not expertise:
-                resolved_entity_types = (
-                    skill.entity_types if hasattr(skill, "entity_types") and skill.entity_types else None
-                )
-
             results = await extractor.extract_multi(
                 texts,
-                entity_types=resolved_entity_types,
-                relationship_types=resolved_relationship_types,
+                entity_types=entity_types,
+                relationship_types=relationship_types,
                 expertise=expertise,
                 context=extraction_context,
                 batch_size=extraction_batch_size,

--- a/src/khora/pipelines/tasks/extract.py
+++ b/src/khora/pipelines/tasks/extract.py
@@ -22,8 +22,8 @@ async def extract_entities(
     retry_wait: float = 2.0,
     extraction_batch_size: int = 10,
     max_tokens: int | None = None,
-    entity_types: list[str] | None = None,
-    relationship_types: list[str] | None = None,
+    entity_types: list[str],
+    relationship_types: list[str],
 ) -> tuple[list[Entity], list[Relationship]]:
     """Extract entities and relationships from chunks.
 
@@ -42,14 +42,13 @@ async def extract_entities(
         retry_wait: Base wait time for exponential backoff between retries
         extraction_batch_size: Maximum texts per extraction batch
         max_tokens: Maximum tokens for LLM response
-        entity_types: Optional entity types to extract (overrides expertise/skill)
-        relationship_types: Optional relationship types to extract (overrides expertise/skill)
+        entity_types: Required entity types to extract
+        relationship_types: Required relationship types to extract
 
     Returns:
         Tuple of (entities, relationships)
     """
     from khora.core.models import Entity, Relationship
-    from khora.core.models.entity import EntityType, RelationshipType
     from khora.extraction.extractors import LLMEntityExtractor
     from khora.extraction.skills import ExpertiseConfig
     from khora.extraction.skills.registry import get_default_registry
@@ -97,31 +96,17 @@ async def extract_entities(
         extractor_kwargs["max_tokens"] = max_tokens
     extractor = LLMEntityExtractor(**extractor_kwargs)
 
-    # Normalize empty lists to None
-    entity_types = entity_types or None
-    relationship_types = relationship_types or None
-
     # Extract from all chunks using adaptive token-budget-based batching
     # Groups chunks into batches that fit within the model's input token budget,
     # reducing API round-trips by up to 5x while avoiding context overflow
     texts = [chunk.content for chunk in chunks]
 
-    # Resolve types: explicit param > expertise > skill > default
-    # When explicit params are provided, pass them directly to the extractor
-    # which will use them over expertise/defaults.
-    resolved_entity_types = entity_types
-    resolved_relationship_types = relationship_types
-
-    if resolved_entity_types is None and not resolved_expertise:
-        # No explicit types and no expertise — use skill types
-        resolved_entity_types = skill.entity_types if hasattr(skill, "entity_types") and skill.entity_types else None
-
     # Use adaptive batching based on token budget (auto-calculated from max_tokens)
     # batch_size=5 is the max texts per batch; actual batching respects token limits
     results = await extractor.extract_multi(
         texts,
-        entity_types=resolved_entity_types,
-        relationship_types=resolved_relationship_types,
+        entity_types=entity_types,
+        relationship_types=relationship_types,
         expertise=resolved_expertise,
         context=context,
         batch_size=extraction_batch_size,
@@ -155,10 +140,7 @@ async def extract_entities(
                     existing.valid_from = chunk.created_at
             else:
                 # Create new entity — preserve original type string from LLM
-                try:
-                    entity_type: EntityType | str = EntityType(extracted.entity_type)
-                except ValueError:
-                    entity_type = extracted.entity_type or "CONCEPT"
+                entity_type = extracted.entity_type or "CONCEPT"
 
                 entity = Entity(
                     namespace_id=chunk.namespace_id,
@@ -185,10 +167,7 @@ async def extract_entities(
                 continue
 
             # Preserve original type string from LLM
-            try:
-                rel_type: RelationshipType | str = RelationshipType(extracted_rel.relationship_type)
-            except ValueError:
-                rel_type = extracted_rel.relationship_type or "RELATES_TO"
+            rel_type = extracted_rel.relationship_type or "RELATES_TO"
 
             # Find source and target entities (normalize names to match dedup keys)
             source_key = entity_name_to_key.get(normalize_entity_name(extracted_rel.source_entity))

--- a/tests/integration/test_incremental_ingestion.py
+++ b/tests/integration/test_incremental_ingestion.py
@@ -469,7 +469,12 @@ class TestIncrementalIngestion:
             patch("khora.telemetry.context.ensure_trace_id"),
             patch("khora.telemetry.context.clear_trace_id"),
         ):
-            await lake.remember("Test content", title="Test")
+            await lake.remember(
+                "Test content",
+                title="Test",
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR"],
+            )
 
         engine.remember.assert_awaited_once()
 
@@ -495,7 +500,13 @@ class TestIncrementalIngestion:
 
         mock_result = {"chunks": 1, "entities": 1, "relationships": 0}
         with patch("khora.pipelines.flows.ingest.process_document", AsyncMock(return_value=mock_result)):
-            await engine.remember("Test content", NAMESPACE_ID, title="Test")
+            await engine.remember(
+                "Test content",
+                NAMESPACE_ID,
+                title="Test",
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR"],
+            )
 
         mock_query_engine.invalidate_caches.assert_called_once_with(NAMESPACE_ID)
 
@@ -531,6 +542,8 @@ class TestIncrementalIngestion:
             await engine.remember_batch(
                 [{"content": "Doc 1"}, {"content": "Doc 2"}],
                 NAMESPACE_ID,
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR"],
             )
 
         mock_query_engine.invalidate_caches.assert_called_once_with(NAMESPACE_ID)
@@ -572,6 +585,8 @@ class TestIncrementalIngestion:
             result = await lake.remember(
                 "Alice Johnson is a senior engineer at Acme Corp.",
                 title="Alice Profile",
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR"],
             )
             assert result.chunks_created == 3
             assert result.entities_extracted == 2
@@ -631,12 +646,20 @@ class TestIncrementalIngestion:
             patch("khora.telemetry.context.clear_trace_id"),
         ):
             # Ingest batch 1
-            r1 = await lake.remember_batch(BATCH_1_DOCS)
+            r1 = await lake.remember_batch(
+                BATCH_1_DOCS,
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR", "MANAGES", "COLLABORATES_WITH"],
+            )
             assert r1.processed == 3
             assert r1.entities == 4
 
             # Ingest batch 2
-            r2 = await lake.remember_batch(BATCH_2_DOCS)
+            r2 = await lake.remember_batch(
+                BATCH_2_DOCS,
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR", "MANAGES", "COLLABORATES_WITH"],
+            )
             assert r2.processed == 2
             assert r2.entities == 2
 
@@ -858,13 +881,25 @@ class TestIncrementalIngestion:
             patch("khora.telemetry.context.ensure_trace_id"),
             patch("khora.telemetry.context.clear_trace_id"),
         ):
-            r1 = await lake.remember_batch(BATCH_1_DOCS)
+            r1 = await lake.remember_batch(
+                BATCH_1_DOCS,
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR", "MANAGES", "COLLABORATES_WITH"],
+            )
             assert r1.processed == 3
 
-            r2 = await lake.remember_batch(BATCH_2_DOCS)
+            r2 = await lake.remember_batch(
+                BATCH_2_DOCS,
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR", "MANAGES", "COLLABORATES_WITH"],
+            )
             assert r2.processed == 2
 
-            r3 = await lake.remember_batch(batch3_docs)
+            r3 = await lake.remember_batch(
+                batch3_docs,
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR", "MANAGES", "COLLABORATES_WITH"],
+            )
             assert r3.processed == 2
 
             result = await lake.recall("Acme Corp team")

--- a/tests/unit/engines/test_vectorcypher_engine.py
+++ b/tests/unit/engines/test_vectorcypher_engine.py
@@ -314,7 +314,12 @@ class TestVectorCypherEngineRemember:
 
         connected_engine._storage.get_document_by_checksum = AsyncMock(return_value=existing_doc)
 
-        result = await connected_engine.remember("test content", namespace_id)
+        result = await connected_engine.remember(
+            "test content",
+            namespace_id,
+            entity_types=["PERSON", "ORGANIZATION", "LOCATION"],
+            relationship_types=["WORKS_FOR", "KNOWS", "LOCATED_IN"],
+        )
 
         assert result.document_id == doc_id
         assert result.metadata.get("duplicate") is True
@@ -342,6 +347,8 @@ class TestVectorCypherEngineRemember:
                 namespace_id,
                 title="Test Doc",
                 source="unit_test",
+                entity_types=["PERSON", "ORGANIZATION", "LOCATION"],
+                relationship_types=["WORKS_FOR", "KNOWS", "LOCATED_IN"],
             )
 
         assert result.document_id == doc_id

--- a/tests/unit/test_extraction_llm.py
+++ b/tests/unit/test_extraction_llm.py
@@ -226,7 +226,13 @@ class TestRenderPrompts:
     def test_extraction_prompt_default(self) -> None:
         """Default extraction prompt includes entity types and text."""
         extractor = LLMEntityExtractor()
-        prompt = extractor._render_extraction_prompt("test text", ["PERSON", "ORGANIZATION"], None, None)
+        prompt = extractor._render_extraction_prompt(
+            "test text",
+            ["PERSON", "ORGANIZATION"],
+            None,
+            None,
+            relationship_types=["WORKS_FOR", "KNOWS"],
+        )
         assert "PERSON" in prompt
         assert "ORGANIZATION" in prompt
         assert "test text" in prompt
@@ -235,7 +241,13 @@ class TestRenderPrompts:
         """Long text is truncated in extraction prompt."""
         extractor = LLMEntityExtractor()
         long_text = "a" * 20000
-        prompt = extractor._render_extraction_prompt(long_text, ["PERSON"], None, None)
+        prompt = extractor._render_extraction_prompt(
+            long_text,
+            ["PERSON"],
+            None,
+            None,
+            relationship_types=["WORKS_FOR"],
+        )
         # Text should be truncated at 8000 chars
         assert len(prompt) < 20000
 
@@ -277,7 +289,11 @@ class TestExtract:
             patch("khora.telemetry.get_collector") as mock_telem,
         ):
             mock_telem.return_value.record_llm_call = MagicMock()
-            result = await extractor.extract("Alice works at Acme Corp")
+            result = await extractor.extract(
+                "Alice works at Acme Corp",
+                entity_types=["PERSON", "ORGANIZATION", "LOCATION"],
+                relationship_types=["WORKS_FOR", "KNOWS", "LOCATED_IN"],
+            )
 
         assert len(result.entities) == 1
         assert result.entities[0].name == "Alice"
@@ -289,7 +305,11 @@ class TestExtract:
 
         with patch("litellm.acompletion", new_callable=AsyncMock, side_effect=Exception("API error")):
             with patch("asyncio.sleep", new_callable=AsyncMock):
-                result = await extractor.extract("test text")
+                result = await extractor.extract(
+                    "test text",
+                    entity_types=["PERSON", "ORGANIZATION"],
+                    relationship_types=["WORKS_FOR", "KNOWS"],
+                )
 
         assert "error" in result.metadata
 
@@ -336,7 +356,12 @@ class TestExtractMulti:
             patch("khora.telemetry.get_collector") as mock_telem,
         ):
             mock_telem.return_value.record_llm_call = MagicMock()
-            results = await extractor.extract_multi(["text1", "text2"], batch_size=5)
+            results = await extractor.extract_multi(
+                ["text1", "text2"],
+                batch_size=5,
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR", "KNOWS"],
+            )
 
         assert len(results) == 2
         assert results[0].entities[0].name == "A"
@@ -402,6 +427,8 @@ class TestTieredExtraction:
             ["Hi alice@test.com"],
             tiered_extraction=True,
             tier1_max_chars=200,
+            entity_types=["PERSON", "EMAIL"],
+            relationship_types=["KNOWS"],
         )
         assert len(results) == 1
         assert results[0].metadata.get("extraction_method") == "regex"

--- a/tests/unit/test_ingest_temporal_chunks.py
+++ b/tests/unit/test_ingest_temporal_chunks.py
@@ -105,6 +105,8 @@ class TestIngestTemporalChunks:
                 document,
                 storage,
                 temporal_store=temporal_store,
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR"],
             )
 
         # The key assertion: temporal_store.create_chunks_batch must have been called
@@ -152,6 +154,8 @@ class TestIngestTemporalChunks:
                 document,
                 storage,
                 # No temporal_store -- default None
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR"],
             )
 
         assert result["chunks"] == 1
@@ -189,6 +193,8 @@ class TestIngestTemporalChunks:
                 document,
                 storage,
                 temporal_store=temporal_store,
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR"],
             )
 
         temporal_store.create_chunks_batch.assert_awaited_once()
@@ -242,6 +248,8 @@ class TestIngestTemporalChunks:
                 document,
                 storage,
                 temporal_store=temporal_store,
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR"],
             )
 
         temporal_store.create_chunks_batch.assert_awaited_once()

--- a/tests/unit/test_logfire_integration.py
+++ b/tests/unit/test_logfire_integration.py
@@ -453,7 +453,12 @@ class TestMemoryLakeSpans:
 
             mock_span_fn.side_effect = tracking_span
 
-            await lake.remember("Hello, this is test content", title="Test")
+            await lake.remember(
+                "Hello, this is test content",
+                title="Test",
+                entity_types=["PERSON", "ORGANIZATION", "LOCATION"],
+                relationship_types=["WORKS_FOR", "KNOWS", "LOCATED_IN"],
+            )
 
         mock_span_fn.assert_called_once()
         call_args = mock_span_fn.call_args
@@ -554,7 +559,11 @@ class TestMemoryLakeSpans:
 
             mock_span_fn.side_effect = tracking_span
 
-            await lake.remember_batch(docs)
+            await lake.remember_batch(
+                docs,
+                entity_types=["PERSON", "ORGANIZATION", "LOCATION"],
+                relationship_types=["WORKS_FOR", "KNOWS", "LOCATED_IN"],
+            )
 
         mock_span_fn.assert_called_once()
         call_args = mock_span_fn.call_args
@@ -597,7 +606,11 @@ class TestSpanAttributeWhitelist:
 
             mock_span_fn.side_effect = tracking_span
 
-            await lake.remember(secret_content)
+            await lake.remember(
+                secret_content,
+                entity_types=["PERSON", "ORGANIZATION", "LOCATION"],
+                relationship_types=["WORKS_FOR", "KNOWS", "LOCATED_IN"],
+            )
 
         call_args = mock_span_fn.call_args
         # The attributes should contain content_length (integer), not the content itself

--- a/tests/unit/test_memory_lake.py
+++ b/tests/unit/test_memory_lake.py
@@ -354,7 +354,12 @@ class TestRemember:
             patch("khora.telemetry.context.ensure_trace_id"),
             patch("khora.telemetry.context.clear_trace_id"),
         ):
-            result = await lake.remember("test content", title="Test")
+            result = await lake.remember(
+                "test content",
+                title="Test",
+                entity_types=["PERSON", "ORGANIZATION", "LOCATION"],
+                relationship_types=["WORKS_FOR", "KNOWS", "LOCATED_IN"],
+            )
 
         assert result is mock_result
         lake._engine.remember.assert_awaited_once()
@@ -852,7 +857,11 @@ class TestEnhancedRememberBatch:
             patch("khora.telemetry.context.ensure_trace_id"),
             patch("khora.telemetry.context.clear_trace_id"),
         ):
-            result = await lake.remember_batch([])
+            result = await lake.remember_batch(
+                [],
+                entity_types=["PERSON", "ORGANIZATION", "LOCATION"],
+                relationship_types=["WORKS_FOR", "KNOWS", "LOCATED_IN"],
+            )
 
         assert isinstance(result, BatchResult)
         assert result.total == 0
@@ -885,7 +894,9 @@ class TestEnhancedRememberBatch:
                     {"content": "Doc 1"},
                     {"content": "Doc 2"},
                     {"content": "Doc 3"},
-                ]
+                ],
+                entity_types=["PERSON", "ORGANIZATION", "LOCATION"],
+                relationship_types=["WORKS_FOR", "KNOWS", "LOCATED_IN"],
             )
 
         assert isinstance(result, BatchResult)

--- a/tests/unit/test_parameterized_extraction.py
+++ b/tests/unit/test_parameterized_extraction.py
@@ -13,11 +13,7 @@ from uuid import uuid4
 import pytest
 
 from khora.extraction.extractors.base import ExtractionResult
-from khora.extraction.extractors.llm import (
-    DEFAULT_ENTITY_TYPES,
-    DEFAULT_RELATIONSHIP_TYPES,
-    LLMEntityExtractor,
-)
+from khora.extraction.extractors.llm import LLMEntityExtractor
 from khora.extraction.skills.base import EntityTypeConfig, ExpertiseConfig
 
 # ---------------------------------------------------------------------------
@@ -118,16 +114,25 @@ def _make_lake(*, connected: bool = False):
 
 
 # ---------------------------------------------------------------------------
-# 1. Default types when None
+# 1. No defaults injected when None — extract() errors without types
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-class TestExtractDefaultTypes:
-    """Calling extract() without entity_types/relationship_types uses defaults."""
+class TestExtractNoDefaultsWhenNone:
+    """Calling extract() without entity_types/relationship_types no longer injects defaults."""
 
-    async def test_extract_default_types_when_none(self) -> None:
-        """Prompt contains DEFAULT_ENTITY_TYPES and DEFAULT_RELATIONSHIP_TYPES."""
+    async def test_extract_none_types_raises_without_expertise(self) -> None:
+        """When entity_types=None, relationship_types=None, and no expertise, extract errors."""
+        extractor = LLMEntityExtractor(model="gpt-4o-mini", max_retries=1)
+
+        with patch("litellm.acompletion", new_callable=AsyncMock):
+            # Without types or expertise, the prompt builder gets None and fails
+            with pytest.raises(TypeError):
+                await extractor.extract("Alice works at Acme Corp in New York.")
+
+    async def test_extract_with_explicit_types_works(self) -> None:
+        """When entity_types and relationship_types are provided, extract succeeds."""
         extractor = LLMEntityExtractor(model="gpt-4o-mini", max_retries=1)
         captured_messages: list = []
 
@@ -136,18 +141,17 @@ class TestExtractDefaultTypes:
             return _make_llm_response()
 
         with patch("litellm.acompletion", side_effect=_capture_acompletion):
-            await extractor.extract("Alice works at Acme Corp in New York.")
+            await extractor.extract(
+                "Alice works at Acme Corp in New York.",
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR"],
+            )
 
         assert len(captured_messages) == 1
         user_prompt = captured_messages[0][1]["content"]
-
-        # All default entity types should appear
-        for et in DEFAULT_ENTITY_TYPES:
-            assert et in user_prompt, f"Default entity type {et!r} not found in prompt"
-
-        # All default relationship types should appear
-        for rt in DEFAULT_RELATIONSHIP_TYPES:
-            assert rt in user_prompt, f"Default relationship type {rt!r} not found in prompt"
+        assert "PERSON" in user_prompt
+        assert "ORGANIZATION" in user_prompt
+        assert "WORKS_FOR" in user_prompt
 
 
 # ---------------------------------------------------------------------------
@@ -172,6 +176,7 @@ class TestExtractCustomEntityTypes:
             await extractor.extract(
                 "BRCA1 gene is targeted by Olaparib.",
                 entity_types=["DRUG", "GENE"],
+                relationship_types=["TARGETS"],
             )
 
         user_prompt = captured_messages[0][1]["content"]
@@ -206,6 +211,7 @@ class TestExtractCustomRelationshipTypes:
         with patch("litellm.acompletion", side_effect=_capture_acompletion):
             await extractor.extract(
                 "BRCA1 is targeted by Olaparib which inhibits PARP.",
+                entity_types=["DRUG", "GENE", "PROTEIN"],
                 relationship_types=["TARGETS", "INHIBITS"],
             )
 
@@ -249,6 +255,7 @@ class TestExtractExplicitOverridesExpertise:
             await extractor.extract(
                 "Olaparib targets BRCA1.",
                 entity_types=["DRUG"],
+                relationship_types=["TARGETS"],
                 expertise=expertise,
             )
 
@@ -260,16 +267,16 @@ class TestExtractExplicitOverridesExpertise:
 
 
 # ---------------------------------------------------------------------------
-# 5. Empty list normalization
+# 5. Empty lists pass through as-is (no defaults injected)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-class TestExtractEmptyListNormalization:
-    """Empty lists [] are treated as None and fall back to defaults."""
+class TestExtractEmptyListNoDefaults:
+    """Empty lists [] are NOT normalized to defaults anymore."""
 
-    async def test_extract_empty_list_uses_defaults(self) -> None:
-        """Empty entity_types=[] and relationship_types=[] use DEFAULT types."""
+    async def test_extract_empty_list_no_defaults_injected(self) -> None:
+        """Empty entity_types=[] and relationship_types=[] do not inject defaults."""
         extractor = LLMEntityExtractor(model="gpt-4o-mini", max_retries=1)
         captured_messages: list = []
 
@@ -286,12 +293,12 @@ class TestExtractEmptyListNormalization:
 
         user_prompt = captured_messages[0][1]["content"]
 
-        # Should contain defaults since empty lists are normalized to None
-        for et in DEFAULT_ENTITY_TYPES:
-            assert et in user_prompt, f"Default entity type {et!r} missing after empty-list normalization"
-
-        for rt in DEFAULT_RELATIONSHIP_TYPES:
-            assert rt in user_prompt, f"Default relationship type {rt!r} missing after empty-list normalization"
+        # Old defaults should NOT appear since empty lists are no longer
+        # normalized to defaults
+        entity_line = [line for line in user_prompt.split("\n") if "Entity types to extract:" in line]
+        if entity_line:
+            assert "PERSON" not in entity_line[0], "Old default PERSON should not be injected for empty list"
+            assert "ORGANIZATION" not in entity_line[0], "Old default ORGANIZATION should not be injected"
 
 
 # ---------------------------------------------------------------------------
@@ -451,3 +458,83 @@ class TestMemoryLakeRememberBatchThreadsTypes:
         call_kwargs = lake._engine.remember_batch.call_args
         assert call_kwargs.kwargs["entity_types"] == ["DRUG"]
         assert call_kwargs.kwargs["relationship_types"] == ["TARGETS"]
+
+
+# ---------------------------------------------------------------------------
+# 10. remember() requires ontology params
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRememberRequiresOntologyParams:
+    """Verify that calling lake.remember() without entity_types or relationship_types raises TypeError."""
+
+    async def test_remember_missing_entity_types_raises(self) -> None:
+        """remember() without entity_types raises TypeError."""
+        lake = _make_lake(connected=True)
+        ns_id = uuid4()
+        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
+
+        with pytest.raises(TypeError):
+            await lake.remember("some text", relationship_types=["KNOWS"])
+
+    async def test_remember_missing_relationship_types_raises(self) -> None:
+        """remember() without relationship_types raises TypeError."""
+        lake = _make_lake(connected=True)
+        ns_id = uuid4()
+        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
+
+        with pytest.raises(TypeError):
+            await lake.remember("some text", entity_types=["PERSON"])
+
+    async def test_remember_missing_both_raises(self) -> None:
+        """remember() without either ontology param raises TypeError."""
+        lake = _make_lake(connected=True)
+        ns_id = uuid4()
+        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
+
+        with pytest.raises(TypeError):
+            await lake.remember("some text")
+
+
+# ---------------------------------------------------------------------------
+# 11. remember_batch() requires ontology params
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRememberBatchRequiresOntologyParams:
+    """Verify that calling lake.remember_batch() without entity_types or relationship_types raises TypeError."""
+
+    async def test_remember_batch_missing_entity_types_raises(self) -> None:
+        """remember_batch() without entity_types raises TypeError."""
+        lake = _make_lake(connected=True)
+        ns_id = uuid4()
+        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
+
+        with pytest.raises(TypeError):
+            await lake.remember_batch(
+                [{"content": "text"}],
+                relationship_types=["KNOWS"],
+            )
+
+    async def test_remember_batch_missing_relationship_types_raises(self) -> None:
+        """remember_batch() without relationship_types raises TypeError."""
+        lake = _make_lake(connected=True)
+        ns_id = uuid4()
+        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
+
+        with pytest.raises(TypeError):
+            await lake.remember_batch(
+                [{"content": "text"}],
+                entity_types=["PERSON"],
+            )
+
+    async def test_remember_batch_missing_both_raises(self) -> None:
+        """remember_batch() without either ontology param raises TypeError."""
+        lake = _make_lake(connected=True)
+        ns_id = uuid4()
+        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
+
+        with pytest.raises(TypeError):
+            await lake.remember_batch([{"content": "text"}])

--- a/tests/unit/test_perf_optimizations.py
+++ b/tests/unit/test_perf_optimizations.py
@@ -166,7 +166,11 @@ class TestB6SemaphoreReleaseDuringRetry:
             patch("khora.telemetry.get_collector") as mock_telem,
         ):
             mock_telem.return_value.record_llm_call = MagicMock()
-            result = await extractor.extract("test text")
+            result = await extractor.extract(
+                "test text",
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR", "KNOWS"],
+            )
 
         assert semaphore_was_free, "Semaphore should be free during retry sleep"
         assert len(result.entities) == 1
@@ -204,7 +208,12 @@ class TestB6SemaphoreReleaseDuringRetry:
             patch("khora.telemetry.get_collector") as mock_telem,
         ):
             mock_telem.return_value.record_llm_call = MagicMock()
-            results = await extractor.extract_multi(["text1"], batch_size=5)
+            results = await extractor.extract_multi(
+                ["text1"],
+                batch_size=5,
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR", "KNOWS"],
+            )
 
         assert semaphore_was_free, "Semaphore should be free during retry sleep"
         assert len(results) == 1
@@ -619,7 +628,12 @@ class TestMultiBatchOptimizations:
             patch("khora.telemetry.get_collector") as mock_telem,
         ):
             mock_telem.return_value.record_llm_call = MagicMock()
-            results = await extractor.extract_multi(["text about Alice"], batch_size=5)
+            results = await extractor.extract_multi(
+                ["text about Alice"],
+                batch_size=5,
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR", "KNOWS"],
+            )
 
         assert len(results) == 1
         assert results[0].entities[0].name == "Alice"
@@ -641,7 +655,12 @@ class TestMultiBatchOptimizations:
             patch("khora.telemetry.get_collector") as mock_telem,
         ):
             mock_telem.return_value.record_llm_call = MagicMock()
-            results = await extractor.extract_multi(["text1", "text2"], batch_size=5)
+            results = await extractor.extract_multi(
+                ["text1", "text2"],
+                batch_size=5,
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR", "KNOWS"],
+            )
 
         assert len(results) == 2
         assert len(results[0].entities) == 0

--- a/tests/unit/test_pipelines_ingest.py
+++ b/tests/unit/test_pipelines_ingest.py
@@ -196,6 +196,8 @@ class TestStreamExtractAndEmbedEntities:
         entities, relationships = await stream_extract_and_embed_entities(
             chunks=[],
             embedder=embedder,
+            entity_types=["PERSON"],
+            relationship_types=["WORKS_FOR"],
         )
 
         assert entities == []
@@ -255,6 +257,8 @@ class TestStreamExtractAndEmbedEntities:
             entities, relationships = await stream_extract_and_embed_entities(
                 chunks=[chunk],
                 embedder=embedder,
+                entity_types=["PERSON"],
+                relationship_types=["WORKS_FOR"],
             )
 
         assert len(entities) == 1
@@ -331,6 +335,8 @@ class TestStreamExtractAndEmbedEntities:
             entities, relationships = await stream_extract_and_embed_entities(
                 chunks=[chunk],
                 embedder=embedder,
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR"],
             )
 
         assert len(entities) == 2
@@ -395,6 +401,8 @@ class TestStreamExtractAndEmbedEntities:
                 chunks=chunks,
                 embedder=embedder,
                 embedding_batch_size=2,  # Small batch size for testing
+                entity_types=["PERSON"],
+                relationship_types=["WORKS_FOR"],
             )
 
         assert len(entities) == 5

--- a/tests/unit/test_pipelines_tasks.py
+++ b/tests/unit/test_pipelines_tasks.py
@@ -208,7 +208,12 @@ class TestExtractEntities:
 
             extractor = LLMEntityExtractor(model="test-model")
             texts = [chunk1.content, chunk2.content]
-            results = await extractor.extract_multi(texts, batch_size=3)
+            results = await extractor.extract_multi(
+                texts,
+                batch_size=3,
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR", "KNOWS"],
+            )
 
         # Collect entities across results and dedup by name:type
         from khora.core.models import Entity
@@ -271,7 +276,12 @@ class TestExtractEntities:
         ):
             mock_telem.return_value.record_llm_call = MagicMock()
             extractor = LLMEntityExtractor(model="test-model")
-            results = await extractor.extract_multi([chunk.content], batch_size=3)
+            results = await extractor.extract_multi(
+                [chunk.content],
+                batch_size=3,
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR", "KNOWS"],
+            )
 
         # Filter with 0.5 threshold
         entities = [e for e in results[0].entities if e.confidence >= 0.5]


### PR DESCRIPTION
## Summary

ADR-005 Track 1: Make Khora ontology-agnostic by removing extraction defaults and requiring callers to explicitly provide entity/relationship types.

- Remove `DEFAULT_ENTITY_TYPES` and `DEFAULT_RELATIONSHIP_TYPES` constants from `extraction/extractors/llm.py`
- Remove `DEFAULT_ENTITY_TYPES` from `EntityResolver` in `entity_resolution.py`
- Make `entity_types: list[str]` and `relationship_types: list[str]` **required** (no default) in:
  - `MemoryLake.remember()` and `remember_batch()` (public API)
  - `MemoryEngineProtocol` (engine protocol)
  - All 3 engine implementations (GraphRAG, Skeleton, VectorCypher) — both public and internal methods
  - `extract_entities()` pipeline task
  - `stream_extract_and_embed_entities()`, `process_document()`, `ingest_documents()`, `_extract_cross_chunk_relationships()` in ingest pipeline
- Remove empty-list-to-None normalization in `LLMEntityExtractor.extract_multi()`
- Remove all fallback-to-defaults logic throughout the pipeline
- Update docs and docstring examples to reflect required params

**Breaking change**: Callers must now pass `entity_types` and `relationship_types` explicitly. This blocks DYT-268 (Peras), DYT-269 (Genesis), DYT-270 (Khora-Benchmarks).

## Test plan
- [x] All 1477 tests pass (unit + integration)
- [x] New tests verify `TypeError` when `entity_types`/`relationship_types` omitted from `remember()`/`remember_batch()`
- [x] Coverage: 53.69% (above 30% threshold)
- [x] `make format` passes
- [x] `make lint` — ruff/black/isort pass; `ty` has 16 pre-existing diagnostics (unchanged)
- [x] No remaining references to `DEFAULT_ENTITY_TYPES`/`DEFAULT_RELATIONSHIP_TYPES` in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)