### PR TITLE
DYT-1953: Implement count_documents() and last_activity_at in Stats

### DIFF
--- a/src/khora/db/migrations/versions/019_document_last_activity_index.py
+++ b/src/khora/db/migrations/versions/019_document_last_activity_index.py
@@ -1,0 +1,33 @@
+"""Add composite index for document last activity queries.
+
+Revision ID: 019_document_last_activity_index
+Revises: 018_halfvec_hnsw_indexes
+Create Date: 2026-04-07
+
+DYT-1953: Add composite index (namespace_id, created_at) on documents table
+to optimize queries for namespace statistics, particularly get_last_activity_at()
+which uses MAX(created_at) with namespace_id filtering.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "019_document_last_activity_index"
+down_revision: str | Sequence[str] | None = "018_halfvec_hnsw_indexes"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add composite index for efficient last activity queries."""
+    op.create_index(
+        "ix_documents_namespace_created_at",
+        "documents",
+        ["namespace_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    """Remove composite index."""
+    op.drop_index("ix_documents_namespace_created_at", "documents")

--- a/src/khora/db/models.py
+++ b/src/khora/db/models.py
@@ -170,6 +170,7 @@ class DocumentModel(Base):
     __table_args__ = (
         Index("ix_documents_namespace_checksum", "namespace_id", "checksum"),
         Index("ix_documents_namespace_source_type", "namespace_id", "source_type"),
+        Index("ix_documents_namespace_created_at", "namespace_id", "created_at"),
     )
 
     def __repr__(self) -> str:

--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -928,6 +928,7 @@ class ChronicleEngine:
         chunk_count = 0
         entity_count = 0
         relationship_count = 0
+        last_activity_at = None
 
         try:
             doc_count = await storage.count_documents(namespace_id)
@@ -949,11 +950,17 @@ class ChronicleEngine:
         except (AttributeError, NotImplementedError):
             pass
 
+        try:
+            last_activity_at = await storage.get_last_activity_at(namespace_id)
+        except (AttributeError, NotImplementedError):
+            pass
+
         return Stats(
             documents=doc_count,
             chunks=chunk_count,
             entities=entity_count,
             relationships=relationship_count,
+            last_activity_at=last_activity_at,
         )
 
     async def health_check(self) -> dict[str, Any]:

--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -931,7 +931,7 @@ class ChronicleEngine:
         last_activity_at = None
 
         try:
-            doc_count = await storage.count_documents(namespace_id)
+            doc_count, last_activity_at = await storage.get_document_stats(namespace_id)
         except (AttributeError, NotImplementedError):
             pass
 
@@ -947,11 +947,6 @@ class ChronicleEngine:
 
         try:
             relationship_count = await storage.count_relationships(namespace_id)
-        except (AttributeError, NotImplementedError):
-            pass
-
-        try:
-            last_activity_at = await storage.get_last_activity_at(namespace_id)
         except (AttributeError, NotImplementedError):
             pass
 

--- a/src/khora/engines/graphrag/engine.py
+++ b/src/khora/engines/graphrag/engine.py
@@ -688,6 +688,7 @@ class GraphRAGEngine:
         chunk_count = 0
         entity_count = 0
         relationship_count = 0
+        last_activity_at = None
 
         try:
             doc_count = await storage.count_documents(namespace_id)
@@ -709,11 +710,17 @@ class GraphRAGEngine:
         except (AttributeError, NotImplementedError):
             pass
 
+        try:
+            last_activity_at = await storage.get_last_activity_at(namespace_id)
+        except (AttributeError, NotImplementedError):
+            pass
+
         return Stats(
             documents=doc_count,
             chunks=chunk_count,
             entities=entity_count,
             relationships=relationship_count,
+            last_activity_at=last_activity_at,
         )
 
     async def health_check(self) -> dict[str, Any]:

--- a/src/khora/engines/graphrag/engine.py
+++ b/src/khora/engines/graphrag/engine.py
@@ -691,7 +691,7 @@ class GraphRAGEngine:
         last_activity_at = None
 
         try:
-            doc_count = await storage.count_documents(namespace_id)
+            doc_count, last_activity_at = await storage.get_document_stats(namespace_id)
         except (AttributeError, NotImplementedError):
             pass
 
@@ -707,11 +707,6 @@ class GraphRAGEngine:
 
         try:
             relationship_count = await storage.count_relationships(namespace_id)
-        except (AttributeError, NotImplementedError):
-            pass
-
-        try:
-            last_activity_at = await storage.get_last_activity_at(namespace_id)
         except (AttributeError, NotImplementedError):
             pass
 

--- a/src/khora/engines/protocol.py
+++ b/src/khora/engines/protocol.py
@@ -313,12 +313,17 @@ class MemoryEngineProtocol(Protocol):
     # =========================================================================
 
     async def stats(self, namespace_id: UUID) -> Stats:
-        """Get document/chunk/entity/relationship counts for a namespace.
+        """Get document/chunk/entity/relationship counts and last activity time for a namespace.
 
         Args:
             namespace_id: Namespace UUID
 
         Returns:
-            Stats with document/chunk/entity/relationship counts
+            Stats with:
+            - documents: Count of documents in the namespace
+            - chunks: Count of document chunks
+            - entities: Count of extracted entities
+            - relationships: Count of entity relationships
+            - last_activity_at: Timestamp of most recent document (None if namespace is empty)
         """
         ...

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -1018,7 +1018,7 @@ class SkeletonConstructionEngine:
         last_activity_at = None
 
         try:
-            doc_count = await storage.count_documents(namespace_id)
+            doc_count, last_activity_at = await storage.get_document_stats(namespace_id)
         except (AttributeError, NotImplementedError):
             pass
 
@@ -1034,11 +1034,6 @@ class SkeletonConstructionEngine:
 
         try:
             relationship_count = await storage.count_relationships(namespace_id)
-        except (AttributeError, NotImplementedError):
-            pass
-
-        try:
-            last_activity_at = await storage.get_last_activity_at(namespace_id)
         except (AttributeError, NotImplementedError):
             pass
 

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -1011,33 +1011,43 @@ class SkeletonConstructionEngine:
         """Get document/chunk/entity/relationship counts for a namespace."""
         storage = self._get_storage()
 
-        # Get counts
+        doc_count = 0
+        chunk_count = 0
+        entity_count = 0
+        relationship_count = 0
+        last_activity_at = None
+
         try:
-            doc_count = await storage.count_documents(namespace_id)  # type: ignore[unresolved-attribute]
+            doc_count = await storage.count_documents(namespace_id)
         except (AttributeError, NotImplementedError):
-            documents = await storage.list_documents(namespace_id, limit=0)
-            doc_count = len(documents) if documents else 0
+            pass
 
         try:
             chunk_count = await storage.count_chunks(namespace_id)
         except (AttributeError, NotImplementedError):
-            chunk_count = 0  # Skeleton engine chunks are in temporal_store
+            pass
 
         try:
             entity_count = await storage.count_entities(namespace_id)
         except (AttributeError, NotImplementedError):
-            entity_count = 0
+            pass
 
         try:
-            relationship_count = await storage.count_relationships(namespace_id)  # type: ignore[unresolved-attribute]
+            relationship_count = await storage.count_relationships(namespace_id)
         except (AttributeError, NotImplementedError):
-            relationship_count = 0
+            pass
+
+        try:
+            last_activity_at = await storage.get_last_activity_at(namespace_id)
+        except (AttributeError, NotImplementedError):
+            pass
 
         return Stats(
             documents=doc_count,
             chunks=chunk_count,
             entities=entity_count,
             relationships=relationship_count,
+            last_activity_at=last_activity_at,
         )
 
     async def health_check(self) -> dict[str, Any]:

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -2324,7 +2324,7 @@ class VectorCypherEngine:
         last_activity_at = None
 
         try:
-            doc_count = await storage.count_documents(namespace_id)
+            doc_count, last_activity_at = await storage.get_document_stats(namespace_id)
         except (AttributeError, NotImplementedError):
             pass
 
@@ -2341,11 +2341,6 @@ class VectorCypherEngine:
 
         try:
             relationship_count = await storage.count_relationships(namespace_id)
-        except (AttributeError, NotImplementedError):
-            pass
-
-        try:
-            last_activity_at = await storage.get_last_activity_at(namespace_id)
         except (AttributeError, NotImplementedError):
             pass
 

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -2318,11 +2318,15 @@ class VectorCypherEngine:
         storage = self._get_storage()
         dual_nodes = self._get_dual_nodes()
 
+        doc_count = 0
+        entity_count = 0
+        relationship_count = 0
+        last_activity_at = None
+
         try:
-            doc_count = await storage.count_documents(namespace_id)  # type: ignore[unresolved-attribute]
+            doc_count = await storage.count_documents(namespace_id)
         except (AttributeError, NotImplementedError):
-            documents = await storage.list_documents(namespace_id, limit=0)
-            doc_count = len(documents) if documents else 0
+            pass
 
         # Get chunk count
         if dual_nodes is not None:
@@ -2333,18 +2337,24 @@ class VectorCypherEngine:
         try:
             entity_count = await storage.count_entities(namespace_id)
         except (AttributeError, NotImplementedError):
-            entity_count = 0
+            pass
 
         try:
-            relationship_count = await storage.count_relationships(namespace_id)  # type: ignore[unresolved-attribute]
+            relationship_count = await storage.count_relationships(namespace_id)
         except (AttributeError, NotImplementedError):
-            relationship_count = 0
+            pass
+
+        try:
+            last_activity_at = await storage.get_last_activity_at(namespace_id)
+        except (AttributeError, NotImplementedError):
+            pass
 
         return Stats(
             documents=doc_count,
             chunks=chunk_count,
             entities=entity_count,
             relationships=relationship_count,
+            last_activity_at=last_activity_at,
         )
 
     async def health_check(self) -> dict[str, Any]:

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field, replace
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
@@ -88,6 +89,7 @@ class Stats:
     chunks: int
     entities: int
     relationships: int
+    last_activity_at: datetime | None = None
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/khora/storage/backends/base.py
+++ b/src/khora/storage/backends/base.py
@@ -146,6 +146,16 @@ class RelationalBackendProtocol(Protocol):
         ...
 
     @abstractmethod
+    async def count_documents(self, namespace_id: UUID) -> int:
+        """Count documents in a namespace."""
+        ...
+
+    @abstractmethod
+    async def get_last_activity_at(self, namespace_id: UUID) -> datetime | None:
+        """Get the most recent document creation timestamp in a namespace."""
+        ...
+
+    @abstractmethod
     async def get_document_by_checksum(self, namespace_id: UUID, checksum: str) -> Document | None:
         """Get a document by its content checksum (for deduplication)."""
         ...

--- a/src/khora/storage/backends/base.py
+++ b/src/khora/storage/backends/base.py
@@ -147,12 +147,22 @@ class RelationalBackendProtocol(Protocol):
 
     @abstractmethod
     async def count_documents(self, namespace_id: UUID) -> int:
-        """Count documents in a namespace."""
+        """Count documents in a namespace.
+
+        Args:
+            namespace_id: Namespace UUID
+
+        Returns:
+            Total number of documents. Returns 0 if namespace is empty.
+        """
         ...
 
     @abstractmethod
     async def get_last_activity_at(self, namespace_id: UUID) -> datetime | None:
-        """Get the most recent document creation timestamp in a namespace."""
+        """Get the most recent document creation timestamp in a namespace.
+
+        Returns None if the namespace has no documents.
+        """
         ...
 
     @abstractmethod

--- a/src/khora/storage/backends/base.py
+++ b/src/khora/storage/backends/base.py
@@ -161,9 +161,24 @@ class RelationalBackendProtocol(Protocol):
     async def get_last_activity_at(self, namespace_id: UUID) -> datetime | None:
         """Get the most recent document creation timestamp in a namespace.
 
-        Returns None if the namespace has no documents.
+        Args:
+            namespace_id: Namespace UUID
+
+        Returns:
+            datetime: Timestamp of the most recently created document (UTC)
+            None: If the namespace has no documents
         """
         ...
+
+    async def get_document_stats(self, namespace_id: UUID) -> tuple[int, datetime | None]:
+        """Count documents and get last activity in a single query.
+
+        Returns (count, last_activity_at). Backends may override for efficiency;
+        the default falls back to two separate calls.
+        """
+        count = await self.count_documents(namespace_id)
+        last_activity = await self.get_last_activity_at(namespace_id)
+        return count, last_activity
 
     @abstractmethod
     async def get_document_by_checksum(self, namespace_id: UUID, checksum: str) -> Document | None:

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -441,6 +441,22 @@ class PostgreSQLBackend(AsyncSessionMixin):
                 return True
             return False
 
+    async def count_documents(self, namespace_id: UUID) -> int:
+        """Count documents in a namespace."""
+        async with self._get_session() as session:
+            result = await session.execute(
+                select(func.count(DocumentModel.id)).where(DocumentModel.namespace_id == namespace_id)
+            )
+            return result.scalar_one()
+
+    async def get_last_activity_at(self, namespace_id: UUID) -> datetime | None:
+        """Get the most recent document creation timestamp in a namespace."""
+        async with self._get_session() as session:
+            result = await session.execute(
+                select(func.max(DocumentModel.created_at)).where(DocumentModel.namespace_id == namespace_id)
+            )
+            return result.scalar_one_or_none()
+
     async def get_document_by_checksum(self, namespace_id: UUID, checksum: str) -> Document | None:
         """Get a document by its content checksum (for deduplication).
 

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -457,6 +457,18 @@ class PostgreSQLBackend(AsyncSessionMixin):
             )
             return result.scalar_one_or_none()
 
+    async def get_document_stats(self, namespace_id: UUID) -> tuple[int, datetime | None]:
+        """Get document count and last activity timestamp in a single query."""
+        async with self._get_session() as session:
+            result = await session.execute(
+                select(
+                    func.count(DocumentModel.id),
+                    func.max(DocumentModel.created_at),
+                ).where(DocumentModel.namespace_id == namespace_id)
+            )
+            row = result.one()
+            return row[0], row[1]
+
     async def get_document_by_checksum(self, namespace_id: UUID, checksum: str) -> Document | None:
         """Get a document by its content checksum (for deduplication).
 

--- a/src/khora/storage/backends/surrealdb/relational.py
+++ b/src/khora/storage/backends/surrealdb/relational.py
@@ -424,6 +424,18 @@ class SurrealDBRelationalAdapter:
         )
         return row["latest"] if row else None
 
+    async def get_document_stats(self, namespace_id: UUID) -> tuple[int, datetime | None]:
+        """Get document count and last activity timestamp in a single query."""
+        ns_str = str(namespace_id)
+        row = await self._conn.query_one(
+            "SELECT count() AS cnt, math::max(created_at) AS latest "
+            "FROM document WHERE namespace_id = $ns GROUP ALL",
+            {"ns": ns_str},
+        )
+        if not row:
+            return 0, None
+        return (row["cnt"] or 0), row["latest"]
+
     async def get_document_by_checksum(self, namespace_id: UUID, checksum: str) -> Document | None:
         """Get a document by content checksum within a namespace."""
         ns_str = str(namespace_id)

--- a/src/khora/storage/backends/surrealdb/relational.py
+++ b/src/khora/storage/backends/surrealdb/relational.py
@@ -413,7 +413,7 @@ class SurrealDBRelationalAdapter:
             "SELECT count() AS cnt FROM document WHERE namespace_id = $ns GROUP ALL",
             {"ns": ns_str},
         )
