### PR TITLE
DYT-595: Add missing enum values to document_status on create_tables()

### DIFF
--- a/alembic/versions/014_sync_document_status_enum.py
+++ b/alembic/versions/014_sync_document_status_enum.py
@@ -1,0 +1,39 @@
+"""Add missing 'pending' and 'archived' values to document_status enum.
+
+Revision ID: 014_sync_document_status_enum
+Revises: 013_drop_previous_version_id
+Create Date: 2026-03-18
+
+The Python DocumentStatus enum defines PENDING, PROCESSING, COMPLETED, FAILED,
+and ARCHIVED, but databases created by older Khora versions (via create_tables()
+or earlier migrations) may only have a subset of these values.
+
+ALTER TYPE ... ADD VALUE IF NOT EXISTS is used so this migration is safe to run
+on databases that already have the values.
+
+Note: ADD VALUE cannot run inside a transaction, so autocommit mode is required.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers
+revision: str = "014_sync_document_status_enum"
+down_revision: str = "013_drop_previous_version_id"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ADD VALUE IF NOT EXISTS is idempotent — safe if values already present.
+    # Must run outside a transaction block.
+    op.execute("COMMIT")
+    op.execute("ALTER TYPE document_status ADD VALUE IF NOT EXISTS 'pending'")
+    op.execute("ALTER TYPE document_status ADD VALUE IF NOT EXISTS 'archived'")
+
+
+def downgrade() -> None:
+    # PostgreSQL does not support DROP VALUE from an enum type.
+    # Downgrade is a no-op; the extra values are harmless.
+    pass

--- a/src/khora/db/schema.py
+++ b/src/khora/db/schema.py
@@ -1,0 +1,39 @@
+"""Schema synchronisation helpers.
+
+Ensures PostgreSQL enum types stay in sync with their Python counterparts
+across library upgrades, even when ``Base.metadata.create_all`` is used
+(which only creates a type if it doesn't already exist).
+"""
+
+from __future__ import annotations
+
+from loguru import logger
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from khora.core.models.document import DocumentStatus
+
+# Map of PostgreSQL enum type name → Python enum members.
+_ENUM_SYNC: dict[str, list[str]] = {
+    "document_status": [s.value for s in DocumentStatus],
+}
+
+
+async def sync_enum_values(engine: AsyncEngine) -> None:
+    """Add any missing values to PostgreSQL enum types.
+
+    ``ALTER TYPE … ADD VALUE IF NOT EXISTS`` cannot run inside a
+    transaction, so we obtain a connection in *autocommit* mode.
+    """
+    async with engine.connect() as conn:
+        await conn.execution_options(isolation_level="AUTOCOMMIT")
+        for type_name, values in _ENUM_SYNC.items():
+            for value in values:
+                stmt = text(f"ALTER TYPE {type_name} ADD VALUE IF NOT EXISTS :val")
+                try:
+                    await conn.execute(stmt, {"val": value})
+                except Exception:
+                    # Type may not exist yet (first run) — create_all will
+                    # create it with all values.  Log and continue.
+                    logger.debug(f"Skipping enum sync for {type_name}.{value}")
+                    break

--- a/src/khora/db/schema.py
+++ b/src/khora/db/schema.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from loguru import logger
 from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from khora.core.models.document import DocumentStatus
@@ -29,10 +30,10 @@ async def sync_enum_values(engine: AsyncEngine) -> None:
         await conn.execution_options(isolation_level="AUTOCOMMIT")
         for type_name, values in _ENUM_SYNC.items():
             for value in values:
-                stmt = text(f"ALTER TYPE {type_name} ADD VALUE IF NOT EXISTS :val")
+                stmt = text(f"ALTER TYPE {type_name} ADD VALUE IF NOT EXISTS '{value}'")
                 try:
-                    await conn.execute(stmt, {"val": value})
-                except Exception:
+                    await conn.execute(stmt)
+                except ProgrammingError:
                     # Type may not exist yet (first run) — create_all will
                     # create it with all values.  Log and continue.
                     logger.debug(f"Skipping enum sync for {type_name}.{value}")

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -17,6 +17,7 @@ from tenacity import AsyncRetrying, retry_if_exception, stop_after_attempt, wait
 
 from khora.core.models import Chunk, ChunkMetadata
 from khora.db.models import Base, ChunkModel, EntityModel
+from khora.db.schema import sync_enum_values
 from khora.storage.backends.mixins import AsyncSessionMixin
 from khora.telemetry import trace
 
@@ -190,6 +191,7 @@ class PgVectorBackend(AsyncSessionMixin):
             raise RuntimeError("Backend not connected. Call connect() first.")
         async with self._engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
+        await sync_enum_values(self._engine)
 
     # =========================================================================
     # Chunk operations

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -22,6 +22,7 @@ from khora.db.models import (
     MemoryNamespaceModel,
     SyncCheckpointModel,
 )
+from khora.db.schema import sync_enum_values
 from khora.storage.backends.base import PaginatedResult
 from khora.storage.backends.mixins import AsyncSessionMixin, retry_on_deadlock
 
@@ -120,6 +121,7 @@ class PostgreSQLBackend(AsyncSessionMixin):
             raise RuntimeError("Backend not connected. Call connect() first.")
         async with self._engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
+        await sync_enum_values(self._engine)
 
     # =========================================================================
     # Namespace operations

--- a/src/khora/storage/event_store.py
+++ b/src/khora/storage/event_store.py
@@ -16,7 +16,6 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from khora.core.models import MemoryEvent
 from khora.core.models.event import EventType
 from khora.db.models import Base, MemoryEventModel
-from khora.db.schema import sync_enum_values
 from khora.storage.backends.mixins import AsyncSessionMixin
 
 
@@ -110,7 +109,6 @@ class PostgreSQLEventStore(AsyncSessionMixin):
             raise RuntimeError("Event store not connected. Call connect() first.")
         async with self._engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
-        await sync_enum_values(self._engine)
 
     async def append_event(self, event: MemoryEvent, *, session: AsyncSession | None = None) -> MemoryEvent:
         """Append an event to the log."""

--- a/src/khora/storage/event_store.py
+++ b/src/khora/storage/event_store.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from khora.core.models import MemoryEvent
 from khora.core.models.event import EventType
 from khora.db.models import Base, MemoryEventModel
+from khora.db.schema import sync_enum_values
 from khora.storage.backends.mixins import AsyncSessionMixin
 
 
@@ -109,6 +110,7 @@ class PostgreSQLEventStore(AsyncSessionMixin):
             raise RuntimeError("Event store not connected. Call connect() first.")
         async with self._engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
+        await sync_enum_values(self._engine)
 
     async def append_event(self, event: MemoryEvent, *, session: AsyncSession | None = None) -> MemoryEvent:
         """Append an event to the log."""

--- a/tests/unit/test_sync_enum.py
+++ b/tests/unit/test_sync_enum.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock
 
 import pytest
+from sqlalchemy.exc import ProgrammingError
 
 from khora.db.schema import sync_enum_values
 
@@ -36,12 +37,9 @@ async def test_sync_enum_values_executes_alter_type_for_each_value():
 
     # Should have issued ALTER TYPE for each DocumentStatus value
     execute_calls = mock_conn.execute.call_args_list
-    executed_values = [c.args[1]["val"] for c in execute_calls]
-    assert "pending" in executed_values
-    assert "processing" in executed_values
-    assert "completed" in executed_values
-    assert "failed" in executed_values
-    assert "archived" in executed_values
+    executed_stmts = [str(c.args[0].text) for c in execute_calls]
+    for value in ("pending", "processing", "completed", "failed", "archived"):
+        assert any(f"'{value}'" in s for s in executed_stmts), f"missing ALTER for {value}"
 
 
 @pytest.mark.unit
@@ -49,7 +47,7 @@ async def test_sync_enum_values_handles_missing_type_gracefully():
     """If the enum type does not yet exist (first run), sync_enum_values
     should catch the exception and not raise."""
     mock_conn = AsyncMock()
-    mock_conn.execute.side_effect = Exception("type does not exist")
+    mock_conn.execute.side_effect = ProgrammingError("ALTER TYPE", {}, Exception("type does not exist"))
     engine = _make_engine(mock_conn)
 
     # Should not raise

--- a/tests/unit/test_sync_enum.py
+++ b/tests/unit/test_sync_enum.py
@@ -1,0 +1,56 @@
+"""Tests for khora.db.schema – enum synchronisation helpers."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import pytest
+
+from khora.db.schema import sync_enum_values
+
+
+def _make_engine(mock_conn: AsyncMock) -> AsyncMock:
+    """Create a mock AsyncEngine whose .connect() yields *mock_conn*."""
+    engine = AsyncMock()
+
+    @asynccontextmanager
+    async def _connect():
+        yield mock_conn
+
+    engine.connect = _connect
+    return engine
+
+
+@pytest.mark.unit
+async def test_sync_enum_values_executes_alter_type_for_each_value():
+    """sync_enum_values issues ALTER TYPE … ADD VALUE IF NOT EXISTS for every
+    value defined in the _ENUM_SYNC mapping."""
+    mock_conn = AsyncMock()
+    engine = _make_engine(mock_conn)
+
+    await sync_enum_values(engine)
+
+    # Should have called execution_options for autocommit
+    mock_conn.execution_options.assert_called_once_with(isolation_level="AUTOCOMMIT")
+
+    # Should have issued ALTER TYPE for each DocumentStatus value
+    execute_calls = mock_conn.execute.call_args_list
+    executed_values = [c.args[1]["val"] for c in execute_calls]
+    assert "pending" in executed_values
+    assert "processing" in executed_values
+    assert "completed" in executed_values
+    assert "failed" in executed_values
+    assert "archived" in executed_values
+
+
+@pytest.mark.unit
+async def test_sync_enum_values_handles_missing_type_gracefully():
+    """If the enum type does not yet exist (first run), sync_enum_values
+    should catch the exception and not raise."""
+    mock_conn = AsyncMock()
+    mock_conn.execute.side_effect = Exception("type does not exist")
+    engine = _make_engine(mock_conn)
+
+    # Should not raise
+    await sync_enum_values(engine)


### PR DESCRIPTION
## Summary
- Databases created by older Khora versions may lack `pending` and/or `archived` in the PostgreSQL `document_status` enum. Since `Base.metadata.create_all` only creates the type if absent, library upgrades never added the missing values — causing `asyncpg.InvalidTextRepresentationError` on document inserts in downstream consumers (Poros).
- Added `sync_enum_values()` helper (`src/khora/db/schema.py`) that issues `ALTER TYPE … ADD VALUE IF NOT EXISTS` in autocommit mode after `create_all`
- Called from all three `create_tables()` methods: `PostgreSQLBackend`, `PGVectorBackend`, `PostgreSQLEventStore`
- Added Alembic migration `014_sync_document_status_enum` for managed deployments
- Added unit tests for the new helper

## Test plan
- [x] Unit tests pass (1585 passed)
- [x] Lint + type check clean (`make lint`)
- [x] Coverage ≥30% (52.84%)
- [ ] Manual verification: deploy to staging and confirm documents with `status='pending'` insert successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)