### PR TITLE
DYT-513: Logfire spans for LLM extraction, entity dedup, skeleton build

### DIFF
--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -696,7 +696,12 @@ class VectorCypherEngine:
             else:
                 skeleton = SkeletonIndexer(core_ratio=self._vc_config.skeleton_core_ratio)
                 skeleton.add_chunks_batch(chunks)
-                core_ids = await asyncio.to_thread(skeleton.build_skeleton)
+                with trace_span(
+                    "khora.vectorcypher.skeleton_build",
+                    chunk_count=len(chunks),
+                    core_ratio=self._vc_config.skeleton_core_ratio,
+                ):
+                    core_ids = await asyncio.to_thread(skeleton.build_skeleton)
 
             logger.debug(f"Skeleton indexing: {len(core_ids)}/{len(chunks)} core chunks")
             span.set_attribute("core_chunks", len(core_ids))
@@ -835,7 +840,12 @@ class VectorCypherEngine:
             effective_ratio = skeleton_ratio_override or self._vc_config.skeleton_core_ratio
             skeleton = SkeletonIndexer(core_ratio=effective_ratio)
             skeleton.add_chunks_batch(chunks)
-            core_ids = await asyncio.to_thread(skeleton.build_skeleton)
+            with trace_span(
+                "khora.vectorcypher.skeleton_build",
+                chunk_count=len(chunks),
+                core_ratio=effective_ratio,
+            ):
+                core_ids = await asyncio.to_thread(skeleton.build_skeleton)
 
         logger.debug(f"Skeleton indexing (deferred): {len(core_ids)}/{len(chunks)} core chunks")
 

--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -659,23 +659,24 @@ class LLMEntityExtractor(EntityExtractor):
                     async with self._semaphore:
                         import time as _time
 
+                        from khora.telemetry import get_collector, trace_span
+
                         _t0 = _time.perf_counter()
-                        response = await litellm.acompletion(
-                            model=self._model,
-                            messages=[
-                                {"role": "system", "content": system_prompt},
-                                {"role": "user", "content": extraction_prompt},
-                            ],
-                            temperature=self._temperature,
-                            max_tokens=self._max_tokens,
-                            timeout=self._timeout,
-                            response_format=self._get_response_format(),
-                        )
+                        with trace_span("khora.extraction.llm_call", model=self._model, call_type="single"):
+                            response = await litellm.acompletion(
+                                model=self._model,
+                                messages=[
+                                    {"role": "system", "content": system_prompt},
+                                    {"role": "user", "content": extraction_prompt},
+                                ],
+                                temperature=self._temperature,
+                                max_tokens=self._max_tokens,
+                                timeout=self._timeout,
+                                response_format=self._get_response_format(),
+                            )
                         _latency = (_time.perf_counter() - _t0) * 1000
 
                         # Record telemetry
