### PR TITLE
DYT-2049: Fix get_neo4j_password() dropping split credentials

### DIFF
--- a/docs/AI_CHANGELOG.md
+++ b/docs/AI_CHANGELOG.md
@@ -6,3 +6,4 @@
 - 2026-04-01: DYT-1798: Switch discovery models to LiteLLM YAML config
 - 2026-04-01: DYT-1884: Add KhoraError exception hierarchy, fix silent swallowing
 - 2026-04-08: DYT-1948: Add configurable query timeout for Neo4j get_entity_neighborhoods
+- 2026-04-08: DYT-2049: Fix get_neo4j_password() returning empty when credentials are split from URL

--- a/docs/architecture/storage-backends.md
+++ b/docs/architecture/storage-backends.md
@@ -253,6 +253,35 @@ Or via environment:
 export KHORA_NEO4J_URL="bolt://neo4j:password@localhost:7687"
 ```
 
+**New-style graph config (recommended):**
+
+```python
+from khora.config.schema import KhoraConfig, Neo4jConfig, StorageSettings
+
+# Embedded credentials
+cfg = KhoraConfig(
+    database_url="postgresql://user:pass@localhost:5432/khora",
+    storage=StorageSettings(
+        graph=Neo4jConfig(url="bolt://neo4j:password@localhost:7687"),
+    ),
+)
+
+# Split credentials (URL and password managed separately — e.g. password
+# sourced from a secrets manager, URL from service discovery)
+cfg = KhoraConfig(
+    database_url="postgresql://user:pass@localhost:5432/khora",
+    storage=StorageSettings(
+        graph=Neo4jConfig(
+            url="bolt://localhost:7687",
+            user="neo4j",
+            password="from-secrets-manager",
+        ),
+    ),
+)
+```
+
+Embedded credentials in the URL take precedence; the explicit `password` field is used as the fallback when the URL has none.
+
 ## Dual Entity Storage
 
 Here's something important: **entities live in both Neo4j AND pgvector**.

--- a/src/khora/config/schema.py
+++ b/src/khora/config/schema.py
@@ -22,19 +22,29 @@ class ParsedNeo4jUrl:
     database: str
 
     @classmethod
-    def parse(cls, url: str, default_user: str = "neo4j", default_database: str = "neo4j") -> ParsedNeo4jUrl:
+    def parse(
+        cls,
+        url: str,
+        default_user: str = "neo4j",
+        default_password: str = "",
+        default_database: str = "neo4j",
+    ) -> ParsedNeo4jUrl:
         """Parse a Neo4j URL with optional embedded credentials.
 
         Supports formats:
         - bolt://host:port
         - bolt://user:password@host:port
         - bolt://user:password@host:port/database
+
+        ``default_password`` is used when the URL has no embedded password, so
+        callers can pass a separately-configured password (e.g. from
+        ``Neo4jConfig.password``) and have it flow through correctly.
         """
         parsed = urlparse(url)
 
         # Extract user and password from URL
         user = parsed.username or default_user
-        password = parsed.password or ""
+        password = parsed.password or default_password
 
         # Extract database from path (e.g., /mydb -> mydb)
         database = parsed.path.lstrip("/") if parsed.path and parsed.path != "/" else default_database
@@ -883,8 +893,14 @@ class KhoraConfig(BaseSettings):
         # Use graph config defaults if available
         graph = self.storage.graph
         default_user = graph.user if isinstance(graph, Neo4jConfig) else self.storage.neo4j_user
+        default_password = graph.password if isinstance(graph, Neo4jConfig) else self.storage.neo4j_password
         default_db = graph.database if isinstance(graph, Neo4jConfig) else self.storage.neo4j_database
-        return ParsedNeo4jUrl.parse(raw_url, default_user=default_user, default_database=default_db)
+        return ParsedNeo4jUrl.parse(
+            raw_url,
+            default_user=default_user,
+            default_password=default_password,
+            default_database=default_db,
+        )
 
     def get_neo4j_url(self) -> str | None:
         """Get Neo4j URL without credentials (for driver connection).

--- a/src/khora/config/schema.py
+++ b/src/khora/config/schema.py
@@ -911,7 +911,13 @@ class KhoraConfig(BaseSettings):
         return parsed.url if parsed else None
 
     def get_neo4j_user(self) -> str:
-        """Get Neo4j username from URL or config."""
+        """Get Neo4j username.
+
+        Precedence: username embedded in ``Neo4jConfig.url`` (or the legacy
+        ``neo4j_url``) wins. Otherwise, falls back to the separately-configured
+        ``Neo4jConfig.user`` (or the legacy ``neo4j_user``). Returns ``"neo4j"``
+        when neither is set.
+        """
         parsed = self._parse_neo4j_url()
         if parsed:
             return parsed.user
@@ -921,7 +927,13 @@ class KhoraConfig(BaseSettings):
         return self.storage.neo4j_user
 
     def get_neo4j_password(self) -> str:
-        """Get Neo4j password from URL or config."""
+        """Get Neo4j password.
+
+        Precedence: password embedded in ``Neo4jConfig.url`` (or the legacy
+        ``neo4j_url``) wins. Otherwise, falls back to the separately-configured
+        ``Neo4jConfig.password`` (or the legacy ``neo4j_password``). Returns an
+        empty string when neither is set.
+        """
         parsed = self._parse_neo4j_url()
         if parsed:
             return parsed.password
@@ -931,7 +943,13 @@ class KhoraConfig(BaseSettings):
         return self.storage.neo4j_password
 
     def get_neo4j_database(self) -> str:
-        """Get Neo4j database from URL or config."""
+        """Get Neo4j database name.
+
+        Precedence: database embedded in ``Neo4jConfig.url`` path (or the legacy
+        ``neo4j_url``) wins. Otherwise, falls back to the separately-configured
+        ``Neo4jConfig.database`` (or the legacy ``neo4j_database``). Returns
+        ``"neo4j"`` when neither is set.
+        """
         parsed = self._parse_neo4j_url()
         if parsed:
             return parsed.database

--- a/tests/unit/test_config_backends.py
+++ b/tests/unit/test_config_backends.py
@@ -236,7 +236,10 @@ class TestGetNeo4jCredentials:
         assert cfg.get_neo4j_password() == "secretpass"
         assert cfg.get_neo4j_database() == "mydb"
 
-    def test_get_neo4j_password_legacy_flat_fields(self) -> None:
+    def test_get_neo4j_password_legacy_flat_fields_are_migrated_into_graph_config(self) -> None:
+        # StorageSettings._migrate_legacy_fields() migrates the flat neo4j_*
+        # fields into a Neo4jConfig at validation time, so _parse_neo4j_url()
+        # takes the new-style `graph` branch here, not the legacy `else` branch.
         cfg = KhoraConfig(
             database_url="postgresql://x@y/z",
             storage=StorageSettings(
@@ -247,6 +250,28 @@ class TestGetNeo4jCredentials:
         )
         assert cfg.get_neo4j_password() == "legacypass"
         assert cfg.get_neo4j_user() == "legacy"
+
+    def test_get_neo4j_password_top_level_neo4j_url_shortcut_falls_through_storage_defaults(
+        self,
+    ) -> None:
+        """Top-level ``KhoraConfig.neo4j_url`` bypasses StorageSettings migration.
+
+        This exercises the ``else`` branch of ``_parse_neo4j_url`` where
+        defaults come from ``self.storage.neo4j_*`` rather than a migrated
+        ``Neo4jConfig`` — ``_migrate_legacy_fields`` lives on
+        ``StorageSettings`` and only sees fields passed under ``storage=``,
+        so the top-level shortcut never triggers it.
+        """
+        cfg = KhoraConfig(
+            database_url="postgresql://x@y/z",
+            neo4j_url="bolt://localhost:7687",
+        )
+        # No graph config, no storage.neo4j_password set — defaults apply.
+        assert cfg.storage.graph is None
+        assert cfg.get_neo4j_url() == "bolt://localhost:7687"
+        assert cfg.get_neo4j_user() == "neo4j"  # default
+        assert cfg.get_neo4j_password() == ""  # default
+        assert cfg.get_neo4j_database() == "neo4j"  # default
 
 
 @pytest.mark.unit
@@ -260,3 +285,22 @@ class TestParsedNeo4jUrl:
     def test_parse_embedded_password_overrides_default(self) -> None:
         parsed = ParsedNeo4jUrl.parse("bolt://user:embedded@localhost:7687", default_password="fallback")
         assert parsed.password == "embedded"
+
+    def test_parse_neo4j_scheme_preserved(self) -> None:
+        """``neo4j://`` routing URLs are parsed and reconstructed with scheme intact."""
+        parsed = ParsedNeo4jUrl.parse("neo4j://user:pass@cluster.example.com:7687")
+        assert parsed.url == "neo4j://cluster.example.com:7687"
+        assert parsed.user == "user"
+        assert parsed.password == "pass"
+
+    def test_parse_explicit_empty_password_falls_through_to_default(self) -> None:
+        """A URL like ``bolt://user:@host:7687`` (trailing colon, no password)
+        is indistinguishable from a credential-free URL — ``urlparse`` returns
+        an empty string for ``.password``, and the ``default_password`` fallback
+        fires. This is intentional: Neo4j rejects empty-auth connections on
+        most servers, so falling through to a configured default is the
+        sensible behavior.
+        """
+        parsed = ParsedNeo4jUrl.parse("bolt://user:@localhost:7687", default_password="fallback")
+        assert parsed.user == "user"
+        assert parsed.password == "fallback"

--- a/tests/unit/test_config_backends.py
+++ b/tests/unit/test_config_backends.py
@@ -9,6 +9,7 @@ from khora.config.schema import (
     KuzuConfig,
     MemgraphConfig,
     Neo4jConfig,
+    ParsedNeo4jUrl,
     PgVectorConfig,
     StorageSettings,
 )
@@ -202,3 +203,60 @@ class TestKhoraConfigGraphHelpers:
         vector = config.get_vector_config()
         assert isinstance(vector, PgVectorConfig)
         assert vector.url == "postgresql://localhost:5432/khora"
+
+
+@pytest.mark.unit
+class TestGetNeo4jCredentials:
+    """Regression tests for DYT-2049: Neo4j credentials must flow through when split from URL."""
+
+    def test_get_neo4j_password_prefers_explicit_graph_password_over_credential_free_url(self) -> None:
+        graph = Neo4jConfig(url="bolt://localhost:7687", user="neo4j", password="secretpass")
+        cfg = KhoraConfig(database_url="postgresql://x@y/z", storage=StorageSettings(graph=graph))
+        assert cfg.get_neo4j_password() == "secretpass"
+
+    def test_get_neo4j_password_extracts_from_embedded_url(self) -> None:
+        graph = Neo4jConfig(url="bolt://neo4j:secretpass@localhost:7687")
+        cfg = KhoraConfig(database_url="postgresql://x@y/z", storage=StorageSettings(graph=graph))
+        assert cfg.get_neo4j_password() == "secretpass"
+
+    def test_get_neo4j_password_embedded_url_wins_over_field(self) -> None:
+        graph = Neo4jConfig(url="bolt://neo4j:urlpass@localhost:7687", password="fieldpass")
+        cfg = KhoraConfig(database_url="postgresql://x@y/z", storage=StorageSettings(graph=graph))
+        assert cfg.get_neo4j_password() == "urlpass"
+
+    def test_get_neo4j_user_and_database_fall_through_from_credential_free_url(self) -> None:
+        graph = Neo4jConfig(
+            url="bolt://localhost:7687",
+            user="admin",
+            password="secretpass",
+            database="mydb",
+        )
+        cfg = KhoraConfig(database_url="postgresql://x@y/z", storage=StorageSettings(graph=graph))
+        assert cfg.get_neo4j_user() == "admin"
+        assert cfg.get_neo4j_password() == "secretpass"
+        assert cfg.get_neo4j_database() == "mydb"
+
+    def test_get_neo4j_password_legacy_flat_fields(self) -> None:
+        cfg = KhoraConfig(
+            database_url="postgresql://x@y/z",
+            storage=StorageSettings(
+                neo4j_url="bolt://localhost:7687",
+                neo4j_user="legacy",
+                neo4j_password="legacypass",
+            ),
+        )
+        assert cfg.get_neo4j_password() == "legacypass"
+        assert cfg.get_neo4j_user() == "legacy"
+
+
+@pytest.mark.unit
+class TestParsedNeo4jUrl:
+    """Direct contract tests for ParsedNeo4jUrl.parse()."""
+
+    def test_parse_respects_default_password_when_url_has_none(self) -> None:
+        parsed = ParsedNeo4jUrl.parse("bolt://localhost:7687", default_password="fallbackpass")
+        assert parsed.password == "fallbackpass"
+
+    def test_parse_embedded_password_overrides_default(self) -> None:
+        parsed = ParsedNeo4jUrl.parse("bolt://user:embedded@localhost:7687", default_password="fallback")
+        assert parsed.password == "embedded"


### PR DESCRIPTION
## Summary

- `ParsedNeo4jUrl.parse()` silently overwrote the password with `""` whenever the Neo4j URL had no embedded credentials, so `KhoraConfig.get_neo4j_password()` returned an empty string for the common `Neo4jConfig(url="bolt://host:7687", password="…")` pattern. VectorCypher then handed empty auth to the Neo4j driver and blew up with `AuthError`. This is the root cause of the peras staging incident (DYT-2048).
- Fix threads `default_password` through `ParsedNeo4jUrl.parse()` and `KhoraConfig._parse_neo4j_url()` alongside `default_user` / `default_database` (ticket approach B). The `get_neo4j_*` accessors are unchanged — the fix lives at the source, so user/database get the same fall-through and the asymmetry called out in the ticket is gone.
- `ParsedNeo4jUrl.parse()` keeps `default_password=""` as its default, so external callers that don't pass it are unaffected.
- Adds seven tests covering the regression, embedded-credentials precedence, user/database fall-through, legacy flat fields, and the direct `ParsedNeo4jUrl.parse()` contract.
- Closes DYT-2049.

## Test plan

- [x] `uv run pytest tests/unit/test_config_backends.py -v` — 20 passed
- [x] `uv run pytest tests/unit/ -q` — 2449 passed, 5 skipped, coverage 53% (gate 46%)
- [x] `make format`
- [x] `make lint` (pre-existing `_accel.py` shadowing warning is unrelated)
- [x] Manual reproduction from the ticket now returns `"secretpass"` instead of `""`