-        return row["cnt"] if row else 0
+        return (row["cnt"] or 0) if row else 0
 
     async def get_last_activity_at(self, namespace_id: UUID) -> datetime | None:
         """Get the most recent document creation timestamp in a namespace."""

--- a/src/khora/storage/backends/surrealdb/relational.py
+++ b/src/khora/storage/backends/surrealdb/relational.py
@@ -406,6 +406,24 @@ class SurrealDBRelationalAdapter:
         deleted = await self._conn.query("DELETE $rid RETURN BEFORE", {"rid": rid})
         return bool(deleted)
 
+    async def count_documents(self, namespace_id: UUID) -> int:
+        """Count documents in a namespace."""
+        ns_str = str(namespace_id)
+        row = await self._conn.query_one(
+            "SELECT count() AS cnt FROM document WHERE namespace_id = $ns GROUP ALL",
+            {"ns": ns_str},
+        )
+        return row["cnt"] if row else 0
+
+    async def get_last_activity_at(self, namespace_id: UUID) -> datetime | None:
+        """Get the most recent document creation timestamp in a namespace."""
+        ns_str = str(namespace_id)
+        row = await self._conn.query_one(
+            "SELECT math::max(created_at) AS latest FROM document WHERE namespace_id = $ns GROUP ALL",
+            {"ns": ns_str},
+        )
+        return row["latest"] if row else None
+
     async def get_document_by_checksum(self, namespace_id: UUID, checksum: str) -> Document | None:
         """Get a document by content checksum within a namespace."""
         ns_str = str(namespace_id)

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -412,13 +412,34 @@ class StorageCoordinator:
         return await self.relational.delete_document(document_id)
 
     async def count_documents(self, namespace_id: UUID) -> int:
