### PR TITLE
DYT-2381: Exclude FAILED documents from dedup checksum lookups

### DIFF
--- a/src/khora/db/migrations/versions/020_partial_index_dedup_active.py
+++ b/src/khora/db/migrations/versions/020_partial_index_dedup_active.py
@@ -1,0 +1,35 @@
+"""Add partial index for dedup queries excluding failed documents.
+
+Revision ID: 020_partial_index_dedup_active
+Revises: 019_document_last_activity_index
+Create Date: 2026-04-14
+
+DYT-2381: Add partial index (namespace_id, checksum) WHERE status != 'failed'
+on documents table. This allows dedup lookups to skip failed documents without
+scanning rows that will never match.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "020_partial_index_dedup_active"
+down_revision: str | Sequence[str] | None = "019_document_last_activity_index"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add partial index for dedup excluding failed docs."""
+    op.create_index(
+        "ix_documents_namespace_checksum_active",
+        "documents",
+        ["namespace_id", "checksum"],
+        postgresql_where=text("status != 'failed'"),
+    )
+
+
+def downgrade() -> None:
+    """Remove partial index."""
+    op.drop_index("ix_documents_namespace_checksum_active", table_name="documents")

--- a/src/khora/db/models.py
+++ b/src/khora/db/models.py
@@ -169,6 +169,12 @@ class DocumentModel(Base):
 
     __table_args__ = (
         Index("ix_documents_namespace_checksum", "namespace_id", "checksum"),
+        Index(
+            "ix_documents_namespace_checksum_active",
+            "namespace_id",
+            "checksum",
+            postgresql_where=text("status != 'failed'"),
+        ),
         Index("ix_documents_namespace_source_type", "namespace_id", "source_type"),
         Index("ix_documents_namespace_created_at", "namespace_id", "created_at"),
     )

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -477,7 +477,9 @@ class PostgreSQLBackend(AsyncSessionMixin):
         async with self._get_session() as session:
             result = await session.execute(
                 select(DocumentModel).where(
-                    DocumentModel.namespace_id == namespace_id, DocumentModel.checksum == checksum
+                    DocumentModel.namespace_id == namespace_id,
+                    DocumentModel.checksum == checksum,
+                    DocumentModel.status != DocumentStatus.FAILED,
                 )
             )
             model = result.scalars().first()
