### PR TITLE
DYT-433: Fix broken imports in skeleton/vectorcypher engines

### DIFF
--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -289,20 +289,18 @@ class SkeletonConstructionEngine:
         Unlike GraphRAG, this focuses on fast chunking and embedding without
         full entity extraction. Entity extraction can be done lazily on retrieval.
         """
-        from khora.pipelines.chunking import create_chunker  # type: ignore[unresolved-import]
-        from khora.pipelines.chunking.config import ChunkerConfig  # type: ignore[unresolved-import]
+        from khora.extraction.chunkers import create_chunker
 
         storage = self._get_storage()
         embedder = self._get_embedder()
         temporal_store = self._get_temporal_store()
 
         # Create chunker
-        chunker_config = ChunkerConfig(
+        chunker = create_chunker(
             strategy=self._config.pipeline.chunking_strategy,
             chunk_size=self._config.pipeline.chunk_size,
             chunk_overlap=self._config.pipeline.chunk_overlap,
         )
-        chunker = create_chunker(chunker_config)
 
         # Chunk the document (run in thread to avoid blocking event loop during
         # CPU-bound tiktoken operations)

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -550,8 +550,7 @@ class VectorCypherEngine:
         5. Store chunks in pgvector and create Chunk nodes in Neo4j
         6. Link entities to chunks via MENTIONED_IN
         """
-        from khora.pipelines.chunking import create_chunker  # type: ignore[unresolved-import]
-        from khora.pipelines.chunking.config import ChunkerConfig  # type: ignore[unresolved-import]
+        from khora.extraction.chunkers import create_chunker
 
         with trace_span(
             "khora.vectorcypher.process_document",
@@ -564,12 +563,11 @@ class VectorCypherEngine:
             dual_nodes = self._get_dual_nodes()
 
             # Create chunker
-            chunker_config = ChunkerConfig(
+            chunker = create_chunker(
                 strategy=self._config.pipeline.chunking_strategy,
                 chunk_size=self._config.pipeline.chunk_size,
                 chunk_overlap=self._config.pipeline.chunk_overlap,
             )
-            chunker = create_chunker(chunker_config)
 
             # Chunk the document
             with trace_span("khora.vectorcypher.chunking"):
@@ -926,20 +924,18 @@ class VectorCypherEngine:
         Returns:
             Tuple of (chunks_created, entities, relationships, entity_chunk_links)
         """
-        from khora.pipelines.chunking import create_chunker  # type: ignore[unresolved-import]
-        from khora.pipelines.chunking.config import ChunkerConfig  # type: ignore[unresolved-import]
+        from khora.extraction.chunkers import create_chunker
 
         storage = self._get_storage()
         embedder = self._get_embedder()
         temporal_store = self._get_temporal_store()
         dual_nodes = self._get_dual_nodes()
 
-        chunker_config = ChunkerConfig(
+        chunker = create_chunker(
             strategy=self._config.pipeline.chunking_strategy,
             chunk_size=self._config.pipeline.chunk_size,
             chunk_overlap=self._config.pipeline.chunk_overlap,
         )
-        chunker = create_chunker(chunker_config)
         raw_chunks = await asyncio.to_thread(chunker.chunk, document.content)
 
         if not raw_chunks:


### PR DESCRIPTION
## Summary
- Fix `ModuleNotFoundError` in skeleton and vectorcypher engines caused by stale imports from `khora.pipelines.chunking` (module no longer exists)
- Update all 3 import sites to use `khora.extraction.chunkers.create_chunker` with direct keyword arguments (`strategy`, `chunk_size`, `chunk_overlap`) instead of the removed `ChunkerConfig` object
- Eliminates the need for shim workarounds in Peras (`conftest.py`) and dokimion (`sitecustomize.py`)

## Test plan
- [x] Unit tests pass (1573 passed)
- [x] Lint and type checks pass
- [ ] Manual verification: instantiate `MemoryLake(config, engine="vectorcypher")` and `MemoryLake(config, engine="skeleton")` — confirm no import errors
- [ ] Remove Peras conftest shim and dokimion sitecustomize shim in follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)