### PR TITLE
DYT-1948: Add configurable query timeout for Neo4j get_entity_neighborhoods

### DIFF
--- a/docs/AI_CHANGELOG.md
+++ b/docs/AI_CHANGELOG.md
@@ -5,3 +5,4 @@
 - 2026-04-03: DYT-1733: Normalize simple path relevance scores to [0,1]
 - 2026-04-01: DYT-1798: Switch discovery models to LiteLLM YAML config
 - 2026-04-01: DYT-1884: Add KhoraError exception hierarchy, fix silent swallowing
+- 2026-04-08: DYT-1948: Add configurable query timeout for Neo4j get_entity_neighborhoods

--- a/src/khora/config/schema.py
+++ b/src/khora/config/schema.py
@@ -78,6 +78,22 @@ class Neo4jConfig(BaseModel):
         description="Seconds of idle time after which connections are checked for liveness "
         "before being returned from the pool. None disables the check.",
     )
+    query_timeout: float | None = Field(
+        default=5.0,
+        gt=0,
+        description=(
+            "Per-transaction timeout in seconds for bounded read queries "
+            "(currently applied only to get_entity_neighborhoods). Bounds the "
+            "worst ~0.5-1% of outlier queries that otherwise hold connections "
+            "for 27+ seconds and exhaust the pool. The Neo4j server terminates "
+            "transactions exceeding this duration, raising ClientError with "
+            "code Neo.ClientError.Transaction.TransactionTimedOut* — the "
+            "client catches this and returns an empty neighborhood dict. "
+            "Set to None to disable entirely. Values <= 0 are rejected "
+            "(the driver would interpret 0 as 'run forever', which defeats "
+            "the purpose)."
+        ),
+    )
     entity_write_concurrency: int = Field(default=12, description="Max concurrent entity write transactions")
     relationship_write_concurrency: int = Field(default=8, description="Max concurrent relationship write transactions")
 

--- a/src/khora/config/schema.py
+++ b/src/khora/config/schema.py
@@ -81,17 +81,26 @@ class Neo4jConfig(BaseModel):
     query_timeout: float | None = Field(
         default=5.0,
         gt=0,
+        le=300,
         description=(
-            "Per-transaction timeout in seconds for bounded read queries "
-            "(currently applied only to get_entity_neighborhoods). Bounds the "
-            "worst ~0.5-1% of outlier queries that otherwise hold connections "
-            "for 27+ seconds and exhaust the pool. The Neo4j server terminates "
-            "transactions exceeding this duration, raising ClientError with "
-            "code Neo.ClientError.Transaction.TransactionTimedOut* — the "
-            "client catches this and returns an empty neighborhood dict. "
-            "Set to None to disable entirely. Values <= 0 are rejected "
-            "(the driver would interpret 0 as 'run forever', which defeats "
-            "the purpose)."
+            "Per-transaction timeout in seconds for bounded read queries. "
+            "Currently applied ONLY to DualNodeManager.get_entity_neighborhoods "
+            "in the VectorCypher engine — Neo4jBackend.get_neighborhood and "
+            "get_neighborhoods_batch in storage/backends/neo4j.py do NOT "
+            "currently respect this setting (see DYT-1948 follow-up). Bounds "
+            "the worst ~0.5-1% of outlier queries that otherwise hold "
+            "connections for 27+ seconds and exhaust the pool. The Neo4j "
+            "server terminates transactions exceeding this duration, raising "
+            "ClientError with code Neo.ClientError.Transaction.TransactionTimedOut* "
+            "— the client catches this and returns an empty neighborhood dict. "
+            "Set to None to disable entirely. Values <= 0 are rejected (the "
+            "driver would interpret 0 as 'run forever', which defeats the "
+            "purpose). Values above 300 seconds (5 minutes) are also rejected "
+            "as a sanity cap: any recall budget that tolerates a 5-minute "
+            "neighborhood lookup is better served by batched offline jobs, "
+            "not interactive reads. Override via env var "
+            "KHORA_STORAGE__GRAPH__QUERY_TIMEOUT (note the double underscores "
+            "— StorageSettings nests graph config via env_nested_delimiter='__')."
         ),
     )
     entity_write_concurrency: int = Field(default=12, description="Max concurrent entity write transactions")

--- a/src/khora/engines/vectorcypher/dual_nodes.py
+++ b/src/khora/engines/vectorcypher/dual_nodes.py
@@ -24,7 +24,7 @@ from neo4j import unit_of_work
 from neo4j.exceptions import ClientError
 
 from khora.storage.backends.mixins import deserialize_dict, serialize_dict
-from khora.telemetry import trace
+from khora.telemetry import trace, trace_span
 
 if TYPE_CHECKING:
     from neo4j import AsyncDriver
@@ -100,6 +100,13 @@ class DualNodeManager:
         self._driver = driver
         self._database = database
         self._query_timeout = query_timeout
+        # Pre-bind the unit_of_work decorator once. The factory call is
+        # cheap but non-zero and the produced decorator is fully reusable
+        # — see neo4j.unit_of_work: it closes over (metadata, timeout) and
+        # returns a plain wrapper function that can decorate any number of
+        # transaction callables. Hoisting shaves an allocation per call
+        # on the hot neighborhood lookup path.
+        self._timed_unit_of_work = unit_of_work(timeout=query_timeout) if query_timeout is not None else None
 
     async def ensure_indexes(self) -> None:
         """Create indexes for Chunk and TimeNode nodes."""
@@ -570,14 +577,15 @@ class DualNodeManager:
             )
             return [record.data() async for record in result]
 
-        # Apply the configured transaction timeout via unit_of_work. The Neo4j
-        # Python driver's `tx.run()` does NOT accept a timeout kwarg — timeouts
-        # must be set at transaction-begin time, which unit_of_work does by
-        # attaching metadata the session reads when starting the managed tx.
-        # TODO(follow-up): add a timeout counter / trace attribute so ops can
-        # alert on timeout frequency rather than relying on result_count=0.
-        if self._query_timeout is not None:
-            _work = unit_of_work(timeout=self._query_timeout)(_work)
+        # Apply the configured transaction timeout via the pre-bound
+        # unit_of_work decorator (hoisted in __init__). The Neo4j Python
+        # driver's `tx.run()` does NOT accept a timeout kwarg — timeouts
+        # must be set at transaction-begin time, which unit_of_work does
+        # by attaching metadata the session reads when starting the
+        # managed tx. Hoisting means we pay the factory cost once per
+        # DualNodeManager rather than once per query.
+        if self._timed_unit_of_work is not None:
+            _work = self._timed_unit_of_work(_work)
 
         try:
             async with self._driver.session(database=self._database) as session:
@@ -587,6 +595,22 @@ class DualNodeManager:
             # tuple, not a prefix match) so we don't swallow syntax errors,
             # auth failures, or constraint violations that are also ClientError.
             if exc.code in _NEO4J_TIMEOUT_CODES:
+                # Emit a dedicated child span so operators can alert on
+                # timeout frequency in Logfire/OTEL via a span-name filter
+                # (the ".timeout" suffix). The parent @trace span records
+                # result_count=0 on timeout, but a distinct span carries
+                # the timeout-specific attributes ops needs for dashboards
+                # (configured timeout, entity count, depth, error code).
+                with trace_span(
+                    "khora.neo4j.get_entity_neighborhoods.timeout",
+                    timeout_s=self._query_timeout,
+                    entity_count=len(entity_ids),
+                    depth=depth,
+                    code=exc.code,
+                    namespace_id=str(namespace_id),
+                    timeout_occurred=True,
+                ):
+                    pass  # attributes set via kwargs; no inner work
                 logger.warning(
                     "Neo4j get_entity_neighborhoods timed out after {timeout}s "
                     "(namespace_id={ns}, entity_count={n}, depth={d}, code={code}); "
@@ -596,10 +620,8 @@ class DualNodeManager:
                     n=len(entity_ids),
                     d=depth,
                     code=exc.code,
+                    timeout_occurred=True,
                 )
-                # TODO(DYT-1948-followup): emit dedicated telemetry counter for
-                # query timeouts. @trace already records result_count=0 which
-                # is the minimum viable signal but we want explicit alerting.
                 return {}
             raise
 

--- a/src/khora/engines/vectorcypher/dual_nodes.py
+++ b/src/khora/engines/vectorcypher/dual_nodes.py
@@ -20,6 +20,8 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from loguru import logger
+from neo4j import unit_of_work
+from neo4j.exceptions import ClientError
 
 from khora.storage.backends.mixins import deserialize_dict, serialize_dict
 from khora.telemetry import trace
@@ -28,6 +30,17 @@ if TYPE_CHECKING:
     from neo4j import AsyncDriver
 
     from khora.engines.skeleton.backends import TemporalChunk, TemporalFilter
+
+
+# Neo4j 5.x splits timeout errors into two codes depending on whether
+# the timeout fired from the server's db.transaction.timeout setting
+# or from our client-configured unit_of_work(timeout=...). We catch
+# both so that our configured ceiling is always respected regardless
+# of which code path the server takes.
+_NEO4J_TIMEOUT_CODES = (
+    "Neo.ClientError.Transaction.TransactionTimedOut",
+    "Neo.ClientError.Transaction.TransactionTimedOutClientConfiguration",
+)
 
 
 @dataclass
@@ -68,15 +81,25 @@ class DualNodeManager:
     - Chunk retrieval via MENTIONED_IN for context
     """
 
-    def __init__(self, driver: AsyncDriver, database: str = "neo4j"):
+    def __init__(
+        self,
+        driver: AsyncDriver,
+        database: str = "neo4j",
+        *,
+        query_timeout: float | None = None,
+    ) -> None:
         """Initialize the manager.
 
         Args:
             driver: Neo4j async driver
             database: Database name
+            query_timeout: Optional per-transaction timeout in seconds,
+                applied to ``get_entity_neighborhoods`` to bound runaway
+                variable-length path queries. ``None`` disables the timeout.
         """
         self._driver = driver
         self._database = database
+        self._query_timeout = query_timeout
 
     async def ensure_indexes(self) -> None:
         """Create indexes for Chunk and TimeNode nodes."""
@@ -538,18 +561,47 @@ class DualNodeManager:
                [x IN related_raw WHERE x IS NOT NULL] AS related_entities
         """
 
-        async with self._driver.session(database=self._database) as session:
+        async def _work(tx):
+            result = await tx.run(
+                query,
+                entity_ids=[str(eid) for eid in entity_ids],
+                namespace_id=str(namespace_id),
+                limit=limit_per_entity,
+            )
+            return [record.data() async for record in result]
 
-            async def _work(tx):
-                result = await tx.run(
-                    query,
-                    entity_ids=[str(eid) for eid in entity_ids],
-                    namespace_id=str(namespace_id),
-                    limit=limit_per_entity,
+        # Apply the configured transaction timeout via unit_of_work. The Neo4j
+        # Python driver's `tx.run()` does NOT accept a timeout kwarg — timeouts
+        # must be set at transaction-begin time, which unit_of_work does by
+        # attaching metadata the session reads when starting the managed tx.
+        # TODO(follow-up): add a timeout counter / trace attribute so ops can
+        # alert on timeout frequency rather than relying on result_count=0.
+        if self._query_timeout is not None:
+            _work = unit_of_work(timeout=self._query_timeout)(_work)
+
+        try:
+            async with self._driver.session(database=self._database) as session:
+                records = await session.execute_read(_work)
+        except ClientError as exc:
+            # Match only the two known transaction-timeout codes (explicit
+            # tuple, not a prefix match) so we don't swallow syntax errors,
+            # auth failures, or constraint violations that are also ClientError.
+            if exc.code in _NEO4J_TIMEOUT_CODES:
+                logger.warning(
+                    "Neo4j get_entity_neighborhoods timed out after {timeout}s "
+                    "(namespace_id={ns}, entity_count={n}, depth={d}, code={code}); "
+                    "returning empty neighborhood",
+                    timeout=self._query_timeout,
+                    ns=namespace_id,
+                    n=len(entity_ids),
+                    d=depth,
+                    code=exc.code,
                 )
-                return [record.data() async for record in result]
-
-            records = await session.execute_read(_work)
+                # TODO(DYT-1948-followup): emit dedicated telemetry counter for
+                # query timeouts. @trace already records result_count=0 which
+                # is the minimum viable signal but we want explicit alerting.
+                return {}
+            raise
 
         return {record["source_id"]: record["related_entities"] for record in records}
 

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -300,6 +300,7 @@ class VectorCypherEngine:
         # Detect unified SurrealDB backend — skips Neo4j and uses SurrealDB for everything
         is_surrealdb = getattr(self._config.storage, "backend", "postgres") == "surrealdb"
         neo4j_database = "neo4j"
+        neo4j_query_timeout: float | None = 5.0
 
         if not is_surrealdb:
             # Connect to Neo4j (required for VectorCypher with traditional stack)
@@ -313,6 +314,7 @@ class VectorCypherEngine:
             pool_size = getattr(neo4j_cfg, "max_connection_pool_size", 100) if neo4j_cfg else 100
             max_conn_lifetime = getattr(neo4j_cfg, "max_connection_lifetime", 900) if neo4j_cfg else 900
             liveness_timeout = getattr(neo4j_cfg, "liveness_check_timeout", 30.0) if neo4j_cfg else 30.0
+            neo4j_query_timeout = getattr(neo4j_cfg, "query_timeout", 5.0) if neo4j_cfg else 5.0
             self._neo4j_driver = AsyncGraphDatabase.driver(
                 neo4j_url,
                 auth=(self._config.get_neo4j_user(), self._config.get_neo4j_password()),
@@ -376,7 +378,11 @@ class VectorCypherEngine:
 
         # Initialize dual node manager (Neo4j only — SurrealDB uses graph adapter)
         if not is_surrealdb:
-            self._dual_nodes = DualNodeManager(self._neo4j_driver, neo4j_database)
+            self._dual_nodes = DualNodeManager(
+                self._neo4j_driver,
+                neo4j_database,
+                query_timeout=neo4j_query_timeout,
+            )
             await self._dual_nodes.ensure_indexes()
 
         # Initialize router
@@ -425,6 +431,7 @@ class VectorCypherEngine:
             database=neo4j_database,
             config=retriever_config,
             storage=self._storage,
+            neo4j_query_timeout=neo4j_query_timeout,
         )
 
         # Initialize telemetry

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -171,6 +171,7 @@ class VectorCypherRetriever:
         config: RetrieverConfig | None = None,
         router_config: RouterConfig | None = None,
         storage: StorageCoordinator | None = None,
+        neo4j_query_timeout: float | None = None,
     ):
         """Initialize the retriever.
 
@@ -182,6 +183,9 @@ class VectorCypherRetriever:
             config: Retriever configuration
             router_config: Router configuration (optional, for LLM routing etc.)
             storage: Storage coordinator for entity vector search via pgvector
+            neo4j_query_timeout: Optional per-transaction timeout in seconds
+                forwarded to the underlying ``DualNodeManager`` to bound
+                ``get_entity_neighborhoods``. ``None`` disables the timeout.
         """
         self._vector_store = vector_store
         self._neo4j_driver = neo4j_driver
