### PR TITLE
DYT-289: Add granular telemetry spans to recall and ingestion paths

### DIFF
--- a/src/khora/engines/skeleton/backends/pgvector.py
+++ b/src/khora/engines/skeleton/backends/pgvector.py
@@ -39,6 +39,7 @@ from khora.engines.skeleton.backends import (
     TemporalSearchResult,
     TemporalVectorStore,
 )
+from khora.telemetry import trace_span
 
 if TYPE_CHECKING:
     from khora.config import KhoraConfig
@@ -286,6 +287,35 @@ class PgVectorTemporalStore(TemporalVectorStore):
         QUALITY FIX: When vector search returns insufficient results, automatically
         falls back to keyword search to improve recall on non-core chunks.
         """
+        with trace_span(
+            "khora.temporal_store.search",
+            namespace_id=str(namespace_id),
+            limit=limit,
+            hybrid=hybrid_alpha is not None,
+        ) as _search_span:
+            results = await self._search_inner(
+                namespace_id,
+                query_embedding,
+                limit=limit,
+                min_similarity=min_similarity,
+                temporal_filter=temporal_filter,
+                hybrid_alpha=hybrid_alpha,
+                query_text=query_text,
+            )
+            _search_span.set_attribute("result_count", len(results))
+            return results
+
+    async def _search_inner(
+        self,
+        namespace_id: UUID,
+        query_embedding: list[float],
+        *,
+        limit: int = 10,
+        min_similarity: float = 0.0,
+        temporal_filter: TemporalFilter | None = None,
+        hybrid_alpha: float | None = None,
+        query_text: str | None = None,
+    ) -> list[TemporalSearchResult]:
         async with self._get_session() as session:
             # Build base conditions
             conditions = [khora_chunks_table.c.namespace_id == namespace_id]

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -569,7 +569,8 @@ class VectorCypherEngine:
             chunker = create_chunker(chunker_config)
 
             # Chunk the document
-            raw_chunks = await asyncio.to_thread(chunker.chunk, document.content)
+            with trace_span("khora.vectorcypher.chunking"):
+                raw_chunks = await asyncio.to_thread(chunker.chunk, document.content)
 
             if not raw_chunks:
                 document.mark_completed(0, 0)
@@ -578,8 +579,9 @@ class VectorCypherEngine:
                 return 0, 0, 0
 
             # Embed chunks in batch
-            chunk_texts = [c.content for c in raw_chunks]
-            embeddings = await embedder.embed_batch(chunk_texts)
+            with trace_span("khora.vectorcypher.embed_batch", chunk_count=len(raw_chunks)):
+                chunk_texts = [c.content for c in raw_chunks]
+                embeddings = await embedder.embed_batch(chunk_texts)
 
             # Extract metadata
             doc_metadata = document.metadata.custom if document.metadata else {}
@@ -1030,6 +1032,11 @@ class VectorCypherEngine:
 
         return validated
 
+    @trace(
+        "khora.vectorcypher.recall",
+        include={"namespace_id", "limit", "mode"},
+        result=lambda r: {"chunk_count": len(r.chunks), "entity_count": len(r.entities)},
+    )
     async def recall(
         self,
         query: str,
@@ -1068,11 +1075,14 @@ class VectorCypherEngine:
         # Replaces the old regex + dateparser approach with categorized signals.
         temporal_signal: TemporalSignal | None = None
         if temporal_filter is None:
-            detector = TemporalDetector()
-            temporal_signal = detector.detect(query)
-            # EXPLICIT category produces a date-range TemporalFilter for pushdown
-            if temporal_signal.temporal_filter is not None:
-                temporal_filter = temporal_signal.temporal_filter
+            with trace_span("khora.vectorcypher.temporal_detect") as td_span:
+                detector = TemporalDetector()
+                temporal_signal = detector.detect(query)
+                td_span.set_attribute("category", temporal_signal.category.value)
+                td_span.set_attribute("confidence", temporal_signal.confidence)
+                # EXPLICIT category produces a date-range TemporalFilter for pushdown
+                if temporal_signal.temporal_filter is not None:
+                    temporal_filter = temporal_signal.temporal_filter
 
         # Use VectorCypher retriever
         result = await retriever.retrieve(

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -237,12 +237,16 @@ class VectorCypherRetriever:
                         del self._cache[cache_key]
 
             # Step 1: Route query to determine strategy
-            routing = await self._router.route(query)
+            with trace_span("khora.vectorcypher.route") as route_span:
+                routing = await self._router.route(query)
+                route_span.set_attribute("complexity", routing.complexity.value)
+                route_span.set_attribute("use_graph", routing.use_graph)
             logger.debug(f"Query routing: {routing.complexity.value} (use_graph={routing.use_graph})")
             span.set_attribute("routing_complexity", routing.complexity.value)
 
             # Step 2: Embed the query
-            query_embedding = await self._embedder.embed(query)
+            with trace_span("khora.vectorcypher.embed_query"):
+                query_embedding = await self._embedder.embed(query)
 
             # Step 3: Vector search for entry points
             if routing.complexity == QueryComplexity.SIMPLE:
@@ -413,19 +417,23 @@ class VectorCypherRetriever:
         if temporal_filter is not None and effective_recency > 0:
             effective_recency = max(effective_recency, 0.4)
         if effective_recency > 0:
-            recency_scores = self._calculate_recency_scores(fused_results, decay_days_override=_tp.decay_days_override)
-            fused_results = apply_recency_boost(
-                fused_results,
-                recency_scores,
-                recency_weight=effective_recency,
-            )
+            with trace_span("khora.vectorcypher.recency_boost", chunk_count=len(fused_results)):
+                recency_scores = self._calculate_recency_scores(
+                    fused_results, decay_days_override=_tp.decay_days_override
+                )
+                fused_results = apply_recency_boost(
+                    fused_results,
+                    recency_scores,
+                    recency_weight=effective_recency,
+                )
 
         # Step 8b: Apply coherence scoring to penalize word-shuffled confounders
         if self._config.coherence_weight > 0:
-            fused_results = apply_coherence_boost(
-                fused_results,
-                coherence_weight=self._config.coherence_weight,
-            )
+            with trace_span("khora.vectorcypher.coherence_boost", chunk_count=len(fused_results)):
+                fused_results = apply_coherence_boost(
+                    fused_results,
+                    coherence_weight=self._config.coherence_weight,
+                )
 
         # Normalize scores
         fused_results = normalize_scores(fused_results)
@@ -514,50 +522,53 @@ class VectorCypherRetriever:
         For SIMPLE-routed queries, uses a lower hybrid_alpha (0.5) to give
         BM25 equal weight — lexical overlap is stronger for factual queries.
         """
