### PR TITLE
DYT-315: Flatten namespace model — require namespace_id, remove name/description/slug

### DIFF
--- a/alembic/versions/011_drop_namespace_slug.py
+++ b/alembic/versions/011_drop_namespace_slug.py
@@ -1,0 +1,94 @@
+"""Drop slug column from memory_namespaces (DYT-315).
+
+Revision ID: 011_drop_namespace_slug
+Revises: 010_flatten_namespace_hierarchy
+Create Date: 2026-03-09
+
+The ORM model no longer has a slug field — namespaces are identified by
+UUID and looked up by name.  The physical slug column is NOT NULL, so
+INSERTs will fail unless the column is removed.
+
+Steps:
+1. Drop uq_namespace_slug_version unique constraint (from migration 010)
+2. Drop idx_namespace_slug_active partial index (from migration 010)
+3. Drop slug column
+4. Add uq_namespace_name_version unique constraint on (name, version)
+5. Add idx_namespace_name_active partial index on name WHERE is_active
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy import text
+
+from alembic import op
+
+revision: str = "011_drop_namespace_slug"
+down_revision: str | Sequence[str] | None = "010_flatten_namespace_hierarchy"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # =========================================================================
+    # Step 1: Drop slug unique constraint (created in migration 010)
+    # =========================================================================
+    op.drop_constraint("uq_namespace_slug_version", "memory_namespaces", type_="unique")
+
+    # =========================================================================
+    # Step 2: Drop slug partial index (created in migration 010)
+    # =========================================================================
+    op.drop_index("idx_namespace_slug_active", table_name="memory_namespaces")
+
+    # =========================================================================
+    # Step 3: Drop the slug column
+    # =========================================================================
+    # The name column already exists (created in migration 000).
+    # Drop the auto-created index on slug first, then the column.
+    op.drop_index("ix_memory_namespaces_slug", table_name="memory_namespaces")
+    op.drop_column("memory_namespaces", "slug")
+
+    # =========================================================================
+    # Step 4: Add unique constraint on (name, version)
+    # =========================================================================
+    op.create_unique_constraint("uq_namespace_name_version", "memory_namespaces", ["name", "version"])
+
+    # =========================================================================
+    # Step 5: Add partial index on name for active namespaces
+    # =========================================================================
+    op.create_index(
+        "idx_namespace_name_active",
+        "memory_namespaces",
+        ["name"],
+        postgresql_where=sa.text("is_active = true"),
+    )
+
+
+def downgrade() -> None:
+    # Reverse step 5: Drop name partial index
+    op.drop_index("idx_namespace_name_active", table_name="memory_namespaces")
+
+    # Reverse step 4: Drop name unique constraint
+    op.drop_constraint("uq_namespace_name_version", "memory_namespaces", type_="unique")
+
+    # Reverse step 3: Re-add slug column as NULLABLE (cannot reconstruct values)
+    op.add_column(
+        "memory_namespaces",
+        sa.Column("slug", sa.String(255), nullable=True),
+    )
+    # Backfill slug from name (best effort — lowercase with hyphens)
+    op.execute(text("UPDATE memory_namespaces SET slug = lower(replace(name, ' ', '-'))"))
+    # Recreate the auto-generated index on slug
+    op.create_index("ix_memory_namespaces_slug", "memory_namespaces", ["slug"])
+
+    # Reverse step 2: Re-add slug partial index
+    op.create_index(
+        "idx_namespace_slug_active",
+        "memory_namespaces",
+        ["slug"],
+        postgresql_where=sa.text("is_active = true"),
+    )
+
+    # Reverse step 1: Re-add slug unique constraint
+    # Note: slug is nullable after downgrade, so this constraint allows NULLs
+    op.create_unique_constraint("uq_namespace_slug_version", "memory_namespaces", ["slug", "version"])

--- a/alembic/versions/011_drop_namespace_slug.py
+++ b/alembic/versions/011_drop_namespace_slug.py
@@ -1,19 +1,18 @@
-"""Drop slug column from memory_namespaces (DYT-315).
+"""Drop slug, name, description columns from memory_namespaces (DYT-315).
 
 Revision ID: 011_drop_namespace_slug
 Revises: 010_flatten_namespace_hierarchy
 Create Date: 2026-03-09
 
-The ORM model no longer has a slug field — namespaces are identified by
-UUID and looked up by name.  The physical slug column is NOT NULL, so
-INSERTs will fail unless the column is removed.
+The ORM model no longer has slug, name, or description fields — namespaces
+are identified by UUID only.  These physical columns must be removed so
+INSERTs don't fail on NOT NULL constraints for removed fields.
 
 Steps:
 1. Drop uq_namespace_slug_version unique constraint (from migration 010)
 2. Drop idx_namespace_slug_active partial index (from migration 010)
 3. Drop slug column
-4. Add uq_namespace_name_version unique constraint on (name, version)
-5. Add idx_namespace_name_active partial index on name WHERE is_active
+4. Drop name and description columns (no longer in domain model)
 """
 
 from collections.abc import Sequence
@@ -43,33 +42,29 @@ def upgrade() -> None:
     # =========================================================================
     # Step 3: Drop the slug column
     # =========================================================================
-    # The name column already exists (created in migration 000).
     # Drop the auto-created index on slug first, then the column.
     op.drop_index("ix_memory_namespaces_slug", table_name="memory_namespaces")
     op.drop_column("memory_namespaces", "slug")
 
     # =========================================================================
-    # Step 4: Add unique constraint on (name, version)
+    # Step 4: Drop name and description columns
     # =========================================================================
-    op.create_unique_constraint("uq_namespace_name_version", "memory_namespaces", ["name", "version"])
-
-    # =========================================================================
-    # Step 5: Add partial index on name for active namespaces
-    # =========================================================================
-    op.create_index(
-        "idx_namespace_name_active",
-        "memory_namespaces",
-        ["name"],
-        postgresql_where=sa.text("is_active = true"),
-    )
+    op.drop_column("memory_namespaces", "name")
+    op.drop_column("memory_namespaces", "description")
 
 
 def downgrade() -> None:
-    # Reverse step 5: Drop name partial index
-    op.drop_index("idx_namespace_name_active", table_name="memory_namespaces")
-
-    # Reverse step 4: Drop name unique constraint
-    op.drop_constraint("uq_namespace_name_version", "memory_namespaces", type_="unique")
+    # Reverse step 4: Re-add name and description columns
+    op.add_column(
+        "memory_namespaces",
+        sa.Column("name", sa.String(255), nullable=True),
+    )
+    op.add_column(
+        "memory_namespaces",
+        sa.Column("description", sa.Text(), server_default="", nullable=True),
+    )
+    # Backfill name from id (best effort — cannot reconstruct original values)
+    op.execute(text("UPDATE memory_namespaces SET name = id::text WHERE name IS NULL"))
 
     # Reverse step 3: Re-add slug column as NULLABLE (cannot reconstruct values)
     op.add_column(

--- a/docs/architecture/multi-tenancy.md
+++ b/docs/architecture/multi-tenancy.md
@@ -15,17 +15,17 @@ async with MemoryLake() as lake:
     # Store in a specific namespace (required)
     await lake.remember(
         "Important document content...",
-        namespace_id=namespace_id
+        namespace=namespace_id
     )
 
     # Search within that namespace (required)
     results = await lake.recall(
         "What's in those documents?",
-        namespace_id=namespace_id
+        namespace=namespace_id
     )
 ```
 
-The `namespace_id` parameter is **required** — there is no default namespace. Omitting it raises a `ValueError`.
+The `namespace` parameter is **required** — there is no default namespace. Omitting it raises a `ValueError`.
 
 This isolation is enforced at the database level:
 
@@ -54,7 +54,7 @@ async with MemoryLake() as lake:
     # Now store data
     await lake.remember(
         "Important content...",
-        namespace_id=namespace.id
+        namespace=namespace.id
     )
 ```
 

--- a/docs/architecture/multi-tenancy.md
+++ b/docs/architecture/multi-tenancy.md
@@ -1,31 +1,8 @@
 # Multi-Tenancy
 
-> **Status (v0.2.3):** The `TenancyMode` enum and ACL enforcement code described below exist in the codebase but are **not wired at runtime**. Currently only namespace-level row filtering is active. See `docs/design/namespace-optimization-plan.md` for the implementation roadmap.
+> **Status:** The `TenancyMode` enum exists in the codebase but is **not wired at runtime**. Currently only namespace-level row filtering is active.
 
-Different teams need different data. Different projects shouldn't mix. Sometimes you need complete isolation for compliance. Khora's multi-tenancy model handles all of this through a simple hierarchy: Organizations contain Workspaces contain Namespaces.
-
-## The Hierarchy
-
-```
-Acme Corporation (Organization)
-│
-├── Engineering (Workspace)
-│   ├── production (Namespace)    ← Live data
-│   ├── production-v2 (Namespace) ← New version being staged
-│   └── sandbox (Namespace)       ← Experiments
-│
-└── Product (Workspace)
-    ├── research (Namespace)
-    └── competitor-analysis (Namespace)
-```
-
-Each level serves a purpose:
-
-**Organization** - Your company. Handles billing, sets global policies, defines whether data is shared or isolated at the infrastructure level.
-
-**Workspace** - A team or project. Groups related namespaces, provides a boundary for access control.
-
-**Namespace** - Where data actually lives. Every document, chunk, entity, and relationship belongs to exactly one namespace. This is your unit of isolation.
+Khora isolates data through **namespaces**. Every document, chunk, entity, and relationship belongs to exactly one namespace. This is the sole unit of isolation — there is no organization or workspace hierarchy within khora. Higher-level grouping (organizations, teams, etc.) is the responsibility of the consuming service.
 
 ## Namespaces: Where Data Lives
 
@@ -48,6 +25,8 @@ async with MemoryLake() as lake:
     )
 ```
 
+If you omit the `namespace` parameter, khora uses a default namespace (created automatically on first use).
+
 This isolation is enforced at the database level:
 
 ```sql
@@ -60,9 +39,42 @@ ORDER BY similarity DESC;
 
 You can't accidentally see another namespace's data.
 
+## Creating Namespaces
+
+```python
+from khora import MemoryLake
+from khora.core.models import MemoryNamespace
+
+async with MemoryLake() as lake:
+    # Create a namespace
+    namespace = await lake.storage.create_namespace(
+        MemoryNamespace(name="Production")
+    )
+
+    # Now store data
+    await lake.remember(
+        "Important content...",
+        namespace=namespace.id
+    )
+```
+
+## Finding Namespaces
+
+```python
+# By name
+ns = await lake.storage.get_namespace_by_name("production")
+
+# By UUID
+ns = await lake.storage.get_namespace(namespace_id)
+
+# List all (active only by default)
+result = await lake.storage.list_namespaces()
+namespaces = result.items
+```
+
 ## Namespace Versioning
 
-Here's a powerful feature: namespaces can be versioned. This solves a common problem - how do you replace all your data without downtime?
+Namespaces can be versioned. This solves a common problem - how do you replace all your data without downtime?
 
 ### The Problem
 
@@ -72,15 +84,15 @@ Say you have a "production" namespace with 100,000 documents. You want to rebuil
 
 ```
 Before:
-  production (v1) ← active, serving queries
+  production (v1) <- active, serving queries
 
 During rebuild:
-  production (v1) ← still active, serving queries
-  production (v2) ← inactive, being populated
+  production (v1) <- still active, serving queries
+  production (v2) <- inactive, being populated
 
 After:
-  production (v1) ← now inactive
-  production (v2) ← now active, serving queries
+  production (v1) <- now inactive
+  production (v2) <- now active, serving queries
 ```
 
 The swap is atomic. One moment users see v1, the next they see v2. No downtime, no partial data.