-        """Count documents in a namespace."""
+        """Count documents in a namespace.
+
+        Args:
+            namespace_id: Namespace UUID
+
+        Returns:
+            Total number of documents in the namespace (0 if empty)
+
+        Raises:
+            RuntimeError: If relational backend is not configured
+        """
         if not self.relational:
             raise RuntimeError("Relational backend not configured")
         return await self.relational.count_documents(namespace_id)
 
     async def get_last_activity_at(self, namespace_id: UUID) -> datetime | None:
-        """Get the most recent document creation timestamp in a namespace."""
+        """Get the most recent document creation timestamp in a namespace.
+
+        Args:
+            namespace_id: Namespace UUID
+
+        Returns:
+            Timestamp of the most recently created document in the namespace.
+            None if the namespace has no documents.
+
+        Raises:
+            RuntimeError: If relational backend is not configured
+        """
         if not self.relational:
             raise RuntimeError("Relational backend not configured")
         return await self.relational.get_last_activity_at(namespace_id)

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -444,6 +444,12 @@ class StorageCoordinator:
             raise RuntimeError("Relational backend not configured")
         return await self.relational.get_last_activity_at(namespace_id)
 
+    async def get_document_stats(self, namespace_id: UUID) -> tuple[int, datetime | None]:
+        """Get document count and last activity timestamp in a single query."""
+        if not self.relational:
+            raise RuntimeError("Relational backend not configured")
+        return await self.relational.get_document_stats(namespace_id)
+
     async def get_document_by_checksum(self, namespace_id: UUID, checksum: str) -> Document | None:
         """Get a document by its content checksum."""
         if not self.relational:

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -411,6 +411,18 @@ class StorageCoordinator:
 
         return await self.relational.delete_document(document_id)
 
+    async def count_documents(self, namespace_id: UUID) -> int:
+        """Count documents in a namespace."""
+        if not self.relational:
+            raise RuntimeError("Relational backend not configured")
+        return await self.relational.count_documents(namespace_id)
+
+    async def get_last_activity_at(self, namespace_id: UUID) -> datetime | None:
+        """Get the most recent document creation timestamp in a namespace."""
+        if not self.relational:
+            raise RuntimeError("Relational backend not configured")
+        return await self.relational.get_last_activity_at(namespace_id)
+
     async def get_document_by_checksum(self, namespace_id: UUID, checksum: str) -> Document | None:
         """Get a document by its content checksum."""
         if not self.relational:

