### PR TITLE
DYT-1346: Fix halfvec HNSW indexes causing full sequential scans

### DIFF
--- a/src/khora/db/migrations/versions/018_halfvec_hnsw_indexes.py
+++ b/src/khora/db/migrations/versions/018_halfvec_hnsw_indexes.py
@@ -1,0 +1,89 @@
+"""Add halfvec HNSW expression indexes for float16 embeddings.
+
+Revision ID: 018_halfvec_hnsw_indexes
+Revises: 017_temporal_coalesce_index
+Create Date: 2026-03-28
+
+DYT-1346: Create halfvec HNSW expression indexes that cast embedding columns
+to halfvec(1536), using halfvec_cosine_ops.  Float16 precision yields ~50%
+smaller index size with minimal recall loss.  Requires pgvector >= 0.7.0.
+
+Uses CREATE INDEX CONCURRENTLY (cannot run inside a transaction), so each
+index operation uses an autocommit block.  Invalid indexes left behind by
+interrupted builds are detected via pg_index.indisvalid, dropped, and
+recreated.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "018_halfvec_hnsw_indexes"
+down_revision: str | Sequence[str] | None = "017_temporal_coalesce_index"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Index definitions
+_INDEXES = [
+    {
+        "name": "ix_chunks_embedding_halfvec_hnsw",
+        "table": "chunks",
+    },
+    {
+        "name": "ix_entities_embedding_halfvec_hnsw",
+        "table": "entities",
+    },
+]
+
+
+def _drop_invalid_index(index_name: str) -> None:
+    """Drop an index if it exists and is marked invalid (indisvalid = false).
+
+    An invalid index is left behind when CREATE INDEX CONCURRENTLY is
+    interrupted.  We must remove it before re-creating, because
+    IF NOT EXISTS will skip creation even for invalid indexes.
+    """
+    conn = op.get_bind()
+    is_invalid = conn.execute(
+        text(
+            "SELECT EXISTS ("
+            "  SELECT 1 FROM pg_class c"
+            "  JOIN pg_index i ON i.indexrelid = c.oid"
+            "  WHERE c.relname = :name AND NOT i.indisvalid"
+            ")"
+        ),
+        {"name": index_name},
+    ).scalar()
+    if is_invalid:
+        with op.get_context().autocommit_block():
+            op.execute(text(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}"))
+
+
+def upgrade() -> None:
+    for idx in _INDEXES:
+        name = idx["name"]
+        table = idx["table"]
+
+        # If a previous interrupted build left an invalid index, remove it
+        # so that IF NOT EXISTS doesn't skip the create.  The read query
+        # in _drop_invalid_index runs inside the migration transaction
+        # (read-only, safe); only the DROP uses autocommit_block because
+        # DROP INDEX CONCURRENTLY cannot run inside a transaction.
+        _drop_invalid_index(name)
+
+        with op.get_context().autocommit_block():
+            op.execute(
+                text(
+                    f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} "
+                    f"ON {table} USING hnsw ((embedding::halfvec(1536)) halfvec_cosine_ops) "
+                    f"WITH (m = 24, ef_construction = 128)"
+                )
+            )
+
+
+def downgrade() -> None:
+    for idx in _INDEXES:
+        name = idx["name"]
+        with op.get_context().autocommit_block():
+            op.execute(text(f"DROP INDEX CONCURRENTLY IF EXISTS {name}"))

--- a/src/khora/db/migrations/versions/018_halfvec_hnsw_indexes.py
+++ b/src/khora/db/migrations/versions/018_halfvec_hnsw_indexes.py
@@ -24,6 +24,11 @@ down_revision: str | Sequence[str] | None = "017_temporal_coalesce_index"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
+# Default embedding dimension. Deployments using a different
+# embedding_dimension config value will need a custom migration
+# to create indexes matching their dimension.
+_EMBEDDING_DIMENSION = 1536
+
 # Index definitions
 _INDEXES = [
     {
@@ -76,7 +81,7 @@ def upgrade() -> None:
             op.execute(
                 text(
                     f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} "
-                    f"ON {table} USING hnsw ((embedding::halfvec(1536)) halfvec_cosine_ops) "
+                    f"ON {table} USING hnsw ((embedding::halfvec({_EMBEDDING_DIMENSION})) halfvec_cosine_ops) "
                     f"WITH (m = 24, ef_construction = 128)"
                 )
             )

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -130,24 +130,21 @@ class PgVectorBackend(AsyncSessionMixin):
         async with self._engine.begin() as conn:
             await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
 
-        # Detect halfvec support (pgvector >= 0.7.0)
+        # Detect halfvec support (pgvector >= 0.7.0) and verify HNSW indexes
         if self._use_halfvec:
-            self._halfvec_available = await self._detect_halfvec_support()
-            if self._halfvec_available:
-                logger.info("halfvec (float16) support detected — enabled for similarity search")
-            else:
-                logger.warning(
-                    "halfvec requested but pgvector extension < 0.7.0 — " "falling back to full-precision vectors"
-                )
-
-        # Verify halfvec HNSW indexes exist before enabling halfvec mode
-        if self._halfvec_available:
-            if not await self._check_halfvec_indexes():
+            halfvec_supported = await self._detect_halfvec_support()
+            if not halfvec_supported:
+                self._halfvec_available = False
+                logger.warning("halfvec requested but pgvector < 0.7.0 — falling back to full-precision vectors")
+            elif not await self._check_halfvec_indexes():
                 self._halfvec_available = False
                 logger.warning(
                     "halfvec HNSW indexes not found — falling back to full-precision vectors. "
                     "Run migrations to create them."
                 )
+            else:
+                self._halfvec_available = True
+                logger.info("halfvec (float16) support detected — enabled for similarity search")
 
         logger.info("Connected to pgvector")
 
@@ -195,21 +192,31 @@ class PgVectorBackend(AsyncSessionMixin):
             return False
 
     async def _check_halfvec_indexes(self) -> bool:
-        """Check if both halfvec HNSW indexes exist in the database."""
+        """Check if both halfvec HNSW indexes exist and are valid in the database."""
         required = {"ix_chunks_embedding_halfvec_hnsw", "ix_entities_embedding_halfvec_hnsw"}
         try:
             async with self._get_session() as session:
                 result = await session.execute(
                     text(
-                        "SELECT indexname FROM pg_indexes "
-                        "WHERE indexname IN ('ix_chunks_embedding_halfvec_hnsw', "
+                        "SELECT c.relname, i.indisvalid FROM pg_class c "
+                        "JOIN pg_index i ON i.indexrelid = c.oid "
+                        "WHERE c.relname IN ('ix_chunks_embedding_halfvec_hnsw', "
                         "'ix_entities_embedding_halfvec_hnsw')"
                     )
                 )
-                found = {row[0] for row in result.all()}
-                return required.issubset(found)
+                rows = result.all()
+                valid = set()
+                for name, is_valid in rows:
+                    if is_valid:
+                        valid.add(name)
+                    else:
+                        logger.warning(
+                            f"halfvec index {name} exists but is invalid "
+                            "(interrupted build?) — re-run migrations to rebuild it"
+                        )
+                return required.issubset(valid)
         except Exception as e:
-            logger.debug(f"Failed to check halfvec indexes: {e}")
+            logger.warning(f"Failed to check halfvec indexes: {e}")
             return False
 
     async def create_tables(self) -> None:

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -140,6 +140,15 @@ class PgVectorBackend(AsyncSessionMixin):
                     "halfvec requested but pgvector extension < 0.7.0 — " "falling back to full-precision vectors"
                 )
 
+        # Verify halfvec HNSW indexes exist before enabling halfvec mode
+        if self._halfvec_available:
+            if not await self._check_halfvec_indexes():
+                self._halfvec_available = False
+                logger.warning(
+                    "halfvec HNSW indexes not found — falling back to full-precision vectors. "
+                    "Run migrations to create them."
+                )
+
         logger.info("Connected to pgvector")
 
     async def disconnect(self) -> None:
@@ -183,6 +192,24 @@ class PgVectorBackend(AsyncSessionMixin):
                 return (major, minor) >= (0, 7)
         except Exception as e:
             logger.debug(f"Failed to detect pgvector version: {e}")
+            return False
+
+    async def _check_halfvec_indexes(self) -> bool:
+        """Check if both halfvec HNSW indexes exist in the database."""
+        required = {"ix_chunks_embedding_halfvec_hnsw", "ix_entities_embedding_halfvec_hnsw"}
+        try:
+            async with self._get_session() as session:
+                result = await session.execute(
+                    text(
+                        "SELECT indexname FROM pg_indexes "
+                        "WHERE indexname IN ('ix_chunks_embedding_halfvec_hnsw', "
+                        "'ix_entities_embedding_halfvec_hnsw')"
+                    )
+                )
+                found = {row[0] for row in result.all()}
+                return required.issubset(found)
+        except Exception as e:
+            logger.debug(f"Failed to check halfvec indexes: {e}")
             return False
 
     async def create_tables(self) -> None:

--- a/src/khora/storage/optimize.py
+++ b/src/khora/storage/optimize.py
@@ -471,56 +471,6 @@ async def reindex_hnsw_concurrently(engine) -> dict:
     return result
 
 
-async def create_halfvec_indexes(
-    engine,
-    *,
-    embedding_dimension: int = 1536,
-    hnsw_m: int = 24,
-    hnsw_ef_construction: int = 128,
-) -> dict:
-    """Create halfvec expression HNSW indexes for reduced index size.
-
-    These indexes cast the full-precision ``vector`` column to ``halfvec``
-    (float16) at index time, yielding ~50% smaller HNSW indexes with
-    minimal recall loss.
-
-    Requires pgvector extension >= 0.7.0.
-
-    Args:
-        engine: An ``sqlalchemy.ext.asyncio.AsyncEngine`` instance.
-        embedding_dimension: Dimension of embedding vectors.
-        hnsw_m: HNSW M parameter.
-        hnsw_ef_construction: HNSW ef_construction parameter.
-
-    Returns:
-        Dict with ``indexes_created`` count and ``errors``.
-    """
-    from sqlalchemy import text
-
-    result: dict[str, Any] = {
-        "indexes_created": 0,
-        "errors": [],
-    }
-
-    async with engine.begin() as conn:
-        for idx in HALFVEC_INDEXES:
-            try:
-                sql = idx["sql"].format(
-                    dim=embedding_dimension,
-                    m=hnsw_m,
-                    ef_construction=hnsw_ef_construction,
-                )
-                logger.debug(f"Creating halfvec index {idx['name']} ({idx['purpose']})")
-                await conn.execute(text(sql))
-                result["indexes_created"] += 1
-            except Exception as e:
-                msg = f"Halfvec index {idx['name']}: {e}"
-                result["errors"].append(msg)
-                logger.warning(msg)
-
-    return result
-
-
 async def optimize_postgresql(engine, *, reindex_hnsw: bool = True) -> dict:
     """Create optimal PostgreSQL indexes, run ANALYZE, and optionally reindex HNSW.
 

