### PR TITLE
DYT-2497: Graceful degradation in VectorCypher retriever when Neo4j is unavailable

### DIFF
--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -615,7 +615,7 @@ class VectorCypherRetriever:
             expanded_entities = {}
             entity_info_map = {}
             graph_fallback = True
-            graph_error_msg = f"{type(exc).__name__}: {str(exc)[:200]}"
+            graph_error_msg = type(exc).__name__
 
         # Step 4b: Bi-temporal version filtering
         # For EXPLICIT temporal queries with a parsed date, narrow entities to
@@ -934,7 +934,9 @@ class VectorCypherRetriever:
         entity_ids_str = [str(eid) for eid, _ in all_entity_scores]
 
         # Start relationship fetch immediately (doesn't need full Entity objects)
-        if self._dual_nodes is not None:
+        # Skip Neo4j relationship fetch when graph is unavailable to avoid
+        # blocking on a second timeout.
+        if self._dual_nodes is not None and not graph_fallback:
             rels_task = asyncio.create_task(
                 self._dual_nodes.get_relationships_between(
                     entity_ids_str,
@@ -1120,6 +1122,7 @@ class VectorCypherRetriever:
         # Update metadata to indicate fallback was used
         result.metadata["fallback_mode"] = "vector_only"
         result.metadata["graph_unavailable"] = True
+        result.metadata["graph_fallback"] = True
 
         return result
 

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -24,7 +24,17 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from loguru import logger
-from neo4j.exceptions import Neo4jError
+from neo4j.exceptions import (
+    ServiceUnavailable,
+    SessionExpired,
+    TransientError,
+)
+
+try:
+    from neo4j.exceptions import ConnectionAcquisitionTimeoutError, ConnectionPoolError
+except ImportError:
+    ConnectionAcquisitionTimeoutError = ServiceUnavailable  # type: ignore[misc,assignment]
+    ConnectionPoolError = ServiceUnavailable  # type: ignore[misc,assignment]
 
 from khora.core.models import Chunk, ChunkMetadata, Entity, Relationship
 from khora.telemetry import trace_span
@@ -54,6 +64,16 @@ if TYPE_CHECKING:
     from khora.extraction.embedders import EmbedderProtocol  # type: ignore[unresolved-import]
     from khora.query.reranking import CrossEncoderReranker, LLMReranker
     from khora.storage import StorageCoordinator
+
+# Transient Neo4j errors that trigger graceful degradation rather than
+# failing the entire request. Excludes ClientError (query bugs) and
+# generic Neo4jError.
+_NEO4J_TRANSIENT_ERRORS: tuple[type[Exception], ...] = (
+    ServiceUnavailable,
+    ConnectionPoolError,
+    SessionExpired,
+    TransientError,
+)
 
 
 @dataclass
@@ -331,7 +351,7 @@ class VectorCypherRetriever:
                         temporal_params=params,
                         temporal_signal=temporal_signal,
                     )
-                except Neo4jError as e:
+                except _NEO4J_TRANSIENT_ERRORS as e:
                     logger.warning(f"Graph search failed, falling back to vector-only: {e}")
                     result = await self._vector_only_fallback(
                         query=query,
@@ -578,12 +598,24 @@ class VectorCypherRetriever:
         # Step 4: Cypher expand to find related entities
         # For temporal queries (STATE_QUERY/RECENCY/CHANGE), prefer currently-valid
         # entities by filtering out those whose valid_until has passed.
-        expanded_entities, entity_info_map = await self._cypher_expand(
-            entry_entity_ids=[e[0] for e in entry_entities],
-            namespace_id=namespace_id,
-            depth=depth,
-            prefer_current=_tp.temporal_sort,
-        )
+        graph_fallback = False
+        graph_error_msg: str | None = None
+        try:
+            expanded_entities, entity_info_map = await self._cypher_expand(
+                entry_entity_ids=[e[0] for e in entry_entities],
+                namespace_id=namespace_id,
+                depth=depth,
+                prefer_current=_tp.temporal_sort,
+            )
+        except _NEO4J_TRANSIENT_ERRORS as exc:
+            logger.warning(
+                f"Neo4j unavailable during cypher_expand for namespace={namespace_id}, "
+                f"falling back to vector-only results: {type(exc).__name__}: {exc}"
+            )
+            expanded_entities = {}
+            entity_info_map = {}
+            graph_fallback = True
+            graph_error_msg = f"{type(exc).__name__}: {str(exc)[:200]}"
 
         # Step 4b: Bi-temporal version filtering
         # For EXPLICIT temporal queries with a parsed date, narrow entities to
@@ -598,29 +630,47 @@ class VectorCypherRetriever:
                 target_date = getattr(tf, "occurred_before", None) or getattr(tf, "occurred_after", None)
                 if target_date is not None:
                     with trace_span("khora.vectorcypher.version_filter", target_date=target_date.isoformat()):
-                        all_entity_ids = await self._version_filter_entities(
-                            entity_ids=all_entity_ids,
-                            namespace_id=namespace_id,
-                            target_date=target_date,
-                        )
+                        try:
+                            all_entity_ids = await self._version_filter_entities(
+                                entity_ids=all_entity_ids,
+                                namespace_id=namespace_id,
+                                target_date=target_date,
+                            )
+                        except _NEO4J_TRANSIENT_ERRORS as exc:
+                            logger.warning(
+                                f"Version filter failed for namespace={namespace_id}, "
+                                f"skipping: {type(exc).__name__}: {exc}"
+                            )
 
             elif temporal_signal.category == TemporalCategory.CHANGE:
                 # For CHANGE queries, fetch version history via SUPERSEDES edges
                 with trace_span("khora.vectorcypher.version_history", entity_count=len(all_entity_ids)):
-                    version_history = await self._fetch_version_history(
-                        entity_ids=all_entity_ids,
-                        namespace_id=namespace_id,
-                    )
+                    try:
+                        version_history = await self._fetch_version_history(
+                            entity_ids=all_entity_ids,
+                            namespace_id=namespace_id,
+                        )
+                    except _NEO4J_TRANSIENT_ERRORS as exc:
+                        logger.warning(
+                            f"Version history fetch failed for namespace={namespace_id}, "
+                            f"skipping: {type(exc).__name__}: {exc}"
+                        )
+                        version_history = None
 
         # Step 5: Fetch chunks from all entities
-        graph_chunks = await self._fetch_chunks_from_entities(
-            entity_ids=all_entity_ids,
-            namespace_id=namespace_id,
-            temporal_filter=temporal_filter,
-            limit=limit * 2,  # Fetch more for fusion
-            temporal_sort=_tp.temporal_sort,
-            prefer_current=_tp.temporal_sort,
-        )
+        # Skip when graph is unavailable — _fetch_chunks_from_entities uses
+        # Neo4j via DualNodeManager and would fail with the same error.
+        if graph_fallback:
+            graph_chunks: list[tuple[UUID, float, Chunk]] = []
+        else:
+            graph_chunks = await self._fetch_chunks_from_entities(
+                entity_ids=all_entity_ids,
+                namespace_id=namespace_id,
+                temporal_filter=temporal_filter,
+                limit=limit * 2,  # Fetch more for fusion
+                temporal_sort=_tp.temporal_sort,
+                prefer_current=_tp.temporal_sort,
+            )
 
         # Step 6: Wait for parallel vector chunk search to complete
         # This was started at the beginning and may already be done.
@@ -1025,6 +1075,8 @@ class VectorCypherRetriever:
                 "version_history": version_history,
                 # Search provenance: which method(s) found each chunk
                 "search_methods": search_methods,
+                "graph_fallback": graph_fallback,
+                **({"graph_error": graph_error_msg} if graph_error_msg else {}),
             },
         )
 

