### PR TITLE
DYT-2120: Pass connection_acquisition_timeout to Neo4j driver

### DIFF
--- a/docs/AI_CHANGELOG.md
+++ b/docs/AI_CHANGELOG.md
@@ -10,3 +10,5 @@
 - 2026-04-12: DYT-2286: Consolidate toolchain — ruff replaces black, isort, pyupgrade, bandit
 - 2026-04-12: DYT-2294: Add khora extract + khora search CLI commands
 - 2026-04-12: DYT-2298: SQLite embedded backend for zero-infra CLI mode
+- 2026-04-12: DYT-2299: CLI tests and docs for extract + search commands
+- 2026-04-14: DYT-2120: Pass connection_acquisition_timeout to Neo4j driver

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -296,6 +296,24 @@ class VectorCypherEngine:
         self._router: QueryComplexityRouter | None = None
         self._connected = False
 
+    @staticmethod
+    def _neo4j_driver_kwargs(neo4j_cfg: Any) -> dict[str, Any]:
+        """Extract Neo4j driver kwargs from config.
+
+        Centralises the config → driver mapping so new fields cannot be
+        silently omitted.
+        """
+
+        def _get(attr: str, default: Any) -> Any:
+            return getattr(neo4j_cfg, attr, default) if neo4j_cfg else default
+
+        return {
+            "max_connection_pool_size": _get("max_connection_pool_size", 100),
+            "max_connection_lifetime": _get("max_connection_lifetime", 900),
+            "liveness_check_timeout": _get("liveness_check_timeout", 30.0),
+            "connection_acquisition_timeout": _get("connection_acquisition_timeout", 60.0),
+        }
+
     async def connect(self) -> None:
         """Connect to all storage backends."""
         if self._connected:
@@ -317,18 +335,12 @@ class VectorCypherEngine:
                 )
 
             neo4j_cfg = self._config.get_graph_config()
-            pool_size = getattr(neo4j_cfg, "max_connection_pool_size", 100) if neo4j_cfg else 100
-            max_conn_lifetime = getattr(neo4j_cfg, "max_connection_lifetime", 900) if neo4j_cfg else 900
-            liveness_timeout = getattr(neo4j_cfg, "liveness_check_timeout", 30.0) if neo4j_cfg else 30.0
             neo4j_query_timeout = getattr(neo4j_cfg, "query_timeout", 5.0) if neo4j_cfg else 5.0
-            acquisition_timeout = getattr(neo4j_cfg, "connection_acquisition_timeout", 60.0) if neo4j_cfg else 60.0
+            driver_kwargs = self._neo4j_driver_kwargs(neo4j_cfg)
             self._neo4j_driver = AsyncGraphDatabase.driver(
                 neo4j_url,
                 auth=(self._config.get_neo4j_user(), self._config.get_neo4j_password()),
-                max_connection_pool_size=pool_size,
-                max_connection_lifetime=max_conn_lifetime,
-                connection_acquisition_timeout=acquisition_timeout,
-                liveness_check_timeout=liveness_timeout,
+                **driver_kwargs,
                 keep_alive=True,
             )
             await self._neo4j_driver.verify_connectivity()

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -321,11 +321,13 @@ class VectorCypherEngine:
             max_conn_lifetime = getattr(neo4j_cfg, "max_connection_lifetime", 900) if neo4j_cfg else 900
             liveness_timeout = getattr(neo4j_cfg, "liveness_check_timeout", 30.0) if neo4j_cfg else 30.0
             neo4j_query_timeout = getattr(neo4j_cfg, "query_timeout", 5.0) if neo4j_cfg else 5.0
+            acquisition_timeout = getattr(neo4j_cfg, "connection_acquisition_timeout", 60.0) if neo4j_cfg else 60.0
             self._neo4j_driver = AsyncGraphDatabase.driver(
                 neo4j_url,
                 auth=(self._config.get_neo4j_user(), self._config.get_neo4j_password()),
                 max_connection_pool_size=pool_size,
                 max_connection_lifetime=max_conn_lifetime,
+                connection_acquisition_timeout=acquisition_timeout,
                 liveness_check_timeout=liveness_timeout,
                 keep_alive=True,
             )

--- a/tests/unit/engines/test_vectorcypher_engine.py
+++ b/tests/unit/engines/test_vectorcypher_engine.py
@@ -743,6 +743,89 @@ class TestVectorCypherEngineValidateRecallResults:
 
 
 @pytest.mark.unit
