### PR TITLE
DYT-882: Add publish workflows for CodeArtifact

### DIFF
--- a/.github/workflows/publish-accel.yml
+++ b/.github/workflows/publish-accel.yml
@@ -80,6 +80,9 @@ jobs:
           args: --release --out dist
           working-directory: rust/khora-accel
           manylinux: auto
+          # sccache caches compiled Rust artifacts across runs, cutting rebuild times
+          # significantly for incremental changes (retries, re-runs, close version bumps).
+          sccache: 'true'
 
       # Upload the built wheel so the publish job can download all of them.
       # Each artifact is named by target to avoid collisions.

--- a/.github/workflows/publish-accel.yml
+++ b/.github/workflows/publish-accel.yml
@@ -1,0 +1,139 @@
+# Publish khora-accel native wheels to AWS CodeArtifact.
+#
+# khora-accel is a Rust/PyO3 extension that provides accelerated operations (MMR,
+# cosine similarity, BM25, etc.). It must be compiled per-platform, so this workflow
+# uses a build matrix to produce wheels for 4 targets:
+#   - Linux x86_64   (ubuntu-latest, native compilation)
+#   - Linux aarch64  (ubuntu-latest, cross-compiled via maturin/zig)
+#   - macOS x86_64   (macos-13, the last Intel runner)
+#   - macOS aarch64  (macos-latest, Apple Silicon)
+#
+# The build job compiles wheels in parallel, uploads them as artifacts, then a single
+# publish job downloads all wheels and uploads them to CodeArtifact in one batch.
+#
+# Authentication: GitHub OIDC federation (same pattern as publish.yml).
+# Concurrency: separate group (publish-accel) so it doesn't block the pure-Python
+# publish workflow. cancel-in-progress: false to avoid partial uploads.
+
+name: Publish khora-accel to CodeArtifact
+
+on:
+  push:
+    tags:
+      # Matches v0.5.0, v1.0.0, v2.0.0-rc1, etc.
+      - "v[0-9]*"
+  workflow_dispatch:
+
+# OIDC requires id-token:write; contents:read for checkout.
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: publish-accel
+  # Don't cancel an in-flight publish — let it finish to avoid partial uploads.
+  cancel-in-progress: false
+
+jobs:
+  # ==========================================================================
+  # Build: compile native wheels for each platform target in parallel.
+  # Each matrix entry produces one .whl file uploaded as a GitHub Actions artifact.
+  # ==========================================================================
+  build:
+    strategy:
+      # Don't fail-fast: if one platform fails, still build the others so we can
+      # publish partial platform coverage rather than nothing.
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            # Cross-compiled from x86_64 runner using maturin's built-in zig linker.
+            target: aarch64-unknown-linux-gnu
+          - os: macos-13
+            # macos-13 is the last GitHub-hosted Intel macOS runner.
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            # macos-latest = Apple Silicon (M-series) runner.
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      # PyO3/maturin-action handles Rust toolchain installation, cross-compilation
+      # setup (zig for Linux aarch64), and maturin invocation.
+      # The crate requires Rust 1.83+ (see rust/khora-accel/Cargo.toml rust-version).
+      # manylinux: auto lets maturin pick the appropriate manylinux tag for Linux.
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          working-directory: rust/khora-accel
+          manylinux: auto
+
+      # Upload the built wheel so the publish job can download all of them.
+      # Each artifact is named by target to avoid collisions.
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.target }}
+          path: rust/khora-accel/dist/*.whl
+
+  # ==========================================================================
+  # Publish: download all platform wheels and upload to CodeArtifact in one batch.
+  # Runs only after all build matrix jobs succeed.
+  # ==========================================================================
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      # Download all wheel-* artifacts into a single dist/ directory.
+      # merge-multiple: true flattens them so twine sees all .whl files.
+      - name: Download all wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheel-*
+          merge-multiple: true
+          path: dist/
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      # Only twine is needed in the publish job — no build tools required.
+      - name: Install twine
+        run: uv pip install twine --system
+
+      # Exchange the GitHub OIDC token for temporary AWS credentials.
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::956322716887:role/github-actions-codeartifact-publish
+          aws-region: us-west-2
+
+      # Fetch a CodeArtifact auth token and mask it in CI logs.
+      - name: Get CodeArtifact authorization token
+        run: |
+          TOKEN=$(aws codeartifact get-authorization-token --domain deyta --query authorizationToken --output text)
+          echo "::add-mask::$TOKEN"
+          echo "CA_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+
+      # Upload all platform wheels to CodeArtifact in a single twine invocation.
+      - name: Publish to CodeArtifact
+        run: |
+          twine upload \
+            --repository-url https://deyta-956322716887.d.codeartifact.us-west-2.amazonaws.com/pypi/packages/ \
+            --username aws \
+            --password "${{ env.CA_TOKEN }}" \
+            dist/*

--- a/.github/workflows/publish-accel.yml
+++ b/.github/workflows/publish-accel.yml
@@ -41,8 +41,9 @@ jobs:
   # ==========================================================================
   build:
     strategy:
-      # Don't fail-fast: if one platform fails, still build the others so we can
-      # publish partial platform coverage rather than nothing.
+      # Don't fail-fast: if one platform fails, the others still complete so their
+      # build logs are available for debugging. Note: the publish job requires ALL
+      # builds to succeed (needs: build), so a single platform failure blocks publish.
       fail-fast: false
       matrix:
         include:

--- a/.github/workflows/publish-accel.yml
+++ b/.github/workflows/publish-accel.yml
@@ -64,6 +64,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # Extract the version from the git tag (e.g. v0.5.0 → 0.5.0) and stamp it
+      # into Cargo.toml so the built wheel carries the correct version.
+      # This makes the git tag the single source of truth — no manual version
+      # bumps in Cargo.toml are needed.
+      - name: Set version from tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "Publishing khora-accel version: $VERSION"
+          sed -i.bak "s/^version = .*/version = \"$VERSION\"/" rust/khora-accel/Cargo.toml
+          rm -f rust/khora-accel/Cargo.toml.bak
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Full history required for hatch-vcs to derive version from git tags.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -71,8 +74,8 @@ jobs:
           echo "CA_TOKEN=$TOKEN" >> "$GITHUB_ENV"
 
       # Use `python -m build` directly — NOT `uv run python -m build`.
