### PR TITLE
DYT-1309: Update CLAUDE.md to match current codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,26 +33,63 @@ MemoryLake (facade) -> Engine (graphrag | skeleton | vectorcypher) -> StorageCoo
 - `MemoryNamespace` is the sole multi-tenant isolation boundary
 - Config uses `KHORA_` env vars with `__` for nesting
 
+## Public API
+
+Exported from `khora/__init__.py`: `MemoryLake`, `RememberResult`, `RecallResult`, `BatchResult`, `Stats`, `LLMUsage`, `SearchMode`, `KhoraConfig`, `DocumentSource`, `ExpertiseConfig`, `EntityTypeConfig`, `RelationshipTypeConfig`, `create_engine`, `list_engines`, `register_engine`.
+
+- **LLMUsage**: Token/cost tracking dataclass consumed by Poros/Peras (DYT-645). Fields: `operation`, `model`, `prompt_tokens`, `completion_tokens`, `total_tokens`, `latency_ms`, `batch_size`. Changes require coordination.
+- **ExpertiseConfig**: Domain expertise definition (ADR-022 stable API). Defines entity types, relationship types, correlation rules, inference rules. Changes require coordination.
+- All result types are frozen dataclasses with `llm_usage: list[LLMUsage]` for cost attribution.
+
 ## Key Entry Points
 
-- `memory_lake.py`: `remember()`, `recall()`, `forget()`, `remember_batch()`, namespace helpers
+- `memory_lake.py`: `remember()`, `recall()`, `forget()`, `remember_batch()`, namespace helpers. Accepts `expertise: ExpertiseConfig`
+- `extraction/skills/base.py`: `ExpertiseConfig`, `EntityTypeConfig`, `RelationshipTypeConfig` (ADR-022 stable)
 - `storage/coordinator.py`: backend orchestration and transaction handling
 - `storage/factory.py`: backend creation with shared engine pools
 - `db/session.py`: `DatabaseManager` lifecycle
 - `db/models.py`: SQLAlchemy ORM models
 - `engines/`: GraphRAG, Skeleton Construction, VectorCypher
 - `query/engine.py`: `HybridQueryEngine`
-- `_accel.py`: Rust/NumPy/Python acceleration facade
-- `pipelines/flows/ingest.py`: ingestion pipeline with entity ID mapping
+- `_accel.py`: Rust/NumPy/Python acceleration facade (cosine, pagerank, entity resolution, community detection, temporal)
+- `pipelines/flows/ingest.py`: 3-phase ingestion pipeline (stage → enrich → expand)
+- `extraction/entity_resolution.py`: multi-strategy entity deduplication
+- `extraction/expansion/`: semantic expansion, cross-tool unification, relationship inference
+- `config/schema.py`: `KhoraConfig` Pydantic settings (storage, LLM, pipeline, query, tenancy)
+- `telemetry/`: optional PostgreSQL-backed telemetry collector + `@trace` decorator
 - `db/migrations/env.py`: Alembic env with advisory locking
 
 ## Engine Selection
 
 | Use Case | Engine | Key Trait |
 |----------|--------|-----------|
-| Knowledge bases, entity exploration | `graphrag` | Full graph extraction, requires Neo4j or Kuzu |
-| Multi-hop queries, complex relationships | `vectorcypher` | Vector + Cypher hybrid, requires Neo4j |
+| Knowledge bases, entity exploration | `graphrag` | Full graph extraction, requires Neo4j or SurrealDB |
+| Multi-hop queries, complex relationships | `vectorcypher` | Vector + Cypher hybrid, requires Neo4j or SurrealDB |
 | Chat history, event streams, cost-sensitive workloads | `skeleton` | Temporal-first, 5-10x fewer LLM calls, Neo4j optional |
+
+## Entity Extraction Pipeline
+
+3-phase async pipeline in `pipelines/flows/ingest.py`:
+
+1. **Stage** — checksum-based change detection, skip unchanged docs
+2. **Enrich** — parallel per document: chunk (fixed/semantic/recursive/conversation), embed (LiteLLM), extract entities (LLM), selective extraction (top 70% chunks to LLM), entity dedup, co-occurrence edges, store
+3. **Expand** (optional) — cross-tool entity unification, relationship inference (smart/batch/incremental/none)
+
+Built-in skills: `general.yaml` (9 entity types, 21 relationship types), `slack.yaml` (Slack-optimized).
+
+Entity resolution: 5-strategy dedup (exact → alias → attribute → embedding → fuzzy) with per-type thresholds.
+
+## Configuration
+
+`KhoraConfig` uses Pydantic BaseSettings with `KHORA_` prefix and `__` nesting.
+
+Key sections: `storage` (backend, graph, vector, PostgreSQL), `llm` (model, embedding_model, extraction_model), `pipeline` (chunking, selective_extraction), `query` (search mode, fusion weights, reranking, HyDE), `tenancy`.
+
+## Dependencies & Extras
+
+Core: `sqlalchemy[asyncio]`, `asyncpg`, `pgvector`, `neo4j`, `litellm`, `tiktoken`, `sentence-transformers`, `pydantic-settings`, `click`, `rich`, `loguru`, `tenacity`, `dateparser`, `jinja2`, `pyyaml`.
+
+Optional: `surrealdb`, `embedded`, `logfire`, `nlp`, `accel`, `rust`, `memgraph`, `arcadedb`, `graph-all`, `all-backends`, `reranking`, `dev`.
 
 ## Testing
 