--- a/tests/unit/engines/test_engine_stats.py
+++ b/tests/unit/engines/test_engine_stats.py
@@ -1,0 +1,389 @@
+"""Unit tests for engine stats() methods — last_activity_at and fallback behavior."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from khora.memory_lake import Stats
+
+
+def _make_mock_storage(
+    *,
+    doc_count: int = 5,
+    chunk_count: int = 20,
+    entity_count: int = 10,
+    relationship_count: int = 8,
+    last_activity_at: datetime | None = datetime(2026, 4, 7, 12, 0, 0, tzinfo=UTC),
+) -> AsyncMock:
+    """Create a mock StorageCoordinator with count methods."""
+    storage = AsyncMock()
+    storage.count_documents = AsyncMock(return_value=doc_count)
+    storage.count_chunks = AsyncMock(return_value=chunk_count)
+    storage.count_entities = AsyncMock(return_value=entity_count)
+    storage.count_relationships = AsyncMock(return_value=relationship_count)
+    storage.get_last_activity_at = AsyncMock(return_value=last_activity_at)
+    storage.get_document_stats = AsyncMock(return_value=(doc_count, last_activity_at))
+    return storage
+
+
+# =========================================================================
+# Chronicle
+# =========================================================================
+
+
+class TestChronicleStats:
+    """Tests for ChronicleEngine.stats()."""
+
+    def _make_engine(self, storage: AsyncMock) -> object:
+        from khora.engines.chronicle.engine import ChronicleEngine
+
+        config = MagicMock()
+        config.get_postgresql_url.return_value = "postgresql://localhost/test"
+        config.get_graph_config.return_value = MagicMock()
+        config.get_vector_config.return_value = MagicMock()
+        config.storage.postgresql_pool_size = 5
+        config.storage.postgresql_max_overflow = 10
+        config.storage.embedding_dimension = 1536
+        config.llm.model = "gpt-4o-mini"
+        config.llm.embedding_model = "text-embedding-3-small"
+        config.llm.embedding_dimension = 1536
+        config.llm.timeout = 30
+        config.llm.max_retries = 3
+        config.llm.max_concurrent_llm_calls = 5
+        config.pipeline.chunking_strategy = "recursive"
+        config.pipeline.chunk_size = 1000
+        config.pipeline.chunk_overlap = 200
+        config.pipeline.extract_entities = True
+        config.telemetry_database_url = None
+        config.telemetry_service_name = "test"
+
+        engine = ChronicleEngine(config)
+        engine._connected = True
+        engine._storage = storage
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_stats_includes_last_activity_at(self) -> None:
+        """stats() returns last_activity_at from storage."""
+        ts = datetime(2026, 4, 7, 12, 0, 0, tzinfo=UTC)
+        storage = _make_mock_storage(last_activity_at=ts)
+        engine = self._make_engine(storage)
+
+        result = await engine.stats(uuid4())
+
+        assert isinstance(result, Stats)
+        assert result.documents == 5
+        assert result.chunks == 20
+        assert result.entities == 10
+        assert result.relationships == 8
+        assert result.last_activity_at == ts
+
+    @pytest.mark.asyncio
+    async def test_stats_last_activity_at_none(self) -> None:
+        """stats() returns None last_activity_at for empty namespace."""
+        storage = _make_mock_storage(last_activity_at=None)
+        engine = self._make_engine(storage)
+
+        result = await engine.stats(uuid4())
+
+        assert result.last_activity_at is None
+
+    @pytest.mark.asyncio
+    async def test_stats_get_document_stats_fallback(self) -> None:
+        """stats() handles AttributeError on get_document_stats gracefully."""
+        storage = _make_mock_storage()
+        storage.get_document_stats = AsyncMock(side_effect=AttributeError)
+        engine = self._make_engine(storage)
+
+        result = await engine.stats(uuid4())
+
+        assert result.documents == 0
+        assert result.last_activity_at is None
+
+    @pytest.mark.asyncio
+    async def test_stats_get_document_stats_not_implemented(self) -> None:
+        """stats() handles NotImplementedError on get_document_stats."""
+        storage = _make_mock_storage()
+        storage.get_document_stats = AsyncMock(side_effect=NotImplementedError)
+        engine = self._make_engine(storage)
+
+        result = await engine.stats(uuid4())
+
+        assert result.documents == 0
+        assert result.last_activity_at is None
+
+
+# =========================================================================
+# GraphRAG
+# =========================================================================
+
+
+class TestGraphRAGStats:
+    """Tests for GraphRAGEngine.stats()."""
+
+    def _make_engine(self, storage: AsyncMock) -> object:
+        from khora.engines.graphrag.engine import GraphRAGEngine
+
+        config = MagicMock()
+        config.get_postgresql_url.return_value = "postgresql://localhost/test"
+        config.get_graph_config.return_value = MagicMock()
+        config.get_vector_config.return_value = MagicMock()
+        config.storage.postgresql_pool_size = 5
+        config.storage.postgresql_max_overflow = 10
+        config.storage.embedding_dimension = 1536
+        config.llm.model = "gpt-4o-mini"
+        config.llm.embedding_model = "text-embedding-3-small"
+        config.llm.embedding_dimension = 1536
+        config.llm.timeout = 30
+        config.llm.max_retries = 3
+        config.llm.max_concurrent_llm_calls = 5
+        config.pipeline.chunking_strategy = "recursive"
+        config.pipeline.chunk_size = 1000
+        config.pipeline.chunk_overlap = 200
+        config.pipeline.extract_entities = True
+        config.telemetry_database_url = None
+        config.telemetry_service_name = "test"
+
+        engine = GraphRAGEngine(config)
+        engine._connected = True
+        engine._storage = storage
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_stats_includes_last_activity_at(self) -> None:
+        """stats() returns last_activity_at from storage."""
+        ts = datetime(2026, 4, 7, 12, 0, 0, tzinfo=UTC)
+        storage = _make_mock_storage(last_activity_at=ts)
+        engine = self._make_engine(storage)
+
+        result = await engine.stats(uuid4())
+
+        assert isinstance(result, Stats)
+        assert result.documents == 5
+        assert result.last_activity_at == ts
+
+    @pytest.mark.asyncio
+    async def test_stats_get_document_stats_fallback(self) -> None:
+        """stats() handles AttributeError on get_document_stats gracefully."""
+        storage = _make_mock_storage()
+        storage.get_document_stats = AsyncMock(side_effect=AttributeError)
+        engine = self._make_engine(storage)
+
+        result = await engine.stats(uuid4())
+
+        assert result.documents == 0
+        assert result.last_activity_at is None
+        assert result.chunks == 20
+
+
+# =========================================================================
+# Skeleton
+# =========================================================================
+
+
+class TestSkeletonStats:
+    """Tests for SkeletonConstructionEngine.stats()."""
+
+    def _make_engine(self, storage: AsyncMock) -> object:
+        from khora.engines.skeleton.engine import SkeletonConstructionEngine
+
+        config = MagicMock()
+        config.get_postgresql_url.return_value = "postgresql://localhost/test"
+        config.get_graph_config.return_value = MagicMock()
+        config.get_vector_config.return_value = MagicMock()
+        config.storage.postgresql_pool_size = 5
+        config.storage.postgresql_max_overflow = 10
+        config.storage.embedding_dimension = 1536
+        config.llm.model = "gpt-4o-mini"
+        config.llm.embedding_model = "text-embedding-3-small"
+        config.llm.embedding_dimension = 1536
+        config.llm.timeout = 30
+        config.llm.max_retries = 3
+        config.llm.max_concurrent_llm_calls = 5
+        config.pipeline.chunking_strategy = "recursive"
+        config.pipeline.chunk_size = 1000
+        config.pipeline.chunk_overlap = 200
+        config.pipeline.extract_entities = True
+        config.telemetry_database_url = None
+        config.telemetry_service_name = "test"
+
+        engine = SkeletonConstructionEngine(config)
+        engine._connected = True
+        engine._storage = storage
+        engine._temporal_store = AsyncMock()
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_stats_includes_last_activity_at(self) -> None:
+        """stats() returns last_activity_at from storage."""
+        ts = datetime(2026, 4, 7, 12, 0, 0, tzinfo=UTC)
+        storage = _make_mock_storage(last_activity_at=ts)
+        engine = self._make_engine(storage)
+
+        result = await engine.stats(uuid4())
+
+        assert isinstance(result, Stats)
+        assert result.documents == 5
+        assert result.last_activity_at == ts
+
+    @pytest.mark.asyncio
+    async def test_stats_get_document_stats_fallback(self) -> None:
+        """stats() defaults doc_count to 0 on get_document_stats failure."""
+        storage = _make_mock_storage()
+        storage.get_document_stats = AsyncMock(side_effect=AttributeError)
+        engine = self._make_engine(storage)
+
+        result = await engine.stats(uuid4())
+
+        assert result.documents == 0
+        assert result.last_activity_at is None
+        # list_documents should NOT be called as fallback
+        storage.list_documents.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_stats_count_chunks_fallback(self) -> None:
+        """stats() handles count_chunks failure gracefully."""
+        storage = _make_mock_storage()
+        storage.count_chunks = AsyncMock(side_effect=NotImplementedError)
+        engine = self._make_engine(storage)
+
+        result = await engine.stats(uuid4())
+
+        assert result.chunks == 0
+        assert result.documents == 5
+
+
+# =========================================================================
+# VectorCypher
+# =========================================================================
+
+
+class TestVectorCypherStats:
+    """Tests for VectorCypherEngine.stats()."""
+
+    def _make_engine(self, storage: AsyncMock, *, dual_nodes: AsyncMock | None = None) -> object:
+        from khora.engines.vectorcypher.engine import VectorCypherEngine
+
+        config = MagicMock()
+        config.get_postgresql_url.return_value = "postgresql://localhost/test"
+        config.get_neo4j_url.return_value = "bolt://localhost:7687"
+        config.get_neo4j_user.return_value = "neo4j"
+        config.get_neo4j_password.return_value = "password"
+        config.get_neo4j_database.return_value = "neo4j"
+        config.get_graph_config.return_value = MagicMock()
+        config.get_vector_config.return_value = MagicMock()
+        config.storage.postgresql_pool_size = 5
+        config.storage.postgresql_max_overflow = 10
+        config.storage.embedding_dimension = 1536
+        config.llm.model = "gpt-4o-mini"
+        config.llm.embedding_model = "text-embedding-3-small"
+        config.llm.embedding_dimension = 1536
+        config.llm.timeout = 30
+        config.llm.max_retries = 3
+        config.llm.max_concurrent_llm_calls = 5
+        config.pipeline.chunking_strategy = "recursive"
+        config.pipeline.chunk_size = 1000
+        config.pipeline.chunk_overlap = 200
+        config.pipeline.extract_entities = True
+        config.telemetry_database_url = None
+        config.telemetry_service_name = "test"
+
+        engine = VectorCypherEngine(config)
+        engine._connected = True
+        engine._storage = storage
+        engine._temporal_store = AsyncMock()
+        engine._temporal_store.count_chunks = AsyncMock(return_value=20)
+        engine._dual_nodes = dual_nodes
+        engine._neo4j_driver = AsyncMock()
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_stats_includes_last_activity_at(self) -> None:
+        """stats() returns last_activity_at from storage."""
+        ts = datetime(2026, 4, 7, 12, 0, 0, tzinfo=UTC)
+        storage = _make_mock_storage(last_activity_at=ts)
+        engine = self._make_engine(storage)
+
+        result = await engine.stats(uuid4())
+
+        assert isinstance(result, Stats)
+        assert result.documents == 5
+        assert result.last_activity_at == ts
+
+    @pytest.mark.asyncio
+    async def test_stats_uses_dual_nodes_for_chunks(self) -> None:
+        """stats() uses dual_nodes.count_chunks when available."""
+        storage = _make_mock_storage()
+        dual_nodes = AsyncMock()
+        dual_nodes.count_chunks = AsyncMock(return_value=42)
+        engine = self._make_engine(storage, dual_nodes=dual_nodes)
+
+        result = await engine.stats(uuid4())
+
+        assert result.chunks == 42
+        dual_nodes.count_chunks.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stats_uses_temporal_store_for_chunks(self) -> None:
+        """stats() falls back to temporal_store.count_chunks when no dual_nodes."""
+        storage = _make_mock_storage()
+        engine = self._make_engine(storage, dual_nodes=None)
+
+        result = await engine.stats(uuid4())
+
+        assert result.chunks == 20  # from temporal_store mock
+
+    @pytest.mark.asyncio
+    async def test_stats_get_document_stats_fallback(self) -> None:
+        """stats() defaults doc_count to 0 on get_document_stats failure."""
+        storage = _make_mock_storage()
+        storage.get_document_stats = AsyncMock(side_effect=AttributeError)
+        engine = self._make_engine(storage)
+
+        result = await engine.stats(uuid4())
+
+        assert result.documents == 0
+        assert result.last_activity_at is None
+        storage.list_documents.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_stats_relationship_count_fallback(self) -> None:
+        """stats() handles NotImplementedError on count_relationships."""
+        storage = _make_mock_storage()
+        storage.count_relationships = AsyncMock(side_effect=NotImplementedError)
+        engine = self._make_engine(storage)
+
+        result = await engine.stats(uuid4())
+
+        assert result.relationships == 0
+        assert result.documents == 5
+
+
+# =========================================================================
+# Stats dataclass
+# =========================================================================
+
+
+class TestStatsDataclass:
+    """Tests for the Stats dataclass itself."""
+
+    def test_last_activity_at_default_none(self) -> None:
+        """last_activity_at defaults to None."""
+        stats = Stats(documents=1, chunks=2, entities=3, relationships=4)
+        assert stats.last_activity_at is None
+
+    def test_last_activity_at_set(self) -> None:
+        """last_activity_at can be set explicitly."""
+        ts = datetime(2026, 4, 7, 12, 0, 0, tzinfo=UTC)
+        stats = Stats(documents=1, chunks=2, entities=3, relationships=4, last_activity_at=ts)
+        assert stats.last_activity_at == ts
+
+    def test_stats_frozen(self) -> None:
+        """Stats is frozen (immutable)."""
+        stats = Stats(documents=1, chunks=2, entities=3, relationships=4)
+        with pytest.raises(AttributeError):
+            stats.documents = 10  # type: ignore[misc]

--- a/tests/unit/test_memory_lake.py
+++ b/tests/unit/test_memory_lake.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import warnings
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -662,6 +663,31 @@ class TestStats:
         assert s.chunks == 500
         assert s.entities == 200
         assert s.relationships == 150
+
+    def test_last_activity_at_default_none(self) -> None:
+        """last_activity_at defaults to None for backward compatibility."""
+        s = Stats(documents=1, chunks=2, entities=3, relationships=4)
+        assert s.last_activity_at is None
+
+    def test_last_activity_at_with_value(self) -> None:
+        """last_activity_at accepts a datetime value."""
+        from datetime import UTC, datetime
+
+        ts = datetime(2026, 4, 7, 12, 0, 0, tzinfo=UTC)
+        s = Stats(
+            documents=1,
+            chunks=2,
+            entities=3,
+            relationships=4,
+            last_activity_at=ts,
+        )
+        assert s.last_activity_at == ts
+
+    def test_frozen(self) -> None:
+        """Stats is immutable."""
+        s = Stats(documents=1, chunks=2, entities=3, relationships=4)
+        with pytest.raises(AttributeError):
+            s.last_activity_at = datetime.now()  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -408,15 +408,15 @@ class TestMigrationPackageStructure:
         assert env_path.exists(), f"env.py not found at {env_path}"
 
     @pytest.mark.unit
-    def test_versions_dir_has_19_files(self):
-        """versions/ directory contains 19 migration files."""
+    def test_versions_dir_has_20_files(self):
+        """versions/ directory contains 20 migration files."""
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
         # Filter out __pycache__ and __init__
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
         assert (
-            len(migration_files) == 19
-        ), f"Expected 19 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
+            len(migration_files) == 20
+        ), f"Expected 20 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
 
     @pytest.mark.unit
     def test_env_py_constants(self):

--- a/tests/unit/test_stats_methods.py
+++ b/tests/unit/test_stats_methods.py
@@ -1,0 +1,584 @@
+"""Tests for DYT-1953: count_documents, get_last_activity_at, get_document_stats, and engine stats().
+
+Covers:
+- Engine stats() methods returning last_activity_at for all 4 engines
+- Engine stats() fallback behavior when storage methods raise
+- SurrealDB relational adapter: count_documents, get_last_activity_at, get_document_stats
+- StorageCoordinator: get_document_stats delegation (not on coordinator yet, tested at backend level)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from khora.memory_lake import Stats
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_khora_config() -> MagicMock:
+    """Create a mock KhoraConfig sufficient for engine construction."""
+    config = MagicMock()
+    config.get_postgresql_url.return_value = "postgresql://localhost/test"
+    config.get_neo4j_url.return_value = None
+    config.get_neo4j_user.return_value = None
+    config.get_neo4j_password.return_value = None
+    config.get_neo4j_database.return_value = None
+    config.get_graph_config.return_value = None
+    config.get_vector_config.return_value = None
+    config.storage.postgresql_pool_size = 5
+    config.storage.postgresql_max_overflow = 10
+    config.storage.embedding_dimension = 1536
+    config.llm.model = "gpt-4o-mini"
+    config.llm.embedding_model = "text-embedding-3-small"
+    config.llm.embedding_dimension = 1536
+    config.llm.timeout = 30
+    config.llm.max_retries = 3
+    config.llm.extraction_model = None
+    config.llm.max_concurrent_llm_calls = 5
+    config.pipeline.chunking_strategy = "recursive"
+    config.pipeline.chunk_size = 1000
+    config.pipeline.chunk_overlap = 200
+    config.pipeline.extract_entities = True
+    config.telemetry_database_url = None
+    config.telemetry_service_name = "test"
+    return config
+
+
+def _mock_storage(
+    *,
+    doc_count: int = 5,
+    chunk_count: int = 20,
+    entity_count: int = 10,
+    relationship_count: int = 8,
+    last_activity_at: datetime | None = None,
+) -> AsyncMock:
+    """Create a mock StorageCoordinator with count methods.
+
+    Engines call get_document_stats() which returns (doc_count, last_activity_at).
+    """
+    storage = AsyncMock()
+    storage.get_document_stats = AsyncMock(return_value=(doc_count, last_activity_at))
+    storage.count_chunks = AsyncMock(return_value=chunk_count)
+    storage.count_entities = AsyncMock(return_value=entity_count)
+    storage.count_relationships = AsyncMock(return_value=relationship_count)
+    return storage
+
+
+# ===========================================================================
+# Engine stats() tests
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestChronicleEngineStats:
+    """Tests for ChronicleEngine.stats() with last_activity_at."""
+
+    @pytest.mark.asyncio
+    async def test_stats_returns_last_activity_at(self) -> None:
+        """stats() populates last_activity_at from storage."""
+        from khora.engines.chronicle.engine import ChronicleEngine
+
+        ts = datetime(2026, 4, 7, 12, 0, 0, tzinfo=UTC)
+        config = _mock_khora_config()
+        engine = ChronicleEngine(config)
+        engine._connected = True
+        engine._storage = _mock_storage(
+            doc_count=3,
+            chunk_count=10,
+            entity_count=5,
+            relationship_count=2,
+            last_activity_at=ts,
+        )
+
+        ns_id = uuid4()
+        result = await engine.stats(ns_id)
+
+        assert isinstance(result, Stats)
+        assert result.documents == 3
+        assert result.chunks == 10
+        assert result.entities == 5
+        assert result.relationships == 2
+        assert result.last_activity_at == ts
+
+    @pytest.mark.asyncio
+    async def test_stats_last_activity_at_none_when_empty(self) -> None:
+        """stats() returns None for last_activity_at when namespace is empty."""
+        from khora.engines.chronicle.engine import ChronicleEngine
+
+        config = _mock_khora_config()
+        engine = ChronicleEngine(config)
+        engine._connected = True
+        engine._storage = _mock_storage(
+            doc_count=0,
+            chunk_count=0,
+            entity_count=0,
+            relationship_count=0,
+            last_activity_at=None,
+        )
+
+        result = await engine.stats(uuid4())
+        assert result.last_activity_at is None
+        assert result.documents == 0
+
+    @pytest.mark.asyncio
+    async def test_stats_fallback_on_attribute_error(self) -> None:
+        """stats() gracefully falls back when storage methods raise AttributeError."""
+        from khora.engines.chronicle.engine import ChronicleEngine
+
+        config = _mock_khora_config()
+        engine = ChronicleEngine(config)
+        engine._connected = True
+
+        storage = AsyncMock()
+        storage.get_document_stats = AsyncMock(side_effect=AttributeError)
+        storage.count_chunks = AsyncMock(side_effect=AttributeError)
+        storage.count_entities = AsyncMock(side_effect=AttributeError)
+        storage.count_relationships = AsyncMock(side_effect=AttributeError)
+        engine._storage = storage
+
+        result = await engine.stats(uuid4())
+
+        assert result.documents == 0
+        assert result.chunks == 0
+        assert result.entities == 0
+        assert result.relationships == 0
+        assert result.last_activity_at is None
+
+    @pytest.mark.asyncio
+    async def test_stats_fallback_on_not_implemented(self) -> None:
+        """stats() gracefully falls back when storage methods raise NotImplementedError."""
+        from khora.engines.chronicle.engine import ChronicleEngine
+
+        config = _mock_khora_config()
+        engine = ChronicleEngine(config)
+        engine._connected = True
+
+        storage = AsyncMock()
+        storage.get_document_stats = AsyncMock(side_effect=NotImplementedError)
+        storage.count_chunks = AsyncMock(side_effect=NotImplementedError)
+        storage.count_entities = AsyncMock(side_effect=NotImplementedError)
+        storage.count_relationships = AsyncMock(side_effect=NotImplementedError)
+        engine._storage = storage
+
+        result = await engine.stats(uuid4())
+
+        assert result.documents == 0
+        assert result.last_activity_at is None
+
+
+@pytest.mark.unit
+class TestGraphRAGEngineStats:
+    """Tests for GraphRAGEngine.stats() with last_activity_at."""
+
+    @pytest.mark.asyncio
+    async def test_stats_returns_last_activity_at(self) -> None:
+        """stats() populates last_activity_at from storage."""
+        from khora.engines.graphrag.engine import GraphRAGEngine
+
+        ts = datetime(2026, 3, 15, 8, 30, 0, tzinfo=UTC)
+        config = _mock_khora_config()
+        engine = GraphRAGEngine(config)
+        engine._connected = True
+        engine._storage = _mock_storage(
+            doc_count=7,
+            chunk_count=35,
+            entity_count=12,
+            relationship_count=9,
+            last_activity_at=ts,
+        )
+
+        result = await engine.stats(uuid4())
+
+        assert result.documents == 7
+        assert result.chunks == 35
+        assert result.entities == 12
+        assert result.relationships == 9
+        assert result.last_activity_at == ts
+
+    @pytest.mark.asyncio
+    async def test_stats_fallback_on_error(self) -> None:
+        """stats() returns zeros and None when all storage methods fail."""
+        from khora.engines.graphrag.engine import GraphRAGEngine
+
+        config = _mock_khora_config()
+        engine = GraphRAGEngine(config)
+        engine._connected = True
+
+        storage = AsyncMock()
+        storage.get_document_stats = AsyncMock(side_effect=AttributeError)
+        storage.count_chunks = AsyncMock(side_effect=NotImplementedError)
+        storage.count_entities = AsyncMock(side_effect=AttributeError)
+        storage.count_relationships = AsyncMock(side_effect=NotImplementedError)
+        engine._storage = storage
+
+        result = await engine.stats(uuid4())
+
+        assert result.documents == 0
+        assert result.chunks == 0
+        assert result.entities == 0
+        assert result.relationships == 0
+        assert result.last_activity_at is None
+
+
+@pytest.mark.unit
+class TestSkeletonEngineStats:
+    """Tests for SkeletonConstructionEngine.stats() with last_activity_at."""
+
+    @pytest.mark.asyncio
+    async def test_stats_returns_last_activity_at(self) -> None:
+        """stats() populates last_activity_at from storage."""
+        from khora.engines.skeleton.engine import SkeletonConstructionEngine
+
+        ts = datetime(2026, 2, 20, 16, 45, 0, tzinfo=UTC)
+        config = _mock_khora_config()
+        engine = SkeletonConstructionEngine(config, backend="pgvector")
+        engine._connected = True
+        engine._storage = _mock_storage(
+            doc_count=2,
+            chunk_count=8,
+            entity_count=4,
+            relationship_count=1,
+            last_activity_at=ts,
+        )
+
+        result = await engine.stats(uuid4())
+
+        assert result.documents == 2
+        assert result.chunks == 8
+        assert result.entities == 4
+        assert result.relationships == 1
+        assert result.last_activity_at == ts
+
+    @pytest.mark.asyncio
+    async def test_stats_fallback_all_errors(self) -> None:
+        """stats() returns zeros and None when all storage methods fail."""
+        from khora.engines.skeleton.engine import SkeletonConstructionEngine
+
+        config = _mock_khora_config()
+        engine = SkeletonConstructionEngine(config, backend="pgvector")
+        engine._connected = True
+
+        storage = AsyncMock()
+        storage.get_document_stats = AsyncMock(side_effect=AttributeError)
+        storage.count_chunks = AsyncMock(side_effect=NotImplementedError)
+        storage.count_entities = AsyncMock(side_effect=AttributeError)
+        storage.count_relationships = AsyncMock(side_effect=NotImplementedError)
+        engine._storage = storage
+
+        result = await engine.stats(uuid4())
+
+        assert result.documents == 0
+        assert result.chunks == 0
+        assert result.entities == 0
+        assert result.relationships == 0
+        assert result.last_activity_at is None
+
+
+@pytest.mark.unit
+class TestVectorCypherEngineStats:
+    """Tests for VectorCypherEngine.stats() with last_activity_at."""
+
+    def _make_engine(self) -> "VectorCypherEngine":  # noqa: F821
+        from khora.engines.vectorcypher.engine import VectorCypherEngine
+
+        config = _mock_khora_config()
+        config.get_neo4j_url.return_value = "bolt://localhost:7687"
+        config.get_neo4j_user.return_value = "neo4j"
+        config.get_neo4j_password.return_value = "password"
+        config.get_neo4j_database.return_value = "neo4j"
+        config.get_graph_config.return_value = MagicMock()
+        config.get_vector_config.return_value = MagicMock()
+        return VectorCypherEngine(config)
+
+    @pytest.mark.asyncio
+    async def test_stats_returns_last_activity_at_with_dual_nodes(self) -> None:
+        """stats() returns last_activity_at; uses dual_nodes for chunk count."""
+        ts = datetime(2026, 1, 10, 9, 0, 0, tzinfo=UTC)
+        engine = self._make_engine()
+        engine._connected = True
+        engine._storage = _mock_storage(
+            doc_count=4,
+            entity_count=6,
+            relationship_count=3,
+            last_activity_at=ts,
+        )
+        engine._dual_nodes = AsyncMock()
+        engine._dual_nodes.count_chunks = AsyncMock(return_value=15)
+
+        result = await engine.stats(uuid4())
+
+        assert result.documents == 4
+        assert result.chunks == 15
+        assert result.entities == 6
+        assert result.relationships == 3
+        assert result.last_activity_at == ts
+
+    @pytest.mark.asyncio
+    async def test_stats_returns_last_activity_at_with_temporal_store(self) -> None:
+        """stats() uses temporal_store for chunk count when dual_nodes is None."""
+        ts = datetime(2026, 1, 10, 9, 0, 0, tzinfo=UTC)
+        engine = self._make_engine()
+        engine._connected = True
+        engine._storage = _mock_storage(
+            doc_count=4,
+            entity_count=6,
+            relationship_count=3,
+            last_activity_at=ts,
+        )
+        engine._dual_nodes = None
+        engine._temporal_store = AsyncMock()
+        engine._temporal_store.count_chunks = AsyncMock(return_value=12)
+
+        result = await engine.stats(uuid4())
+
+        assert result.documents == 4
+        assert result.chunks == 12
+        assert result.last_activity_at == ts
+
+    @pytest.mark.asyncio
+    async def test_stats_fallback_on_error(self) -> None:
+        """stats() returns zeros and None when storage methods fail."""
+        engine = self._make_engine()
+        engine._connected = True
+
+        storage = AsyncMock()
+        storage.get_document_stats = AsyncMock(side_effect=AttributeError)
+        storage.count_entities = AsyncMock(side_effect=NotImplementedError)
+        storage.count_relationships = AsyncMock(side_effect=AttributeError)
+        engine._storage = storage
+        engine._dual_nodes = AsyncMock()
+        engine._dual_nodes.count_chunks = AsyncMock(return_value=0)
+
+        result = await engine.stats(uuid4())
+
+        assert result.documents == 0
+        assert result.entities == 0
+        assert result.relationships == 0
+        assert result.last_activity_at is None
+
+    @pytest.mark.asyncio
+    async def test_stats_partial_failure(self) -> None:
+        """stats() returns partial results when only some methods fail."""
+        ts = datetime(2026, 4, 1, 0, 0, 0, tzinfo=UTC)
+        engine = self._make_engine()
+        engine._connected = True
+
+        storage = AsyncMock()
+        storage.get_document_stats = AsyncMock(return_value=(10, ts))
+        storage.count_entities = AsyncMock(side_effect=AttributeError)
+        storage.count_relationships = AsyncMock(return_value=5)
+        engine._storage = storage
+        engine._dual_nodes = AsyncMock()
+        engine._dual_nodes.count_chunks = AsyncMock(return_value=50)
+
+        result = await engine.stats(uuid4())
+
+        assert result.documents == 10
+        assert result.chunks == 50
+        assert result.entities == 0  # fallback
+        assert result.relationships == 5
+        assert result.last_activity_at == ts
+
+
+# ===========================================================================
+# SurrealDB Backend Tests
+# ===========================================================================
+
+
+def _make_mock_conn(**query_returns: object) -> MagicMock:
+    """Create a mock SurrealDBConnection with sensible defaults."""
+    conn = MagicMock()
+    conn.connected = True
+    conn.connect = AsyncMock()
+    conn.disconnect = AsyncMock()
+    conn.is_healthy = AsyncMock(return_value=True)
+    conn.query = AsyncMock(return_value=query_returns.get("query", []))
+    conn.query_one = AsyncMock(return_value=query_returns.get("query_one", None))
+    conn.execute = AsyncMock(return_value=query_returns.get("execute", None))
+    return conn
+
+
+@pytest.mark.unit
+class TestSurrealDBCountDocuments:
+    """Tests for SurrealDBRelationalAdapter.count_documents()."""
+
+    @pytest.mark.asyncio
+    async def test_count_documents(self) -> None:
+        """count_documents returns count from SurrealDB query."""
+        from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter
+
+        conn = _make_mock_conn()
+        conn.query_one = AsyncMock(return_value={"cnt": 42})
+        adapter = SurrealDBRelationalAdapter(conn)
+
+        ns_id = uuid4()
+        result = await adapter.count_documents(ns_id)
+
+        assert result == 42
+        conn.query_one.assert_awaited_once()
+        call_args = conn.query_one.call_args
+        assert str(ns_id) in str(call_args)
+
+    @pytest.mark.asyncio
+    async def test_count_documents_empty_namespace(self) -> None:
+        """count_documents returns 0 when no documents exist."""
+        from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter
+
+        conn = _make_mock_conn()
+        conn.query_one = AsyncMock(return_value=None)
+        adapter = SurrealDBRelationalAdapter(conn)
+
+        result = await adapter.count_documents(uuid4())
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_count_documents_null_cnt(self) -> None:
+        """count_documents returns 0 when cnt is None."""
+        from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter
+
+        conn = _make_mock_conn()
+        conn.query_one = AsyncMock(return_value={"cnt": None})
+        adapter = SurrealDBRelationalAdapter(conn)
+
+        result = await adapter.count_documents(uuid4())
+        assert result == 0
+
+
+@pytest.mark.unit
+class TestSurrealDBGetLastActivityAt:
+    """Tests for SurrealDBRelationalAdapter.get_last_activity_at()."""
+
+    @pytest.mark.asyncio
+    async def test_get_last_activity_at(self) -> None:
+        """get_last_activity_at returns the latest timestamp."""
+        from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter
+
+        ts = datetime(2026, 4, 7, 12, 0, 0, tzinfo=UTC)
+        conn = _make_mock_conn()
+        conn.query_one = AsyncMock(return_value={"latest": ts})
+        adapter = SurrealDBRelationalAdapter(conn)
+
+        ns_id = uuid4()
+        result = await adapter.get_last_activity_at(ns_id)
+
+        assert result == ts
+
+    @pytest.mark.asyncio
+    async def test_get_last_activity_at_empty_namespace(self) -> None:
+        """get_last_activity_at returns None when namespace is empty."""
+        from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter
+
+        conn = _make_mock_conn()
+        conn.query_one = AsyncMock(return_value=None)
+        adapter = SurrealDBRelationalAdapter(conn)
+
+        result = await adapter.get_last_activity_at(uuid4())
+        assert result is None
+
+
+@pytest.mark.unit
+class TestSurrealDBGetDocumentStats:
+    """Tests for SurrealDBRelationalAdapter.get_document_stats()."""
+
+    @pytest.mark.asyncio
+    async def test_get_document_stats(self) -> None:
+        """get_document_stats returns (count, last_activity_at) tuple."""
+        from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter
+
+        ts = datetime(2026, 4, 7, 12, 0, 0, tzinfo=UTC)
+        conn = _make_mock_conn()
+        conn.query_one = AsyncMock(return_value={"cnt": 15, "latest": ts})
+        adapter = SurrealDBRelationalAdapter(conn)
+
+        ns_id = uuid4()
+        count, last_activity = await adapter.get_document_stats(ns_id)
+
+        assert count == 15
+        assert last_activity == ts
+
+    @pytest.mark.asyncio
+    async def test_get_document_stats_empty_namespace(self) -> None:
+        """get_document_stats returns (0, None) for empty namespace."""
+        from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter
+
+        conn = _make_mock_conn()
+        conn.query_one = AsyncMock(return_value=None)
+        adapter = SurrealDBRelationalAdapter(conn)
+
+        count, last_activity = await adapter.get_document_stats(uuid4())
+
+        assert count == 0
+        assert last_activity is None
+
+    @pytest.mark.asyncio
+    async def test_get_document_stats_null_cnt(self) -> None:
+        """get_document_stats handles null cnt gracefully."""
+        from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter
+
+        conn = _make_mock_conn()
+        conn.query_one = AsyncMock(return_value={"cnt": None, "latest": None})
+        adapter = SurrealDBRelationalAdapter(conn)
+
+        count, last_activity = await adapter.get_document_stats(uuid4())
+
+        assert count == 0
+        assert last_activity is None
+
+
+# ===========================================================================
+# Base backend get_document_stats default implementation
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestBaseBackendGetDocumentStats:
+    """Tests for RelationalBackend.get_document_stats() default implementation."""
+
+    @pytest.mark.asyncio
+    async def test_default_delegates_to_individual_methods(self) -> None:
+        """Default get_document_stats calls count_documents + get_last_activity_at."""
+        from khora.storage.backends.base import RelationalBackendProtocol
+
+        ts = datetime(2026, 4, 7, 12, 0, 0, tzinfo=UTC)
+
+        # Create a concrete subclass with mocked abstract methods
+        class FakeRelational(RelationalBackendProtocol):
+            async def connect(self): ...
+            async def disconnect(self): ...
+            async def is_healthy(self) -> bool:
+                return True
+
+            async def create_namespace(self, ns): ...
+            async def get_namespace(self, ns_id): ...
+            async def resolve_namespace(self, ns_id): ...
+            async def deactivate_namespace(self, ns_id): ...
+            async def update_namespace(self, ns): ...
+            async def list_namespaces(self, **kw): ...
+            async def create_namespace_version(self, **kw): ...
+            async def create_document(self, doc): ...
+            async def get_document(self, doc_id): ...
+            async def list_documents(self, ns_id, **kw): ...
+            async def update_document(self, doc): ...
+            async def delete_document(self, doc_id): ...
+            async def get_document_by_checksum(self, ns_id, checksum): ...
+            async def get_sync_checkpoint(self, ns_id, source): ...
+            async def set_sync_checkpoint(self, ns_id, source, checkpoint): ...
+
+            async def count_documents(self, namespace_id):
+                return 42
+
+            async def get_last_activity_at(self, namespace_id):
+                return ts
+
+        backend = FakeRelational()
+        count, last_activity = await backend.get_document_stats(uuid4())
+
+        assert count == 42
+        assert last_activity == ts