-      # uv run creates a venv and may not find the build backend (uv_build) on the
-      # system path. This was a lesson learned from deyta-core PR #17.
+      # uv run creates a project venv where build/twine aren't installed.
+      # hatch-vcs reads the version from the most recent git tag automatically.
       - name: Build wheel
         run: python -m build
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,11 +38,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          # fetch-depth: 0 fetches full history. Not strictly required since khora's
-          # version is hardcoded in pyproject.toml (no hatch-vcs), but included as a
-          # safety measure in case version inference is added later.
-          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,93 @@
+# Publish the pure-Python khora wheel to AWS CodeArtifact.
+#
+# Trigger: any tag matching v[0-9]* (e.g. v0.5.0, v1.0.0-rc1) plus manual dispatch.
+# The CI workflow (ci.yml) also fires on v* tags, so tests run in parallel with publish.
+#
+# Authentication uses GitHub OIDC federation — no long-lived AWS credentials are stored
+# in repository secrets. The GitHub Actions runner exchanges its OIDC JWT for short-lived
+# AWS credentials scoped to the codeartifact-publish IAM role.
+#
+# Concurrency: only one publish job runs at a time (group: publish). We set
+# cancel-in-progress: false so that if two tags are pushed quickly, the second waits
+# rather than cancelling the first — avoiding partial/missing uploads.
+
+name: Publish khora to CodeArtifact
+
+on:
+  push:
+    tags:
+      # Matches v0.5.0, v1.0.0, v2.0.0-rc1, etc.
+      - "v[0-9]*"
+  workflow_dispatch:
+
+# OIDC requires id-token:write to mint the JWT that AWS STS will verify.
+# contents:read is the minimum needed to checkout the repo.
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: publish
+  # Don't cancel an in-flight publish — let it finish to avoid partial uploads.
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # fetch-depth: 0 fetches full history. Not strictly required since khora's
+          # version is hardcoded in pyproject.toml (no hatch-vcs), but included as a
+          # safety measure in case version inference is added later.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      # Install build (PEP 517 frontend) and twine (PyPI uploader) into the system
+      # Python so they're available outside a virtual environment.
+      - name: Install build dependencies
+        run: uv pip install build twine --system
+
+      # Exchange the GitHub OIDC token for temporary AWS credentials.
+      # The IAM role is scoped to CodeArtifact publish operations only.
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::956322716887:role/github-actions-codeartifact-publish
+          aws-region: us-west-2
+
+      # Fetch a 12-hour CodeArtifact auth token and mask it in logs so it never
+      # appears in plain text, even if a subsequent step echoes the environment.
+      - name: Get CodeArtifact authorization token
+        run: |
+          TOKEN=$(aws codeartifact get-authorization-token --domain deyta --query authorizationToken --output text)
+          echo "::add-mask::$TOKEN"
+          echo "CA_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+
+      # Use `python -m build` directly — NOT `uv run python -m build`.
+      # uv run creates a venv and may not find the build backend (uv_build) on the
+      # system path. This was a lesson learned from deyta-core PR #17.
+      - name: Build wheel
+        run: python -m build
+
+      # Upload all artifacts (wheel + sdist) to the CodeArtifact PyPI endpoint.
+      # --username aws is required by CodeArtifact's PyPI interface; the actual
+      # authentication is handled by the token.
+      - name: Publish to CodeArtifact
+        run: |
+          twine upload \
+            --repository-url https://deyta-956322716887.d.codeartifact.us-west-2.amazonaws.com/pypi/packages/ \
+            --username aws \
+            --password "${{ env.CA_TOKEN }}" \
+            dist/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,9 @@ IMPORTANT: When bumping the version, always update **all four files** and regene
 3. `rust/khora-accel/Cargo.toml` — khora-accel version
 4. `rust/khora-accel/pyproject.toml` — khora-accel version
 5. Run `uv lock` and `cargo generate-lockfile` in `rust/khora-accel/`