+class TestVectorCypherEngineConnectAcquisitionTimeout:
+    """Tests for connection_acquisition_timeout being passed to Neo4j driver."""
+
+    @pytest.fixture
+    def mock_config(self) -> MagicMock:
+        """Create a mock KhoraConfig."""
+        config = MagicMock()
+        config.get_postgresql_url.return_value = "postgresql://localhost/test"
+        config.get_neo4j_url.return_value = "bolt://localhost:7687"
+        config.get_neo4j_user.return_value = "neo4j"
+        config.get_neo4j_password.return_value = "password"
+        config.get_neo4j_database.return_value = "neo4j"
+        config.get_graph_config.return_value = MagicMock()
+        config.get_vector_config.return_value = MagicMock()
+        config.storage.postgresql_pool_size = 5
+        config.storage.postgresql_max_overflow = 10
+        config.storage.embedding_dimension = 1536
+        config.storage.backend = "postgres"
+        config.llm.model = "gpt-4o-mini"
+        config.llm.embedding_model = "text-embedding-3-small"
+        config.llm.embedding_dimension = 1536
+        config.llm.timeout = 30
+        config.llm.max_retries = 3
+        config.llm.max_concurrent_llm_calls = 5
+        config.pipeline.chunking_strategy = "recursive"
+        config.pipeline.chunk_size = 1000
+        config.pipeline.chunk_overlap = 200
+        config.pipeline.extract_entities = True
+        config.telemetry_database_url = None
+        config.telemetry_service_name = "test"
+        return config
+
+    @pytest.mark.asyncio
+    async def test_custom_acquisition_timeout(self, mock_config: MagicMock) -> None:
+        """Test that connection_acquisition_timeout from config is passed to driver."""
+        neo4j_cfg = MagicMock()
+        neo4j_cfg.connection_acquisition_timeout = 2.5
+        mock_config.get_graph_config.return_value = neo4j_cfg
+
+        engine = VectorCypherEngine(mock_config)
+
+        mock_driver = AsyncMock()
+        sentinel = RuntimeError("stop after driver")
+        with (
+            patch("neo4j.AsyncGraphDatabase.driver", return_value=mock_driver) as mock_driver_cls,
+            patch(
+                "khora.engines.vectorcypher.engine.create_storage_coordinator",
+                side_effect=sentinel,
+            ),
+            pytest.raises(RuntimeError, match="stop after driver"),
+        ):
+            await engine.connect()
+
+        mock_driver_cls.assert_called_once()
+        call_kwargs = mock_driver_cls.call_args[1]
+        assert call_kwargs["connection_acquisition_timeout"] == 2.5
+
+    @pytest.mark.asyncio
+    async def test_default_acquisition_timeout(self, mock_config: MagicMock) -> None:
+        """Test that default 60.0 is used when config has no connection_acquisition_timeout."""
+        neo4j_cfg = MagicMock(spec=[])
+        mock_config.get_graph_config.return_value = neo4j_cfg
+
+        engine = VectorCypherEngine(mock_config)
+
+        mock_driver = AsyncMock()
+        sentinel = RuntimeError("stop after driver")
+        with (
+            patch("neo4j.AsyncGraphDatabase.driver", return_value=mock_driver) as mock_driver_cls,
+            patch(
+                "khora.engines.vectorcypher.engine.create_storage_coordinator",
+                side_effect=sentinel,
+            ),
+            pytest.raises(RuntimeError, match="stop after driver"),
+        ):
+            await engine.connect()
+
+        mock_driver_cls.assert_called_once()
+        call_kwargs = mock_driver_cls.call_args[1]
+        assert call_kwargs["connection_acquisition_timeout"] == 60.0
+
+
+@pytest.mark.unit
 class TestVectorCypherEngineParseDatetime:
     """Tests for _parse_datetime helper."""
 

--- a/tests/unit/engines/test_vectorcypher_engine.py
+++ b/tests/unit/engines/test_vectorcypher_engine.py
@@ -803,6 +803,7 @@ class TestVectorCypherEngineConnectAcquisitionTimeout:
     @pytest.mark.asyncio
     async def test_default_acquisition_timeout(self, mock_config: MagicMock) -> None:
         """Test that default 60.0 is used when config has no connection_acquisition_timeout."""
+        # spec=[] prevents MagicMock from auto-creating attributes, so getattr falls through to default
         neo4j_cfg = MagicMock(spec=[])
         mock_config.get_graph_config.return_value = neo4j_cfg
 
@@ -823,6 +824,32 @@ class TestVectorCypherEngineConnectAcquisitionTimeout:
         mock_driver_cls.assert_called_once()
         call_kwargs = mock_driver_cls.call_args[1]
         assert call_kwargs["connection_acquisition_timeout"] == 60.0
+
+    @pytest.mark.asyncio
+    async def test_none_graph_config_uses_defaults(self, mock_config: MagicMock) -> None:
+        """Test that None graph config falls through to all driver defaults."""
+        mock_config.get_graph_config.return_value = None
+
+        engine = VectorCypherEngine(mock_config)
+
+        mock_driver = AsyncMock()
+        sentinel = RuntimeError("stop after driver")
+        with (
+            patch("neo4j.AsyncGraphDatabase.driver", return_value=mock_driver) as mock_driver_cls,
+            patch(
+                "khora.engines.vectorcypher.engine.create_storage_coordinator",
+                side_effect=sentinel,
+            ),
+            pytest.raises(RuntimeError, match="stop after driver"),
+        ):
+            await engine.connect()
+
+        mock_driver_cls.assert_called_once()
+        call_kwargs = mock_driver_cls.call_args[1]
+        assert call_kwargs["connection_acquisition_timeout"] == 60.0
+        assert call_kwargs["max_connection_pool_size"] == 100
+        assert call_kwargs["max_connection_lifetime"] == 900
+        assert call_kwargs["liveness_check_timeout"] == 30.0
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- **Bug fix**: `VectorCypherEngine.connect()` was constructing `AsyncGraphDatabase.driver(...)` without forwarding `connection_acquisition_timeout` from `Neo4jConfig`, causing the driver to fall back to its 60s default instead of the 10s configured in peras (DYT-1950)
- Adds one line to read `connection_acquisition_timeout` from config (default 60.0 to match Neo4j driver default) and one line to pass it to the driver constructor
- `Neo4jBackend.connect()` was audited and already passes this correctly — no fix needed there
- Adds two unit tests verifying the kwarg is forwarded (custom value 2.5 and default 60.0)

## Test plan
- [x] Unit tests pass (2557 passed, 5 skipped)
- [x] Coverage above threshold (52.66% > 46%)
- [x] Lint and format clean
- [ ] After deploy: Logfire query should show `within 10.0s` in new `ConnectionAcquisitionTimeoutError` messages instead of `within 60.0s`