### PR TITLE
DYT-1555: Restructure CLAUDE.md per ADR-035 standard template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,78 +19,13 @@ uv run khora ontology preview <file.yaml>         # Rich preview
 
 ## Architecture
 
-```
-MemoryLake → Engine (graphrag | skeleton | vectorcypher) → StorageCoordinator
-                                        ├── PostgreSQL (documents, tenancy)
-                                        ├── pgvector (embeddings)
-                                        └── Graph backend (Neo4j | SurrealDB | ...)
-
-Traditional stack: PostgreSQL + pgvector + Neo4j  (three databases)
-Unified stack:     SurrealDB                      (one database, all roles)
-```
-
 - **Engines:** implement `MemoryEngineProtocol` in `engines/protocol.py`
 - **Graph backends:** Neo4j, SurrealDB, Memgraph, ArcadeDB — implement `GraphBackend` in `storage/backends/base.py`
 - **SurrealDB:** unified backend (graph + vector + relational). Modes: `memory://`, `surrealkv://` (embedded), `ws://` (remote). Set `backend: surrealdb` in config
 - **Extraction skills:** YAML-defined in `extraction/skills/builtin/`. Generate with `khora ontology construct`
 - **Config:** env vars with `KHORA_` prefix and single underscore (e.g., `KHORA_QUERY_ENABLE_HYDE=true`, `KHORA_LLM_MODEL=gpt-4o`). Legacy `__` nesting also supported
 
-## Public API
-
-Exported from `khora/__init__.py`:
-
-```python
-from khora import (
-    MemoryLake,           # Primary interface (async context manager via memory_lake())
-    RememberResult,       # Result of remember()
-    RecallResult,         # Result of recall()
-    BatchResult,          # Result of remember_batch()
-    Stats,                # Namespace statistics
-    LLMUsage,             # Token/cost tracking (consumed by Poros/Peras — DYT-645)
-    SearchMode,           # VECTOR | GRAPH | HYBRID | ALL
-    KhoraConfig,          # Main Pydantic configuration
-    DocumentSource,       # Lightweight doc metadata for attribution
-    ExpertiseConfig,      # Domain expertise definition (ADR-022 stable API)
-    EntityTypeConfig,     # Entity type definition
-    RelationshipTypeConfig,  # Relationship type definition
-    create_engine,        # Instantiate engine by name
-    list_engines,         # ["graphrag", "skeleton", "vectorcypher"]
-    register_engine,      # Register custom engine class
-)
-```
-
-### MemoryLake Methods
-
-| Method | Purpose |
-|--------|---------|
-| `remember(content, *, namespace, expertise, ...)` | Store content, extract entities |
-| `remember_batch(documents, *, namespace, expertise, ...)` | Batch ingest with optimization |
-| `recall(query, *, namespace, limit, mode, min_similarity, ...)` | Retrieve memories |
-| `forget(document_id, *, namespace)` | Remove a memory |
-| `create_namespace()` / `get_namespace()` / `get_namespace_by_stable_id()` | Namespace management |
-| `get_entity()` / `list_entities()` / `search_entities()` / `find_related_entities()` | Entity operations |
-| `get_document()` / `list_documents()` | Document retrieval |
-| `stats(*, namespace)` | Namespace statistics |
-| `health_check()` | Backend health status |
-| `connect()` / `disconnect()` | Lifecycle (or use `async with memory_lake()`) |
-
-### Result Types (frozen dataclasses)
-
-**LLMUsage** — token tracking for cost attribution (Poros/Peras consume this):
-- `operation`, `model`, `prompt_tokens`, `completion_tokens`, `total_tokens`, `latency_ms`, `batch_size`
-
-**RememberResult** — single document ingest result:
-- `document_id`, `chunks`, `entities`, `relationships`, `llm_usage: list[LLMUsage]`
-
-**BatchResult** — batch ingest result:
-- `total`, `processed`, `skipped`, `failed`, `chunks`, `entities`, `relationships`, `metadata`, `llm_usage: list[LLMUsage]`
-
-**RecallResult** — query result:
-- `query`, `namespace_id`, `chunks`, `entities`, `context_text` (pre-formatted for LLM), `relationships` (VectorCypher only), `llm_usage`
-
-**Stats** — namespace counters
-
-## Key Entry Points
+### Key Entry Points
 
 - `memory_lake.py` — `remember()`, `recall()`, `forget()`, `remember_batch()`. Accepts `expertise: ExpertiseConfig`
 - `extraction/skills/base.py` — `ExpertiseConfig`, `EntityTypeConfig`, `RelationshipTypeConfig` (ADR-022 stable)