@@ -91,13 +128,13 @@ Every feature, bugfix, or task follows: **Linear ticket → branch → implement
 1. Search Linear for an existing ticket matching the task. If none exists, create one.
 2. Assign yourself (or the requesting user) to the ticket.
 3. Move the ticket to **In Progress**.
-4. Create a branch from `staging` (default) following the branch naming convention below. For hotfixes, branch from `main`.
+4. Create a branch from `main` (default) following the branch naming convention below.
 5. Begin implementation.
 
 ### Finishing work
 1. Run the project-defined lint, format, and test commands.
 2. Commit all changes with a clear message.
-3. Push the branch and open a PR to `staging` by default. Only hotfixes target `main`.
+3. Push the branch and open a PR to `main`.
 4. Add the PR link as a comment on the Linear ticket.
 5. Move the ticket to **Done** only after the PR is merged.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,17 +33,115 @@ Unified stack:     SurrealDB                      (one database, all roles)
 - **Extraction skills:** YAML-defined in `extraction/skills/builtin/`. Generate with `khora ontology construct`
 - **Config:** env vars with `KHORA_` prefix, `__` nesting (e.g., `KHORA_QUERY__ENABLE_HYDE=true`)
 
+## Public API
+
+Exported from `khora/__init__.py`:
+
+```python
+from khora import (
+    MemoryLake,           # Primary interface (async context manager via memory_lake())
+    RememberResult,       # Result of remember()
+    RecallResult,         # Result of recall()
+    BatchResult,          # Result of remember_batch()
+    Stats,                # Namespace statistics
+    LLMUsage,             # Token/cost tracking (consumed by Poros/Peras — DYT-645)
+    SearchMode,           # VECTOR | GRAPH | HYBRID | ALL
+    KhoraConfig,          # Main Pydantic configuration
+    DocumentSource,       # Lightweight doc metadata for attribution
+    ExpertiseConfig,      # Domain expertise definition (ADR-022 stable API)
+    EntityTypeConfig,     # Entity type definition
+    RelationshipTypeConfig,  # Relationship type definition
+    create_engine,        # Instantiate engine by name
+    list_engines,         # ["graphrag", "skeleton", "vectorcypher"]
+    register_engine,      # Register custom engine class
+)
+```
+
+### MemoryLake Methods
+
+| Method | Purpose |
+|--------|---------|
+| `remember(content, *, namespace, expertise, ...)` | Store content, extract entities |
+| `remember_batch(documents, *, namespace, expertise, ...)` | Batch ingest with optimization |
+| `recall(query, *, namespace, limit, mode, min_similarity, ...)` | Retrieve memories |
+| `forget(document_id, *, namespace)` | Remove a memory |
+| `create_namespace()` / `get_namespace()` / `get_namespace_by_stable_id()` | Namespace management |
+| `get_entity()` / `list_entities()` / `search_entities()` / `find_related_entities()` | Entity operations |
+| `get_document()` / `list_documents()` | Document retrieval |
+| `stats(*, namespace)` | Namespace statistics |
+| `health_check()` | Backend health status |
+| `connect()` / `disconnect()` | Lifecycle (or use `async with memory_lake()`) |
+
+### Result Types (frozen dataclasses)
+
+**LLMUsage** — token tracking for cost attribution (Poros/Peras consume this):
+- `operation`, `model`, `prompt_tokens`, `completion_tokens`, `total_tokens`, `latency_ms`, `batch_size`
+
+**RememberResult** — single document ingest result:
+- `document_id`, `chunks`, `entities`, `relationships`, `llm_usage: list[LLMUsage]`
+
+**BatchResult** — batch ingest result:
+- `total`, `processed`, `skipped`, `failed`, `chunks`, `entities`, `relationships`, `metadata`, `llm_usage: list[LLMUsage]`
+
+**RecallResult** — query result:
+- `query`, `namespace_id`, `chunks`, `entities`, `context_text` (pre-formatted for LLM), `relationships` (VectorCypher only), `llm_usage`
+
+**Stats** — namespace counters
+
 ## Key Entry Points
 
 - `memory_lake.py` — `remember()`, `recall()`, `forget()`, `remember_batch()`. Accepts `expertise: ExpertiseConfig`
