### PR TITLE
DYT-2117: Delete DualNodeManager.count_chunks dead code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 
 ## [Unreleased] — Graph Backends, Temporal Precision, Discovery Agent Overhaul
 
+### Breaking changes
+- Remove `DualNodeManager.count_chunks` — dead code after DYT-2116 routed chunk counts through Postgres (#363). Use `PgVectorBackend.count_chunks` or `StorageCoordinator.count_chunks` instead
+
 ### New graph backends
 - AWS Neptune with Bolt protocol + IAM SigV4 auth (#272)
 - PostgreSQL AGE with Cypher-in-SQL, shares PG connection pool (#273)

--- a/src/khora/engines/vectorcypher/dual_nodes.py
+++ b/src/khora/engines/vectorcypher/dual_nodes.py
@@ -849,30 +849,6 @@ class DualNodeManager:
         logger.debug(f"Deleted {deleted} Chunk nodes for document {document_id}")
         return deleted
 
-    # NOTE: Unused after DYT-2116 (stats routed through Postgres). Tracked for removal in DYT-2117.
-    async def count_chunks(self, namespace_id: UUID) -> int:
-        """Count Chunk nodes in a namespace.
-
-        Args:
-            namespace_id: Namespace ID
-
-        Returns:
-            Number of chunks
-        """
-        query = """
-        MATCH (c:Chunk {namespace_id: $namespace_id})
-        RETURN count(c) AS count
-        """
-
-        async with self._driver.session(database=self._database) as session:
-
-            async def _work(tx):
-                result = await tx.run(query, namespace_id=str(namespace_id))
-                record = await result.single()
-                return record["count"] if record else 0
-
-            return await session.execute_read(_work)
-
 
 __all__ = [
     "ChunkNode",

--- a/tests/unit/engines/test_dual_nodes.py
+++ b/tests/unit/engines/test_dual_nodes.py
@@ -754,22 +754,6 @@ class TestDualNodeManagerDeleteOperations:
 
 
 @pytest.mark.unit
-class TestDualNodeManagerCountChunks:
-    """Tests for count_chunks method."""
-
-    @pytest.mark.asyncio
-    async def test_count_chunks(self) -> None:
-        """Test counting chunks in a namespace."""
-        driver, session = _make_neo4j_driver()
-        session.execute_read = AsyncMock(return_value=42)
-
-        manager = DualNodeManager(driver)
-        count = await manager.count_chunks(uuid4())
-
-        assert count == 42
-
-
-@pytest.mark.unit
 class TestDualNodeManagerGetEntityChannels:
     """Tests for get_entity_channels method."""
 

--- a/tests/unit/engines/test_engine_stats.py
+++ b/tests/unit/engines/test_engine_stats.py
@@ -326,20 +326,6 @@ class TestVectorCypherStats:
         storage.count_chunks.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_stats_no_neo4j_calls(self) -> None:
-        """stats() does not call dual_nodes.count_chunks."""
-        storage = _make_mock_storage()
-        dual_nodes = AsyncMock()
-        dual_nodes.count_chunks = AsyncMock(return_value=99)
-        engine = self._make_engine(storage, dual_nodes=dual_nodes)
-
-        result = await engine.stats(uuid4())
-
-        assert result.chunks == 20  # from storage, not dual_nodes
-        dual_nodes.count_chunks.assert_not_awaited()
-        storage.count_chunks.assert_awaited_once()
-
-    @pytest.mark.asyncio
     async def test_stats_get_document_stats_fallback(self) -> None:
         """stats() defaults doc_count to 0 on get_document_stats failure."""
         storage = _make_mock_storage()


### PR DESCRIPTION
## Summary
- Delete `DualNodeManager.count_chunks` from `dual_nodes.py` — dead code after DYT-2116 routed chunk counts through Postgres (#363)
- Delete associated tests: `TestDualNodeManagerCountChunks` and `test_stats_no_neo4j_calls`
- Add breaking change entry to CHANGELOG.md noting the removal and alternatives (`PgVectorBackend.count_chunks`, `StorageCoordinator.count_chunks`)

The method lacked `@trace` and `_timed_unit_of_work` wrappers, which caused a 60-second silent gap during Neo4j pool exhaustion (IGR-20). Deleting it prevents re-introduction of the problem.

## Test plan
- [x] `ruff check` and `ruff format --check` pass
- [x] All 2642 tests pass (0 failures, 53.4% coverage)
- [x] Grep confirms zero remaining references to `dual_nodes.count_chunks` or `DualNodeManager.count_chunks`
- [x] `count_chunks` on other classes (PgVectorBackend, StorageCoordinator, base.py, sqlite.py, surrealdb, mixins.py) remains intact