### PR TITLE
DYT-2428: Wire external_id through MemoryLake API and all engines

### DIFF
--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -339,7 +339,6 @@ class ChronicleEngine:
         expertise: ExpertiseConfig | None = None,
         extraction_config_hash: str | None = None,
         chunk_strategy: ChunkStrategy | None = None,
-        external_id: str | None = None,
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -359,7 +358,6 @@ class ChronicleEngine:
             expertise: Optional expertise config (ADR-022)
             extraction_config_hash: Optional hash for change detection
             chunk_strategy: Override chunking strategy for this call
-            external_id: Optional caller-supplied external identifier for the document.
 
         Returns:
             RememberResult with document_id and counts
@@ -406,7 +404,6 @@ class ChronicleEngine:
             content=content,
             metadata=doc_metadata,
             extraction_config_hash=extraction_config_hash,
-            external_id=external_id,
         )
         document = await storage.create_document(document)
         timings["document_create_ms"] = (time.perf_counter() - start) * 1000
@@ -1139,9 +1136,6 @@ class ChronicleEngine:
             }
             if extraction_config_hash is not None:
                 entry["extraction_config_hash"] = extraction_config_hash
-            ext_id = doc_data.get("external_id")
-            if ext_id is not None:
-                entry["external_id"] = ext_id
             doc_inputs.append(entry)
         timings["prepare_inputs_ms"] = (time.perf_counter() - start) * 1000
 

--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -339,6 +339,7 @@ class ChronicleEngine:
         expertise: ExpertiseConfig | None = None,
         extraction_config_hash: str | None = None,
         chunk_strategy: ChunkStrategy | None = None,
+        external_id: str | None = None,
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -358,6 +359,7 @@ class ChronicleEngine:
             expertise: Optional expertise config (ADR-022)
             extraction_config_hash: Optional hash for change detection
             chunk_strategy: Override chunking strategy for this call
+            external_id: Optional caller-supplied external identifier for the document.
 
         Returns:
             RememberResult with document_id and counts
@@ -404,6 +406,7 @@ class ChronicleEngine:
             content=content,
             metadata=doc_metadata,
             extraction_config_hash=extraction_config_hash,
+            external_id=external_id,
         )
         document = await storage.create_document(document)
         timings["document_create_ms"] = (time.perf_counter() - start) * 1000
@@ -1136,6 +1139,9 @@ class ChronicleEngine:
             }
             if extraction_config_hash is not None:
                 entry["extraction_config_hash"] = extraction_config_hash
+            ext_id = doc_data.get("external_id")
+            if ext_id is not None:
+                entry["external_id"] = ext_id
             doc_inputs.append(entry)
         timings["prepare_inputs_ms"] = (time.perf_counter() - start) * 1000
 

--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -339,6 +339,7 @@ class ChronicleEngine:
         expertise: ExpertiseConfig | None = None,
         extraction_config_hash: str | None = None,
         chunk_strategy: ChunkStrategy | None = None,
+        external_id: str | None = None,
     ) -> RememberResult:
         """Store content in the memory engine.
 

--- a/src/khora/engines/graphrag/engine.py
+++ b/src/khora/engines/graphrag/engine.py
@@ -215,6 +215,7 @@ class GraphRAGEngine:
         expertise: ExpertiseConfig | None = None,
         extraction_config_hash: str | None = None,
         chunk_strategy: ChunkStrategy | None = None,
+        external_id: str | None = None,
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -235,6 +236,7 @@ class GraphRAGEngine:
             chunk_strategy: Override chunking strategy for this call.
                 Valid values: "fixed", "semantic", "recursive", "conversation".
                 When None (default), uses the configured pipeline default.
+            external_id: Optional caller-supplied external identifier for the document.
 
         Returns:
             RememberResult with document_id, counts, and timing metrics in metadata.
@@ -284,6 +286,7 @@ class GraphRAGEngine:
             content=content,
             metadata=doc_metadata,
             extraction_config_hash=extraction_config_hash,
+            external_id=external_id,
         )
         document = await storage.create_document(document)
         timings["document_create_ms"] = (time.perf_counter() - start) * 1000
@@ -500,6 +503,9 @@ class GraphRAGEngine:
             }
             if extraction_config_hash is not None:
                 entry["extraction_config_hash"] = extraction_config_hash
+            ext_id = doc_data.get("external_id")
+            if ext_id is not None:
+                entry["external_id"] = ext_id
             doc_inputs.append(entry)
         timings["prepare_inputs_ms"] = (time.perf_counter() - start) * 1000
 

--- a/src/khora/engines/graphrag/engine.py
+++ b/src/khora/engines/graphrag/engine.py
@@ -215,6 +215,7 @@ class GraphRAGEngine:
         expertise: ExpertiseConfig | None = None,
         extraction_config_hash: str | None = None,
         chunk_strategy: ChunkStrategy | None = None,
+        external_id: str | None = None,
     ) -> RememberResult:
         """Store content in the memory engine.
 

