### PR TITLE
DYT-645: Add LLMUsage type, usage accumulator, and response enrichment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,21 +10,15 @@ LINEAR_TEAM: {TEAM_KEY}
 
 <!-- LINEAR_TEAM: the Linear team key used for branch names and issue refs (e.g., ENG) -->
 
-## Project Overview
+## Commands
 
-<!-- Replace with 2-3 sentences describing what this project does, who it serves, -->
-<!-- and any critical context an agent or new contributor needs up front.          -->
-
-## Tech Stack
-
-<!-- Replace with the actual stack. Add or remove lines as needed. -->
-
-- **Language:** {e.g., TypeScript, Python, Go}
-- **Framework:** {e.g., Next.js, FastAPI, Gin}
-- **Database:** {e.g., PostgreSQL, DynamoDB}
-- **ORM / Query layer:** {e.g., Prisma, SQLAlchemy, raw SQL}
-- **Package manager:** {e.g., pnpm, uv, go modules}
-- **Infra / Hosting:** {e.g., Vercel, AWS, Fly.io}
+```bash
+make test              # Run tests (pytest, coverage ≥30%)
+make format            # Format code (black, isort, ruff)
+make lint              # Lint + typecheck (ruff, ty)
+make dev               # Start local databases (postgres + neo4j)
+uv run alembic upgrade head  # Run migrations
+```
 
 ## Architecture
 
@@ -53,6 +47,7 @@ MemoryLake (facade) → Engine (graphrag | skeleton | vectorcypher) → StorageC
 - `_accel.py` — Rust/NumPy/Python acceleration facade (MMR, cosine, `detect_temporal_category()`, BM25, etc.)
 - `engines/vectorcypher/temporal_detection.py` — `TemporalDetector`, category-specific `RetrievalParams` for VectorCypher recall
 - `pipelines/flows/ingest.py` — Document ingestion pipeline with entity ID mapping
+- `db/migrations/env.py` — Alembic env with advisory locking and programmatic config
 
 ## Engine Selection
 
@@ -62,26 +57,24 @@ MemoryLake (facade) → Engine (graphrag | skeleton | vectorcypher) → StorageC
 | Multi-hop queries, complex relationships | `vectorcypher` | Vector + Cypher hybrid, requires Neo4j |
 | Chat history, event streams, cost-sensitive | `skeleton` | Temporal-first, 5-10x fewer LLM calls, Neo4j optional |
 
-## Tech Stack
-
-<!-- Replace with the actual stack. Add or remove lines as needed. -->
-
-- **Language:** {e.g., TypeScript, Python, Go}
-- **Framework:** {e.g., Next.js, FastAPI, Gin}
-- **Database:** {e.g., PostgreSQL, DynamoDB}
-- **ORM / Query layer:** {e.g., Prisma, SQLAlchemy, raw SQL}
-- **Package manager:** {e.g., pnpm, uv, go modules}
-- **Infra / Hosting:** {e.g., Vercel, AWS, Fly.io}
-
-## Commands
+## Testing
 
 ```bash
-make test              # Run tests (pytest, coverage ≥30%)
-make format            # Format code (black, isort, ruff)
-make lint              # Lint + typecheck (ruff, ty)
-make dev               # Start local databases (postgres + neo4j)
-uv run alembic upgrade head  # Run migrations
+uv run pytest tests/unit/ -v               # Unit tests only
+uv run pytest -k "test_remember" -v         # By name
+uv run pytest tests/unit/test_memory_lake.py  # Single file
 ```
+
+Markers: `@pytest.mark.unit`, `@pytest.mark.integration`, `@pytest.mark.e2e`. Async tests use `asyncio_mode = "auto"`.
+
+## Version Bumps
+
+IMPORTANT: When bumping the version, always update **all four files** and regenerate lockfiles:
+1. `pyproject.toml` — khora version
+2. `src/khora/__init__.py` — `__version__`
+3. `rust/khora-accel/Cargo.toml` — khora-accel version
+4. `rust/khora-accel/pyproject.toml` — khora-accel version
+5. Run `uv lock` and `cargo generate-lockfile` in `rust/khora-accel/`
 
 ## Claude Code Settings
 
@@ -236,24 +229,21 @@ The recommended command sequence for feature development:
 
 Default team profiles are deployed to `.ttoj/templates/team-profiles/` and referenced by the `/team:*` commands. To customize team composition for this project, edit the deployed profiles or create project-specific overrides in `.claude/commands/team/`.
 
-## Testing
+## AI Changelog
 