+- `extraction/skills/base.py` — `ExpertiseConfig`, `EntityTypeConfig`, `RelationshipTypeConfig` (ADR-022 stable)
 - `storage/coordinator.py` — `transaction()` for atomic multi-backend ops
 - `storage/backends/base.py` — `GraphBackend` protocol (implement for new backends)
 - `storage/backends/surrealdb/` — Unified SurrealDB backend
 - `db/models.py` — SQLAlchemy ORM (UUID columns use `as_uuid=True`)
-- `_accel.py` — Rust/NumPy acceleration (MMR, cosine, BM25, temporal detection)
+- `_accel.py` — Rust/NumPy acceleration (MMR, cosine, pagerank, entity resolution, community detection, temporal)
 - `cli/ontology/` — Ontology construction: `commands.py`, `flow.py`, `inference/`, `sources/`, `sampling/`
-- `pipelines/flows/ingest.py` — Document ingestion pipeline
+- `pipelines/flows/ingest.py` — Document ingestion pipeline (3-phase: stage → enrich → expand)
 - `db/migrations/env.py` — Alembic with advisory locking
+- `config/schema.py` — `KhoraConfig` Pydantic settings (storage, LLM, pipeline, query, tenancy)
+- `telemetry/` — Optional PostgreSQL-backed telemetry collector + `@trace` decorator
+
+## Entity Extraction Pipeline
+
+3-phase pipeline in `pipelines/flows/ingest.py`:
+
+```
+Phase 1: Stage — checksum-based change detection, skip unchanged docs
+Phase 2: Enrich (parallel per document):
+  ├── Chunk (fixed | semantic | recursive | conversation)
+  ├── Embed (LiteLLM, shared embedder) ─┐ concurrent
+  ├── Extract entities (LLM) ───────────┘
+  ├── Selective extraction — score chunks by importance, top-K to LLM
+  ├── Entity deduplication (smart O(1) index or fuzzy resolution)
+  ├── Co-occurrence edges + optional cross-chunk relationships
+  └── Store (chunks → pgvector, entities → graph, embeddings → vector)
+Phase 3: Semantic Expansion (optional):
+  ├── Cross-tool entity unification
+  └── Relationship inference (smart | batch | incremental | none)
+```
+
+**Chunkers** (`extraction/chunkers/`): `FixedChunker` (token-based), `SemanticChunker` (sentence boundaries), `RecursiveChunker` (hierarchical), `ConversationChunker` (speaker-aware)
+
+**Builtin skills** (`extraction/skills/builtin/`): `general.yaml` (9 entity types, 21 relationship types), `slack.yaml` (Slack-optimized with channel/message correlation)
+
+**Entity resolution** (`extraction/entity_resolution.py`): 5-strategy dedup (exact → alias → attribute → embedding → fuzzy). Per-type thresholds (PERSON 0.92, DATE 0.95, default 0.85)
+
+**Semantic expansion** (`extraction/expansion/`): `SemanticExpander` orchestrates `CrossToolUnifier` + `RelationshipInferrer` + `RuleEngine`
+
+## Configuration
+
+`KhoraConfig` (Pydantic BaseSettings, env prefix `KHORA_`, nested delimiter `__`):
+
+| Section | Key Settings |
+|---------|-------------|
+| **storage** | `backend` (`postgres`/`surrealdb`), graph config (Neo4j/Memgraph/ArcadeDB/SurrealDB), vector config (pgvector/ArcadeDB/SurrealDB), PostgreSQL pool tuning, HNSW parameters |
+| **llm** | `model` (default `gpt-4o-mini`), `embedding_model` (`text-embedding-3-small`), `extraction_model`, `embedding_dimension` (1536), temperature, max_tokens, max_concurrent_llm_calls, LiteLLM router config |
+| **pipeline** | `chunking_strategy`, `chunk_size` (512), `extract_entities`, `selective_extraction` (true), `extraction_importance_ratio` (0.7), `skip_embedding_entity_types` (DATE, URL, EMAIL) |
+| **query** | `default_mode` (hybrid), fusion weights (vector 0.5, graph 0.3, keyword 0.2), reranking, HyDE, recency bias, entity linking, BM25, temporal resolver |
+| **tenancy** | `default_mode` (shared/isolated), `enforce_namespace` |
+| Top-level | `database_url`, `neo4j_url`, `debug`, `telemetry_database_url`, `telemetry_service_name` |
 
 ## Engine Selection
 
@@ -52,6 +150,31 @@ Unified stack:     SurrealDB                      (one database, all roles)
 | Knowledge bases, entity exploration | `graphrag` | Neo4j or SurrealDB |
 | Multi-hop queries, complex relationships | `vectorcypher` | Neo4j or SurrealDB |
 | Chat history, cost-sensitive | `skeleton` | Graph backend optional |
