### PR TITLE
DYT-1897: Add .dispatch/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,6 +221,9 @@ __marimo__/
 .claude/
 !.claude/docs/
 
+# Dispatch coordinator runtime files
+.dispatch/
+
 # TTOJ installer metadata
 .ttoj.toml
 .ttoj-backups/


### PR DESCRIPTION
## Summary
- Adds `.dispatch/` directory to `.gitignore` so dispatch coordinator runtime files (agent state, CI metadata, audit results) are not tracked by git

## Test plan
- [x] No code changes — gitignore-only update
- [x] All existing tests pass (2415 passed, 5 skipped)