-```bash
-uv run pytest tests/unit/ -v               # Unit tests only
-uv run pytest -k "test_remember" -v         # By name
-uv run pytest tests/unit/test_memory_lake.py  # Single file
+After every completed task, append an entry to `docs/AI_CHANGELOG.md`. Create the file if it doesn't exist.
+
+### Format
+
+```
+- YYYY-MM-DD: TICKET-ID: Brief description of change
 ```
 
-Markers: `@pytest.mark.unit`, `@pytest.mark.integration`, `@pytest.mark.e2e`. Async tests use `asyncio_mode = "auto"`.
-
-## Version Bumps
-
-IMPORTANT: When bumping the version, always update **all four files** and regenerate lockfiles:
-1. `pyproject.toml` — khora version
-2. `src/khora/__init__.py` — `__version__`
-3. `rust/khora-accel/Cargo.toml` — khora-accel version
-4. `rust/khora-accel/pyproject.toml` — khora-accel version
-5. Run `uv lock` and `cargo generate-lockfile` in `rust/khora-accel/`
+- One line per task, max 72 characters.
+- Use the Linear ticket ID (e.g., `DYT-42`) when available.
+- If there is no ticket, omit the ticket ID: `- YYYY-MM-DD: Brief description of change`.
+- Append new entries at the bottom of the file.
+- Do not edit or remove existing entries.
 
 ## Conventions
 
@@ -278,5 +268,8 @@ IMPORTANT: When bumping the version, always update **all four files** and regene
 - **Entity unique constraint** — `entities(namespace_id, name, entity_type)` has a UNIQUE constraint (migration 008). Entity upserts use `ON CONFLICT` on this constraint. Dedup migration is irreversible
 - **Pre-normalized embeddings** — All embeddings are L2-normalized at ingest time. Scoring uses `batch_dot_product` instead of `batch_cosine_similarity` for ~3x speedup. Dot product of unit vectors = cosine similarity
 - **MMR diversity enabled by default** — `enable_diversity=True` in `QuerySettings`. The MMR stage runs in Rust via `_accel.mmr_diversity_select` with NumPy and pure-Python fallbacks
-- **`include_sources` on read methods** — `recall()`, `get_entity()`, `list_entities()`, `find_related_entities()`, and `search_entities()` accept `include_sources: bool = False`. When `False`, no extra query runs — zero overhead. When `True`, `_populate_sources()` batch-fetches `DocumentSource` metadata (chunked at 1 000 IDs) and populates `chunk.source_document` and `entity.source_documents` in-place
+- **`include_sources` on read methods** — `recall()`, `get_entity()`, `list_entities()`, `find_related_entities()`, and `search_entities()` accept `include_sources: bool = False`. When `False` (default), no extra query runs — zero overhead. When `True`, `_populate_sources()` batch-fetches `DocumentSource` metadata (chunked at 1 000 IDs) and populates `chunk.source_document`, `entity.source_documents`, and `relationship.source_documents` in-place
 - **`ty` type checker** — Pre-commit hook runs `ty check src/` which passes clean (`All checks passed!`). If ty fails on your changes, fix the diagnostics before committing
+- **Migrations are bundled** — Alembic migrations live in `src/khora/db/migrations/`, not `alembic/`. Root `alembic.ini` is for dev CLI only. Programmatic usage via `run_migrations(database_url)` or `MemoryLake(run_migrations=True)` needs no `.ini` file
+- **Dedicated version table** — Khora uses `khora_alembic_version` (not `alembic_version`) to avoid conflicts with downstream apps. Existing deployments must run all migrations fresh against the new version table (clean cut)
+- **Migration advisory lock** — `run_migrations()` acquires `pg_advisory_xact_lock(LOCK_ID)` where `LOCK_ID = int.from_bytes(hashlib.md5(b"khora_migrations").digest()[:8], "big", signed=True)` (= `6001515088189075507`). 60s timeout. Safe for concurrent startups

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,15 +10,21 @@ LINEAR_TEAM: {TEAM_KEY}
 
 <!-- LINEAR_TEAM: the Linear team key used for branch names and issue refs (e.g., ENG) -->
 
-## Commands
+## Project Overview
 
-```bash
-make test              # Run tests (pytest, coverage ≥30%)
-make format            # Format code (black, isort, ruff)
-make lint              # Lint + typecheck (ruff, ty)
-make dev               # Start local databases (postgres + neo4j)
-uv run alembic upgrade head  # Run migrations
-```
+<!-- Replace with 2-3 sentences describing what this project does, who it serves, -->
+<!-- and any critical context an agent or new contributor needs up front.          -->
+
+## Tech Stack
+
+<!-- Replace with the actual stack. Add or remove lines as needed. -->
+
+- **Language:** {e.g., TypeScript, Python, Go}
+- **Framework:** {e.g., Next.js, FastAPI, Gin}
+- **Database:** {e.g., PostgreSQL, DynamoDB}
+- **ORM / Query layer:** {e.g., Prisma, SQLAlchemy, raw SQL}
+- **Package manager:** {e.g., pnpm, uv, go modules}
+- **Infra / Hosting:** {e.g., Vercel, AWS, Fly.io}
 
 ## Architecture
 
@@ -47,7 +53,6 @@ MemoryLake (facade) → Engine (graphrag | skeleton | vectorcypher) → StorageC
 - `_accel.py` — Rust/NumPy/Python acceleration facade (MMR, cosine, `detect_temporal_category()`, BM25, etc.)
 - `engines/vectorcypher/temporal_detection.py` — `TemporalDetector`, category-specific `RetrievalParams` for VectorCypher recall
 - `pipelines/flows/ingest.py` — Document ingestion pipeline with entity ID mapping
-- `db/migrations/env.py` — Alembic env with advisory locking and programmatic config
 
 ## Engine Selection
 
@@ -57,24 +62,26 @@ MemoryLake (facade) → Engine (graphrag | skeleton | vectorcypher) → StorageC
 | Multi-hop queries, complex relationships | `vectorcypher` | Vector + Cypher hybrid, requires Neo4j |
 | Chat history, event streams, cost-sensitive | `skeleton` | Temporal-first, 5-10x fewer LLM calls, Neo4j optional |
 
-## Testing
+## Tech Stack
+
+<!-- Replace with the actual stack. Add or remove lines as needed. -->
+
+- **Language:** {e.g., TypeScript, Python, Go}
+- **Framework:** {e.g., Next.js, FastAPI, Gin}
+- **Database:** {e.g., PostgreSQL, DynamoDB}
+- **ORM / Query layer:** {e.g., Prisma, SQLAlchemy, raw SQL}
+- **Package manager:** {e.g., pnpm, uv, go modules}
+- **Infra / Hosting:** {e.g., Vercel, AWS, Fly.io}
+
+## Commands
 
 ```bash