+
+## Acceleration (`_accel.py`)
+
+3-tier: Rust (`khora-accel` wheel, Pyo3 + rayon) → NumPy/RapidFuzz → pure Python. Override: `KHORA_ACCEL_BACKEND` env var (`rust`/`numpy`/`python`).
+
+Key functions: `cosine_similarity`, `batch_cosine_similarity`, `pairwise_cosine_above_threshold`, `levenshtein_similarity`, `batch_levenshtein`, `pagerank`, `reciprocal_rank_fusion`, `weighted_rrf`, `mmr_diversity_select`, `resolve_entities_batch`, `normalize_entity_name`, `detect_temporal_category`, `batch_temporal_filter`, `detect_communities`, `deduplicate_chunks`, `extract_keywords`
+
+## Dependencies & Extras
+
+Core: `sqlalchemy[asyncio]`, `asyncpg`, `pgvector`, `neo4j`, `litellm`, `tiktoken`, `sentence-transformers`, `pydantic-settings`, `click`, `rich`, `loguru`, `tenacity`, `dateparser`, `jinja2`, `pyyaml`
+
+| Extra | Install | Purpose |
+|-------|---------|---------|
+| `surrealdb` | `pip install khora[surrealdb]` | SurrealDB unified backend |
+| `embedded` | `pip install khora[embedded]` | SurrealDB embedded mode |
+| `logfire` | `pip install khora[logfire]` | Logfire observability |
+| `nlp` | `pip install khora[nlp]` | spaCy NLP |
+| `accel` | `pip install khora[accel]` | RapidFuzz CPU acceleration |
+| `rust` | `pip install khora[rust]` | Rust-accelerated ops (khora-accel) |
+| `memgraph` | `pip install khora[memgraph]` | Memgraph backend |
+| `arcadedb` | `pip install khora[arcadedb]` | ArcadeDB backend |
+| `graph-all` | `pip install khora[graph-all]` | All graph backends |
+| `all-backends` | `pip install khora[all-backends]` | All backends |
+| `reranking` | `pip install khora[reranking]` | Neural reranking |
+| `dev` | `pip install khora[dev]` | Testing & linting |
 
 ## Testing
 
@@ -94,12 +217,18 @@ Versions from git tags — no manual bumps. `git tag vX.Y.Z && git push origin v
 - **Pre-normalized embeddings** — L2-normalized at ingest. Uses `batch_dot_product` (3x faster than cosine)
 - **Entity unique constraint** — `(namespace_id, name, entity_type)` UNIQUE in both PostgreSQL and SurrealDB
 - **Namespace versioning** — dual IDs: `id` (row-level) vs `namespace_id` (stable). Public API uses `namespace_id`, resolves to `id` via indexed lookup
+- **Selective extraction** — KET-RAG style: scores chunk importance, sends top 70% to LLM, rest get co-occurrence edges only
+- **Entity resolution** — multi-strategy dedup with per-type thresholds (PERSON 0.92, DATE 0.95, default 0.85)
+- **Semantic expansion** — optional cross-tool entity unification + relationship inference (4 modes: smart/batch/incremental/none)
 
 ### Optional Dependencies
 - **spaCy:** `_HAS_SPACY` flag, falls back to regex sentence splitting
 - **Logfire:** `_HAS_LOGFIRE` flag, `trace_span()` yields no-op when absent. Install: `pip install khora[logfire]`
 - **`@trace` decorator:** `from khora.telemetry import trace`. Zero overhead when logfire absent
+- **Telemetry collector:** `KHORA_TELEMETRY_DATABASE_URL` enables PostgreSQL-backed event recording. Without it, `NoOpCollector` is used (zero cost)
 
 ### Downstream
 - `genesis` and `khora-benchmarks` depend on khora. `lake.storage` is a stable public API
+- **LLMUsage contract:** `LLMUsage` fields are consumed by Poros/Peras for cost tracking (DYT-645) — changes require coordination
+- **ExpertiseConfig contract:** ADR-022 stable API — `ExpertiseConfig`, `EntityTypeConfig`, `RelationshipTypeConfig` changes require coordination
 - `scripts/` vendored from TTOJ — skip in audits

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ This project embodies that philosophy: **Khora is a memory lake**—a receptacle
 
 Khora is a **Memory Lake** system that combines three storage paradigms:
 
-- **Knowledge Graph** (Neo4j) — Entities and their relationships
-- **Vector Database** (pgvector) — Semantic embeddings for similarity search
-- **Relational Database** (PostgreSQL) — Documents, events, and metadata
+- **Knowledge Graph** (Neo4j, SurrealDB, Memgraph, ArcadeDB) — Entities and their relationships
+- **Vector Database** (pgvector, SurrealDB) — Semantic embeddings for similarity search
+- **Relational Database** (PostgreSQL, SurrealDB) — Documents, events, and metadata
 
-It supports **multi-tenancy** with hierarchical isolation (Organization → Workspace → Namespace), **event sourcing** for complete audit trails, and **hybrid search** combining vector similarity, graph traversal, and keyword matching.
+It supports **multi-tenancy** with namespace-level isolation, **event sourcing** for complete audit trails, and **hybrid search** combining vector similarity, graph traversal, and keyword matching. A **unified SurrealDB** backend can replace all three databases.
 
 ### Key Features
 
@@ -27,8 +27,10 @@ It supports **multi-tenancy** with hierarchical isolation (Organization → Work
 - **Multi-Tenancy**: Namespace-level isolation (shared mode with ACLs designed but not yet active)
 - **Event Sourcing**: Immutable event log for temporal queries and audit trails
 - **LiteLLM Integration**: Unified access to OpenAI, Anthropic, Google, and other providers
-- **Prefect Pipelines**: Orchestrated ingestion with checksum-based change detection
-- **Semantic Extraction**: LLM-powered entity and relationship extraction
+- **3-Phase Ingestion**: Stage → enrich → expand pipeline with checksum-based change detection
+- **Semantic Extraction**: LLM-powered entity and relationship extraction with domain expertise
+- **Cost Tracking**: `LLMUsage` type for token/cost attribution (consumed by Poros/Peras)
+- **Rust Acceleration**: Optional native Rust extensions for CPU-bound operations (cosine, pagerank, entity resolution)
 
 ---
 
@@ -59,7 +61,7 @@ async with MemoryLake("postgresql://...", engine="graphrag") as lake:
     related = await lake.find_related_entities(entity_id, max_depth=2)
 ```
 
