### PR TITLE
DYT-984: Replace slots implementation-detail tests with behavioral checks

### DIFF
--- a/docs/AI_CHANGELOG.md
+++ b/docs/AI_CHANGELOG.md
@@ -22,3 +22,4 @@
 - 2026-03-24: DYT-882: Switch to git-tag-based versioning (hatch-vcs)
 - 2026-03-24: DYT-882: Consolidate into single release pipeline, fix accel builds
 - 2026-03-24: DYT-882: Remove auto-initialize from pyo3 (manylinux compat)
+- 2026-03-24: DYT-984: Replace __slots__ detail tests with behavioral checks

--- a/tests/unit/test_slots.py
+++ b/tests/unit/test_slots.py
@@ -7,6 +7,8 @@ it, these tests catch the regression via observable behaviour — not by
 inspecting the class attribute.
 """
 
+from uuid import uuid4
+
 import pytest
 
 from khora.core.models.document import Chunk, ChunkMetadata, DocumentMetadata
@@ -95,8 +97,6 @@ class TestSlottedInstancesRejectArbitraryAttrs:
 
 
 # ── minimal construction helpers ─────────────────────────────────────
-
-from uuid import uuid4  # noqa: E402
 
 
 def _minimal_kwargs(cls):

--- a/tests/unit/test_slots.py
+++ b/tests/unit/test_slots.py
@@ -1,23 +1,141 @@
-"""Verify slots=True was applied to high-frequency dataclasses."""
+"""Verify slotted dataclasses reject arbitrary attributes and omit __dict__.
+
+These models are instantiated in bulk during ingestion and retrieval (thousands
+of Chunk / Entity / Relationship objects per recall).  The slots=True
+optimisation saves ~40-60 bytes per instance.  If someone accidentally drops
+it, these tests catch the regression via observable behaviour — not by
+inspecting the class attribute.
+"""
+
+import pytest
 
 from khora.core.models.document import Chunk, ChunkMetadata, DocumentMetadata
 from khora.core.models.entity import Entity, Episode, Relationship
 from khora.memory_lake import BatchResult, RecallResult, RememberResult, Stats
 
 
-class TestSlotsApplied:
-    def test_document_models_have_slots(self):
-        assert hasattr(DocumentMetadata, "__slots__")
-        assert hasattr(ChunkMetadata, "__slots__")
-        assert hasattr(Chunk, "__slots__")
+# ── helpers ──────────────────────────────────────────────────────────
 
-    def test_entity_models_have_slots(self):
-        assert hasattr(Entity, "__slots__")
-        assert hasattr(Relationship, "__slots__")
-        assert hasattr(Episode, "__slots__")
+# High-frequency models that are allocated in hot loops.
+_HOT_PATH_CLASSES = [
+    DocumentMetadata,
+    ChunkMetadata,
+    Chunk,
+    Entity,
+    Relationship,
+    Episode,
+]
 
-    def test_result_types_have_slots(self):
-        assert hasattr(RememberResult, "__slots__")
-        assert hasattr(BatchResult, "__slots__")
-        assert hasattr(RecallResult, "__slots__")
-        assert hasattr(Stats, "__slots__")
+# Frozen result types returned from public API methods.
+_FROZEN_RESULT_CLASSES = [
+    RememberResult,
+    BatchResult,
+    RecallResult,
+    Stats,
+]
+
+
+# ── behavioural tests ───────────────────────────────────────────────
+
+
+class TestSlottedInstancesOmitDict:
+    """Instances of slotted dataclasses must not carry a per-instance __dict__.
+
+    The absence of __dict__ is the observable memory-saving behaviour that
+    slots=True provides.  If __dict__ reappears, every instance grows by
+    ~100+ bytes — a meaningful regression when thousands are in flight.
+    """
+
+    @pytest.mark.parametrize("cls", _HOT_PATH_CLASSES, ids=lambda c: c.__name__)
+    def test_hot_path_model_instance_has_no_dict(self, cls):
+        instance = cls()
+        assert not hasattr(instance, "__dict__"), (
+            f"{cls.__name__} instance has __dict__ — "
+            "slots=True may have been removed from the dataclass decorator"
+        )
+
+    @pytest.mark.parametrize(
+        "cls", _FROZEN_RESULT_CLASSES, ids=lambda c: c.__name__
+    )
+    def test_frozen_result_instance_has_no_dict(self, cls):
+        # Frozen dataclasses require all fields at construction; use
+        # sensible defaults to avoid importing extra types.
+        kwargs = _minimal_kwargs(cls)
+        instance = cls(**kwargs)
+        assert not hasattr(instance, "__dict__"), (
+            f"{cls.__name__} instance has __dict__ — "
+            "slots=True may have been removed from the dataclass decorator"
+        )
+
+
+class TestSlottedInstancesRejectArbitraryAttrs:
+    """Slotted classes must raise AttributeError on undeclared attributes.
+
+    This protects against silent data corruption where a typo like
+    ``chunk.metdata = ...`` silently creates a new attribute instead of
+    raising immediately.
+    """
+
+    @pytest.mark.parametrize("cls", _HOT_PATH_CLASSES, ids=lambda c: c.__name__)
+    def test_hot_path_model_rejects_extra_attr(self, cls):
+        instance = cls()
+        with pytest.raises(AttributeError):
+            instance._undeclared_test_attr = "oops"  # type: ignore[attr-defined]
+
+    @pytest.mark.parametrize(
+        "cls", _FROZEN_RESULT_CLASSES, ids=lambda c: c.__name__
+    )
+    def test_frozen_result_rejects_extra_attr(self, cls):
+        kwargs = _minimal_kwargs(cls)
+        instance = cls(**kwargs)
+        # Frozen+slotted dataclasses may raise AttributeError or TypeError
+        # depending on the Python version and dataclass internals.
+        with pytest.raises((AttributeError, TypeError)):
+            instance._undeclared_test_attr = "oops"  # type: ignore[attr-defined]
+
+
+# ── minimal construction helpers ─────────────────────────────────────
+
+from uuid import uuid4  # noqa: E402
+
+
+def _minimal_kwargs(cls):
+    """Return the smallest set of kwargs needed to construct *cls*."""
+    name = cls.__name__
+    ns = uuid4()
+
+    if name == "RememberResult":
+        return {
+            "document_id": uuid4(),
+            "namespace_id": ns,
+            "chunks_created": 0,
+            "entities_extracted": 0,
+            "relationships_created": 0,
+        }
+    if name == "BatchResult":
+        return {
+            "total": 0,
+            "processed": 0,
+            "skipped": 0,
+            "failed": 0,
+            "chunks": 0,
+            "entities": 0,
+            "relationships": 0,
+        }
+    if name == "RecallResult":
+        return {
+            "query": "",
+            "namespace_id": ns,
+            "chunks": [],
+            "entities": [],
+            "context_text": "",
+        }
+    if name == "Stats":
+        return {
+            "documents": 0,
+            "chunks": 0,
+            "entities": 0,
+            "relationships": 0,
+        }
+    msg = f"No minimal kwargs defined for {name}"
+    raise ValueError(msg)

--- a/tests/unit/test_slots.py
+++ b/tests/unit/test_slots.py
@@ -15,7 +15,6 @@ from khora.core.models.document import Chunk, ChunkMetadata, DocumentMetadata
 from khora.core.models.entity import Entity, Episode, Relationship
 from khora.memory_lake import BatchResult, RecallResult, RememberResult, Stats
 
-
 # ── helpers ──────────────────────────────────────────────────────────
 
 # High-frequency models that are allocated in hot loops.
@@ -52,21 +51,17 @@ class TestSlottedInstancesOmitDict:
     def test_hot_path_model_instance_has_no_dict(self, cls):
         instance = cls()
         assert not hasattr(instance, "__dict__"), (
-            f"{cls.__name__} instance has __dict__ — "
-            "slots=True may have been removed from the dataclass decorator"
+            f"{cls.__name__} instance has __dict__ — " "slots=True may have been removed from the dataclass decorator"
         )
 
-    @pytest.mark.parametrize(
-        "cls", _FROZEN_RESULT_CLASSES, ids=lambda c: c.__name__
-    )
+    @pytest.mark.parametrize("cls", _FROZEN_RESULT_CLASSES, ids=lambda c: c.__name__)
     def test_frozen_result_instance_has_no_dict(self, cls):
         # Frozen dataclasses require all fields at construction; use
         # sensible defaults to avoid importing extra types.
         kwargs = _minimal_kwargs(cls)
         instance = cls(**kwargs)
         assert not hasattr(instance, "__dict__"), (
-            f"{cls.__name__} instance has __dict__ — "
-            "slots=True may have been removed from the dataclass decorator"
+            f"{cls.__name__} instance has __dict__ — " "slots=True may have been removed from the dataclass decorator"
         )
 
 
@@ -84,9 +79,7 @@ class TestSlottedInstancesRejectArbitraryAttrs:
         with pytest.raises(AttributeError):
             instance._undeclared_test_attr = "oops"  # type: ignore[attr-defined]
 
-    @pytest.mark.parametrize(
-        "cls", _FROZEN_RESULT_CLASSES, ids=lambda c: c.__name__
-    )
+    @pytest.mark.parametrize("cls", _FROZEN_RESULT_CLASSES, ids=lambda c: c.__name__)
     def test_frozen_result_rejects_extra_attr(self, cls):
         kwargs = _minimal_kwargs(cls)
         instance = cls(**kwargs)


### PR DESCRIPTION
## Summary
- Replaced low-signal `hasattr(cls, "__slots__")` assertions in `tests/unit/test_slots.py` with behavioral tests
- New tests verify two observable consequences of `slots=True`:
  1. **No `__dict__` on instances** — catches memory regression if slots is accidentally removed
  2. **Rejects undeclared attributes** — catches data integrity regression (typos silently creating new attrs)
- Parametrized across all 10 slotted dataclasses (6 hot-path models + 4 frozen result types)
- All 20 tests are deterministic, no timing dependencies

## Test plan
- [x] `uv run pytest tests/unit/test_slots.py -v` — all 20 pass
- [x] `uv run pytest tests/unit/ -v` — full suite passes (1926 passed, 52% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)