-uv run pytest tests/unit/ -v               # Unit tests only
-uv run pytest -k "test_remember" -v         # By name
-uv run pytest tests/unit/test_memory_lake.py  # Single file
+make test              # Run tests (pytest, coverage ≥30%)
+make format            # Format code (black, isort, ruff)
+make lint              # Lint + typecheck (ruff, ty)
+make dev               # Start local databases (postgres + neo4j)
+uv run alembic upgrade head  # Run migrations
 ```
-
-Markers: `@pytest.mark.unit`, `@pytest.mark.integration`, `@pytest.mark.e2e`. Async tests use `asyncio_mode = "auto"`.
-
-## Version Bumps
-
-IMPORTANT: When bumping the version, always update **all four files** and regenerate lockfiles:
-1. `pyproject.toml` — khora version
-2. `src/khora/__init__.py` — `__version__`
-3. `rust/khora-accel/Cargo.toml` — khora-accel version
-4. `rust/khora-accel/pyproject.toml` — khora-accel version
-5. Run `uv lock` and `cargo generate-lockfile` in `rust/khora-accel/`
 
 ## Claude Code Settings
 
@@ -229,21 +236,24 @@ The recommended command sequence for feature development:
 
 Default team profiles are deployed to `.ttoj/templates/team-profiles/` and referenced by the `/team:*` commands. To customize team composition for this project, edit the deployed profiles or create project-specific overrides in `.claude/commands/team/`.
 
-## AI Changelog
+## Testing
 
-After every completed task, append an entry to `docs/AI_CHANGELOG.md`. Create the file if it doesn't exist.
-
-### Format
-
-```
-- YYYY-MM-DD: TICKET-ID: Brief description of change
+```bash
+uv run pytest tests/unit/ -v               # Unit tests only
+uv run pytest -k "test_remember" -v         # By name
+uv run pytest tests/unit/test_memory_lake.py  # Single file
 ```
 
-- One line per task, max 72 characters.
-- Use the Linear ticket ID (e.g., `DYT-42`) when available.
-- If there is no ticket, omit the ticket ID: `- YYYY-MM-DD: Brief description of change`.
-- Append new entries at the bottom of the file.
-- Do not edit or remove existing entries.
+Markers: `@pytest.mark.unit`, `@pytest.mark.integration`, `@pytest.mark.e2e`. Async tests use `asyncio_mode = "auto"`.
+
+## Version Bumps
+
+IMPORTANT: When bumping the version, always update **all four files** and regenerate lockfiles:
+1. `pyproject.toml` — khora version
+2. `src/khora/__init__.py` — `__version__`
+3. `rust/khora-accel/Cargo.toml` — khora-accel version
+4. `rust/khora-accel/pyproject.toml` — khora-accel version
+5. Run `uv lock` and `cargo generate-lockfile` in `rust/khora-accel/`
 
 ## Conventions
 
@@ -268,8 +278,5 @@ After every completed task, append an entry to `docs/AI_CHANGELOG.md`. Create th
 - **Entity unique constraint** — `entities(namespace_id, name, entity_type)` has a UNIQUE constraint (migration 008). Entity upserts use `ON CONFLICT` on this constraint. Dedup migration is irreversible
 - **Pre-normalized embeddings** — All embeddings are L2-normalized at ingest time. Scoring uses `batch_dot_product` instead of `batch_cosine_similarity` for ~3x speedup. Dot product of unit vectors = cosine similarity
 - **MMR diversity enabled by default** — `enable_diversity=True` in `QuerySettings`. The MMR stage runs in Rust via `_accel.mmr_diversity_select` with NumPy and pure-Python fallbacks
-- **`include_sources` on read methods** — `recall()`, `get_entity()`, `list_entities()`, `find_related_entities()`, and `search_entities()` accept `include_sources: bool = False`. When `False` (default), no extra query runs — zero overhead. When `True`, `_populate_sources()` batch-fetches `DocumentSource` metadata (chunked at 1 000 IDs) and populates `chunk.source_document`, `entity.source_documents`, and `relationship.source_documents` in-place
+- **`include_sources` on read methods** — `recall()`, `get_entity()`, `list_entities()`, `find_related_entities()`, and `search_entities()` accept `include_sources: bool = False`. When `False`, no extra query runs — zero overhead. When `True`, `_populate_sources()` batch-fetches `DocumentSource` metadata (chunked at 1 000 IDs) and populates `chunk.source_document` and `entity.source_documents` in-place
 - **`ty` type checker** — Pre-commit hook runs `ty check src/` which passes clean (`All checks passed!`). If ty fails on your changes, fix the diagnostics before committing
-- **Migrations are bundled** — Alembic migrations live in `src/khora/db/migrations/`, not `alembic/`. Root `alembic.ini` is for dev CLI only. Programmatic usage via `run_migrations(database_url)` or `MemoryLake(run_migrations=True)` needs no `.ini` file
-- **Dedicated version table** — Khora uses `khora_alembic_version` (not `alembic_version`) to avoid conflicts with downstream apps. Existing deployments must run all migrations fresh against the new version table (clean cut)
-- **Migration advisory lock** — `run_migrations()` acquires `pg_advisory_xact_lock(LOCK_ID)` where `LOCK_ID = int.from_bytes(hashlib.md5(b"khora_migrations").digest()[:8], "big", signed=True)` (= `6001515088189075507`). 60s timeout. Safe for concurrent startups

--- a/docs/AI_CHANGELOG.md
+++ b/docs/AI_CHANGELOG.md
@@ -1,0 +1,3 @@
+# AI Changelog
+
+- 2026-03-20: DYT-645: Add LLMUsage type, usage accumulator, response enrichment