-**Requirements:** PostgreSQL + pgvector + Neo4j/Kuzu/Memgraph
+**Requirements:** PostgreSQL + pgvector + Neo4j/Memgraph/SurrealDB
 
 ### Skeleton Construction Engine (Temporal-First)
 
@@ -154,7 +156,7 @@ Comprehensive documentation is available in the [`docs/`](docs/) directory:
 | [Events](docs/data-models/events.md) | MemoryEvent types and usage |
 | **Extraction Pipeline** | |
 | [Overview](docs/extraction/overview.md) | Pipeline components and flow |
-| [Ingestion Pipeline](docs/extraction/ingestion-pipeline.md) | Two-phase ingestion with Prefect |
+| [Ingestion Pipeline](docs/extraction/ingestion-pipeline.md) | Three-phase async ingestion pipeline |
 | [Chunkers](docs/extraction/chunkers.md) | Fixed, semantic, recursive chunking |
 | [Embedders](docs/extraction/embedders.md) | LiteLLM-based embedding generation |
 | [Extractors](docs/extraction/extractors.md) | LLM entity and relationship extraction |
@@ -348,20 +350,20 @@ async with MemoryLake() as lake:
 from khora import MemoryLake
 
 async with MemoryLake() as lake:
-    # Simple: Get or create a namespace by name
-    namespace_id = await lake.ensure_namespace("physics", description="Physics research")
+    # Create a namespace
+    ns = await lake.create_namespace(name="physics", description="Physics research")
 
     # Store memories in specific namespace
     await lake.remember(
         "Important research findings...",
-        namespace=namespace_id,
+        namespace=ns.namespace_id,
     )
 
     # Query within namespace (isolated from other namespaces)
-    results = await lake.recall("findings", namespace=namespace_id)
+    results = await lake.recall("findings", namespace=ns.namespace_id)
 
     # Get namespace statistics
-    stats = await lake.stats(namespace=namespace_id)
+    stats = await lake.stats(namespace=ns.namespace_id)
     print(f"Documents: {stats.documents}, Entities: {stats.entities}")
 ```
 
@@ -377,7 +379,7 @@ async with MemoryLake() as lake:
 │                                                                              │
 │  ┌──────────────┐   ┌──────────────┐   ┌──────────────┐   ┌──────────────┐   │
 │  │    Query     │   │  Pipelines   │   │  VectorCypher│   │   Config     │   │
-│  │   Engine     │   │  (Prefect)   │   │   Router     │   │   Resolver   │   │
+│  │   Engine     │   │  (Async)     │   │   Router     │   │   Resolver   │   │
 │  └──────┬───────┘   └──────┬───────┘   └──────┬───────┘   └──────┬───────┘   │
 │         │                  │                  │                  │           │
 ├─────────┴──────────────────┴──────────────────┴──────────────────┴───────────┤
@@ -398,19 +400,19 @@ async with MemoryLake() as lake:
 | Component | Purpose |
 |-----------|---------|
 | `MemoryLake` | Primary API for remember/recall/forget operations |
-| `StorageCoordinator` | Orchestrates all storage backends |
-| `HybridQueryEngine` | Combines vector, graph, and keyword search |
-| `PipelineManager` | Manages Prefect ingestion flows |
+| `StorageCoordinator` | Orchestrates all storage backends with atomic transactions |
+| `HybridQueryEngine` | Combines vector, graph, and keyword search with RRF fusion |
+| `PipelineManager` | Manages async ingestion flows |
 | `ACLEnforcer` | Cross-layer permission enforcement |
 
 ### Storage Backends
 
 | Backend | Technology | Purpose |
 |---------|------------|---------|
-| Relational | PostgreSQL | Documents, events, permissions, metadata |
-| Vector | pgvector | Embeddings for semantic similarity search |
-| Graph | Neo4j | Entity nodes and relationship edges |
-| Event Store | PostgreSQL | Immutable event log for sourcing |
+| Relational | PostgreSQL or SurrealDB | Documents, events, permissions, metadata |
+| Vector | pgvector, ArcadeDB, or SurrealDB | Embeddings for semantic similarity search |
+| Graph | Neo4j, SurrealDB, Memgraph, or ArcadeDB | Entity nodes and relationship edges |
+| Event Store | PostgreSQL or SurrealDB | Immutable event log for sourcing |
 
 ### Data Flow
 
@@ -435,14 +437,25 @@ async with MemoryLake() as lake:
 
 ### Environment Variables
 
+All config uses the `KHORA_` prefix with `__` for nested sections (e.g., `KHORA_LLM__MODEL=gpt-4o`).
+
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `KHORA_DATABASE_URL` | PostgreSQL connection URL | Required |
 | `KHORA_NEO4J_URL` | Neo4j connection URL | `bolt://localhost:7687` |
 | `KHORA_NEO4J_USER` | Neo4j username | `neo4j` |
 | `KHORA_NEO4J_PASSWORD` | Neo4j password | Required for Neo4j |