@@ -90,13 +102,10 @@ The swap is atomic. One moment users see v1, the next they see v2. No downtime, 
 ```python
 async with MemoryLake() as lake:
     # 1. Get current namespace
-    current = await lake.storage.get_namespace_by_name(
-        workspace_id, "production"
-    )
+    current = await lake.storage.get_namespace_by_name("production")
 
     # 2. Create new version
     new_version = await lake.storage.create_namespace_version(
-        workspace_id,
         name="production",
         previous_version=current
     )
@@ -134,64 +143,12 @@ await lake.storage.deactivate_namespace(new_version.id)
 
 Keep old versions around until you're confident the new one is working.
 
-## Tenancy Modes
-
-### Shared Mode (Default)
-
-All organizations share the same database infrastructure. Isolation is achieved through row-level filtering on `namespace_id`.
-
-```python
-Organization(
-    name="Acme Corp",
-    tenancy_mode=TenancyMode.SHARED
-)
-```
-
-**Pros:**
-- Lower cost (shared infrastructure)
-- Simpler operations
-- Good enough for most use cases
-
-**Cons:**
-- Data is logically separate but physically together
-- May not satisfy strict compliance requirements
-
-### Isolated Mode
-
-Each organization gets its own database instances. Complete physical separation.
-
-```python
-Organization(
-    name="SecureCorp",
-    tenancy_mode=TenancyMode.ISOLATED
-)
-```
-
-**Pros:**
-- Complete data isolation
-- Meets HIPAA, SOC2, and similar requirements
-- Independent scaling and maintenance
-
-**Cons:**
-- Higher cost (dedicated infrastructure)
-- More operational complexity
-
-**Configuration:**
-```python
-# Each isolated org needs its own connection strings
-org_config = {
-    "postgresql_url": "postgresql://securecorp:pass@securecorp-db:5432/khora",
-    "neo4j_url": "bolt://securecorp-graph:7687"
-}
-```
-
 ## Configuration Overrides
 
 Each namespace can override global settings. Maybe one namespace needs a different embedding model, or stricter similarity thresholds:
 
 ```python
 namespace = MemoryNamespace(
-    workspace_id=workspace_id,
     name="High-Precision Research",
     config_overrides={
         "embedding_model": "text-embedding-3-large",
@@ -202,11 +159,9 @@ namespace = MemoryNamespace(
 )
 ```
 
-Configuration resolves top-down:
+Configuration resolves:
 1. Namespace overrides (highest priority)
-2. Workspace defaults
-3. Organization defaults
-4. Global config (lowest priority)
+2. Global config (lowest priority)
 
 ## Sync Checkpoints
 
@@ -240,95 +195,14 @@ await lake.storage.set_sync_checkpoint(
 )
 ```
 
-## Access Control
-
-Permissions flow down the hierarchy:
-
-```
-Organization (admin role)
-    │
-    └── Workspace (member role)
-            │
-            └── Namespace (read/write permissions)
-```
-
-If you can access an organization, you can access its workspaces (subject to workspace permissions). If you can access a workspace, you can access its namespaces (subject to namespace permissions).
-
-```python
-from khora.acl import ACLEnforcer, ACLContext
-
-enforcer = ACLEnforcer(storage)
-
-# Check before accessing
-context = ACLContext(
-    user_id="user-123",
-    namespace_id=namespace_id,
-    operation="read"
-)
-
-if await enforcer.check_permission(context):
-    results = await lake.recall(query, namespace=namespace_id)
-else:
-    raise PermissionDenied()
-```
-
-## Setting Up the Hierarchy
-
-### Create Everything
-
-```python
-from khora import MemoryLake
-from khora.core.models import Organization, Workspace, MemoryNamespace
-
-async with MemoryLake() as lake:
-    # Organization
-    org = await lake.storage.create_organization(
-        Organization(name="Acme Corp")
-    )
-
-    # Workspace
-    workspace = await lake.storage.create_workspace(
-        Workspace(
-            organization_id=org.id,
-            name="Engineering"
-        )
-    )
-
-    # Namespace
-    namespace = await lake.storage.create_namespace(
-        MemoryNamespace(
-            workspace_id=workspace.id,
-            name="Production"
-        )
-    )
-
-    # Now store data
-    await lake.remember(
-        "Important content...",
-        namespace=namespace.id
-    )
-```
-
-### Find Existing Namespaces
-
-```python
-# By name
-ns = await lake.storage.get_namespace_by_name(workspace_id, "production")
-
-# List all in a workspace
-namespaces = await lake.storage.list_namespaces(workspace_id)
-
-# Filter to active only
-active = [ns for ns in namespaces if ns.is_active]
-```
-
-### Cross-Namespace Queries
+## Cross-Namespace Queries
 
 Need to search multiple namespaces? (Note: this bypasses isolation - make sure you have permission)
 
 ```python
 all_results = []
-for namespace in await lake.storage.list_namespaces(workspace_id):
+result = await lake.storage.list_namespaces()
+for namespace in result.items:
     if namespace.is_active and user_can_access(namespace):
         results = await lake.recall(query, namespace=namespace.id)
         all_results.extend(results.chunks)

--- a/docs/architecture/multi-tenancy.md
+++ b/docs/architecture/multi-tenancy.md
@@ -90,14 +90,14 @@ The swap is atomic. One moment users see v1, the next they see v2. No downtime, 
 ```python
 async with MemoryLake() as lake:
     # 1. Get current namespace
-    current = await lake.storage.get_namespace_by_slug(
+    current = await lake.storage.get_namespace_by_name(
         workspace_id, "production"
     )
 
     # 2. Create new version
     new_version = await lake.storage.create_namespace_version(
         workspace_id,
-        slug="production",
+        name="production",
         previous_version=current
     )
     # new_version.version = 2
@@ -193,7 +193,6 @@ Each namespace can override global settings. Maybe one namespace needs a differe
 namespace = MemoryNamespace(
     workspace_id=workspace_id,
     name="High-Precision Research",
-    slug="research",
     config_overrides={
         "embedding_model": "text-embedding-3-large",
         "embedding_dimension": 3072,
@@ -284,15 +283,14 @@ from khora.core.models import Organization, Workspace, MemoryNamespace
 async with MemoryLake() as lake:
     # Organization
     org = await lake.storage.create_organization(
-        Organization(name="Acme Corp", slug="acme")
+        Organization(name="Acme Corp")
     )
 
     # Workspace
     workspace = await lake.storage.create_workspace(
         Workspace(
             organization_id=org.id,
-            name="Engineering",
-            slug="engineering"
+            name="Engineering"
         )
     )
 
@@ -300,8 +298,7 @@ async with MemoryLake() as lake:
     namespace = await lake.storage.create_namespace(
         MemoryNamespace(
             workspace_id=workspace.id,
-            name="Production",
-            slug="production"
+            name="Production"
         )
     )
 
@@ -315,8 +312,8 @@ async with MemoryLake() as lake:
 ### Find Existing Namespaces
 
 ```python
-# By slug
-ns = await lake.storage.get_namespace_by_slug(workspace_id, "production")
+# By name
+ns = await lake.storage.get_namespace_by_name(workspace_id, "production")
 
 # List all in a workspace
 namespaces = await lake.storage.list_namespaces(workspace_id)

--- a/docs/architecture/multi-tenancy.md
+++ b/docs/architecture/multi-tenancy.md
@@ -6,26 +6,26 @@ Khora isolates data through **namespaces**. Every document, chunk, entity, and r
 
 ## Namespaces: Where Data Lives
 
-All your data is scoped to namespaces. When you call `remember()` or `recall()`, you're always operating within a namespace:
+All your data is scoped to namespaces. When you call `remember()` or `recall()`, you must always specify a namespace:
 
 ```python
 from khora import MemoryLake
 
 async with MemoryLake() as lake:
-    # Store in a specific namespace
+    # Store in a specific namespace (required)
     await lake.remember(
         "Important document content...",
-        namespace=namespace_id
+        namespace_id=namespace_id
     )
 
-    # Search within that namespace
+    # Search within that namespace (required)
     results = await lake.recall(
         "What's in those documents?",
-        namespace=namespace_id
+        namespace_id=namespace_id
     )
 ```
 
-If you omit the `namespace` parameter, khora uses a default namespace (created automatically on first use).
+The `namespace_id` parameter is **required** — there is no default namespace. Omitting it raises a `ValueError`.
 
 This isolation is enforced at the database level:
 
@@ -46,24 +46,21 @@ from khora import MemoryLake
 from khora.core.models import MemoryNamespace
 
 async with MemoryLake() as lake:
-    # Create a namespace
+    # Create a namespace (UUID-identified, no name/description)
     namespace = await lake.storage.create_namespace(
-        MemoryNamespace(name="Production")
+        MemoryNamespace()
     )
 
     # Now store data
     await lake.remember(
         "Important content...",
-        namespace=namespace.id
+        namespace_id=namespace.id
     )
 ```
 
 ## Finding Namespaces
 
 ```python
-# By name
-ns = await lake.storage.get_namespace_by_name("production")
-
 # By UUID
 ns = await lake.storage.get_namespace(namespace_id)
 
@@ -101,12 +98,11 @@ The swap is atomic. One moment users see v1, the next they see v2. No downtime, 
 
 ```python
 async with MemoryLake() as lake:
-    # 1. Get current namespace
-    current = await lake.storage.get_namespace_by_name("production")
+    # 1. Get current namespace by UUID
+    current = await lake.storage.get_namespace(current_namespace_id)
 
     # 2. Create new version
     new_version = await lake.storage.create_namespace_version(
-        name="production",
         previous_version=current
     )
     # new_version.version = 2
@@ -149,7 +145,6 @@ Each namespace can override global settings. Maybe one namespace needs a differe
 
 ```python
 namespace = MemoryNamespace(
-    name="High-Precision Research",
     config_overrides={
         "embedding_model": "text-embedding-3-large",
         "embedding_dimension": 3072,

--- a/docs/architecture/storage-backends.md
+++ b/docs/architecture/storage-backends.md
@@ -47,30 +47,19 @@ CREATE TABLE documents (
 );
 ```
 
-**Tenant Hierarchy** - Who owns what:
+**Namespaces** - The sole isolation boundary:
 ```sql
--- Organization (top level, e.g., your company)
--- └── Workspace (team or project)
---     └── Namespace (isolated data container)
-
-CREATE TABLE organizations (
+CREATE TABLE memory_namespaces (
     id UUID PRIMARY KEY,
-    name VARCHAR(255),
-    tenancy_mode VARCHAR(20)  -- shared or isolated
-);
-
-CREATE TABLE workspaces (
-    id UUID PRIMARY KEY,
-    organization_id UUID REFERENCES organizations(id),
-    name VARCHAR(255)
-);
-
-CREATE TABLE namespaces (
-    id UUID PRIMARY KEY,
-    workspace_id UUID REFERENCES workspaces(id),
-    name VARCHAR(255),
+    tenancy_mode VARCHAR(20),  -- shared or isolated
     version INTEGER DEFAULT 1,
-    is_active BOOLEAN DEFAULT TRUE
+    is_active BOOLEAN DEFAULT TRUE,
+    previous_version_id UUID REFERENCES memory_namespaces(id),
+    config_overrides JSONB DEFAULT '{}',
+    sync_checkpoints JSONB DEFAULT '{}',
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ
 );
 ```
 
@@ -578,6 +567,6 @@ pip install khora[all-backends]
 
 ## What's Next?
 
-- **[Multi-Tenancy](multi-tenancy.md)** - Organizations, workspaces, namespaces
+- **[Multi-Tenancy](multi-tenancy.md)** - Namespace isolation
 - **[Event Sourcing](event-sourcing.md)** - The immutable event log
 - **[Overview](overview.md)** - High-level architecture

--- a/docs/architecture/storage-backends.md
+++ b/docs/architecture/storage-backends.md
@@ -56,7 +56,6 @@ CREATE TABLE documents (
 CREATE TABLE organizations (
     id UUID PRIMARY KEY,
     name VARCHAR(255),
-    slug VARCHAR(100) UNIQUE,
     tenancy_mode VARCHAR(20)  -- shared or isolated
 );
 

--- a/docs/engines/skeleton-engine.md
+++ b/docs/engines/skeleton-engine.md
@@ -101,7 +101,6 @@ async with MemoryLake("postgresql://...", engine="skeleton") as lake:
 | `recall()` | Retrieve memories with temporal filtering and hybrid search |
 | `forget()` | Remove a memory from the engine |
 | `remember_batch()` | Batch ingestion with parallel processing |
-| `ensure_namespace()` | Get or create namespace by name |
 | `stats()` | Get document/chunk/entity counts |
 
 ### TemporalEdgeStorage (`src/khora/engines/skeleton/temporal_edges.py`)

--- a/docs/prds/DYT-315-remove-namespace-slugs.md
+++ b/docs/prds/DYT-315-remove-namespace-slugs.md
@@ -1,6 +1,6 @@
-# PRD-001: Remove Namespace Slugs
+# PRD-001: Flatten Namespace Model
 
-**Status:** Draft
+**Status:** Implemented
 **Author:** Filip
 **Date:** 2026-03-08
 **Linear:** DYT-315
@@ -9,35 +9,38 @@
 
 ### Problem Statement
 
-Khora's public API accepts both UUIDs and slug strings for namespace identification (`_resolve_namespace()` in `memory_lake.py`). This dual-lookup path adds complexity: slug auto-generation logic, a dedicated `get_namespace_by_slug()` method through every storage layer, a DB column with unique constraints and partial indexes, and branching resolution code. Slug-based lookup is unused by downstream consumers (genesis, khora-benchmarks) and the human-readable slug functionality belongs in the peras service layer, not in the storage library.
+Khora's namespace model carries unnecessary complexity: dual UUID/slug identification, optional namespace parameters with implicit default provisioning, and `name`/`description` metadata fields that belong in the service layer. Slug-based lookup is unused by downstream consumers (genesis, khora-benchmarks), default namespace auto-creation masks missing configuration errors, and human-readable metadata belongs in peras — not in the storage library. The namespace should be a lean, required UUID isolation boundary.
 
 ### Goals
 
-- All public API functions (`remember`, `recall`, `forget`, `remember_batch`) accept `UUID` or `str` (converted to UUID) for namespace identification — no slug lookup path
+- All public API functions (`remember`, `recall`, `forget`, `remember_batch`) require a `namespace_id: UUID` parameter — no optional namespace, no slug lookup path
 - Remove the `slug` column from `memory_namespaces` table and all associated constraints/indexes
-- Remove `get_namespace_by_slug()` from storage backends, coordinator, and engine layers
-- Remove slug field from `MemoryNamespace` domain model and auto-generation logic
-- Reduce code surface area (estimated ~15 files, ~100+ lines removed)
+- Remove `name` and `description` columns from `memory_namespaces` table and domain model
+- Remove `get_namespace_by_slug()` and `get_or_create_default_namespace()` from all layers
+- Remove `get_namespace_by_name()` (no longer needed without name field)
+- Namespace becomes a pure UUID isolation boundary: `id`, `version`, `is_active`, `config_overrides`, timestamps
+- Reduce code surface area (estimated ~15 files, ~150+ lines removed)
 
 ### Non-Goals
 
-- **Database migration** — no new Alembic migration file to drop the DB column. The ORM model removes the `slug` mapped column, so SQLAlchemy ignores it, but the physical column remains in the database until a migration is added separately
 - **Backward compatibility** — no deprecation period or shim; clean break
-- **Adding slug functionality to peras** — that's a peras concern
-- **Changing namespace creation API** — `create_namespace()` still takes a name; it just no longer generates or stores a slug
-- **Making namespace_id required** — `namespace` parameter stays optional in public API; `get_or_create_default_namespace()` convenience is preserved
+- **Adding slug/name functionality to peras** — that's a peras concern
+- **Changing namespace table structure beyond stated columns** — `version`, `is_active`, `config_overrides`, and timestamp columns are preserved
 
 ### Requirements
 
 #### Functional Requirements
 
-1. **FR-1:** `MemoryNamespace` domain model (`core/models/tenancy.py`) must not contain a `slug` field
-2. **FR-2:** `MemoryNamespaceModel` ORM (`db/models.py`) must not contain a `slug` column, its unique constraint (`uq_namespace_slug_version`), or its partial index (`idx_namespace_slug_active`)
-3. **FR-3:** `_resolve_namespace()` in `memory_lake.py` must accept `UUID` or `str` (converted to `UUID`), raising `ValueError` for non-UUID-parseable strings. The slug lookup branch is removed
-4. **FR-4:** `get_namespace_by_slug()` must be removed from `RelationalBackend` protocol, `PostgreSQLBackend`, and `StorageCoordinator`
-5. **FR-5:** All three engines (GraphRAG, Skeleton, VectorCypher) must replace the `get_namespace_by_slug("default")` call inside `get_or_create_default_namespace()` with a name-based lookup (e.g., `get_namespace_by_name("default")`). The `get_or_create_default_namespace()` method and optional `namespace` parameter in the public API are preserved
-6. **FR-6:** `create_namespace_version()` in coordinator must not accept a `slug` parameter
-7. **FR-7:** All tests referencing slug behavior must be removed or rewritten to use UUID-only paths
+1. **FR-1:** `MemoryNamespace` domain model (`core/models/tenancy.py`) must not contain `slug`, `name`, or `description` fields. Remove `__post_init__` auto-generation logic
+2. **FR-2:** `MemoryNamespaceModel` ORM (`db/models.py`) must not contain `slug`, `name`, or `description` columns, nor the `uq_namespace_slug_version` constraint or `idx_namespace_slug_active` index
+3. **FR-3:** `namespace_id` parameter must be **required** (not optional) in all public API methods (`remember`, `recall`, `forget`, `remember_batch`). Accept `UUID` or `str` (converted to `UUID`), raising `ValueError` for non-UUID-parseable strings
+4. **FR-4:** `_resolve_namespace()` in `memory_lake.py` must not have a fallback to default namespace. Remove the `get_or_create_default_namespace()` call path
+5. **FR-5:** `get_or_create_default_namespace()` must be removed from `MemoryLake`, all three engines (GraphRAG, Skeleton, VectorCypher), and the `MemoryEngineProtocol`
+6. **FR-6:** `get_namespace_by_slug()` must be removed from `RelationalBackend` protocol, `PostgreSQLBackend`, and `StorageCoordinator`
+7. **FR-7:** `get_namespace_by_name()` must be removed from `RelationalBackend` protocol, `PostgreSQLBackend`, and `StorageCoordinator`
+8. **FR-8:** `create_namespace()` and `create_namespace_version()` must not accept `slug`, `name`, or `description` parameters
+9. **FR-9:** Alembic migration to drop `slug`, `name`, and `description` columns and add a unique constraint on `(namespace_id)` or equivalent as needed
+10. **FR-10:** All tests referencing slug, name, description, or default namespace behavior must be removed or rewritten
 
 #### Non-Functional Requirements
 
@@ -48,7 +51,8 @@ Khora's public API accepts both UUIDs and slug strings for namespace identificat
 ### User Stories
 
 - As a **library consumer**, I want namespace identification to use only UUIDs so that there is one unambiguous way to reference a namespace.
-- As a **khora maintainer**, I want to remove the slug abstraction so that the storage layer has less code to maintain and fewer edge cases.
+- As a **library consumer**, I want namespace to be a required parameter so that missing tenant context fails loudly rather than silently creating a default.
+- As a **khora maintainer**, I want to remove slug, name, description, and default provisioning so that the namespace model is a minimal isolation boundary with less code to maintain.
 
 ### Technical Approach
 
@@ -56,46 +60,51 @@ Khora's public API accepts both UUIDs and slug strings for namespace identificat
 
 | File | Change |
 |------|--------|
-| `src/khora/core/models/tenancy.py` | Remove `slug` field and `__post_init__` auto-generation |
-| `src/khora/db/models.py` | Remove `slug` column, `uq_namespace_slug_version` constraint, `idx_namespace_slug_active` index |
-| `src/khora/memory_lake.py` | Simplify `_resolve_namespace()` to UUID-only; remove slug branch |
-| `src/khora/storage/backends/base.py` | Remove `get_namespace_by_slug()` from protocol |
-| `src/khora/storage/backends/postgresql.py` | Remove `get_namespace_by_slug()` impl; remove `slug=` mappings in create/update |
-| `src/khora/storage/coordinator.py` | Remove `get_namespace_by_slug()` and `slug` param from `create_namespace_version()` |
-| `src/khora/engines/graphrag/engine.py` | Replace `get_namespace_by_slug("default")` with `get_or_create_default_namespace()`; remove `slug` param from `create_namespace()` calls |
+| `src/khora/core/models/tenancy.py` | Remove `slug`, `name`, `description` fields and `__post_init__` auto-generation |
+| `src/khora/db/models.py` | Remove `slug`, `name`, `description` columns, `uq_namespace_slug_version` constraint, `idx_namespace_slug_active` index |
+| `src/khora/memory_lake.py` | Make `namespace_id` required in public API; simplify `_resolve_namespace()` to UUID-only; remove `get_or_create_default_namespace()` and its fallback |
+| `src/khora/storage/backends/base.py` | Remove `get_namespace_by_slug()` and `get_namespace_by_name()` from protocol; remove `name`/`description` from `create_namespace()` signature |
+| `src/khora/storage/backends/postgresql.py` | Remove `get_namespace_by_slug()`, `get_namespace_by_name()` impls; remove `slug=`/`name=`/`description=` mappings in create/update |
+| `src/khora/storage/coordinator.py` | Remove `get_namespace_by_slug()`, `get_namespace_by_name()`; remove `slug`/`name`/`description` params from `create_namespace_version()` |
+| `src/khora/engines/graphrag/engine.py` | Remove `get_or_create_default_namespace()`, `_default_namespace_id` cache; remove `name=` from `create_namespace()` calls |
 | `src/khora/engines/skeleton/engine.py` | Same as above |
 | `src/khora/engines/vectorcypher/engine.py` | Same as above |
+| `src/khora/engines/protocol.py` | Remove `get_or_create_default_namespace()` from `MemoryEngineProtocol` |
 
 **Files to modify (tests):**
 
 | File | Change |
 |------|--------|
-| `tests/unit/test_models.py` | Remove `test_namespace_auto_slug` and slug references in namespace creation |
-| `tests/unit/test_memory_lake.py` | Remove `test_slug_lookup`, `test_slug_not_found_raises`; update any namespace fixtures |
-
+| `tests/unit/test_models.py` | Remove `test_namespace_auto_slug`, slug/name/description references in namespace creation |
+| `tests/unit/test_memory_lake.py` | Remove `test_slug_lookup`, `test_slug_not_found_raises`, default namespace tests; update fixtures to always pass `namespace_id` |
 
 **Files to modify (docs):**
 
 | File | Change |
 |------|--------|
-| `docs/architecture/multi-tenancy.md` | Remove slug-based examples |
-| `docs/architecture/storage-backends.md` | Remove `slug VARCHAR` from schema docs |
+| `docs/architecture/multi-tenancy.md` | Remove slug-based examples; document required namespace_id; remove name/description references |
+| `docs/architecture/storage-backends.md` | Remove `slug VARCHAR`, `name VARCHAR`, `description TEXT` from schema docs |
 
-**Default namespace strategy:** Engines currently do `get_namespace_by_slug("default")`. After removal, add a `get_or_create_default_namespace()` method on the coordinator that looks up by `name="default"` and creates if missing. All three engines call this instead of the slug-based path.
+**Files to add (migrations):**
+
+| File | Change |
+|------|--------|
+| `src/khora/db/migrations/versions/XXX_drop_namespace_slug_name_desc.py` | Drop `slug`, `name`, `description` columns; drop old constraints/indexes; add new constraints as needed |
 
 ### Success Metrics
 
 | Metric | Target | Measurement |
 |--------|--------|-------------|
-| Lines of slug-related code removed | ~100+ | Diff stats |
-| Files modified | ~13 | Diff stats |
+| Lines of namespace-related code removed | ~150+ | Diff stats |
+| Files modified | ~15 | Diff stats |
 | Tests passing | 100% | `make test` |
 | Lint/typecheck clean | 0 errors | `make lint` |
 
 ### Open Questions
 
-- [x] **Default namespace resolution:** ~~(a) well-known UUID constant, (b) name lookup, (c) `get_or_create_default_namespace()`.~~ Decision: (c) — new coordinator method that looks up by name and creates if missing
-- [x] **Engine `create_namespace()` methods:** ~~Slug param needed?~~ Decision: `name` alone suffices; `slug` param removed
+- [x] **Default namespace resolution:** ~~(a) well-known UUID constant, (b) name lookup, (c) `get_or_create_default_namespace()`.~~ Decision: none — namespace is always required, no default provisioning
+- [x] **Engine `create_namespace()` methods:** ~~Slug param needed?~~ Decision: only `id` and optional `config_overrides`; `slug`, `name`, `description` removed
+- [x] **Database migration:** ~~Separate or included?~~ Decision: included in this PR — Alembic migration drops `slug`, `name`, `description` columns
 
 ### Timeline
 

--- a/docs/prds/DYT-315-remove-namespace-slugs.md
+++ b/docs/prds/DYT-315-remove-namespace-slugs.md
@@ -1,0 +1,102 @@
+# PRD-001: Remove Namespace Slugs
+
+**Status:** Draft
+**Author:** Filip
+**Date:** 2026-03-08
+**Linear:** DYT-315
+
+---
+
+### Problem Statement
+
+Khora's public API accepts both UUIDs and slug strings for namespace identification (`_resolve_namespace()` in `memory_lake.py`). This dual-lookup path adds complexity: slug auto-generation logic, a dedicated `get_namespace_by_slug()` method through every storage layer, a DB column with unique constraints and partial indexes, and branching resolution code. Slug-based lookup is unused by downstream consumers (genesis, khora-benchmarks) and the human-readable slug functionality belongs in the peras service layer, not in the storage library.
+
+### Goals
+
+- All public API functions (`remember`, `recall`, `forget`, `remember_batch`) accept `UUID` or `str` (converted to UUID) for namespace identification — no slug lookup path
+- Remove the `slug` column from `memory_namespaces` table and all associated constraints/indexes
+- Remove `get_namespace_by_slug()` from storage backends, coordinator, and engine layers
+- Remove slug field from `MemoryNamespace` domain model and auto-generation logic
+- Reduce code surface area (estimated ~15 files, ~100+ lines removed)
+
+### Non-Goals
+
+- **Database migration** — no new Alembic migration file to drop the DB column. The ORM model removes the `slug` mapped column, so SQLAlchemy ignores it, but the physical column remains in the database until a migration is added separately
+- **Backward compatibility** — no deprecation period or shim; clean break
+- **Adding slug functionality to peras** — that's a peras concern
+- **Changing namespace creation API** — `create_namespace()` still takes a name; it just no longer generates or stores a slug
+- **Making namespace_id required** — `namespace` parameter stays optional in public API; `get_or_create_default_namespace()` convenience is preserved
+
+### Requirements
+
+#### Functional Requirements
+
+1. **FR-1:** `MemoryNamespace` domain model (`core/models/tenancy.py`) must not contain a `slug` field
+2. **FR-2:** `MemoryNamespaceModel` ORM (`db/models.py`) must not contain a `slug` column, its unique constraint (`uq_namespace_slug_version`), or its partial index (`idx_namespace_slug_active`)
+3. **FR-3:** `_resolve_namespace()` in `memory_lake.py` must accept `UUID` or `str` (converted to `UUID`), raising `ValueError` for non-UUID-parseable strings. The slug lookup branch is removed
+4. **FR-4:** `get_namespace_by_slug()` must be removed from `RelationalBackend` protocol, `PostgreSQLBackend`, and `StorageCoordinator`
+5. **FR-5:** All three engines (GraphRAG, Skeleton, VectorCypher) must replace the `get_namespace_by_slug("default")` call inside `get_or_create_default_namespace()` with a name-based lookup (e.g., `get_namespace_by_name("default")`). The `get_or_create_default_namespace()` method and optional `namespace` parameter in the public API are preserved
+6. **FR-6:** `create_namespace_version()` in coordinator must not accept a `slug` parameter
+7. **FR-7:** All tests referencing slug behavior must be removed or rewritten to use UUID-only paths
+
+#### Non-Functional Requirements
+
+1. **NFR-1:** All existing unit tests pass after changes
+2. **NFR-2:** Coverage remains at or above current threshold (30%)
+3. **NFR-3:** `make lint` and `ty check src/` pass clean
+
+### User Stories
+
+- As a **library consumer**, I want namespace identification to use only UUIDs so that there is one unambiguous way to reference a namespace.
+- As a **khora maintainer**, I want to remove the slug abstraction so that the storage layer has less code to maintain and fewer edge cases.
+
+### Technical Approach
+
+**Files to modify (source):**
+
+| File | Change |
+|------|--------|
+| `src/khora/core/models/tenancy.py` | Remove `slug` field and `__post_init__` auto-generation |
+| `src/khora/db/models.py` | Remove `slug` column, `uq_namespace_slug_version` constraint, `idx_namespace_slug_active` index |
+| `src/khora/memory_lake.py` | Simplify `_resolve_namespace()` to UUID-only; remove slug branch |
+| `src/khora/storage/backends/base.py` | Remove `get_namespace_by_slug()` from protocol |
+| `src/khora/storage/backends/postgresql.py` | Remove `get_namespace_by_slug()` impl; remove `slug=` mappings in create/update |
+| `src/khora/storage/coordinator.py` | Remove `get_namespace_by_slug()` and `slug` param from `create_namespace_version()` |
+| `src/khora/engines/graphrag/engine.py` | Replace `get_namespace_by_slug("default")` with `get_or_create_default_namespace()`; remove `slug` param from `create_namespace()` calls |
+| `src/khora/engines/skeleton/engine.py` | Same as above |
+| `src/khora/engines/vectorcypher/engine.py` | Same as above |
+
+**Files to modify (tests):**
+
+| File | Change |
+|------|--------|
+| `tests/unit/test_models.py` | Remove `test_namespace_auto_slug` and slug references in namespace creation |
+| `tests/unit/test_memory_lake.py` | Remove `test_slug_lookup`, `test_slug_not_found_raises`; update any namespace fixtures |
+
+
+**Files to modify (docs):**
+
+| File | Change |
+|------|--------|
+| `docs/architecture/multi-tenancy.md` | Remove slug-based examples |
+| `docs/architecture/storage-backends.md` | Remove `slug VARCHAR` from schema docs |
+
+**Default namespace strategy:** Engines currently do `get_namespace_by_slug("default")`. After removal, add a `get_or_create_default_namespace()` method on the coordinator that looks up by `name="default"` and creates if missing. All three engines call this instead of the slug-based path.
+
+### Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Lines of slug-related code removed | ~100+ | Diff stats |
+| Files modified | ~13 | Diff stats |
+| Tests passing | 100% | `make test` |
+| Lint/typecheck clean | 0 errors | `make lint` |
+
+### Open Questions
+
+- [x] **Default namespace resolution:** ~~(a) well-known UUID constant, (b) name lookup, (c) `get_or_create_default_namespace()`.~~ Decision: (c) — new coordinator method that looks up by name and creates if missing
+- [x] **Engine `create_namespace()` methods:** ~~Slug param needed?~~ Decision: `name` alone suffices; `slug` param removed
+
+### Timeline
+
+Single implementation phase — all changes in one PR.

--- a/src/khora/core/models/tenancy.py
+++ b/src/khora/core/models/tenancy.py
@@ -35,8 +35,6 @@ class MemoryNamespace:
     """
 
     id: UUID = field(default_factory=uuid4)
-    name: str = ""
-    description: str = ""
     tenancy_mode: TenancyMode = TenancyMode.SHARED
 
     # Versioning fields

--- a/src/khora/core/models/tenancy.py
+++ b/src/khora/core/models/tenancy.py
@@ -36,7 +36,6 @@ class MemoryNamespace:
 
     id: UUID = field(default_factory=uuid4)
     name: str = ""
-    slug: str = ""
     description: str = ""
     tenancy_mode: TenancyMode = TenancyMode.SHARED
 
@@ -54,7 +53,3 @@ class MemoryNamespace:
     metadata: dict[str, Any] = field(default_factory=dict)
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
-
-    def __post_init__(self) -> None:
-        if not self.slug and self.name:
-            self.slug = self.name.lower().replace(" ", "-")

--- a/src/khora/db/models.py
+++ b/src/khora/db/models.py
@@ -66,7 +66,6 @@ class MemoryNamespaceModel(Base):
 
     id: Mapped[UUIDType] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
-    slug: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     description: Mapped[str] = mapped_column(Text, default="")
     tenancy_mode: Mapped[str] = mapped_column(
         Enum(TenancyMode, name="tenancy_mode", create_constraint=True, values_callable=lambda e: [m.value for m in e]),
@@ -97,13 +96,6 @@ class MemoryNamespaceModel(Base):
     events: Mapped[list[MemoryEventModel]] = relationship("MemoryEventModel", back_populates="namespace")
     expertise_definitions: Mapped[list[ExpertiseDefinitionModel]] = relationship(
         "ExpertiseDefinitionModel", back_populates="namespace"
-    )
-
-    __table_args__ = (
-        # Slugs are globally unique per version
-        UniqueConstraint("slug", "version", name="uq_namespace_slug_version"),
-        # Partial index for efficient active namespace queries
-        Index("idx_namespace_slug_active", "slug", "version", postgresql_where="is_active = true"),
     )
 
     def __repr__(self) -> str:

--- a/src/khora/db/models.py
+++ b/src/khora/db/models.py
@@ -63,6 +63,10 @@ class MemoryNamespaceModel(Base):
     """
 
     __tablename__ = "memory_namespaces"
+    __table_args__ = (
+        UniqueConstraint("name", "version", name="uq_namespace_name_version"),
+        Index("idx_namespace_name_active", "name", postgresql_where="is_active = true"),
+    )
 
     id: Mapped[UUIDType] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     name: Mapped[str] = mapped_column(String(255), nullable=False)

--- a/src/khora/db/models.py
+++ b/src/khora/db/models.py
@@ -63,14 +63,8 @@ class MemoryNamespaceModel(Base):
     """
 
     __tablename__ = "memory_namespaces"
-    __table_args__ = (
-        UniqueConstraint("name", "version", name="uq_namespace_name_version"),
-        Index("idx_namespace_name_active", "name", postgresql_where="is_active = true"),
-    )
 
     id: Mapped[UUIDType] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
-    name: Mapped[str] = mapped_column(String(255), nullable=False)
-    description: Mapped[str] = mapped_column(Text, default="")
     tenancy_mode: Mapped[str] = mapped_column(
         Enum(TenancyMode, name="tenancy_mode", create_constraint=True, values_callable=lambda e: [m.value for m in e]),
         default=TenancyMode.SHARED,
@@ -103,7 +97,7 @@ class MemoryNamespaceModel(Base):
     )
 
     def __repr__(self) -> str:
-        return f"<MemoryNamespace(id={self.id!r}, name={self.name!r})>"
+        return f"<MemoryNamespace(id={self.id!r})>"
 
 
 # =============================================================================

--- a/src/khora/engines/graphrag/engine.py
+++ b/src/khora/engines/graphrag/engine.py
@@ -517,13 +517,12 @@ class GraphRAGEngine:
 
         storage = self._get_storage()
 
-        # Try to find existing default namespace by slug
-        default_namespace = await storage.get_namespace_by_slug("default")
+        # Try to find existing default namespace by name
+        default_namespace = await storage.get_namespace_by_name("default")
         if not default_namespace:
             default_namespace = await storage.create_namespace(
                 MemoryNamespace(
                     name="Default",
-                    slug="default",
                 )
             )
 
@@ -558,9 +557,8 @@ class GraphRAGEngine:
         """Get or create a namespace by name."""
         storage = self._get_storage()
 
-        # Try to find namespace by slug
-        slug = name.lower().replace(" ", "-")
-        existing_ns = await storage.get_namespace_by_slug(slug)
+        # Try to find namespace by name
+        existing_ns = await storage.get_namespace_by_name(name)
         if existing_ns:
             return existing_ns.id
 
@@ -568,7 +566,6 @@ class GraphRAGEngine:
         new_ns = await storage.create_namespace(
             MemoryNamespace(
                 name=name,
-                slug=slug,
                 description=description,
             )
         )

--- a/src/khora/engines/graphrag/engine.py
+++ b/src/khora/engines/graphrag/engine.py
@@ -518,7 +518,7 @@ class GraphRAGEngine:
         storage = self._get_storage()
 
         # Try to find existing default namespace by name
-        default_namespace = await storage.get_namespace_by_name("default")
+        default_namespace = await storage.get_namespace_by_name("Default")
         if not default_namespace:
             default_namespace = await storage.create_namespace(
                 MemoryNamespace(

--- a/src/khora/engines/graphrag/engine.py
+++ b/src/khora/engines/graphrag/engine.py
@@ -133,9 +133,6 @@ class GraphRAGEngine:
         self._query_engine: HybridQueryEngine | None = None
         self._connected = False
 
-        # Default namespace for simple usage
-        self._default_namespace_id: UUID | None = None
-
     async def connect(self) -> None:
         """Connect to all storage backends."""
         if self._connected:
@@ -510,36 +507,13 @@ class GraphRAGEngine:
     # Namespace Management
     # =========================================================================
 
-    async def get_or_create_default_namespace(self) -> UUID:
-        """Get or create a default namespace for simple usage."""
-        if self._default_namespace_id:
-            return self._default_namespace_id
-
-        storage = self._get_storage()
-
-        # Try to find existing default namespace by name
-        default_namespace = await storage.get_namespace_by_name("Default")
-        if not default_namespace:
-            default_namespace = await storage.create_namespace(
-                MemoryNamespace(
-                    name="Default",
-                )
-            )
-
-        self._default_namespace_id = default_namespace.id
-        return self._default_namespace_id
-
     async def create_namespace(
         self,
-        name: str,
         *,
-        description: str = "",
         config_overrides: dict[str, Any] | None = None,
     ) -> MemoryNamespace:
         """Create a new memory namespace."""
         namespace = MemoryNamespace(
-            name=name,
-            description=description,
             config_overrides=config_overrides or {},
         )
         return await self._get_storage().create_namespace(namespace)
@@ -547,29 +521,6 @@ class GraphRAGEngine:
     async def get_namespace(self, namespace_id: UUID) -> MemoryNamespace | None:
         """Get a namespace by ID."""
         return await self._get_storage().get_namespace(namespace_id)
-
-    async def ensure_namespace(
-        self,
-        name: str,
-        *,
-        description: str = "",
-    ) -> UUID:
-        """Get or create a namespace by name."""
-        storage = self._get_storage()
-
-        # Try to find namespace by name
-        existing_ns = await storage.get_namespace_by_name(name)
-        if existing_ns:
-            return existing_ns.id
-
-        # Create new namespace
-        new_ns = await storage.create_namespace(
-            MemoryNamespace(
-                name=name,
-                description=description,
-            )
-        )
-        return new_ns.id
 
     # =========================================================================
     # Entity Operations

--- a/src/khora/engines/protocol.py
+++ b/src/khora/engines/protocol.py
@@ -148,26 +148,14 @@ class MemoryEngineProtocol(Protocol):
     # Namespace Operations
     # =========================================================================
 
-    async def get_or_create_default_namespace(self) -> UUID:
-        """Get or create a default namespace for simple usage.
-
-        Returns:
-            Default namespace UUID
-        """
-        ...
-
     async def create_namespace(
         self,
-        name: str,
         *,
-        description: str = "",
         config_overrides: dict[str, Any] | None = None,
     ) -> MemoryNamespace:
         """Create a new memory namespace.
 
         Args:
-            name: Namespace name
-            description: Optional description
             config_overrides: Optional configuration overrides
 
         Returns:
@@ -183,25 +171,6 @@ class MemoryEngineProtocol(Protocol):
 
         Returns:
             MemoryNamespace or None if not found
-        """
-        ...
-
-    async def ensure_namespace(
-        self,
-        name: str,
-        *,
-        description: str = "",
-    ) -> UUID:
-        """Get or create a namespace by name.
-
-        Creates the namespace if it doesn't exist.
-
-        Args:
-            name: Namespace name
-            description: Optional description
-
-        Returns:
-            Namespace UUID
         """
         ...
 

--- a/src/khora/engines/protocol.py
+++ b/src/khora/engines/protocol.py
@@ -197,7 +197,7 @@ class MemoryEngineProtocol(Protocol):
         Creates the namespace if it doesn't exist.
 
         Args:
-            name: Namespace name (will be slugified)
+            name: Namespace name
             description: Optional description
 
         Returns:

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -730,7 +730,7 @@ class SkeletonConstructionEngine:
         storage = self._get_storage()
 
         # Try to find existing default namespace by name
-        default_namespace = await storage.get_namespace_by_name("default")
+        default_namespace = await storage.get_namespace_by_name("Default")
         if not default_namespace:
             default_namespace = await storage.create_namespace(
                 MemoryNamespace(

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -729,13 +729,12 @@ class SkeletonConstructionEngine:
 
         storage = self._get_storage()
 
-        # Try to find existing default namespace by slug
-        default_namespace = await storage.get_namespace_by_slug("default")
+        # Try to find existing default namespace by name
+        default_namespace = await storage.get_namespace_by_name("default")
         if not default_namespace:
             default_namespace = await storage.create_namespace(
                 MemoryNamespace(
                     name="Default",
-                    slug="default",
                 )
             )
 
@@ -770,9 +769,8 @@ class SkeletonConstructionEngine:
         """Get or create a namespace by name."""
         storage = self._get_storage()
 
-        # Try to find namespace by slug
-        slug = name.lower().replace(" ", "-")
-        existing_ns = await storage.get_namespace_by_slug(slug)
+        # Try to find namespace by name
+        existing_ns = await storage.get_namespace_by_name(name)
         if existing_ns:
             return existing_ns.id
 
@@ -780,7 +778,6 @@ class SkeletonConstructionEngine:
         new_ns = await storage.create_namespace(
             MemoryNamespace(
                 name=name,
-                slug=slug,
                 description=description,
             )
         )

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -112,9 +112,6 @@ class SkeletonConstructionEngine:
         self._embedder: LiteLLMEmbedder | None = None
         self._connected = False
 
-        # Default namespace for simple usage
-        self._default_namespace_id: UUID | None = None
-
     async def connect(self) -> None:
         """Connect to all storage backends."""
         if self._connected:
@@ -722,36 +719,13 @@ class SkeletonConstructionEngine:
     # Namespace Management
     # =========================================================================
 
-    async def get_or_create_default_namespace(self) -> UUID:
-        """Get or create a default namespace for simple usage."""
-        if self._default_namespace_id:
-            return self._default_namespace_id
-
-        storage = self._get_storage()
-
-        # Try to find existing default namespace by name
-        default_namespace = await storage.get_namespace_by_name("Default")
-        if not default_namespace:
-            default_namespace = await storage.create_namespace(
-                MemoryNamespace(
-                    name="Default",
-                )
-            )
-
-        self._default_namespace_id = default_namespace.id
-        return self._default_namespace_id
-
     async def create_namespace(
         self,
-        name: str,
         *,
-        description: str = "",
         config_overrides: dict[str, Any] | None = None,
     ) -> MemoryNamespace:
         """Create a new memory namespace."""
         namespace = MemoryNamespace(
-            name=name,
-            description=description,
             config_overrides=config_overrides or {},
         )
         return await self._get_storage().create_namespace(namespace)
@@ -759,29 +733,6 @@ class SkeletonConstructionEngine:
     async def get_namespace(self, namespace_id: UUID) -> MemoryNamespace | None:
         """Get a namespace by ID."""
         return await self._get_storage().get_namespace(namespace_id)
-
-    async def ensure_namespace(
-        self,
-        name: str,
-        *,
-        description: str = "",
-    ) -> UUID:
-        """Get or create a namespace by name."""
-        storage = self._get_storage()
-
-        # Try to find namespace by name
-        existing_ns = await storage.get_namespace_by_name(name)
-        if existing_ns:
-            return existing_ns.id
-
-        # Create new namespace
-        new_ns = await storage.create_namespace(
-            MemoryNamespace(
-                name=name,
-                description=description,
-            )
-        )
-        return new_ns.id
 
     # =========================================================================
     # Entity Operations (minimal for Khora engine)

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -1560,13 +1560,12 @@ class VectorCypherEngine:
 
         storage = self._get_storage()
 
-        # Try to find existing default namespace by slug
-        default_namespace = await storage.get_namespace_by_slug("default")
+        # Try to find existing default namespace by name
+        default_namespace = await storage.get_namespace_by_name("default")
         if not default_namespace:
             default_namespace = await storage.create_namespace(
                 MemoryNamespace(
                     name="Default",
-                    slug="default",
                 )
             )
 
@@ -1601,16 +1600,14 @@ class VectorCypherEngine:
         """Get or create a namespace by name."""
         storage = self._get_storage()
 
-        # Try to find namespace by slug
-        slug = name.lower().replace(" ", "-")
-        existing_ns = await storage.get_namespace_by_slug(slug)
+        # Try to find namespace by name
+        existing_ns = await storage.get_namespace_by_name(name)
         if existing_ns:
             return existing_ns.id
 
         new_ns = await storage.create_namespace(
             MemoryNamespace(
                 name=name,
-                slug=slug,
                 description=description,
             )
         )

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -270,9 +270,6 @@ class VectorCypherEngine:
         self._router: QueryComplexityRouter | None = None
         self._connected = False
 
-        # Default namespace cache
-        self._default_namespace_id: UUID | None = None
-
     async def connect(self) -> None:
         """Connect to all storage backends."""
         if self._connected:
@@ -1553,36 +1550,13 @@ class VectorCypherEngine:
     # Namespace Management
     # =========================================================================
 
-    async def get_or_create_default_namespace(self) -> UUID:
-        """Get or create a default namespace for simple usage."""
-        if self._default_namespace_id:
-            return self._default_namespace_id
-
-        storage = self._get_storage()
-
-        # Try to find existing default namespace by name
-        default_namespace = await storage.get_namespace_by_name("Default")
-        if not default_namespace:
-            default_namespace = await storage.create_namespace(
-                MemoryNamespace(
-                    name="Default",
-                )
-            )
-
-        self._default_namespace_id = default_namespace.id
-        return self._default_namespace_id
-
     async def create_namespace(
         self,
-        name: str,
         *,
-        description: str = "",
         config_overrides: dict[str, Any] | None = None,
     ) -> MemoryNamespace:
         """Create a new memory namespace."""
         namespace = MemoryNamespace(
-            name=name,
-            description=description,
             config_overrides=config_overrides or {},
         )
         return await self._get_storage().create_namespace(namespace)
@@ -1590,28 +1564,6 @@ class VectorCypherEngine:
     async def get_namespace(self, namespace_id: UUID) -> MemoryNamespace | None:
         """Get a namespace by ID."""
         return await self._get_storage().get_namespace(namespace_id)
-
-    async def ensure_namespace(
-        self,
-        name: str,
-        *,
-        description: str = "",
-    ) -> UUID:
-        """Get or create a namespace by name."""
-        storage = self._get_storage()
-
-        # Try to find namespace by name
-        existing_ns = await storage.get_namespace_by_name(name)
-        if existing_ns:
-            return existing_ns.id
-
-        new_ns = await storage.create_namespace(
-            MemoryNamespace(
-                name=name,
-                description=description,
-            )
-        )
-        return new_ns.id
 
     # =========================================================================
     # Entity Operations

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -1561,7 +1561,7 @@ class VectorCypherEngine:
         storage = self._get_storage()
 
         # Try to find existing default namespace by name
-        default_namespace = await storage.get_namespace_by_name("default")
+        default_namespace = await storage.get_namespace_by_name("Default")
         if not default_namespace:
             default_namespace = await storage.create_namespace(
                 MemoryNamespace(

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -96,7 +96,7 @@ class MemoryLake:
 
         # Common - explicit database URL
         async with MemoryLake("postgresql://localhost/mydb") as lake:
-            results = await lake.recall("What do I know about...", namespace="my-ns")
+            results = await lake.recall("What do I know about...", namespace=namespace_id)
 
         # With graph backend
         async with MemoryLake("postgresql://...", graph_url="bolt://localhost:7687") as lake:

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -91,7 +91,7 @@ class MemoryLake:
     Usage:
         # Simplest - from env vars (KHORA_DATABASE_URL)
         async with MemoryLake() as lake:
-            await lake.remember("Important fact...", namespace="my-ns",
+            await lake.remember("Important fact...", namespace=namespace_id,
                 entity_types=["PERSON", "CONCEPT"], relationship_types=["RELATES_TO"])
 
         # Common - explicit database URL
@@ -250,34 +250,24 @@ class MemoryLake:
 
     async def create_namespace(
         self,
-        name: str,
         *,
-        description: str = "",
         config_overrides: dict[str, Any] | None = None,
     ) -> MemoryNamespace:
         """Create a new memory namespace.
 
         Args:
-            name: Namespace name
-            description: Optional description
             config_overrides: Optional configuration overrides
 
         Returns:
             Created MemoryNamespace
         """
         return await self._get_engine().create_namespace(
-            name,
-            description=description,
             config_overrides=config_overrides,
         )
 
     async def get_namespace(self, namespace_id: UUID) -> MemoryNamespace | None:
         """Get a namespace by ID."""
         return await self._get_engine().get_namespace(namespace_id)
-
-    async def get_or_create_default_namespace(self) -> UUID:
-        """Get or create a default namespace for simple usage."""
-        return await self._get_engine().get_or_create_default_namespace()
 
     # =========================================================================
     # Core API: remember, recall, forget
@@ -287,7 +277,7 @@ class MemoryLake:
         self,
         content: str,
         *,
-        namespace: str | UUID | None = None,
+        namespace: str | UUID,
         title: str = "",
         source: str = "",
         metadata: dict[str, Any] | None = None,
@@ -305,7 +295,7 @@ class MemoryLake:
 
         Args:
             content: Content to remember
-            namespace: Namespace name, ID, or None for default
+            namespace: Namespace UUID (as UUID or string)
             title: Optional title for the content
             source: Optional source identifier
             metadata: Optional metadata
@@ -339,7 +329,7 @@ class MemoryLake:
         self,
         documents: list[dict[str, Any]],
         *,
-        namespace: str | UUID | None = None,
+        namespace: str | UUID,
         skill_name: str = "general_entities",
         max_concurrent: int = 10,
         deduplicate: bool = True,
@@ -366,7 +356,7 @@ class MemoryLake:
                 - title: str (optional)
                 - source: str (optional)
                 - metadata: dict (optional)
-            namespace: Namespace name, ID, or None for default
+            namespace: Namespace UUID (as UUID or string)
             skill_name: Extraction skill to use
             max_concurrent: Maximum concurrent document processing
             deduplicate: Deduplicate entities across documents (default: True)
@@ -402,7 +392,7 @@ class MemoryLake:
         self,
         query: str,
         *,
-        namespace: str | UUID | None = None,
+        namespace: str | UUID,
         limit: int = 10,
         mode: SearchMode = SearchMode.HYBRID,
         min_similarity: float = 0.0,
@@ -432,7 +422,7 @@ class MemoryLake:
 
         Args:
             query: Query text
-            namespace: Namespace name, ID, or None for default
+            namespace: Namespace UUID (as UUID or string)
             limit: Maximum results to return
             mode: Search mode (VECTOR, GRAPH, HYBRID, ALL)
             min_similarity: Minimum similarity threshold
@@ -464,24 +454,22 @@ class MemoryLake:
         self,
         document_id: UUID,
         *,
-        namespace: str | UUID | None = None,
+        namespace: str | UUID,
     ) -> bool:
         """Remove a memory from the lake.
 
         Args:
             document_id: ID of the document to remove
-            namespace: Namespace for verification (optional)
+            namespace: Namespace UUID (as UUID or string)
 
         Returns:
             True if deleted, False if not found
         """
-        namespace_id = None
-        if namespace:
-            namespace_id = await self._resolve_namespace(namespace)
+        namespace_id = await self._resolve_namespace(namespace)
 
         with trace_span(
             "khora.forget",
-            namespace_id=str(namespace_id) if namespace_id else "",
+            namespace_id=str(namespace_id),
             document_id=str(document_id),
         ):
             return await self._get_engine().forget(document_id, namespace_id)
@@ -497,7 +485,7 @@ class MemoryLake:
     async def list_entities(
         self,
         *,
-        namespace: str | UUID | None = None,
+        namespace: str | UUID,
         entity_type: str | None = None,
         limit: int = 100,
     ) -> list[Entity]:
@@ -509,7 +497,7 @@ class MemoryLake:
         self,
         entity_id: UUID,
         *,
-        namespace: str | UUID | None = None,
+        namespace: str | UUID,
         max_depth: int = 2,
         limit: int = 20,
     ) -> list[tuple[Entity, float]]:
@@ -540,13 +528,13 @@ class MemoryLake:
     async def list_documents(
         self,
         *,
-        namespace: str | UUID | None = None,
+        namespace: str | UUID,
         limit: int = 100,
     ) -> list[Document]:
         """List documents in a namespace.
 
         Args:
-            namespace: Namespace name, ID, or None for default
+            namespace: Namespace UUID (as UUID or string)
             limit: Maximum documents to return
 
         Returns:
@@ -559,14 +547,14 @@ class MemoryLake:
         self,
         query: str,
         *,
-        namespace: str | UUID | None = None,
+        namespace: str | UUID,
         limit: int = 10,
     ) -> list[Entity]:
         """Search entities by query text using embedding similarity.
 
         Args:
             query: Search query text
-            namespace: Namespace name, ID, or None for default
+            namespace: Namespace UUID (as UUID or string)
             limit: Maximum entities to return
 
         Returns:
@@ -575,11 +563,11 @@ class MemoryLake:
         namespace_id = await self._resolve_namespace(namespace)
         return await self._get_engine().search_entities(query, namespace_id, limit=limit)
 
-    async def stats(self, *, namespace: str | UUID | None = None) -> Stats:
+    async def stats(self, *, namespace: str | UUID) -> Stats:
         """Get document/chunk/entity/relationship counts for a namespace.
 
         Args:
-            namespace: Namespace name, ID, or None for default
+            namespace: Namespace UUID (as UUID or string)
 
         Returns:
             Stats with document/chunk/entity/relationship counts
@@ -587,35 +575,12 @@ class MemoryLake:
         namespace_id = await self._resolve_namespace(namespace)
         return await self._get_engine().stats(namespace_id)
 
-    async def ensure_namespace(
-        self,
-        name: str,
-        *,
-        description: str = "",
-    ) -> UUID:
-        """Get or create a namespace by name.
-
-        This is a convenience method for simple usage where you just want
-        a namespace by name without managing it explicitly.
-
-        Args:
-            name: Namespace name
-            description: Optional description
-
-        Returns:
-            Namespace UUID
-        """
-        return await self._get_engine().ensure_namespace(name, description=description)
-
     # =========================================================================
     # Helpers
     # =========================================================================
 
-    async def _resolve_namespace(self, namespace: str | UUID | None) -> UUID:
+    async def _resolve_namespace(self, namespace: str | UUID) -> UUID:
         """Resolve a namespace reference to a UUID."""
-        if namespace is None:
-            return await self.get_or_create_default_namespace()
-
         if isinstance(namespace, UUID):
             return namespace
 
@@ -623,7 +588,7 @@ class MemoryLake:
         try:
             return UUID(namespace)
         except ValueError:
-            raise ValueError(f"Invalid namespace: {namespace!r}. Must be a UUID or None for default.")
+            raise ValueError(f"Invalid namespace: {namespace!r}. Must be a valid UUID.")
 
     async def health_check(self) -> dict[str, Any]:
         """Check health of all components."""

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -599,7 +599,7 @@ class MemoryLake:
         a namespace by name without managing it explicitly.
 
         Args:
-            name: Namespace name (will be slugified)
+            name: Namespace name
             description: Optional description
 
         Returns:
@@ -623,19 +623,7 @@ class MemoryLake:
         try:
             return UUID(namespace)
         except ValueError:
-            pass
-
-        # Look up by slug (globally unique)
-        engine = self._get_engine()
-        if not hasattr(engine, "_storage") or engine._storage is None:
-            raise RuntimeError("Engine does not support namespace lookup by slug")
-
-        storage = engine._storage
-        ns = await storage.get_namespace_by_slug(namespace)  # type: ignore[unresolved-attribute]
-        if ns:
-            return ns.id
-
-        raise ValueError(f"Namespace not found: {namespace}")
+            raise ValueError(f"Invalid namespace: {namespace!r}. Must be a UUID or None for default.")
 
     async def health_check(self) -> dict[str, Any]:
         """Check health of all components."""

--- a/src/khora/storage/backends/base.py
+++ b/src/khora/storage/backends/base.py
@@ -70,19 +70,6 @@ class RelationalBackendProtocol(Protocol):
         ...
 
     @abstractmethod
-    async def get_namespace_by_name(self, name: str, *, active_only: bool = True) -> MemoryNamespace | None:
-        """Get a namespace by name.
-
-        Args:
-            name: Namespace name
-            active_only: If True, only return active namespace (default)
-
-        Returns:
-            MemoryNamespace or None if not found
-        """
-        ...
-
-    @abstractmethod
     async def list_namespaces(
         self, *, active_only: bool = True, limit: int = 100, offset: int = 0
     ) -> PaginatedResult[MemoryNamespace]:
@@ -97,14 +84,12 @@ class RelationalBackendProtocol(Protocol):
     @abstractmethod
     async def create_namespace_version(
         self,
-        name: str,
         *,
         previous_version: MemoryNamespace | None = None,
     ) -> MemoryNamespace:
         """Create a new version of a namespace.
 
         Args:
-            name: Namespace name
             previous_version: The previous version to supersede (if any)
 
         Returns:

--- a/src/khora/storage/backends/base.py
+++ b/src/khora/storage/backends/base.py
@@ -70,8 +70,16 @@ class RelationalBackendProtocol(Protocol):
         ...
 
     @abstractmethod
-    async def get_namespace_by_slug(self, slug: str, *, active_only: bool = True) -> MemoryNamespace | None:
-        """Get a namespace by slug (globally unique)."""
+    async def get_namespace_by_name(self, name: str, *, active_only: bool = True) -> MemoryNamespace | None:
+        """Get a namespace by name.
+
+        Args:
+            name: Namespace name
+            active_only: If True, only return active namespace (default)
+
+        Returns:
+            MemoryNamespace or None if not found
+        """
         ...
 
     @abstractmethod
@@ -89,14 +97,14 @@ class RelationalBackendProtocol(Protocol):
     @abstractmethod
     async def create_namespace_version(
         self,
-        slug: str,
+        name: str,
         *,
         previous_version: MemoryNamespace | None = None,
     ) -> MemoryNamespace:
         """Create a new version of a namespace.
 
         Args:
-            slug: Namespace slug
+            name: Namespace name
             previous_version: The previous version to supersede (if any)
 
         Returns:

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -127,7 +127,6 @@ class PostgreSQLBackend(AsyncSessionMixin):
             model = MemoryNamespaceModel(
                 id=namespace.id,
                 name=namespace.name,
-                slug=namespace.slug,
                 description=namespace.description,
                 tenancy_mode=namespace.tenancy_mode,
                 version=namespace.version,
@@ -151,11 +150,11 @@ class PostgreSQLBackend(AsyncSessionMixin):
             model = result.scalar_one_or_none()
             return self._namespace_model_to_domain(model) if model else None
 
-    async def get_namespace_by_slug(self, slug: str, *, active_only: bool = True) -> MemoryNamespace | None:
-        """Get a namespace by slug (globally unique).
+    async def get_namespace_by_name(self, name: str, *, active_only: bool = True) -> MemoryNamespace | None:
+        """Get a namespace by name.
 
         Args:
-            slug: Namespace slug
+            name: Namespace name
             active_only: If True, only return active namespace (default)
 
         Returns:
@@ -163,7 +162,7 @@ class PostgreSQLBackend(AsyncSessionMixin):
         """
         async with self._get_session() as session:
             query = select(MemoryNamespaceModel).where(
-                MemoryNamespaceModel.slug == slug,
+                MemoryNamespaceModel.name == name,
             )
             if active_only:
                 query = query.where(MemoryNamespaceModel.is_active == True)  # noqa: E712
@@ -208,7 +207,6 @@ class PostgreSQLBackend(AsyncSessionMixin):
                 .where(MemoryNamespaceModel.id == namespace.id)
                 .values(
                     name=namespace.name,
-                    slug=namespace.slug,
                     description=namespace.description,
                     version=namespace.version,
                     is_active=namespace.is_active,
@@ -227,7 +225,6 @@ class PostgreSQLBackend(AsyncSessionMixin):
         return MemoryNamespace(
             id=model.id,
             name=model.name,
-            slug=model.slug,
             description=model.description,
             tenancy_mode=TenancyMode(model.tenancy_mode) if isinstance(model.tenancy_mode, str) else model.tenancy_mode,
             version=model.version,
@@ -242,7 +239,7 @@ class PostgreSQLBackend(AsyncSessionMixin):
 
     async def create_namespace_version(
         self,
-        slug: str,
+        name: str,
         *,
         previous_version: MemoryNamespace | None = None,
     ) -> MemoryNamespace:
@@ -252,7 +249,7 @@ class PostgreSQLBackend(AsyncSessionMixin):
         The previous version is marked as inactive.
 
         Args:
-            slug: Namespace slug
+            name: Namespace name
             previous_version: The previous version to supersede (if any)
 
         Returns:
@@ -272,8 +269,7 @@ class PostgreSQLBackend(AsyncSessionMixin):
         # Create new namespace with incremented version
         namespace = MemoryNamespace(
             id=uuid4(),
-            name=previous_version.name if previous_version else f"Namespace {slug}",
-            slug=slug,
+            name=previous_version.name if previous_version else name,
             description=previous_version.description if previous_version else "",
             version=new_version,
             is_active=True,

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -126,8 +126,6 @@ class PostgreSQLBackend(AsyncSessionMixin):
         async with self._get_session() as session:
             model = MemoryNamespaceModel(
                 id=namespace.id,
-                name=namespace.name,
-                description=namespace.description,
                 tenancy_mode=namespace.tenancy_mode,
                 version=namespace.version,
                 is_active=namespace.is_active,
@@ -147,26 +145,6 @@ class PostgreSQLBackend(AsyncSessionMixin):
         """Get a namespace by ID."""
         async with self._get_session() as session:
             result = await session.execute(select(MemoryNamespaceModel).where(MemoryNamespaceModel.id == namespace_id))
-            model = result.scalar_one_or_none()
-            return self._namespace_model_to_domain(model) if model else None
-
-    async def get_namespace_by_name(self, name: str, *, active_only: bool = True) -> MemoryNamespace | None:
-        """Get a namespace by name.
-
-        Args:
-            name: Namespace name
-            active_only: If True, only return active namespace (default)
-
-        Returns:
-            MemoryNamespace or None if not found
-        """
-        async with self._get_session() as session:
-            query = select(MemoryNamespaceModel).where(
-                MemoryNamespaceModel.name == name,
-            )
-            if active_only:
-                query = query.where(MemoryNamespaceModel.is_active == True)  # noqa: E712
-            result = await session.execute(query)
             model = result.scalar_one_or_none()
             return self._namespace_model_to_domain(model) if model else None
 
@@ -206,8 +184,6 @@ class PostgreSQLBackend(AsyncSessionMixin):
                 update(MemoryNamespaceModel)
                 .where(MemoryNamespaceModel.id == namespace.id)
                 .values(
-                    name=namespace.name,
-                    description=namespace.description,
                     version=namespace.version,
                     is_active=namespace.is_active,
                     previous_version_id=namespace.previous_version_id,
@@ -224,8 +200,6 @@ class PostgreSQLBackend(AsyncSessionMixin):
         """Convert MemoryNamespaceModel to domain MemoryNamespace."""
         return MemoryNamespace(
             id=model.id,
-            name=model.name,
-            description=model.description,
             tenancy_mode=TenancyMode(model.tenancy_mode) if isinstance(model.tenancy_mode, str) else model.tenancy_mode,
             version=model.version,
             is_active=model.is_active,
@@ -239,7 +213,6 @@ class PostgreSQLBackend(AsyncSessionMixin):
 
     async def create_namespace_version(
         self,
-        name: str,
         *,
         previous_version: MemoryNamespace | None = None,
     ) -> MemoryNamespace:
@@ -249,7 +222,6 @@ class PostgreSQLBackend(AsyncSessionMixin):
         The previous version is marked as inactive.
 
         Args:
-            name: Namespace name
             previous_version: The previous version to supersede (if any)
 
         Returns:
@@ -269,8 +241,6 @@ class PostgreSQLBackend(AsyncSessionMixin):
         # Create new namespace with incremented version
         namespace = MemoryNamespace(
             id=uuid4(),
-            name=previous_version.name if previous_version else name,
-            description=previous_version.description if previous_version else "",
             version=new_version,
             is_active=True,
             previous_version_id=previous_id,

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -286,11 +286,11 @@ class StorageCoordinator:
             raise RuntimeError("Relational backend not configured")
         return await self.relational.get_namespace(namespace_id)
 
-    async def get_namespace_by_slug(self, slug: str) -> MemoryNamespace | None:
-        """Get a namespace by slug (globally unique)."""
+    async def get_namespace_by_name(self, name: str) -> MemoryNamespace | None:
+        """Get a namespace by name."""
         if not self.relational:
             raise RuntimeError("Relational backend not configured")
-        return await self.relational.get_namespace_by_slug(slug)
+        return await self.relational.get_namespace_by_name(name)
 
     async def list_namespaces(
         self, *, active_only: bool = True, limit: int = 100, offset: int = 0
@@ -308,14 +308,14 @@ class StorageCoordinator:
 
     async def create_namespace_version(
         self,
-        slug: str,
+        name: str,
         *,
         previous_version: MemoryNamespace | None = None,
     ) -> MemoryNamespace:
         """Create a new version of a namespace.
 
         Args:
-            slug: Namespace slug
+            name: Namespace name
             previous_version: The previous version to supersede (if any)
 
         Returns:
@@ -323,7 +323,7 @@ class StorageCoordinator:
         """
         if not self.relational:
             raise RuntimeError("Relational backend not configured")
-        return await self.relational.create_namespace_version(slug, previous_version=previous_version)
+        return await self.relational.create_namespace_version(name, previous_version=previous_version)
 
     async def deactivate_namespace(self, namespace_id: UUID) -> None:
         """Mark a namespace version as inactive.

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -286,12 +286,6 @@ class StorageCoordinator:
             raise RuntimeError("Relational backend not configured")
         return await self.relational.get_namespace(namespace_id)
 
-    async def get_namespace_by_name(self, name: str) -> MemoryNamespace | None:
-        """Get a namespace by name."""
-        if not self.relational:
-            raise RuntimeError("Relational backend not configured")
-        return await self.relational.get_namespace_by_name(name)
-
     async def list_namespaces(
         self, *, active_only: bool = True, limit: int = 100, offset: int = 0
     ) -> PaginatedResult[MemoryNamespace]:
@@ -308,14 +302,12 @@ class StorageCoordinator:
 
     async def create_namespace_version(
         self,
-        name: str,
         *,
         previous_version: MemoryNamespace | None = None,
     ) -> MemoryNamespace:
         """Create a new version of a namespace.
 
         Args:
-            name: Namespace name
             previous_version: The previous version to supersede (if any)
 
         Returns:
@@ -323,7 +315,7 @@ class StorageCoordinator:
         """
         if not self.relational:
             raise RuntimeError("Relational backend not configured")
-        return await self.relational.create_namespace_version(name, previous_version=previous_version)
+        return await self.relational.create_namespace_version(previous_version=previous_version)
 
     async def deactivate_namespace(self, namespace_id: UUID) -> None:
         """Mark a namespace version as inactive.

--- a/tests/integration/test_incremental_ingestion.py
+++ b/tests/integration/test_incremental_ingestion.py
@@ -470,6 +470,7 @@ class TestIncrementalIngestion:
         ):
             await lake.remember(
                 "Test content",
+                namespace=NAMESPACE_ID,
                 title="Test",
                 entity_types=["PERSON", "ORGANIZATION"],
                 relationship_types=["WORKS_FOR"],
@@ -583,6 +584,7 @@ class TestIncrementalIngestion:
             # Remember
             result = await lake.remember(
                 "Alice Johnson is a senior engineer at Acme Corp.",
+                namespace=NAMESPACE_ID,
                 title="Alice Profile",
                 entity_types=["PERSON", "ORGANIZATION"],
                 relationship_types=["WORKS_FOR"],
@@ -591,7 +593,7 @@ class TestIncrementalIngestion:
             assert result.entities_extracted == 2
 
             # Recall
-            recall_result = await lake.recall("Alice Acme Corp")
+            recall_result = await lake.recall("Alice Acme Corp", namespace=NAMESPACE_ID)
             assert len(recall_result.chunks) == 1
             assert "Alice" in recall_result.context_text
 
@@ -647,6 +649,7 @@ class TestIncrementalIngestion:
             # Ingest batch 1
             r1 = await lake.remember_batch(
                 BATCH_1_DOCS,
+                namespace=NAMESPACE_ID,
                 entity_types=["PERSON", "ORGANIZATION"],
                 relationship_types=["WORKS_FOR", "MANAGES", "COLLABORATES_WITH"],
             )
@@ -656,6 +659,7 @@ class TestIncrementalIngestion:
             # Ingest batch 2
             r2 = await lake.remember_batch(
                 BATCH_2_DOCS,
+                namespace=NAMESPACE_ID,
                 entity_types=["PERSON", "ORGANIZATION"],
                 relationship_types=["WORKS_FOR", "MANAGES", "COLLABORATES_WITH"],
             )
@@ -663,7 +667,7 @@ class TestIncrementalIngestion:
             assert r2.entities == 2
 
             # Recall — should find content from both batches
-            result = await lake.recall("Acme Corp employees")
+            result = await lake.recall("Acme Corp employees", namespace=NAMESPACE_ID)
             assert len(result.chunks) == 4  # All 4 employee docs
             assert len(result.entities) == 5  # All entities including Acme Corp
 
@@ -882,6 +886,7 @@ class TestIncrementalIngestion:
         ):
             r1 = await lake.remember_batch(
                 BATCH_1_DOCS,
+                namespace=NAMESPACE_ID,
                 entity_types=["PERSON", "ORGANIZATION"],
                 relationship_types=["WORKS_FOR", "MANAGES", "COLLABORATES_WITH"],
             )
@@ -889,6 +894,7 @@ class TestIncrementalIngestion:
 
             r2 = await lake.remember_batch(
                 BATCH_2_DOCS,
+                namespace=NAMESPACE_ID,
                 entity_types=["PERSON", "ORGANIZATION"],
                 relationship_types=["WORKS_FOR", "MANAGES", "COLLABORATES_WITH"],
             )
@@ -896,12 +902,13 @@ class TestIncrementalIngestion:
 
             r3 = await lake.remember_batch(
                 batch3_docs,
+                namespace=NAMESPACE_ID,
                 entity_types=["PERSON", "ORGANIZATION"],
                 relationship_types=["WORKS_FOR", "MANAGES", "COLLABORATES_WITH"],
             )
             assert r3.processed == 2
 
-            result = await lake.recall("Acme Corp team")
+            result = await lake.recall("Acme Corp team", namespace=NAMESPACE_ID)
             assert len(result.chunks) == 5
             chunk_texts = [c[0] for c in result.chunks]
             assert any("Alice" in t for t in chunk_texts), "Batch 1 content missing"
@@ -932,10 +939,8 @@ def _make_connected_lake() -> MemoryLake:
     mock_engine = MagicMock()
     mock_engine._storage = MagicMock()
     mock_engine._embedder = MagicMock()
-    mock_engine._default_namespace_id = None
     mock_engine.connect = AsyncMock()
     mock_engine.disconnect = AsyncMock()
-    mock_engine.get_or_create_default_namespace = AsyncMock(return_value=NAMESPACE_ID)
     mock_engine.remember = AsyncMock()
     mock_engine.recall = AsyncMock()
     mock_engine.remember_batch = AsyncMock()

--- a/tests/unit/test_logfire_integration.py
+++ b/tests/unit/test_logfire_integration.py
@@ -76,7 +76,6 @@ def _mock_engine() -> MagicMock:
     mock_eng = MagicMock()
     mock_eng._storage = MagicMock()
     mock_eng._embedder = MagicMock()
-    mock_eng._default_namespace_id = None
     mock_eng.connect = AsyncMock()
     mock_eng.disconnect = AsyncMock()
     mock_eng.health_check = AsyncMock(return_value={"status": "healthy"})
@@ -84,10 +83,8 @@ def _mock_engine() -> MagicMock:
     mock_eng.recall = AsyncMock()
     mock_eng.forget = AsyncMock()
     mock_eng.remember_batch = AsyncMock()
-    mock_eng.get_or_create_default_namespace = AsyncMock(return_value=uuid4())
     mock_eng.create_namespace = AsyncMock()
     mock_eng.get_namespace = AsyncMock()
-    mock_eng.ensure_namespace = AsyncMock()
     mock_eng.get_entity = AsyncMock()
     mock_eng.list_entities = AsyncMock(return_value=[])
     mock_eng.find_related_entities = AsyncMock(return_value=[])
@@ -424,7 +421,6 @@ class TestMemoryLakeSpans:
         """remember() creates a logfire span with namespace_id and content_length."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
         lake._engine.remember = AsyncMock(
             return_value=RememberResult(
                 document_id=uuid4(),
@@ -455,6 +451,7 @@ class TestMemoryLakeSpans:
 
             await lake.remember(
                 "Hello, this is test content",
+                namespace=ns_id,
                 title="Test",
                 entity_types=["PERSON", "ORGANIZATION", "LOCATION"],
                 relationship_types=["WORKS_FOR", "KNOWS", "LOCATED_IN"],
@@ -471,7 +468,6 @@ class TestMemoryLakeSpans:
         """recall() creates a logfire span with namespace_id and query_length."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
         lake._engine.recall = AsyncMock(
             return_value=RecallResult(
                 query="test query",
@@ -495,7 +491,7 @@ class TestMemoryLakeSpans:
 
             mock_span_fn.side_effect = tracking_span
 
-            await lake.recall("test query")
+            await lake.recall("test query", namespace=ns_id)
 
         mock_span_fn.assert_called_once()
         call_args = mock_span_fn.call_args
@@ -508,6 +504,7 @@ class TestMemoryLakeSpans:
         """forget() creates a logfire span with document_id."""
         lake = _make_lake(connected=True)
         doc_id = uuid4()
+        ns_id = uuid4()
         lake._engine.forget = AsyncMock(return_value=True)
 
         with patch("khora.memory_lake.trace_span") as mock_span_fn:
@@ -519,7 +516,7 @@ class TestMemoryLakeSpans:
 
             mock_span_fn.side_effect = tracking_span
 
-            await lake.forget(doc_id)
+            await lake.forget(doc_id, namespace=ns_id)
 
         mock_span_fn.assert_called_once()
         call_args = mock_span_fn.call_args
@@ -531,7 +528,6 @@ class TestMemoryLakeSpans:
         """remember_batch() creates a logfire span with namespace_id and batch_size."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
         lake._engine.remember_batch = AsyncMock(
             return_value=BatchResult(
                 total=3,
@@ -561,6 +557,7 @@ class TestMemoryLakeSpans:
 
             await lake.remember_batch(
                 docs,
+                namespace=ns_id,
                 entity_types=["PERSON", "ORGANIZATION", "LOCATION"],
                 relationship_types=["WORKS_FOR", "KNOWS", "LOCATED_IN"],
             )
@@ -580,7 +577,6 @@ class TestSpanAttributeWhitelist:
         """remember() span attributes contain content_length, not the content itself."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
         lake._engine.remember = AsyncMock(
             return_value=RememberResult(
                 document_id=uuid4(),
@@ -608,6 +604,7 @@ class TestSpanAttributeWhitelist:
 
             await lake.remember(
                 secret_content,
+                namespace=ns_id,
                 entity_types=["PERSON", "ORGANIZATION", "LOCATION"],
                 relationship_types=["WORKS_FOR", "KNOWS", "LOCATED_IN"],
             )
@@ -624,7 +621,6 @@ class TestSpanAttributeWhitelist:
         """recall() span attributes contain the query text."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
         lake._engine.recall = AsyncMock(
             return_value=RecallResult(
                 query="test query",
@@ -648,7 +644,7 @@ class TestSpanAttributeWhitelist:
 
             mock_span_fn.side_effect = tracking_span
 
-            await lake.recall("test query")
+            await lake.recall("test query", namespace=ns_id)
 
         call_args = mock_span_fn.call_args
         assert call_args[1]["query"] == "test query"

--- a/tests/unit/test_memory_lake.py
+++ b/tests/unit/test_memory_lake.py
@@ -301,30 +301,6 @@ class TestResolveNamespace:
         result = await lake._resolve_namespace(None)
         assert result == default_id
 
-    @pytest.mark.asyncio
-    async def test_slug_lookup(self) -> None:
-        """Non-UUID string looks up namespace by slug (globally unique)."""
-        lake = _make_lake(connected=True)
-
-        found_ns = MagicMock()
-        found_ns.id = uuid4()
-
-        lake._engine._storage.get_namespace_by_slug = AsyncMock(return_value=found_ns)
-
-        result = await lake._resolve_namespace("my-namespace")
-        assert result == found_ns.id
-        lake._engine._storage.get_namespace_by_slug.assert_awaited_once_with("my-namespace")
-
-    @pytest.mark.asyncio
-    async def test_slug_not_found_raises(self) -> None:
-        """Non-UUID string that doesn't exist raises ValueError."""
-        lake = _make_lake(connected=True)
-
-        lake._engine._storage.get_namespace_by_slug = AsyncMock(return_value=None)
-
-        with pytest.raises(ValueError, match="Namespace not found"):
-            await lake._resolve_namespace("nonexistent")
-
 
 # ---------------------------------------------------------------------------
 # remember

--- a/tests/unit/test_memory_lake.py
+++ b/tests/unit/test_memory_lake.py
@@ -45,9 +45,6 @@ def _mock_engine() -> MagicMock:
     mock_eng._storage = MagicMock()
     mock_eng._embedder = MagicMock()
 
-    # Default namespace ID
-    mock_eng._default_namespace_id = None
-
     # Lifecycle
     mock_eng.connect = AsyncMock()
     mock_eng.disconnect = AsyncMock()
@@ -60,10 +57,8 @@ def _mock_engine() -> MagicMock:
     mock_eng.remember_batch = AsyncMock()
 
     # Namespace operations
-    mock_eng.get_or_create_default_namespace = AsyncMock(return_value=uuid4())
     mock_eng.create_namespace = AsyncMock()
     mock_eng.get_namespace = AsyncMock()
-    mock_eng.ensure_namespace = AsyncMock()
 
     # Entity operations
     mock_eng.get_entity = AsyncMock()
@@ -292,16 +287,6 @@ class TestResolveNamespace:
         assert result == ns_id
 
     @pytest.mark.asyncio
-    async def test_none_calls_get_or_create_default(self) -> None:
-        """None resolves via get_or_create_default_namespace on engine."""
-        lake = _make_lake(connected=True)
-        default_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=default_id)
-
-        result = await lake._resolve_namespace(None)
-        assert result == default_id
-
-    @pytest.mark.asyncio
     async def test_invalid_string_raises_value_error(self) -> None:
         """Non-UUID string raises ValueError."""
         lake = _make_lake(connected=True)
@@ -322,7 +307,6 @@ class TestRemember:
         """remember() delegates to engine.remember()."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
 
         mock_result = RememberResult(
             document_id=uuid4(),
@@ -339,6 +323,7 @@ class TestRemember:
         ):
             result = await lake.remember(
                 "test content",
+                namespace=ns_id,
                 title="Test",
                 entity_types=["PERSON", "ORGANIZATION", "LOCATION"],
                 relationship_types=["WORKS_FOR", "KNOWS", "LOCATED_IN"],
@@ -366,7 +351,6 @@ class TestRecall:
         """recall() delegates to engine.recall() and returns result."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
 
         mock_result = RecallResult(
             query="search query",
@@ -382,7 +366,7 @@ class TestRecall:
             patch("khora.telemetry.context.ensure_trace_id"),
             patch("khora.telemetry.context.clear_trace_id"),
         ):
-            result = await lake.recall("search query")
+            result = await lake.recall("search query", namespace=ns_id)
 
         assert isinstance(result, RecallResult)
         assert result.query == "search query"
@@ -395,7 +379,6 @@ class TestRecall:
 
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
 
         mock_result = RecallResult(
             query="test",
@@ -410,7 +393,7 @@ class TestRecall:
             patch("khora.telemetry.context.ensure_trace_id"),
             patch("khora.telemetry.context.clear_trace_id"),
         ):
-            await lake.recall("test", mode=SearchMode.VECTOR)
+            await lake.recall("test", namespace=ns_id, mode=SearchMode.VECTOR)
 
         call_kwargs = lake._engine.recall.call_args
         assert call_kwargs.kwargs.get("mode") == SearchMode.VECTOR
@@ -426,27 +409,15 @@ class TestForget:
 
     @pytest.mark.asyncio
     async def test_forget_delegates_to_engine(self) -> None:
-        """forget() delegates to engine.forget()."""
-        lake = _make_lake(connected=True)
-        doc_id = uuid4()
-
-        lake._engine.forget = AsyncMock(return_value=True)
-
-        result = await lake.forget(doc_id)
-        assert result is True
-        lake._engine.forget.assert_awaited_once_with(doc_id, None)
-
-    @pytest.mark.asyncio
-    async def test_forget_with_namespace(self) -> None:
-        """forget() resolves namespace and passes to engine."""
+        """forget() delegates to engine.forget() with required namespace."""
         lake = _make_lake(connected=True)
         doc_id = uuid4()
         ns_id = uuid4()
 
-        lake._engine.forget = AsyncMock(return_value=False)
+        lake._engine.forget = AsyncMock(return_value=True)
 
         result = await lake.forget(doc_id, namespace=ns_id)
-        assert result is False
+        assert result is True
         lake._engine.forget.assert_awaited_once_with(doc_id, ns_id)
 
 
@@ -476,12 +447,11 @@ class TestEntityOperations:
         """list_entities delegates to engine with filters."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
 
         mock_entities = [MagicMock(), MagicMock()]
         lake._engine.list_entities = AsyncMock(return_value=mock_entities)
 
-        result = await lake.list_entities(entity_type="PERSON", limit=50)
+        result = await lake.list_entities(namespace=ns_id, entity_type="PERSON", limit=50)
         assert result == mock_entities
         lake._engine.list_entities.assert_awaited_once_with(ns_id, entity_type="PERSON", limit=50)
 
@@ -490,13 +460,12 @@ class TestEntityOperations:
         """find_related_entities delegates to engine."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
         entity_id = uuid4()
 
         mock_related = [(MagicMock(), 0.8)]
         lake._engine.find_related_entities = AsyncMock(return_value=mock_related)
 
-        result = await lake.find_related_entities(entity_id, max_depth=3)
+        result = await lake.find_related_entities(entity_id, namespace=ns_id, max_depth=3)
         assert result == mock_related
 
 
@@ -510,13 +479,13 @@ class TestNamespaceManagement:
 
     @pytest.mark.asyncio
     async def test_create_namespace(self) -> None:
-        """create_namespace delegates to engine without workspace_id."""
+        """create_namespace delegates to engine."""
         lake = _make_lake(connected=True)
 
         mock_ns = MagicMock()
         lake._engine.create_namespace = AsyncMock(return_value=mock_ns)
 
-        result = await lake.create_namespace("test-ns", description="Test")
+        result = await lake.create_namespace()
         assert result is mock_ns
         lake._engine.create_namespace.assert_awaited_once()
 
@@ -531,16 +500,6 @@ class TestNamespaceManagement:
 
         result = await lake.get_namespace(ns_id)
         assert result is mock_ns
-
-    @pytest.mark.asyncio
-    async def test_get_or_create_default_namespace(self) -> None:
-        """get_or_create_default_namespace delegates to engine."""
-        lake = _make_lake(connected=True)
-        default_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=default_id)
-
-        result = await lake.get_or_create_default_namespace()
-        assert result == default_id
 
 
 # ---------------------------------------------------------------------------
@@ -727,7 +686,6 @@ class TestRecallRawMode:
         """raw=True is passed to engine."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
 
         mock_result = RecallResult(
             query="test",
@@ -742,7 +700,7 @@ class TestRecallRawMode:
             patch("khora.telemetry.context.ensure_trace_id"),
             patch("khora.telemetry.context.clear_trace_id"),
         ):
-            await lake.recall("test query", raw=True)
+            await lake.recall("test query", namespace=ns_id, raw=True)
 
         call_kwargs = lake._engine.recall.call_args
         assert call_kwargs.kwargs.get("raw") is True
@@ -774,12 +732,11 @@ class TestConvenienceMethods:
         """list_documents delegates to engine with namespace."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
 
         mock_docs = [MagicMock(), MagicMock()]
         lake._engine.list_documents = AsyncMock(return_value=mock_docs)
 
-        result = await lake.list_documents(limit=50)
+        result = await lake.list_documents(namespace=ns_id, limit=50)
         assert result == mock_docs
         lake._engine.list_documents.assert_awaited_once_with(ns_id, limit=50)
 
@@ -788,26 +745,14 @@ class TestConvenienceMethods:
         """search_entities delegates to engine."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
 
         mock_entities = [MagicMock()]
         lake._engine.search_entities = AsyncMock(return_value=mock_entities)
 
-        result = await lake.search_entities("test query", limit=5)
+        result = await lake.search_entities("test query", namespace=ns_id, limit=5)
 
         assert len(result) == 1
         lake._engine.search_entities.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_ensure_namespace(self) -> None:
-        """ensure_namespace delegates to engine."""
-        lake = _make_lake(connected=True)
-        ns_id = uuid4()
-        lake._engine.ensure_namespace = AsyncMock(return_value=ns_id)
-
-        result = await lake.ensure_namespace("my-namespace", description="Test")
-        assert result == ns_id
-        lake._engine.ensure_namespace.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -823,7 +768,6 @@ class TestEnhancedRememberBatch:
         """Empty batch returns BatchResult with zeros."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
         lake._engine.remember_batch = AsyncMock(
             return_value=BatchResult(
                 total=0,
@@ -842,6 +786,7 @@ class TestEnhancedRememberBatch:
         ):
             result = await lake.remember_batch(
                 [],
+                namespace=ns_id,
                 entity_types=["PERSON", "ORGANIZATION", "LOCATION"],
                 relationship_types=["WORKS_FOR", "KNOWS", "LOCATED_IN"],
             )
@@ -855,7 +800,6 @@ class TestEnhancedRememberBatch:
         """remember_batch() returns BatchResult with aggregated stats."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
         lake._engine.remember_batch = AsyncMock(
             return_value=BatchResult(
                 total=3,
@@ -878,6 +822,7 @@ class TestEnhancedRememberBatch:
                     {"content": "Doc 2"},
                     {"content": "Doc 3"},
                 ],
+                namespace=ns_id,
                 entity_types=["PERSON", "ORGANIZATION", "LOCATION"],
                 relationship_types=["WORKS_FOR", "KNOWS", "LOCATED_IN"],
             )

--- a/tests/unit/test_memory_lake.py
+++ b/tests/unit/test_memory_lake.py
@@ -301,6 +301,13 @@ class TestResolveNamespace:
         result = await lake._resolve_namespace(None)
         assert result == default_id
 
+    @pytest.mark.asyncio
+    async def test_invalid_string_raises_value_error(self) -> None:
+        """Non-UUID string raises ValueError."""
+        lake = _make_lake(connected=True)
+        with pytest.raises(ValueError, match="Invalid namespace"):
+            await lake._resolve_namespace("not-a-uuid")
+
 
 # ---------------------------------------------------------------------------
 # remember

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -378,15 +378,13 @@ class TestTenancyModels:
     """Tests for tenancy models (MemoryNamespace)."""
 
     def test_create_namespace(self) -> None:
-        """Test namespace creation without workspace_id."""
-        ns = MemoryNamespace(name="Project Alpha")
-        assert ns.name == "Project Alpha"
+        """Test namespace creation with UUID."""
+        ns = MemoryNamespace()
         assert ns.id is not None
 
     def test_namespace_with_config(self) -> None:
         """Test namespace with configuration overrides."""
         ns = MemoryNamespace(
-            name="Test",
             config_overrides={"extraction_skill": "technical_docs"},
         )
         assert ns.config_overrides["extraction_skill"] == "technical_docs"
@@ -394,27 +392,36 @@ class TestTenancyModels:
     def test_namespace_sync_checkpoints(self) -> None:
         """Test namespace sync checkpoints."""
         ns = MemoryNamespace(
-            name="Test",
             sync_checkpoints={"source1": "checkpoint123"},
         )
         assert ns.sync_checkpoints["source1"] == "checkpoint123"
 
     def test_namespace_tenancy_mode_defaults_to_shared(self) -> None:
         """Test that MemoryNamespace.tenancy_mode defaults to SHARED."""
-        ns = MemoryNamespace(name="Test")
+        ns = MemoryNamespace()
         assert ns.tenancy_mode == TenancyMode.SHARED
 
     def test_namespace_tenancy_mode_isolated(self) -> None:
         """Test that MemoryNamespace.tenancy_mode can be set to ISOLATED."""
-        ns = MemoryNamespace(name="Test", tenancy_mode=TenancyMode.ISOLATED)
+        ns = MemoryNamespace(tenancy_mode=TenancyMode.ISOLATED)
         assert ns.tenancy_mode == TenancyMode.ISOLATED
 
     def test_namespace_no_workspace_id_attribute(self) -> None:
         """Test that MemoryNamespace no longer has workspace_id."""
-        ns = MemoryNamespace(name="Test")
+        ns = MemoryNamespace()
         assert not hasattr(ns, "workspace_id")
 
     def test_namespace_no_full_path_attribute(self) -> None:
         """Test that MemoryNamespace no longer has full_path."""
-        ns = MemoryNamespace(name="Test")
+        ns = MemoryNamespace()
         assert not hasattr(ns, "full_path")
+
+    def test_namespace_no_name_attribute(self) -> None:
+        """Test that MemoryNamespace no longer has name."""
+        ns = MemoryNamespace()
+        assert not hasattr(ns, "name")
+
+    def test_namespace_no_description_attribute(self) -> None:
+        """Test that MemoryNamespace no longer has description."""
+        ns = MemoryNamespace()
+        assert not hasattr(ns, "description")

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -379,21 +379,14 @@ class TestTenancyModels:
 
     def test_create_namespace(self) -> None:
         """Test namespace creation without workspace_id."""
-        ns = MemoryNamespace(name="Project Alpha", slug="project-alpha")
+        ns = MemoryNamespace(name="Project Alpha")
         assert ns.name == "Project Alpha"
-        assert ns.slug == "project-alpha"
         assert ns.id is not None
-
-    def test_namespace_auto_slug(self) -> None:
-        """Test namespace auto-generates slug from name."""
-        ns = MemoryNamespace(name="My Project")
-        assert ns.slug == "my-project"
 
     def test_namespace_with_config(self) -> None:
         """Test namespace with configuration overrides."""
         ns = MemoryNamespace(
             name="Test",
-            slug="test",
             config_overrides={"extraction_skill": "technical_docs"},
         )
         assert ns.config_overrides["extraction_skill"] == "technical_docs"

--- a/tests/unit/test_parameterized_extraction.py
+++ b/tests/unit/test_parameterized_extraction.py
@@ -77,7 +77,6 @@ def _mock_engine() -> MagicMock:
     mock_eng = MagicMock()
     mock_eng._storage = MagicMock()
     mock_eng._embedder = MagicMock()
-    mock_eng._default_namespace_id = None
     mock_eng.connect = AsyncMock()
     mock_eng.disconnect = AsyncMock()
     mock_eng.health_check = AsyncMock(return_value={"status": "healthy"})
@@ -85,10 +84,8 @@ def _mock_engine() -> MagicMock:
     mock_eng.recall = AsyncMock()
     mock_eng.forget = AsyncMock()
     mock_eng.remember_batch = AsyncMock()
-    mock_eng.get_or_create_default_namespace = AsyncMock(return_value=uuid4())
     mock_eng.create_namespace = AsyncMock()
     mock_eng.get_namespace = AsyncMock()
-    mock_eng.ensure_namespace = AsyncMock()
     mock_eng.get_entity = AsyncMock()
     mock_eng.list_entities = AsyncMock(return_value=[])
     mock_eng.find_related_entities = AsyncMock(return_value=[])
@@ -389,7 +386,6 @@ class TestMemoryLakeRememberThreadsTypes:
 
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
 
         mock_result = RememberResult(
             document_id=uuid4(),
@@ -406,6 +402,7 @@ class TestMemoryLakeRememberThreadsTypes:
         ):
             await lake.remember(
                 "Olaparib targets BRCA1.",
+                namespace=ns_id,
                 entity_types=["DRUG", "GENE"],
                 relationship_types=["TARGETS"],
             )
@@ -431,7 +428,6 @@ class TestMemoryLakeRememberBatchThreadsTypes:
 
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
 
         mock_result = BatchResult(
             total=1,
@@ -450,6 +446,7 @@ class TestMemoryLakeRememberBatchThreadsTypes:
         ):
             await lake.remember_batch(
                 [{"content": "Olaparib targets BRCA1."}],
+                namespace=ns_id,
                 entity_types=["DRUG"],
                 relationship_types=["TARGETS"],
             )
@@ -473,28 +470,25 @@ class TestRememberRequiresOntologyParams:
         """remember() without entity_types raises TypeError."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
 
         with pytest.raises(TypeError):
-            await lake.remember("some text", relationship_types=["KNOWS"])
+            await lake.remember("some text", namespace=ns_id, relationship_types=["KNOWS"])
 
     async def test_remember_missing_relationship_types_raises(self) -> None:
         """remember() without relationship_types raises TypeError."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
 
         with pytest.raises(TypeError):
-            await lake.remember("some text", entity_types=["PERSON"])
+            await lake.remember("some text", namespace=ns_id, entity_types=["PERSON"])
 
     async def test_remember_missing_both_raises(self) -> None:
         """remember() without either ontology param raises TypeError."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
 
         with pytest.raises(TypeError):
-            await lake.remember("some text")
+            await lake.remember("some text", namespace=ns_id)
 
 
 # ---------------------------------------------------------------------------
@@ -510,11 +504,11 @@ class TestRememberBatchRequiresOntologyParams:
         """remember_batch() without entity_types raises TypeError."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
 
         with pytest.raises(TypeError):
             await lake.remember_batch(
                 [{"content": "text"}],
+                namespace=ns_id,
                 relationship_types=["KNOWS"],
             )
 
@@ -522,11 +516,11 @@ class TestRememberBatchRequiresOntologyParams:
         """remember_batch() without relationship_types raises TypeError."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
 
         with pytest.raises(TypeError):
             await lake.remember_batch(
                 [{"content": "text"}],
+                namespace=ns_id,
                 entity_types=["PERSON"],
             )
 
@@ -534,7 +528,6 @@ class TestRememberBatchRequiresOntologyParams:
         """remember_batch() without either ontology param raises TypeError."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
-        lake._engine.get_or_create_default_namespace = AsyncMock(return_value=ns_id)
 
         with pytest.raises(TypeError):
-            await lake.remember_batch([{"content": "text"}])
+            await lake.remember_batch([{"content": "text"}], namespace=ns_id)

--- a/tests/unit/test_vectorcypher_engine.py
+++ b/tests/unit/test_vectorcypher_engine.py
@@ -40,7 +40,6 @@ def _make_engine_with_mocks(
     engine._dual_nodes = None
     engine._router = None
     engine._connected = True
-    engine._default_namespace_id = None
 
     return engine
 


### PR DESCRIPTION
## Summary

- **Remove namespace slugs**: Eliminate dual UUID/slug identification path; all namespace lookups use UUID only
- **Make namespace_id required**: All public API methods (`remember`, `recall`, `forget`, `remember_batch`, `list_entities`, `find_related_entities`, `list_documents`, `search_entities`, `stats`) now require `namespace_id: str | UUID` — no implicit default namespace
- **Remove name/description from namespace**: `MemoryNamespace` becomes a pure UUID isolation boundary (`id`, `version`, `is_active`, `config_overrides`, timestamps)
- **Remove dead methods**: `get_or_create_default_namespace()`, `get_namespace_by_name()`, `get_namespace_by_slug()`, `ensure_namespace()` removed from all layers (MemoryLake, protocol, 3 engines, backends, coordinator)
- **Migration**: Alembic 011 drops `slug`, `name`, `description` columns with reversible downgrade
- **Docs**: Updated multi-tenancy and storage-backends architecture docs; PRD marked Implemented

**Net result**: 20 files changed, 346 insertions, 670 deletions (net -324 lines)

### Breaking changes
- `namespace` parameter is now **required** in all public API methods (was optional with default provisioning)
- `MemoryNamespace` no longer has `name`, `description`, or `slug` fields
- `ensure_namespace()`, `get_or_create_default_namespace()` removed from public API
- **khora-benchmarks** needs a companion PR to pass explicit `namespace_id` (currently calls `get_or_create_default_namespace()`)

## Test plan
- [x] Unit tests pass (1473 passed, 4 skipped)
- [x] Coverage at 53.76% (threshold: 30%)
- [x] `make lint` clean (ruff, black, isort)
- [x] `ty check src/` clean (14 pre-existing warnings, 0 errors)
- [x] Pre-commit hooks pass
- [ ] Manual: verify khora-benchmarks companion PR before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)