@@ -105,94 +40,9 @@ from khora import (
 - `config/schema.py` — `KhoraConfig` Pydantic settings (storage, LLM, pipeline, query, tenancy)
 - `telemetry/` — Optional PostgreSQL-backed telemetry collector + `@trace` decorator
 
-## Entity Extraction Pipeline
+## Conventions
 
-3-phase pipeline in `pipelines/flows/ingest.py`:
-
-```
-Phase 1: Stage — checksum-based change detection, skip unchanged docs
-Phase 2: Enrich (parallel per document):
-  ├── Chunk (fixed | semantic | recursive | conversation)
-  ├── Embed (LiteLLM, shared embedder) ─┐ concurrent
-  ├── Extract entities (LLM) ───────────┘
-  ├── Selective extraction — score chunks by importance, top-K to LLM
-  ├── Entity deduplication (smart O(1) index or fuzzy resolution)
-  ├── Co-occurrence edges + optional cross-chunk relationships
-  └── Store (chunks → pgvector, entities → graph, embeddings → vector)
-Phase 3: Semantic Expansion (optional):
-  ├── Cross-tool entity unification
-  └── Relationship inference (smart | batch | incremental | none)
-```
-
-**Chunkers** (`extraction/chunkers/`): `FixedChunker` (token-based), `SemanticChunker` (sentence boundaries), `RecursiveChunker` (hierarchical), `ConversationChunker` (speaker-aware)
-
-**Builtin skills** (`extraction/skills/builtin/`): `general.yaml` (9 entity types, 21 relationship types), `slack.yaml` (Slack-optimized with channel/message correlation)
-
-**Entity resolution** (`extraction/entity_resolution.py`): 5-strategy dedup (exact → alias → attribute → embedding → fuzzy). Per-type thresholds (PERSON 0.92, DATE 0.95, default 0.85)
-
-**Semantic expansion** (`extraction/expansion/`): `SemanticExpander` orchestrates `CrossToolUnifier` + `RelationshipInferrer` + `RuleEngine`
-
-## Configuration
-
-`KhoraConfig` (Pydantic BaseSettings, env prefix `KHORA_`). Each section has its own prefix for clean single-underscore env vars (e.g., `KHORA_LLM_MODEL`, `KHORA_QUERY_ENABLE_HYDE`):
-
-| Section | Key Settings |
-|---------|-------------|
-| **storage** | `backend` (`postgres`/`surrealdb`), graph config (Neo4j/Memgraph/ArcadeDB/SurrealDB), vector config (pgvector/ArcadeDB/SurrealDB), PostgreSQL pool tuning, HNSW parameters |
-| **llm** | `model` (default `gpt-4o-mini`), `embedding_model` (`text-embedding-3-small`), `extraction_model`, `embedding_dimension` (1536), temperature, max_tokens, max_concurrent_llm_calls, LiteLLM router config |
-| **pipeline** | `chunking_strategy`, `chunk_size` (512), `extract_entities`, `selective_extraction` (true), `extraction_importance_ratio` (0.7), `skip_embedding_entity_types` (DATE, URL, EMAIL) |
-| **query** | `default_mode` (hybrid), fusion weights (vector 0.5, graph 0.3, keyword 0.2), reranking, HyDE, recency bias, entity linking, BM25, temporal resolver |
-| **tenancy** | `default_mode` (shared/isolated), `enforce_namespace` |
-| Top-level | `database_url`, `neo4j_url`, `debug`, `telemetry_database_url`, `telemetry_service_name` |
-
-## Engine Selection
-
-| Use Case | Engine | Requires |
-|----------|--------|----------|
-| Knowledge bases, entity exploration | `graphrag` | Neo4j or SurrealDB |
-| Multi-hop queries, complex relationships | `vectorcypher` | Neo4j or SurrealDB |
-| Chat history, cost-sensitive | `skeleton` | Graph backend optional |
-
-## Acceleration (`_accel.py`)
-
-3-tier: Rust (`khora-accel` wheel, Pyo3 + rayon) → NumPy/RapidFuzz → pure Python. Override: `KHORA_ACCEL_BACKEND` env var (`rust`/`numpy`/`python`).
-
-Key functions: `cosine_similarity`, `batch_cosine_similarity`, `pairwise_cosine_above_threshold`, `levenshtein_similarity`, `batch_levenshtein`, `pagerank`, `reciprocal_rank_fusion`, `weighted_rrf`, `mmr_diversity_select`, `resolve_entities_batch`, `normalize_entity_name`, `detect_temporal_category`, `batch_temporal_filter`, `detect_communities`, `deduplicate_chunks`, `extract_keywords`
-
-## Dependencies & Extras
-
-Core: `sqlalchemy[asyncio]`, `asyncpg`, `pgvector`, `neo4j`, `litellm`, `tiktoken`, `sentence-transformers`, `pydantic-settings`, `click`, `rich`, `loguru`, `tenacity`, `dateparser`, `jinja2`, `pyyaml`
-
-| Extra | Install | Purpose |
-|-------|---------|---------|
-| `surrealdb` | `pip install khora[surrealdb]` | SurrealDB unified backend |
-| `embedded` | `pip install khora[embedded]` | SurrealDB embedded mode |
-| `logfire` | `pip install khora[logfire]` | Logfire observability |
-| `nlp` | `pip install khora[nlp]` | spaCy NLP |
-| `accel` | `pip install khora[accel]` | RapidFuzz CPU acceleration |
-| `rust` | `pip install khora[rust]` | Rust-accelerated ops (khora-accel) |
-| `memgraph` | `pip install khora[memgraph]` | Memgraph backend |
-| `arcadedb` | `pip install khora[arcadedb]` | ArcadeDB backend |
-| `graph-all` | `pip install khora[graph-all]` | All graph backends |
-| `all-backends` | `pip install khora[all-backends]` | All backends |
-| `reranking` | `pip install khora[reranking]` | Neural reranking |
-| `dev` | `pip install khora[dev]` | Testing & linting |
-
-## Testing
-
-```bash
-uv run pytest tests/unit/ -v               # Unit tests
-uv run pytest -k "test_remember" -v         # By name
-uv run pytest tests/unit/test_memory_lake.py  # Single file
-```
-
-Markers: `@pytest.mark.unit`, `@pytest.mark.integration`, `@pytest.mark.e2e`. Async: `asyncio_mode = "auto"`.
-
-## Releasing
-
-Versions from git tags — no manual bumps. `git tag vX.Y.Z && git push origin vX.Y.Z` triggers publish workflows. See [`docs/RELEASE.md`](docs/RELEASE.md).
-
-## Version Bumps
+### Version Bumps
 
 When bumping the version, update all of the following and regenerate lockfiles:
 
@@ -201,6 +51,50 @@ When bumping the version, update all of the following and regenerate lockfiles:
 3. `rust/khora-accel/Cargo.toml`
 4. `rust/khora-accel/pyproject.toml`
 5. Run `uv lock` and `cargo generate-lockfile` in `rust/khora-accel/`
+
+## Gotchas
+
+### Migrations & Schema
+- **Never use `create_tables()`** — deprecated, bypasses Alembic. Use `run_migrations()` or `MemoryLake(run_migrations=True)`. Create new migrations with `uv run alembic revision --autogenerate -m "desc"`
+- **Version table:** `khora_alembic_version` (not `alembic_version`) — avoids conflicts with downstream apps
+- **Advisory lock:** `run_migrations()` uses `pg_advisory_xact_lock` (ID `6001515088189075507`), 60s timeout
+- **Migrations bundled** in `src/khora/db/migrations/`, not `alembic/`. Root `alembic.ini` is dev-only
+- **Skip-ahead:** When multiple services share a DB with different Khora versions, `run_migrations()` detects if the DB revision is unknown (ahead) and skips gracefully — returns `MigrationResult(success=True, skipped=True)`. Signaled via `_DatabaseAheadError` from `env.py` to `session.py`
+- **Fresh-DB behavior:** On a PostgreSQL database with no `khora_alembic_version` table yet, `run_migrations()` / `MemoryLake(run_migrations=True)` correctly creates all tables from scratch. Prior to v0.6.6 (DYT-1447), querying the missing version table inside an explicit transaction caused `InFailedSQLTransactionError`. The fix uses `information_schema.tables` to check table existence before querying it — never issuing a statement that could abort the transaction.
+
+### UUID & Type Handling
+- **ORM:** all 52 UUID columns use `as_uuid=True` — native `uuid.UUID`, never `str()` wrap
+- **Graph boundary:** Neo4j/Memgraph need `str(uuid)` at the driver boundary only
+- **SurrealDB:** `RecordID` accepts UUID objects directly (no `str()` needed since SDK 2.0)
+
+### Backend Specifics
+- **Shared engine pools:** `StorageFactory` caches by URL. Shared-engine backends skip `dispose()`
+- **Transactions:** `async with coordinator.transaction() as txn:` for atomic multi-backend ops
+- **SurrealDB unified:** all four adapters share one `SurrealDBConnection`. Coordinator skips duplicate writes
+- **SurrealDB schema:** declarative (`DEFINE IF NOT EXISTS`), auto-initializes on `connect()`. No Alembic
+- **SurrealDB SDK:** pinned `>=2.0.0a1` for 3.x support. Install: `pip install khora[surrealdb]`
+- **SurrealDB KNN broken:** `<|K|>` unreliable in embedded mode. Uses brute-force cosine + HNSW instead
+- **SurrealDB entity gate:** `_SurrealDBEntityKeyGate` serializes concurrent upserts by (ns, name, type) key
+
+### Extraction & Search
+- **Pre-normalized embeddings** — L2-normalized at ingest. Uses `batch_dot_product` (3x faster than cosine)
+- **Entity unique constraint** — `(namespace_id, name, entity_type)` UNIQUE in both PostgreSQL and SurrealDB
+- **Namespace versioning** — dual IDs: `id` (row-level) vs `namespace_id` (stable). Public API uses `namespace_id`, resolves to `id` via indexed lookup
+- **Selective extraction** — KET-RAG style: scores chunk importance, sends top 70% to LLM, rest get co-occurrence edges only
+- **Entity resolution** — multi-strategy dedup with per-type thresholds (PERSON 0.92, DATE 0.95, default 0.85)
+- **Semantic expansion** — optional cross-tool entity unification + relationship inference (4 modes: smart/batch/incremental/none)
+
+### Optional Dependencies
+- **spaCy:** `_HAS_SPACY` flag, falls back to regex sentence splitting
+- **Logfire:** `_HAS_LOGFIRE` flag, `trace_span()` yields no-op when absent. Install: `pip install khora[logfire]`
+- **`@trace` decorator:** `from khora.telemetry import trace`. Zero overhead when logfire absent
+- **Telemetry collector:** `KHORA_TELEMETRY_DATABASE_URL` enables PostgreSQL-backed event recording. Without it, `NoOpCollector` is used (zero cost)
+
+### Downstream
+- `genesis` and `khora-benchmarks` depend on khora. `lake.storage` is a stable public API
+- **LLMUsage contract:** `LLMUsage` fields are consumed by Poros/Peras for cost tracking (DYT-645) — changes require coordination
+- **ExpertiseConfig contract:** ADR-022 stable API — `ExpertiseConfig`, `EntityTypeConfig`, `RelationshipTypeConfig` changes require coordination
+- `scripts/` vendored from TTOJ — skip in audits
 
 # Workflow Reference
 
@@ -342,50 +236,6 @@ The recommended command sequence for feature development:
 ## Team Configuration
 
 Default team profiles are deployed to `.ttoj/templates/team-profiles/` and referenced by the `/team:*` commands. To customize team composition for this project, edit the deployed profiles or create project-specific overrides in `.claude/commands/team/`.
-
-## Gotchas
-
-### Migrations & Schema
-- **Never use `create_tables()`** — deprecated, bypasses Alembic. Use `run_migrations()` or `MemoryLake(run_migrations=True)`. Create new migrations with `uv run alembic revision --autogenerate -m "desc"`
-- **Version table:** `khora_alembic_version` (not `alembic_version`) — avoids conflicts with downstream apps
-- **Advisory lock:** `run_migrations()` uses `pg_advisory_xact_lock` (ID `6001515088189075507`), 60s timeout
-- **Migrations bundled** in `src/khora/db/migrations/`, not `alembic/`. Root `alembic.ini` is dev-only
-- **Skip-ahead:** When multiple services share a DB with different Khora versions, `run_migrations()` detects if the DB revision is unknown (ahead) and skips gracefully — returns `MigrationResult(success=True, skipped=True)`. Signaled via `_DatabaseAheadError` from `env.py` to `session.py`
-- **Fresh-DB behavior:** On a PostgreSQL database with no `khora_alembic_version` table yet, `run_migrations()` / `MemoryLake(run_migrations=True)` correctly creates all tables from scratch. Prior to v0.6.6 (DYT-1447), querying the missing version table inside an explicit transaction caused `InFailedSQLTransactionError`. The fix uses `information_schema.tables` to check table existence before querying it — never issuing a statement that could abort the transaction.
-
-### UUID & Type Handling
-- **ORM:** all 52 UUID columns use `as_uuid=True` — native `uuid.UUID`, never `str()` wrap
-- **Graph boundary:** Neo4j/Memgraph need `str(uuid)` at the driver boundary only
-- **SurrealDB:** `RecordID` accepts UUID objects directly (no `str()` needed since SDK 2.0)
-
-### Backend Specifics
-- **Shared engine pools:** `StorageFactory` caches by URL. Shared-engine backends skip `dispose()`
-- **Transactions:** `async with coordinator.transaction() as txn:` for atomic multi-backend ops
-- **SurrealDB unified:** all four adapters share one `SurrealDBConnection`. Coordinator skips duplicate writes
-- **SurrealDB schema:** declarative (`DEFINE IF NOT EXISTS`), auto-initializes on `connect()`. No Alembic
-- **SurrealDB SDK:** pinned `>=2.0.0a1` for 3.x support. Install: `pip install khora[surrealdb]`
-- **SurrealDB KNN broken:** `<|K|>` unreliable in embedded mode. Uses brute-force cosine + HNSW instead
-- **SurrealDB entity gate:** `_SurrealDBEntityKeyGate` serializes concurrent upserts by (ns, name, type) key
-
-### Extraction & Search
-- **Pre-normalized embeddings** — L2-normalized at ingest. Uses `batch_dot_product` (3x faster than cosine)
-- **Entity unique constraint** — `(namespace_id, name, entity_type)` UNIQUE in both PostgreSQL and SurrealDB
-- **Namespace versioning** — dual IDs: `id` (row-level) vs `namespace_id` (stable). Public API uses `namespace_id`, resolves to `id` via indexed lookup
-- **Selective extraction** — KET-RAG style: scores chunk importance, sends top 70% to LLM, rest get co-occurrence edges only
-- **Entity resolution** — multi-strategy dedup with per-type thresholds (PERSON 0.92, DATE 0.95, default 0.85)
-- **Semantic expansion** — optional cross-tool entity unification + relationship inference (4 modes: smart/batch/incremental/none)
-
-### Optional Dependencies
-- **spaCy:** `_HAS_SPACY` flag, falls back to regex sentence splitting
-- **Logfire:** `_HAS_LOGFIRE` flag, `trace_span()` yields no-op when absent. Install: `pip install khora[logfire]`
-- **`@trace` decorator:** `from khora.telemetry import trace`. Zero overhead when logfire absent
-- **Telemetry collector:** `KHORA_TELEMETRY_DATABASE_URL` enables PostgreSQL-backed event recording. Without it, `NoOpCollector` is used (zero cost)
-
-### Downstream
-- `genesis` and `khora-benchmarks` depend on khora. `lake.storage` is a stable public API
-- **LLMUsage contract:** `LLMUsage` fields are consumed by Poros/Peras for cost tracking (DYT-645) — changes require coordination
-- **ExpertiseConfig contract:** ADR-022 stable API — `ExpertiseConfig`, `EntityTypeConfig`, `RelationshipTypeConfig` changes require coordination
-- `scripts/` vendored from TTOJ — skip in audits
 
 
 ## Codex Skill Mapping

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,78 +17,13 @@ uv run khora ontology preview <file.yaml>         # Rich preview
 
 ## Architecture
 
-```
-MemoryLake → Engine (graphrag | skeleton | vectorcypher) → StorageCoordinator
-                                        ├── PostgreSQL (documents, tenancy)
-                                        ├── pgvector (embeddings)
-                                        └── Graph backend (Neo4j | SurrealDB | ...)
-
-Traditional stack: PostgreSQL + pgvector + Neo4j  (three databases)
-Unified stack:     SurrealDB                      (one database, all roles)
-```
-
 - **Engines:** implement `MemoryEngineProtocol` in `engines/protocol.py`
 - **Graph backends:** Neo4j, SurrealDB, Memgraph, ArcadeDB — implement `GraphBackend` in `storage/backends/base.py`
 - **SurrealDB:** unified backend (graph + vector + relational). Modes: `memory://`, `surrealkv://` (embedded), `ws://` (remote). Set `backend: surrealdb` in config
 - **Extraction skills:** YAML-defined in `extraction/skills/builtin/`. Generate with `khora ontology construct`
 - **Config:** env vars with `KHORA_` prefix and single underscore (e.g., `KHORA_QUERY_ENABLE_HYDE=true`, `KHORA_LLM_MODEL=gpt-4o`). Legacy `__` nesting also supported
 
-## Public API
-
-Exported from `khora/__init__.py`:
-
-```python
-from khora import (
-    MemoryLake,           # Primary interface (async context manager via memory_lake())
-    RememberResult,       # Result of remember()
-    RecallResult,         # Result of recall()
-    BatchResult,          # Result of remember_batch()
-    Stats,                # Namespace statistics
-    LLMUsage,             # Token/cost tracking (consumed by Poros/Peras — DYT-645)
-    SearchMode,           # VECTOR | GRAPH | HYBRID | ALL
-    KhoraConfig,          # Main Pydantic configuration
-    DocumentSource,       # Lightweight doc metadata for attribution
-    ExpertiseConfig,      # Domain expertise definition (ADR-022 stable API)
-    EntityTypeConfig,     # Entity type definition
-    RelationshipTypeConfig,  # Relationship type definition
-    create_engine,        # Instantiate engine by name
-    list_engines,         # ["graphrag", "skeleton", "vectorcypher"]
-    register_engine,      # Register custom engine class
-)
-```
-
-### MemoryLake Methods
-
-| Method | Purpose |
-|--------|---------|
-| `remember(content, *, namespace, expertise, ...)` | Store content, extract entities |
-| `remember_batch(documents, *, namespace, expertise, ...)` | Batch ingest with optimization |
-| `recall(query, *, namespace, limit, mode, min_similarity, ...)` | Retrieve memories |
-| `forget(document_id, *, namespace)` | Remove a memory |
-| `create_namespace()` / `get_namespace()` / `get_namespace_by_stable_id()` | Namespace management |
-| `get_entity()` / `list_entities()` / `search_entities()` / `find_related_entities()` | Entity operations |
-| `get_document()` / `list_documents()` | Document retrieval |
-| `stats(*, namespace)` | Namespace statistics |
-| `health_check()` | Backend health status |
-| `connect()` / `disconnect()` | Lifecycle (or use `async with memory_lake()`) |
-
-### Result Types (frozen dataclasses)
-
-**LLMUsage** — token tracking for cost attribution (Poros/Peras consume this):
-- `operation`, `model`, `prompt_tokens`, `completion_tokens`, `total_tokens`, `latency_ms`, `batch_size`
-
-**RememberResult** — single document ingest result:
-- `document_id`, `chunks`, `entities`, `relationships`, `llm_usage: list[LLMUsage]`
-
-**BatchResult** — batch ingest result:
-- `total`, `processed`, `skipped`, `failed`, `chunks`, `entities`, `relationships`, `metadata`, `llm_usage: list[LLMUsage]`
-
-**RecallResult** — query result:
-- `query`, `namespace_id`, `chunks`, `entities`, `context_text` (pre-formatted for LLM), `relationships` (VectorCypher only), `llm_usage`
-
-**Stats** — namespace counters
-
-## Key Entry Points
+### Key Entry Points
 
 - `memory_lake.py` — `remember()`, `recall()`, `forget()`, `remember_batch()`. Accepts `expertise: ExpertiseConfig`
 - `extraction/skills/base.py` — `ExpertiseConfig`, `EntityTypeConfig`, `RelationshipTypeConfig` (ADR-022 stable)
@@ -103,94 +38,9 @@ from khora import (
 - `config/schema.py` — `KhoraConfig` Pydantic settings (storage, LLM, pipeline, query, tenancy)
 - `telemetry/` — Optional PostgreSQL-backed telemetry collector + `@trace` decorator
 
-## Entity Extraction Pipeline
+## Conventions
 
-3-phase pipeline in `pipelines/flows/ingest.py`:
-
-```
-Phase 1: Stage — checksum-based change detection, skip unchanged docs
-Phase 2: Enrich (parallel per document):
-  ├── Chunk (fixed | semantic | recursive | conversation)
-  ├── Embed (LiteLLM, shared embedder) ─┐ concurrent
-  ├── Extract entities (LLM) ───────────┘
-  ├── Selective extraction — score chunks by importance, top-K to LLM
-  ├── Entity deduplication (smart O(1) index or fuzzy resolution)
-  ├── Co-occurrence edges + optional cross-chunk relationships
-  └── Store (chunks → pgvector, entities → graph, embeddings → vector)
-Phase 3: Semantic Expansion (optional):
-  ├── Cross-tool entity unification
-  └── Relationship inference (smart | batch | incremental | none)
-```
-
-**Chunkers** (`extraction/chunkers/`): `FixedChunker` (token-based), `SemanticChunker` (sentence boundaries), `RecursiveChunker` (hierarchical), `ConversationChunker` (speaker-aware)
-
-**Builtin skills** (`extraction/skills/builtin/`): `general.yaml` (9 entity types, 21 relationship types), `slack.yaml` (Slack-optimized with channel/message correlation)
-
-**Entity resolution** (`extraction/entity_resolution.py`): 5-strategy dedup (exact → alias → attribute → embedding → fuzzy). Per-type thresholds (PERSON 0.92, DATE 0.95, default 0.85)
-
-**Semantic expansion** (`extraction/expansion/`): `SemanticExpander` orchestrates `CrossToolUnifier` + `RelationshipInferrer` + `RuleEngine`
-
-## Configuration
-
-`KhoraConfig` (Pydantic BaseSettings, env prefix `KHORA_`). Each section has its own prefix for clean single-underscore env vars (e.g., `KHORA_LLM_MODEL`, `KHORA_QUERY_ENABLE_HYDE`):
-
-| Section | Key Settings |
-|---------|-------------|
-| **storage** | `backend` (`postgres`/`surrealdb`), graph config (Neo4j/Memgraph/ArcadeDB/SurrealDB), vector config (pgvector/ArcadeDB/SurrealDB), PostgreSQL pool tuning, HNSW parameters |
-| **llm** | `model` (default `gpt-4o-mini`), `embedding_model` (`text-embedding-3-small`), `extraction_model`, `embedding_dimension` (1536), temperature, max_tokens, max_concurrent_llm_calls, LiteLLM router config |
-| **pipeline** | `chunking_strategy`, `chunk_size` (512), `extract_entities`, `selective_extraction` (true), `extraction_importance_ratio` (0.7), `skip_embedding_entity_types` (DATE, URL, EMAIL) |
-| **query** | `default_mode` (hybrid), fusion weights (vector 0.5, graph 0.3, keyword 0.2), reranking, HyDE, recency bias, entity linking, BM25, temporal resolver |
-| **tenancy** | `default_mode` (shared/isolated), `enforce_namespace` |
-| Top-level | `database_url`, `neo4j_url`, `debug`, `telemetry_database_url`, `telemetry_service_name` |
-
-## Engine Selection
-
-| Use Case | Engine | Requires |
-|----------|--------|----------|
-| Knowledge bases, entity exploration | `graphrag` | Neo4j or SurrealDB |
-| Multi-hop queries, complex relationships | `vectorcypher` | Neo4j or SurrealDB |
-| Chat history, cost-sensitive | `skeleton` | Graph backend optional |
-
-## Acceleration (`_accel.py`)
-
-3-tier: Rust (`khora-accel` wheel, Pyo3 + rayon) → NumPy/RapidFuzz → pure Python. Override: `KHORA_ACCEL_BACKEND` env var (`rust`/`numpy`/`python`).
-
-Key functions: `cosine_similarity`, `batch_cosine_similarity`, `pairwise_cosine_above_threshold`, `levenshtein_similarity`, `batch_levenshtein`, `pagerank`, `reciprocal_rank_fusion`, `weighted_rrf`, `mmr_diversity_select`, `resolve_entities_batch`, `normalize_entity_name`, `detect_temporal_category`, `batch_temporal_filter`, `detect_communities`, `deduplicate_chunks`, `extract_keywords`
-
-## Dependencies & Extras
-
-Core: `sqlalchemy[asyncio]`, `asyncpg`, `pgvector`, `neo4j`, `litellm`, `tiktoken`, `sentence-transformers`, `pydantic-settings`, `click`, `rich`, `loguru`, `tenacity`, `dateparser`, `jinja2`, `pyyaml`
-
-| Extra | Install | Purpose |
-|-------|---------|---------|
-| `surrealdb` | `pip install khora[surrealdb]` | SurrealDB unified backend |
-| `embedded` | `pip install khora[embedded]` | SurrealDB embedded mode |
-| `logfire` | `pip install khora[logfire]` | Logfire observability |
-| `nlp` | `pip install khora[nlp]` | spaCy NLP |
-| `accel` | `pip install khora[accel]` | RapidFuzz CPU acceleration |
-| `rust` | `pip install khora[rust]` | Rust-accelerated ops (khora-accel) |
-| `memgraph` | `pip install khora[memgraph]` | Memgraph backend |
-| `arcadedb` | `pip install khora[arcadedb]` | ArcadeDB backend |
-| `graph-all` | `pip install khora[graph-all]` | All graph backends |
-| `all-backends` | `pip install khora[all-backends]` | All backends |
-| `reranking` | `pip install khora[reranking]` | Neural reranking |
-| `dev` | `pip install khora[dev]` | Testing & linting |
-
-## Testing
-
-```bash
-uv run pytest tests/unit/ -v               # Unit tests
-uv run pytest -k "test_remember" -v         # By name
-uv run pytest tests/unit/test_memory_lake.py  # Single file
-```
-
-Markers: `@pytest.mark.unit`, `@pytest.mark.integration`, `@pytest.mark.e2e`. Async: `asyncio_mode = "auto"`.
-
-## Releasing
-
-Versions from git tags — no manual bumps. `git tag vX.Y.Z && git push origin vX.Y.Z` triggers publish workflows. See [`docs/RELEASE.md`](docs/RELEASE.md).
-
-## Version Bumps
+### Version Bumps
 
 When bumping the version, update all of the following and regenerate lockfiles:
 
@@ -199,8 +49,6 @@ When bumping the version, update all of the following and regenerate lockfiles:
 3. `rust/khora-accel/Cargo.toml`
 4. `rust/khora-accel/pyproject.toml`
 5. Run `uv lock` and `cargo generate-lockfile` in `rust/khora-accel/`
-
-@.claude/docs/workflow.md
 
 ## Gotchas
 
@@ -245,3 +93,5 @@ When bumping the version, update all of the following and regenerate lockfiles:
 - **LLMUsage contract:** `LLMUsage` fields are consumed by Poros/Peras for cost tracking (DYT-645) — changes require coordination
 - **ExpertiseConfig contract:** ADR-022 stable API — `ExpertiseConfig`, `EntityTypeConfig`, `RelationshipTypeConfig` changes require coordination
 - `scripts/` vendored from TTOJ — skip in audits
+
+@.claude/docs/workflow.md

--- a/tests/unit/test_claudemd_structure.py
+++ b/tests/unit/test_claudemd_structure.py
@@ -1,0 +1,169 @@
+"""Tests for CLAUDE.md structure and content preservation after ADR-035 restructuring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# Resolve CLAUDE.md relative to this test file: tests/unit/ -> project root
+CLAUDE_MD = Path(__file__).parents[2] / "CLAUDE.md"
+
+
+@pytest.fixture(scope="module")
+def claude_md_content() -> str:
+    """Read CLAUDE.md once for all tests in this module."""
+    assert CLAUDE_MD.exists(), f"CLAUDE.md not found at {CLAUDE_MD}"
+    return CLAUDE_MD.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Section structure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRequiredSections:
+    """CLAUDE.md must follow the ADR-035 standard template sections."""
+
+    @pytest.mark.parametrize(
+        "heading",
+        [
+            "## Commands",
+            "## Architecture",
+            "## Conventions",
+            "## Gotchas",
+        ],
+    )
+    def test_required_top_level_sections(self, claude_md_content: str, heading: str) -> None:
+        assert heading in claude_md_content, f"Missing required section: {heading}"
+
+    def test_starts_with_project_name(self, claude_md_content: str) -> None:
+        assert claude_md_content.startswith("# Khora"), "CLAUDE.md must start with '# Khora'"
+
+    def test_gotcha_subsections(self, claude_md_content: str) -> None:
+        """Gotchas section must retain its subsections."""
+        for subsection in [
+            "### Migrations & Schema",
+            "### UUID & Type Handling",
+            "### Backend Specifics",
+            "### Downstream",
+        ]:
+            assert subsection in claude_md_content, f"Missing Gotchas subsection: {subsection}"
+
+
+# ---------------------------------------------------------------------------
+# Critical gotchas (must be preserved verbatim)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCriticalGotchas:
+    """Four critical gotchas that must never be lost during restructuring."""
+
+    def test_create_tables_deprecated(self, claude_md_content: str) -> None:
+        assert "create_tables()" in claude_md_content, (
+            "Missing critical gotcha: create_tables() deprecation warning"
+        )
+        assert "deprecated" in claude_md_content.lower(), (
+            "create_tables() must be marked as deprecated"
+        )
+
+    def test_khora_alembic_version_table(self, claude_md_content: str) -> None:
+        assert "khora_alembic_version" in claude_md_content, (
+            "Missing critical gotcha: khora_alembic_version table naming"
+        )
+
+    def test_as_uuid_true(self, claude_md_content: str) -> None:
+        assert "as_uuid=True" in claude_md_content, (
+            "Missing critical gotcha: as_uuid=True UUID handling"
+        )
+        assert "52 UUID columns" in claude_md_content, (
+            "Must mention all 52 UUID columns"
+        )
+
+    def test_surrealdb_knn_broken(self, claude_md_content: str) -> None:
+        assert "SurrealDB KNN broken" in claude_md_content, (
+            "Missing critical gotcha: SurrealDB KNN broken"
+        )
+        assert "<|K|>" in claude_md_content, (
+            "Must mention <|K|> operator as unreliable"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Additional content preservation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestContentPreservation:
+    """Important content that must survive the restructuring."""
+
+    def test_llmusage_contract(self, claude_md_content: str) -> None:
+        assert "LLMUsage contract" in claude_md_content
+
+    def test_expertiseconfig_contract(self, claude_md_content: str) -> None:
+        assert "ExpertiseConfig contract" in claude_md_content
+
+    def test_pg_advisory_xact_lock(self, claude_md_content: str) -> None:
+        assert "pg_advisory_xact_lock" in claude_md_content
+
+    def test_database_ahead_error(self, claude_md_content: str) -> None:
+        assert "_DatabaseAheadError" in claude_md_content
+
+    def test_in_failed_sql_transaction_error(self, claude_md_content: str) -> None:
+        assert "InFailedSQLTransactionError" in claude_md_content
+
+    def test_surrealdb_entity_key_gate(self, claude_md_content: str) -> None:
+        assert "_SurrealDBEntityKeyGate" in claude_md_content
+
+    def test_version_bumps_checklist(self, claude_md_content: str) -> None:
+        """All 5 version bump items must be listed."""
+        for item in [
+            "pyproject.toml",
+            "src/khora/__init__.py",
+            "rust/khora-accel/Cargo.toml",
+            "rust/khora-accel/pyproject.toml",
+            "uv lock",
+        ]:
+            assert item in claude_md_content, f"Version bump checklist missing: {item}"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "make test",
+            "make format",
+            "make lint",
+            "make dev",
+        ],
+    )
+    def test_make_commands_present(self, claude_md_content: str, command: str) -> None:
+        assert command in claude_md_content, f"Missing make command: {command}"
+
+    def test_workflow_import(self, claude_md_content: str) -> None:
+        """The @import for workflow.md must be present."""
+        assert "@.claude/docs/workflow.md" in claude_md_content
+
+
+# ---------------------------------------------------------------------------
+# Removed content (README-duplicated sections)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRemovedDuplicateContent:
+    """Sections that duplicate README content should NOT be in CLAUDE.md."""
+
+    @pytest.mark.parametrize(
+        "heading",
+        [
+            "## Public API",
+            "## Engine Selection",
+            "## Dependencies & Extras",
+        ],
+    )
+    def test_readme_sections_removed(self, claude_md_content: str, heading: str) -> None:
+        assert heading not in claude_md_content, (
+            f"README-duplicated section should be removed: {heading}"
+        )

--- a/tests/unit/test_claudemd_structure.py
+++ b/tests/unit/test_claudemd_structure.py
@@ -62,33 +62,21 @@ class TestCriticalGotchas:
     """Four critical gotchas that must never be lost during restructuring."""
 
     def test_create_tables_deprecated(self, claude_md_content: str) -> None:
-        assert "create_tables()" in claude_md_content, (
-            "Missing critical gotcha: create_tables() deprecation warning"
-        )
-        assert "deprecated" in claude_md_content.lower(), (
-            "create_tables() must be marked as deprecated"
-        )
+        assert "create_tables()" in claude_md_content, "Missing critical gotcha: create_tables() deprecation warning"
+        assert "deprecated" in claude_md_content.lower(), "create_tables() must be marked as deprecated"
 
     def test_khora_alembic_version_table(self, claude_md_content: str) -> None:
-        assert "khora_alembic_version" in claude_md_content, (
-            "Missing critical gotcha: khora_alembic_version table naming"
-        )
+        assert (
+            "khora_alembic_version" in claude_md_content
+        ), "Missing critical gotcha: khora_alembic_version table naming"
 
     def test_as_uuid_true(self, claude_md_content: str) -> None:
-        assert "as_uuid=True" in claude_md_content, (
-            "Missing critical gotcha: as_uuid=True UUID handling"
-        )
-        assert "52 UUID columns" in claude_md_content, (
-            "Must mention all 52 UUID columns"
-        )
+        assert "as_uuid=True" in claude_md_content, "Missing critical gotcha: as_uuid=True UUID handling"
+        assert "52 UUID columns" in claude_md_content, "Must mention all 52 UUID columns"
 
     def test_surrealdb_knn_broken(self, claude_md_content: str) -> None:
-        assert "SurrealDB KNN broken" in claude_md_content, (
-            "Missing critical gotcha: SurrealDB KNN broken"
-        )
-        assert "<|K|>" in claude_md_content, (
-            "Must mention <|K|> operator as unreliable"
-        )
+        assert "SurrealDB KNN broken" in claude_md_content, "Missing critical gotcha: SurrealDB KNN broken"
+        assert "<|K|>" in claude_md_content, "Must mention <|K|> operator as unreliable"
 
 
 # ---------------------------------------------------------------------------
@@ -164,6 +152,4 @@ class TestRemovedDuplicateContent:
         ],
     )
     def test_readme_sections_removed(self, claude_md_content: str, heading: str) -> None:
-        assert heading not in claude_md_content, (
-            f"README-duplicated section should be removed: {heading}"
-        )
+        assert heading not in claude_md_content, f"README-duplicated section should be removed: {heading}"


### PR DESCRIPTION
## Summary
- Restructure CLAUDE.md to ADR-035 standard template: Identity → Commands → Architecture → Conventions → Gotchas → @import
- Remove README-duplicated content: architecture diagram, public API, MemoryLake methods, result types, entity extraction pipeline, configuration table, engine selection, acceleration, dependencies & extras, testing, releasing sections (~150 lines removed)
- Preserve all 6 gotcha subsections verbatim (Migrations & Schema, UUID & Type Handling, Backend Specifics, Extraction & Search, Optional Dependencies, Downstream)
- Merge Key Entry Points into Architecture section
- Move Version Bumps under new Conventions section
- Add 25 content preservation integration tests validating structure, critical gotchas, and removed sections

### Traceability Matrix

| Section | Disposition | Rationale |
|---------|-------------|-----------|
| Identity + Commands | **KEEP** | ADR-035 required |
| Architecture (bullets) | **KEEP** | Agent-essential pointers |
| Architecture (ASCII diagram) | **REMOVE** | README L374-396 |
| Key Entry Points | **KEEP** | Merged under Architecture |
| Public API + Methods + Result Types | **REMOVE** | README L639-854, derivable from code |
| Entity Extraction Pipeline | **REMOVE** | README L419-430, L496-518 |
| Configuration table | **REMOVE** | README L436-493 |
| Engine Selection | **REMOVE** | README L37-130 |
| Acceleration | **REMOVE** | README L33, L173-174, derivable |
| Dependencies & Extras | **REMOVE** | README prerequisites + pyproject.toml |
| Testing | **REMOVE** | README L622-634, Commands has `make test` |
| Releasing | **REMOVE** | Brief pointer to docs/RELEASE.md |
| Version Bumps | **KEEP** | Under Conventions — not in README |
| All Gotchas (6 subsections) | **KEEP** | Zero README coverage — verbatim |
| @import workflow | **KEEP** | ADR-034 reference |

## Test plan
- [x] All 2271 unit tests pass
- [x] 25 new CLAUDE.md structure tests pass
- [x] Coverage: 52.87% (threshold: 46%)
- [x] 4 critical gotchas verified: `create_tables()`, `khora_alembic_version`, `as_uuid=True`, SurrealDB KNN
- [x] Downstream contracts preserved: LLMUsage, ExpertiseConfig
- [x] Formatter + linter pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)