@@ -199,7 +203,9 @@ class VectorCypherRetriever:
                 complex_depth=self._config.default_depth,
             )
         self._router = QueryComplexityRouter(router_config)
-        self._dual_nodes = DualNodeManager(neo4j_driver, database) if neo4j_driver else None
+        self._dual_nodes = (
+            DualNodeManager(neo4j_driver, database, query_timeout=neo4j_query_timeout) if neo4j_driver else None
+        )
 
         # Query result cache (LRU + TTL)
         self._cache: dict[str, tuple[float, VectorCypherResult]] = {}

--- a/tests/integration/test_dual_nodes_timeout_integration.py
+++ b/tests/integration/test_dual_nodes_timeout_integration.py
@@ -1,0 +1,138 @@
+"""Composition-level integration test for DYT-1948 Neo4j query timeout.
+
+Verifies end-to-end wiring from ``KhoraConfig`` → VectorCypher engine
+pattern → ``DualNodeManager`` → ``unit_of_work`` decoration → ``ClientError``
+timeout catch, without requiring a running Neo4j instance.
+
+This test is marked ``@pytest.mark.integration`` (not ``unit``) because it
+exercises the full configuration-to-execution composition that unit tests
+mock piecewise — specifically the wiring path:
+
+    KHORA_STORAGE__GRAPH__QUERY_TIMEOUT=<value>
+      → KhoraConfig() load
+      → Neo4jConfig.query_timeout
+      → engine.py:  getattr(neo4j_cfg, "query_timeout", 5.0)
+      → DualNodeManager(query_timeout=...)
+      → __init__ hoist: self._timed_unit_of_work = unit_of_work(timeout=...)
+      → get_entity_neighborhoods(): _work = self._timed_unit_of_work(_work)
+      → session.execute_read(_work)
+      → ClientError catch
+      → trace_span(".timeout") + warning + return {}
+
+The failure mode this catches is *wiring drift*: a future refactor that
+renames the config field, changes the env var delimiter, drops the
+``getattr`` in ``engine.py``, or un-hoists the decorator would break one
+link in this chain without failing any individual unit test.
+
+Real-Neo4j protocol compatibility (driver-to-server timeout transmission,
+wire-level error code handling) is out of scope for CI because khora's CI
+does NOT provision a Neo4j instance. Local developers wanting that
+coverage can run the test suite against a dev Neo4j via ``make dev``
+and a suggested ``NEO4J_INTEGRATION_TEST=1`` env var — a follow-up
+ticket will add that real-driver coverage when useful.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from neo4j.exceptions import ClientError, Neo4jError
+
+from khora.config.schema import KhoraConfig, Neo4jConfig
+from khora.engines.vectorcypher.dual_nodes import (
+    _NEO4J_TIMEOUT_CODES,
+    DualNodeManager,
+)
+
+
+def _timeout_error(
+    code: str = "Neo.ClientError.Transaction.TransactionTimedOut",
+) -> ClientError:
+    exc = Neo4jError._basic_hydrate(neo4j_code=code, message="timed out")
+    assert isinstance(exc, ClientError), f"neo4j _basic_hydrate unexpectedly returned {type(exc).__name__}"
+    return exc
+
+
+def _driver_raising_timeout(code: str) -> MagicMock:
+    """Build a fake AsyncDriver whose ``execute_read`` raises the given code."""
+    driver = MagicMock()
+    session = AsyncMock()
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    driver.session.return_value = ctx
+    session.execute_read = AsyncMock(side_effect=_timeout_error(code))
+    return driver
+
+
+@pytest.mark.integration
+class TestDyt1948TimeoutCompositionIntegration:
+    """Full composition: config → manager → timeout catch → empty dict."""
+
+    def test_config_env_var_wires_through_to_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``KHORA_STORAGE__GRAPH__QUERY_TIMEOUT`` reaches ``DualNodeManager``.
+
+        Exercises the exact env var documented in
+        ``Neo4jConfig.query_timeout.description`` (double underscore
+        nesting, per ``env_nested_delimiter='__'``).
+        """
+        monkeypatch.setenv("KHORA_STORAGE__GRAPH__BACKEND", "neo4j")
+        monkeypatch.setenv("KHORA_STORAGE__GRAPH__URL", "bolt://localhost:7687")
+        monkeypatch.setenv("KHORA_STORAGE__GRAPH__QUERY_TIMEOUT", "4.2")
+
+        cfg = KhoraConfig()
+        graph_cfg = cfg.get_graph_config()
+        assert isinstance(graph_cfg, Neo4jConfig)
+        assert graph_cfg.query_timeout == 4.2
+
+        # Mirror the exact getattr pattern ``engine.py`` uses to resolve
+        # the timeout with a 5.0 fallback for older config objects.
+        resolved = getattr(graph_cfg, "query_timeout", 5.0) if graph_cfg else 5.0
+        assert resolved == 4.2
+
+        driver = _driver_raising_timeout(_NEO4J_TIMEOUT_CODES[0])
+        manager = DualNodeManager(driver, query_timeout=resolved)
+        assert manager._query_timeout == 4.2
+        # Hoisted decorator exists — catches a future un-hoist regression
+        # at the composition boundary, not just at the unit level.
+        assert manager._timed_unit_of_work is not None
+
+    @pytest.mark.parametrize("timeout_code", _NEO4J_TIMEOUT_CODES)
+    @pytest.mark.asyncio
+    async def test_full_path_degrades_to_empty_on_timeout(self, timeout_code: str) -> None:
+        """Both timeout codes produce ``{}`` from the full composition path."""
+        driver = _driver_raising_timeout(timeout_code)
+        manager = DualNodeManager(driver, query_timeout=1.0)
+
+        result = await manager.get_entity_neighborhoods(
+            [uuid4(), uuid4()],
+            uuid4(),
+            depth=2,
+        )
+        assert result == {}
+        # The driver session was actually exercised — guards against
+        # a future short-circuit that skips the Neo4j call entirely
+        # based on ``query_timeout`` being set.
+        driver.session.assert_called_once_with(database="neo4j")
+
+    @pytest.mark.asyncio
+    async def test_disabled_timeout_skips_decoration_end_to_end(self) -> None:
+        """``query_timeout=None`` wires through to no decoration at all."""
+        driver = MagicMock()
+        session = AsyncMock()
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=session)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        driver.session.return_value = ctx
+        session.execute_read = AsyncMock(return_value=[])
+
+        manager = DualNodeManager(driver, query_timeout=None)
+        assert manager._timed_unit_of_work is None
+
+        result = await manager.get_entity_neighborhoods([uuid4()], uuid4())
+        assert result == {}
+        # Sanity-check that the decoration skip did not accidentally
+        # short-circuit the rest of the method.
+        driver.session.assert_called_once()

