### PR TITLE
DYT-1229: Build khora-accel wheels for Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,27 +80,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python: ["3.13", "3.14"]
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - aarch64-apple-darwin
         include:
-          # Python 3.13
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            python: "3.13"
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            python: "3.13"
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            python: "3.13"
-          # Python 3.14
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            python: "3.14"
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            python: "3.14"
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            python: "3.14"
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,8 @@ jobs:
   # Dev Release — publish dev versions on every merge to main.
   #
   # Pipeline (mirrors release.yml structure):
-  #   test ──> build-accel-dev (3 platforms) ──┬──> publish-dev-khora
-  #                                            └──> publish-dev-accel
+  #   test ──> build-accel-dev (3 platforms × 2 Python versions) ──┬──> publish-dev-khora
+  #                                                              └──> publish-dev-accel
   #
   # Version: hatch-vcs produces e.g. 0.5.5.dev14 (PEP 440 dev release).
   # khora-accel: git describe → semver pre-release (0.5.5-dev.14).
@@ -81,12 +81,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Python 3.13
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            python: "3.13"
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+            python: "3.13"
           - os: macos-latest
             target: aarch64-apple-darwin
+            python: "3.13"
+          # Python 3.14
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            python: "3.14"
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            python: "3.14"
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            python: "3.14"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -129,13 +143,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "${{ matrix.python }}"
 
       - name: Build wheel
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter python3.13
+          args: --release --out dist --interpreter python${{ matrix.python }}
           working-directory: rust/khora-accel
           manylinux: auto
           sccache: 'true'
@@ -143,7 +157,7 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: dev-wheel-${{ matrix.target }}
+          name: dev-wheel-${{ matrix.target }}-cp${{ matrix.python }}
           path: rust/khora-accel/dist/*.whl
 
   publish-dev-khora:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@
 # This is the ONLY workflow that runs on tag push; ci.yml handles PRs and branches.
 #
 # Pipeline:
-#   test ──> build-accel (3-platform matrix) ──┬──> publish-khora
-#                                              └──> publish-accel
+#   test ──> build-accel (3 platforms × 2 Python versions) ──┬──> publish-khora
+#                                                           └──> publish-accel
 #
 # Authentication: GitHub OIDC federation — no long-lived AWS credentials.
 # Concurrency: one release at a time; never cancel in-flight publishes.
@@ -114,7 +114,7 @@ jobs:
             dist/*
 
   # ============================================================================
-  # Build khora-accel — native wheels for 3 platforms via maturin.
+  # Build khora-accel — native wheels for 3 platforms × 2 Python versions via maturin.
   # Runs after tests pass. Builds must complete before either publish job starts.
   # ============================================================================
   build-accel:
@@ -123,12 +123,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Python 3.13
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            python: "3.13"
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+            python: "3.13"
           - os: macos-latest
             target: aarch64-apple-darwin
+            python: "3.13"
+          # Python 3.14
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            python: "3.14"
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            python: "3.14"
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            python: "3.14"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -146,15 +160,15 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "${{ matrix.python }}"
 
-      # --interpreter python3.13 ensures the manylinux container uses Python 3.13
-      # (not the default 3.8), matching requires-python >= 3.13.
+      # --interpreter ensures the manylinux container uses the correct Python
+      # (not the default 3.8), matching requires-python.
       - name: Build wheel
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter python3.13
+          args: --release --out dist --interpreter python${{ matrix.python }}
           working-directory: rust/khora-accel
           manylinux: auto
           sccache: 'true'
@@ -162,7 +176,7 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.target }}
+          name: wheel-${{ matrix.target }}-cp${{ matrix.python }}
           path: rust/khora-accel/dist/*.whl
 
   # ============================================================================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,27 +122,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python: ["3.13", "3.14"]
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - aarch64-apple-darwin
         include:
-          # Python 3.13
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            python: "3.13"
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            python: "3.13"
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            python: "3.13"
-          # Python 3.14
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            python: "3.14"
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            python: "3.14"
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            python: "3.14"
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## Summary
- Expand `build-accel` matrix in `release.yml` from 3 entries (3 platforms × Python 3.13 only) to 6 entries (3 platforms × Python 3.13 + 3.14)
- Apply the same expansion to `build-accel-dev` matrix in `ci.yml` for dev releases
- Update `actions/setup-python` and maturin `--interpreter` to use `${{ matrix.python }}` instead of hardcoded `python3.13`
- Add `-cp${{ matrix.python }}` suffix to artifact names to avoid collisions between Python versions
- Update pipeline comments to reflect the new "3 platforms × 2 Python versions" structure

Unblocks downstream consumers (e.g. `khora-benchmarks`) that use universal resolution with `requires-python >= "3.13"` — uv no longer fails for the Python 3.14 split.

Closes DYT-1229

## Test plan
- [ ] CI passes (workflow YAML syntax is valid)
- [ ] Trigger a manual `release.yml` run and verify 6 build-accel jobs spawn (3 platforms × 2 Python versions)
- [ ] Verify artifact names include the `-cp3.13` / `-cp3.14` suffix
- [ ] Verify `publish-accel` job downloads and uploads all 6 wheels
- [ ] After merge: verify `uv lock` in `khora-benchmarks` resolves without `--python 3.13` workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)