### PR TITLE
DYT-766: Add Neo4j connection pool tuning for Aura compatibility

### DIFF
--- a/src/khora/config/schema.py
+++ b/src/khora/config/schema.py
@@ -62,6 +62,16 @@ class Neo4jConfig(BaseModel):
     password: str = Field(default="", description="Neo4j password")
     database: str = Field(default="neo4j", description="Neo4j database name")
     max_connection_pool_size: int = Field(default=100, description="Neo4j connection pool size")
+    max_connection_lifetime: int = Field(
+        default=900,
+        description="Max seconds a connection stays in the pool before rotation. "
+        "Set below the server-side TTL (e.g. Aura ~20min) to avoid reset errors.",
+    )
+    liveness_check_timeout: float | None = Field(
+        default=30.0,
+        description="Seconds of idle time after which connections are checked for liveness "
+        "before being returned from the pool. None disables the check.",
+    )
     connection_acquisition_timeout: float = Field(
         default=60.0, description="Timeout in seconds waiting for a connection from the pool"
     )

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -292,10 +292,19 @@ class VectorCypherEngine:
 
         neo4j_cfg = self._config.get_graph_config()
         pool_size = getattr(neo4j_cfg, "max_connection_pool_size", 100) if neo4j_cfg else 100
+        max_lifetime = getattr(neo4j_cfg, "max_connection_lifetime", 900) if neo4j_cfg else 900
+        liveness_timeout = getattr(neo4j_cfg, "liveness_check_timeout", 30.0) if neo4j_cfg else 30.0
+        driver_kwargs: dict[str, object] = {
+            "max_connection_pool_size": pool_size,
+            "max_connection_lifetime": max_lifetime,
+            "keep_alive": True,
+        }
+        if liveness_timeout is not None:
+            driver_kwargs["liveness_check_timeout"] = liveness_timeout
         self._neo4j_driver = AsyncGraphDatabase.driver(
             neo4j_url,
             auth=(self._config.get_neo4j_user(), self._config.get_neo4j_password()),
-            max_connection_pool_size=pool_size,
+            **driver_kwargs,
         )
         await self._neo4j_driver.verify_connectivity()
 

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -201,6 +201,8 @@ class Neo4jBackend(GraphBackendBase):
         password: str = "",
         database: str = "neo4j",
         max_connection_pool_size: int = 100,
+        max_connection_lifetime: int = 900,
+        liveness_check_timeout: float | None = 30.0,
         connection_acquisition_timeout: float = 60.0,
         retry_delay_jitter_factor: float = 0.5,
         entity_write_concurrency: int = _DEFAULT_ENTITY_WRITE_CONCURRENCY,
@@ -214,6 +216,8 @@ class Neo4jBackend(GraphBackendBase):
             password: Database password
             database: Database name
             max_connection_pool_size: Maximum connection pool size
+            max_connection_lifetime: Max seconds before a pooled connection is rotated
+            liveness_check_timeout: Idle seconds before a connection is checked for liveness
             connection_acquisition_timeout: Timeout waiting for a connection from the pool
             retry_delay_jitter_factor: Jitter factor for transaction retry delays (0.0-1.0)
             entity_write_concurrency: Max concurrent entity write transactions
@@ -224,6 +228,8 @@ class Neo4jBackend(GraphBackendBase):
         self._password = password
         self._database = database
         self._max_connection_pool_size = max_connection_pool_size
+        self._max_connection_lifetime = max_connection_lifetime
+        self._liveness_check_timeout = liveness_check_timeout
         self._connection_acquisition_timeout = connection_acquisition_timeout
         self._retry_delay_jitter_factor = retry_delay_jitter_factor
         self._driver: AsyncDriver | None = None
@@ -240,6 +246,8 @@ class Neo4jBackend(GraphBackendBase):
             password=config.password,
             database=config.database,
             max_connection_pool_size=getattr(config, "max_connection_pool_size", 100),
+            max_connection_lifetime=getattr(config, "max_connection_lifetime", 900),
+            liveness_check_timeout=getattr(config, "liveness_check_timeout", 30.0),
             connection_acquisition_timeout=getattr(config, "connection_acquisition_timeout", 60.0),
             retry_delay_jitter_factor=getattr(config, "retry_delay_jitter_factor", 0.5),
             entity_write_concurrency=getattr(config, "entity_write_concurrency", _DEFAULT_ENTITY_WRITE_CONCURRENCY),
@@ -277,6 +285,8 @@ class Neo4jBackend(GraphBackendBase):
         instance._password = ""
         instance._database = database
         instance._max_connection_pool_size = 0
+        instance._max_connection_lifetime = 900
+        instance._liveness_check_timeout = 30.0
         instance._connection_acquisition_timeout = 60.0
         instance._retry_delay_jitter_factor = 0.5
         instance._driver = driver
@@ -293,12 +303,19 @@ class Neo4jBackend(GraphBackendBase):
             return
 
         logger.info(f"Connecting to Neo4j at {self._url}...")
+        driver_kwargs: dict[str, Any] = {
+            "max_connection_pool_size": self._max_connection_pool_size,
+            "max_connection_lifetime": self._max_connection_lifetime,
+            "connection_acquisition_timeout": self._connection_acquisition_timeout,
+            "retry_delay_jitter_factor": self._retry_delay_jitter_factor,
+            "keep_alive": True,
+        }
+        if self._liveness_check_timeout is not None:
+            driver_kwargs["liveness_check_timeout"] = self._liveness_check_timeout
         self._driver = AsyncGraphDatabase.driver(
             self._url,
             auth=(self._user, self._password),
-            max_connection_pool_size=self._max_connection_pool_size,
-            connection_acquisition_timeout=self._connection_acquisition_timeout,
-            retry_delay_jitter_factor=self._retry_delay_jitter_factor,
+            **driver_kwargs,
         )
         # Verify connectivity
         await self._driver.verify_connectivity()


### PR DESCRIPTION
## Summary
- Add `max_connection_lifetime` (default 900s) and `liveness_check_timeout` (default 30s) to `Neo4jConfig`
- Pass these parameters through to `AsyncGraphDatabase.driver()` in both `Neo4jBackend.connect()` and `VectorCypherEngine.connect()`
- Explicitly set `keep_alive=True` on all driver instantiations
- Fixes recurring ~20min `ConnectionResetError` bursts on Neo4j Aura (`f23f62d3`) affecting both poros and peras

## Context
Neo4j Aura (or network infrastructure on the path) resets idle connections after ~20 minutes. The previous driver defaults (`max_connection_lifetime=3600s`, `liveness_check_timeout=None`) meant connections lingered well past the server-side TTL, causing periodic `ConnectionResetError(104, 'Connection reset by peer')` across all cluster nodes simultaneously.

## Test plan
- [x] All 1910 unit tests pass
- [ ] Deploy to staging and monitor for absence of `ConnectionResetError` spikes over 1+ hour window
- [ ] Verify bridge poll cycle times stay within 60s interval consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)