--- a/tests/unit/engines/test_dual_nodes.py
+++ b/tests/unit/engines/test_dual_nodes.py
@@ -3,16 +3,31 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from neo4j.exceptions import ClientError, Neo4jError
 
 from khora.engines.vectorcypher.dual_nodes import (
+    _NEO4J_TIMEOUT_CODES,
     ChunkNode,
     DualNodeManager,
     EntityChunkLink,
 )
+
+
+def _make_neo4j_error(code: str, message: str = "boom") -> Neo4jError:
+    """Build a Neo4jError subclass instance with a given server-side code.
+
+    The driver's ``code`` attribute is a read-only property derived from
+    ``_neo4j_code``, so the public constructor cannot set it. We use the
+    same internal factory the driver itself uses when hydrating server
+    errors, which guarantees the resulting instance is the correct
+    subclass (e.g. ``ClientError`` for ``Neo.ClientError.*``) and exposes
+    the requested ``code``.
+    """
+    return Neo4jError._basic_hydrate(neo4j_code=code, message=message)
 
 
 def _make_neo4j_driver() -> tuple[MagicMock, AsyncMock]:
@@ -116,6 +131,24 @@ class TestDualNodeManagerInit:
         driver = MagicMock()
         manager = DualNodeManager(driver, database="custom_db")
         assert manager._database == "custom_db"
+
+    def test_init_default_query_timeout_is_none(self) -> None:
+        """Default query_timeout is None (opt-in at the engine layer)."""
+        driver = MagicMock()
+        manager = DualNodeManager(driver)
+        assert manager._query_timeout is None
+
+    def test_init_stores_query_timeout(self) -> None:
+        """A non-None query_timeout is stored on the instance."""
+        driver = MagicMock()
+        manager = DualNodeManager(driver, query_timeout=2.5)
+        assert manager._query_timeout == 2.5
+
+    def test_init_query_timeout_is_keyword_only(self) -> None:
+        """query_timeout must be passed as a keyword argument."""
+        driver = MagicMock()
+        with pytest.raises(TypeError):
+            DualNodeManager(driver, "neo4j", 2.5)  # type: ignore[misc]
 
 
 @pytest.mark.unit
@@ -371,6 +404,175 @@ class TestDualNodeManagerGetEntityNeighborhoods:
         await manager.get_entity_neighborhoods([uuid4()], uuid4(), depth=0)
         # Depth 10 should be clamped to 4
         await manager.get_entity_neighborhoods([uuid4()], uuid4(), depth=10)