+| `KHORA_STORAGE__BACKEND` | Backend mode | `postgres` or `surrealdb` |
+| `KHORA_LLM__MODEL` | Primary LLM model | `gpt-4o-mini` |
+| `KHORA_LLM__EMBEDDING_MODEL` | Embedding model | `text-embedding-3-small` |
+| `KHORA_LLM__EXTRACTION_MODEL` | Extraction model (optional) | Same as `model` |
+| `KHORA_PIPELINE__CHUNK_SIZE` | Chunk size in tokens | `512` |
+| `KHORA_PIPELINE__SELECTIVE_EXTRACTION` | KET-RAG importance filtering | `true` |
+| `KHORA_QUERY__DEFAULT_MODE` | Default search mode | `hybrid` |
+| `KHORA_QUERY__ENABLE_HYDE` | HyDE query expansion | `auto` |
+| `KHORA_TELEMETRY_DATABASE_URL` | PostgreSQL for telemetry events | Disabled |
+| `KHORA_ACCEL_BACKEND` | Acceleration tier | Auto-detect (`rust`/`numpy`/`python`) |
 | `KHORA_DEBUG` | Enable debug mode | `false` |
-| `KHORA_AUTH_ENABLED` | Enable authentication | `true` |
 | `OPENAI_API_KEY` | OpenAI API key (for embeddings) | - |
 | `ANTHROPIC_API_KEY` | Anthropic API key (for extraction) | - |
 
@@ -478,22 +491,30 @@ model_list:
       api_key: os.environ/ANTHROPIC_API_KEY
 ```
 
-### Extraction Skills
+### Extraction Skills & Expertise
 
-Configure entity extraction in your code:
+Configure entity extraction using `ExpertiseConfig` (ADR-022 stable API) or the simpler `ExtractionSkill`:
 
 ```python
-from khora.extraction.skills import ExtractionSkill
+from khora import ExpertiseConfig, EntityTypeConfig, RelationshipTypeConfig
 
