### PR TITLE
DYT-761: Widen extraction_config_hash to VARCHAR(255)

### DIFF
--- a/docs/AI_CHANGELOG.md
+++ b/docs/AI_CHANGELOG.md
@@ -4,3 +4,4 @@
 - 2026-03-21: DYT-697: Add expertise API pass-through to MemoryLake
 - 2026-03-22: DYT-752: Add extraction_config_hash column + migration
 - 2026-03-22: DYT-753: Deprecate create_tables/init_db, add migration drift CI
+- 2026-03-22: DYT-761: Widen extraction_config_hash to VARCHAR(255)

--- a/src/khora/core/models/document.py
+++ b/src/khora/core/models/document.py
@@ -76,11 +76,11 @@ class Document:
     entity_count: int = 0
     error_message: str | None = None
 
-    # Extraction config tracking (SHA-256 hex digest, max 64 chars)
+    # Extraction config tracking (supports SHA-512, compound keys, etc.)
     extraction_config_hash: str | None = None
 
-    # Maximum length for extraction_config_hash (matches DB column String(64))
-    _EXTRACTION_HASH_MAX_LEN: int = field(default=64, init=False, repr=False, compare=False)
+    # Maximum length for extraction_config_hash (matches DB column String(255))
+    _EXTRACTION_HASH_MAX_LEN: int = field(default=255, init=False, repr=False, compare=False)
 
     # Timestamps
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))

--- a/src/khora/core/models/document.py
+++ b/src/khora/core/models/document.py
@@ -76,7 +76,7 @@ class Document:
     entity_count: int = 0
     error_message: str | None = None
 
-    # Extraction config tracking (supports SHA-512, compound keys, etc.)
+    # Extraction config tracking (max 255 chars; accommodates compound keys)
     extraction_config_hash: str | None = None
 
     # Maximum length for extraction_config_hash (matches DB column String(255))

--- a/src/khora/db/migrations/versions/016_widen_extraction_config_hash.py
+++ b/src/khora/db/migrations/versions/016_widen_extraction_config_hash.py
@@ -1,0 +1,40 @@
+"""Widen extraction_config_hash from VARCHAR(64) to VARCHAR(255).
+
+Revision ID: 016_widen_extraction_config_hash
+Revises: 015_add_extraction_config_hash
+Create Date: 2026-03-22
+
+DYT-761: The original DYT-697 widening was reverted by the DYT-752 merge.
+VARCHAR(255) accommodates SHA-512, compound keys, and other hash algorithms.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers
+revision: str = "016_widen_extraction_config_hash"
+down_revision: str = "015_add_extraction_config_hash"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "documents",
+        "extraction_config_hash",
+        existing_type=sa.String(64),
+        type_=sa.String(255),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "documents",
+        "extraction_config_hash",
+        existing_type=sa.String(255),
+        type_=sa.String(64),
+        existing_nullable=True,
+    )

--- a/src/khora/db/migrations/versions/016_widen_extraction_config_hash.py
+++ b/src/khora/db/migrations/versions/016_widen_extraction_config_hash.py
@@ -31,6 +31,14 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Truncate any hashes longer than 64 chars before shrinking the column,
+    # so the ALTER doesn't fail or silently truncate on strict databases.
+    op.execute(
+        sa.text(
+            "UPDATE documents SET extraction_config_hash = LEFT(extraction_config_hash, 64) "
+            "WHERE LENGTH(extraction_config_hash) > 64"
+        )
+    )
     op.alter_column(
         "documents",
         "extraction_config_hash",

--- a/src/khora/db/migrations/versions/016_widen_extraction_config_hash.py
+++ b/src/khora/db/migrations/versions/016_widen_extraction_config_hash.py
@@ -5,7 +5,7 @@ Revises: 015_add_extraction_config_hash
 Create Date: 2026-03-22
 
 DYT-761: The original DYT-697 widening was reverted by the DYT-752 merge.
-VARCHAR(255) accommodates SHA-512, compound keys, and other hash algorithms.
+VARCHAR(255) accommodates compound keys and longer hash algorithms.
 """
 
 from collections.abc import Sequence

--- a/src/khora/db/models.py
+++ b/src/khora/db/models.py
@@ -151,7 +151,7 @@ class DocumentModel(Base):
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Ontology-aware re-extraction (ADR-018)
-    extraction_config_hash: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
+    extraction_config_hash: Mapped[str | None] = mapped_column(String(255), nullable=True, index=True)
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))

--- a/tests/unit/test_expertise_passthrough.py
+++ b/tests/unit/test_expertise_passthrough.py
@@ -283,23 +283,23 @@ class TestDocumentModelExtractionConfigHash:
         assert hasattr(DocumentModel, "extraction_config_hash")
         col = DocumentModel.__table__.columns["extraction_config_hash"]
         assert col.nullable is True
-        assert col.type.length == 64
+        assert col.type.length == 255
 
     def test_extraction_config_hash_rejects_overlength(self) -> None:
-        """extraction_config_hash longer than 64 chars raises ValueError."""
+        """extraction_config_hash longer than 255 chars raises ValueError."""
         import pytest
 
         from khora.core.models.document import Document
 
-        with pytest.raises(ValueError, match="at most 64 characters"):
-            Document(content="test", extraction_config_hash="x" * 65)
+        with pytest.raises(ValueError, match="at most 255 characters"):
+            Document(content="test", extraction_config_hash="x" * 256)
 
-    def test_extraction_config_hash_accepts_64_chars(self) -> None:
-        """extraction_config_hash of exactly 64 chars is accepted."""
+    def test_extraction_config_hash_accepts_255_chars(self) -> None:
+        """extraction_config_hash of exactly 255 chars is accepted."""
         from khora.core.models.document import Document
 
-        doc = Document(content="test", extraction_config_hash="a" * 64)
-        assert len(doc.extraction_config_hash) == 64  # type: ignore[arg-type]
+        doc = Document(content="test", extraction_config_hash="a" * 255)
+        assert len(doc.extraction_config_hash) == 255  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -380,14 +380,14 @@ class TestMigrationPackageStructure:
         assert env_path.exists(), f"env.py not found at {env_path}"
 
     @pytest.mark.unit
-    def test_versions_dir_has_16_files(self):
-        """versions/ directory contains 16 migration files."""
+    def test_versions_dir_has_17_files(self):
+        """versions/ directory contains 17 migration files."""
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
         # Filter out __pycache__ and __init__
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
-        assert len(migration_files) == 16, (
-            f"Expected 16 migration files, found {len(migration_files)}: " f"{[f.name for f in migration_files]}"
+        assert len(migration_files) == 17, (
+            f"Expected 17 migration files, found {len(migration_files)}: " f"{[f.name for f in migration_files]}"
         )
 
     @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Adds migration 016 to `ALTER COLUMN documents.extraction_config_hash` from `VARCHAR(64)` to `VARCHAR(255)`
- Updates `DocumentModel` in `db/models.py` to `String(255)`
- Updates domain model `Document` max-length validation from 64 to 255
- Fixes a regression from DYT-752 merge that reverted the original DYT-697 widening

## Test plan
- [x] All 1910 unit tests pass
- [x] Migration chain test validates contiguous 000→016 revision chain
- [x] Migration drift test confirms ORM and migrations are in sync
- [x] Migration file count test updated for 17 migration files
- [x] Domain model validation tests updated for 255-char limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)