### PR TITLE
Pass dimensions param to litellm embedding calls

### DIFF
--- a/src/khora/extraction/embedders/litellm.py
+++ b/src/khora/extraction/embedders/litellm.py
@@ -403,6 +403,7 @@ class LiteLLMEmbedder(Embedder):
                         model=self._model,
                         input=sanitized,
                         timeout=self._timeout,
+                        dimensions=self._dimension,
                     )
                     _latency = (_time.perf_counter() - _t0) * 1000
                     req_span.set_attribute("latency_ms", round(_latency, 2))


### PR DESCRIPTION
## Summary
- Forward the configured `embedding_dimension` to `litellm.aembedding()` via the `dimensions` parameter
- Without this, `text-embedding-3-large` returns 3072-dim vectors that don't fit `vector(1536)` columns
- The dimension was already configured in `LiteLLMConfig` but never passed to the API call

## Test plan
- [x] Verified with full LAMC ingestion (6980 sections) using `text-embedding-3-large` with `embedding_dimension=1536`
- [x] No dimension mismatch errors during pgvector insert
- [x] 650-question eval scored 7.3/10 (up from 6.0 with `text-embedding-3-small`)