-skill = ExtractionSkill(
-    name="custom_entities",
-    description="Extract domain-specific entities",
-    entity_types=["COMPANY", "PRODUCT", "TECHNOLOGY"],
-    relationship_types=["DEVELOPS", "COMPETES_WITH", "USES"],
+# Domain-specific expertise configuration
+expertise = ExpertiseConfig(
+    name="custom_domain",
+    entity_types=[
+        EntityTypeConfig(name="COMPANY", description="A business entity"),
+        EntityTypeConfig(name="PRODUCT", description="A product or service"),
+    ],
+    relationship_types=[
+        RelationshipTypeConfig(name="DEVELOPS", source_types=["COMPANY"], target_types=["PRODUCT"]),
+    ],
 )
 
-await lake.remember(content, skill_name="custom_entities")
+await lake.remember(content, expertise=expertise)
+await lake.remember_batch(documents, expertise=expertise)
 ```
+
+Built-in skills in `extraction/skills/builtin/`: `general.yaml` (9 entity types, 21 relationship types), `slack.yaml` (Slack-optimized).
 
 ---
 
@@ -526,12 +547,15 @@ khora/
 │   │   ├── models.py            # SQLAlchemy ORM
 │   │   └── session.py           # DatabaseManager + async sessions
 │   ├── extraction/              # Content processing
-│   │   ├── chunkers/            # Text chunking strategies
-│   │   ├── embedders/           # Embedding generation
-│   │   ├── extractors/          # Entity extraction
-│   │   └── skills/              # Extraction configurations
-│   ├── pipelines/               # Prefect workflows
-│   │   ├── flows/               # Ingestion and sync flows
+│   │   ├── chunkers/            # Text chunking (fixed, semantic, recursive, conversation)
+│   │   ├── embedders/           # Embedding generation (LiteLLM)
+│   │   ├── extractors/          # LLM entity extraction
+│   │   ├── expansion/           # Semantic expansion, entity unification, inference
+│   │   ├── skills/              # Extraction configurations (ExpertiseConfig, ExtractionSkill)
+│   │   ├── entity_resolution.py # Multi-strategy entity deduplication
+│   │   └── importance.py        # Chunk importance scoring (selective extraction)
+│   ├── pipelines/               # Async workflows
+│   │   ├── flows/               # Ingestion and sync flows (3-phase pipeline)
 │   │   ├── tasks/               # Individual pipeline tasks
 │   │   ├── manager.py           # Pipeline orchestration
 │   │   └── registry.py          # Pipeline registration
@@ -539,13 +563,17 @@ khora/
 │   │   ├── engine.py            # HybridQueryEngine
 │   │   ├── fusion.py            # Reciprocal Rank Fusion
 │   │   └── temporal.py          # Time-based queries
+│   ├── telemetry/               # Observability
+│   │   ├── collector.py         # PostgreSQL-backed telemetry collector
+│   │   ├── trace_decorator.py   # @trace decorator (Logfire integration)
+│   │   └── noop.py              # NoOpCollector (zero cost when disabled)
+│   ├── _accel.py                # Rust/NumPy/Python acceleration facade
 │   └── storage/                 # Storage backends
-│       ├── backends/            # PostgreSQL, pgvector, Neo4j
+│       ├── backends/            # PostgreSQL, pgvector, Neo4j, SurrealDB, Memgraph, ArcadeDB
 │       ├── coordinator.py       # Backend orchestration + TransactionContext
 │       ├── event_store.py       # Event sourcing
 │       └── factory.py           # Storage initialization + shared pools
 ├── tests/                       # Test suite
-├── alembic/                     # Database migrations
 ├── examples/config/             # Example configurations
 ├── compose.yaml                 # Development databases
 └── pyproject.toml               # Project configuration
@@ -619,15 +647,19 @@ class MemoryLake:
         self,
         database_url: str | KhoraConfig | None = None,
         *,
+        engine: str = "graphrag",
         graph_url: str | None = None,
         embedding_model: str = "text-embedding-3-small",
+        run_migrations: bool = False,
     ):
         """Initialize the Memory Lake.
 
         Args:
             database_url: PostgreSQL URL, KhoraConfig, or None (reads from env)
+            engine: Engine name ("graphrag", "skeleton", "vectorcypher")
             graph_url: Optional Neo4j URL (bolt://user:pass@host:port)
             embedding_model: Embedding model to use
+            run_migrations: Auto-run Alembic migrations on connect
         """
 ```
 
@@ -638,11 +670,14 @@ class MemoryLake:
         self,
         content: str,
         *,
-        namespace: str | UUID | None = None,
+        namespace: str | UUID,
         title: str = "",
         source: str = "",
-        metadata: dict = {},
+        metadata: dict | None = None,
         skill_name: str = "general_entities",
+        expertise: ExpertiseConfig | None = None,
+        extraction_config_hash: str | None = None,
+        chunk_strategy: ChunkStrategy | None = None,
     ) -> RememberResult:
         """Store content in the memory lake."""
 
@@ -650,12 +685,15 @@ class MemoryLake:
         self,
         documents: list[dict],
         *,
-        namespace: str | UUID | None = None,
+        namespace: str | UUID,
         skill_name: str = "general_entities",
         max_concurrent: int = 10,
         deduplicate: bool = True,
         infer_relationships: bool = True,
         on_progress: Callable[[int, int], None] | None = None,
+        expertise: ExpertiseConfig | None = None,
+        extraction_config_hash: str | None = None,
+        chunk_strategy: ChunkStrategy | None = None,
     ) -> BatchResult:
         """Store multiple documents with automatic optimization."""
 
@@ -669,6 +707,7 @@ class MemoryLake:
         min_similarity: float = 0.0,
         agentic: bool = False,
         raw: bool = False,  # Skip all LLM features
+        include_sources: bool = False,
     ) -> RecallResult:
         """Recall memories relevant to a query."""
 