--- a/tests/unit/engines/test_vectorcypher_retriever.py
+++ b/tests/unit/engines/test_vectorcypher_retriever.py
@@ -715,9 +715,11 @@ class TestGracefulDegradation:
 
         assert isinstance(result, VectorCypherResult)
         assert result.metadata["graph_fallback"] is True
-        assert "ConnectionAcquisitionTimeoutError" in result.metadata.get(
-            "graph_error", ""
-        ) or "ServiceUnavailable" in result.metadata.get("graph_error", "")
+        # graph_error contains the exception type name
+        assert result.metadata.get("graph_error") in (
+            "ConnectionAcquisitionTimeoutError",
+            "ServiceUnavailable",  # fallback alias on older neo4j SDKs
+        )
         # Should have chunks from vector search
         assert len(result.chunks) > 0
         # _fetch_chunks_from_entities must NOT have been called
@@ -826,3 +828,112 @@ class TestGracefulDegradation:
         assert len(result.chunks) > 0
         # version_history should be None due to the failure
         assert result.metadata.get("version_history") is None
+
+    @pytest.mark.asyncio
+    async def test_graceful_degradation_on_session_expired(self, retriever: VectorCypherRetriever, ns_id: UUID) -> None:
+        """SessionExpired from _cypher_expand triggers graceful degradation."""
+        from neo4j.exceptions import SessionExpired
+
+        retriever._cypher_expand = AsyncMock(side_effect=SessionExpired("Session no longer valid"))
+        retriever._fetch_chunks_from_entities = AsyncMock(return_value=[])
+
+        result = await retriever.retrieve("What is Python?", ns_id)
+
+        assert result.metadata["graph_fallback"] is True
+        assert result.metadata.get("graph_error") == "SessionExpired"
+        assert len(result.chunks) > 0
+        retriever._fetch_chunks_from_entities.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_graceful_degradation_on_transient_error(self, retriever: VectorCypherRetriever, ns_id: UUID) -> None:
+        """TransientError from _cypher_expand triggers graceful degradation."""
+        from neo4j.exceptions import TransientError
+
+        retriever._cypher_expand = AsyncMock(side_effect=TransientError("Database unavailable"))
+        retriever._fetch_chunks_from_entities = AsyncMock(return_value=[])
+
+        result = await retriever.retrieve("What is Python?", ns_id)
+
+        assert result.metadata["graph_fallback"] is True
+        assert result.metadata.get("graph_error") == "TransientError"
+        assert len(result.chunks) > 0
+        retriever._fetch_chunks_from_entities.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cypher_expand_fallback_emits_warning(self, retriever: VectorCypherRetriever, ns_id: UUID) -> None:
+        """Warning log is emitted when _cypher_expand falls back."""
+        from unittest.mock import patch
+
+        from neo4j.exceptions import ServiceUnavailable
+
+        retriever._cypher_expand = AsyncMock(side_effect=ServiceUnavailable("Connection refused"))
+        retriever._fetch_chunks_from_entities = AsyncMock(return_value=[])
+
+        with patch("khora.engines.vectorcypher.retriever.logger") as mock_logger:
+            await retriever.retrieve("What is Python?", ns_id)
+
+        warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
+        assert any("Neo4j unavailable during cypher_expand" in c for c in warning_calls)
+
+    @pytest.mark.asyncio
+    async def test_version_filter_fallback_emits_warning(self, retriever: VectorCypherRetriever, ns_id: UUID) -> None:
+        """Warning log is emitted when _version_filter_entities falls back."""
+        from datetime import datetime
+        from unittest.mock import patch
+
+        from neo4j.exceptions import ServiceUnavailable
+
+        from khora.engines.skeleton.backends import TemporalFilter
+        from khora.engines.vectorcypher.temporal_detection import (
+            TemporalCategory,
+            TemporalSignal,
+        )
+
+        expanded_id = uuid4()
+        retriever._cypher_expand = AsyncMock(
+            return_value=(
+                {expanded_id: 0.7},
+                {str(expanded_id): {"name": "Test", "entity_type": "CONCEPT"}},
+            )
+        )
+        retriever._version_filter_entities = AsyncMock(side_effect=ServiceUnavailable("Connection refused"))
+        chunk = Chunk(id=uuid4(), namespace_id=ns_id, document_id=uuid4(), content="graph chunk")
+        retriever._fetch_chunks_from_entities = AsyncMock(return_value=[(chunk.id, 0.8, chunk)])
+
+        tf = TemporalFilter(occurred_before=datetime(2025, 1, 1, tzinfo=UTC))
+        temporal_signal = TemporalSignal(
+            is_temporal=True,
+            category=TemporalCategory.EXPLICIT,
+            confidence=0.9,
+            source="dictionary",
+            temporal_filter=tf,
+        )
+
+        with patch("khora.engines.vectorcypher.retriever.logger") as mock_logger:
+            await retriever.retrieve("What happened before 2025?", ns_id, temporal_signal=temporal_signal)
+
+        warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
+        assert any("Version filter failed" in c for c in warning_calls)
+
+    @pytest.mark.asyncio
+    async def test_outer_fallback_on_fetch_chunks_failure(self, retriever: VectorCypherRetriever, ns_id: UUID) -> None:
+        """When _cypher_expand succeeds but _fetch_chunks_from_entities raises
+        a transient error, the outer catch in retrieve() fires and returns
+        vector-only results via _vector_only_fallback."""
+        from neo4j.exceptions import ServiceUnavailable
+
+        expanded_id = uuid4()
+        retriever._cypher_expand = AsyncMock(
+            return_value=(
+                {expanded_id: 0.7},
+                {str(expanded_id): {"name": "Test", "entity_type": "CONCEPT"}},
+            )
+        )
+        retriever._fetch_chunks_from_entities = AsyncMock(side_effect=ServiceUnavailable("Connection refused"))
+
+        result = await retriever.retrieve("What is Python?", ns_id)
+
+        assert isinstance(result, VectorCypherResult)
+        # Outer fallback sets these metadata keys
+        assert result.metadata.get("graph_fallback") is True
+        assert len(result.chunks) > 0