+6. Commit, tag (`git tag vX.Y.Z`), and push — the `v*` tag triggers `publish.yml` and `publish-accel.yml` to publish both packages to CodeArtifact
+
+See [`docs/RELEASE.md`](docs/RELEASE.md) for the full release process.
 
 ## Claude Code Settings
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,17 +67,15 @@ uv run pytest tests/unit/test_memory_lake.py  # Single file
 
 Markers: `@pytest.mark.unit`, `@pytest.mark.integration`, `@pytest.mark.e2e`. Async tests use `asyncio_mode = "auto"`.
 
-## Version Bumps
+## Releasing
 
-IMPORTANT: When bumping the version, always update **all four files** and regenerate lockfiles:
-1. `pyproject.toml` — khora version
-2. `src/khora/__init__.py` — `__version__`
-3. `rust/khora-accel/Cargo.toml` — khora-accel version
-4. `rust/khora-accel/pyproject.toml` — khora-accel version
-5. Run `uv lock` and `cargo generate-lockfile` in `rust/khora-accel/`
-6. Commit, tag (`git tag vX.Y.Z`), and push — the `v*` tag triggers `publish.yml` and `publish-accel.yml` to publish both packages to CodeArtifact
+Versions are derived from git tags — no manual version bumps needed:
+- **khora**: `hatch-vcs` reads the version from git tags at build time
+- **khora-accel**: `publish-accel.yml` stamps the tag version into `Cargo.toml` at build time
 
-See [`docs/RELEASE.md`](docs/RELEASE.md) for the full release process.
+To release: `git tag vX.Y.Z && git push origin vX.Y.Z` — both publish workflows trigger automatically.
+
+See [`docs/RELEASE.md`](docs/RELEASE.md) for the full process.
 
 ## Claude Code Settings
 

