### PR TITLE
DYT-271: Remove EntityType / RelationshipType enums

### DIFF
--- a/src/khora/core/__init__.py
+++ b/src/khora/core/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from .models.document import Chunk, ChunkMetadata, Document, DocumentMetadata
-from .models.entity import Entity, EntityType, Episode, Relationship, RelationshipType
+from .models.entity import Entity, Episode, Relationship
 from .models.event import EventType, MemoryEvent
 from .models.tenancy import MemoryNamespace, TenancyMode
 
@@ -18,10 +18,8 @@ __all__ = [
     "ChunkMetadata",
     # Entity
     "Entity",
-    "EntityType",
     "Episode",
     "Relationship",
-    "RelationshipType",
     # Event
     "MemoryEvent",
     "EventType",

--- a/src/khora/core/models/__init__.py
+++ b/src/khora/core/models/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from .document import Chunk, ChunkMetadata, Document, DocumentMetadata
-from .entity import Entity, EntityType, Episode, Relationship, RelationshipType
+from .entity import Entity, Episode, Relationship
 from .event import EventType, MemoryEvent
 from .tenancy import MemoryNamespace, TenancyMode
 
@@ -18,10 +18,8 @@ __all__ = [
     "ChunkMetadata",
     # Entity
     "Entity",
-    "EntityType",
     "Episode",
     "Relationship",
-    "RelationshipType",
     # Event
     "MemoryEvent",
     "EventType",

--- a/src/khora/core/models/entity.py
+++ b/src/khora/core/models/entity.py
@@ -8,69 +8,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from enum import Enum
 from typing import Any
 from uuid import UUID, uuid4
-
-
-class EntityType(str, Enum):
-    """Standard entity types for knowledge extraction."""
-
-    PERSON = "PERSON"
-    ORGANIZATION = "ORGANIZATION"
-    LOCATION = "LOCATION"
-    CONCEPT = "CONCEPT"
-    EVENT = "EVENT"
-    PRODUCT = "PRODUCT"
-    TECHNOLOGY = "TECHNOLOGY"
-    DATE = "DATE"
-    CUSTOM = "CUSTOM"
-
-
-class RelationshipType(str, Enum):
-    """Standard relationship types for knowledge graphs."""
-
-    # Person relationships
-    WORKS_FOR = "WORKS_FOR"
-    KNOWS = "KNOWS"
-    MANAGES = "MANAGES"
-    REPORTS_TO = "REPORTS_TO"
-    COLLABORATES_WITH = "COLLABORATES_WITH"
-
-    # Organization relationships
-    OWNS = "OWNS"
-    PART_OF = "PART_OF"
-    COMPETES_WITH = "COMPETES_WITH"
-    PARTNERS_WITH = "PARTNERS_WITH"
-
-    # Location relationships
-    LOCATED_IN = "LOCATED_IN"
-    HEADQUARTERED_IN = "HEADQUARTERED_IN"
-
-    # Concept relationships
-    RELATES_TO = "RELATES_TO"
-    DEPENDS_ON = "DEPENDS_ON"
-    IMPLEMENTS = "IMPLEMENTS"
-    DERIVED_FROM = "DERIVED_FROM"
-
-    # Temporal relationships
-    PRECEDES = "PRECEDES"
-    FOLLOWS = "FOLLOWS"
-    CONCURRENT_WITH = "CONCURRENT_WITH"
-
-    # Generic
-    ASSOCIATED_WITH = "ASSOCIATED_WITH"
-    CUSTOM = "CUSTOM"
-
-
-def entity_type_str(et: EntityType | str) -> str:
-    """Get the string value of an entity type (enum or plain string)."""
-    return et.value if isinstance(et, EntityType) else str(et)
-
-
-def relationship_type_str(rt: RelationshipType | str) -> str:
-    """Get the string value of a relationship type (enum or plain string)."""
-    return rt.value if isinstance(rt, RelationshipType) else str(rt)
 
 
 @dataclass(slots=True)
@@ -85,7 +24,7 @@ class Entity:
     id: UUID = field(default_factory=uuid4)
     namespace_id: UUID = field(default_factory=uuid4)
     name: str = ""
-    entity_type: EntityType | str = EntityType.CONCEPT
+    entity_type: str = "CONCEPT"
     description: str = ""
 
     # Attributes from extraction
@@ -129,7 +68,7 @@ class Entity:
         """Validate and clean attributes using the registered schema for this entity type."""
         from khora.core.models.schemas import validate_attributes
 
-        self.attributes = validate_attributes(entity_type_str(self.entity_type), self.attributes)
+        self.attributes = validate_attributes(self.entity_type, self.attributes)
 
     def merge_with(self, other: Entity) -> None:
         """Merge another entity into this one (deduplication)."""
@@ -173,7 +112,7 @@ class Relationship:
     namespace_id: UUID = field(default_factory=uuid4)
     source_entity_id: UUID = field(default_factory=uuid4)
     target_entity_id: UUID = field(default_factory=uuid4)
-    relationship_type: RelationshipType | str = RelationshipType.RELATES_TO
+    relationship_type: str = "RELATES_TO"
     description: str = ""
 
     # Additional properties

--- a/src/khora/extraction/entity_resolution.py
+++ b/src/khora/extraction/entity_resolution.py
@@ -22,7 +22,6 @@ from khora._accel import (
     levenshtein_similarity,
     sequence_match_ratio,
 )
-from khora.core.models.entity import entity_type_str
 
 if TYPE_CHECKING:
     from khora.core.models import Entity
@@ -738,9 +737,7 @@ class EntityResolver:
             namespace_id: Namespace the entity belongs to
             entity: Entity to add to cache
         """
-        from khora.core.models.entity import entity_type_str
-
-        entity_type = entity_type_str(entity.entity_type)
+        entity_type = entity.entity_type
         cache_key = f"{namespace_id}:{entity_type}"
 
         if cache_key in self._entity_cache:
@@ -880,7 +877,7 @@ class EntityResolver:
 
                 for entity_id, score in results:
                     entity = await self._storage.get_entity(entity_id)
-                    if entity and entity_type_str(entity.entity_type) == entity_type:
+                    if entity and entity.entity_type == entity_type:
                         # Skip if already matched
                         if entity in [c.entity for c in candidates]:
                             continue
@@ -977,7 +974,7 @@ async def resolve_and_merge_entity(
         Tuple of (entity, is_new) where is_new indicates if a new entity
         should be created (False means use the returned existing entity)
     """
-    from khora.core.models import Entity, EntityType
+    from khora.core.models import Entity
 
     if resolver is None:
         resolver = EntityResolver(storage, embedder)
@@ -1041,15 +1038,10 @@ async def resolve_and_merge_entity(
         return existing, False
 
     # Create new entity
-    try:
-        etype: EntityType | str = EntityType(entity_type.upper())
-    except ValueError:
-        etype = entity_type.upper() or "CONCEPT"
-
     new_entity = Entity(
         namespace_id=namespace_id,
         name=name,
-        entity_type=etype,
+        entity_type=entity_type.upper() or "CONCEPT",
         description=description,
         attributes=attributes or {},
         source_tool=source_tool,

--- a/src/khora/extraction/expansion/cross_tool_unifier.py
+++ b/src/khora/extraction/expansion/cross_tool_unifier.py
@@ -223,11 +223,7 @@ class CrossToolUnifier:
         # Filter by entity types if specified
         candidates = entities
         if entity_types:
-            candidates = [
-                e
-                for e in entities
-                if str(e.entity_type.value if hasattr(e.entity_type, "value") else e.entity_type) in entity_types
-            ]
+            candidates = [e for e in entities if str(e.entity_type) in entity_types]
 
         # Group by field values
         for field_name in match_fields:
@@ -263,7 +259,7 @@ class CrossToolUnifier:
         for entity in entities:
             key = (
                 entity.name.lower().strip(),
-                str(entity.entity_type.value if hasattr(entity.entity_type, "value") else entity.entity_type),
+                str(entity.entity_type),
             )
             if key not in name_type_groups:
                 name_type_groups[key] = []
@@ -350,7 +346,7 @@ class CrossToolUnifier:
         # Fallback: O(n^2) pairwise within type groups
         type_groups: dict[str, list[Entity]] = {}
         for entity in entities:
-            type_key = str(entity.entity_type.value if hasattr(entity.entity_type, "value") else entity.entity_type)
+            type_key = str(entity.entity_type)
             if type_key not in type_groups:
                 type_groups[type_key] = []
             type_groups[type_key].append(entity)

--- a/src/khora/extraction/expansion/entity_index.py
+++ b/src/khora/extraction/expansion/entity_index.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 from khora._accel import batch_dot_product, levenshtein_similarity, normalize_entity_name
-from khora.core.models.entity import entity_type_str
 
 if TYPE_CHECKING:
     from khora.core.models import Entity
@@ -77,7 +76,7 @@ class EntityIndex:
 
         Complexity: O(1) amortized.
         """
-        key = (normalize_entity_name(entity.name), entity_type_str(entity.entity_type))
+        key = (normalize_entity_name(entity.name), entity.entity_type)
 
         existing = self._exact.get(key)
         if existing is not None:
@@ -87,7 +86,7 @@ class EntityIndex:
         self._exact[key] = entity
         self._by_id[entity.id] = entity
 
-        type_str = entity_type_str(entity.entity_type)
+        type_str = entity.entity_type
         self._type.setdefault(type_str, []).append(entity)
 
         for token in _tokenize(entity.name):
@@ -138,7 +137,7 @@ class EntityIndex:
         Returns:
             List of candidate entities, prioritized by blocking level match.
         """
-        type_str = entity_type_str(entity.entity_type)
+        type_str = entity.entity_type
         normalized_name = normalize_entity_name(entity.name)
 
         # Fast path: no entities of this type
@@ -203,7 +202,7 @@ class EntityIndex:
         Returns:
             List of (candidate, similarity) pairs, highest first.
         """
-        type_str = entity_type_str(entity.entity_type)
+        type_str = entity.entity_type
         tokens = _tokenize(entity.name)
         if not tokens:
             return []
@@ -223,7 +222,7 @@ class EntityIndex:
             candidate = self._by_id.get(cid)
             if candidate is None:
                 continue
-            if entity_type_str(candidate.entity_type) != type_str:
+            if candidate.entity_type != type_str:
                 continue
             # Skip exact matches (already handled by add())
             if normalize_entity_name(candidate.name) == normalized:
@@ -255,7 +254,7 @@ class EntityIndex:
         if not entity.embedding:
             return []
 
-        type_str = entity_type_str(entity.entity_type)
+        type_str = entity.entity_type
         tokens = _tokenize(entity.name)
 
         # Gather candidate IDs via token blocking
@@ -272,7 +271,7 @@ class EntityIndex:
             candidate = self._by_id.get(cid)
             if candidate is None or not candidate.embedding:
                 continue
-            if entity_type_str(candidate.entity_type) != type_str:
+            if candidate.entity_type != type_str:
                 continue
             valid_candidates.append(candidate)
             candidate_embeddings.append(candidate.embedding)

--- a/src/khora/extraction/expansion/relationship_inferrer.py
+++ b/src/khora/extraction/expansion/relationship_inferrer.py
@@ -185,8 +185,7 @@ class RelationshipTypeIndex:
     @staticmethod
     def _get_type_str(rel: Relationship) -> str:
         """Extract relationship type as string."""
-        rt = rel.relationship_type
-        return str(rt.value) if hasattr(rt, "value") else str(rt)
+        return rel.relationship_type
 
 
 class RelationshipInferrer:
@@ -256,29 +255,18 @@ class RelationshipInferrer:
         logger.debug(f"Built relationship index: {self._rel_index.stats()}")
 
         # Diagnostic logging
-        entity_types = Counter(
-            e.entity_type.value if hasattr(e.entity_type, "value") else str(e.entity_type) for e in entities
-        )
+        entity_types = Counter(e.entity_type for e in entities)
         logger.debug(f"Inference input: {len(entities)} entities, types: {dict(entity_types)}")
 
-        rel_types = Counter(
-            r.relationship_type.value if hasattr(r.relationship_type, "value") else str(r.relationship_type)
-            for r in relationships
-        )
+        rel_types = Counter(r.relationship_type for r in relationships)
         logger.debug(f"Inference input: {len(relationships)} relationships, types: {dict(rel_types)}")
 
         # Detailed pattern diagnostics (debug-only to avoid overhead)
         if logger._core.min_level <= 10:  # type: ignore[unresolved-attribute]  # DEBUG level
-            entity_type_lookup = {
-                e.id: (e.entity_type.value if hasattr(e.entity_type, "value") else str(e.entity_type)) for e in entities
-            }
+            entity_type_lookup = {e.id: e.entity_type for e in entities}
             rel_type_patterns: dict[str, Counter] = {}
             for r in relationships:
-                rt = (
-                    str(r.relationship_type.value)
-                    if hasattr(r.relationship_type, "value")
-                    else str(r.relationship_type)
-                )
+                rt = r.relationship_type
                 source_type = entity_type_lookup.get(r.source_entity_id, "UNKNOWN")
                 target_type = entity_type_lookup.get(r.target_entity_id, "UNKNOWN")
                 if rt not in rel_type_patterns:
@@ -301,13 +289,8 @@ class RelationshipInferrer:
                     expected_entities.add(cond.target_type)
 
         if expected_rels or expected_entities:
-            actual_rel_types = {
-                r.relationship_type.value if hasattr(r.relationship_type, "value") else str(r.relationship_type)
-                for r in relationships
-            }
-            actual_entity_types = {
-                e.entity_type.value if hasattr(e.entity_type, "value") else str(e.entity_type) for e in entities
-            }
+            actual_rel_types = {r.relationship_type for r in relationships}
+            actual_entity_types = {e.entity_type for e in entities}
             if not (actual_rel_types & expected_rels):
                 logger.debug(
                     f"No relationship type overlap: rules expect {sorted(expected_rels)}, "
@@ -420,8 +403,8 @@ class RelationshipInferrer:
             if not e1 or not e2:
                 continue
 
-            et1 = e1.entity_type.value if hasattr(e1.entity_type, "value") else str(e1.entity_type)
-            et2 = e2.entity_type.value if hasattr(e2.entity_type, "value") else str(e2.entity_type)
+            et1 = e1.entity_type
+            et2 = e2.entity_type
             if frozenset({et1, et2}) in INVALID_PAIRS:
                 continue
 
@@ -645,9 +628,7 @@ class RelationshipInferrer:
         existing_keys: set[tuple[UUID, UUID, str]] = set()
 
         for rel in existing_relationships:
-            rel_type = str(
-                rel.relationship_type.value if hasattr(rel.relationship_type, "value") else rel.relationship_type
-            )
+            rel_type = rel.relationship_type
             existing_keys.add((rel.source_entity_id, rel.target_entity_id, rel_type))
 
         for inf in already_inferred:
@@ -670,26 +651,19 @@ class RelationshipInferrer:
     ) -> list[Relationship]:
         """Convert inferred relationships to mock Relationship objects for next pass."""
         from khora.core.models import Relationship
-        from khora.core.models.entity import RelationshipType
 
         mock_rels = []
         # Get namespace from first entity if available
         namespace_id = entities[0].namespace_id if entities else uuid4()
 
         for inf in inferred:
-            # Preserve original type string for domain-specific types
-            try:
-                rel_type: RelationshipType | str = RelationshipType[inf.relationship_type]
-            except (KeyError, AttributeError):
-                rel_type = inf.relationship_type
-
             mock_rels.append(
                 Relationship(
                     id=uuid4(),
                     namespace_id=namespace_id,
                     source_entity_id=inf.source_entity_id,
                     target_entity_id=inf.target_entity_id,
-                    relationship_type=rel_type,
+                    relationship_type=inf.relationship_type,
                     description=inf.description,
                     properties={},
                     source_document_ids=[],
@@ -718,20 +692,13 @@ def to_relationship(
         Domain Relationship model
     """
     from khora.core.models import Relationship
-    from khora.core.models.entity import RelationshipType
-
-    # Preserve original type string for domain-specific types
-    try:
-        rel_type: RelationshipType | str = RelationshipType[inferred.relationship_type]
-    except (KeyError, AttributeError):
-        rel_type = inferred.relationship_type
 
     return Relationship(
         id=uuid4(),
         namespace_id=namespace_id,
         source_entity_id=inferred.source_entity_id,
         target_entity_id=inferred.target_entity_id,
-        relationship_type=rel_type,
+        relationship_type=inferred.relationship_type,
         description=inferred.description,
         properties={
             "inferred": True,

--- a/src/khora/extraction/expansion/rule_engine.py
+++ b/src/khora/extraction/expansion/rule_engine.py
@@ -64,7 +64,7 @@ class RuleEvaluationContext:
             ctx.entity_index[name_key].append(entity)
 
             # Index by type
-            type_key = str(entity.entity_type.value if hasattr(entity.entity_type, "value") else entity.entity_type)
+            type_key = str(entity.entity_type)
             if type_key not in ctx.type_index:
                 ctx.type_index[type_key] = []
             ctx.type_index[type_key].append(entity)
@@ -74,9 +74,7 @@ class RuleEvaluationContext:
 
         # Build relationship indices
         for rel in relationships:
-            rel_type = str(
-                rel.relationship_type.value if hasattr(rel.relationship_type, "value") else rel.relationship_type
-            )
+            rel_type = str(rel.relationship_type)
             if rel_type not in ctx.relationship_index:
                 ctx.relationship_index[rel_type] = []
             ctx.relationship_index[rel_type].append(rel)
@@ -113,7 +111,7 @@ class RuleEvaluationContext:
                     self.entity_index[name_key] = []
                 self.entity_index[name_key].append(entity)
 
-                type_key = str(entity.entity_type.value if hasattr(entity.entity_type, "value") else entity.entity_type)
+                type_key = str(entity.entity_type)
                 if type_key not in self.type_index:
                     self.type_index[type_key] = []
                 self.type_index[type_key].append(entity)
@@ -124,9 +122,7 @@ class RuleEvaluationContext:
             if rel not in self.relationships:
                 self.relationships.append(rel)
 
-                rel_type = str(
-                    rel.relationship_type.value if hasattr(rel.relationship_type, "value") else rel.relationship_type
-                )
+                rel_type = str(rel.relationship_type)
                 if rel_type not in self.relationship_index:
                     self.relationship_index[rel_type] = []
                 self.relationship_index[rel_type].append(rel)
@@ -456,32 +452,20 @@ class RuleEngine:
                     # Chain pattern: prev.target -> next.source
                     target_key = str(prev_rel.target_entity_id)
                     for cand in context.rels_by_source.get(target_key, []):
-                        cand_type = str(
-                            cand.relationship_type.value
-                            if hasattr(cand.relationship_type, "value")
-                            else cand.relationship_type
-                        )
+                        cand_type = str(cand.relationship_type)
                         if cand_type == cond_rel_type:
                             candidate_rels.append(cand)
 
                     # Shared source pattern: prev.source == next.source
                     source_key = str(prev_rel.source_entity_id)
                     for cand in context.rels_by_source.get(source_key, []):
-                        cand_type = str(
-                            cand.relationship_type.value
-                            if hasattr(cand.relationship_type, "value")
-                            else cand.relationship_type
-                        )
+                        cand_type = str(cand.relationship_type)
                         if cand_type == cond_rel_type and cand not in candidate_rels:
                             candidate_rels.append(cand)
 
                     # Shared target pattern: prev.target == next.target
                     for cand in context.rels_by_target.get(target_key, []):
-                        cand_type = str(
-                            cand.relationship_type.value
-                            if hasattr(cand.relationship_type, "value")
-                            else cand.relationship_type
-                        )
+                        cand_type = str(cand.relationship_type)
                         if cand_type == cond_rel_type and cand not in candidate_rels:
                             candidate_rels.append(cand)
 
@@ -569,7 +553,7 @@ class RuleEngine:
         if entity_types:
             filtered = []
             for e in candidates:
-                actual_type = str(e.entity_type.value if hasattr(e.entity_type, "value") else e.entity_type)
+                actual_type = str(e.entity_type)
                 # Check if actual type matches any of the expected types via hierarchy
                 if any(types_match(actual_type, expected_type) for expected_type in entity_types):
                     filtered.append(e)
@@ -648,16 +632,8 @@ class RuleEngine:
                 continue
 
             # Get actual entity types
-            actual_source_type = str(
-                source_entity.entity_type.value
-                if hasattr(source_entity.entity_type, "value")
-                else source_entity.entity_type
-            )
-            actual_target_type = str(
-                target_entity.entity_type.value
-                if hasattr(target_entity.entity_type, "value")
-                else target_entity.entity_type
-            )
+            actual_source_type = str(source_entity.entity_type)
+            actual_target_type = str(target_entity.entity_type)
 
             # Use hierarchy-aware type matching
             source_matches = not source_type or types_match(actual_source_type, source_type)

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -210,7 +210,6 @@ async def stream_extract_and_embed_entities(
         Tuple of (entities with embeddings, relationships)
     """
     from khora.core.models import Entity, Relationship
-    from khora.core.models.entity import EntityType, RelationshipType
     from khora.extraction.extractors import LLMEntityExtractor
     from khora.extraction.skills.registry import get_default_registry
 
@@ -302,10 +301,7 @@ async def stream_extract_and_embed_entities(
                         if _vu and (not existing.valid_until or _vu > existing.valid_until):
                             existing.valid_until = _vu
                     else:
-                        try:
-                            entity_type: EntityType | str = EntityType(extracted.entity_type)
-                        except ValueError:
-                            entity_type = extracted.entity_type or "CONCEPT"
+                        entity_type = extracted.entity_type or "CONCEPT"
 
                         # Prefer LLM-extracted temporal bounds over chunk timestamp
                         _t = extracted.temporal
@@ -335,10 +331,7 @@ async def stream_extract_and_embed_entities(
                     if extracted_rel.confidence < min_relationship_confidence:
                         continue
 
-                    try:
-                        rel_type: RelationshipType | str = RelationshipType(extracted_rel.relationship_type)
-                    except ValueError:
-                        rel_type = extracted_rel.relationship_type or "RELATES_TO"
+                    rel_type = extracted_rel.relationship_type or "RELATES_TO"
 
                     norm_source = _norm_cache[extracted_rel.source_entity]
                     norm_target = _norm_cache[extracted_rel.target_entity]
@@ -446,10 +439,7 @@ async def stream_extract_and_embed_entities(
                         if pair in existing_pairs or (pair[1], pair[0]) in existing_pairs:
                             continue
                         existing_pairs.add(pair)
-                        try:
-                            cross_rel_type: RelationshipType | str = RelationshipType(extracted_rel.relationship_type)
-                        except ValueError:
-                            cross_rel_type = extracted_rel.relationship_type or "RELATES_TO"
+                        cross_rel_type = extracted_rel.relationship_type or "RELATES_TO"
                         all_relationships.append(
                             Relationship(
                                 namespace_id=chunks[0].namespace_id,

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -50,7 +50,7 @@ def _should_skip_entity_embedding(
     """
     if not skip_types:
         return False
-    entity_type = entity.entity_type.value if hasattr(entity.entity_type, "value") else str(entity.entity_type)
+    entity_type = entity.entity_type
     _skip_upper = frozenset(t.upper() for t in skip_types)
     if entity_type.upper() not in _skip_upper:
         return False
@@ -1037,7 +1037,7 @@ async def process_document(
                 # Build name+type -> stored_id mapping from upsert results
                 name_type_to_stored: dict[str, str] = {}
                 for entity, is_new in upsert_results:
-                    et = entity.entity_type.value if hasattr(entity.entity_type, "value") else str(entity.entity_type)
+                    et = entity.entity_type
                     key = f"{_store_norm[entity.name]}:{et}"
                     stored_id = str(entity.id)
                     name_type_to_stored[key] = stored_id
@@ -1047,11 +1047,7 @@ async def process_document(
 
                 # Map every original entity ID to its stored counterpart by name+type
                 for orig_entity in entities:
-                    et = (
-                        orig_entity.entity_type.value
-                        if hasattr(orig_entity.entity_type, "value")
-                        else str(orig_entity.entity_type)
-                    )
+                    et = orig_entity.entity_type
                     key = f"{_store_norm[orig_entity.name]}:{et}"
                     stored_id = name_type_to_stored.get(key)
                     if stored_id:
@@ -1493,16 +1489,11 @@ async def run_smart_resolution(
     logger.info(f"Smart resolution: loaded {len(relationships)} relationships from storage")
 
     if relationships:
-        rel_type_dist = Counter(
-            str(r.relationship_type.value if hasattr(r.relationship_type, "value") else r.relationship_type)
-            for r in relationships
-        )
+        rel_type_dist = Counter(r.relationship_type for r in relationships)
         logger.info(f"Smart resolution: relationship types: {dict(rel_type_dist.most_common(15))}")
 
     if resolved_entities:
-        ent_type_dist = Counter(
-            str(e.entity_type.value if hasattr(e.entity_type, "value") else e.entity_type) for e in resolved_entities
-        )
+        ent_type_dist = Counter(e.entity_type for e in resolved_entities)
         logger.info(f"Smart resolution: entity types: {dict(ent_type_dist.most_common(15))}")
 
     # Check entity ID overlap between relationships and resolved_entities

--- a/src/khora/query/linking.py
+++ b/src/khora/query/linking.py
@@ -17,7 +17,6 @@ from uuid import UUID
 from loguru import logger
 
 from khora._accel import sequence_match_ratio
-from khora.core.models.entity import entity_type_str
 
 from .understanding import EntityMention
 
@@ -316,7 +315,7 @@ class EntityLinker:
 
                 if ratio >= self._fuzzy_threshold:
                     # Apply type penalty so wrong-type matches score lower
-                    penalty = self._type_penalty(mention.entity_type, entity_type_str(entity.entity_type))
+                    penalty = self._type_penalty(mention.entity_type, entity.entity_type)
                     matches.append((entity, ratio * penalty))
 
             # Also try partial matching (for handling first/last name, abbreviations)
@@ -326,7 +325,7 @@ class EntityLinker:
 
                 # Check if mention is contained in entity name or vice versa
                 entity_name_lower = entity.name.lower()
-                penalty = self._type_penalty(mention.entity_type, entity_type_str(entity.entity_type))
+                penalty = self._type_penalty(mention.entity_type, entity.entity_type)
                 if mention_name_lower in entity_name_lower:
                     ratio = len(mention_name_lower) / len(entity_name_lower)
                     if ratio >= 0.5:  # At least 50% match
@@ -385,9 +384,9 @@ class EntityLinker:
                 entity = await self._storage.get_entity(entity_id)
                 if entity:
                     # Only include entities of compatible types
-                    if self._types_compatible(mention.entity_type, entity_type_str(entity.entity_type)):
+                    if self._types_compatible(mention.entity_type, entity.entity_type):
                         # Apply type penalty so exact type matches rank higher
-                        penalty = self._type_penalty(mention.entity_type, entity_type_str(entity.entity_type))
+                        penalty = self._type_penalty(mention.entity_type, entity.entity_type)
                         matches.append((entity, score * penalty))
 
         except Exception as e:

--- a/src/khora/query/reranking.py
+++ b/src/khora/query/reranking.py
@@ -13,8 +13,6 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from loguru import logger
 
-from khora.core.models.entity import entity_type_str
-
 if TYPE_CHECKING:
     from khora.config.llm import LiteLLMConfig
     from khora.core.models import Chunk, Entity
@@ -457,7 +455,7 @@ async def rerank_entities(
         RerankCandidate(
             item=entity,
             original_score=score,
-            content=f"{entity.name}: {entity.description or ''} ({entity_type_str(entity.entity_type)})",
+            content=f"{entity.name}: {entity.description or ''} ({entity.entity_type})",
             metadata=entity.metadata,
         )
         for entity, score in entities

--- a/src/khora/storage/backends/arcadedb.py
+++ b/src/khora/storage/backends/arcadedb.py
@@ -17,7 +17,6 @@ from uuid import UUID
 from loguru import logger
 
 from khora.core.models import Chunk, ChunkMetadata, Entity, Episode, Relationship
-from khora.core.models.entity import EntityType, RelationshipType
 from khora.storage.backends.mixins import (
     GraphBackendBase,
     VectorBackendBase,
@@ -266,9 +265,7 @@ class ArcadeDBBackend(GraphBackendBase, VectorBackendBase):
             id=parse_uuid(row["id"]),
             namespace_id=parse_uuid(row["namespace_id"]),
             name=row["name"],
-            entity_type=(
-                EntityType(row["entity_type"]) if row["entity_type"] in EntityType.__members__ else row["entity_type"]
-            ),
+            entity_type=row["entity_type"],
             description=row.get("description", ""),
             attributes=deserialize_dict(row.get("attributes")),
             source_document_ids=parse_uuid_list(row.get("source_document_ids")),
@@ -289,7 +286,7 @@ class ArcadeDBBackend(GraphBackendBase, VectorBackendBase):
             namespace_id=parse_uuid(row["namespace_id"]),
             source_entity_id=parse_uuid(source_id),
             target_entity_id=parse_uuid(target_id),
-            relationship_type=(RelationshipType(rel_type) if rel_type in RelationshipType.__members__ else rel_type),
+            relationship_type=rel_type,
             description=row.get("description", ""),
             properties=deserialize_dict(row.get("properties")),
             source_document_ids=parse_uuid_list(row.get("source_document_ids")),
@@ -339,7 +336,7 @@ class ArcadeDBBackend(GraphBackendBase, VectorBackendBase):
     # ==================================================================
 
     async def create_entity(self, entity: Entity) -> Entity:
-        entity_type_val = entity.entity_type.value if isinstance(entity.entity_type, EntityType) else entity.entity_type
+        entity_type_val = entity.entity_type
         await self._cypher(
             """
             CREATE (e:Entity {
@@ -500,11 +497,7 @@ class ArcadeDBBackend(GraphBackendBase, VectorBackendBase):
     # ------------------------------------------------------------------
 
     async def create_relationship(self, relationship: Relationship) -> Relationship:
-        rel_type = (
-            relationship.relationship_type.value
-            if isinstance(relationship.relationship_type, RelationshipType)
-            else relationship.relationship_type
-        )
+        rel_type = relationship.relationship_type
         # ArcadeDB: use RELATES_TO edge type, store the logical type as a property
         await self._cypher(
             """

--- a/src/khora/storage/backends/kuzu.py
+++ b/src/khora/storage/backends/kuzu.py
@@ -14,7 +14,6 @@ from uuid import UUID
 from loguru import logger
 
 from khora.core.models import Entity, Episode, Relationship
-from khora.core.models.entity import EntityType, RelationshipType
 from khora.storage.backends.mixins import (
     GraphBackendBase,
     deserialize_dict,
@@ -179,9 +178,7 @@ class KuzuBackend(GraphBackendBase):
             id=parse_uuid(row["id"]),
             namespace_id=parse_uuid(row["namespace_id"]),
             name=row["name"],
-            entity_type=(
-                EntityType(row["entity_type"]) if row["entity_type"] in EntityType.__members__ else row["entity_type"]
-            ),
+            entity_type=row["entity_type"],
             description=row.get("description", ""),
             attributes=deserialize_dict(row.get("attributes")),
             source_document_ids=parse_uuid_list(row.get("source_document_ids")),
@@ -203,7 +200,7 @@ class KuzuBackend(GraphBackendBase):
             namespace_id=parse_uuid(row["namespace_id"]),
             source_entity_id=parse_uuid(source_id),
             target_entity_id=parse_uuid(target_id),
-            relationship_type=(RelationshipType(rel_type) if rel_type in RelationshipType.__members__ else rel_type),
+            relationship_type=rel_type,
             description=row.get("description", ""),
             properties=deserialize_dict(row.get("properties")),
             source_document_ids=parse_uuid_list(row.get("source_document_ids")),
@@ -240,9 +237,7 @@ class KuzuBackend(GraphBackendBase):
             "id": str(entity.id),
             "namespace_id": str(entity.namespace_id),
             "name": entity.name,
-            "entity_type": (
-                entity.entity_type.value if isinstance(entity.entity_type, EntityType) else entity.entity_type
-            ),
+            "entity_type": entity.entity_type,
             "description": entity.description,
             "attributes": serialize_dict(entity.attributes) or "{}",
             "source_document_ids": [str(d) for d in entity.source_document_ids],
@@ -438,11 +433,7 @@ class KuzuBackend(GraphBackendBase):
     # ------------------------------------------------------------------
 
     async def create_relationship(self, relationship: Relationship) -> Relationship:
-        rel_type = (
-            relationship.relationship_type.value
-            if isinstance(relationship.relationship_type, RelationshipType)
-            else relationship.relationship_type
-        )
+        rel_type = relationship.relationship_type
         params = {
             "source_id": str(relationship.source_entity_id),
             "target_id": str(relationship.target_entity_id),

--- a/src/khora/storage/backends/memgraph.py
+++ b/src/khora/storage/backends/memgraph.py
@@ -18,7 +18,6 @@ from uuid import UUID
 from loguru import logger
 
 from khora.core.models import Entity, Episode, Relationship
-from khora.core.models.entity import EntityType, RelationshipType
 from khora.storage.backends.mixins import (
     GraphBackendBase,
     deserialize_dict,
@@ -131,11 +130,7 @@ class MemgraphBackend(GraphBackendBase):
             id=UUID(node["id"]),
             namespace_id=UUID(node["namespace_id"]),
             name=node["name"],
-            entity_type=(
-                EntityType(node["entity_type"])
-                if node["entity_type"] in EntityType.__members__
-                else node["entity_type"]
-            ),
+            entity_type=node["entity_type"],
             description=node.get("description", ""),
             attributes=deserialize_dict(node.get("attributes")),
             source_document_ids=[UUID(d) for d in node.get("source_document_ids", [])],
@@ -157,7 +152,7 @@ class MemgraphBackend(GraphBackendBase):
             namespace_id=UUID(rel["namespace_id"]),
             source_entity_id=UUID(source_id),
             target_entity_id=UUID(target_id),
-            relationship_type=(RelationshipType(rel_type) if rel_type in RelationshipType.__members__ else rel_type),
+            relationship_type=rel_type,
             description=rel.get("description", ""),
             properties=deserialize_dict(rel.get("properties")),
             source_document_ids=[UUID(d) for d in rel.get("source_document_ids", [])],
@@ -217,9 +212,7 @@ class MemgraphBackend(GraphBackendBase):
             "id": str(entity.id),
             "namespace_id": str(entity.namespace_id),
             "name": entity.name,
-            "entity_type": (
-                entity.entity_type.value if isinstance(entity.entity_type, EntityType) else entity.entity_type
-            ),
+            "entity_type": entity.entity_type,
             "description": entity.description,
             "attributes": serialize_dict(entity.attributes),
             "source_document_ids": [str(d) for d in entity.source_document_ids],
@@ -387,11 +380,7 @@ class MemgraphBackend(GraphBackendBase):
     async def create_relationship(self, relationship: Relationship) -> Relationship:
         driver = self._get_driver()
 
-        rel_type = (
-            relationship.relationship_type.value
-            if isinstance(relationship.relationship_type, RelationshipType)
-            else relationship.relationship_type
-        )
+        rel_type = relationship.relationship_type
 
         # Dynamic relationship type via f-string (parameterized labels not supported in Cypher)
         query = f"""

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -19,7 +19,6 @@ from loguru import logger
 from neo4j import AsyncDriver, AsyncGraphDatabase, AsyncManagedTransaction
 
 from khora.core.models import Entity, Episode, Relationship
-from khora.core.models.entity import EntityType, RelationshipType
 from khora.storage.backends.mixins import (
     GraphBackendBase,
 )
@@ -57,7 +56,7 @@ class _EntityKeyGate:
             (
                 str(e.namespace_id),
                 e.name,
-                e.entity_type.value if hasattr(e.entity_type, "value") else str(e.entity_type),
+                str(e.entity_type),
             )
             for e in entities
         }
@@ -109,7 +108,7 @@ def _entity_to_cypher_params(entity: Entity) -> dict[str, Any]:
         "id": str(entity.id),
         "namespace_id": str(entity.namespace_id),
         "name": entity.name,
-        "entity_type": (entity.entity_type.value if isinstance(entity.entity_type, EntityType) else entity.entity_type),
+        "entity_type": entity.entity_type,
         "description": entity.description,
         "attributes": _serialize_dict(entity.attributes),
         "source_document_ids": [str(d) for d in entity.source_document_ids],
@@ -592,7 +591,7 @@ class Neo4jBackend(GraphBackendBase):
             key=lambda e: (
                 str(e.namespace_id),
                 e.name,
-                e.entity_type.value if isinstance(e.entity_type, EntityType) else e.entity_type,
+                e.entity_type,
             ),
         )
 
@@ -659,11 +658,7 @@ class Neo4jBackend(GraphBackendBase):
         # eliminating a second round of write transactions on overlapping nodes.
         all_rels = list(relationships)
         for rel in relationships:
-            rel_type_str = _sanitize_neo4j_label(
-                rel.relationship_type.value
-                if isinstance(rel.relationship_type, RelationshipType)
-                else rel.relationship_type
-            )
+            rel_type_str = _sanitize_neo4j_label(rel.relationship_type)
             inverse_type = BIDIRECTIONAL_TYPES.get(rel_type_str)
             if inverse_type and inverse_type != rel_type_str:
                 inv = copy(rel)
@@ -677,11 +672,7 @@ class Neo4jBackend(GraphBackendBase):
         # Group by relationship type (required for dynamic rel type in Cypher)
         type_groups: dict[str, list[Relationship]] = {}
         for rel in all_rels:
-            rel_type = _sanitize_neo4j_label(
-                rel.relationship_type.value
-                if isinstance(rel.relationship_type, RelationshipType)
-                else rel.relationship_type
-            )
+            rel_type = _sanitize_neo4j_label(rel.relationship_type)
             type_groups.setdefault(rel_type, []).append(rel)
 
         async def _create_type_group(rel_type: str, rels: list[Relationship]) -> int:
@@ -754,11 +745,7 @@ class Neo4jBackend(GraphBackendBase):
             id=UUID(node["id"]),
             namespace_id=UUID(node["namespace_id"]),
             name=node["name"],
-            entity_type=(
-                EntityType(node["entity_type"])
-                if node["entity_type"] in EntityType.__members__
-                else node["entity_type"]
-            ),
+            entity_type=node["entity_type"],
             description=node.get("description", ""),
             attributes=_deserialize_dict(node.get("attributes")),
             source_document_ids=[UUID(d) for d in node.get("source_document_ids", [])],
@@ -781,11 +768,7 @@ class Neo4jBackend(GraphBackendBase):
         driver = self._get_driver()
         params = _relationship_to_cypher_params(relationship)
 
-        rel_type = _sanitize_neo4j_label(
-            relationship.relationship_type.value
-            if isinstance(relationship.relationship_type, RelationshipType)
-            else relationship.relationship_type
-        )
+        rel_type = _sanitize_neo4j_label(relationship.relationship_type)
 
         async def _create(tx: AsyncManagedTransaction) -> None:
             # Use dynamic relationship type with MERGE to prevent duplicates
@@ -916,7 +899,7 @@ class Neo4jBackend(GraphBackendBase):
             namespace_id=UUID(rel["namespace_id"]),
             source_entity_id=UUID(source_id),
             target_entity_id=UUID(target_id),
-            relationship_type=(RelationshipType(rel_type) if rel_type in RelationshipType.__members__ else rel_type),
+            relationship_type=rel_type,
             description=rel.get("description", ""),
             properties=_deserialize_dict(rel.get("properties")),
             source_document_ids=[UUID(d) for d in rel.get("source_document_ids", [])],

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -486,9 +486,7 @@ class PgVectorBackend(AsyncSessionMixin):
                 id=entity.id,
                 namespace_id=entity.namespace_id,
                 name=entity.name,
-                entity_type=(
-                    entity.entity_type.value if hasattr(entity.entity_type, "value") else str(entity.entity_type)
-                ),
+                entity_type=entity.entity_type,
                 description=entity.description,
                 attributes=entity.attributes,
                 source_document_ids=entity.source_document_ids,
@@ -589,9 +587,7 @@ class PgVectorBackend(AsyncSessionMixin):
                     "id": entity.id,
                     "namespace_id": entity.namespace_id,
                     "name": entity.name,
-                    "entity_type": (
-                        entity.entity_type.value if hasattr(entity.entity_type, "value") else str(entity.entity_type)
-                    ),
+                    "entity_type": (entity.entity_type),
                     "description": entity.description,
                     "attributes": entity.attributes,
                     "source_document_ids": entity.source_document_ids,

--- a/tests/integration/test_incremental_ingestion.py
+++ b/tests/integration/test_incremental_ingestion.py
@@ -20,7 +20,6 @@ from uuid import UUID, uuid4
 import pytest
 
 from khora.core.models import Chunk, ChunkMetadata, Document, DocumentMetadata, Entity, Relationship
-from khora.core.models.entity import EntityType, RelationshipType
 from khora.memory_lake import BatchResult, MemoryLake, RecallResult, RememberResult
 
 # ---------------------------------------------------------------------------
@@ -74,7 +73,7 @@ def _make_chunk(
 
 def _make_entity(
     name: str,
-    entity_type: EntityType | str = EntityType.PERSON,
+    entity_type: str = "PERSON",
     *,
     doc_ids: list[UUID] | None = None,
     embedding: list[float] | None = None,
@@ -96,7 +95,7 @@ def _make_entity(
 def _make_relationship(
     source: Entity,
     target: Entity,
-    rel_type: RelationshipType | str = RelationshipType.WORKS_FOR,
+    rel_type: str = "WORKS_FOR",
 ) -> Relationship:
     """Create a test relationship."""
     return Relationship(
@@ -262,15 +261,15 @@ class TestIncrementalIngestion:
         ]
         chunks = [_make_chunk(d["content"], doc_ids[i], chunk_index=0) for i, d in enumerate(BATCH_1_DOCS)]
 
-        alice = _make_entity("alice johnson", EntityType.PERSON, doc_ids=[doc_ids[0]])
-        bob = _make_entity("bob smith", EntityType.PERSON, doc_ids=[doc_ids[1]])
-        acme = _make_entity("acme corp", EntityType.ORGANIZATION, doc_ids=[doc_ids[0], doc_ids[1], doc_ids[2]])
-        sf = _make_entity("san francisco", EntityType.LOCATION, doc_ids=[doc_ids[2]])
+        alice = _make_entity("alice johnson", "PERSON", doc_ids=[doc_ids[0]])
+        bob = _make_entity("bob smith", "PERSON", doc_ids=[doc_ids[1]])
+        acme = _make_entity("acme corp", "ORGANIZATION", doc_ids=[doc_ids[0], doc_ids[1], doc_ids[2]])
+        sf = _make_entity("san francisco", "LOCATION", doc_ids=[doc_ids[2]])
 
         relationships = [
-            _make_relationship(alice, acme, RelationshipType.WORKS_FOR),
-            _make_relationship(bob, acme, RelationshipType.WORKS_FOR),
-            _make_relationship(acme, sf, RelationshipType.HEADQUARTERED_IN),
+            _make_relationship(alice, acme, "WORKS_FOR"),
+            _make_relationship(bob, acme, "WORKS_FOR"),
+            _make_relationship(acme, sf, "HEADQUARTERED_IN"),
         ]
 
         state.add_batch(documents, chunks, [alice, bob, acme, sf], relationships)
@@ -296,18 +295,18 @@ class TestIncrementalIngestion:
         ]
         chunks = [_make_chunk(d["content"], doc_ids[i], chunk_index=0) for i, d in enumerate(BATCH_2_DOCS)]
 
-        charlie = _make_entity("charlie brown", EntityType.PERSON, doc_ids=[doc_ids[0]])
-        dave = _make_entity("dave wilson", EntityType.PERSON, doc_ids=[doc_ids[1]])
+        charlie = _make_entity("charlie brown", "PERSON", doc_ids=[doc_ids[0]])
+        dave = _make_entity("dave wilson", "PERSON", doc_ids=[doc_ids[1]])
         # Alice appears again — should be merged, not duplicated
-        alice_again = _make_entity("alice johnson", EntityType.PERSON, doc_ids=[doc_ids[0]])
+        alice_again = _make_entity("alice johnson", "PERSON", doc_ids=[doc_ids[0]])
         # Acme appears again — should be merged
-        acme_again = _make_entity("acme corp", EntityType.ORGANIZATION, doc_ids=[doc_ids[0], doc_ids[1]])
+        acme_again = _make_entity("acme corp", "ORGANIZATION", doc_ids=[doc_ids[0], doc_ids[1]])
         # Bob appears again
-        bob_again = _make_entity("bob smith", EntityType.PERSON, doc_ids=[doc_ids[1]])
+        bob_again = _make_entity("bob smith", "PERSON", doc_ids=[doc_ids[1]])
 
         relationships = [
-            _make_relationship(charlie, _find_entity(state, "acme corp"), RelationshipType.WORKS_FOR),
-            _make_relationship(dave, _find_entity(state, "acme corp"), RelationshipType.WORKS_FOR),
+            _make_relationship(charlie, _find_entity(state, "acme corp"), "WORKS_FOR"),
+            _make_relationship(dave, _find_entity(state, "acme corp"), "WORKS_FOR"),
             _make_relationship(charlie, _find_entity(state, "alice johnson"), "COLLABORATES_WITH"),
             _make_relationship(dave, _find_entity(state, "bob smith"), "COLLABORATES_WITH"),
         ]
@@ -346,7 +345,7 @@ class TestIncrementalIngestion:
             r for r in batch1_data.relationships if r.source_entity_id == alice.id and r.target_entity_id == acme.id
         ]
         assert len(works_for_rels) == 1
-        assert works_for_rels[0].relationship_type == RelationshipType.WORKS_FOR
+        assert works_for_rels[0].relationship_type == "WORKS_FOR"
 
     # -----------------------------------------------------------------------
     # Test: Batch 2 ingestion preserves batch 1 data
@@ -422,7 +421,7 @@ class TestIncrementalIngestion:
         works_for_acme = [
             r
             for r in batch2_data.relationships
-            if r.target_entity_id == acme.id and str(r.relationship_type) in ("WORKS_FOR", "RelationshipType.WORKS_FOR")
+            if r.target_entity_id == acme.id and str(r.relationship_type) == "WORKS_FOR"
         ]
         # Alice, Bob, Charlie, Dave all WORKS_FOR Acme
         assert len(works_for_acme) == 4
@@ -748,15 +747,15 @@ class TestIncrementalIngestion:
         ]
         chunks = [_make_chunk(d["content"], doc_ids[i], chunk_index=0) for i, d in enumerate(batch3_docs)]
 
-        eve = _make_entity("eve martinez", EntityType.PERSON, doc_ids=[doc_ids[0]])
-        beta = _make_entity("beta inc", EntityType.ORGANIZATION, doc_ids=[doc_ids[1]])
+        eve = _make_entity("eve martinez", "PERSON", doc_ids=[doc_ids[0]])
+        beta = _make_entity("beta inc", "ORGANIZATION", doc_ids=[doc_ids[1]])
         # Alice and Acme appear again — must merge
-        alice_again = _make_entity("alice johnson", EntityType.PERSON, doc_ids=[doc_ids[1]])
-        acme_again = _make_entity("acme corp", EntityType.ORGANIZATION, doc_ids=[doc_ids[0], doc_ids[1]])
-        dave_again = _make_entity("dave wilson", EntityType.PERSON, doc_ids=[doc_ids[0]])
+        alice_again = _make_entity("alice johnson", "PERSON", doc_ids=[doc_ids[1]])
+        acme_again = _make_entity("acme corp", "ORGANIZATION", doc_ids=[doc_ids[0], doc_ids[1]])
+        dave_again = _make_entity("dave wilson", "PERSON", doc_ids=[doc_ids[0]])
 
         relationships = [
-            _make_relationship(eve, _find_entity(state, "acme corp"), RelationshipType.WORKS_FOR),
+            _make_relationship(eve, _find_entity(state, "acme corp"), "WORKS_FOR"),
             _make_relationship(eve, _find_entity(state, "dave wilson"), "COLLABORATES_WITH"),
             _make_relationship(_find_entity(state, "acme corp"), beta, "ACQUIRED"),
             _make_relationship(_find_entity(state, "alice johnson"), beta, "LEADS_INTEGRATION"),

--- a/tests/unit/test_attribute_schemas.py
+++ b/tests/unit/test_attribute_schemas.py
@@ -2,7 +2,7 @@
 
 from pydantic import BaseModel
 
-from khora.core.models.entity import Entity, EntityType
+from khora.core.models.entity import Entity
 from khora.core.models.schemas import (
     ATTRIBUTE_SCHEMAS,
     register_attribute_schema,
@@ -89,7 +89,7 @@ class TestEntityValidation:
         """Entity.validate() should clean attributes via schema."""
         entity = Entity(
             name="Alice",
-            entity_type=EntityType.PERSON,
+            entity_type="PERSON",
             attributes={"name": "Alice", "title": "CTO", "garbage": None},
         )
         entity.validate()
@@ -100,7 +100,7 @@ class TestEntityValidation:
         """Entity.validate() should pass through for CUSTOM type."""
         entity = Entity(
             name="Something",
-            entity_type=EntityType.CUSTOM,
+            entity_type="CUSTOM",
             attributes={"foo": "bar"},
         )
         entity.validate()

--- a/tests/unit/test_entity_index.py
+++ b/tests/unit/test_entity_index.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import pytest
 
 from khora._accel import cosine_similarity, levenshtein_similarity, normalize_entity_name
-from khora.core.models.entity import Entity, EntityType
+from khora.core.models.entity import Entity
 from khora.extraction.expansion.entity_index import (
     EntityIndex,
     _tokenize,
@@ -20,7 +20,7 @@ from khora.extraction.expansion.entity_index import (
 
 def _make_entity(
     name: str = "Test Entity",
-    entity_type: EntityType = EntityType.PERSON,
+    entity_type: str = "PERSON",
     namespace_id=None,
     embedding: list[float] | None = None,
     confidence: float = 1.0,
@@ -115,8 +115,8 @@ class TestEntityIndexAdd:
 
     def test_add_duplicate_returns_existing(self):
         idx = EntityIndex()
-        e1 = _make_entity("Alice", entity_type=EntityType.PERSON)
-        e2 = _make_entity("alice", entity_type=EntityType.PERSON)  # same name, diff case
+        e1 = _make_entity("Alice", entity_type="PERSON")
+        e2 = _make_entity("alice", entity_type="PERSON")  # same name, diff case
         idx.add(e1)
         result = idx.add(e2)
         assert result is e1
@@ -124,8 +124,8 @@ class TestEntityIndexAdd:
 
     def test_different_types_not_duplicate(self):
         idx = EntityIndex()
-        e1 = _make_entity("Mercury", entity_type=EntityType.PERSON)
-        e2 = _make_entity("Mercury", entity_type=EntityType.LOCATION)
+        e1 = _make_entity("Mercury", entity_type="PERSON")
+        e2 = _make_entity("Mercury", entity_type="LOCATION")
         idx.add(e1)
         result = idx.add(e2)
         assert result is None  # different type -> not a duplicate
@@ -149,7 +149,7 @@ class TestEntityIndexLookup:
 
     def test_get_by_name(self):
         idx = EntityIndex()
-        e = _make_entity("Alice", entity_type=EntityType.PERSON)
+        e = _make_entity("Alice", entity_type="PERSON")
         idx.add(e)
         assert idx.get_by_name("Alice", "PERSON") is e
         assert idx.get_by_name("alice", "PERSON") is e
@@ -160,9 +160,9 @@ class TestFuzzyCandidates:
     def test_finds_similar_names(self):
         idx = EntityIndex()
         ns = uuid4()
-        e1 = _make_entity("Microsoft Corporation", EntityType.ORGANIZATION, ns)
-        e2 = _make_entity("Microsoft Corp", EntityType.ORGANIZATION, ns)
-        e3 = _make_entity("Apple Inc", EntityType.ORGANIZATION, ns)
+        e1 = _make_entity("Microsoft Corporation", "ORGANIZATION", ns)
+        e2 = _make_entity("Microsoft Corp", "ORGANIZATION", ns)
+        e3 = _make_entity("Apple Inc", "ORGANIZATION", ns)
         idx.add(e1)
         idx.add(e2)
         idx.add(e3)
@@ -175,8 +175,8 @@ class TestFuzzyCandidates:
     def test_respects_type_filter(self):
         idx = EntityIndex()
         ns = uuid4()
-        e1 = _make_entity("John", EntityType.PERSON, ns)
-        e2 = _make_entity("Johns", EntityType.ORGANIZATION, ns)
+        e1 = _make_entity("John", "PERSON", ns)
+        e2 = _make_entity("Johns", "ORGANIZATION", ns)
         idx.add(e1)
         idx.add(e2)
 
@@ -206,9 +206,9 @@ class TestEmbeddingCandidates:
         emb2 = [0.99, 0.1, 0.0]  # very similar
         emb3 = [0.0, 0.0, 1.0]  # orthogonal
 
-        e1 = _make_entity("Entity A", EntityType.CONCEPT, ns, embedding=emb1)
-        e2 = _make_entity("Entity B", EntityType.CONCEPT, ns, embedding=emb2)
-        e3 = _make_entity("Entity C", EntityType.CONCEPT, ns, embedding=emb3)
+        e1 = _make_entity("Entity A", "CONCEPT", ns, embedding=emb1)
+        e2 = _make_entity("Entity B", "CONCEPT", ns, embedding=emb2)
+        e3 = _make_entity("Entity C", "CONCEPT", ns, embedding=emb3)
         idx.add(e1)
         idx.add(e2)
         idx.add(e3)
@@ -235,8 +235,8 @@ class TestEmbeddingCandidates:
         emb1 = [1.0, 0.0, 0.0]
         emb2 = [0.99, 0.1, 0.0]
 
-        e1 = _make_entity("Alpha Beta", EntityType.CONCEPT, ns, embedding=emb1)
-        e2 = _make_entity("Gamma Delta", EntityType.CONCEPT, ns, embedding=emb2)  # no shared tokens
+        e1 = _make_entity("Alpha Beta", "CONCEPT", ns, embedding=emb1)
+        e2 = _make_entity("Gamma Delta", "CONCEPT", ns, embedding=emb2)  # no shared tokens
         idx.add(e1)
         idx.add(e2)
 
@@ -258,9 +258,9 @@ class TestEntityIndexBulk:
     def test_get_entities_by_type(self):
         idx = EntityIndex()
         for i in range(3):
-            idx.add(_make_entity(f"Person {i}", EntityType.PERSON))
+            idx.add(_make_entity(f"Person {i}", "PERSON"))
         for i in range(2):
-            idx.add(_make_entity(f"Org {i}", EntityType.ORGANIZATION))
+            idx.add(_make_entity(f"Org {i}", "ORGANIZATION"))
 
         assert len(idx.get_entities_by_type("PERSON")) == 3
         assert len(idx.get_entities_by_type("ORGANIZATION")) == 2
@@ -268,8 +268,8 @@ class TestEntityIndexBulk:
 
     def test_stats(self):
         idx = EntityIndex()
-        idx.add(_make_entity("John Smith", EntityType.PERSON))
-        idx.add(_make_entity("Jane Doe", EntityType.PERSON))
+        idx.add(_make_entity("John Smith", "PERSON"))
+        idx.add(_make_entity("Jane Doe", "PERSON"))
 
         stats = idx.stats()
         assert stats["total_entities"] == 2

--- a/tests/unit/test_entity_resolution.py
+++ b/tests/unit/test_entity_resolution.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 import pytest
 
-from khora.core.models.entity import Entity, EntityType
+from khora.core.models.entity import Entity
 from khora.extraction.entity_resolution import (
     DEFAULT_MERGE_THRESHOLDS,
     EntityResolver,
@@ -23,7 +23,7 @@ from khora.extraction.entity_resolution import (
 )
 
 
-def _make_entity(name: str = "Test", entity_type: EntityType = EntityType.PERSON, **kwargs) -> Entity:
+def _make_entity(name: str = "Test", entity_type: str = "PERSON", **kwargs) -> Entity:
     """Helper to create an Entity with sensible defaults."""
     return Entity(
         namespace_id=kwargs.get("namespace_id", uuid4()),
@@ -249,7 +249,7 @@ class TestResolveAndMergeEntity:
         )
         assert is_new is True
         assert entity.name == "NewPerson"
-        assert entity.entity_type == EntityType.PERSON
+        assert entity.entity_type == "PERSON"
         assert entity.description == "Brand new person"
 
     @pytest.mark.asyncio
@@ -343,7 +343,7 @@ class TestEntityResolverPreloadedCache:
         """with_preloaded_cache loads entities for all default types."""
         ns_id = uuid4()
         alice = _make_entity("Alice", namespace_id=ns_id)
-        acme = _make_entity("Acme Corp", EntityType.ORGANIZATION, namespace_id=ns_id)
+        acme = _make_entity("Acme Corp", "ORGANIZATION", namespace_id=ns_id)
 
         storage = MagicMock()
 
@@ -631,7 +631,7 @@ class TestAttributeMatching:
         ns_id = uuid4()
         existing = _make_entity(
             "Acme Corporation",
-            EntityType.ORGANIZATION,
+            "ORGANIZATION",
             namespace_id=ns_id,
             attributes={"website": "https://www.acme.com"},
         )
@@ -653,7 +653,7 @@ class TestAttributeMatching:
         ns_id = uuid4()
         existing = _make_entity(
             "Times Square",
-            EntityType.LOCATION,
+            "LOCATION",
             namespace_id=ns_id,
             attributes={"coordinates": "40.7580, -73.9855"},
         )
@@ -675,7 +675,7 @@ class TestAttributeMatching:
         ns_id = uuid4()
         existing = _make_entity(
             "TensorFlow",
-            EntityType.TECHNOLOGY,
+            "TECHNOLOGY",
             namespace_id=ns_id,
             attributes={"vendor": "Google", "type": "framework"},
         )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 from khora.core.models import Chunk, Document, Entity, Relationship
 from khora.core.models.document import ChunkMetadata, DocumentMetadata, DocumentStatus
-from khora.core.models.entity import EntityType, Episode, RelationshipType
+from khora.core.models.entity import Episode
 from khora.core.models.event import EventType, MemoryEvent
 from khora.core.models.tenancy import MemoryNamespace, TenancyMode
 
@@ -109,15 +109,15 @@ class TestEntity:
 
     def test_create_entity(self) -> None:
         """Test basic entity creation."""
-        entity = Entity(name="John Smith", entity_type=EntityType.PERSON)
+        entity = Entity(name="John Smith", entity_type="PERSON")
         assert entity.name == "John Smith"
-        assert entity.entity_type == EntityType.PERSON
+        assert entity.entity_type == "PERSON"
 
     def test_entity_with_attributes(self) -> None:
         """Test entity with attributes."""
         entity = Entity(
             name="Acme Corp",
-            entity_type=EntityType.ORGANIZATION,
+            entity_type="ORGANIZATION",
             attributes={"industry": "Technology", "employees": 500},
         )
         assert entity.attributes["industry"] == "Technology"
@@ -127,7 +127,7 @@ class TestEntity:
         """Test entity with description."""
         entity = Entity(
             name="Python",
-            entity_type=EntityType.TECHNOLOGY,
+            entity_type="TECHNOLOGY",
             description="A programming language",
         )
         assert entity.description == "A programming language"
@@ -136,7 +136,7 @@ class TestEntity:
         """Test entity confidence score."""
         entity = Entity(
             name="Test",
-            entity_type=EntityType.CONCEPT,
+            entity_type="CONCEPT",
             confidence=0.85,
         )
         assert entity.confidence == 0.85
@@ -147,7 +147,7 @@ class TestEntity:
         chunk_id = uuid4()
         entity = Entity(
             name="Test",
-            entity_type=EntityType.CONCEPT,
+            entity_type="CONCEPT",
             source_document_ids=[doc_id],
             source_chunk_ids=[chunk_id],
         )
@@ -158,7 +158,7 @@ class TestEntity:
         """Test entity mention counting."""
         entity = Entity(
             name="Test",
-            entity_type=EntityType.CONCEPT,
+            entity_type="CONCEPT",
             mention_count=5,
         )
         assert entity.mention_count == 5
@@ -168,7 +168,7 @@ class TestEntity:
         now = datetime.now(timezone.utc)
         entity = Entity(
             name="Test",
-            entity_type=EntityType.EVENT,
+            entity_type="EVENT",
             valid_from=now,
             valid_until=now,
         )
@@ -181,14 +181,14 @@ class TestEntity:
         doc_id2 = uuid4()
         entity1 = Entity(
             name="Test",
-            entity_type=EntityType.PERSON,
+            entity_type="PERSON",
             source_document_ids=[doc_id1],
             mention_count=2,
             confidence=0.8,
         )
         entity2 = Entity(
             name="Test",
-            entity_type=EntityType.PERSON,
+            entity_type="PERSON",
             source_document_ids=[doc_id2],
             mention_count=3,
             confidence=0.9,
@@ -212,18 +212,18 @@ class TestRelationship:
         rel = Relationship(
             source_entity_id=source_id,
             target_entity_id=target_id,
-            relationship_type=RelationshipType.WORKS_FOR,
+            relationship_type="WORKS_FOR",
         )
         assert rel.source_entity_id == source_id
         assert rel.target_entity_id == target_id
-        assert rel.relationship_type == RelationshipType.WORKS_FOR
+        assert rel.relationship_type == "WORKS_FOR"
 
     def test_relationship_with_properties(self) -> None:
         """Test relationship with properties."""
         rel = Relationship(
             source_entity_id=uuid4(),
             target_entity_id=uuid4(),
-            relationship_type=RelationshipType.WORKS_FOR,
+            relationship_type="WORKS_FOR",
             properties={"since": "2020", "role": "Engineer"},
         )
         assert rel.properties["since"] == "2020"
@@ -234,7 +234,7 @@ class TestRelationship:
         rel = Relationship(
             source_entity_id=uuid4(),
             target_entity_id=uuid4(),
-            relationship_type=RelationshipType.KNOWS,
+            relationship_type="KNOWS",
             confidence=0.75,
         )
         assert rel.confidence == 0.75
@@ -244,7 +244,7 @@ class TestRelationship:
         rel = Relationship(
             source_entity_id=uuid4(),
             target_entity_id=uuid4(),
-            relationship_type=RelationshipType.COLLABORATES_WITH,
+            relationship_type="COLLABORATES_WITH",
             description="Worked together on Project X",
         )
         assert rel.description == "Worked together on Project X"
@@ -254,7 +254,7 @@ class TestRelationship:
         rel = Relationship(
             source_entity_id=uuid4(),
             target_entity_id=uuid4(),
-            relationship_type=RelationshipType.RELATES_TO,
+            relationship_type="RELATES_TO",
             weight=0.5,
         )
         assert rel.weight == 0.5

--- a/tests/unit/test_neo4j_helpers.py
+++ b/tests/unit/test_neo4j_helpers.py
@@ -6,7 +6,6 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 from khora.core.models import Entity, Relationship
-from khora.core.models.entity import EntityType, RelationshipType
 from khora.storage.backends.neo4j import _entity_to_cypher_params, _relationship_to_cypher_params
 
 
@@ -21,7 +20,7 @@ class TestEntityToCypherParams:
         entity = Entity(
             namespace_id=uuid4(),
             name="Alice",
-            entity_type=EntityType.PERSON,
+            entity_type="PERSON",
             description="A person",
             attributes={"role": "engineer"},
             source_document_ids=[doc_id],
@@ -66,7 +65,7 @@ class TestEntityToCypherParams:
         entity = Entity(
             namespace_id=uuid4(),
             name="Test",
-            entity_type=EntityType.CONCEPT,
+            entity_type="CONCEPT",
             valid_from=vf,
             valid_until=vu,
         )
@@ -79,7 +78,7 @@ class TestEntityToCypherParams:
         entity = Entity(
             namespace_id=uuid4(),
             name="Test",
-            entity_type=EntityType.CONCEPT,
+            entity_type="CONCEPT",
             attributes={"key": "value"},
         )
         params = _entity_to_cypher_params(entity)
@@ -100,7 +99,7 @@ class TestRelationshipToCypherParams:
             namespace_id=uuid4(),
             source_entity_id=src,
             target_entity_id=tgt,
-            relationship_type=RelationshipType.WORKS_FOR,
+            relationship_type="WORKS_FOR",
             description="works for",
             properties={"since": "2020"},
             confidence=0.9,
@@ -143,7 +142,7 @@ class TestRelationshipToCypherParams:
             namespace_id=uuid4(),
             source_entity_id=uuid4(),
             target_entity_id=uuid4(),
-            relationship_type=RelationshipType.RELATES_TO,
+            relationship_type="RELATES_TO",
             properties={"key": "value"},
         )
         params = _relationship_to_cypher_params(rel)

--- a/tests/unit/test_pipelines_tasks.py
+++ b/tests/unit/test_pipelines_tasks.py
@@ -217,7 +217,6 @@ class TestExtractEntities:
 
         # Collect entities across results and dedup by name:type
         from khora.core.models import Entity
-        from khora.core.models.entity import EntityType
 
         all_entities: dict[str, Entity] = {}
         for chunk, result in zip([chunk1, chunk2], results):
@@ -226,15 +225,10 @@ class TestExtractEntities:
                 if key in all_entities:
                     all_entities[key].mention_count += 1
                 else:
-                    entity_type = EntityType.CONCEPT
-                    try:
-                        entity_type = EntityType(extracted.entity_type)
-                    except ValueError:
-                        pass
                     entity = Entity(
                         namespace_id=chunk.namespace_id,
                         name=extracted.name,
-                        entity_type=entity_type,
+                        entity_type=extracted.entity_type or "CONCEPT",
                         description=extracted.description,
                         source_document_ids=[chunk.document_id],
                         source_chunk_ids=[chunk.id],

--- a/tests/unit/test_query_linking.py
+++ b/tests/unit/test_query_linking.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 import pytest
 
-from khora.core.models.entity import Entity, EntityType
+from khora.core.models.entity import Entity
 from khora.query.linking import (
     EntityLinker,
     LinkedEntity,
@@ -17,7 +17,7 @@ from khora.query.linking import (
 from khora.query.understanding import EntityMention
 
 
-def _make_entity(name: str, entity_type: EntityType = EntityType.PERSON) -> Entity:
+def _make_entity(name: str, entity_type: str = "PERSON") -> Entity:
     """Helper to create an Entity."""
     return Entity(
         namespace_id=uuid4(),

--- a/tests/unit/test_saas_extraction.py
+++ b/tests/unit/test_saas_extraction.py
@@ -1,6 +1,6 @@
 """Tests for tool-schema extraction, source boosting, and type-aware linking."""
 
-from khora.core.models.entity import Entity, EntityType
+from khora.core.models.entity import Entity
 from khora.extraction.extractors.base import ExtractedEntity
 from khora.extraction.extractors.llm import LLMEntityExtractor
 from khora.extraction.skills.base import ExpertiseConfig
@@ -139,7 +139,7 @@ class TestAttributeRelevanceBoost:
 
         entity = Entity(
             name="ENG-123",
-            entity_type=EntityType.CONCEPT,
+            entity_type="CONCEPT",
             attributes={"priority": "urgent", "assignee": "Alice"},
         )
         boost = HybridQueryEngine._attribute_relevance_boost(entity, ["urgent", "alice"])
@@ -152,7 +152,7 @@ class TestAttributeRelevanceBoost:
 
         entity = Entity(
             name="ENG-456",
-            entity_type=EntityType.CONCEPT,
+            entity_type="CONCEPT",
             attributes={"priority": "low", "assignee": "Bob"},
         )
         boost = HybridQueryEngine._attribute_relevance_boost(entity, ["urgent", "alice"])
@@ -164,7 +164,7 @@ class TestAttributeRelevanceBoost:
 
         entity = Entity(
             name="Test",
-            entity_type=EntityType.CONCEPT,
+            entity_type="CONCEPT",
             attributes={"a": "foo", "b": "foo", "c": "foo", "d": "foo", "e": "foo"},
         )
         boost = HybridQueryEngine._attribute_relevance_boost(entity, ["foo"])
@@ -174,6 +174,6 @@ class TestAttributeRelevanceBoost:
         """Entity with no attributes should get zero boost."""
         from khora.query.engine import HybridQueryEngine
 
-        entity = Entity(name="Test", entity_type=EntityType.CONCEPT, attributes={})
+        entity = Entity(name="Test", entity_type="CONCEPT", attributes={})
         boost = HybridQueryEngine._attribute_relevance_boost(entity, ["urgent"])
         assert boost == 0.0

--- a/tests/unit/test_vectorcypher_engine.py
+++ b/tests/unit/test_vectorcypher_engine.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 
 import pytest
 
-from khora.core.models import Entity, EntityType
+from khora.core.models import Entity
 from khora.engines.vectorcypher.engine import VectorCypherConfig, VectorCypherEngine
 
 
@@ -83,7 +83,7 @@ class TestVectorCypherSearchEntities:
             id=entity_id,
             namespace_id=namespace_id,
             name="Test Entity",
-            entity_type=EntityType.CONCEPT,
+            entity_type="CONCEPT",
             description="A test entity for search.",
         )
 


### PR DESCRIPTION
## Summary
- Remove `EntityType` and `RelationshipType` enum classes from `core/models/entity.py` (ADR-005 Track 2)
- Change `Entity.entity_type` and `Relationship.relationship_type` to plain `str` fields (defaults: `"CONCEPT"`, `"RELATES_TO"`)
- Remove `entity_type_str()` and `relationship_type_str()` helper functions
- Remove enum exports from `core/models/__init__.py` and `core/__init__.py`
- Remove ~27 enum serialization guards (`isinstance`, `__members__`, `hasattr(x, "value")`) from 5 storage backends (neo4j, memgraph, kuzu, arcadedb, pgvector)
- Remove enum guards from pipeline/query/extraction modules (ingest.py, rule_engine.py, cross_tool_unifier.py, relationship_inferrer.py, linking.py, reranking.py, entity_resolution.py, entity_index.py)
- Replace `EntityType.PERSON` etc. with string literals across 10 test files
- Update `docs/data-models/knowledge-graph.md` to reflect plain string types
- Net: -203 lines across 26 files

## Related ADRs
- [ADR-005: Remove Ontology Definitions from Khora](https://github.com/DeytaHQ/hegemon/blob/main/architecture/decisions/005-remove-khora-ontology-definitions.md) — Track 2

## Test plan
- [x] All 1452 unit tests pass
- [x] Coverage 53% (above 46% threshold)
- [x] `ruff check` passes
- [x] `black --check` passes
- [x] `ty check` — no new diagnostics (14 pre-existing warnings)
- [x] Zero remaining enum references in src/ or tests/