+
+
+@pytest.mark.unit
+class TestDualNodeManagerGetEntityNeighborhoodsTimeout:
+    """Tests for the configurable per-transaction timeout in get_entity_neighborhoods.
+
+    The Neo4j Python driver applies transaction-level timeouts via
+    ``neo4j.unit_of_work(timeout=...)``, which decorates the read closure
+    that ``session.execute_read`` runs. The DualNodeManager should:
+      * skip the decorator entirely when ``query_timeout`` is None,
+      * apply it (with the configured value) otherwise,
+      * convert the two known transaction-timeout error codes into an
+        empty result dict + warning log,
+      * re-raise any other error so callers still see real failures.
+    """
+
+    @pytest.mark.asyncio
+    async def test_wraps_work_with_unit_of_work_when_timeout_set(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When query_timeout is set, _work is wrapped via unit_of_work(timeout=...)."""
+        driver, session = _make_neo4j_driver()
+        session.execute_read = AsyncMock(return_value=[])
+
+        # Replace unit_of_work in the dual_nodes module with a passthrough
+        # decorator that records how it was invoked.
+        decorator_factory = MagicMock(side_effect=lambda fn: fn)
+        unit_of_work_mock = MagicMock(return_value=decorator_factory)
+        monkeypatch.setattr(
+            "khora.engines.vectorcypher.dual_nodes.unit_of_work",
+            unit_of_work_mock,
+        )
+
+        manager = DualNodeManager(driver, query_timeout=3.0)
+        result = await manager.get_entity_neighborhoods([uuid4()], uuid4(), depth=1)
+
+        assert result == {}
+        unit_of_work_mock.assert_called_once_with(timeout=3.0)
+        # The returned decorator must have been applied to the inner _work fn.
+        decorator_factory.assert_called_once()
+        # And execute_read must still have been invoked once with the
+        # (now-wrapped) function.
+        session.execute_read.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_unit_of_work_when_timeout_none(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When query_timeout is None, unit_of_work is NOT invoked."""
+        driver, session = _make_neo4j_driver()
+        session.execute_read = AsyncMock(return_value=[])
+
+        unit_of_work_mock = MagicMock()
+        monkeypatch.setattr(
+            "khora.engines.vectorcypher.dual_nodes.unit_of_work",
+            unit_of_work_mock,
+        )
+
+        manager = DualNodeManager(driver)  # default: query_timeout=None
+        result = await manager.get_entity_neighborhoods([uuid4()], uuid4(), depth=1)
+
+        assert result == {}
+        unit_of_work_mock.assert_not_called()
+        session.execute_read.assert_awaited_once()
+
+    @pytest.mark.parametrize("timeout_code", _NEO4J_TIMEOUT_CODES)
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_timeout_codes(self, timeout_code: str) -> None:
+        """Both server- and client-configured timeout codes degrade to {}."""
+        driver, session = _make_neo4j_driver()
+        timeout_exc = _make_neo4j_error(timeout_code, message="transaction timed out")
+        # Sanity-check the constructed exception so a future driver upgrade
+        # that breaks _basic_hydrate would fail loudly here, not silently
+        # masquerade as a successful test.
+        assert isinstance(timeout_exc, ClientError)
+        assert timeout_exc.code == timeout_code
+
+        session.execute_read = AsyncMock(side_effect=timeout_exc)
+
+        manager = DualNodeManager(driver, query_timeout=1.0)
+
+        with patch("khora.engines.vectorcypher.dual_nodes.logger") as mock_logger:
+            result = await manager.get_entity_neighborhoods([uuid4()], uuid4(), depth=2)
+
+        assert result == {}
+        mock_logger.warning.assert_called_once()
+
+        # The warning includes the offending code so ops can grep for it.
+        warning_call = mock_logger.warning.call_args
+        assert warning_call.kwargs.get("code") == timeout_code
+        assert warning_call.kwargs.get("timeout") == 1.0
+
+    @pytest.mark.asyncio
+    async def test_reraises_non_timeout_client_error(self) -> None:
+        """Non-timeout ClientErrors (e.g. syntax errors) propagate to the caller."""
+        driver, session = _make_neo4j_driver()
+        syntax_exc = _make_neo4j_error(
+            "Neo.ClientError.Statement.SyntaxError",
+            message="Cypher syntax error",
+        )
+        # Make sure we built a real ClientError-shaped instance — if a
+        # future driver split this code into a different class hierarchy
+        # the test setup itself should fail rather than the assertion.
+        assert isinstance(syntax_exc, ClientError)
+        assert syntax_exc.code not in _NEO4J_TIMEOUT_CODES
+
+        session.execute_read = AsyncMock(side_effect=syntax_exc)
+        manager = DualNodeManager(driver, query_timeout=1.0)
+
+        with pytest.raises(ClientError) as excinfo:
+            await manager.get_entity_neighborhoods([uuid4()], uuid4(), depth=1)
+
+        assert excinfo.value.code == "Neo.ClientError.Statement.SyntaxError"
+
+    @pytest.mark.asyncio
+    async def test_reraises_non_client_errors(self) -> None:
+        """Errors that are not ClientError (e.g. RuntimeError) also propagate."""
+        driver, session = _make_neo4j_driver()
+        session.execute_read = AsyncMock(side_effect=RuntimeError("connection lost"))
+        manager = DualNodeManager(driver, query_timeout=1.0)
+
+        with pytest.raises(RuntimeError, match="connection lost"):
+            await manager.get_entity_neighborhoods([uuid4()], uuid4(), depth=1)
+
+    @pytest.mark.asyncio
+    async def test_timeout_disabled_still_handles_results(self) -> None:
+        """With query_timeout=None, normal execution returns parsed neighborhoods."""
+        driver, session = _make_neo4j_driver()
+        source_id = str(uuid4())
+        related_id = str(uuid4())
+        session.execute_read = AsyncMock(
+            return_value=[
+                {
+                    "source_id": source_id,
+                    "source_name": "alice",
+                    "source_entity_type": "PERSON",
+                    "source_description": None,
+                    "source_source_tool": None,
+                    "related_entities": [
+                        {
+                            "id": related_id,
+                            "name": "bob",
+                            "entity_type": "PERSON",
+                            "description": None,
+                            "source_tool": None,
+                            "distance": 1,
+                        }
+                    ],
+                }
+            ]
+        )
+
+        manager = DualNodeManager(driver)
+        result = await manager.get_entity_neighborhoods([uuid4()], uuid4(), depth=1)
+
+        assert result == {
+            source_id: [
+                {
+                    "id": related_id,
+                    "name": "bob",
+                    "entity_type": "PERSON",
+                    "description": None,
+                    "source_tool": None,
+                    "distance": 1,
+                }
+            ]
+        }
 
 
 @pytest.mark.unit

--- a/tests/unit/engines/test_dual_nodes.py
+++ b/tests/unit/engines/test_dual_nodes.py
@@ -17,8 +17,8 @@ from khora.engines.vectorcypher.dual_nodes import (
 )
 
 
-def _make_neo4j_error(code: str, message: str = "boom") -> Neo4jError:
-    """Build a Neo4jError subclass instance with a given server-side code.
+def _make_neo4j_error(code: str, message: str = "boom") -> ClientError:
+    """Build a ClientError instance with a given server-side code.
 
     The driver's ``code`` attribute is a read-only property derived from
     ``_neo4j_code``, so the public constructor cannot set it. We use the
@@ -27,7 +27,18 @@ def _make_neo4j_error(code: str, message: str = "boom") -> Neo4jError:
     subclass (e.g. ``ClientError`` for ``Neo.ClientError.*``) and exposes
     the requested ``code``.
     """
-    return Neo4jError._basic_hydrate(neo4j_code=code, message=message)
+    exc = Neo4jError._basic_hydrate(neo4j_code=code, message=message)
+    # Guard against a future driver refactor silently returning a
+    # different subclass. Our except clause in dual_nodes.py catches
+    # only ClientError — if _basic_hydrate starts returning a bare
+    # Neo4jError (or a different hierarchy), the test would pass
+    # vacuously and the production code would break in prod.
+    assert isinstance(exc, ClientError), (
+        f"expected ClientError for code {code}, got {type(exc).__name__} — "
+        "neo4j driver may have changed internal API"
+    )
+    assert exc.code == code, f"expected code={code}, got {exc.code}"
+    return exc
 
 
 def _make_neo4j_driver() -> tuple[MagicMock, AsyncMock]:
@@ -425,29 +436,99 @@ class TestDualNodeManagerGetEntityNeighborhoodsTimeout:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """When query_timeout is set, _work is wrapped via unit_of_work(timeout=...)."""
-        driver, session = _make_neo4j_driver()
-        session.execute_read = AsyncMock(return_value=[])
+        """When query_timeout is set, the closure passed to execute_read is
+        the decorated one — end-to-end, not just "the decorator was called".
 
-        # Replace unit_of_work in the dual_nodes module with a passthrough
-        # decorator that records how it was invoked.
-        decorator_factory = MagicMock(side_effect=lambda fn: fn)
-        unit_of_work_mock = MagicMock(return_value=decorator_factory)
+        This guards against a refactor that drops the wrap or rebinds
+        ``_work`` back to the original between the decorate step and the
+        execute_read call. We verify by:
+          * Spying on ``unit_of_work`` to tag its output with a sentinel
+            attribute (``_is_timed_work``) AND preserve the driver's
+            real ``.timeout`` attribute.
+          * Capturing the function handed to ``session.execute_read`` and
+            asserting the sentinel is present.
+          * Actually invoking the captured function with a mock tx so we
+            exercise the full wrap → execute_read → _work path.
+        """
+        driver, session = _make_neo4j_driver()
+
+        # Import the real neo4j.unit_of_work so the spy delegates to
+        # it (keeps the .timeout attribute the driver sets).
+        from neo4j import unit_of_work as real_unit_of_work
+
+        decorator_calls: list[float | None] = []
+
+        def _spy_unit_of_work(*, timeout: float | None = None, **kwargs):
+            decorator_calls.append(timeout)
+            real_decorator = real_unit_of_work(timeout=timeout, **kwargs)
+
+            def _marking_decorator(fn):
+                wrapped = real_decorator(fn)
+                wrapped._is_timed_work = True  # test-only sentinel
+                return wrapped
+
+            return _marking_decorator
+
         monkeypatch.setattr(
             "khora.engines.vectorcypher.dual_nodes.unit_of_work",
-            unit_of_work_mock,
+            _spy_unit_of_work,
         )
+
+        # Capture whatever function is passed to execute_read, and
+        # actually invoke it against a mock tx so the inner closure
+        # runs (otherwise the test degenerates to "mock returned []").
+        captured: dict[str, object] = {}
+
+        async def _capture_execute_read(work_fn):
+            captured["work_fn"] = work_fn
+
+            # Build a minimal AsyncManagedTransaction-shaped mock.
+            async def _empty_result_iter():
+                if False:  # pragma: no cover
+                    yield
+                return
+
+            class _AsyncIter:
+                def __aiter__(self):
+                    return self
+
+                async def __anext__(self):
+                    raise StopAsyncIteration
+
+            result_cursor = MagicMock()
+            result_cursor.__aiter__ = lambda self: _AsyncIter()
+            fake_tx = AsyncMock()
+            fake_tx.run = AsyncMock(return_value=result_cursor)
+
+            inner = await work_fn(fake_tx)
+            captured["inner_called"] = True
+            captured["inner_result"] = inner
+            return inner
+
+        session.execute_read = AsyncMock(side_effect=_capture_execute_read)
 
         manager = DualNodeManager(driver, query_timeout=3.0)
         result = await manager.get_entity_neighborhoods([uuid4()], uuid4(), depth=1)
 
+        # unit_of_work was called exactly once — during __init__'s hoist,
+        # NOT per get_entity_neighborhoods call. Behaviour-locks the
+        # M8 hoist against accidental un-hoisting.
+        assert decorator_calls == [3.0]
+
+        # The function reaching execute_read MUST carry:
+        #   (1) our test sentinel — proves our decorator ran,
+        #   (2) the driver's own .timeout attribute — proves it's still
+        #       the real neo4j.unit_of_work wrapper (not something we
+        #       accidentally unwrapped along the way).
+        work_fn = captured["work_fn"]
+        assert getattr(
+            work_fn, "_is_timed_work", False
+        ), "decorator was not applied to the function handed to execute_read"
+        assert getattr(work_fn, "timeout", None) == 3.0, "wrapped function missing the driver's .timeout attribute"
+
+        # The inner Cypher closure actually ran (full end-to-end wrap).
+        assert captured.get("inner_called") is True
         assert result == {}
-        unit_of_work_mock.assert_called_once_with(timeout=3.0)
-        # The returned decorator must have been applied to the inner _work fn.
-        decorator_factory.assert_called_once()
-        # And execute_read must still have been invoked once with the
-        # (now-wrapped) function.
-        session.execute_read.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_skips_unit_of_work_when_timeout_none(
@@ -477,9 +558,9 @@ class TestDualNodeManagerGetEntityNeighborhoodsTimeout:
         """Both server- and client-configured timeout codes degrade to {}."""
         driver, session = _make_neo4j_driver()
         timeout_exc = _make_neo4j_error(timeout_code, message="transaction timed out")
-        # Sanity-check the constructed exception so a future driver upgrade
-        # that breaks _basic_hydrate would fail loudly here, not silently
-        # masquerade as a successful test.
+        # _make_neo4j_error already asserts isinstance(ClientError) + code
+        # internally (see the guard in the helper). Re-assert here as a
+        # call-site layer of defence.
         assert isinstance(timeout_exc, ClientError)
         assert timeout_exc.code == timeout_code
 
@@ -493,10 +574,26 @@ class TestDualNodeManagerGetEntityNeighborhoodsTimeout:
         assert result == {}
         mock_logger.warning.assert_called_once()
 
-        # The warning includes the offending code so ops can grep for it.
         warning_call = mock_logger.warning.call_args
+        # Structured kwargs (operators rely on these for filtering).
         assert warning_call.kwargs.get("code") == timeout_code
         assert warning_call.kwargs.get("timeout") == 1.0
+        assert warning_call.kwargs.get("timeout_occurred") is True
+        assert warning_call.kwargs.get("n") == 1
+        assert warning_call.kwargs.get("d") == 2
+        # Template assertions (M7). When loguru is patched,
+        # ``mock_logger.warning.call_args.args[0]`` is the RAW template
+        # string (verified at runtime), NOT the interpolated form. These
+        # guard against a future refactor silently dropping the structured
+        # fields or switching to f-string interpolation — in either case
+        # the placeholder markers disappear from args[0] and the assertion
+        # fires.
+        template = warning_call.args[0]
+        assert "timed out" in template
+        assert "{timeout}" in template
+        assert "{code}" in template
+        assert "{n}" in template
+        assert "{d}" in template
 
     @pytest.mark.asyncio
     async def test_reraises_non_timeout_client_error(self) -> None:
@@ -573,6 +670,72 @@ class TestDualNodeManagerGetEntityNeighborhoodsTimeout:
                 }
             ]
         }
+
+    @pytest.mark.asyncio
+    async def test_emits_timeout_telemetry_span(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """On timeout, a dedicated trace_span is emitted with structured attrs.
+
+        Replaces the former ``TODO(DYT-1948-followup)`` telemetry counter —
+        operators can now alert on span name ``*.timeout`` in Logfire/OTEL
+        and filter by ``timeout_s``, ``entity_count``, ``depth``, ``code``,
+        and ``namespace_id`` attributes.
+        """
+        from contextlib import contextmanager
+
+        driver, session = _make_neo4j_driver()
+        timeout_exc = _make_neo4j_error(
+            "Neo.ClientError.Transaction.TransactionTimedOut",
+            message="transaction timed out",
+        )
+        session.execute_read = AsyncMock(side_effect=timeout_exc)
+
+        captured_spans: list[tuple[str, dict]] = []
+
+        @contextmanager
+        def _fake_trace_span(name, **attributes):
+            entry = (name, dict(attributes))
+            captured_spans.append(entry)
+
+            class _NoOp:
+                def set_attribute(self, key, value):
+                    captured_spans[-1][1][key] = value
+
+                def set_attributes(self, attrs):
+                    captured_spans[-1][1].update(attrs)
+
+            yield _NoOp()
+
+        monkeypatch.setattr(
+            "khora.engines.vectorcypher.dual_nodes.trace_span",
+            _fake_trace_span,
+        )
+
+        manager = DualNodeManager(driver, query_timeout=2.5)
+        ns = uuid4()
+        eids = [uuid4(), uuid4(), uuid4()]
+
+        result = await manager.get_entity_neighborhoods(eids, ns, depth=3)
+
+        assert result == {}
+        # Exactly one span ending in ``.timeout`` — this is the signal
+        # operators will alert on. If a refactor drops the trace_span
+        # call, this test fires.
+        timeout_spans = [s for s in captured_spans if s[0].endswith(".timeout")]
+        assert len(timeout_spans) == 1, f"expected exactly one .timeout span, got {[s[0] for s in captured_spans]}"
+        name, attrs = timeout_spans[0]
+        assert name == "khora.neo4j.get_entity_neighborhoods.timeout"
+        # All five attributes ops needs for dashboard filters.
+        assert attrs["timeout_s"] == 2.5
+        assert attrs["entity_count"] == 3
+        assert attrs["depth"] == 3
+        assert attrs["code"] == "Neo.ClientError.Transaction.TransactionTimedOut"
+        assert attrs["namespace_id"] == str(ns)
+        # The Devil's-Advocate delta: timeout_occurred lives on the
+        # OTEL span as an attribute (not just in the loguru log).
+        assert attrs["timeout_occurred"] is True
 
 
 @pytest.mark.unit

--- a/tests/unit/engines/test_vectorcypher_retriever.py
+++ b/tests/unit/engines/test_vectorcypher_retriever.py
@@ -157,6 +157,40 @@ class TestRetrieverInit:
 
         assert retriever._storage is storage
 
+    def test_init_default_neo4j_query_timeout_is_none(self) -> None:
+        """When the kwarg is omitted, the inner DualNodeManager has no timeout."""
+        retriever = VectorCypherRetriever(
+            vector_store=AsyncMock(),
+            neo4j_driver=AsyncMock(),
+            embedder=AsyncMock(),
+        )
+
+        assert retriever._dual_nodes is not None
+        assert retriever._dual_nodes._query_timeout is None
+
+    def test_init_forwards_neo4j_query_timeout_to_dual_nodes(self) -> None:
+        """neo4j_query_timeout is forwarded to the underlying DualNodeManager."""
+        retriever = VectorCypherRetriever(
+            vector_store=AsyncMock(),
+            neo4j_driver=AsyncMock(),
+            embedder=AsyncMock(),
+            neo4j_query_timeout=3.0,
+        )
+
+        assert retriever._dual_nodes is not None
+        assert retriever._dual_nodes._query_timeout == 3.0
+
+    def test_init_no_dual_nodes_when_driver_missing(self) -> None:
+        """Without a driver, _dual_nodes is None even when timeout is set."""
+        retriever = VectorCypherRetriever(
+            vector_store=AsyncMock(),
+            neo4j_driver=None,
+            embedder=AsyncMock(),
+            neo4j_query_timeout=3.0,
+        )
+
+        assert retriever._dual_nodes is None
+
 
 @pytest.mark.unit
 class TestRetrieverSimpleRetrieve:

--- a/tests/unit/test_config_backends.py
+++ b/tests/unit/test_config_backends.py
@@ -151,13 +151,24 @@ class TestNeo4jConfigQueryTimeout:
         assert isinstance(settings.graph, Neo4jConfig)
         assert settings.graph.query_timeout == 7.5
 
-    @pytest.mark.parametrize("bad_value", [0, 0.0, -1, -0.5])
-    def test_query_timeout_rejects_zero_and_negative(self, bad_value):
-        """Values <= 0 must be rejected: the driver treats 0 as 'run forever',
-        which silently defeats the purpose of the cap. Users who want to
-        disable the timeout must pass ``None`` explicitly."""
+    @pytest.mark.parametrize("bad_value", [0, 0.0, -1, -0.5, 301.0, 1000.0, 1e18])
+    def test_query_timeout_rejects_zero_negative_and_over_cap(self, bad_value):
+        """Values <= 0 and values > 300s are both rejected.
+
+        <= 0: driver treats 0 as 'run forever' (defeats the purpose);
+              negative is nonsense.
+        > 300: sanity cap. A 5-minute per-transaction timeout is already
+               far beyond any reasonable interactive recall budget; higher
+               values almost certainly indicate misconfiguration. Users
+               who truly want no ceiling must pass ``None`` explicitly.
+        """
         with pytest.raises(ValidationError):
             Neo4jConfig(query_timeout=bad_value)
+
+    def test_query_timeout_accepts_boundary_values(self):
+        """Sub-millisecond and exactly 300s are both valid."""
+        assert Neo4jConfig(query_timeout=0.001).query_timeout == 0.001
+        assert Neo4jConfig(query_timeout=300.0).query_timeout == 300.0
 
 
 @pytest.mark.unit

--- a/tests/unit/test_config_backends.py
+++ b/tests/unit/test_config_backends.py
@@ -1,6 +1,7 @@
 """Tests for discriminated-union backend config parsing and backwards compatibility."""
 
 import pytest
+from pydantic import ValidationError
 
 from khora.config.schema import (
     AGEConfig,
@@ -115,6 +116,48 @@ class TestDiscriminatedUnionParsing:
             }
         )
         assert isinstance(settings.vector, PgVectorConfig)
+
+
+@pytest.mark.unit
+class TestNeo4jConfigQueryTimeout:
+    """Tests for the Neo4jConfig.query_timeout field (DYT-1948)."""
+
+    def test_default_query_timeout_is_5_seconds(self):
+        """Default query_timeout caps long-running graph reads at 5 s."""
+        cfg = Neo4jConfig()
+        assert cfg.query_timeout == 5.0
+
+    def test_query_timeout_can_be_overridden(self):
+        """Callers can dial the cap up or down."""
+        cfg = Neo4jConfig(query_timeout=10.0)
+        assert cfg.query_timeout == 10.0
+
+    def test_query_timeout_can_be_disabled(self):
+        """Setting None disables the cap and falls back to the server default."""
+        cfg = Neo4jConfig(query_timeout=None)
+        assert cfg.query_timeout is None
+
+    def test_query_timeout_round_trips_through_storage_settings(self):
+        """The field survives parsing via the discriminated-union loader."""
+        settings = StorageSettings.model_validate(
+            {
+                "graph": {
+                    "backend": "neo4j",
+                    "url": "bolt://neo:7687",
+                    "query_timeout": 7.5,
+                },
+            }
+        )
+        assert isinstance(settings.graph, Neo4jConfig)
+        assert settings.graph.query_timeout == 7.5
+
+    @pytest.mark.parametrize("bad_value", [0, 0.0, -1, -0.5])
+    def test_query_timeout_rejects_zero_and_negative(self, bad_value):
+        """Values <= 0 must be rejected: the driver treats 0 as 'run forever',
+        which silently defeats the purpose of the cap. Users who want to
+        disable the timeout must pass ``None`` explicitly."""
+        with pytest.raises(ValidationError):
+            Neo4jConfig(query_timeout=bad_value)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Production benchmarks show `DualNodeManager.get_entity_neighborhoods` has a bimodal latency distribution: p50 = 30ms, p95 = 150ms, **p99 = 27.3s (max 86s)**. The outliers are caused by combinatorial explosion in the variable-length Cypher path traversal on highly-connected entities. These runaway queries exhaust the Neo4j connection pool and cascade into 34s+ recall latencies and HTTP 500s.

This PR adds a configurable per-transaction timeout that bounds the worst ~0.5-1% of outliers without affecting the common case.

### What changed

- **`Neo4jConfig.query_timeout: float | None`** (default `5.0`, `gt=0`). Settable via env var. `None` disables; `0`/negative rejected by validator.
- **`DualNodeManager.get_entity_neighborhoods`** wraps the managed-read unit-of-work with `neo4j.unit_of_work(timeout=...)` when configured. On timeout, logs a warning (namespace_id, entity_count, depth, error code — no PII) and returns `{}` (downstream callers already handle empty neighborhoods).
- **Exception filter is narrow:** only catches `ClientError` with `.code` in the explicit `_NEO4J_TIMEOUT_CODES` tuple — catches BOTH `Neo.ClientError.Transaction.TransactionTimedOut` (server-default) AND `…TransactionTimedOutClientConfiguration` (client-configured, which is what we actually emit via `unit_of_work`). Syntax errors, auth failures, and constraint violations still propagate normally.
- **Threaded through** `VectorCypherEngine.initialize()` → `DualNodeManager` and `VectorCypherRetriever` via a new keyword-only `neo4j_query_timeout` kwarg.
- **Fully backward-compatible:** `DualNodeManager(driver)` without the kwarg gets `query_timeout=None` (no behavior change). Existing tests unchanged.

### Why `unit_of_work(timeout=...)` and not `tx.run(timeout=...)`

The ticket suggested `tx.run(timeout=...)` but that kwarg does not exist on the Neo4j **Python** driver (the JS/Go drivers have it; Python does not). The correct idiom is `@unit_of_work(timeout=...)` applied to the read closure inside `session.execute_read`. Verified against `neo4j==6.1.0` source.

### Why retries don't amplify the budget

`Neo.ClientError.Transaction.TransactionTimedOut*` hydrates to `ClientError` with `is_retryable() == False`, so `session.execute_read`'s managed retry loop does NOT re-execute on timeout. The 5s budget is a hard ceiling, not an amortized 15s (3× 5s). Verified empirically against the installed driver.

### Out of scope (deliberate)

Per the ticket, only `get_entity_neighborhoods` gets the timeout. Other read methods (`get_relationships_between`, `get_chunks_by_entities`, `get_neighborhoods_batch`, etc.) do not have the same pathological query pattern and are not touched. Peras-side changes (exposing `query_timeout` via `KhoraSettings`) are tracked separately as peras is a different repo.

## Test plan

- [x] `make format && make test` — **2488 passed, 5 skipped**, 53.39% coverage (above 30% gate)
- [x] 21 new tests across 3 files:
  - `tests/unit/test_config_backends.py` — default 5.0, override, `None`, round-trip via discriminated-union loader, **parametrized rejection of `0`/`0.0`/`-1`/`-0.5`**
  - `tests/unit/engines/test_dual_nodes.py` — `_query_timeout` storage, keyword-only enforcement, `unit_of_work` called with correct timeout, `unit_of_work` skipped when `None`, **parametrized test over both members of `_NEO4J_TIMEOUT_CODES` verifying empty-dict return and warning log**, non-timeout `ClientError` re-raised, non-`Neo4jError` re-raised, timeout-disabled happy path
  - `tests/unit/engines/test_vectorcypher_retriever.py` — default kwarg is None, `neo4j_query_timeout=3.0` forwarded to inner `_dual_nodes`, driver=None short-circuits
- [x] Lint clean: ruff, black, isort, ty typecheck (all via pre-commit)
- [x] Manual verification: `Neo4jConfig(query_timeout=0)` now raises `ValidationError`; `Neo4jConfig().query_timeout == 5.0`