--- a/docs/AI_CHANGELOG.md
+++ b/docs/AI_CHANGELOG.md
@@ -19,3 +19,4 @@
 - 2026-03-24: DYT-891: Add publish.yml workflow for khora to CodeArtifact
 - 2026-03-24: DYT-892: Add publish-accel.yml workflow for khora-accel to CodeArtifact
 - 2026-03-24: DYT-882: Add sccache, RELEASE.md, CLAUDE.md publish docs
+- 2026-03-24: DYT-882: Switch to git-tag-based versioning (hatch-vcs)

--- a/docs/AI_CHANGELOG.md
+++ b/docs/AI_CHANGELOG.md
@@ -18,3 +18,4 @@
 - 2026-03-23: DYT-865: Gitignore scripts/slack-notify.py, remove from tracking
 - 2026-03-24: DYT-891: Add publish.yml workflow for khora to CodeArtifact
 - 2026-03-24: DYT-892: Add publish-accel.yml workflow for khora-accel to CodeArtifact
+- 2026-03-24: DYT-882: Add sccache, RELEASE.md, CLAUDE.md publish docs

--- a/docs/AI_CHANGELOG.md
+++ b/docs/AI_CHANGELOG.md
@@ -16,3 +16,5 @@
 - 2026-03-22: DYT-796: Add importance scoring to Skeleton engine
 - 2026-03-23: DYT-820: Fix CI failure on PR #115 — SurrealDB test compatibility
 - 2026-03-23: DYT-865: Gitignore scripts/slack-notify.py, remove from tracking
+- 2026-03-24: DYT-891: Add publish.yml workflow for khora to CodeArtifact
+- 2026-03-24: DYT-892: Add publish-accel.yml workflow for khora-accel to CodeArtifact

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -4,39 +4,36 @@
 
 Tags follow semantic versioning: `v{major}.{minor}.{patch}` (e.g., `v0.5.0`).
 
-The `v` prefix is required -- it triggers the publish workflows.
+The `v` prefix is required — it triggers the publish workflows.
 
-## Version Bumps
+## Versioning
 
-Before tagging a release, update the version in **all four files** and regenerate lockfiles:
+Versions are derived automatically from git tags — no files need manual version bumps.
 
-1. `pyproject.toml` -- khora version
-2. `src/khora/__init__.py` -- `__version__`
-3. `rust/khora-accel/Cargo.toml` -- khora-accel version
-4. `rust/khora-accel/pyproject.toml` -- khora-accel version
-5. Run `uv lock` to regenerate the Python lockfile
-6. Run `cargo generate-lockfile` in `rust/khora-accel/` to regenerate the Cargo lockfile
+| Package | How version is set |
+|---------|-------------------|
+| `khora` | `hatch-vcs` reads the most recent git tag at build time |
+| `khora-accel` | `publish-accel.yml` extracts the tag and stamps it into `Cargo.toml` before maturin builds |
 
-Commit the version bump and lockfile changes before tagging.
+At runtime, `khora.__version__` reads the installed package version via `importlib.metadata`.
+
+In development (no tag on current commit), the version will be something like `0.5.0.dev3+gabc1234`.
 
 ## Publishing
 
-Pushing a `v*` tag triggers two GitHub Actions workflows:
+1. Create and push a tag:
+   ```bash
+   git tag v0.6.0
+   git push origin v0.6.0
+   ```
+2. Two workflows trigger automatically:
 
 | Workflow | Package | What it does |
 |----------|---------|-------------|
-| `publish.yml` | `khora` | Builds a pure Python wheel and publishes to CodeArtifact |
+| `publish.yml` | `khora` | Builds a pure Python wheel via `hatch-vcs` and publishes to CodeArtifact |
 | `publish-accel.yml` | `khora-accel` | Builds native wheels for 4 platforms (Linux x64/ARM64, macOS x64/ARM64) and publishes to CodeArtifact |
 
