### PR TITLE
DYT-1661: Restore concurrent batch extraction with wave-based circuit breaker

### DIFF
--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -241,6 +241,7 @@ class LLMEntityExtractor(EntityExtractor):
         self._timeout = timeout
         self._max_retries = max_retries
         self._retry_wait = retry_wait
+        self._max_concurrent = max_concurrent
         self._semaphore = asyncio.Semaphore(max_concurrent)
 
         # Register litellm failure callback to log 429 rate-limit responses
@@ -1423,12 +1424,24 @@ class LLMEntityExtractor(EntityExtractor):
                 results = [self._filter_by_confidence(r, expertise) for r in results]
             return results
 
-        # Process batches sequentially so the circuit breaker can trip and prevent
-        # wasting time on doomed batch calls.  Individual extractions within each
-        # batch still run concurrently via the semaphore.
-        for batch in batches:
-            results = await _run_batch(batch)
-            all_results.extend(results)
+        # Process batches in waves: concurrent within each wave, circuit breaker
+        # checked between waves.  This restores most of the throughput of the
+        # original asyncio.gather() while letting the breaker trip before the
+        # next wave launches.  Worst-case waste: (wave_size - 1) extra doomed
+        # API calls in the wave where the first failure occurs.
+        wave_size = 4
+        for wave_start in range(0, len(batches), wave_size):
+            if _consecutive_batch_failures >= _BATCH_FAILURE_THRESHOLD:
+                # Circuit breaker tripped between waves — remaining batches
+                # go through single-doc extraction via _run_batch's own check.
+                for batch in batches[wave_start:]:
+                    results = await _run_batch(batch)
+                    all_results.extend(results)
+                break
+            wave = batches[wave_start : wave_start + wave_size]
+            wave_results = await asyncio.gather(*[_run_batch(b) for b in wave])
+            for results in wave_results:
+                all_results.extend(results)
 
         error_count = sum(1 for r in all_results if r.metadata.get("error"))
         logger.debug(


### PR DESCRIPTION
## Summary
- Replace sequential batch processing in `extract_multi()` with wave-based concurrency (waves of 4)
- Circuit breaker is checked between waves — preserves the safety semantics from `6704023`
- Within each wave, batches run concurrently via `asyncio.gather()`
- Store `_max_concurrent` on extractor for future wave-size tuning

### Context

Commit `6704023` switched batch extraction from `asyncio.gather()` to a sequential `for` loop to fix a real bug: the circuit breaker couldn't trip in time because all batches were already in-flight. However, this traded a **permanent ~3x throughput regression** for protection against a rare failure scenario.

### Evidence (Logfire spans from Skynet)

| Run | Ingestion (120 docs) | Notes |
|---|---|---|
| Pre-`6704023` (Mar 29 04:01) | **4.5 min** | All batches concurrent |
| Post-`6704023` / current main (Mar 30-31) | **22-28 min** | Sequential batches |
| **This PR (Skynet run `5310a222`)** | **8.5 min** | **2.9x faster than main** |

### How waves work

```
168 batches (120 docs × ~7 chunks, batch_size=5)

Sequential (current):  [1] → [2] → [3] → ... → [168]  = 168 rounds
Waves of 4:           [1,2,3,4] → [5,6,7,8] → ...     = 42 rounds
                       ↑ circuit breaker checked here
```

Worst case on API failure: 3 extra wasted calls in the failing wave (vs 0 with sequential, vs 167 with full `gather()`).

## Test plan
- [x] 2244 unit tests pass, 0 failures
- [x] Lint clean (ruff), format clean (black)
- [x] Local benchmark: 120 docs, 21 min (matches Skynet baseline — local API latency is the bottleneck)
- [x] **Skynet benchmark: 120 docs, 8.5 min ingestion (2.9x faster than 24.7 min baseline)**
- [x] Run `5310a222` on Skynet: completed, MRR=0.918, 914 entities, $0.05 cost
- [ ] Verify circuit breaker still trips correctly on API degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)