### PR TITLE
DYT-1199: Fix local version stripping for dev releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,8 +154,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    env:
-      SETUPTOOLS_SCM_LOCAL_SCHEME: no-local-version
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -25,7 +25,7 @@ Every merge to `main` publishes a dev release to CodeArtifact via `ci.yml`:
 
 | Package | Version example | How |
 |---------|----------------|-----|
-| `khora` | `0.5.5.dev14` | `hatch-vcs` with `SETUPTOOLS_SCM_LOCAL_SCHEME=no-local-version` |
+| `khora` | `0.5.5.dev14` | `hatch-vcs` with `local_scheme = "no-local-version"` in pyproject.toml |
 | `khora-accel` | `0.5.5-dev.14` (semver) → `0.5.5.dev14` (wheel) | `git describe` → stamp `Cargo.toml` → maturin |
 
 Dev versions are PEP 440 pre-releases. Downstream projects that pin `>=X.Y.Z.dev0` will pick them up.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "vcs"
+raw-options.local_scheme = "no-local-version"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/khora"]


### PR DESCRIPTION
## Summary
- `SETUPTOOLS_SCM_LOCAL_SCHEME` is not a real setuptools-scm env var — dev releases were publishing with `+gXXX` suffix (e.g., `0.5.6.dev11+g469111b32`)
- Move local scheme config to `pyproject.toml` via `raw-options.local_scheme = "no-local-version"` — the proper way to configure this
- Remove the non-functional env var from `ci.yml`
- Update RELEASE.md to reflect the actual mechanism

## Test plan
- [ ] CI passes
- [ ] Next merge to main publishes `khora` as `X.Y.Z.devN` (no `+gXXX` suffix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)