--- a/tests/unit/engines/test_vectorcypher_retriever.py
+++ b/tests/unit/engines/test_vectorcypher_retriever.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import UTC
 from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -623,3 +624,205 @@ class TestSimpleRetrieveScoreNormalization:
         assert len(result.chunks) == 1
         # Single result: normalize_scores sets all-equal scores to 1.0
         assert result.chunks[0][1] == 1.0
+
+
+@pytest.mark.unit
+class TestGracefulDegradation:
+    """Tests for graceful degradation when Neo4j is unavailable."""
+
+    @pytest.fixture
+    def ns_id(self) -> UUID:
+        return uuid4()
+
+    @pytest.fixture
+    def retriever(self, ns_id: UUID) -> VectorCypherRetriever:
+        """Create a retriever with mocked dependencies for graph-path testing."""
+        vector_store = AsyncMock()
+        neo4j_driver = AsyncMock()
+        embedder = AsyncMock()
+        embedder.embed = AsyncMock(return_value=[0.1] * 1536)
+        embedder.model_name = "test-model"
+        embedder.dimension = 1536
+
+        # Mock vector store search — returns chunks for _vector_search_chunks
+        chunk_id = uuid4()
+        doc_id = uuid4()
+        mock_result = MagicMock()
+        mock_result.chunk = MagicMock()
+        mock_result.chunk.id = chunk_id
+        mock_result.chunk.namespace_id = ns_id
+        mock_result.chunk.content = "test chunk content"
+        mock_result.chunk.document_id = doc_id
+        mock_result.chunk.occurred_at = None
+        mock_result.chunk.created_at = None
+        mock_result.chunk.metadata = {}
+        mock_result.combined_score = 0.85
+        mock_result.similarity = 0.85
+        vector_store.search = AsyncMock(return_value=[mock_result])
+
+        # Storage coordinator for entity vector search
+        storage = AsyncMock()
+        entry_entity_id = uuid4()
+        storage.search_similar_entities = AsyncMock(return_value=[(entry_entity_id, 0.9)])
+        storage.get_entities_batch = AsyncMock(return_value={})
+
+        config = RetrieverConfig(query_cache_ttl_seconds=0)
+
+        retriever = VectorCypherRetriever(
+            vector_store=vector_store,
+            neo4j_driver=neo4j_driver,
+            embedder=embedder,
+            config=config,
+            storage=storage,
+        )
+
+        # Route to MODERATE/COMPLEX (use_graph=True) to exercise _vectorcypher_retrieve
+        retriever._router = MagicMock()
+        retriever._router.route = AsyncMock(
+            return_value=RoutingDecision(
+                complexity=QueryComplexity.MODERATE,
+                use_graph=True,
+                graph_depth=2,
+                confidence=0.8,
+                reasoning="moderate query",
+            )
+        )
+        retriever._router.compute_adaptive_depth = MagicMock(return_value=2)
+
+        return retriever
+
+    @pytest.mark.asyncio
+    async def test_retrieve_graceful_degradation_on_neo4j_timeout(
+        self, retriever: VectorCypherRetriever, ns_id: UUID
+    ) -> None:
+        """When _cypher_expand raises ConnectionAcquisitionTimeoutError, the
+        retriever returns valid results with graph_fallback metadata."""
+        from neo4j.exceptions import ServiceUnavailable
+
+        try:
+            from neo4j.exceptions import ConnectionAcquisitionTimeoutError as _CATE
+        except ImportError:
+            _CATE = ServiceUnavailable  # type: ignore[misc,assignment]
+
+        # _cypher_expand raises a transient timeout error
+        retriever._cypher_expand = AsyncMock(
+            side_effect=_CATE("failed to obtain a connection from the pool within 60.0s (timeout)")
+        )
+        # _fetch_chunks_from_entities should NOT be called when graph_fallback=True
+        retriever._fetch_chunks_from_entities = AsyncMock(return_value=[])
+
+        result = await retriever.retrieve("What is Python?", ns_id)
+
+        assert isinstance(result, VectorCypherResult)
+        assert result.metadata["graph_fallback"] is True
+        assert "ConnectionAcquisitionTimeoutError" in result.metadata.get(
+            "graph_error", ""
+        ) or "ServiceUnavailable" in result.metadata.get("graph_error", "")
+        # Should have chunks from vector search
+        assert len(result.chunks) > 0
+        # _fetch_chunks_from_entities must NOT have been called
+        retriever._fetch_chunks_from_entities.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_retrieve_does_not_swallow_client_error(self, retriever: VectorCypherRetriever, ns_id: UUID) -> None:
+        """ClientError from _cypher_expand is NOT caught — it propagates."""
+        from neo4j.exceptions import ClientError
+
+        retriever._cypher_expand = AsyncMock(side_effect=ClientError("Invalid Cypher query"))
+
+        with pytest.raises(ClientError, match="Invalid Cypher query"):
+            await retriever.retrieve("What is Python?", ns_id)
+
+    @pytest.mark.asyncio
+    async def test_version_filter_graceful_degradation(self, retriever: VectorCypherRetriever, ns_id: UUID) -> None:
+        """When _version_filter_entities raises ServiceUnavailable, the
+        retriever still returns valid results (keeps unfiltered entities)."""
+        from neo4j.exceptions import ServiceUnavailable
+
+        from khora.engines.vectorcypher.temporal_detection import (
+            TemporalCategory,
+            TemporalSignal,
+        )
+
+        # _cypher_expand succeeds
+        expanded_id = uuid4()
+        retriever._cypher_expand = AsyncMock(
+            return_value=(
+                {expanded_id: 0.7},
+                {str(expanded_id): {"name": "Test", "entity_type": "CONCEPT"}},
+            )
+        )
+        # _version_filter_entities raises a transient error
+        retriever._version_filter_entities = AsyncMock(side_effect=ServiceUnavailable("Connection refused"))
+        # _fetch_chunks_from_entities succeeds
+        chunk = Chunk(id=uuid4(), namespace_id=ns_id, document_id=uuid4(), content="graph chunk")
+        retriever._fetch_chunks_from_entities = AsyncMock(return_value=[(chunk.id, 0.8, chunk)])
+
+        # Build temporal signal for EXPLICIT path (triggers _version_filter_entities)
+        from datetime import datetime
+
+        from khora.engines.skeleton.backends import TemporalFilter
+
+        tf = TemporalFilter(occurred_before=datetime(2025, 1, 1, tzinfo=UTC))
+        temporal_signal = TemporalSignal(
+            is_temporal=True,
+            category=TemporalCategory.EXPLICIT,
+            confidence=0.9,
+            source="dictionary",
+            temporal_filter=tf,
+        )
+
+        result = await retriever.retrieve(
+            "What happened before 2025?",
+            ns_id,
+            temporal_signal=temporal_signal,
+        )
+
+        assert isinstance(result, VectorCypherResult)
+        # Should complete without raising
+        assert len(result.chunks) > 0
+
+    @pytest.mark.asyncio
+    async def test_version_history_graceful_degradation(self, retriever: VectorCypherRetriever, ns_id: UUID) -> None:
+        """When _fetch_version_history raises ServiceUnavailable, the
+        retriever still returns valid results (version_history becomes None)."""
+        from neo4j.exceptions import ServiceUnavailable
+
+        from khora.engines.vectorcypher.temporal_detection import (
+            TemporalCategory,
+            TemporalSignal,
+        )
+
+        # _cypher_expand succeeds
+        expanded_id = uuid4()
+        retriever._cypher_expand = AsyncMock(
+            return_value=(
+                {expanded_id: 0.7},
+                {str(expanded_id): {"name": "Test", "entity_type": "CONCEPT"}},
+            )
+        )
+        # _fetch_version_history raises a transient error
+        retriever._fetch_version_history = AsyncMock(side_effect=ServiceUnavailable("Connection refused"))
+        # _fetch_chunks_from_entities succeeds
+        chunk = Chunk(id=uuid4(), namespace_id=ns_id, document_id=uuid4(), content="graph chunk")
+        retriever._fetch_chunks_from_entities = AsyncMock(return_value=[(chunk.id, 0.8, chunk)])
+
+        # Build temporal signal for CHANGE path (triggers _fetch_version_history)
+        temporal_signal = TemporalSignal(
+            is_temporal=True,
+            category=TemporalCategory.CHANGE,
+            confidence=0.9,
+            source="dictionary",
+        )
+
+        result = await retriever.retrieve(
+            "How has the policy changed?",
+            ns_id,
+            temporal_signal=temporal_signal,
+        )
+
+        assert isinstance(result, VectorCypherResult)
+        # Should complete without raising
+        assert len(result.chunks) > 0
+        # version_history should be None due to the failure
+        assert result.metadata.get("version_history") is None


