### PR TITLE
DYT-2625: Add KHORA_NEO4J_LOG_LEVEL env var for driver log verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ All settings use the `KHORA_` prefix (e.g., `KHORA_LLM_MODEL=gpt-4o`).
 | `KHORA_QUERY_TEMPORAL_SQL_PUSHDOWN` | Temporal SQL WHERE pushdown | `true` |
 | `KHORA_EXTRACTION_BATCH_SIZE` | Chunks per extraction LLM call | `5` |
 | `KHORA_DEBUG` | Debug logging | `false` |
+| `KHORA_NEO4J_LOG_LEVEL` | Neo4j driver log level (`DEBUG`/`INFO`/`WARNING`/`ERROR`/`CRITICAL`, case-insensitive). No-op when unset | — |
 
 See [full configuration reference](docs/architecture/storage-backends.md) for all options.
 

--- a/examples/neo4j_debug_logging.py
+++ b/examples/neo4j_debug_logging.py
@@ -1,0 +1,50 @@
+"""Demonstrate KHORA_NEO4J_LOG_LEVEL=DEBUG surfacing driver-internal logs.
+
+Run with::
+
+    uv run python examples/neo4j_debug_logging.py
+
+The script sets ``KHORA_NEO4J_LOG_LEVEL=DEBUG`` in-process, initializes
+khora's logging, and then constructs a ``Neo4jBackend`` pointing at the
+local compose stack. The driver emits DEBUG lines as soon as a connection
+is attempted (TLS handshake, pool bootstrap, routing). Those lines are
+routed through khora's ``InterceptHandler`` into loguru and printed to
+stdout.
+
+If no Neo4j is reachable the connect call raises — that's fine; the DEBUG
+lines produced before the failure are the point of the demo.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+# Must be set BEFORE setup_logging() / Neo4jBackend() so the helper sees it.
+os.environ.setdefault("KHORA_NEO4J_LOG_LEVEL", "DEBUG")
+
+from khora.logging_config import setup_logging  # noqa: E402
+from khora.storage.backends.neo4j import Neo4jBackend  # noqa: E402
+
+
+async def main() -> None:
+    setup_logging(level="DEBUG")
+
+    backend = Neo4jBackend(
+        url=os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7688"),
+        user=os.environ.get("KHORA_NEO4J_USER", "neo4j"),
+        password=os.environ.get("KHORA_NEO4J_PASSWORD", "pleaseletmein"),  # noqa: S106
+    )
+
+    try:
+        await backend.connect()
+        print("Connected to Neo4j; driver DEBUG logs should appear above.")
+    except Exception as exc:  # noqa: BLE001 - demo script, surface anything
+        print(f"Connect failed ({type(exc).__name__}: {exc}).")
+        print("Any 'neo4j' DEBUG lines above were produced before the failure.")
+    finally:
+        await backend.disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/khora/logging_config.py
+++ b/src/khora/logging_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import atexit
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -13,6 +14,39 @@ from loguru import logger
 # against re-registering logger.complete when setup_logging() is called more
 # than once (e.g. tests reconfiguring logging between cases).
 _drain_registered = False
+
+# Environment variable that, when set to a valid level name, raises the
+# verbosity of the ``neo4j`` stdlib logger at runtime. Added for DYT-2625 so
+# that operators can enable driver-internal DEBUG lines (pool acquire, TLS,
+# routing) without a code change. See README for accepted values.
+_NEO4J_LOG_LEVEL_ENV = "KHORA_NEO4J_LOG_LEVEL"
+_NEO4J_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+
+
+def apply_neo4j_log_level_from_env() -> None:
+    """Set the ``neo4j`` stdlib logger level from ``KHORA_NEO4J_LOG_LEVEL``.
+
+    No-op when the env var is unset, empty, or holds an unrecognised value
+    (an unrecognised value emits a single loguru WARNING then returns). Safe
+    to call repeatedly — ``Logger.setLevel`` is idempotent.
+
+    Driver log records are routed through khora's ``InterceptHandler`` into
+    loguru when ``setup_logging()`` has been called; downstream services that
+    keep stdlib logging handlers pick them up via their own sinks.
+    """
+    raw = os.environ.get(_NEO4J_LOG_LEVEL_ENV)
+    if not raw:
+        return
+    level = raw.strip().upper()
+    if level not in _NEO4J_LOG_LEVELS:
+        logger.warning(
+            "{} value {!r} is not one of {}; leaving the neo4j logger level unchanged",
+            _NEO4J_LOG_LEVEL_ENV,
+            raw,
+            sorted(_NEO4J_LOG_LEVELS),
+        )
+        return
+    logging.getLogger("neo4j").setLevel(level)
 
 
 class InterceptHandler(logging.Handler):
@@ -105,3 +139,7 @@ def setup_logging(
     # Suppress noisy third-party loggers
     for logger_name in ["httpx", "httpcore", "LiteLLM", "litellm"]:
         logging.getLogger(logger_name).setLevel(logging.WARNING)
+
+    # Apply operator-requested neo4j driver verbosity after the intercept
+    # handler is wired up so the new level actually reaches loguru sinks.
+    apply_neo4j_log_level_from_env()

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -247,6 +247,15 @@ class Neo4jBackend(GraphBackendBase):
         self._owns_driver: bool = True
         self._entity_key_gate = _EntityKeyGate(max_concurrent=entity_write_concurrency)
         self._relationship_write_sem = asyncio.Semaphore(relationship_write_concurrency)
+
+        # DYT-2625: apply operator-requested neo4j driver verbosity so services
+        # that configure their own loguru sinks (bypassing khora's
+        # setup_logging) still get driver logs when they build a backend.
+        # Imported lazily to avoid any import-cycle surprises.
+        from khora.logging_config import apply_neo4j_log_level_from_env
+
+        apply_neo4j_log_level_from_env()
+
         self._init_metrics()
 
     def _init_metrics(self) -> None:

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -8,13 +8,14 @@ mutate global process state.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from khora import logging_config
-from khora.logging_config import setup_logging
+from khora.logging_config import apply_neo4j_log_level_from_env, setup_logging
 
 
 @pytest.fixture(autouse=True)
@@ -95,6 +96,114 @@ def test_setup_logging_file_sink_uses_enqueue(tmp_path: Path):
     file_call = mock_logger.add.call_args_list[1]
     assert file_call.kwargs.get("enqueue") is True
     assert file_call.kwargs.get("rotation") == "10 MB"
+
+
+@pytest.fixture
+def _reset_neo4j_logger_level():
+    """Restore the neo4j stdlib logger level so tests don't leak global state."""
+    neo4j_logger = logging.getLogger("neo4j")
+    original = neo4j_logger.level
+    yield neo4j_logger
+    neo4j_logger.setLevel(original)
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected_level"),
+    [
+        ("DEBUG", logging.DEBUG),
+        ("info", logging.INFO),
+        ("Warning", logging.WARNING),
+        ("ERROR", logging.ERROR),
+        ("critical", logging.CRITICAL),
+    ],
+)
+def test_apply_neo4j_log_level_from_env_sets_level(
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_neo4j_logger_level: logging.Logger,
+    env_value: str,
+    expected_level: int,
+) -> None:
+    """Valid KHORA_NEO4J_LOG_LEVEL values set the neo4j logger level (case-insensitive)."""
+    monkeypatch.setenv("KHORA_NEO4J_LOG_LEVEL", env_value)
+    apply_neo4j_log_level_from_env()
+    assert _reset_neo4j_logger_level.level == expected_level
+
+
+def test_apply_neo4j_log_level_from_env_noop_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_neo4j_logger_level: logging.Logger,
+) -> None:
+    """Unset env var leaves the neo4j logger level untouched."""
+    monkeypatch.delenv("KHORA_NEO4J_LOG_LEVEL", raising=False)
+    _reset_neo4j_logger_level.setLevel(logging.NOTSET)
+    apply_neo4j_log_level_from_env()
+    assert _reset_neo4j_logger_level.level == logging.NOTSET
+
+
+def test_apply_neo4j_log_level_from_env_noop_when_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_neo4j_logger_level: logging.Logger,
+) -> None:
+    """Empty env var value is treated as unset."""
+    monkeypatch.setenv("KHORA_NEO4J_LOG_LEVEL", "")
+    _reset_neo4j_logger_level.setLevel(logging.NOTSET)
+    apply_neo4j_log_level_from_env()
+    assert _reset_neo4j_logger_level.level == logging.NOTSET
+
+
+def test_apply_neo4j_log_level_from_env_ignores_unknown_value(
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_neo4j_logger_level: logging.Logger,
+) -> None:
+    """Unknown values emit a warning via loguru and do NOT change the level or raise."""
+    monkeypatch.setenv("KHORA_NEO4J_LOG_LEVEL", "TRACE")
+    _reset_neo4j_logger_level.setLevel(logging.NOTSET)
+    with patch("khora.logging_config.logger") as mock_logger:
+        apply_neo4j_log_level_from_env()
+    assert _reset_neo4j_logger_level.level == logging.NOTSET
+    mock_logger.warning.assert_called_once()
+
+
+def test_apply_neo4j_log_level_from_env_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_neo4j_logger_level: logging.Logger,
+) -> None:
+    """Calling the helper twice with the same env var is fine."""
+    monkeypatch.setenv("KHORA_NEO4J_LOG_LEVEL", "DEBUG")
+    apply_neo4j_log_level_from_env()
+    apply_neo4j_log_level_from_env()
+    assert _reset_neo4j_logger_level.level == logging.DEBUG
+
+
+def test_setup_logging_picks_up_neo4j_log_level(
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_neo4j_logger_level: logging.Logger,
+) -> None:
+    """setup_logging() routes the env var through apply_neo4j_log_level_from_env."""
+    monkeypatch.setenv("KHORA_NEO4J_LOG_LEVEL", "DEBUG")
+    with (
+        patch("khora.logging_config.logger"),
+        patch("khora.logging_config.atexit.register"),
+        patch("khora.logging_config.logging.basicConfig"),
+    ):
+        setup_logging(level="INFO")
+    assert _reset_neo4j_logger_level.level == logging.DEBUG
+
+
+def test_setup_logging_does_not_touch_neo4j_logger_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_neo4j_logger_level: logging.Logger,
+) -> None:
+    """Default unset behavior: setup_logging() leaves the neo4j logger alone."""
+    monkeypatch.delenv("KHORA_NEO4J_LOG_LEVEL", raising=False)
+    _reset_neo4j_logger_level.setLevel(logging.NOTSET)
+    with (
+        patch("khora.logging_config.logger"),
+        patch("khora.logging_config.atexit.register"),
+        patch("khora.logging_config.logging.basicConfig"),
+    ):
+        setup_logging(level="INFO")
+    assert _reset_neo4j_logger_level.level == logging.NOTSET
 
 
 def test_setup_logging_atexit_not_reregistered_after_first_call():