--- a/src/khora/engines/graphrag/engine.py
+++ b/src/khora/engines/graphrag/engine.py
@@ -215,7 +215,6 @@ class GraphRAGEngine:
         expertise: ExpertiseConfig | None = None,
         extraction_config_hash: str | None = None,
         chunk_strategy: ChunkStrategy | None = None,
-        external_id: str | None = None,
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -236,7 +235,6 @@ class GraphRAGEngine:
             chunk_strategy: Override chunking strategy for this call.
                 Valid values: "fixed", "semantic", "recursive", "conversation".
                 When None (default), uses the configured pipeline default.
-            external_id: Optional caller-supplied external identifier for the document.
 
         Returns:
             RememberResult with document_id, counts, and timing metrics in metadata.
@@ -286,7 +284,6 @@ class GraphRAGEngine:
             content=content,
             metadata=doc_metadata,
             extraction_config_hash=extraction_config_hash,
-            external_id=external_id,
         )
         document = await storage.create_document(document)
         timings["document_create_ms"] = (time.perf_counter() - start) * 1000
@@ -503,9 +500,6 @@ class GraphRAGEngine:
             }
             if extraction_config_hash is not None:
                 entry["extraction_config_hash"] = extraction_config_hash
-            ext_id = doc_data.get("external_id")
-            if ext_id is not None:
-                entry["external_id"] = ext_id
             doc_inputs.append(entry)
         timings["prepare_inputs_ms"] = (time.perf_counter() - start) * 1000
 

--- a/src/khora/engines/protocol.py
+++ b/src/khora/engines/protocol.py
@@ -80,6 +80,8 @@ class MemoryEngineProtocol(Protocol):
                 Valid values: "fixed", "semantic", "recursive", "conversation".
                 When None (default), uses the configured pipeline default.
             external_id: Optional caller-supplied external identifier for the document.
+                Must be None or a non-blank string (max 512 chars).
+                Raises ValueError if constraints are violated.
 
         Returns:
             RememberResult with details
