### PR TITLE
Fix VectorCypher throughput regression from PR #217

### DIFF
--- a/src/khora/config/schema.py
+++ b/src/khora/config/schema.py
@@ -558,21 +558,21 @@ class QuerySettings(BaseSettings):
         description="Score multiplier for entities matched via entity linking.",
     )
 
-    # Structured document features (default on, no-op without khora metadata)
+    # Structured document features (default off — enable per-namespace to avoid per-query DB lookups)
     enable_relationship_expansion: bool = Field(
-        default=True,
+        default=False,
         description="After retrieval, follow relationship edges from top entities to inject "
-        "related chunks. Useful for structured documents with dense cross-references. "
-        "No effect if the graph has no relationships.",
+        "related chunks. Enable per-namespace for structured documents with dense cross-references. "
+        "When True, adds a DB round-trip per query to check for relationship data.",
     )
     relationship_expansion_max: int = Field(
         default=5, ge=1, le=20, description="Maximum additional chunks from relationship expansion"
     )
     enable_taxonomy_boost: bool = Field(
-        default=True,
+        default=False,
         description="Classify query against document hierarchy (chapters/topics) and boost chunks "
         "from matching scope. Reads from namespace.metadata['khora']['taxonomy']. "
-        "No effect if no taxonomy data is present under the khora key.",
+        "When True, adds a DB round-trip per query to fetch namespace metadata.",
     )
     taxonomy_boost_factor: float = Field(
         default=1.5, ge=1.0, le=3.0, description="Score multiplier for chunks from taxonomy-matched scope"

--- a/src/khora/query/engine.py
+++ b/src/khora/query/engine.py
@@ -477,10 +477,10 @@ class QueryConfig:
     # Linked entity boost
     linked_entity_boost: float = 1.5
 
-    # Structured document features (default on, no-op without khora metadata)
-    enable_relationship_expansion: bool = True
+    # Structured document features (default off to avoid per-query DB lookups)
+    enable_relationship_expansion: bool = False
     relationship_expansion_max: int = 5
-    enable_taxonomy_boost: bool = True
+    enable_taxonomy_boost: bool = False
     taxonomy_boost_factor: float = 1.5
 
     @classmethod
@@ -559,9 +559,9 @@ class QueryConfig:
             expanded_query_discount=getattr(settings, "expanded_query_discount", 0.7),
             linked_entity_boost=getattr(settings, "linked_entity_boost", 1.5),
             # Structured document features
-            enable_relationship_expansion=getattr(settings, "enable_relationship_expansion", True),
+            enable_relationship_expansion=getattr(settings, "enable_relationship_expansion", False),
             relationship_expansion_max=getattr(settings, "relationship_expansion_max", 5),
-            enable_taxonomy_boost=getattr(settings, "enable_taxonomy_boost", True),
+            enable_taxonomy_boost=getattr(settings, "enable_taxonomy_boost", False),
             taxonomy_boost_factor=getattr(settings, "taxonomy_boost_factor", 1.5),
         )
 


### PR DESCRIPTION
## Summary

Default `enable_taxonomy_boost` and `enable_relationship_expansion` to **False**, fixing the 5x throughput regression (1,300 → 270 QPS) introduced in PR #217.

## Root Cause

PR #217 added taxonomy boost and relationship expansion to VectorCypher's `recall()` with defaults set to True. Even when no taxonomy or cross-ref data exists, the code executed per-query DB round-trips:
- `get_namespace()` to check for taxonomy metadata
- `get_neighborhoods_batch()` to check for relationship data

These extra queries on every recall caused the throughput drop.

## Fix

Default both flags to False. Structured document users opt in explicitly:
- `KHORA_QUERY_ENABLE_TAXONOMY_BOOST=true`
- `KHORA_QUERY_ENABLE_RELATIONSHIP_EXPANSION=true`

The `synthesize()` cross-ref expansion (which reads from chunk metadata, not namespace) is unaffected — it doesn't use these flags.

## Test plan

- [ ] Verify QPS returns to baseline (~1,300)
- [ ] Verify LAMC pipeline still works with flags enabled via env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)