### PR TITLE
DYT-427: Fix empty pipeline registry by importing flows on package load

### DIFF
--- a/src/khora/pipelines/__init__.py
+++ b/src/khora/pipelines/__init__.py
@@ -6,6 +6,7 @@ processing, and synchronization.
 
 from __future__ import annotations
 
+from . import flows as flows  # noqa: F811 — triggers @pipeline() decorator registration
 from .manager import PipelineManager
 from .registry import PipelineRegistry, pipeline
 

--- a/tests/unit/test_pipeline_manager.py
+++ b/tests/unit/test_pipeline_manager.py
@@ -52,3 +52,22 @@ class TestPipelineManagerErrorContext:
 
         runs = manager.list_runs()
         assert runs[0].error == "RuntimeError: connection lost"
+
+
+class TestPipelineRegistryAutoPopulation:
+    """Importing khora.pipelines must trigger @pipeline() decorator registration."""
+
+    def test_registry_contains_ingest_after_import(self) -> None:
+        """The 'ingest' pipeline is registered when khora.pipelines is imported."""
+        from khora.pipelines.registry import get_registry
+
+        registry = get_registry()
+        assert registry.get("ingest") is not None
+
+    def test_registry_contains_all_builtin_pipelines(self) -> None:
+        """All builtin pipelines are registered after import."""
+        from khora.pipelines.registry import get_registry
+
+        registry = get_registry()
+        for name in ("ingest", "sync_source", "sync_all", "expand_knowledge", "unify_entities"):
+            assert registry.get(name) is not None, f"Pipeline '{name}' not registered"


### PR DESCRIPTION
## Summary
- `pipelines/__init__.py` exports `PipelineManager` but never imported `pipelines/flows/`, so `@pipeline()` decorators never fired and the registry stayed empty
- Added `from . import flows` to trigger decorator registration at import time
- Added tests verifying all 5 builtin pipelines (`ingest`, `sync_source`, `sync_all`, `expand_knowledge`, `unify_entities`) are registered

## Test plan
- [x] Unit tests pass (1505 passed, 4 skipped)
- [x] New tests verify registry auto-population
- [ ] Manual verification: Peras `POST /api/v1/sync/ingest` no longer raises `ValueError: Unknown pipeline: ingest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)