@@ -152,7 +154,8 @@ class MemoryEngineProtocol(Protocol):
         """Store multiple documents with automatic optimization.
 
         Args:
-            documents: List of document dicts with keys: content, title, source, metadata
+            documents: List of document dicts with keys: content, title, source, metadata,
+                external_id (optional caller-supplied external identifier)
             namespace_id: Target namespace UUID
             skill_name: Extraction skill to use
             max_concurrent: Maximum concurrent document processing

--- a/src/khora/engines/protocol.py
+++ b/src/khora/engines/protocol.py
@@ -61,6 +61,7 @@ class MemoryEngineProtocol(Protocol):
         expertise: ExpertiseConfig | None = None,
         extraction_config_hash: str | None = None,
         chunk_strategy: ChunkStrategy | None = None,
+        external_id: str | None = None,
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -78,6 +79,7 @@ class MemoryEngineProtocol(Protocol):
             chunk_strategy: Override chunking strategy for this call only.
                 Valid values: "fixed", "semantic", "recursive", "conversation".
                 When None (default), uses the configured pipeline default.
+            external_id: Optional caller-supplied external identifier for the document.
 
         Returns:
             RememberResult with details

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -207,6 +207,7 @@ class SkeletonConstructionEngine:
         expertise: ExpertiseConfig | None = None,
         extraction_config_hash: str | None = None,
         chunk_strategy: ChunkStrategy | None = None,
+        external_id: str | None = None,
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -221,6 +222,7 @@ class SkeletonConstructionEngine:
             chunk_strategy: Override chunking strategy for this call.
                 Valid values: "fixed", "semantic", "recursive", "conversation".
                 When None (default), uses the configured pipeline default.
+            external_id: Optional caller-supplied external identifier for the document.
 
         Returns:
             RememberResult with document_id and counts
@@ -257,6 +259,7 @@ class SkeletonConstructionEngine:
             content=content,
             metadata=doc_metadata,
             extraction_config_hash=extraction_config_hash,
+            external_id=external_id,
         )
         document = await storage.create_document(document)
 
@@ -762,6 +765,7 @@ class SkeletonConstructionEngine:
                     content=content,
                     metadata=doc_meta,
                     extraction_config_hash=extraction_config_hash,
+                    external_id=doc_data.get("external_id"),
                 )
                 try:
                     document = await storage.create_document(document)

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -207,7 +207,6 @@ class SkeletonConstructionEngine:
         expertise: ExpertiseConfig | None = None,
         extraction_config_hash: str | None = None,
         chunk_strategy: ChunkStrategy | None = None,
-        external_id: str | None = None,
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -222,7 +221,6 @@ class SkeletonConstructionEngine:
             chunk_strategy: Override chunking strategy for this call.
                 Valid values: "fixed", "semantic", "recursive", "conversation".
                 When None (default), uses the configured pipeline default.
-            external_id: Optional caller-supplied external identifier for the document.
 
         Returns:
             RememberResult with document_id and counts
@@ -259,7 +257,6 @@ class SkeletonConstructionEngine:
             content=content,
             metadata=doc_metadata,
             extraction_config_hash=extraction_config_hash,
-            external_id=external_id,
         )
         document = await storage.create_document(document)
 
@@ -765,7 +762,6 @@ class SkeletonConstructionEngine:
                     content=content,
                     metadata=doc_meta,
                     extraction_config_hash=extraction_config_hash,
-                    external_id=doc_data.get("external_id"),
                 )
                 try:
                     document = await storage.create_document(document)

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -207,6 +207,7 @@ class SkeletonConstructionEngine:
         expertise: ExpertiseConfig | None = None,
         extraction_config_hash: str | None = None,
         chunk_strategy: ChunkStrategy | None = None,
+        external_id: str | None = None,
     ) -> RememberResult:
         """Store content in the memory engine.
 

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -548,6 +548,7 @@ class VectorCypherEngine:
         relationship_types: list[str],
         extraction_config_hash: str | None = None,
         chunk_strategy: ChunkStrategy | None = None,
+        external_id: str | None = None,
     ) -> RememberResult:
         """Store content in the memory engine.
 
@@ -564,6 +565,7 @@ class VectorCypherEngine:
             chunk_strategy: Override chunking strategy for this call.
                 Valid values: "fixed", "semantic", "recursive", "conversation".
                 When None (default), uses the configured pipeline default.
+            external_id: Optional caller-supplied external identifier for the document.
 
         Returns:
             RememberResult with document_id and counts
@@ -598,6 +600,7 @@ class VectorCypherEngine:
             content=content,
             metadata=doc_metadata,
             extraction_config_hash=extraction_config_hash,
+            external_id=external_id,
         )
         document = await storage.create_document(document)
 
@@ -1611,6 +1614,7 @@ class VectorCypherEngine:
                             custom=doc_metadata,
                         ),
                         extraction_config_hash=extraction_config_hash,
+                        external_id=doc_data.get("external_id"),
                     )
                     document = await storage.create_document(document)
                     state.document = document

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -372,6 +372,7 @@ class MemoryLake:
         expertise: ExpertiseConfig | None = None,
         extraction_config_hash: str | None = None,
         chunk_strategy: ChunkStrategy | None = None,
+        external_id: str | None = None,
     ) -> RememberResult:
         """Store content in the memory lake.
 
@@ -395,6 +396,7 @@ class MemoryLake:
             chunk_strategy: Override chunking strategy for this call only.
                 Valid values: "fixed", "semantic", "recursive", "conversation".
                 When None (default), uses the configured pipeline default.
+            external_id: Optional caller-supplied external identifier for the document.
 
         Returns:
             RememberResult with details
@@ -426,6 +428,7 @@ class MemoryLake:
                     expertise=expertise,
                     extraction_config_hash=extraction_config_hash,
                     chunk_strategy=chunk_strategy,
+                    external_id=external_id,
                 )
                 return replace(result, llm_usage=collect_usage())
         finally:
@@ -468,6 +471,7 @@ class MemoryLake:
                 - title: str (optional)
                 - source: str (optional)
                 - metadata: dict (optional)