@@ -684,13 +723,14 @@ class MemoryLake:
 #### Convenience Methods
 
 ```python
-    async def ensure_namespace(
-        self,
-        name: str,
-        *,
-        description: str = "",
-    ) -> UUID:
-        """Get or create a namespace by name."""
+    async def create_namespace(self, name: str = "", *, description: str = "") -> MemoryNamespace:
+        """Create a new namespace."""
+
+    async def get_namespace(self, namespace_id: UUID) -> MemoryNamespace | None:
+        """Get a namespace by row ID."""
+
+    async def get_namespace_by_stable_id(self, namespace_id: str | UUID) -> MemoryNamespace | None:
+        """Get a namespace by stable namespace_id."""
 
     async def get_document(self, document_id: UUID) -> Document | None:
         """Get a document by ID."""
@@ -709,6 +749,7 @@ class MemoryLake:
         *,
         namespace: str | UUID | None = None,
         limit: int = 10,
+        include_sources: bool = False,
     ) -> list[Entity]:
         """Search entities by query text using embedding similarity."""
 
@@ -725,6 +766,7 @@ class MemoryLake:
         namespace: str | UUID | None = None,
         entity_type: str | None = None,
         limit: int = 100,
+        include_sources: bool = False,
     ) -> list[Entity]:
         """List entities in a namespace."""
 
@@ -734,14 +776,39 @@ class MemoryLake:
         *,
         max_depth: int = 2,
         limit: int = 20,
+        include_sources: bool = False,
     ) -> list[tuple[Entity, float]]:
         """Find entities related to a given entity."""
+
+    async def get_entity(
+        self,
+        entity_id: UUID,
+        *,
+        include_sources: bool = False,
+    ) -> Entity | None:
+        """Fetch a single entity by ID."""
+
+    async def health_check(self) -> dict[str, Any]:
+        """Check health status of all backends."""
 ```
 
 ### Data Classes
 
+All result types are frozen dataclasses (`slots=True, frozen=True`).
+
 ```python
-@dataclass
+@dataclass(slots=True, frozen=True)
+class LLMUsage:
+    """Token usage tracking — consumed by Poros/Peras for cost attribution (DYT-645)."""
+    operation: str           # "entity_extraction", "embedding", etc.
+    model: str               # "gpt-4o", "text-embedding-3-small", etc.
+    prompt_tokens: int
+    completion_tokens: int   # 0 for embeddings
+    total_tokens: int
+    latency_ms: float
+    batch_size: int = 1      # >1 for embedding batches
+
+@dataclass(slots=True, frozen=True)
 class RememberResult:
     """Result of a remember() operation."""
     document_id: UUID
@@ -750,18 +817,21 @@ class RememberResult:
     entities_extracted: int
     relationships_created: int
     metadata: dict[str, Any]
+    llm_usage: list[LLMUsage]
 
-@dataclass
+@dataclass(slots=True, frozen=True)
 class RecallResult:
     """Result of a recall() operation."""
     query: str
     namespace_id: UUID
     chunks: list[tuple[Chunk, float]]
     entities: list[tuple[Entity, float]]
-    context_text: str
+    context_text: str               # Pre-formatted for LLM consumption
+    relationships: list[tuple[Relationship, float]]  # VectorCypher only
     metadata: dict[str, Any]
+    llm_usage: list[LLMUsage]
 
-@dataclass
+@dataclass(slots=True, frozen=True)
 class BatchResult:
     """Result of remember_batch() operation."""
     total: int        # Total documents submitted
@@ -771,8 +841,10 @@ class BatchResult:
     chunks: int       # Total chunks created
     entities: int     # Total entities extracted
     relationships: int # Total relationships created
+    metadata: dict[str, Any]
+    llm_usage: list[LLMUsage]
 
-@dataclass
+@dataclass(slots=True, frozen=True)
 class Stats:
     """Namespace statistics from stats()."""
     documents: int
@@ -790,7 +862,7 @@ class Stats:
 | `HYBRID` | Combined vector + graph + keyword with RRF fusion |
 | `ALL` | All sources (vector, graph, keyword) |
 
-### Entity Types
+### Entity Types (general.yaml)
 
 | Type | Description |
 |------|-------------|
@@ -801,8 +873,10 @@ class Stats:
 | `EVENT` | Occurrences, incidents |
 | `TECHNOLOGY` | Tools, platforms, languages |
 | `PRODUCT` | Goods, services |
-| `DOCUMENT` | Referenced documents |
-| `OTHER` | Uncategorized entities |
+| `STATE_CHANGE` | Transitions from one state to another |
+| `DATE` | Specific dates, time periods, or temporal references |
+
+Custom entity types can be defined via `ExpertiseConfig` or `ExtractionSkill`.
 
 ### Changes in v0.3.5
 


### PR DESCRIPTION
## Summary
- Add public API surface docs: `LLMUsage`, `BatchResult`, `RememberResult`, `RecallResult`, `Stats`, `ExpertiseConfig`, `SearchMode`, `DocumentSource`, engine functions
- Document entity extraction pipeline: 3-phase ingest (stage → enrich → expand), chunkers, entity resolution, semantic expansion
- Add configuration schema reference: storage, LLM, pipeline, query, tenancy sections
- Document acceleration functions (`_accel.py`), dependency extras, and telemetry system
- Add downstream API contracts: LLMUsage (Poros/Peras DYT-645), ExpertiseConfig (ADR-022)

## Test plan
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] Review CLAUDE.md content against codebase for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)