--- a/src/khora/__init__.py
+++ b/src/khora/__init__.py
@@ -38,7 +38,7 @@ from .cli import main
 from .config import KhoraConfig
 from .core.models.document import DocumentSource
 from .engines import create_engine, list_engines, register_engine
-from .memory_lake import BatchResult, MemoryLake, RecallResult, RememberResult, Stats
+from .memory_lake import BatchResult, LLMUsage, MemoryLake, RecallResult, RememberResult, Stats
 from .query import SearchMode
 
 __version__ = "0.4.0"
@@ -46,6 +46,7 @@ __version__ = "0.4.0"
 __all__ = [
     "main",
     "MemoryLake",
+    "LLMUsage",
     "RememberResult",
     "RecallResult",
     "BatchResult",

--- a/src/khora/config/llm.py
+++ b/src/khora/config/llm.py
@@ -284,6 +284,9 @@ async def acompletion(
         latency_ms=_latency,
     )
 
+    # DYT-645: Extractors call litellm.acompletion() directly, not this helper.
+    # If they switch to this helper, remove their own record_usage() calls to
+    # avoid double-counting.
     from khora.memory_lake import LLMUsage
     from khora.telemetry.context import record_usage
 
@@ -354,6 +357,9 @@ async def aembedding(
         metadata={"batch_size": len(text)},
     )
 
+    # DYT-645: Embedders call litellm.aembedding() directly, not this helper.
+    # If they switch to this helper, remove their own record_usage() calls to
+    # avoid double-counting.
     from khora.memory_lake import LLMUsage
     from khora.telemetry.context import record_usage
 

--- a/src/khora/config/llm.py
+++ b/src/khora/config/llm.py
@@ -271,13 +271,31 @@ async def acompletion(
     from khora.telemetry import get_collector
 
     usage = getattr(response, "usage", None)
+    _prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
+    _completion_tokens = getattr(usage, "completion_tokens", 0) or 0
+    _total_tokens = getattr(usage, "total_tokens", 0) or 0
+    _operation = kwargs.get("_telemetry_op", "completion")
     get_collector().record_llm_call(
-        operation=kwargs.get("_telemetry_op", "completion"),
+        operation=_operation,
         model=config.model,
-        prompt_tokens=getattr(usage, "prompt_tokens", 0) or 0,
-        completion_tokens=getattr(usage, "completion_tokens", 0) or 0,
-        total_tokens=getattr(usage, "total_tokens", 0) or 0,
+        prompt_tokens=_prompt_tokens,
+        completion_tokens=_completion_tokens,
+        total_tokens=_total_tokens,
         latency_ms=_latency,
+    )
+
+    from khora.memory_lake import LLMUsage
+    from khora.telemetry.context import record_usage
+
+    record_usage(
+        LLMUsage(
+            operation=_operation,
+            model=config.model,
+            prompt_tokens=_prompt_tokens,
+            completion_tokens=_completion_tokens,
+            total_tokens=_total_tokens,
+            latency_ms=_latency,
+        )
     )
 
     return response.choices[0].message.content
@@ -325,13 +343,30 @@ async def aembedding(
     from khora.telemetry import get_collector
 
     usage = getattr(response, "usage", None)
+    _prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
+    _total_tokens = getattr(usage, "total_tokens", 0) or 0
     get_collector().record_llm_call(
         operation="embedding",
         model=config.embedding_model,
-        prompt_tokens=getattr(usage, "prompt_tokens", 0) or 0,
-        total_tokens=getattr(usage, "total_tokens", 0) or 0,
+        prompt_tokens=_prompt_tokens,
+        total_tokens=_total_tokens,
         latency_ms=_latency,
         metadata={"batch_size": len(text)},
+    )
+
+    from khora.memory_lake import LLMUsage
+    from khora.telemetry.context import record_usage
+
+    record_usage(
+        LLMUsage(
+            operation="embedding",
+            model=config.embedding_model,
+            prompt_tokens=_prompt_tokens,
+            completion_tokens=0,
+            total_tokens=_total_tokens,
+            latency_ms=_latency,
+            batch_size=len(text),
+        )
     )
 
     return [item["embedding"] for item in response.data]

--- a/src/khora/extraction/embedders/litellm.py
+++ b/src/khora/extraction/embedders/litellm.py
@@ -393,6 +393,21 @@ class LiteLLMEmbedder(Embedder):
                         cache_hit=False,
                     )
 
+                    from khora.memory_lake import LLMUsage
+                    from khora.telemetry.context import record_usage
+
+                    record_usage(
+                        LLMUsage(
+                            operation="embedding",
+                            model=self._model,
+                            prompt_tokens=prompt_tokens,
+                            completion_tokens=0,
+                            total_tokens=total_tokens,
+                            latency_ms=_latency,
+                            batch_size=len(texts),
+                        )
+                    )
+
                 result = [item["embedding"] for item in response.data]
 
                 # Validate embedding dimension on first successful call

--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -705,13 +705,30 @@ class LLMEntityExtractor(EntityExtractor):
 
                         # Record telemetry
                         usage = getattr(response, "usage", None)
+                        _pt = getattr(usage, "prompt_tokens", 0) or 0
+                        _ct = getattr(usage, "completion_tokens", 0) or 0
+                        _tt = getattr(usage, "total_tokens", 0) or 0
                         get_collector().record_llm_call(
                             operation="entity_extraction",
                             model=self._model,
-                            prompt_tokens=getattr(usage, "prompt_tokens", 0) or 0,
-                            completion_tokens=getattr(usage, "completion_tokens", 0) or 0,
-                            total_tokens=getattr(usage, "total_tokens", 0) or 0,
+                            prompt_tokens=_pt,
+                            completion_tokens=_ct,
+                            total_tokens=_tt,
                             latency_ms=_latency,
+                        )
+
+                        from khora.memory_lake import LLMUsage
+                        from khora.telemetry.context import record_usage
+
+                        record_usage(
+                            LLMUsage(
+                                operation="entity_extraction",
+                                model=self._model,
+                                prompt_tokens=_pt,
+                                completion_tokens=_ct,
+                                total_tokens=_tt,
+                                latency_ms=_latency,
+                            )
                         )
 
                     content = response.choices[0].message.content
@@ -829,13 +846,30 @@ class LLMEntityExtractor(EntityExtractor):
                 _latency = (_time.perf_counter() - _t0) * 1000
 
                 usage = getattr(response, "usage", None)
+                _pt = getattr(usage, "prompt_tokens", 0) or 0
+                _ct = getattr(usage, "completion_tokens", 0) or 0
+                _tt = getattr(usage, "total_tokens", 0) or 0
                 get_collector().record_llm_call(
                     operation="relationship_extraction_second_pass",
                     model=self._model,
-                    prompt_tokens=getattr(usage, "prompt_tokens", 0) or 0,
-                    completion_tokens=getattr(usage, "completion_tokens", 0) or 0,
-                    total_tokens=getattr(usage, "total_tokens", 0) or 0,
+                    prompt_tokens=_pt,
+                    completion_tokens=_ct,
+                    total_tokens=_tt,
                     latency_ms=_latency,
+                )
+
+                from khora.memory_lake import LLMUsage
+                from khora.telemetry.context import record_usage
+
+                record_usage(
+                    LLMUsage(
+                        operation="relationship_extraction_second_pass",
+                        model=self._model,
+                        prompt_tokens=_pt,
+                        completion_tokens=_ct,
+                        total_tokens=_tt,
+                        latency_ms=_latency,
+                    )
                 )
 
             content = response.choices[0].message.content
@@ -1425,14 +1459,32 @@ Return ONLY valid JSON, no other text."""
 
                         # Record telemetry
                         usage = getattr(response, "usage", None)
+                        _pt = getattr(usage, "prompt_tokens", 0) or 0
+                        _ct = getattr(usage, "completion_tokens", 0) or 0
+                        _tt = getattr(usage, "total_tokens", 0) or 0
                         get_collector().record_llm_call(
                             operation="entity_extraction_multi",
                             model=self._model,
-                            prompt_tokens=getattr(usage, "prompt_tokens", 0) or 0,
-                            completion_tokens=getattr(usage, "completion_tokens", 0) or 0,
-                            total_tokens=getattr(usage, "total_tokens", 0) or 0,
+                            prompt_tokens=_pt,
+                            completion_tokens=_ct,
+                            total_tokens=_tt,
                             latency_ms=_latency,
                             metadata={"batch_size": len(texts)},
+                        )
+
+                        from khora.memory_lake import LLMUsage
+                        from khora.telemetry.context import record_usage
+
+                        record_usage(
+                            LLMUsage(
+                                operation="entity_extraction_multi",
+                                model=self._model,
+                                prompt_tokens=_pt,
+                                completion_tokens=_ct,
+                                total_tokens=_tt,
+                                latency_ms=_latency,
+                                batch_size=len(texts),
+                            )
                         )
 
                     content = response.choices[0].message.content

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -403,10 +403,8 @@ class MemoryLake:
                     relationship_types=relationship_types,
                 )
                 return replace(result, llm_usage=collect_usage())
-        except Exception:
-            collect_usage()  # clean up context var on failure
-            raise
         finally:
+            collect_usage()  # idempotent — drains queue if not already collected
             clear_trace_id()
 
     async def remember_batch(
@@ -478,10 +476,8 @@ class MemoryLake:
                     relationship_types=relationship_types,
                 )
                 return replace(result, llm_usage=collect_usage())
-        except Exception:
-            collect_usage()  # clean up context var on failure
-            raise
         finally:
+            collect_usage()  # idempotent — drains queue if not already collected
             clear_trace_id()
 
     async def recall(
@@ -559,10 +555,8 @@ class MemoryLake:
                 if include_sources:
                     await self._populate_sources(result.chunks, result.entities, result.relationships)
                 return replace(result, llm_usage=collect_usage())
-        except Exception:
-            collect_usage()  # clean up context var on failure
-            raise
         finally:
+            collect_usage()  # idempotent — drains queue if not already collected
             clear_trace_id()
 
     async def forget(

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -28,6 +28,28 @@ if TYPE_CHECKING:
     from khora.storage import StorageConfig, StorageCoordinator
 
 
+# DYT-645: LLMUsage is a public API type consumed by Poros (DYT-650) and Peras (DYT-651).
+# Changes to field names or types require coordination with those projects.
+@dataclass(slots=True, frozen=True)
+class LLMUsage:
+    """A single LLM API call's token usage.
+
+    Read-only value object — Khora produces it, consumers read it.
+    """
+
+    operation: str
+    """Logical operation name (e.g. "entity_extraction", "embedding")."""
+    model: str
+    """Model identifier (e.g. "gpt-4o", "text-embedding-3-small")."""
+    prompt_tokens: int
+    completion_tokens: int
+    """0 for embeddings."""
+    total_tokens: int
+    latency_ms: float
+    batch_size: int = 1
+    """>1 for embedding batches."""
+
+
 @dataclass(slots=True, frozen=True)
 class RememberResult:
     """Result of a remember operation."""
@@ -38,6 +60,7 @@ class RememberResult:
     entities_extracted: int
     relationships_created: int
     metadata: dict[str, Any] = field(default_factory=dict)
+    llm_usage: list[LLMUsage] = field(default_factory=list)
 
 
 @dataclass(slots=True, frozen=True)
@@ -52,6 +75,7 @@ class BatchResult:
     entities: int
     relationships: int
     metadata: dict[str, Any] = field(default_factory=dict)
+    llm_usage: list[LLMUsage] = field(default_factory=list)
 
 
 @dataclass(slots=True, frozen=True)
@@ -88,6 +112,7 @@ class RecallResult:
     context_text: str
     metadata: dict[str, Any] = field(default_factory=dict)
     relationships: list[tuple[Relationship, float]] = field(default_factory=list)
+    llm_usage: list[LLMUsage] = field(default_factory=list)
 
 
 class MemoryLake:
@@ -353,13 +378,21 @@ class MemoryLake:
         Returns:
             RememberResult with details
         """
-        from khora.telemetry.context import clear_trace_id, ensure_trace_id
+        from dataclasses import replace
+
+        from khora.telemetry.context import (
+            clear_trace_id,
+            collect_usage,
+            ensure_trace_id,
+            start_usage_collection,
+        )
 
         ensure_trace_id()
+        start_usage_collection()
         try:
             namespace_id = await self._resolve_namespace(namespace)
             with trace_span("khora.remember", namespace_id=str(namespace_id), content_length=len(content)):
-                return await self._get_engine().remember(
+                result = await self._get_engine().remember(
                     content,
                     namespace_id,
                     title=title,
@@ -369,6 +402,10 @@ class MemoryLake:
                     entity_types=entity_types,
                     relationship_types=relationship_types,
                 )
+                return replace(result, llm_usage=collect_usage())
+        except Exception:
+            collect_usage()  # clean up context var on failure
+            raise
         finally:
             clear_trace_id()
 
@@ -415,13 +452,21 @@ class MemoryLake:
         Returns:
             BatchResult with aggregated statistics
         """
-        from khora.telemetry.context import clear_trace_id, ensure_trace_id
+        from dataclasses import replace
+
+        from khora.telemetry.context import (
+            clear_trace_id,
+            collect_usage,
+            ensure_trace_id,
+            start_usage_collection,
+        )
 
         ensure_trace_id()
+        start_usage_collection()
         try:
             namespace_id = await self._resolve_namespace(namespace)
             with trace_span("khora.remember_batch", namespace_id=str(namespace_id), batch_size=len(documents)):
-                return await self._get_engine().remember_batch(
+                result = await self._get_engine().remember_batch(
                     documents,
                     namespace_id,
                     skill_name=skill_name,
@@ -432,6 +477,10 @@ class MemoryLake:
                     entity_types=entity_types,
                     relationship_types=relationship_types,
                 )
+                return replace(result, llm_usage=collect_usage())
+        except Exception:
+            collect_usage()  # clean up context var on failure
+            raise
         finally:
             clear_trace_id()
 
@@ -484,9 +533,17 @@ class MemoryLake:
             engine, ``relationships`` contains scored relationship tuples and
             ``context_text`` includes a ``--- Relationships ---`` section.
         """
-        from khora.telemetry.context import clear_trace_id, ensure_trace_id
+        from dataclasses import replace
+
+        from khora.telemetry.context import (
+            clear_trace_id,
+            collect_usage,
+            ensure_trace_id,
+            start_usage_collection,
+        )
 
         ensure_trace_id()
+        start_usage_collection()
         try:
             namespace_id = await self._resolve_namespace(namespace)
             with trace_span("khora.recall", namespace_id=str(namespace_id), query=query):
@@ -501,7 +558,10 @@ class MemoryLake:
                 )
                 if include_sources:
                     await self._populate_sources(result.chunks, result.entities, result.relationships)
-                return result
+                return replace(result, llm_usage=collect_usage())
+        except Exception:
+            collect_usage()  # clean up context var on failure
+            raise
         finally:
             clear_trace_id()
 

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
@@ -378,8 +378,6 @@ class MemoryLake:
         Returns:
             RememberResult with details
         """
-        from dataclasses import replace
-
         from khora.telemetry.context import (
             clear_trace_id,
             collect_usage,
@@ -450,8 +448,6 @@ class MemoryLake:
         Returns:
             BatchResult with aggregated statistics
         """
-        from dataclasses import replace
-
         from khora.telemetry.context import (
             clear_trace_id,
             collect_usage,
@@ -529,8 +525,6 @@ class MemoryLake:
             engine, ``relationships`` contains scored relationship tuples and
             ``context_text`` includes a ``--- Relationships ---`` section.
         """
-        from dataclasses import replace
-
         from khora.telemetry.context import (
             clear_trace_id,
             collect_usage,

--- a/src/khora/telemetry/__init__.py
+++ b/src/khora/telemetry/__init__.py
@@ -23,7 +23,15 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from .collector import TelemetryCollector
-from .context import clear_trace_id, ensure_trace_id, get_trace_id, set_trace_id
+from .context import (
+    clear_trace_id,
+    collect_usage,
+    ensure_trace_id,
+    get_trace_id,
+    record_usage,
+    set_trace_id,
+    start_usage_collection,
+)
 from .logfire_integration import trace_span
 from .noop import NoOpCollector
 from .trace_decorator import trace
@@ -41,6 +49,9 @@ __all__ = [
     "set_trace_id",
     "ensure_trace_id",
     "clear_trace_id",
+    "start_usage_collection",
+    "record_usage",
+    "collect_usage",
     "trace_span",
     "trace",
 ]

--- a/src/khora/telemetry/context.py
+++ b/src/khora/telemetry/context.py
@@ -3,6 +3,9 @@
 Provides request-level trace_id and parent_event_id propagation through
 the async call stack without threading parameters through every function.
 
+Also provides a request-scoped LLMUsage accumulator via asyncio.Queue
+for collecting usage data across concurrent asyncio.gather() calls.
+
 Usage::
 
     from khora.telemetry.context import set_trace_id, ensure_trace_id
@@ -12,15 +15,28 @@ Usage::
 
     # Downstream code automatically inherits trace_id:
     trace_id = get_trace_id()  # returns the UUID set above
+
+    # Usage accumulation:
+    from khora.telemetry.context import start_usage_collection, record_usage, collect_usage
+
+    start_usage_collection()
+    # ... LLM calls record_usage(usage) internally ...
+    entries = collect_usage()  # drains queue, resets contextvar
 """
 
 from __future__ import annotations
 
+import asyncio
 from contextvars import ContextVar
+from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
+
+if TYPE_CHECKING:
+    from khora.memory_lake import LLMUsage
 
 _trace_id_var: ContextVar[UUID | None] = ContextVar("khora_trace_id", default=None)
 _parent_event_id_var: ContextVar[int | None] = ContextVar("khora_parent_event_id", default=None)
+_usage_accumulator: ContextVar[asyncio.Queue[LLMUsage] | None] = ContextVar("khora_usage_accumulator", default=None)
 
 
 def get_trace_id() -> UUID | None:
@@ -60,3 +76,44 @@ def set_parent_event_id(event_id: int | None) -> None:
 def clear_parent_event_id() -> None:
     """Clear the parent event ID."""
     _parent_event_id_var.set(None)
+
+
+# ---------------------------------------------------------------------------
+# Request-scoped LLM usage accumulator
+# ---------------------------------------------------------------------------
+
+
+def start_usage_collection() -> None:
+    """Create a new asyncio.Queue in the contextvar for this request scope.
+
+    Call at the start of a MemoryLake facade method (remember, recall, etc.).
+    """
+    _usage_accumulator.set(asyncio.Queue())
+
+
+def record_usage(usage: LLMUsage) -> None:
+    """Record a single LLMUsage entry into the current request's queue.
+
+    No-op if ``start_usage_collection()`` was not called (i.e. when Khora
+    internals are invoked outside the MemoryLake facade).
+
+    ``put_nowait()`` is safe under cooperative multitasking (asyncio.gather).
+    """
+    q = _usage_accumulator.get()
+    if q is not None:
+        q.put_nowait(usage)
+
+
+def collect_usage() -> list[LLMUsage]:
+    """Drain the queue and reset the contextvar.
+
+    Returns an empty list if collection was never started.
+    """
+    q = _usage_accumulator.get()
+    _usage_accumulator.set(None)
+    if q is None:
+        return []
+    entries: list[LLMUsage] = []
+    while not q.empty():
+        entries.append(q.get_nowait())
+    return entries

--- a/tests/unit/test_llm_usage.py
+++ b/tests/unit/test_llm_usage.py
@@ -1,0 +1,232 @@
+"""Unit tests for LLMUsage dataclass and request-scoped usage accumulator."""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+import pytest
+
+from khora.memory_lake import BatchResult, LLMUsage, RecallResult, RememberResult
+
+# ---------------------------------------------------------------------------
+# LLMUsage dataclass (DYT-646)
+# ---------------------------------------------------------------------------
+
+
+class TestLLMUsage:
+    """Tests for the LLMUsage frozen dataclass."""
+
+    def test_fields(self) -> None:
+        u = LLMUsage(
+            operation="entity_extraction",
+            model="gpt-4o",
+            prompt_tokens=100,
+            completion_tokens=200,
+            total_tokens=300,
+            latency_ms=812.3,
+        )
+        assert u.operation == "entity_extraction"
+        assert u.model == "gpt-4o"
+        assert u.prompt_tokens == 100
+        assert u.completion_tokens == 200
+        assert u.total_tokens == 300
+        assert u.latency_ms == 812.3
+        assert u.batch_size == 1  # default
+
+    def test_batch_size(self) -> None:
+        u = LLMUsage(
+            operation="embedding",
+            model="text-embedding-3-small",
+            prompt_tokens=50,
+            completion_tokens=0,
+            total_tokens=50,
+            latency_ms=100.0,
+            batch_size=10,
+        )
+        assert u.batch_size == 10
+
+    def test_frozen(self) -> None:
+        u = LLMUsage(
+            operation="embedding",
+            model="m",
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            latency_ms=0.0,
+        )
+        with pytest.raises(AttributeError):
+            u.operation = "other"  # type: ignore[misc]
+
+    def test_importable_from_public_api(self) -> None:
+        from khora import LLMUsage as PublicLLMUsage
+
+        assert PublicLLMUsage is LLMUsage
+
+
+# ---------------------------------------------------------------------------
+# Result types include llm_usage field (DYT-649)
+# ---------------------------------------------------------------------------
+
+
+class TestResultLLMUsageField:
+    """Verify llm_usage field on all result types defaults to empty list."""
+
+    def test_remember_result_default(self) -> None:
+        r = RememberResult(
+            document_id=uuid4(),
+            namespace_id=uuid4(),
+            chunks_created=1,
+            entities_extracted=1,
+            relationships_created=0,
+        )
+        assert r.llm_usage == []
+
+    def test_batch_result_default(self) -> None:
+        r = BatchResult(
+            total=5,
+            processed=5,
+            skipped=0,
+            failed=0,
+            chunks=10,
+            entities=3,
+            relationships=2,
+        )
+        assert r.llm_usage == []
+
+    def test_recall_result_default(self) -> None:
+        r = RecallResult(
+            query="test",
+            namespace_id=uuid4(),
+            chunks=[],
+            entities=[],
+            context_text="",
+        )
+        assert r.llm_usage == []
+
+    def test_remember_result_with_usage(self) -> None:
+        usage = [
+            LLMUsage(
+                operation="entity_extraction",
+                model="gpt-4o",
+                prompt_tokens=100,
+                completion_tokens=200,
+                total_tokens=300,
+                latency_ms=500.0,
+            )
+        ]
+        r = RememberResult(
+            document_id=uuid4(),
+            namespace_id=uuid4(),
+            chunks_created=1,
+            entities_extracted=1,
+            relationships_created=0,
+            llm_usage=usage,
+        )
+        assert len(r.llm_usage) == 1
+        assert r.llm_usage[0].operation == "entity_extraction"
+
+
+# ---------------------------------------------------------------------------
+# Usage accumulator (DYT-647)
+# ---------------------------------------------------------------------------
+
+
+class TestUsageAccumulator:
+    """Tests for the request-scoped usage accumulator."""
+
+    def test_collect_without_start_returns_empty(self) -> None:
+        from khora.telemetry.context import collect_usage
+
+        assert collect_usage() == []
+
+    def test_start_record_collect(self) -> None:
+        from khora.telemetry.context import (
+            collect_usage,
+            record_usage,
+            start_usage_collection,
+        )
+
+        start_usage_collection()
+        u = LLMUsage(
+            operation="test",
+            model="m",
+            prompt_tokens=1,
+            completion_tokens=2,
+            total_tokens=3,
+            latency_ms=10.0,
+        )
+        record_usage(u)
+        result = collect_usage()
+        assert len(result) == 1
+        assert result[0] is u
+
+    def test_collect_resets_contextvar(self) -> None:
+        from khora.telemetry.context import (
+            collect_usage,
+            record_usage,
+            start_usage_collection,
+        )
+
+        start_usage_collection()
+        record_usage(
+            LLMUsage(
+                operation="a",
+                model="m",
+                prompt_tokens=0,
+                completion_tokens=0,
+                total_tokens=0,
+                latency_ms=0.0,
+            )
+        )
+        collect_usage()
+        # Second collect should return empty (contextvar reset)
+        assert collect_usage() == []
+
+    def test_record_without_start_is_noop(self) -> None:
+        from khora.telemetry.context import collect_usage, record_usage
+
+        # Should not raise
+        record_usage(
+            LLMUsage(
+                operation="a",
+                model="m",
+                prompt_tokens=0,
+                completion_tokens=0,
+                total_tokens=0,
+                latency_ms=0.0,
+            )
+        )
+        assert collect_usage() == []
+
+    @pytest.mark.asyncio
+    async def test_concurrent_gather_no_loss(self) -> None:
+        """Concurrent asyncio.gather() tasks all accumulate into the same queue."""
+        from khora.telemetry.context import (
+            collect_usage,
+            record_usage,
+            start_usage_collection,
+        )
+
+        start_usage_collection()
+
+        async def record_n(n: int) -> None:
+            for i in range(n):
+                record_usage(
+                    LLMUsage(
+                        operation=f"op_{i}",
+                        model="m",
+                        prompt_tokens=i,
+                        completion_tokens=0,
+                        total_tokens=i,
+                        latency_ms=float(i),
+                    )
+                )
+                # Yield control to simulate real async work
+                await asyncio.sleep(0)
+
+        # 10 concurrent tasks, each recording 5 entries = 50 total
+        await asyncio.gather(*(record_n(5) for _ in range(10)))
+
+        result = collect_usage()
+        assert len(result) == 50

--- a/tests/unit/test_memory_lake.py
+++ b/tests/unit/test_memory_lake.py
@@ -362,7 +362,7 @@ class TestRemember:
                 relationship_types=["WORKS_FOR", "KNOWS", "LOCATED_IN"],
             )
 
-        assert result is mock_result
+        assert result == mock_result
         lake._engine.remember.assert_awaited_once()
 
 

--- a/tests/unit/test_memory_lake.py
+++ b/tests/unit/test_memory_lake.py
@@ -363,6 +363,7 @@ class TestRemember:
             )
 
         assert result == mock_result
+        assert result.llm_usage == []
         lake._engine.remember.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary
- Add `LLMUsage` frozen dataclass to Khora public API (operation, model, prompt_tokens, completion_tokens, total_tokens, latency_ms, batch_size)
- Add request-scoped `asyncio.Queue` accumulator via `contextvars` (`start_usage_collection()`, `record_usage()`, `collect_usage()`) in `telemetry/context.py`
- Add `record_usage()` calls at all LLM call sites: entity extraction (single, multi, relationship second-pass), embedding (API calls only, not cache hits), and shared `acompletion`/`aembedding` helpers
- Add `llm_usage: list[LLMUsage]` field to `BatchResult`, `RememberResult`, `RecallResult` with empty list default
- Wrap `MemoryLake.remember()`, `remember_batch()`, `recall()` with usage collection via `dataclasses.replace()`
- Context var cleaned up on exception paths

**Note:** `LLMUsage` is a public API type consumed by Poros (DYT-650) and Peras (DYT-651). Field changes require coordination.

## Test plan
- [x] Unit tests for `LLMUsage` dataclass (frozen, slotted, fields, public API import)
- [x] Unit tests for all three result types with `llm_usage` default and explicit values
- [x] Unit tests for accumulator lifecycle (start/record/collect, no-op without start, reset after collect)
- [x] Concurrent `asyncio.gather()` test: 10 tasks × 5 entries = 50, no loss
- [x] Existing `test_memory_lake.py` tests pass (66 tests, one `is` → `==` fix for `replace()`)
- [x] Full unit suite: 1879 passed, 53% coverage
- [x] Lint + typecheck clean (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)