### PR TITLE
DYT-1199: Dev release pipeline — publish to CodeArtifact on every merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,14 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # ============================================================================
   # Test Job — runs on all pushes and PRs
@@ -91,11 +99,21 @@ jobs:
       - name: Compute dev version from git describe
         id: version
         run: |
-          DESC=$(git describe --tags --match 'v*' --long)
+          DESC=$(git describe --tags --match 'v*' --long) || {
+            echo "::error::No v* tags found. Create at least one version tag."
+            exit 1
+          }
           echo "git describe: $DESC"
-          TAG=$(echo "$DESC" | sed 's/-[0-9]*-g[0-9a-f]*$//')
-          DISTANCE=$(echo "$DESC" | sed 's/.*-\([0-9]*\)-g[0-9a-f]*$/\1/')
-          BASE=${TAG#v}
+          # Extract distance and hash from the guaranteed --long suffix: -DISTANCE-gHASH
+          DISTANCE=$(echo "$DESC" | grep -oE '\-([0-9]+)\-g[0-9a-f]+$' | cut -d- -f2)
+          # Tag is everything before -DISTANCE-gHASH
+          TAG=$(echo "$DESC" | sed "s/-${DISTANCE}-g[0-9a-f]*$//")
+          # Strip v prefix and any pre-release suffix (e.g. v1.0.0-rc1 → 1.0.0)
+          BASE=$(echo "${TAG#v}" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
+          if [ -z "$BASE" ] || [ -z "$DISTANCE" ]; then
+            echo "::error::Failed to parse git describe output: $DESC"
+            exit 1
+          fi
           MAJOR=$(echo "$BASE" | cut -d. -f1)
           MINOR=$(echo "$BASE" | cut -d. -f2)
           PATCH=$(echo "$BASE" | cut -d. -f3)
@@ -131,11 +149,11 @@ jobs:
 
   publish-dev-khora:
     needs: build-accel-dev
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    permissions:
-      id-token: write
-      contents: read
+    env:
+      SETUPTOOLS_SCM_LOCAL_SCHEME: no-local-version
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -170,9 +188,8 @@ jobs:
       - name: Build wheel
         run: |
           python -m build
+          ls dist/*.whl || { echo "::error::No wheels produced"; exit 1; }
           echo "Built: $(ls dist/)"
-        env:
-          SETUPTOOLS_SCM_LOCAL_SCHEME: no-local-version
 
       - name: Publish to CodeArtifact
         run: |
@@ -184,11 +201,9 @@ jobs:
 
   publish-dev-accel:
     needs: build-accel-dev
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    permissions:
-      id-token: write
-      contents: read
     steps:
       - name: Download all wheel artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -152,6 +151,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
     env:
       SETUPTOOLS_SCM_LOCAL_SCHEME: no-local-version
     steps:
@@ -204,6 +206,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Download all wheel artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   # ============================================================================
-  # Test Job - Runs on all pushes and PRs
+  # Test Job — runs on all pushes and PRs
   # ============================================================================
   test:
     runs-on: ubuntu-latest
@@ -55,3 +55,177 @@ jobs:
           flags: unittests
           name: khora-coverage
           fail_ci_if_error: false
+
+  # ============================================================================
+  # Dev Release — publish dev versions on every merge to main.
+  #
+  # Pipeline (mirrors release.yml structure):
+  #   test ──> build-accel-dev (3 platforms) ──┬──> publish-dev-khora
+  #                                            └──> publish-dev-accel
+  #
+  # Version: hatch-vcs produces e.g. 0.5.5.dev14 (PEP 440 dev release).
+  # khora-accel: git describe → semver pre-release (0.5.5-dev.14).
+  # ============================================================================
+
+  build-accel-dev:
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute dev version from git describe
+        id: version
+        run: |
+          DESC=$(git describe --tags --match 'v*' --long)
+          echo "git describe: $DESC"
+          TAG=$(echo "$DESC" | sed 's/-[0-9]*-g[0-9a-f]*$//')
+          DISTANCE=$(echo "$DESC" | sed 's/.*-\([0-9]*\)-g[0-9a-f]*$/\1/')
+          BASE=${TAG#v}
+          MAJOR=$(echo "$BASE" | cut -d. -f1)
+          MINOR=$(echo "$BASE" | cut -d. -f2)
+          PATCH=$(echo "$BASE" | cut -d. -f3)
+          NEXT_PATCH=$((PATCH + 1))
+          CARGO_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-dev.${DISTANCE}"
+          echo "cargo_version=$CARGO_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing khora-accel dev: $CARGO_VERSION"
+
+      - name: Set version in Cargo.toml
+        run: |
+          sed -i.bak "s/^version = .*/version = \"${{ steps.version.outputs.cargo_version }}\"/" rust/khora-accel/Cargo.toml
+          rm -f rust/khora-accel/Cargo.toml.bak
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --interpreter python3.13
+          working-directory: rust/khora-accel
+          manylinux: auto
+          sccache: 'true'
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-wheel-${{ matrix.target }}
+          path: rust/khora-accel/dist/*.whl
+
+  publish-dev-khora:
+    needs: build-accel-dev
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install build dependencies
+        run: uv pip install build twine --system
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::956322716887:role/github-actions-codeartifact-publish
+          aws-region: us-west-2
+
+      - name: Get CodeArtifact authorization token
+        run: |
+          TOKEN=$(aws codeartifact get-authorization-token --domain deyta --query authorizationToken --output text)
+          echo "::add-mask::$TOKEN"
+          echo "CA_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+
+      - name: Build wheel
+        run: |
+          python -m build
+          echo "Built: $(ls dist/)"
+        env:
+          SETUPTOOLS_SCM_LOCAL_SCHEME: no-local-version
+
+      - name: Publish to CodeArtifact
+        run: |
+          twine upload \
+            --repository-url https://deyta-956322716887.d.codeartifact.us-west-2.amazonaws.com/pypi/packages/ \
+            --username aws \
+            --password "${{ env.CA_TOKEN }}" \
+            dist/*
+
+  publish-dev-accel:
+    needs: build-accel-dev
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download all wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dev-wheel-*
+          merge-multiple: true
+          path: dist/
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: false
+
+      - name: Install twine
+        run: uv pip install twine --system
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::956322716887:role/github-actions-codeartifact-publish
+          aws-region: us-west-2
+
+      - name: Get CodeArtifact authorization token
+        run: |
+          TOKEN=$(aws codeartifact get-authorization-token --domain deyta --query authorizationToken --output text)
+          echo "::add-mask::$TOKEN"
+          echo "CA_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+
+      - name: Publish to CodeArtifact
+        run: |
+          twine upload \
+            --repository-url https://deyta-956322716887.d.codeartifact.us-west-2.amazonaws.com/pypi/packages/ \
+            --username aws \
+            --password "${{ env.CA_TOKEN }}" \
+            dist/*

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -87,7 +87,7 @@ The `>=X.Y.Z.dev0` specifier tells uv to accept dev/pre-release versions for the
 
 The `upgrade-package` setting makes every `uv sync` re-resolve these packages to the latest available version, ignoring the lockfile pin. No CLI flags needed — plain `uv sync` does the right thing.
 
-> **Note:** This will update `uv.lock` on every sync when a newer version is available. This is intentional — commit the lockfile updates as part of normal workflow.
+> **Note:** This will update `uv.lock` on every `uv sync` when a newer dev version is available. With frequent merges to main, expect lockfile changes daily. This is intentional — commit the updates as part of normal workflow. If lockfile churn is disruptive, pin to a specific dev version instead (e.g., `khora==0.5.5.dev14`).
 
 ## Troubleshooting
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -17,9 +17,20 @@ Versions are derived automatically from git tags — no files need manual versio
 
 At runtime, `khora.__version__` reads the installed package version via `importlib.metadata`.
 
-In development (no tag on current commit), the version will be something like `0.5.0.dev3+gabc1234`.
+In development (no tag on current commit), the version will be something like `0.5.5.dev3`.
 
-## Publishing
+## Dev Releases (automatic)
+
+Every merge to `main` publishes a dev release to CodeArtifact via `ci.yml`:
+
+| Package | Version example | How |
+|---------|----------------|-----|
+| `khora` | `0.5.5.dev14` | `hatch-vcs` with `SETUPTOOLS_SCM_LOCAL_SCHEME=no-local-version` |
+| `khora-accel` | `0.5.5-dev.14` (semver) → `0.5.5.dev14` (wheel) | `git describe` → stamp `Cargo.toml` → maturin |
+
+Dev versions are PEP 440 pre-releases. Downstream projects that pin `>=X.Y.Z.dev0` will pick them up.
+
+## Stable Releases (tag-triggered)
 
 1. Create and push a tag:
    ```bash
@@ -56,6 +67,27 @@ aws codeartifact list-package-versions \
   --format pypi \
   --package khora-accel
 ```
+
+## Downstream Projects (always-latest)
+
+For internal projects like `khora-benchmarks` that should always track the latest dev release, add this to their `pyproject.toml`:
+
+```toml
+[project]
+dependencies = [
+    "khora>=0.5.0.dev0",        # .dev0 opts into pre-releases
+    "khora-accel>=0.5.0.dev0",
+]
+
+[tool.uv]
+upgrade-package = ["khora", "khora-accel"]
+```
+
+The `>=X.Y.Z.dev0` specifier tells uv to accept dev/pre-release versions for these packages (under the default `if-necessary-or-explicit` prerelease strategy).
+
+The `upgrade-package` setting makes every `uv sync` re-resolve these packages to the latest available version, ignoring the lockfile pin. No CLI flags needed — plain `uv sync` does the right thing.
+
+> **Note:** This will update `uv.lock` on every sync when a newer version is available. This is intentional — commit the lockfile updates as part of normal workflow.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Add dev release pipeline to `ci.yml` that triggers on every push to `main` (after tests pass)
- Builds `khora` (pure Python) and `khora-accel` (Rust native wheels for 3 platforms) as PEP 440 dev releases (e.g., `0.5.5.dev14`)
- Publishes both packages to CodeArtifact using existing OIDC authentication
- Pipeline mirrors `release.yml` structure: `test → build-accel-dev → publish-dev-khora + publish-dev-accel`
- Documents downstream configuration for always-latest tracking via `upgrade-package` in `[tool.uv]`
- Updates `RELEASE.md` with dev release docs and downstream project setup guide

## Test plan
- [ ] CI passes (lint, type check, tests)
- [ ] Merge to main triggers dev release jobs (verify in GitHub Actions)
- [ ] `khora` and `khora-accel` dev versions appear in CodeArtifact after merge
- [ ] Downstream project with `upgrade-package` config picks up new dev version on `uv sync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)