-        # WS8: Lower alpha for SIMPLE queries to boost BM25 signal
-        effective_alpha = self._config.hybrid_alpha
-        if routing.complexity == QueryComplexity.SIMPLE:
-            effective_alpha = min(effective_alpha, 0.5)
+        with trace_span("khora.vectorcypher.simple_retrieve", namespace_id=str(namespace_id)) as span:
+            # WS8: Lower alpha for SIMPLE queries to boost BM25 signal
+            effective_alpha = self._config.hybrid_alpha
+            if routing.complexity == QueryComplexity.SIMPLE:
+                effective_alpha = min(effective_alpha, 0.5)
 
-        results = await self._vector_store.search(
-            namespace_id=namespace_id,
-            query_embedding=query_embedding,
-            limit=limit,
-            temporal_filter=temporal_filter,
-            hybrid_alpha=effective_alpha,
-            query_text=query,
-        )
-
-        chunk_results: list[tuple[Chunk, float]] = []
-        for r in results:
-            chunk = Chunk(
-                id=r.chunk.id,
-                namespace_id=r.chunk.namespace_id,
-                document_id=r.chunk.document_id,
-                content=r.chunk.content,
-                metadata=ChunkMetadata(
-                    custom={
-                        "occurred_at": r.chunk.occurred_at.isoformat() if r.chunk.occurred_at else None,
-                        **(r.chunk.metadata or {}),
-                    }
-                ),
-                created_at=r.chunk.created_at or r.chunk.occurred_at,
+            results = await self._vector_store.search(
+                namespace_id=namespace_id,
+                query_embedding=query_embedding,
+                limit=limit,
+                temporal_filter=temporal_filter,
+                hybrid_alpha=effective_alpha,
+                query_text=query,
             )
-            chunk_results.append((chunk, r.combined_score or r.similarity))
 
-        # Apply recency boost to simple path (was previously missing)
-        if effective_recency > 0 and chunk_results:
-            fused = [FusedResult(item=c, rrf_score=s, item_id=c.id) for c, s in chunk_results]
-            recency_scores = self._calculate_recency_scores(fused, decay_days_override=decay_days_override)
-            fused = apply_recency_boost(fused, recency_scores, recency_weight=effective_recency)
-            chunk_results = [(r.item, r.rrf_score) for r in fused]
+            chunk_results: list[tuple[Chunk, float]] = []
+            for r in results:
+                chunk = Chunk(
+                    id=r.chunk.id,
+                    namespace_id=r.chunk.namespace_id,
+                    document_id=r.chunk.document_id,
+                    content=r.chunk.content,
+                    metadata=ChunkMetadata(
+                        custom={
+                            "occurred_at": r.chunk.occurred_at.isoformat() if r.chunk.occurred_at else None,
+                            **(r.chunk.metadata or {}),
+                        }
+                    ),
+                    created_at=r.chunk.created_at or r.chunk.occurred_at,
+                )
+                chunk_results.append((chunk, r.combined_score or r.similarity))
 
-        return VectorCypherResult(
-            chunks=chunk_results,
-            entities=[],
-            routing_decision=routing,
-            metadata={"search_mode": "simple_vector"},
-        )
+            # Apply recency boost to simple path (was previously missing)
+            if effective_recency > 0 and chunk_results:
+                fused = [FusedResult(item=c, rrf_score=s, item_id=c.id) for c, s in chunk_results]
+                with trace_span("khora.vectorcypher.recency_boost", chunk_count=len(fused)):
+                    recency_scores = self._calculate_recency_scores(fused, decay_days_override=decay_days_override)
+                    fused = apply_recency_boost(fused, recency_scores, recency_weight=effective_recency)
+                chunk_results = [(r.item, r.rrf_score) for r in fused]
+
+            span.set_attribute("chunk_count", len(chunk_results))
+            return VectorCypherResult(
+                chunks=chunk_results,
+                entities=[],
+                routing_decision=routing,
+                metadata={"search_mode": "simple_vector"},
+            )
 
     async def _vector_search_entities(
         self,
@@ -570,16 +581,19 @@ class VectorCypherRetriever:
             logger.warning("Storage coordinator not available for entity vector search")
             return []
 
-        try:
-            return await self._storage.search_similar_entities(
-                namespace_id,
-                query_embedding,
-                limit=limit,
-                min_similarity=self._config.min_entity_similarity,
-            )
-        except Exception as e:
-            logger.warning(f"Entity vector search failed: {e}")
-            return []
+        with trace_span("khora.vectorcypher.vector_search_entities", namespace_id=str(namespace_id)) as span:
+            try:
+                results = await self._storage.search_similar_entities(
+                    namespace_id,
+                    query_embedding,
+                    limit=limit,
+                    min_similarity=self._config.min_entity_similarity,
+                )
+                span.set_attribute("entity_count", len(results))
+                return results
+            except Exception as e:
+                logger.warning(f"Entity vector search failed: {e}")
+                return []
 
     async def _cypher_expand(
         self,
@@ -661,38 +675,44 @@ class VectorCypherRetriever:
         Returns:
             List of (chunk_id, score, chunk) tuples
         """
-        chunk_records = await self._dual_nodes.get_chunks_by_entities(
-            entity_ids=entity_ids,
-            namespace_id=namespace_id,
-            temporal_filter=temporal_filter,
-            temporal_sort=temporal_sort,
-            limit=limit,
-        )
-
-        results: list[tuple[UUID, float, Chunk]] = []
-        for record in chunk_records:
-            chunk_id = UUID(record["chunk_id"])
-            # Score based on mention count and entity coverage
-            score = float(record.get("total_mentions", 1))
-            entity_count = len(record.get("entity_ids", []))
-            score = score * (1 + 0.1 * entity_count)  # Boost for multiple entity connections
-
-            chunk = Chunk(
-                id=chunk_id,
+        with trace_span(
+            "khora.vectorcypher.fetch_entity_chunks",
+            entity_count=len(entity_ids),
+            namespace_id=str(namespace_id),
+        ) as span:
+            chunk_records = await self._dual_nodes.get_chunks_by_entities(
+                entity_ids=entity_ids,
                 namespace_id=namespace_id,
-                document_id=UUID(record["document_id"]),
-                content=record["content"],
-                metadata=ChunkMetadata(
-                    custom={
-                        "occurred_at": record.get("occurred_at"),
-                        "connected_entities": record.get("entity_ids", []),
-                        **(record.get("metadata") or {}),
-                    }
-                ),
+                temporal_filter=temporal_filter,
+                temporal_sort=temporal_sort,
+                limit=limit,
             )
-            results.append((chunk_id, score, chunk))
 
-        return results
+            results: list[tuple[UUID, float, Chunk]] = []
+            for record in chunk_records:
+                chunk_id = UUID(record["chunk_id"])
+                # Score based on mention count and entity coverage
+                score = float(record.get("total_mentions", 1))
+                entity_count = len(record.get("entity_ids", []))
+                score = score * (1 + 0.1 * entity_count)  # Boost for multiple entity connections
+
+                chunk = Chunk(
+                    id=chunk_id,
+                    namespace_id=namespace_id,
+                    document_id=UUID(record["document_id"]),
+                    content=record["content"],
+                    metadata=ChunkMetadata(
+                        custom={
+                            "occurred_at": record.get("occurred_at"),
+                            "connected_entities": record.get("entity_ids", []),
+                            **(record.get("metadata") or {}),
+                        }
+                    ),
+                )
+                results.append((chunk_id, score, chunk))
+
+            span.set_attribute("chunk_count", len(results))
+            return results
 
     async def _vector_search_chunks(
         self,
@@ -714,35 +734,37 @@ class VectorCypherRetriever:
         Returns:
             List of (chunk_id, score, chunk) tuples
         """
-        results = await self._vector_store.search(
-            namespace_id=namespace_id,
-            query_embedding=query_embedding,
-            limit=limit,
-            temporal_filter=temporal_filter,
-            hybrid_alpha=self._config.hybrid_alpha,
-            query_text=query_text,
-        )
-
-        return [
-            (
-                r.chunk.id,
-                r.combined_score or r.similarity,
-                Chunk(
-                    id=r.chunk.id,
-                    namespace_id=r.chunk.namespace_id,
-                    document_id=r.chunk.document_id,
-                    content=r.chunk.content,
-                    metadata=ChunkMetadata(
-                        custom={
-                            "occurred_at": r.chunk.occurred_at.isoformat() if r.chunk.occurred_at else None,
-                            **(r.chunk.metadata or {}),
-                        }
-                    ),
-                    created_at=r.chunk.created_at or r.chunk.occurred_at,
-                ),
+        with trace_span("khora.vectorcypher.vector_search_chunks", namespace_id=str(namespace_id)) as span:
+            results = await self._vector_store.search(
+                namespace_id=namespace_id,
+                query_embedding=query_embedding,
+                limit=limit,
+                temporal_filter=temporal_filter,
+                hybrid_alpha=self._config.hybrid_alpha,
+                query_text=query_text,
             )
-            for r in results
-        ]
+
+            span.set_attribute("chunk_count", len(results))
+            return [
+                (
+                    r.chunk.id,
+                    r.combined_score or r.similarity,
+                    Chunk(
+                        id=r.chunk.id,
+                        namespace_id=r.chunk.namespace_id,
+                        document_id=r.chunk.document_id,
+                        content=r.chunk.content,
+                        metadata=ChunkMetadata(
+                            custom={
+                                "occurred_at": r.chunk.occurred_at.isoformat() if r.chunk.occurred_at else None,
+                                **(r.chunk.metadata or {}),
+                            }
+                        ),
+                        created_at=r.chunk.created_at or r.chunk.occurred_at,
+                    ),
+                )
+                for r in results
+            ]
 
     def _lazy_expand_chunks(
         self,
@@ -816,32 +838,40 @@ class VectorCypherRetriever:
         Returns:
             Fused and sorted results
         """
-        # Dynamic fusion weights based on query complexity
-        vector_weight = self._config.vector_weight
-        graph_weight = self._config.graph_weight
-        if routing is not None:
-            if routing.complexity == QueryComplexity.SIMPLE:
-                vector_weight = self._config.simple_vector_weight
-                graph_weight = self._config.simple_graph_weight
-            elif routing.complexity == QueryComplexity.COMPLEX:
-                vector_weight = self._config.complex_vector_weight
-                graph_weight = self._config.complex_graph_weight
+        with trace_span(
+            "khora.vectorcypher.rrf_fusion",
+            vector_count=len(vector_chunks),
+            graph_count=len(graph_chunks),
+        ) as span:
+            # Dynamic fusion weights based on query complexity
+            vector_weight = self._config.vector_weight
+            graph_weight = self._config.graph_weight
+            if routing is not None:
+                if routing.complexity == QueryComplexity.SIMPLE:
+                    vector_weight = self._config.simple_vector_weight
+                    graph_weight = self._config.simple_graph_weight
+                elif routing.complexity == QueryComplexity.COMPLEX:
+                    vector_weight = self._config.complex_vector_weight
+                    graph_weight = self._config.complex_graph_weight
 
-        if use_normalization:
-            return weighted_rrf_normalized(
+            span.set_attribute("vector_weight", vector_weight)
+            span.set_attribute("graph_weight", graph_weight)
+
+            if use_normalization:
+                return weighted_rrf_normalized(
+                    vector_results=vector_chunks,
+                    graph_results=graph_chunks,
+                    k=self._config.rrf_k,
+                    vector_weight=vector_weight,
+                    graph_weight=graph_weight,
+                )
+            return weighted_rrf(
                 vector_results=vector_chunks,
                 graph_results=graph_chunks,
                 k=self._config.rrf_k,
                 vector_weight=vector_weight,
                 graph_weight=graph_weight,
             )
-        return weighted_rrf(
-            vector_results=vector_chunks,
-            graph_results=graph_chunks,
-            k=self._config.rrf_k,
-            vector_weight=vector_weight,
-            graph_weight=graph_weight,
-        )
 
     def _calculate_recency_scores(
         self,

--- a/src/khora/query/engine.py
+++ b/src/khora/query/engine.py
@@ -874,7 +874,8 @@ class HybridQueryEngine:
                 elif cfg.enable_hyde == "auto" and understanding is not None:
                     should_hyde = understanding.complexity_score > 0.6 or understanding.intent == QueryIntent.TEMPORAL
                 if should_hyde:
-                    query_embedding = await self._hyde_expander.expand_query_embedding(query_text, query_embedding)
+                    with trace_span("khora.query.hyde"):
+                        query_embedding = await self._hyde_expander.expand_query_embedding(query_text, query_embedding)
                     metadata["hyde_applied"] = True
 
         # Step 3-7: Execute search pipeline (multi-stage or legacy)
@@ -2892,39 +2893,43 @@ class HybridQueryEngine:
         if len(chunks) <= k:
             return chunks
 
-        # Extract embeddings from chunks (if available)
-        chunk_embeddings: list[list[float] | None] = []
-        for chunk, _ in chunks:
-            embedding = getattr(chunk, "embedding", None)
-            if embedding is None and hasattr(chunk, "metadata"):
-                embedding = getattr(chunk.metadata, "embedding", None)
-            chunk_embeddings.append(embedding)
+        with trace_span("khora.query.mmr_diversity", candidate_count=len(chunks), k=k) as span:
+            # Extract embeddings from chunks (if available)
+            chunk_embeddings: list[list[float] | None] = []
+            for chunk, _ in chunks:
+                embedding = getattr(chunk, "embedding", None)
+                if embedding is None and hasattr(chunk, "metadata"):
+                    embedding = getattr(chunk.metadata, "embedding", None)
+                chunk_embeddings.append(embedding)
 
-        # If no embeddings available, fall back to score-based selection
-        if all(e is None for e in chunk_embeddings):
-            return chunks[:k]
+            # If no embeddings available, fall back to score-based selection
+            if all(e is None for e in chunk_embeddings):
+                return chunks[:k]
 
-        # For candidates missing embeddings, use the query embedding as a
-        # placeholder (their relevance score will dominate the MMR calc).
-        filled_embeddings: list[list[float]] = [emb if emb is not None else query_embedding for emb in chunk_embeddings]
+            # For candidates missing embeddings, use the query embedding as a
+            # placeholder (their relevance score will dominate the MMR calc).
+            filled_embeddings: list[list[float]] = [
+                emb if emb is not None else query_embedding for emb in chunk_embeddings
+            ]
 
-        # Compute relevance scores as cosine similarity to query.
-        # Pre-normalize all embeddings (including query) so dot product = cosine.
-        all_vectors = [query_embedding] + filled_embeddings
-        normalized = normalize_embeddings_batch(all_vectors)
-        norm_query = normalized[0]
-        norm_embeddings = normalized[1:]
+            # Compute relevance scores as cosine similarity to query.
+            # Pre-normalize all embeddings (including query) so dot product = cosine.
+            all_vectors = [query_embedding] + filled_embeddings
+            normalized = normalize_embeddings_batch(all_vectors)
+            norm_query = normalized[0]
+            norm_embeddings = normalized[1:]
 
-        # Relevance = batch dot product (Rust/NumPy accelerated)
-        dot_results = _bdp(norm_query, norm_embeddings, threshold=0.0)
-        scores = [0.0] * len(norm_embeddings)
-        for idx, sim in dot_results:
-            scores[idx] = sim
+            # Relevance = batch dot product (Rust/NumPy accelerated)
+            dot_results = _bdp(norm_query, norm_embeddings, threshold=0.0)
+            scores = [0.0] * len(norm_embeddings)
+            for idx, sim in dot_results:
+                scores[idx] = sim
 
-        # Run MMR selection on pre-normalized embeddings
-        selected_indices = mmr_diversity_select(norm_embeddings, scores, lambda_param, k)
+            # Run MMR selection on pre-normalized embeddings
+            selected_indices = mmr_diversity_select(norm_embeddings, scores, lambda_param, k)
 
-        return [chunks[i] for i in selected_indices]
+            span.set_attribute("selected_count", len(selected_indices))
+            return [chunks[i] for i in selected_indices]
 
     @trace(
         "khora.query.find_related_entities",

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -18,6 +18,7 @@ from tenacity import AsyncRetrying, retry_if_exception, stop_after_attempt, wait
 from khora.core.models import Chunk, ChunkMetadata
 from khora.db.models import Base, ChunkModel, EntityModel
 from khora.storage.backends.mixins import AsyncSessionMixin
+from khora.telemetry import trace
 
 if TYPE_CHECKING:
     pass
@@ -312,6 +313,11 @@ class PgVectorBackend(AsyncSessionMixin):
             return 1 - casted_col.cosine_distance(casted_query)
         return 1 - embedding_col.cosine_distance(query_embedding)
 
+    @trace(
+        "khora.pgvector.search_similar",
+        include={"namespace_id", "limit"},
+        result=lambda r: {"result_count": len(r)},
+    )
     async def search_similar(
         self,
         namespace_id: UUID,
@@ -397,6 +403,11 @@ class PgVectorBackend(AsyncSessionMixin):
     # Full-text search operations
     # =========================================================================
 
+    @trace(
+        "khora.pgvector.search_fulltext",
+        include={"namespace_id", "limit"},
+        result=lambda r: {"result_count": len(r)},
+    )
     async def search_fulltext(
         self,
         namespace_id: UUID,
@@ -682,6 +693,11 @@ class PgVectorBackend(AsyncSessionMixin):
 
         return await _retry_on_deadlock(_do_batch)
 
+    @trace(
+        "khora.pgvector.search_similar_entities",
+        include={"namespace_id", "limit"},
+        result=lambda r: {"result_count": len(r)},
+    )
     async def search_similar_entities(
         self,
         namespace_id: UUID,


### PR DESCRIPTION
## Summary

- Adds **20 new trace spans** across the recall, query, and ingestion pipelines for fine-grained latency profiling
- Covers VectorCypher retriever internals (routing, embedding, vector search, entity search, RRF fusion, recency/coherence boosts), engine-level recall + temporal detection + chunking/embedding, query engine HyDE + MMR diversity, pgvector backend searches, and temporal store hybrid search
- Zero overhead when logfire is absent (no-op span path)

Resolves [DYT-289](https://linear.app/deyta/issue/DYT-289/add-granular-telemetry-spans-to-vectorcypher-recall-path)

## Test plan

- [x] All pre-existing unit tests pass (224 passed, 2 pre-existing failures unrelated to this PR)
- [x] `ruff check` clean on all 5 modified files
- [x] `black` + `isort` + `ty` pass via pre-commit hooks
- [ ] Verify spans appear in Logfire dashboard when running benchmarks with logfire enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)