-Both workflows use OIDC authentication -- no secrets required.
-
-### Steps
-
-1. Bump versions in all four files (see above).
-2. Commit: `git commit -m "Bump version to X.Y.Z"`
-3. Tag: `git tag vX.Y.Z`
-4. Push: `git push origin main --tags`
-5. Both workflows trigger automatically.
+Both workflows use OIDC authentication — no secrets required.
 
 ### Manual Publish
 
@@ -66,5 +63,5 @@ aws codeartifact list-package-versions \
 |---------|-------|-----|
 | OIDC credential error | IAM role trust policy misconfigured | Check `github-actions-codeartifact-publish` role in AWS |
 | Twine upload 403 | Expired or invalid CodeArtifact token | Re-run the workflow; tokens are generated per-run |
-| Version mismatch | Tag doesn't match pyproject.toml version | Ensure all 4 version files match the tag |
+| Version shows `0.0.0` or `dev` | No git tags reachable from HEAD | Ensure you've pushed tags: `git push origin --tags` |
 | khora-accel build fails on one platform | Platform-specific compilation issue | Check build logs; other platforms still complete |

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,70 @@
+# Release Process
+
+## Tag Naming
+
+Tags follow semantic versioning: `v{major}.{minor}.{patch}` (e.g., `v0.5.0`).
+
+The `v` prefix is required -- it triggers the publish workflows.
+
+## Version Bumps
+
+Before tagging a release, update the version in **all four files** and regenerate lockfiles:
+
+1. `pyproject.toml` -- khora version
+2. `src/khora/__init__.py` -- `__version__`
+3. `rust/khora-accel/Cargo.toml` -- khora-accel version
+4. `rust/khora-accel/pyproject.toml` -- khora-accel version
+5. Run `uv lock` to regenerate the Python lockfile
+6. Run `cargo generate-lockfile` in `rust/khora-accel/` to regenerate the Cargo lockfile
+
+Commit the version bump and lockfile changes before tagging.
+
+## Publishing
+
+Pushing a `v*` tag triggers two GitHub Actions workflows:
+
+| Workflow | Package | What it does |
+|----------|---------|-------------|
+| `publish.yml` | `khora` | Builds a pure Python wheel and publishes to CodeArtifact |
+| `publish-accel.yml` | `khora-accel` | Builds native wheels for 4 platforms (Linux x64/ARM64, macOS x64/ARM64) and publishes to CodeArtifact |
+
+Both workflows use OIDC authentication -- no secrets required.
+
+### Steps
+
+1. Bump versions in all four files (see above).
+2. Commit: `git commit -m "Bump version to X.Y.Z"`
+3. Tag: `git tag vX.Y.Z`
+4. Push: `git push origin main --tags`
+5. Both workflows trigger automatically.
+
+### Manual Publish
+
+Both workflows support `workflow_dispatch` for manual re-runs from the GitHub Actions UI.
+
+## Verification
+
+After the workflows complete, confirm packages are available:
+
+```bash
+aws codeartifact list-package-versions \
+  --domain deyta \
+  --repository packages \
+  --format pypi \
+  --package khora
+
+aws codeartifact list-package-versions \
+  --domain deyta \
+  --repository packages \
+  --format pypi \
+  --package khora-accel
+```
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| OIDC credential error | IAM role trust policy misconfigured | Check `github-actions-codeartifact-publish` role in AWS |
+| Twine upload 403 | Expired or invalid CodeArtifact token | Re-run the workflow; tokens are generated per-run |
+| Version mismatch | Tag doesn't match pyproject.toml version | Ensure all 4 version files match the tag |
+| khora-accel build fails on one platform | Platform-specific compilation issue | Check build logs; other platforms still complete |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "khora"
-version = "0.5.0"
+dynamic = ["version"]
 description = "Khora is Memory Lake"
 readme = "README.md"
 authors = [
@@ -99,12 +99,14 @@ embedded = ["surrealdb>=1.0.2"]
 khora = "khora:main"
 
 [build-system]
-requires = ["uv_build>=0.8.17,<0.9.0"]
-build-backend = "uv_build"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
-[tool.uv-build]
-# Ensure Alembic migration files and templates are included in the wheel
-data-includes = ["src/khora/db/migrations/versions/*.py", "src/khora/db/migrations/script.py.mako"]
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/khora"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/rust/khora-accel/pyproject.toml
+++ b/rust/khora-accel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "khora-accel"
-version = "0.5.0"
+dynamic = ["version"]
 requires-python = ">=3.13"
 description = "Rust-accelerated operations for Khora memory lake"
 

--- a/src/khora/__init__.py
+++ b/src/khora/__init__.py
@@ -42,7 +42,7 @@ from .extraction.skills import EntityTypeConfig, ExpertiseConfig, RelationshipTy
 from .memory_lake import BatchResult, LLMUsage, MemoryLake, RecallResult, RememberResult, Stats
 from .query import SearchMode
 
-__version__ = "0.5.0"
+__version__ = __import__("importlib").metadata.version("khora")
 
 __all__ = [
     "main",

--- a/uv.lock
+++ b/uv.lock
@@ -1043,7 +1043,6 @@ wheels = [
 
 [[package]]
 name = "khora"
-version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -1199,7 +1198,7 @@ requires-dist = [
     { name = "weaviate-client", marker = "extra == 'all-backends'", specifier = ">=4.20.1" },
     { name = "weaviate-client", marker = "extra == 'weaviate'", specifier = ">=4.20.1" },
 ]
-provides-extras = ["dev", "postgres", "neo4j", "kuzu", "memgraph", "arcadedb", "graph-all", "weaviate", "all-backends", "reranking", "accel", "logfire", "nlp", "rust", "surrealdb", "embedded"]
+provides-extras = ["accel", "all-backends", "arcadedb", "dev", "embedded", "graph-all", "kuzu", "logfire", "memgraph", "neo4j", "nlp", "postgres", "reranking", "rust", "surrealdb", "weaviate"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1217,7 +1216,6 @@ dev = [
 
 [[package]]
 name = "khora-accel"
-version = "0.5.0"
 source = { editable = "rust/khora-accel" }
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `.github/workflows/publish.yml` — builds and publishes the pure Python `khora` wheel to AWS CodeArtifact on `v*` tag push via OIDC authentication
- Add `.github/workflows/publish-accel.yml` — builds and publishes `khora-accel` native Rust/PyO3 wheels for 4 platforms (Linux x64/ARM64, macOS x64/ARM64) using maturin cross-compilation matrix with sccache
- Switch to git-tag-based versioning: `hatch-vcs` for khora (replaces hardcoded version in pyproject.toml), tag-stamped `Cargo.toml` for khora-accel
- Replace `uv_build` backend with `hatchling` + `hatch-vcs` for dynamic version derivation
- Use `importlib.metadata` for runtime `__version__` (no hardcoded version strings)
- Add `docs/RELEASE.md` documenting the zero-manual-bump release process
- Update `CLAUDE.md` releasing section
- Both workflows use GitHub OIDC federation (no long-lived secrets), token masking, concurrency controls, and 60-minute timeouts
- Part of [ADR-025](https://github.com/DeytaHQ/hegemon/blob/main/architecture/decisions/025-khora-deyta-core-on-codeartifact.md)

## Test plan
- [ ] Push a `v*` tag and verify both workflows trigger
- [ ] Verify `khora` wheel appears in CodeArtifact `deyta/packages` with correct version from tag
- [ ] Verify `khora-accel` wheels for all 4 platforms appear in CodeArtifact with correct version
- [ ] Verify `khora.__version__` returns the correct version at runtime
- [ ] Verify existing CI workflow still runs independently on tag push
- [ ] Verify branch pushes and PRs do NOT trigger publish workflows
- [ ] Install published wheels from CodeArtifact in a clean environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)