@@ -520,6 +522,7 @@ class PostgreSQLBackend(AsyncSessionMixin):
                 select(DocumentModel).where(
                     DocumentModel.namespace_id == namespace_id,
                     DocumentModel.checksum.in_(checksums),
+                    DocumentModel.status != DocumentStatus.FAILED,
                 )
             )
             models = result.scalars().all()

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -473,6 +473,7 @@ class PostgreSQLBackend(AsyncSessionMixin):
         """Get a document by its content checksum (for deduplication).
 
         Returns the first matching document if multiple exist with the same checksum.
+        FAILED documents are excluded to allow re-ingestion of previously failed content.
         """
         async with self._get_session() as session:
             result = await session.execute(
@@ -506,6 +507,7 @@ class PostgreSQLBackend(AsyncSessionMixin):
         """Fetch documents by content checksums in a single query.
 
         Used for batch deduplication to avoid N serial DB queries.
+        FAILED documents are excluded to allow re-ingestion of previously failed content.
 
         Args:
             namespace_id: Namespace to search in

--- a/src/khora/storage/backends/sqlite.py
+++ b/src/khora/storage/backends/sqlite.py
@@ -493,6 +493,8 @@ class SQLiteRelationalBackend:
         return row["cnt"], _parse_dt(row["last_at"])
 
     async def get_document_by_checksum(self, namespace_id: UUID, checksum: str) -> Document | None:
+        """Get a document by content checksum. FAILED documents are excluded."""
+        # Note: SQLite (dev/test only) relies on full table scan; no partial index optimization
         cursor = await self._conn.execute(
             "SELECT * FROM documents WHERE namespace_id = ? AND checksum = ? AND status != 'failed' LIMIT 1",
             (str(namespace_id), checksum),

--- a/src/khora/storage/backends/sqlite.py
+++ b/src/khora/storage/backends/sqlite.py
@@ -494,7 +494,7 @@ class SQLiteRelationalBackend:
 
     async def get_document_by_checksum(self, namespace_id: UUID, checksum: str) -> Document | None:
         cursor = await self._conn.execute(
-            "SELECT * FROM documents WHERE namespace_id = ? AND checksum = ? LIMIT 1",
+            "SELECT * FROM documents WHERE namespace_id = ? AND checksum = ? AND status != 'failed' LIMIT 1",
             (str(namespace_id), checksum),
         )
         row = await cursor.fetchone()

--- a/src/khora/storage/backends/surrealdb/relational.py
+++ b/src/khora/storage/backends/surrealdb/relational.py
@@ -436,7 +436,10 @@ class SurrealDBRelationalAdapter:
         return (row["cnt"] or 0), row["latest"]
 
     async def get_document_by_checksum(self, namespace_id: UUID, checksum: str) -> Document | None:
-        """Get a document by content checksum within a namespace."""
+        """Get a document by content checksum within a namespace.
+
+        FAILED documents are excluded to allow re-ingestion of previously failed content.
+        """
         ns_str = str(namespace_id)
         row = await self._conn.query_one(
             "SELECT * FROM document WHERE namespace_id = $ns AND checksum = $checksum AND status != 'failed' LIMIT 1",
@@ -450,6 +453,7 @@ class SurrealDBRelationalAdapter:
         """Fetch documents by content checksums in a single query.
 
         Used for batch deduplication to avoid N serial DB queries.
+        FAILED documents are excluded to allow re-ingestion of previously failed content.
 
         Args:
             namespace_id: Namespace to search in

--- a/src/khora/storage/backends/surrealdb/relational.py
+++ b/src/khora/storage/backends/surrealdb/relational.py
@@ -439,7 +439,7 @@ class SurrealDBRelationalAdapter:
         """Get a document by content checksum within a namespace."""
         ns_str = str(namespace_id)
         row = await self._conn.query_one(
-            "SELECT * FROM document WHERE namespace_id = $ns AND checksum = $checksum LIMIT 1",
+            "SELECT * FROM document WHERE namespace_id = $ns AND checksum = $checksum AND status != 'failed' LIMIT 1",
             {"ns": ns_str, "checksum": checksum},
         )
         if row is None:
@@ -462,7 +462,7 @@ class SurrealDBRelationalAdapter:
             return {}
         ns_str = str(namespace_id)
         rows = await self._conn.query(
-            "SELECT * FROM document WHERE namespace_id = $ns AND checksum IN $checksums",
+            "SELECT * FROM document WHERE namespace_id = $ns AND checksum IN $checksums AND status != 'failed'",
             {"ns": ns_str, "checksums": checksums},
         )
         result: dict[str, Document] = {}

--- a/src/khora/storage/backends/surrealdb/schema.py
+++ b/src/khora/storage/backends/surrealdb/schema.py
@@ -66,6 +66,7 @@ DEFINE FIELD IF NOT EXISTS updated_at ON document TYPE datetime DEFAULT time::no
 DEFINE FIELD IF NOT EXISTS processed_at ON document TYPE option<datetime>;
 DEFINE FIELD IF NOT EXISTS source_timestamp ON document TYPE option<datetime>;
 DEFINE INDEX IF NOT EXISTS idx_document_namespace ON document FIELDS namespace_id;
+-- Note: SurrealDB does not support partial indexes; full index used for dedup queries
 DEFINE INDEX IF NOT EXISTS idx_document_ns_checksum ON document FIELDS namespace_id, checksum;
 DEFINE INDEX IF NOT EXISTS idx_document_ns_status ON document FIELDS namespace_id, status;
 

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -408,14 +408,14 @@ class TestMigrationPackageStructure:
         assert env_path.exists(), f"env.py not found at {env_path}"
 
     @pytest.mark.unit
-    def test_versions_dir_has_20_files(self):
-        """versions/ directory contains 20 migration files."""
+    def test_versions_dir_has_21_files(self):
+        """versions/ directory contains 21 migration files."""
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
         # Filter out __pycache__ and __init__
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
-        assert len(migration_files) == 20, (
-            f"Expected 20 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
+        assert len(migration_files) == 21, (
+            f"Expected 21 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
         )
 
     @pytest.mark.unit

--- a/tests/unit/test_postgresql_checksum_excludes_failed.py
+++ b/tests/unit/test_postgresql_checksum_excludes_failed.py
@@ -1,0 +1,177 @@
+"""Tests for DYT-2381: PostgreSQL backend excludes FAILED documents from checksum lookups.
+
+Verifies that get_document_by_checksum() and get_documents_by_checksums() filter out
+FAILED documents so they can be re-ingested.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from khora.core.models.document import DocumentStatus
+from khora.db.models import DocumentModel
+from khora.storage.backends.postgresql import PostgreSQLBackend
+
+
+def _mock_document_model(*, namespace_id, checksum="abc123", status=DocumentStatus.COMPLETED):
+    """Create a mock DocumentModel."""
+    model = MagicMock(spec=DocumentModel)
+    model.id = uuid4()
+    model.namespace_id = namespace_id
+    model.content = "test content"
+    model.status = status
+    model.source = "test.txt"
+    model.source_type = "file"
+    model.content_type = "text/plain"
+    model.title = "Test"
+    model.author = "tester"
+    model.language = None
+    model.checksum = checksum
+    model.size_bytes = 100
+    model.metadata_ = {}
+    model.chunk_count = 0
+    model.entity_count = 0
+    model.error_message = None
+    model.extraction_config_hash = None
+    model.created_at = datetime.now(UTC)
+    model.updated_at = datetime.now(UTC)
+    model.processed_at = None
+    return model
+
+
+def _make_backend(session_mock) -> PostgreSQLBackend:
+    """Create a PostgreSQLBackend with a mocked session factory."""
+    backend = PostgreSQLBackend.__new__(PostgreSQLBackend)
+
+    @asynccontextmanager
+    async def _fake_session():
+        yield session_mock
+
+    backend._get_session = _fake_session
+    return backend
+
+
+@pytest.mark.unit
+class TestGetDocumentByChecksumExcludesFailed:
+    """Verify get_document_by_checksum filters out FAILED documents (DYT-2381)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_only_failed_exists(self) -> None:
+        """When the only matching doc is FAILED, returns None."""
+        ns_id = uuid4()
+        session = AsyncMock()
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.first.return_value = None
+        session.execute = AsyncMock(return_value=result_mock)
+
+        backend = _make_backend(session)
+        result = await backend.get_document_by_checksum(ns_id, "abc123")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_query_includes_failed_filter(self) -> None:
+        """The SQLAlchemy query includes DocumentModel.status != FAILED."""
+        ns_id = uuid4()
+        session = AsyncMock()
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.first.return_value = None
+        session.execute = AsyncMock(return_value=result_mock)
+
+        backend = _make_backend(session)
+        await backend.get_document_by_checksum(ns_id, "abc123")
+
+        # Inspect the select() statement passed to session.execute
+        call_args = session.execute.call_args
+        stmt = call_args[0][0]
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        assert "status" in compiled
+        assert "FAILED" in compiled.upper() or "failed" in compiled
+
+    @pytest.mark.asyncio
+    async def test_returns_completed_document(self) -> None:
+        """When a COMPLETED doc matches, it is returned."""
+        ns_id = uuid4()
+        model = _mock_document_model(namespace_id=ns_id, checksum="abc123")
+        session = AsyncMock()
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.first.return_value = model
+        session.execute = AsyncMock(return_value=result_mock)
+
+        backend = _make_backend(session)
+        result = await backend.get_document_by_checksum(ns_id, "abc123")
+
+        assert result is not None
+        assert result.id == model.id
+
+
+@pytest.mark.unit
+class TestGetDocumentsByChecksumsExcludesFailed:
+    """Verify get_documents_by_checksums filters out FAILED documents (DYT-2381)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_only_failed_exist(self) -> None:
+        """When all matching docs are FAILED, returns empty dict."""
+        ns_id = uuid4()
+        session = AsyncMock()
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=result_mock)
+
+        backend = _make_backend(session)
+        result = await backend.get_documents_by_checksums(ns_id, ["abc123", "def456"])
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_query_includes_failed_filter(self) -> None:
+        """The SQLAlchemy query includes DocumentModel.status != FAILED."""
+        ns_id = uuid4()
+        session = AsyncMock()
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=result_mock)
+
+        backend = _make_backend(session)
+        await backend.get_documents_by_checksums(ns_id, ["abc123"])
+
+        call_args = session.execute.call_args
+        stmt = call_args[0][0]
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        assert "status" in compiled
+        assert "FAILED" in compiled.upper() or "failed" in compiled
+
+    @pytest.mark.asyncio
+    async def test_returns_completed_documents(self) -> None:
+        """Completed docs are returned, keyed by checksum."""
+        ns_id = uuid4()
+        model1 = _mock_document_model(namespace_id=ns_id, checksum="abc123")
+        model2 = _mock_document_model(namespace_id=ns_id, checksum="def456")
+        session = AsyncMock()
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = [model1, model2]
+        session.execute = AsyncMock(return_value=result_mock)
+
+        backend = _make_backend(session)
+        result = await backend.get_documents_by_checksums(ns_id, ["abc123", "def456"])
+
+        assert len(result) == 2
+        assert "abc123" in result
+        assert "def456" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_checksums_returns_empty(self) -> None:
+        """Empty checksums list returns empty dict without querying."""
+        ns_id = uuid4()
+        session = AsyncMock()
+        backend = _make_backend(session)
+
+        result = await backend.get_documents_by_checksums(ns_id, [])
+
+        assert result == {}
+        session.execute.assert_not_awaited()

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -289,6 +289,29 @@ class TestDocumentCRUD:
         assert fetched is not None
         assert fetched.id == doc.id
 
+    async def test_get_document_by_checksum_excludes_failed(self, relational: SQLiteRelationalBackend):
+        """FAILED documents should not be returned by checksum lookup (DYT-2381)."""
+        ns = _make_namespace()
+        await relational.create_namespace(ns)
+
+        doc = _make_document(ns.id, status=DocumentStatus.FAILED)
+        await relational.create_document(doc)
+
+        fetched = await relational.get_document_by_checksum(ns.id, "abc123")
+        assert fetched is None
+
+    async def test_get_document_by_checksum_returns_completed(self, relational: SQLiteRelationalBackend):
+        """COMPLETED documents should still be returned by checksum lookup."""
+        ns = _make_namespace()
+        await relational.create_namespace(ns)
+
+        doc = _make_document(ns.id, status=DocumentStatus.COMPLETED)
+        await relational.create_document(doc)
+
+        fetched = await relational.get_document_by_checksum(ns.id, "abc123")
+        assert fetched is not None
+        assert fetched.id == doc.id
+
     async def test_get_document_stats(self, relational: SQLiteRelationalBackend):
         ns = _make_namespace()
         await relational.create_namespace(ns)

--- a/tests/unit/test_stage_documents_batch_dedupe.py
+++ b/tests/unit/test_stage_documents_batch_dedupe.py
@@ -163,3 +163,42 @@ class TestStageDocumentsBatchDedupe:
         assert storage.create_document.call_count == 1
         assert all(r is not None for r in results)
         assert all(r is results[0] for r in results)
+
+    @pytest.mark.asyncio
+    async def test_failed_doc_not_treated_as_duplicate(self) -> None:
+        """FAILED doc excluded by storage layer -> new doc created (DYT-2381).
+
+        The storage layer now filters out FAILED docs from checksum lookups,
+        so get_documents_by_checksums returns empty. stage_documents_batch
+        should then create a new document instead of skipping.
+        """
+        content = "previously failed"
+        storage = _make_storage()  # empty = simulates FAILED doc filtered out
+        inputs = [_doc_input(content)]
+
+        results = await stage_documents_batch(inputs, NAMESPACE_ID, storage)
+
+        assert len(results) == 1
+        assert results[0] is not None
+        assert storage.create_document.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_failed_and_completed_docs_mixed(self) -> None:
+        """COMPLETED doc skipped, FAILED doc (filtered out) gets re-created (DYT-2381).
+
+        - doc 0: checksum matches a COMPLETED doc in DB -> None (skipped)
+        - doc 1: checksum had a FAILED doc, storage filtered it out -> new doc created
+        """
+        completed_content = "completed doc"
+        completed_checksum = compute_checksum(completed_content)
+        failed_content = "previously failed doc"
+        # Storage returns only the COMPLETED doc; FAILED doc is filtered out
+        storage = _make_storage(existing_checksums=[completed_checksum])
+        inputs = [_doc_input(completed_content), _doc_input(failed_content)]
+
+        results = await stage_documents_batch(inputs, NAMESPACE_ID, storage)
+
+        assert len(results) == 2
+        assert results[0] is None  # COMPLETED doc skipped
+        assert results[1] is not None  # FAILED doc re-created
+        assert storage.create_document.call_count == 1


### PR DESCRIPTION
## Summary
- Dedup checksum lookups (`get_document_by_checksum`, `get_documents_by_checksums`) now exclude documents with `status=FAILED`, so re-ingesting content that previously failed creates a fresh document instead of being silently skipped
- Fix applied to all 3 storage backends: PostgreSQL (SQLAlchemy enum filter), SurrealDB (SurrealQL `AND status != 'failed'`), SQLite (SQL `AND status != 'failed'`)
- Existing COMPLETED document dedup behavior is unchanged — only FAILED is excluded

## Test plan
- [x] Unit tests: `test_failed_doc_not_treated_as_duplicate` — verifies batch path creates new doc when FAILED is filtered out
- [x] Unit tests: `test_failed_and_completed_docs_mixed` — verifies COMPLETED still deduped, FAILED re-created
- [x] Unit tests: `test_get_document_by_checksum_excludes_failed` — SQLite backend returns None for FAILED doc
- [x] Unit tests: `test_get_document_by_checksum_returns_completed` — SQLite backend still returns COMPLETED doc
- [x] All 2617 unit tests pass, coverage 53.28% (threshold 46%)