--- a/tests/unit/test_halfvec_indexes.py
+++ b/tests/unit/test_halfvec_indexes.py
@@ -100,6 +100,28 @@ class TestConnectHalfvecGuard:
             mock_check.assert_not_called()
             assert backend.halfvec_enabled is False
 
+    async def test_connect_skips_all_halfvec_checks_when_disabled(self) -> None:
+        """When use_halfvec=False, no halfvec detection or index check should occur."""
+        backend = _make_backend(use_halfvec=False)
+
+        with (
+            patch.object(backend, "_detect_halfvec_support", new_callable=AsyncMock) as mock_detect,
+            patch.object(backend, "_check_halfvec_indexes", new_callable=AsyncMock) as mock_check,
+            patch("khora.storage.backends.pgvector.create_async_engine") as mock_engine,
+            patch("khora.storage.backends.pgvector.async_sessionmaker") as mock_session_maker,
+        ):
+            mock_conn = AsyncMock()
+            mock_engine.return_value.begin.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+            mock_engine.return_value.begin.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_session_maker.return_value = MagicMock()
+
+            await backend.connect()
+
+            mock_detect.assert_not_called()
+            mock_check.assert_not_called()
+            assert backend.halfvec_enabled is False
+            assert backend._halfvec_available is None  # Never touched
+
 
 @pytest.mark.unit
 class TestCheckHalfvecIndexes:
@@ -112,8 +134,8 @@ class TestCheckHalfvecIndexes:
 
         mock_result = MagicMock()
         mock_result.all.return_value = [
-            ("ix_chunks_embedding_halfvec_hnsw",),
-            ("ix_entities_embedding_halfvec_hnsw",),
+            ("ix_chunks_embedding_halfvec_hnsw", True),
+            ("ix_entities_embedding_halfvec_hnsw", True),
         ]
 
         mock_session = AsyncMock()
@@ -133,7 +155,7 @@ class TestCheckHalfvecIndexes:
 
         mock_result = MagicMock()
         mock_result.all.return_value = [
-            ("ix_chunks_embedding_halfvec_hnsw",),
+            ("ix_chunks_embedding_halfvec_hnsw", True),
         ]
 
         mock_session = AsyncMock()
@@ -153,6 +175,27 @@ class TestCheckHalfvecIndexes:
 
         mock_session = AsyncMock()
         mock_session.execute.side_effect = RuntimeError("connection lost")
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(backend, "_get_session", return_value=mock_session):
+            result = await backend._check_halfvec_indexes()
+
+        assert result is False
+
+    async def test_returns_false_when_index_invalid(self) -> None:
+        """Should return False when an index exists but is marked invalid."""
+        backend = _make_backend()
+        backend._session_factory = MagicMock()
+
+        mock_result = MagicMock()
+        mock_result.all.return_value = [
+            ("ix_chunks_embedding_halfvec_hnsw", True),
+            ("ix_entities_embedding_halfvec_hnsw", False),  # invalid
+        ]
+
+        mock_session = AsyncMock()
+        mock_session.execute.return_value = mock_result
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=False)
 