### PR DESCRIPTION
## Summary

- **Fix exception hierarchy bug**: The existing `except Neo4jError` fallback did not catch `ConnectionAcquisitionTimeoutError`, `ServiceUnavailable`, or `SessionExpired` because they inherit from `DriverError`, not `Neo4jError`. Replaced with a narrow tuple `_NEO4J_TRANSIENT_ERRORS` containing `ServiceUnavailable`, `ConnectionPoolError`, `SessionExpired`, `TransientError`.
- **Per-step graceful degradation**: Wrapped `_cypher_expand`, `_version_filter_entities`, and `_fetch_version_history` individually so each degrades independently. When `_cypher_expand` fails, the retriever preserves already-computed vector search results (entry entities + chunks from pgvector) instead of discarding them.
- **Skip graph-dependent steps on fallback**: When `graph_fallback=True`, `_fetch_chunks_from_entities` (which also uses Neo4j via DualNodeManager) is skipped to avoid a cascading failure.
- **Metadata flags for consumers**: Result metadata includes `graph_fallback: True` and `graph_error: "<ExceptionType>: <message>"` so downstream services (peras) can detect degraded results and surface a partial-result signal.
- **ClientError not swallowed**: Query bugs (`ClientError`) and other non-transient errors still propagate — only infra blips trigger degradation.

### Context

On 2026-04-15 07:53–07:55 UTC, a ~2min Neo4j outage caused every recall/ask request to 500 even though pgvector results completed in <1s. The timeout error (`ConnectionAcquisitionTimeoutError`) was never caught by the existing `except Neo4jError` because it's a `DriverError` subclass, not a `Neo4jError` subclass. This PR closes that gap.

## Test plan

- [x] `test_retrieve_graceful_degradation_on_neo4j_timeout` — `_cypher_expand` raises `ConnectionAcquisitionTimeoutError` → fallback path returns vector results with `graph_fallback=True`
- [x] `test_retrieve_does_not_swallow_client_error` — `ClientError` propagates (not caught)
- [x] `test_version_filter_graceful_degradation` — `ServiceUnavailable` from `_version_filter_entities` → filter skipped, retrieve succeeds
- [x] `test_version_history_graceful_degradation` — `ServiceUnavailable` from `_fetch_version_history` → version_history=None, retrieve succeeds
- [x] All 29 existing retriever tests pass (no regression)