### PR TITLE
DYT-768: Add max_connection_lifetime and liveness_check_timeout to Neo4j driver config

### DIFF
--- a/docs/AI_CHANGELOG.md
+++ b/docs/AI_CHANGELOG.md
@@ -5,3 +5,4 @@
 - 2026-03-22: DYT-752: Add extraction_config_hash column + migration
 - 2026-03-22: DYT-753: Deprecate create_tables/init_db, add migration drift CI
 - 2026-03-22: DYT-761: Widen extraction_config_hash to VARCHAR(255)
+- 2026-03-22: DYT-768: Add Neo4j connection lifetime and liveness config

--- a/src/khora/config/schema.py
+++ b/src/khora/config/schema.py
@@ -68,6 +68,16 @@ class Neo4jConfig(BaseModel):
     retry_delay_jitter_factor: float = Field(
         default=0.5, description="Jitter factor for transaction retry delays (0.0-1.0)"
     )
+    max_connection_lifetime: int = Field(
+        default=900,
+        description="Max seconds a connection stays in the pool before rotation. "
+        "Set below the server-side TTL (e.g. Aura ~20min) to avoid reset errors.",
+    )
+    liveness_check_timeout: float | None = Field(
+        default=30.0,
+        description="Seconds of idle time after which connections are checked for liveness "
+        "before being returned from the pool. None disables the check.",
+    )
     entity_write_concurrency: int = Field(default=12, description="Max concurrent entity write transactions")
     relationship_write_concurrency: int = Field(default=8, description="Max concurrent relationship write transactions")
 

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -292,10 +292,15 @@ class VectorCypherEngine:
 
         neo4j_cfg = self._config.get_graph_config()
         pool_size = getattr(neo4j_cfg, "max_connection_pool_size", 100) if neo4j_cfg else 100
+        max_conn_lifetime = getattr(neo4j_cfg, "max_connection_lifetime", 900) if neo4j_cfg else 900
+        liveness_timeout = getattr(neo4j_cfg, "liveness_check_timeout", 30.0) if neo4j_cfg else 30.0
         self._neo4j_driver = AsyncGraphDatabase.driver(
             neo4j_url,
             auth=(self._config.get_neo4j_user(), self._config.get_neo4j_password()),
             max_connection_pool_size=pool_size,
+            max_connection_lifetime=max_conn_lifetime,
+            liveness_check_timeout=liveness_timeout,
+            keep_alive=True,
         )
         await self._neo4j_driver.verify_connectivity()
 

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -203,6 +203,8 @@ class Neo4jBackend(GraphBackendBase):
         max_connection_pool_size: int = 100,
         connection_acquisition_timeout: float = 60.0,
         retry_delay_jitter_factor: float = 0.5,
+        max_connection_lifetime: int = 900,
+        liveness_check_timeout: float | None = 30.0,
         entity_write_concurrency: int = _DEFAULT_ENTITY_WRITE_CONCURRENCY,
         relationship_write_concurrency: int = _DEFAULT_RELATIONSHIP_WRITE_CONCURRENCY,
     ) -> None:
@@ -216,6 +218,8 @@ class Neo4jBackend(GraphBackendBase):
             max_connection_pool_size: Maximum connection pool size
             connection_acquisition_timeout: Timeout waiting for a connection from the pool
             retry_delay_jitter_factor: Jitter factor for transaction retry delays (0.0-1.0)
+            max_connection_lifetime: Max seconds a connection stays in the pool before rotation
+            liveness_check_timeout: Seconds of idle time before liveness check (None disables)
             entity_write_concurrency: Max concurrent entity write transactions
             relationship_write_concurrency: Max concurrent relationship write transactions
         """
@@ -226,6 +230,8 @@ class Neo4jBackend(GraphBackendBase):
         self._max_connection_pool_size = max_connection_pool_size
         self._connection_acquisition_timeout = connection_acquisition_timeout
         self._retry_delay_jitter_factor = retry_delay_jitter_factor
+        self._max_connection_lifetime = max_connection_lifetime
+        self._liveness_check_timeout = liveness_check_timeout
         self._driver: AsyncDriver | None = None
         self._owns_driver: bool = True
         self._entity_key_gate = _EntityKeyGate(max_concurrent=entity_write_concurrency)
@@ -242,6 +248,8 @@ class Neo4jBackend(GraphBackendBase):
             max_connection_pool_size=getattr(config, "max_connection_pool_size", 100),
             connection_acquisition_timeout=getattr(config, "connection_acquisition_timeout", 60.0),
             retry_delay_jitter_factor=getattr(config, "retry_delay_jitter_factor", 0.5),
+            max_connection_lifetime=getattr(config, "max_connection_lifetime", 900),
+            liveness_check_timeout=getattr(config, "liveness_check_timeout", 30.0),
             entity_write_concurrency=getattr(config, "entity_write_concurrency", _DEFAULT_ENTITY_WRITE_CONCURRENCY),
             relationship_write_concurrency=getattr(
                 config, "relationship_write_concurrency", _DEFAULT_RELATIONSHIP_WRITE_CONCURRENCY
@@ -279,6 +287,8 @@ class Neo4jBackend(GraphBackendBase):
         instance._max_connection_pool_size = 0
         instance._connection_acquisition_timeout = 60.0
         instance._retry_delay_jitter_factor = 0.5
+        instance._max_connection_lifetime = 900
+        instance._liveness_check_timeout = 30.0
         instance._driver = driver
         instance._owns_driver = False
         instance._entity_key_gate = _EntityKeyGate(max_concurrent=entity_write_concurrency)
@@ -299,6 +309,9 @@ class Neo4jBackend(GraphBackendBase):
             max_connection_pool_size=self._max_connection_pool_size,
             connection_acquisition_timeout=self._connection_acquisition_timeout,
             retry_delay_jitter_factor=self._retry_delay_jitter_factor,
+            max_connection_lifetime=self._max_connection_lifetime,
+            liveness_check_timeout=self._liveness_check_timeout,
+            keep_alive=True,
         )
         # Verify connectivity
         await self._driver.verify_connectivity()


### PR DESCRIPTION
## Summary
- Add `max_connection_lifetime` (default 900s) and `liveness_check_timeout` (default 30s) fields to `Neo4jConfig`
- Pass both params through `Neo4jBackend.__init__`, `from_config`, and `connect()` to `AsyncGraphDatabase.driver()`
- Pass both params in `VectorCypherEngine.connect()` driver instantiation
- Explicitly set `keep_alive=True` on all `AsyncGraphDatabase.driver()` calls
- Prevents periodic `ConnectionResetError` bursts on Neo4j Aura by rotating connections before the server-side TTL (~20min)

## Test plan
- [x] All 1935 unit tests pass
- [x] Lint passes (pre-existing ty diagnostics only)
- [x] Defaults are backwards-compatible — no config changes needed for existing deployments
- [ ] Verify on Aura: connection reset errors should stop after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)