--- a/tests/unit/test_stats_methods.py
+++ b/tests/unit/test_stats_methods.py
@@ -285,7 +285,7 @@ class TestSkeletonEngineStats:
 class TestVectorCypherEngineStats:
     """Tests for VectorCypherEngine.stats() with last_activity_at."""
 
-    def _make_engine(self) -> "VectorCypherEngine":  # noqa: F821
+    def _make_engine(self) -> VectorCypherEngine:  # noqa: F821
         from khora.engines.vectorcypher.engine import VectorCypherEngine
 
         config = _mock_khora_config()

--- a/tests/unit/test_storage_coordinator.py
+++ b/tests/unit/test_storage_coordinator.py
@@ -173,6 +173,55 @@ class TestDocumentOps:
         assert result is True
 
     @pytest.mark.asyncio
+    async def test_count_documents(self) -> None:
+        """count_documents delegates to relational."""
+        ns_id = uuid4()
+        rel = MagicMock()
+        rel.count_documents = AsyncMock(return_value=42)
+        coord = StorageCoordinator(relational=rel)
+        result = await coord.count_documents(ns_id)
+        assert result == 42
+        rel.count_documents.assert_awaited_once_with(ns_id)
+
+    @pytest.mark.asyncio
+    async def test_count_documents_missing_relational(self) -> None:
+        """count_documents without relational raises RuntimeError."""
+        coord = StorageCoordinator()
+        with pytest.raises(RuntimeError, match="Relational backend not configured"):
+            await coord.count_documents(uuid4())
+
+    @pytest.mark.asyncio
+    async def test_get_last_activity_at(self) -> None:
+        """get_last_activity_at delegates to relational."""
+        from datetime import UTC, datetime
+
+        ns_id = uuid4()
+        ts = datetime(2026, 4, 7, 12, 0, 0, tzinfo=UTC)
+        rel = MagicMock()
+        rel.get_last_activity_at = AsyncMock(return_value=ts)
+        coord = StorageCoordinator(relational=rel)
+        result = await coord.get_last_activity_at(ns_id)
+        assert result == ts
+        rel.get_last_activity_at.assert_awaited_once_with(ns_id)
+
+    @pytest.mark.asyncio
+    async def test_get_last_activity_at_none(self) -> None:
+        """get_last_activity_at returns None when no documents exist."""
+        ns_id = uuid4()
+        rel = MagicMock()
+        rel.get_last_activity_at = AsyncMock(return_value=None)
+        coord = StorageCoordinator(relational=rel)
+        result = await coord.get_last_activity_at(ns_id)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_last_activity_at_missing_relational(self) -> None:
+        """get_last_activity_at without relational raises RuntimeError."""
+        coord = StorageCoordinator()
+        with pytest.raises(RuntimeError, match="Relational backend not configured"):
+            await coord.get_last_activity_at(uuid4())
+
+    @pytest.mark.asyncio
     async def test_missing_relational(self) -> None:
         """Operations without relational raise RuntimeError."""
         coord = StorageCoordinator()