+                - external_id: str (optional) — caller-supplied external identifier
             namespace: Namespace UUID (as UUID or string)
             skill_name: Extraction skill to use
             max_concurrent: Maximum concurrent document processing

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -397,6 +397,8 @@ class MemoryLake:
                 Valid values: "fixed", "semantic", "recursive", "conversation".
                 When None (default), uses the configured pipeline default.
             external_id: Optional caller-supplied external identifier for the document.
+                Must be None or a non-blank string (max 512 chars).
+                Raises ValueError if constraints are violated.
 
         Returns:
             RememberResult with details
@@ -416,9 +418,7 @@ class MemoryLake:
                 # NOTE: expertise and extraction_config_hash are always forwarded,
                 # even when None. Custom engines registered via register_engine()
                 # must accept these kwargs to remain compatible (ADR-022).
-                result = await self._get_engine().remember(
-                    content,
-                    namespace_id,
+                remember_kwargs: dict[str, Any] = dict(
                     title=title,
                     source=source,
                     metadata=metadata,
@@ -428,7 +428,13 @@ class MemoryLake:
                     expertise=expertise,
                     extraction_config_hash=extraction_config_hash,
                     chunk_strategy=chunk_strategy,
-                    external_id=external_id,
+                )
+                if external_id is not None:
+                    remember_kwargs["external_id"] = external_id
+                result = await self._get_engine().remember(
+                    content,
+                    namespace_id,
+                    **remember_kwargs,
                 )
                 return replace(result, llm_usage=collect_usage())
         finally:

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -418,7 +418,9 @@ class MemoryLake:
                 # NOTE: expertise and extraction_config_hash are always forwarded,
                 # even when None. Custom engines registered via register_engine()
                 # must accept these kwargs to remain compatible (ADR-022).
-                remember_kwargs: dict[str, Any] = dict(
+                result = await self._get_engine().remember(
+                    content,
+                    namespace_id,
                     title=title,
                     source=source,
                     metadata=metadata,
@@ -428,13 +430,7 @@ class MemoryLake:
                     expertise=expertise,
                     extraction_config_hash=extraction_config_hash,
                     chunk_strategy=chunk_strategy,
-                )
-                if external_id is not None:
-                    remember_kwargs["external_id"] = external_id
-                result = await self._get_engine().remember(
-                    content,
-                    namespace_id,
-                    **remember_kwargs,
+                    external_id=external_id,
                 )
                 return replace(result, llm_usage=collect_usage())
         finally:

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -618,6 +618,7 @@ async def stage_document(
         namespace_id=namespace_id,
         content=content,
         metadata=metadata,
+        external_id=doc_input.get("external_id"),
         created_at=created_at,
         updated_at=created_at,  # Set updated_at to source time too
         source_timestamp=source_timestamp,
@@ -696,6 +697,7 @@ async def stage_documents_batch(
             content=content,
             metadata=metadata,
             extraction_config_hash=doc_input.get("extraction_config_hash"),
+            external_id=doc_input.get("external_id"),
             created_at=created_at,
             updated_at=created_at,
             source_timestamp=source_timestamp,
@@ -766,6 +768,7 @@ async def _stage_all_documents(
             content=content,
             metadata=metadata,
             extraction_config_hash=doc_input.get("extraction_config_hash"),
+            external_id=doc_input.get("external_id"),
             created_at=created_at,
             updated_at=created_at,
             source_timestamp=source_timestamp,

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -618,7 +618,6 @@ async def stage_document(
         namespace_id=namespace_id,
         content=content,
         metadata=metadata,
-        external_id=doc_input.get("external_id"),
         created_at=created_at,
         updated_at=created_at,  # Set updated_at to source time too
         source_timestamp=source_timestamp,
@@ -697,7 +696,6 @@ async def stage_documents_batch(
             content=content,
             metadata=metadata,
             extraction_config_hash=doc_input.get("extraction_config_hash"),
-            external_id=doc_input.get("external_id"),
             created_at=created_at,
             updated_at=created_at,
             source_timestamp=source_timestamp,
@@ -768,7 +766,6 @@ async def _stage_all_documents(
             content=content,
             metadata=metadata,
             extraction_config_hash=doc_input.get("extraction_config_hash"),
-            external_id=doc_input.get("external_id"),
             created_at=created_at,
             updated_at=created_at,
             source_timestamp=source_timestamp,

--- a/tests/unit/test_external_id_passthrough.py
+++ b/tests/unit/test_external_id_passthrough.py
@@ -75,7 +75,7 @@ class TestRememberWithExternalId:
 
         assert result == mock_result
         call_kwargs = lake._engine.remember.call_args.kwargs
-        assert "external_id" not in call_kwargs
+        assert call_kwargs["external_id"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_external_id_passthrough.py
+++ b/tests/unit/test_external_id_passthrough.py
@@ -1,0 +1,219 @@
+"""Unit tests for DYT-2428: external_id pass-through.
+
+Tests the full chain from MemoryLake → Engine for the external_id parameter.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from khora.memory_lake import BatchResult, RememberResult
+
+from .helpers import RESOLVE_ROW_ID, make_lake
+
+# ---------------------------------------------------------------------------
+# 1. MemoryLake.remember() with external_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRememberWithExternalId:
+    """DYT-2428: remember() accepts and forwards external_id."""
+
+    @pytest.mark.asyncio
+    async def test_remember_passes_external_id_to_engine(self) -> None:
+        """external_id param is forwarded to the engine."""
+        lake = make_lake(connected=True)
+        ns_id = uuid4()
+
+        mock_result = RememberResult(
+            document_id=uuid4(),
+            namespace_id=RESOLVE_ROW_ID,
+            chunks_created=3,
+            entities_extracted=2,
+            relationships_created=1,
+        )
+        lake._engine.remember = AsyncMock(return_value=mock_result)
+
+        result = await lake.remember(
+            "Alice works for Acme Corp",
+            namespace=ns_id,
+            entity_types=["PERSON", "COMPANY"],
+            relationship_types=["WORKS_FOR"],
+            external_id="ext-123",
+        )
+
+        assert result == mock_result
+        call_kwargs = lake._engine.remember.call_args.kwargs
+        assert call_kwargs["external_id"] == "ext-123"
+
+    @pytest.mark.asyncio
+    async def test_remember_without_external_id_backward_compat(self) -> None:
+        """Calling without external_id omits it from engine kwargs (backward compat)."""
+        lake = make_lake(connected=True)
+        ns_id = uuid4()
+
+        mock_result = RememberResult(
+            document_id=uuid4(),
+            namespace_id=RESOLVE_ROW_ID,
+            chunks_created=1,
+            entities_extracted=0,
+            relationships_created=0,
+        )
+        lake._engine.remember = AsyncMock(return_value=mock_result)
+
+        result = await lake.remember(
+            "test content",
+            namespace=ns_id,
+            entity_types=["PERSON"],
+            relationship_types=["KNOWS"],
+        )
+
+        assert result == mock_result
+        call_kwargs = lake._engine.remember.call_args.kwargs
+        assert "external_id" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# 2. MemoryLake.remember_batch() with external_id in doc dicts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRememberBatchWithExternalId:
+    """DYT-2428: remember_batch() passes doc dicts through (including external_id)."""
+
+    @pytest.mark.asyncio
+    async def test_remember_batch_passes_docs_with_external_id(self) -> None:
+        """Doc dicts with external_id are forwarded unchanged to the engine."""
+        lake = make_lake(connected=True)
+        ns_id = uuid4()
+
+        mock_result = BatchResult(
+            total=2,
+            processed=2,
+            skipped=0,
+            failed=0,
+            chunks=4,
+            entities=2,
+            relationships=1,
+        )
+        lake._engine.remember_batch = AsyncMock(return_value=mock_result)
+
+        docs = [
+            {"content": "Alice works for Acme", "external_id": "ext-1"},
+            {"content": "Bob works for Globex", "external_id": "ext-2"},
+        ]
+
+        result = await lake.remember_batch(
+            docs,
+            namespace=ns_id,
+            entity_types=["PERSON", "COMPANY"],
+            relationship_types=["WORKS_FOR"],
+        )
+
+        assert result == mock_result
+        call_args = lake._engine.remember_batch.call_args
+        passed_docs = call_args.args[0]
+        assert passed_docs[0]["external_id"] == "ext-1"
+        assert passed_docs[1]["external_id"] == "ext-2"
+
+    @pytest.mark.asyncio
+    async def test_remember_batch_mixed_docs(self) -> None:
+        """Batch with some docs having external_id and some without."""
+        lake = make_lake(connected=True)
+        ns_id = uuid4()
+
+        mock_result = BatchResult(
+            total=2,
+            processed=2,
+            skipped=0,
+            failed=0,
+            chunks=4,
+            entities=2,
+            relationships=1,
+        )
+        lake._engine.remember_batch = AsyncMock(return_value=mock_result)
+
+        docs = [
+            {"content": "Alice works for Acme", "external_id": "ext-1"},
+            {"content": "Bob works for Globex"},
+        ]
+
+        result = await lake.remember_batch(
+            docs,
+            namespace=ns_id,
+            entity_types=["PERSON", "COMPANY"],
+            relationship_types=["WORKS_FOR"],
+        )
+
+        assert result == mock_result
+        call_args = lake._engine.remember_batch.call_args
+        passed_docs = call_args.args[0]
+        assert passed_docs[0]["external_id"] == "ext-1"
+        assert "external_id" not in passed_docs[1]
+
+
+# ---------------------------------------------------------------------------
+# 3. Protocol and engine signature verification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExternalIdSignatures:
+    """Verify external_id exists in protocol and engine signatures."""
+
+    def test_protocol_remember_has_external_id(self) -> None:
+        """MemoryEngineProtocol.remember includes external_id parameter."""
+        from khora.engines.protocol import MemoryEngineProtocol
+
+        sig = inspect.signature(MemoryEngineProtocol.remember)
+        assert "external_id" in sig.parameters
+        param = sig.parameters["external_id"]
+        assert param.default is None
+
+    def test_vectorcypher_remember_has_external_id(self) -> None:
+        """VectorCypherEngine.remember includes external_id parameter."""
+        from khora.engines.vectorcypher.engine import VectorCypherEngine
+
+        sig = inspect.signature(VectorCypherEngine.remember)
+        assert "external_id" in sig.parameters
+        param = sig.parameters["external_id"]
+        assert param.default is None
+
+    def test_memory_lake_remember_has_external_id(self) -> None:
+        """MemoryLake.remember includes external_id parameter."""
+        from khora.memory_lake import MemoryLake
+
+        sig = inspect.signature(MemoryLake.remember)
+        assert "external_id" in sig.parameters
+        param = sig.parameters["external_id"]
+        assert param.default is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Domain model accepts external_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDocumentModelExternalId:
+    """DYT-2428: Document domain model supports external_id."""
+
+    def test_document_accepts_external_id(self) -> None:
+        """Document can be constructed with external_id."""
+        from khora.core.models.document import Document
+
+        doc = Document(content="test", external_id="ext-abc")
+        assert doc.external_id == "ext-abc"
+
+    def test_document_external_id_defaults_to_none(self) -> None:
+        """Document external_id defaults to None for backward compatibility."""
+        from khora.core.models.document import Document
+
+        doc = Document(content="test")
+        assert doc.external_id is None

--- a/tests/unit/test_memory_lake.py
+++ b/tests/unit/test_memory_lake.py
@@ -290,10 +290,150 @@ class TestRemember:
         assert result.llm_usage == []
         lake._engine.remember.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_remember_passes_external_id(self) -> None:
+        """remember() passes external_id through to engine.remember()."""
+        lake = _make_lake(connected=True)
+        ns_id = uuid4()
+
+        mock_result = RememberResult(
+            document_id=uuid4(),
+            namespace_id=ns_id,
+            chunks_created=1,
+            entities_extracted=0,
+            relationships_created=0,
+        )
+        lake._engine.remember = AsyncMock(return_value=mock_result)
+
+        with (
+            patch("khora.telemetry.context.ensure_trace_id"),
+            patch("khora.telemetry.context.clear_trace_id"),
+        ):
+            await lake.remember(
+                "test content",
+                namespace=ns_id,
+                entity_types=["PERSON"],
+                relationship_types=["KNOWS"],
+                external_id="test-123",
+            )
+
+        call_kwargs = lake._engine.remember.call_args.kwargs
+        assert call_kwargs["external_id"] == "test-123"
+
+    @pytest.mark.asyncio
+    async def test_remember_without_external_id(self) -> None:
+        """remember() without external_id passes None (backward compat)."""
+        lake = _make_lake(connected=True)
+        ns_id = uuid4()
+
+        mock_result = RememberResult(
+            document_id=uuid4(),
+            namespace_id=ns_id,
+            chunks_created=1,
+            entities_extracted=0,
+            relationships_created=0,
+        )
+        lake._engine.remember = AsyncMock(return_value=mock_result)
+
+        with (
+            patch("khora.telemetry.context.ensure_trace_id"),
+            patch("khora.telemetry.context.clear_trace_id"),
+        ):
+            await lake.remember(
+                "test content",
+                namespace=ns_id,
+                entity_types=["PERSON"],
+                relationship_types=["KNOWS"],
+            )
+
+        call_kwargs = lake._engine.remember.call_args.kwargs
+        assert call_kwargs["external_id"] is None
+
 
 # ---------------------------------------------------------------------------
 # remember_batch
 # ---------------------------------------------------------------------------
+
+
+class TestRememberBatchExternalId:
+    """Tests for external_id pass-through in remember_batch()."""
+
+    @pytest.mark.asyncio
+    async def test_remember_batch_passes_external_id_in_doc_dicts(self) -> None:
+        """remember_batch() forwards doc dicts containing external_id to engine."""
+        lake = _make_lake(connected=True)
+        ns_id = uuid4()
+
+        lake._engine.remember_batch = AsyncMock(
+            return_value=BatchResult(
+                total=1,
+                processed=1,
+                skipped=0,
+                failed=0,
+                chunks=2,
+                entities=1,
+                relationships=0,
+            )
+        )
+
+        docs = [{"content": "doc one", "external_id": "ext-abc"}]
+
+        with (
+            patch("khora.telemetry.context.ensure_trace_id"),
+            patch("khora.telemetry.context.clear_trace_id"),
+        ):
+            await lake.remember_batch(
+                docs,
+                namespace=ns_id,
+                entity_types=["PERSON"],
+                relationship_types=["KNOWS"],
+            )
+
+        # The doc dicts are passed as the first positional arg to engine.remember_batch
+        call_args = lake._engine.remember_batch.call_args
+        passed_docs = call_args.args[0]
+        assert passed_docs[0]["external_id"] == "ext-abc"
+
+    @pytest.mark.asyncio
+    async def test_remember_batch_mixed_external_ids(self) -> None:
+        """remember_batch() with mixed docs (some with external_id, some without)."""
+        lake = _make_lake(connected=True)
+        ns_id = uuid4()
+
+        lake._engine.remember_batch = AsyncMock(
+            return_value=BatchResult(
+                total=3,
+                processed=3,
+                skipped=0,
+                failed=0,
+                chunks=6,
+                entities=3,
+                relationships=1,
+            )
+        )
+
+        docs = [
+            {"content": "doc one", "external_id": "ext-1"},
+            {"content": "doc two"},
+            {"content": "doc three", "external_id": "ext-3"},
+        ]
+
+        with (
+            patch("khora.telemetry.context.ensure_trace_id"),
+            patch("khora.telemetry.context.clear_trace_id"),
+        ):
+            await lake.remember_batch(
+                docs,
+                namespace=ns_id,
+                entity_types=["PERSON"],
+                relationship_types=["KNOWS"],
+            )
+
+        call_args = lake._engine.remember_batch.call_args
+        passed_docs = call_args.args[0]
+        assert passed_docs[0]["external_id"] == "ext-1"
+        assert "external_id" not in passed_docs[1]
+        assert passed_docs[2]["external_id"] == "ext-3"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_memory_lake.py
+++ b/tests/unit/test_memory_lake.py
@@ -322,7 +322,7 @@ class TestRemember:
 
     @pytest.mark.asyncio
     async def test_remember_without_external_id(self) -> None:
-        """remember() without external_id omits it from engine kwargs (backward compat)."""
+        """remember() without external_id passes None (backward compat)."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
 
@@ -347,7 +347,7 @@ class TestRemember:
             )
 
         call_kwargs = lake._engine.remember.call_args.kwargs
-        assert "external_id" not in call_kwargs
+        assert call_kwargs["external_id"] is None
 
     @pytest.mark.asyncio
     async def test_remember_passes_special_char_external_id(self) -> None:

--- a/tests/unit/test_memory_lake.py
+++ b/tests/unit/test_memory_lake.py
@@ -322,7 +322,7 @@ class TestRemember:
 
     @pytest.mark.asyncio
     async def test_remember_without_external_id(self) -> None:
-        """remember() without external_id passes None (backward compat)."""
+        """remember() without external_id omits it from engine kwargs (backward compat)."""
         lake = _make_lake(connected=True)
         ns_id = uuid4()
 
@@ -347,7 +347,78 @@ class TestRemember:
             )
 
         call_kwargs = lake._engine.remember.call_args.kwargs
-        assert call_kwargs["external_id"] is None
+        assert "external_id" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_remember_passes_special_char_external_id(self) -> None:
+        """remember() passes external_id with special characters through unchanged."""
+        lake = _make_lake(connected=True)
+        ns_id = uuid4()
+
+        mock_result = RememberResult(
+            document_id=uuid4(),
+            namespace_id=ns_id,
+            chunks_created=1,
+            entities_extracted=0,
+            relationships_created=0,
+        )
+        lake._engine.remember = AsyncMock(return_value=mock_result)
+
+        special_id = "org/repo#123 — «test» 'quotes' & unicode: café ñ 日本語"
+
+        with (
+            patch("khora.telemetry.context.ensure_trace_id"),
+            patch("khora.telemetry.context.clear_trace_id"),
+        ):
+            await lake.remember(
+                "test content",
+                namespace=ns_id,
+                entity_types=["PERSON"],
+                relationship_types=["KNOWS"],
+                external_id=special_id,
+            )
+
+        call_kwargs = lake._engine.remember.call_args.kwargs
+        assert call_kwargs["external_id"] == special_id
+
+
+class TestExternalIdValidation:
+    """Tests for Document-level external_id validation."""
+
+    def test_blank_external_id_rejected(self) -> None:
+        """Document rejects blank external_id."""
+        from khora.core.models import Document
+
+        with pytest.raises(ValueError, match="non-blank"):
+            Document(external_id="")
+
+    def test_whitespace_only_external_id_rejected(self) -> None:
+        """Document rejects whitespace-only external_id."""
+        from khora.core.models import Document
+
+        with pytest.raises(ValueError, match="non-blank"):
+            Document(external_id="   ")
+
+    def test_oversized_external_id_rejected(self) -> None:
+        """Document rejects external_id exceeding 512 chars."""
+        from khora.core.models import Document
+
+        with pytest.raises(ValueError, match="at most 512"):
+            Document(external_id="x" * 513)
+
+    def test_max_length_external_id_accepted(self) -> None:
+        """Document accepts external_id at exactly 512 chars."""
+        from khora.core.models import Document
+
+        doc = Document(external_id="x" * 512)
+        assert doc.external_id == "x" * 512
+
+    def test_none_external_id_accepted(self) -> None:
+        """Document accepts None external_id (default)."""
+        from khora.core.models import Document
+
+        doc = Document()
+        assert doc.external_id is None
 
 
 # ---------------------------------------------------------------------------
@@ -389,8 +460,9 @@ class TestRememberBatchExternalId:
                 relationship_types=["KNOWS"],
             )
 
-        # The doc dicts are passed as the first positional arg to engine.remember_batch
+        # Doc dicts are the first positional arg to engine.remember_batch
         call_args = lake._engine.remember_batch.call_args
+        assert call_args.args, "remember_batch should receive doc list as positional arg"
         passed_docs = call_args.args[0]
         assert passed_docs[0]["external_id"] == "ext-abc"
 
@@ -430,6 +502,7 @@ class TestRememberBatchExternalId:
             )
 
         call_args = lake._engine.remember_batch.call_args
+        assert call_args.args, "remember_batch should receive doc list as positional arg"
         passed_docs = call_args.args[0]
         assert passed_docs[0]["external_id"] == "ext-1"
         assert "external_id" not in passed_docs[1]


### PR DESCRIPTION
## Summary
- Add `external_id: str | None = None` parameter to `MemoryLake.remember()` and forward it through the engine stack
- Update `MemoryEngineProtocol.remember()` signature with `external_id`
- Wire `external_id` through all 4 engines (vectorcypher, skeleton, graphrag, chronicle) in both `remember()` and batch paths
- Wire `external_id` through the shared ingest pipeline (`pipelines/flows/ingest.py`)
- `remember_batch()` reads `external_id` per-document from doc dicts — no signature change needed
- Add unit tests verifying round-trip for `remember()` and `remember_batch()` with and without `external_id`

Part of [ADR-050: Khora Document Identity Primitive](https://github.com/DeytaHQ/hegemon/blob/main/architecture/decisions/050-khora-document-identity-primitive.md). Depends on DYT-2427 (merged).

Linear: https://linear.app/deyta/issue/DYT-2428

## Test plan
- [x] `make format` passes (ruff format + ruff check)
- [x] `make test` passes (2707 passed, 5 skipped, coverage 53.72% ≥ 46% threshold)
- [x] `remember()` with `external_id="test-123"` stores value on Document
- [x] `remember_batch()` with mixed docs (some with external_id, some without) stores correctly per-doc
- [x] `remember()` without `external_id` works unchanged (backward compat)
- [x] All existing tests pass unchanged