--- a/tests/unit/test_halfvec_indexes.py
+++ b/tests/unit/test_halfvec_indexes.py
@@ -1,0 +1,198 @@
+"""Unit tests for PgVectorBackend halfvec index guard and cosine similarity.
+
+Verifies that:
+- connect() correctly enables/disables halfvec based on extension + index presence
+- _check_halfvec_indexes() handles present, partial, and error cases
+- _cosine_similarity() uses HALFVEC cast when enabled, plain vector when not
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from khora.storage.backends.pgvector import PgVectorBackend
+
+
+def _make_backend(*, use_halfvec: bool = True, embedding_dimension: int = 1536) -> PgVectorBackend:
+    """Create a PgVectorBackend without connecting to a real database."""
+    backend = PgVectorBackend.__new__(PgVectorBackend)
+    backend._database_url = "postgresql+asyncpg://localhost/test"
+    backend._embedding_dimension = embedding_dimension
+    backend._echo = False
+    backend._pool_size = 5
+    backend._max_overflow = 10
+    backend._pool_pre_ping = False
+    backend._hnsw_ef_search = 100
+    backend._use_halfvec = use_halfvec
+    backend._halfvec_available = None
+    backend._engine = None
+    backend._engine_shared = False
+    backend._session_factory = None
+    return backend
+
+
+@pytest.mark.unit
+class TestConnectHalfvecGuard:
+    """Tests for halfvec guard logic in connect()."""
+
+    async def test_connect_disables_halfvec_when_indexes_missing(self) -> None:
+        """When extension supports halfvec but indexes are missing, halfvec should be disabled."""
+        backend = _make_backend(use_halfvec=True)
+
+        with (
+            patch.object(backend, "_detect_halfvec_support", new_callable=AsyncMock, return_value=True),
+            patch.object(backend, "_check_halfvec_indexes", new_callable=AsyncMock, return_value=False),
+            patch("khora.storage.backends.pgvector.create_async_engine") as mock_engine,
+            patch("khora.storage.backends.pgvector.async_sessionmaker") as mock_session_maker,
+        ):
+            # Set up engine mock to handle the CREATE EXTENSION call
+            mock_conn = AsyncMock()
+            mock_engine.return_value.begin.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+            mock_engine.return_value.begin.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_session_maker.return_value = MagicMock()
+            backend._engine = None
+            backend._session_factory = None
+
+            await backend.connect()
+
+            assert backend.halfvec_enabled is False
+            assert backend._halfvec_available is False
+
+    async def test_connect_enables_halfvec_when_indexes_present(self) -> None:
+        """When extension supports halfvec and indexes exist, halfvec should be enabled."""
+        backend = _make_backend(use_halfvec=True)
+
+        with (
+            patch.object(backend, "_detect_halfvec_support", new_callable=AsyncMock, return_value=True),
+            patch.object(backend, "_check_halfvec_indexes", new_callable=AsyncMock, return_value=True),
+            patch("khora.storage.backends.pgvector.create_async_engine") as mock_engine,
+            patch("khora.storage.backends.pgvector.async_sessionmaker") as mock_session_maker,
+        ):
+            mock_conn = AsyncMock()
+            mock_engine.return_value.begin.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+            mock_engine.return_value.begin.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_session_maker.return_value = MagicMock()
+
+            await backend.connect()
+
+            assert backend.halfvec_enabled is True
+            assert backend._halfvec_available is True
+
+    async def test_connect_skips_index_check_when_extension_unsupported(self) -> None:
+        """When pgvector < 0.7.0, _check_halfvec_indexes should not be called."""
+        backend = _make_backend(use_halfvec=True)
+
+        with (
+            patch.object(backend, "_detect_halfvec_support", new_callable=AsyncMock, return_value=False),
+            patch.object(backend, "_check_halfvec_indexes", new_callable=AsyncMock) as mock_check,
+            patch("khora.storage.backends.pgvector.create_async_engine") as mock_engine,
+            patch("khora.storage.backends.pgvector.async_sessionmaker") as mock_session_maker,
+        ):
+            mock_conn = AsyncMock()
+            mock_engine.return_value.begin.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+            mock_engine.return_value.begin.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_session_maker.return_value = MagicMock()
+
+            await backend.connect()
+
+            mock_check.assert_not_called()
+            assert backend.halfvec_enabled is False
+
+
+@pytest.mark.unit
+class TestCheckHalfvecIndexes:
+    """Tests for _check_halfvec_indexes()."""
+
+    async def test_returns_true_when_both_exist(self) -> None:
+        """Should return True when both halfvec HNSW indexes are found."""
+        backend = _make_backend()
+        backend._session_factory = MagicMock()
+
+        mock_result = MagicMock()
+        mock_result.all.return_value = [
+            ("ix_chunks_embedding_halfvec_hnsw",),
+            ("ix_entities_embedding_halfvec_hnsw",),
+        ]
+
+        mock_session = AsyncMock()
+        mock_session.execute.return_value = mock_result
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(backend, "_get_session", return_value=mock_session):
+            result = await backend._check_halfvec_indexes()
+
+        assert result is True
+
+    async def test_returns_false_when_partial(self) -> None:
+        """Should return False when only one halfvec index exists."""
+        backend = _make_backend()
+        backend._session_factory = MagicMock()
+
+        mock_result = MagicMock()
+        mock_result.all.return_value = [
+            ("ix_chunks_embedding_halfvec_hnsw",),
+        ]
+
+        mock_session = AsyncMock()
+        mock_session.execute.return_value = mock_result
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(backend, "_get_session", return_value=mock_session):
+            result = await backend._check_halfvec_indexes()
+
+        assert result is False
+
+    async def test_returns_false_on_error(self) -> None:
+        """Should return False (graceful fallback) when query raises an exception."""
+        backend = _make_backend()
+        backend._session_factory = MagicMock()
+
+        mock_session = AsyncMock()
+        mock_session.execute.side_effect = RuntimeError("connection lost")
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(backend, "_get_session", return_value=mock_session):
+            result = await backend._check_halfvec_indexes()
+
+        assert result is False
+
+
+@pytest.mark.unit
+class TestCosineSimilarityHalfvec:
+    """Tests for _cosine_similarity() halfvec cast behavior."""
+
+    def test_uses_halfvec_cast_when_enabled(self) -> None:
+        """When halfvec is enabled, the SQL expression should contain HALFVEC cast."""
+        backend = _make_backend(use_halfvec=True)
+        backend._halfvec_available = True
+
+        mock_col = MagicMock()
+        query_embedding = [0.1] * 1536
+
+        expr = backend._cosine_similarity(mock_col, query_embedding)
+
+        # The expression should involve func.cast calls — the column should NOT
+        # have cosine_distance called directly on it (it's called on the casted version)
+        compiled = str(expr)
+        assert "CAST" in compiled.upper() or "halfvec" in compiled.lower() or "cast" in compiled.lower()
+        # The original column's cosine_distance should NOT be called directly
+        mock_col.cosine_distance.assert_not_called()
+
+    def test_uses_vector_when_disabled(self) -> None:
+        """When halfvec is disabled, cosine_distance is called directly on the column."""
+        backend = _make_backend(use_halfvec=False)
+        backend._halfvec_available = False
+
+        mock_col = MagicMock()
+        mock_col.cosine_distance.return_value = MagicMock()
+        query_embedding = [0.1] * 1536
+
+        backend._cosine_similarity(mock_col, query_embedding)
+
+        # The column's cosine_distance should be called directly with the query embedding
+        mock_col.cosine_distance.assert_called_once_with(query_embedding)

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -408,15 +408,15 @@ class TestMigrationPackageStructure:
         assert env_path.exists(), f"env.py not found at {env_path}"
 
     @pytest.mark.unit
-    def test_versions_dir_has_18_files(self):
-        """versions/ directory contains 18 migration files."""
+    def test_versions_dir_has_19_files(self):
+        """versions/ directory contains 19 migration files."""
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
         # Filter out __pycache__ and __init__
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
         assert (
-            len(migration_files) == 18
-        ), f"Expected 18 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
+            len(migration_files) == 19
+        ), f"Expected 19 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
 
     @pytest.mark.unit
     def test_env_py_constants(self):


### PR DESCRIPTION
## Summary
- **Add Alembic migration 018** creating halfvec expression HNSW indexes (`halfvec_cosine_ops`, m=24, ef_construction=128) on `chunks` and `entities` tables. Handles invalid indexes from interrupted builds via `pg_index.indisvalid` check. Uses `autocommit_block()` for `CONCURRENTLY` operations (zero-downtime).
- **Add connect() guard** in `PgVectorBackend` that verifies halfvec HNSW indexes exist before enabling halfvec mode. Falls back to full-precision `vector_cosine_ops` index with a warning if missing — prevents silent sequential scans.
- **Remove dead `create_halfvec_indexes()`** from `optimize.py` — was never called from anywhere and used wrong transaction mode (`engine.begin()`) that would fail with `CREATE INDEX CONCURRENTLY`.
- **Update migration count** in `test_migration_bundling.py` from 18 → 19.

### Root cause
PR #16 added halfvec as opt-in (`use_halfvec=False`) with index definitions in `optimize.py`. PR #46 flipped the default to `True` without creating the indexes. All similarity queries cast to `halfvec(1536)` but the planner ignored `vector_cosine_ops` indexes, causing full sequential scans (~70s on ~12K entities, should be ~5-50ms).

## Test plan
- [x] 8 new unit tests in `tests/unit/test_halfvec_indexes.py` covering:
  - connect() guard: enables/disables/skips halfvec based on extension + index presence
  - `_check_halfvec_indexes()`: both present, partial, error cases
  - `_cosine_similarity()`: HALFVEC cast when enabled, plain vector when disabled
- [x] Full unit test suite passes (2207 passed, 0 failed)
- [x] Coverage ≥ 46% threshold met (54.02%)
- [x] `make format` and `make lint` clean
- [ ] Manual: Run migration on staging DB, verify `EXPLAIN ANALYZE` shows index scan instead of seq scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes DYT-1346