--- a/tests/unit/test_surrealdb_backend.py
+++ b/tests/unit/test_surrealdb_backend.py
@@ -847,6 +847,73 @@ class TestRelationalAdapterDocument:
         result = await adapter.get_document_sources_batch([])
         assert result == {}
 
+    async def test_count_documents(self) -> None:
+        from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter
+
+        ns_id = uuid4()
+        conn = _make_mock_conn()
+        conn.query_one = AsyncMock(return_value={"cnt": 7})
+        adapter = SurrealDBRelationalAdapter(conn)
+
+        result = await adapter.count_documents(ns_id)
+        assert result == 7
+
+    async def test_count_documents_empty(self) -> None:
+        from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter
+
+        conn = _make_mock_conn()
+        conn.query_one = AsyncMock(return_value=None)
+        adapter = SurrealDBRelationalAdapter(conn)
+
+        result = await adapter.count_documents(uuid4())
+        assert result == 0
+
+    async def test_get_last_activity_at(self) -> None:
+        from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter
+
+        ns_id = uuid4()
+        ts = datetime(2026, 4, 7, 12, 0, 0, tzinfo=UTC)
+        conn = _make_mock_conn()
+        conn.query_one = AsyncMock(return_value={"latest": ts})
+        adapter = SurrealDBRelationalAdapter(conn)
+
+        result = await adapter.get_last_activity_at(ns_id)
+        assert result == ts
+
+    async def test_get_last_activity_at_empty(self) -> None:
+        from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter
+
+        conn = _make_mock_conn()
+        conn.query_one = AsyncMock(return_value=None)
+        adapter = SurrealDBRelationalAdapter(conn)
+
+        result = await adapter.get_last_activity_at(uuid4())
+        assert result is None
+
+    async def test_get_document_stats(self) -> None:
+        from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter
+
+        ns_id = uuid4()
+        ts = datetime(2026, 4, 7, 12, 0, 0, tzinfo=UTC)
+        conn = _make_mock_conn()
+        conn.query_one = AsyncMock(return_value={"cnt": 5, "latest": ts})
+        adapter = SurrealDBRelationalAdapter(conn)
+
+        count, last_activity = await adapter.get_document_stats(ns_id)
+        assert count == 5
+        assert last_activity == ts
+
+    async def test_get_document_stats_empty(self) -> None:
+        from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter
+
+        conn = _make_mock_conn()
+        conn.query_one = AsyncMock(return_value=None)
+        adapter = SurrealDBRelationalAdapter(conn)
+
+        count, last_activity = await adapter.get_document_stats(uuid4())
+        assert count == 0
+        assert last_activity is None
+
 
 # ── Relational Adapter — sync checkpoint operations ───────────────────────
 