--- a/tests/unit/test_neo4j_backend.py
+++ b/tests/unit/test_neo4j_backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -53,6 +54,40 @@ class TestNeo4jBackendInit:
         backend = Neo4jBackend("bolt://localhost:7687")
         assert backend._query_timeout == 5.0
         assert backend._timed_unit_of_work is not None
+
+
+@pytest.mark.unit
+class TestNeo4jBackendLogLevelFromEnv:
+    """DYT-2625: Neo4jBackend.__init__ applies KHORA_NEO4J_LOG_LEVEL from env."""
+
+    @pytest.fixture
+    def _reset_neo4j_logger_level(self):
+        neo4j_logger = logging.getLogger("neo4j")
+        original = neo4j_logger.level
+        yield neo4j_logger
+        neo4j_logger.setLevel(original)
+
+    def test_init_applies_env_var(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        _reset_neo4j_logger_level: logging.Logger,
+    ) -> None:
+        """Constructor raises the neo4j logger verbosity when env var is set."""
+        monkeypatch.setenv("KHORA_NEO4J_LOG_LEVEL", "DEBUG")
+        _reset_neo4j_logger_level.setLevel(logging.NOTSET)
+        Neo4jBackend("bolt://localhost:7687")
+        assert _reset_neo4j_logger_level.level == logging.DEBUG
+
+    def test_init_noop_when_env_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        _reset_neo4j_logger_level: logging.Logger,
+    ) -> None:
+        """Constructor does not touch the neo4j logger when env var is absent."""
+        monkeypatch.delenv("KHORA_NEO4J_LOG_LEVEL", raising=False)
+        _reset_neo4j_logger_level.setLevel(logging.NOTSET)
+        Neo4jBackend("bolt://localhost:7687")
+        assert _reset_neo4j_logger_level.level == logging.NOTSET
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Add `KHORA_NEO4J_LOG_LEVEL` env var (DEBUG/INFO/WARNING/ERROR/CRITICAL, case-insensitive) to toggle the Python `neo4j` stdlib logger level at runtime — useful for diagnosing pool-acquire stalls, TLS handshake timing, routing refreshes (see IGR-56).
- New helper `apply_neo4j_log_level_from_env()` in `khora.logging_config` is called from both `setup_logging()` and `Neo4jBackend.__init__`, so the toggle works whether downstream services (peras, poros) use khora's logging helper or configure their own loguru sinks.
- Default (unset) is a no-op — no change to existing log output. Unknown values emit one loguru WARNING and leave the logger untouched (operator typos must not crash backend init).
- README documents the new env knob next to the other `KHORA_*` settings.
- `examples/neo4j_debug_logging.py` demonstrates the feature end-to-end — `uv run python examples/neo4j_debug_logging.py` produces ~15 driver DEBUG lines (`<POOL>`, `<WORKSPACE>`, `<RESOLVE>`, `<OPEN>`, …) before the expected connection failure against an absent local Neo4j.

## Test plan
- [x] `uv run pytest tests/unit/test_logging_config.py tests/unit/test_neo4j_backend.py` — 31 passed (new tests cover DEBUG/INFO/warning/mixed-case/empty/unknown/idempotent/default-unset and `Neo4jBackend.__init__` application).
- [x] Full suite: `uv run pytest --cov=src/khora --cov-branch --cov-fail-under=30` — 2782 passed, coverage 54.21%.
- [x] `uv run ruff check . && uv run ruff format --check . && uv run ty check src/` — clean (pre-existing ty warnings only; no new diagnostics).
- [x] Manual run of `examples/neo4j_debug_logging.py` with `KHORA_NEO4J_LOG_LEVEL=DEBUG` surfaces `neo4j` DEBUG lines through khora's loguru sink before the connect failure.