### PR TITLE
DYT-882: Fix publish-accel uv cache failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v4
         with:
-          enable-cache: true
+          enable-cache: false
 
       - name: Install twine
         run: uv pip install twine --system

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,11 @@ jobs:
           merge-multiple: true
           path: dist/
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v4
         with:

--- a/docs/AI_CHANGELOG.md
+++ b/docs/AI_CHANGELOG.md
@@ -23,3 +23,4 @@
 - 2026-03-24: DYT-882: Consolidate into single release pipeline, fix accel builds
 - 2026-03-24: DYT-882: Remove auto-initialize from pyo3 (manylinux compat)
 - 2026-03-24: DYT-984: Replace __slots__ detail tests with behavioral checks
+- 2026-03-25: DYT-882: Fix publish-accel uv cache failure


### PR DESCRIPTION
## Summary
- Disable uv caching (`enable-cache: false`) in the `publish-accel` job of the release pipeline
- The job has no `actions/checkout` step (it only downloads pre-built wheel artifacts), so `setup-uv`'s default cache glob `**/uv.lock` finds nothing and fails with: `No file matched to [**/uv.lock]`
- Caching is unnecessary here — the job only runs `uv pip install twine --system`
- This was the sole cause of the v0.5.3 release failure (all builds succeeded, `publish-khora` succeeded, only `publish-accel` failed)

## Test plan
- [ ] Push a `v*` tag and verify the `publish-accel` job completes successfully
- [ ] Verify all `khora-accel` platform wheels are published to CodeArtifact
- [ ] Verify `publish-khora` job is unaffected (still uses `enable-cache: true` with checkout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)