### PR DESCRIPTION
## Summary
- **Bug fix**: Namespace stats were showing `Documents: 0` and `Last Activity: Never` for all namespaces regardless of actual content
- **Root cause**: `count_documents()` did not exist on `StorageCoordinator` or any backend, causing `AttributeError` → fallback to `list_documents(limit=0)` which always returned empty. `Stats` dataclass had no timestamp field
- **Fix**: Added `count_documents()` and `get_last_activity_at()` across the full storage stack:
  - `RelationalBackendProtocol` (abstract methods)
  - `PostgreSQLBackend` (SQLAlchemy `func.count()` / `func.max()`)
  - `SurrealDBRelationalAdapter` (SurrealQL `count()` / `math::max()`)
  - `StorageCoordinator` (delegation with relational backend guard)
- Added `last_activity_at: datetime | None = None` to `Stats` dataclass (backward-compatible default)
- Updated all 4 engine `stats()` methods (skeleton, chronicle, graphrag, vectorcypher) to call new coordinator methods
- Cleaned up broken `limit=0` fallbacks and stale `type: ignore[unresolved-attribute]` comments

**Note for Peras team**: `Stats` dataclass now has a 5th field `last_activity_at`. The `= None` default ensures backward compatibility for keyword construction. Verify no positional unpacking exists in Peras before mapping this field (see DYT-1955).

## Test plan
- [x] All 2423 existing tests pass (0 failures)
- [x] Coverage: 51.71% (above 30% threshold)
- [x] New unit tests for `Stats.last_activity_at` field (default None, with value, frozen)
- [x] New unit tests for `StorageCoordinator.count_documents()` and `get_last_activity_at()` (delegation, None case, missing relational guard)
- [x] Formatting passes (black, isort, ruff)
- [ ] Verify in staging: namespace overview shows correct document counts and last activity timestamps

Blocks: DYT-1955 (Peras mapping)