-                        from khora.telemetry import get_collector
-
                         usage = getattr(response, "usage", None)
                         get_collector().record_llm_call(
                             operation="entity_extraction",
@@ -783,21 +784,22 @@ class LLMEntityExtractor(EntityExtractor):
             async with self._semaphore:
                 import time as _time
 
-                _t0 = _time.perf_counter()
-                response = await litellm.acompletion(
-                    model=self._model,
-                    messages=[
-                        {"role": "system", "content": DEFAULT_SYSTEM_PROMPT},
-                        {"role": "user", "content": prompt},
-                    ],
-                    temperature=self._temperature,
-                    max_tokens=self._max_tokens,
-                    timeout=self._timeout,
-                    response_format=self._get_response_format(),
-                )
-                _latency = (_time.perf_counter() - _t0) * 1000
+                from khora.telemetry import get_collector, trace_span
 
-                from khora.telemetry import get_collector
+                _t0 = _time.perf_counter()
+                with trace_span("khora.extraction.llm_call", model=self._model, call_type="relationship_second_pass"):
+                    response = await litellm.acompletion(
+                        model=self._model,
+                        messages=[
+                            {"role": "system", "content": DEFAULT_SYSTEM_PROMPT},
+                            {"role": "user", "content": prompt},
+                        ],
+                        temperature=self._temperature,
+                        max_tokens=self._max_tokens,
+                        timeout=self._timeout,
+                        response_format=self._get_response_format(),
+                    )
+                _latency = (_time.perf_counter() - _t0) * 1000
 
                 usage = getattr(response, "usage", None)
                 get_collector().record_llm_call(
@@ -1366,23 +1368,29 @@ Return ONLY valid JSON, no other text."""
                     async with self._semaphore:
                         import time as _time
 
+                        from khora.telemetry import get_collector, trace_span
+
                         _t0 = _time.perf_counter()
-                        response = await litellm.acompletion(
+                        with trace_span(
+                            "khora.extraction.llm_call",
                             model=self._model,
-                            messages=[
-                                {"role": "system", "content": system_prompt or DEFAULT_SYSTEM_PROMPT},
-                                {"role": "user", "content": prompt},
-                            ],
-                            temperature=self._temperature,
-                            max_tokens=self._max_tokens,
-                            timeout=self._timeout,
-                            response_format=self._get_multi_response_format(),
-                        )
+                            call_type="multi_batch",
+                            batch_size=len(texts),
+                        ):
+                            response = await litellm.acompletion(
+                                model=self._model,
+                                messages=[
+                                    {"role": "system", "content": system_prompt or DEFAULT_SYSTEM_PROMPT},
+                                    {"role": "user", "content": prompt},
+                                ],
+                                temperature=self._temperature,
+                                max_tokens=self._max_tokens,
+                                timeout=self._timeout,
+                                response_format=self._get_multi_response_format(),
+                            )
                         _latency = (_time.perf_counter() - _t0) * 1000
 
                         # Record telemetry
-                        from khora.telemetry import get_collector
-
                         usage = getattr(response, "usage", None)
                         get_collector().record_llm_call(
                             operation="entity_extraction_multi",

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -937,16 +937,21 @@ async def process_document(
         if entity_index is not None and inference_mode == "smart":
             # Smart mode: within-doc exact dedup via shared EntityIndex.
             # Cross-document resolution + inference deferred to run_smart_resolution().
-            deduped_entities = []
-            for entity in entities:
-                existing = entity_index.add(entity)
-                if existing is not None:
-                    # Merge into existing (already in index)
-                    existing.merge_with(entity)
-                    # Map the dropped entity's ID to the surviving entity's ID
-                    dedup_id_mapping[str(entity.id)] = str(existing.id)
-                else:
-                    deduped_entities.append(entity)
+            from khora.telemetry import trace_span
+
+            with trace_span("khora.ingestion.entity_dedup", input_count=len(entities), mode="smart") as _dedup_span:
+                deduped_entities = []
+                for entity in entities:
+                    existing = entity_index.add(entity)
+                    if existing is not None:
+                        # Merge into existing (already in index)
+                        existing.merge_with(entity)
+                        # Map the dropped entity's ID to the surviving entity's ID
+                        dedup_id_mapping[str(entity.id)] = str(existing.id)
+                    else:
+                        deduped_entities.append(entity)
+                _dedup_span.set_attribute("output_count", len(deduped_entities))
+                _dedup_span.set_attribute("duplicates_found", len(dedup_id_mapping))
             if len(entities) != len(deduped_entities):
                 logger.debug(
                     f"Document {document.id}: smart dedup {len(entities)} -> {len(deduped_entities)} entities "
@@ -956,39 +961,46 @@ async def process_document(
 
         elif enable_expansion and resolved_expertise:
             from khora.extraction.expansion import SemanticExpander
+            from khora.telemetry import trace_span
 
-            # For incremental mode, fetch existing entities/relationships from storage
-            # to enable cross-document inference
-            expansion_entities = list(entities)
-            expansion_relationships = list(relationships)
+            with trace_span(
+                "khora.ingestion.expansion",
+                mode=inference_mode,
+                input_entities=len(entities),
+                input_relationships=len(relationships),
+            ):
+                # For incremental mode, fetch existing entities/relationships from storage
+                # to enable cross-document inference
+                expansion_entities = list(entities)
+                expansion_relationships = list(relationships)
 
-            if inference_mode == "incremental":
-                # Query existing entities and relationships from the namespace
-                existing_entities = await storage.list_entities(document.namespace_id, limit=1000)
-                existing_relationships = await storage.list_relationships(document.namespace_id, limit=5000)
+                if inference_mode == "incremental":
+                    # Query existing entities and relationships from the namespace
+                    existing_entities = await storage.list_entities(document.namespace_id, limit=1000)
+                    existing_relationships = await storage.list_relationships(document.namespace_id, limit=5000)
 
-                # Add existing data to expansion context
-                expansion_entities.extend(existing_entities)
-                expansion_relationships.extend(existing_relationships)
+                    # Add existing data to expansion context
+                    expansion_entities.extend(existing_entities)
+                    expansion_relationships.extend(existing_relationships)
 
-                logger.debug(
-                    f"Document {document.id}: incremental mode - added {len(existing_entities)} existing entities, "
-                    f"{len(existing_relationships)} existing relationships to expansion context"
+                    logger.debug(
+                        f"Document {document.id}: incremental mode - added {len(existing_entities)} existing entities, "
+                        f"{len(existing_relationships)} existing relationships to expansion context"
+                    )
+
+                # For batch mode, skip inference (only do unification on current doc)
+                # Inference will be run separately after all documents are processed
+                enable_inference = inference_mode != "batch" and inference_mode != "none"
+
+                expander = SemanticExpander(
+                    expertise=resolved_expertise,
+                    enable_inference=enable_inference,
                 )
-
-            # For batch mode, skip inference (only do unification on current doc)
-            # Inference will be run separately after all documents are processed
-            enable_inference = inference_mode != "batch" and inference_mode != "none"
-
-            expander = SemanticExpander(
-                expertise=resolved_expertise,
-                enable_inference=enable_inference,
-            )
-            expansion_result = await expander.expand(
-                entities=expansion_entities,
-                relationships=expansion_relationships,
-                namespace_id=document.namespace_id,
-            )
+                expansion_result = await expander.expand(
+                    entities=expansion_entities,
+                    relationships=expansion_relationships,
+                    namespace_id=document.namespace_id,
+                )
 
             # Only keep entities from current document (not the existing ones we added)
             # The existing entities are already stored


### PR DESCRIPTION
## Summary
Adds trace spans to previously uninstrumented khora code paths:

- **LLM extraction calls**: `khora.extraction.llm_call` wrapping each `litellm.acompletion` (single, relationship_second_pass, multi_batch)
- **Entity dedup**: `khora.ingestion.entity_dedup` around smart mode dedup with input/output/duplicate counts
- **Semantic expansion**: `khora.ingestion.expansion` around SemanticExpander with mode and counts
- **Skeleton build**: `khora.vectorcypher.skeleton_build` around PageRank core chunk selection

## Test plan
- [x] `make prek` passes (black, isort, ruff, ty)
- [x] Unit tests pass
- [ ] Verify spans appear in Logfire during benchmark run

Closes DYT-513

🤖 Generated with [Claude Code](https://claude.com/claude-code)