### PR TITLE
DYT-830: Fix temporal query performance with expression index

### DIFF
--- a/src/khora/db/migrations/versions/017_temporal_coalesce_index.py
+++ b/src/khora/db/migrations/versions/017_temporal_coalesce_index.py
@@ -1,0 +1,36 @@
+"""Add expression index for temporal COALESCE queries.
+
+Revision ID: 017_temporal_coalesce_index
+Revises: 016_widen_extraction_config_hash
+Create Date: 2026-03-23
+
+DYT-830: Temporal queries ("what happened in last 7 days?") take 40+ seconds
+because search_similar and search_fulltext filter on
+COALESCE(source_timestamp, created_at) but no index covers that expression.
+PostgreSQL cannot use the existing (namespace_id, created_at) or
+(namespace_id, source_timestamp) B-tree indexes for COALESCE, so every
+temporal query does a sequential scan.
+
+This adds a composite expression index that matches the exact COALESCE
+used in the WHERE clauses, enabling index range scans.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "017_temporal_coalesce_index"
+down_revision: str = "016_widen_extraction_config_hash"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_chunks_ns_temporal "
+        "ON chunks (namespace_id, (COALESCE(source_timestamp, created_at)))"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_chunks_ns_temporal")

--- a/src/khora/query/engine.py
+++ b/src/khora/query/engine.py
@@ -2239,12 +2239,14 @@ class HybridQueryEngine:
 
         result: list[tuple[Any, float]] = []
         for chunk, score in chunks:
-            created_at = getattr(chunk, "created_at", None)
-            if created_at is None:
+            # Use source_timestamp when available, matching the SQL
+            # COALESCE(source_timestamp, created_at) pushdown.
+            effective_ts = getattr(chunk, "source_timestamp", None) or getattr(chunk, "created_at", None)
+            if effective_ts is None:
                 result.append((chunk, score))
                 continue
 
-            ts = _dt_to_epoch(_TF._normalize_tz(created_at))
+            ts = _dt_to_epoch(_TF._normalize_tz(effective_ts))
             if ts is None:
                 result.append((chunk, score))
                 continue

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -380,14 +380,14 @@ class TestMigrationPackageStructure:
         assert env_path.exists(), f"env.py not found at {env_path}"
 
     @pytest.mark.unit
-    def test_versions_dir_has_17_files(self):
-        """versions/ directory contains 17 migration files."""
+    def test_versions_dir_has_18_files(self):
+        """versions/ directory contains 18 migration files."""
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
         # Filter out __pycache__ and __init__
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
-        assert len(migration_files) == 17, (
-            f"Expected 17 migration files, found {len(migration_files)}: " f"{[f.name for f in migration_files]}"
+        assert len(migration_files) == 18, (
+            f"Expected 18 migration files, found {len(migration_files)}: " f"{[f.name for f in migration_files]}"
         )
 
     @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Temporal queries ("what happened in last 7 days?") were timing out at 40+ seconds because `search_similar` and `search_fulltext` filter on `COALESCE(source_timestamp, created_at)` but no index covers that expression — PostgreSQL falls back to sequential scan
- Added migration 017: composite expression index on `(namespace_id, COALESCE(source_timestamp, created_at))` enabling index range scans
- Fixed `_soft_temporal_score` to use `source_timestamp` when available, matching the SQL COALESCE behavior (previously only checked `created_at`, causing scoring inconsistency with the SQL pushdown)

## Test plan
- [x] All 1909 unit tests pass
- [x] Lint and format clean
- [ ] Run `uv run alembic upgrade head` on staging to apply migration 017
- [ ] Verify with `EXPLAIN ANALYZE` that temporal queries use `ix_chunks_ns_temporal` index
- [ ] Confirm query latency drops from 40s+ to sub-second

🤖 Generated with [Claude Code](https://claude.com/claude-code)