### PR TITLE
chore: Fix Codecov CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,8 @@ jobs:
         uses: codecov/codecov-action@v5
         if: always()
         with:
-          file: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
           flags: unittests
           name: khora-coverage
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Add `CODECOV_TOKEN` secret reference (required for codecov-action v5)
- Fix `file` → `files` parameter name

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Confirm Codecov upload step succeeds (or gracefully skips if token not yet configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)