### PR TITLE
DYT-2629: Fix silent data loss in Neo4jBackend.get_neighborhoods_batch

### DIFF
--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -2267,12 +2267,16 @@ class Neo4jBackend(GraphBackendBase):
         if relationship_types:
             rel_filter = ":" + "|".join(_sanitize_neo4j_label(rt) for rt in relationship_types)
 
-        # Use UNWIND to process all entities in a single query
+        # Use UNWIND to process all entities in a single query.
+        # Project relationship properties in Cypher: [r*1..N] binds a list
+        # of relationships per path, so collect(r) yields list-of-lists.
+        # Projecting via list comprehension avoids raw Relationship objects
+        # that serialize as opaque tuples (DYT-2629).
         query = f"""
         UNWIND $entity_ids AS eid
         MATCH (center:Entity {{id: eid}})
         OPTIONAL MATCH (center)-[r{rel_filter}*1..{depth}]-(other:Entity)
-        With eid, center, collect(DISTINCT other)[0..$limit] as neighbors, collect(DISTINCT r)[0..$limit] as rels
+        With eid, center, collect(DISTINCT other)[0..$limit] as neighbors, collect(DISTINCT [rel IN r | {{props: properties(rel), type: type(rel)}}])[0..$limit] as rels
         RETURN eid, neighbors, rels
         """
 
@@ -2316,7 +2320,9 @@ class Neo4jBackend(GraphBackendBase):
                 if rel_list:
                     for r in rel_list if isinstance(rel_list, list) else [rel_list]:
                         if r:
-                            relationships.append(_element_to_dict(r))
+                            d = dict(r.get("props") or {})
+                            d["relationship_type"] = r.get("type")
+                            relationships.append(d)
             neighborhoods[eid] = {"entities": nodes, "relationships": relationships}
 
         return neighborhoods

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -2166,7 +2166,7 @@ class Neo4jBackend(GraphBackendBase):
         # Fallback query if APOC is not available
         fallback_query = f"""
         MATCH (center:Entity {{id: $entity_id}})-[r{rel_filter}*1..{depth}]-(other:Entity)
-        RETURN collect(DISTINCT other) as nodes, collect(DISTINCT r) as relationships
+        RETURN collect(DISTINCT other) as nodes, collect(DISTINCT [rel IN r | {{props: properties(rel), type: type(rel)}}]) as relationships
         LIMIT $limit
         """
 
@@ -2228,7 +2228,12 @@ class Neo4jBackend(GraphBackendBase):
 
         if record:
             nodes = [_element_to_dict(n) for n in record.get("nodes", [])]
-            relationships = [_element_to_dict(r) for r in record.get("relationships", [])]
+            relationships = []
+            for rel_list in record.get("relationships", []):
+                if rel_list:
+                    for r in rel_list if isinstance(rel_list, list) else [rel_list]:
+                        if r:
+                            relationships.append({**r.get("props", {}), "relationship_type": r.get("type")})
             return {"entities": nodes, "relationships": relationships}
 
         return {"entities": [], "relationships": []}
@@ -2320,9 +2325,7 @@ class Neo4jBackend(GraphBackendBase):
                 if rel_list:
                     for r in rel_list if isinstance(rel_list, list) else [rel_list]:
                         if r:
-                            d = dict(r.get("props") or {})
-                            d["relationship_type"] = r.get("type")
-                            relationships.append(d)
+                            relationships.append({**r.get("props", {}), "relationship_type": r.get("type")})
             neighborhoods[eid] = {"entities": nodes, "relationships": relationships}
 
         return neighborhoods

--- a/tests/integration/test_neo4j_get_neighborhoods_batch_integration.py
+++ b/tests/integration/test_neo4j_get_neighborhoods_batch_integration.py
@@ -1,0 +1,389 @@
+"""Real-Neo4j integration test for ``Neo4jBackend.get_neighborhoods_batch`` (DYT-2629).
+
+This test exercises the full Cypher → driver → ``result.data()`` →
+relationship property extraction path against a running Neo4j instance to verify
+that relationship properties are correctly preserved through variable-length
+path traversals.
+
+Why this is marked ``@pytest.mark.integration`` and gated by
+``NEO4J_INTEGRATION_TEST=1``:
+
+    Khora's CI does NOT provision a Neo4j instance. Real-Neo4j coverage lives
+    behind an opt-in env var so CI stays green while local developers
+    running ``make dev`` can exercise it.
+
+How to run locally:
+
+    make dev  # starts postgres + neo4j via docker compose
+    NEO4J_INTEGRATION_TEST=1 uv run pytest \
+        tests/integration/test_neo4j_get_neighborhoods_batch_integration.py -v
+
+Connection parameters are read from env vars with sensible defaults that
+match the ``make dev`` compose stack:
+
+    KHORA_NEO4J_URL       (default: bolt://localhost:7687)
+    KHORA_NEO4J_USERNAME  (default: neo4j)
+    KHORA_NEO4J_PASSWORD  (default: password)
+
+The test verifies that:
+1. Relationship properties are correctly extracted from variable-length paths
+2. Relationship types are preserved
+3. Multiple relationships per path are correctly flattened
+4. Edge cases (no neighbors, depth=1, etc.) are handled correctly
+"""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+
+from khora.core.models.entity import Entity, Relationship
+from khora.storage.backends.neo4j import Neo4jBackend
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("NEO4J_INTEGRATION_TEST"),
+    reason="set NEO4J_INTEGRATION_TEST=1 to run against real Neo4j (requires make dev)",
+)
+class TestNeo4jGetNeighborhoodsBatchIntegration:
+    """End-to-end regression lock for DYT-2629 against a real Neo4j."""
+
+    @pytest.mark.asyncio
+    async def test_returns_relationships_with_properties_depth_1(self) -> None:
+        """Create entities + relationships, read back via get_neighborhoods_batch depth=1.
+
+        Verifies that relationship properties are correctly extracted from
+        the Cypher result even when using variable-length path syntax
+        [r*1..1] (which still produces list-of-relationships shape).
+        """
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        namespace_id = uuid4()
+        entity_a = Entity(
+            namespace_id=namespace_id,
+            name=f"alice-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="Alice",
+        )
+        entity_b = Entity(
+            namespace_id=namespace_id,
+            name=f"bob-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="Bob",
+        )
+        relationship = Relationship(
+            namespace_id=namespace_id,
+            source_entity_id=entity_a.id,
+            target_entity_id=entity_b.id,
+            relationship_type="KNOWS",
+            description="alice knows bob",
+            properties={"since": "2024", "strength": "strong"},
+            confidence=0.9,
+            weight=0.75,
+        )
+
+        try:
+            await backend.create_entity(entity_a)
+            await backend.create_entity(entity_b)
+            await backend.create_relationship(relationship)
+
+            result = await backend.get_neighborhoods_batch(
+                [entity_a.id],
+                depth=1,
+                limit_per_entity=50,
+            )
+
+            assert entity_a.id in result
+            neighborhood = result[entity_a.id]
+            assert "entities" in neighborhood
+            assert "relationships" in neighborhood
+
+            # Should find entity_b as a neighbor
+            assert len(neighborhood["entities"]) >= 1
+            entity_names = [e.get("name") for e in neighborhood["entities"]]
+            assert entity_b.name in entity_names
+
+            # Should find the relationship with all properties preserved
+            assert len(neighborhood["relationships"]) >= 1
+            rels = neighborhood["relationships"]
+            rel = None
+            for r in rels:
+                if r.get("id") == str(relationship.id):
+                    rel = r
+                    break
+
+            assert rel is not None, f"Relationship {relationship.id} not found in results"
+            assert rel["id"] == str(relationship.id)
+            assert rel["namespace_id"] == str(namespace_id)
+            assert rel["relationship_type"] == "KNOWS"
+            assert rel["description"] == "alice knows bob"
+            assert rel["confidence"] == 0.9
+            assert rel["weight"] == 0.75
+            # Properties and metadata should be preserved (stored as JSON strings in DB)
+            assert rel.get("properties") is not None
+            assert rel.get("metadata") is not None
+
+        finally:
+            # Best-effort cleanup
+            try:
+                await backend.delete_relationship(relationship.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_a.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_b.id)
+            except Exception:  # noqa: BLE001
+                pass
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_returns_relationships_with_properties_depth_2(self) -> None:
+        """Create a chain of entities (A-B-C), read via get_neighborhoods_batch depth=2.
+
+        Tests variable-length paths with depth > 1, which creates
+        multi-hop traversals. Verifies that all relationships along
+        the paths are correctly extracted.
+        """
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        namespace_id = uuid4()
+        entity_a = Entity(
+            namespace_id=namespace_id,
+            name=f"alice-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="Alice",
+        )
+        entity_b = Entity(
+            namespace_id=namespace_id,
+            name=f"bob-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="Bob",
+        )
+        entity_c = Entity(
+            namespace_id=namespace_id,
+            name=f"charlie-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="Charlie",
+        )
+
+        rel_ab = Relationship(
+            namespace_id=namespace_id,
+            source_entity_id=entity_a.id,
+            target_entity_id=entity_b.id,
+            relationship_type="KNOWS",
+            description="alice knows bob",
+            properties={"confidence_level": "high"},
+            confidence=0.95,
+            weight=0.8,
+        )
+        rel_bc = Relationship(
+            namespace_id=namespace_id,
+            source_entity_id=entity_b.id,
+            target_entity_id=entity_c.id,
+            relationship_type="WORKS_WITH",
+            description="bob works with charlie",
+            properties={"project": "xyz"},
+            confidence=0.85,
+            weight=0.7,
+        )
+
+        try:
+            await backend.create_entity(entity_a)
+            await backend.create_entity(entity_b)
+            await backend.create_entity(entity_c)
+            await backend.create_relationship(rel_ab)
+            await backend.create_relationship(rel_bc)
+
+            result = await backend.get_neighborhoods_batch(
+                [entity_a.id],
+                depth=2,
+                limit_per_entity=50,
+            )
+
+            assert entity_a.id in result
+            neighborhood = result[entity_a.id]
+
+            # At depth=2 from A, we should find B (direct) and C (2-hop)
+            entity_ids_found = {e.get("id"): e for e in neighborhood["entities"]}
+            assert str(entity_b.id) in entity_ids_found, "Entity B should be a neighbor"
+            assert str(entity_c.id) in entity_ids_found, "Entity C should be a neighbor at depth 2"
+
+            # Should find both relationships
+            rels = neighborhood["relationships"]
+            rel_ids = {r.get("id") for r in rels}
+            assert str(rel_ab.id) in rel_ids, f"Relationship {rel_ab.id} (A-B) not found"
+            assert str(rel_bc.id) in rel_ids, f"Relationship {rel_bc.id} (B-C) not found"
+
+            # Verify properties on both relationships
+            for rel in rels:
+                if rel.get("id") == str(rel_ab.id):
+                    assert rel["relationship_type"] == "KNOWS"
+                    assert rel["description"] == "alice knows bob"
+                    assert rel["confidence"] == 0.95
+                elif rel.get("id") == str(rel_bc.id):
+                    assert rel["relationship_type"] == "WORKS_WITH"
+                    assert rel["description"] == "bob works with charlie"
+                    assert rel["confidence"] == 0.85
+
+        finally:
+            # Best-effort cleanup
+            try:
+                await backend.delete_relationship(rel_bc.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_relationship(rel_ab.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_a.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_b.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_c.id)
+            except Exception:  # noqa: BLE001
+                pass
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_batch_multiple_entities_independently(self) -> None:
+        """Create two separate entity neighborhoods, verify get_neighborhoods_batch
+        returns independent results for each.
+        """
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        namespace_id = uuid4()
+        entity_1 = Entity(
+            namespace_id=namespace_id,
+            name=f"entity1-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="Entity 1",
+        )
+        entity_1_neighbor = Entity(
+            namespace_id=namespace_id,
+            name=f"entity1_neighbor-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="Neighbor of Entity 1",
+        )
+        entity_2 = Entity(
+            namespace_id=namespace_id,
+            name=f"entity2-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="Entity 2",
+        )
+        entity_2_neighbor = Entity(
+            namespace_id=namespace_id,
+            name=f"entity2_neighbor-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="Neighbor of Entity 2",
+        )
+
+        rel_1 = Relationship(
+            namespace_id=namespace_id,
+            source_entity_id=entity_1.id,
+            target_entity_id=entity_1_neighbor.id,
+            relationship_type="KNOWS",
+            description="relationship 1",
+            confidence=0.9,
+        )
+        rel_2 = Relationship(
+            namespace_id=namespace_id,
+            source_entity_id=entity_2.id,
+            target_entity_id=entity_2_neighbor.id,
+            relationship_type="COLLABORATES_WITH",
+            description="relationship 2",
+            confidence=0.8,
+        )
+
+        try:
+            await backend.create_entity(entity_1)
+            await backend.create_entity(entity_1_neighbor)
+            await backend.create_entity(entity_2)
+            await backend.create_entity(entity_2_neighbor)
+            await backend.create_relationship(rel_1)
+            await backend.create_relationship(rel_2)
+
+            result = await backend.get_neighborhoods_batch(
+                [entity_1.id, entity_2.id],
+                depth=1,
+            )
+
+            assert entity_1.id in result
+            assert entity_2.id in result
+
+            # Entity 1's neighborhood should have entity_1_neighbor
+            neighborhood_1 = result[entity_1.id]
+            entity_1_neighbor_ids = {e.get("id") for e in neighborhood_1["entities"]}
+            assert str(entity_1_neighbor.id) in entity_1_neighbor_ids
+
+            # Entity 2's neighborhood should have entity_2_neighbor
+            neighborhood_2 = result[entity_2.id]
+            entity_2_neighbor_ids = {e.get("id") for e in neighborhood_2["entities"]}
+            assert str(entity_2_neighbor.id) in entity_2_neighbor_ids
+
+            # Verify relationships are distinct
+            rel_1_found = any(r.get("id") == str(rel_1.id) for r in neighborhood_1["relationships"])
+            rel_2_found = any(r.get("id") == str(rel_2.id) for r in neighborhood_2["relationships"])
+            assert rel_1_found, "Relationship 1 should be in Entity 1's neighborhood"
+            assert rel_2_found, "Relationship 2 should be in Entity 2's neighborhood"
+
+            # Verify relationship types are correct
+            for rel in neighborhood_1["relationships"]:
+                if rel.get("id") == str(rel_1.id):
+                    assert rel["relationship_type"] == "KNOWS"
+            for rel in neighborhood_2["relationships"]:
+                if rel.get("id") == str(rel_2.id):
+                    assert rel["relationship_type"] == "COLLABORATES_WITH"
+
+        finally:
+            # Best-effort cleanup
+            try:
+                await backend.delete_relationship(rel_1.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_relationship(rel_2.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_1.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_1_neighbor.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_2.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_2_neighbor.id)
+            except Exception:  # noqa: BLE001
+                pass
+            await backend.disconnect()

--- a/tests/unit/test_neo4j_backend.py
+++ b/tests/unit/test_neo4j_backend.py
@@ -220,6 +220,349 @@ class TestNeo4jBackendGetNeighborhoodsBatchTimeout:
         assert excinfo.value.code == "Neo.ClientError.Statement.SyntaxError"
 
 
+@pytest.mark.unit
+class TestNeo4jBackendGetNeighborhoodsBatchDataHandling:
+    """Tests for get_neighborhoods_batch relationship data handling (DYT-2629)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_dict_for_empty_entity_ids(self) -> None:
+        """get_neighborhoods_batch returns {} when passed an empty list."""
+        driver, session = _make_neo4j_driver()
+        backend = Neo4jBackend.from_driver(driver, query_timeout=1.0)
+
+        result = await backend.get_neighborhoods_batch([])
+
+        assert result == {}
+        session.execute_read.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_structure_with_entities_and_relationships(self) -> None:
+        """Returns dict with {entity_id: {'entities': [...], 'relationships': [...]}}."""
+        driver, session = _make_neo4j_driver()
+
+        entity_id = uuid4()
+        neighbor_id = uuid4()
+        rel_id = uuid4()
+        rel_type = "KNOWS"
+
+        # Simulate Cypher result shape: list-of-lists (one per path)
+        # This is what [rel IN r | {props: properties(rel), type: type(rel)}]
+        # returns when [r*1..N] produces multiple relationships per path
+        rel_data = {
+            "props": {
+                "id": str(rel_id),
+                "namespace_id": str(uuid4()),
+                "source_entity_id": str(entity_id),
+                "target_entity_id": str(neighbor_id),
+                "description": "test rel",
+                "properties": "{}",
+                "source_document_ids": [],
+                "source_chunk_ids": [],
+                "valid_from": None,
+                "valid_until": None,
+                "confidence": 0.9,
+                "weight": 0.8,
+                "metadata": "{}",
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-02T00:00:00+00:00",
+            },
+            "type": rel_type,
+        }
+
+        neighbor_data = {"id": str(neighbor_id), "name": "neighbor"}
+
+        # Simulate result from Cypher: list of records
+        async def mock_work(tx):
+            return [
+                {
+                    "eid": str(entity_id),
+                    "neighbors": [neighbor_data],
+                    "rels": [[rel_data]],  # List of rel lists (one per path)
+                }
+            ]
+
+        session.execute_read = AsyncMock(side_effect=mock_work)
+
+        backend = Neo4jBackend.from_driver(driver, query_timeout=1.0)
+        result = await backend.get_neighborhoods_batch([entity_id])
+
+        assert entity_id in result
+        assert "entities" in result[entity_id]
+        assert "relationships" in result[entity_id]
+        assert len(result[entity_id]["entities"]) == 1
+        assert len(result[entity_id]["relationships"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_preserves_relationship_properties(self) -> None:
+        """Relationship properties and type are correctly extracted and included."""
+        driver, session = _make_neo4j_driver()
+
+        entity_id = uuid4()
+        neighbor_id = uuid4()
+        rel_id = uuid4()
+        rel_type = "WORKS_WITH"
+
+        rel_data = {
+            "props": {
+                "id": str(rel_id),
+                "namespace_id": str(uuid4()),
+                "source_entity_id": str(entity_id),
+                "target_entity_id": str(neighbor_id),
+                "description": "colleague",
+                "properties": '{"department": "eng"}',
+                "source_document_ids": ["doc1"],
+                "source_chunk_ids": ["chunk1"],
+                "valid_from": "2026-01-01T00:00:00+00:00",
+                "valid_until": None,
+                "confidence": 0.95,
+                "weight": 0.5,
+                "metadata": '{"source": "org"}',
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-02T00:00:00+00:00",
+            },
+            "type": rel_type,
+        }
+
+        neighbor_data = {"id": str(neighbor_id), "name": "colleague"}
+
+        async def mock_work(tx):
+            return [
+                {
+                    "eid": str(entity_id),
+                    "neighbors": [neighbor_data],
+                    "rels": [[rel_data]],
+                }
+            ]
+
+        session.execute_read = AsyncMock(side_effect=mock_work)
+
+        backend = Neo4jBackend.from_driver(driver, query_timeout=1.0)
+        result = await backend.get_neighborhoods_batch([entity_id])
+
+        rel = result[entity_id]["relationships"][0]
+        # Verify all properties from props are included
+        assert rel["id"] == str(rel_id)
+        assert rel["namespace_id"] == rel_data["props"]["namespace_id"]
+        assert rel["description"] == "colleague"
+        assert rel["confidence"] == 0.95
+        assert rel["weight"] == 0.5
+        # Verify type is added
+        assert rel["relationship_type"] == rel_type
+
+    @pytest.mark.asyncio
+    async def test_handles_multiple_entities(self) -> None:
+        """Correctly handles batch of multiple entity IDs."""
+        driver, session = _make_neo4j_driver()
+
+        entity_id_1 = uuid4()
+        entity_id_2 = uuid4()
+        neighbor_id_1 = uuid4()
+        neighbor_id_2 = uuid4()
+
+        rel_data_1 = {
+            "props": {
+                "id": str(uuid4()),
+                "namespace_id": str(uuid4()),
+                "description": "rel1",
+                "properties": "{}",
+                "source_document_ids": [],
+                "source_chunk_ids": [],
+                "valid_from": None,
+                "valid_until": None,
+                "confidence": 0.9,
+                "weight": 0.8,
+                "metadata": "{}",
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-02T00:00:00+00:00",
+            },
+            "type": "KNOWS",
+        }
+
+        rel_data_2 = {
+            "props": {
+                "id": str(uuid4()),
+                "namespace_id": str(uuid4()),
+                "description": "rel2",
+                "properties": "{}",
+                "source_document_ids": [],
+                "source_chunk_ids": [],
+                "valid_from": None,
+                "valid_until": None,
+                "confidence": 0.8,
+                "weight": 0.7,
+                "metadata": "{}",
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-02T00:00:00+00:00",
+            },
+            "type": "COLLABORATES_WITH",
+        }
+
+        async def mock_work(tx):
+            return [
+                {
+                    "eid": str(entity_id_1),
+                    "neighbors": [{"id": str(neighbor_id_1), "name": "n1"}],
+                    "rels": [[rel_data_1]],
+                },
+                {
+                    "eid": str(entity_id_2),
+                    "neighbors": [{"id": str(neighbor_id_2), "name": "n2"}],
+                    "rels": [[rel_data_2]],
+                },
+            ]
+
+        session.execute_read = AsyncMock(side_effect=mock_work)
+
+        backend = Neo4jBackend.from_driver(driver, query_timeout=1.0)
+        result = await backend.get_neighborhoods_batch([entity_id_1, entity_id_2])
+
+        assert len(result) == 2
+        assert entity_id_1 in result
+        assert entity_id_2 in result
+        assert result[entity_id_1]["relationships"][0]["relationship_type"] == "KNOWS"
+        assert result[entity_id_2]["relationships"][0]["relationship_type"] == "COLLABORATES_WITH"
+
+    @pytest.mark.asyncio
+    async def test_handles_no_neighbors(self) -> None:
+        """Entity with no neighbors returns empty entities and relationships lists."""
+        driver, session = _make_neo4j_driver()
+
+        entity_id = uuid4()
+
+        async def mock_work(tx):
+            return [
+                {
+                    "eid": str(entity_id),
+                    "neighbors": [],
+                    "rels": [],
+                }
+            ]
+
+        session.execute_read = AsyncMock(side_effect=mock_work)
+
+        backend = Neo4jBackend.from_driver(driver, query_timeout=1.0)
+        result = await backend.get_neighborhoods_batch([entity_id])
+
+        assert entity_id in result
+        assert result[entity_id]["entities"] == []
+        assert result[entity_id]["relationships"] == []
+
+    @pytest.mark.asyncio
+    async def test_handles_multiple_relationships_per_path(self) -> None:
+        """Entity with multiple relationships per path (depth > 1) are flattened correctly."""
+        driver, session = _make_neo4j_driver()
+
+        entity_id = uuid4()
+        neighbor_id = uuid4()
+        rel_id_1 = uuid4()
+        rel_id_2 = uuid4()
+
+        rel_data_1 = {
+            "props": {
+                "id": str(rel_id_1),
+                "namespace_id": str(uuid4()),
+                "description": "rel1",
+                "properties": "{}",
+                "source_document_ids": [],
+                "source_chunk_ids": [],
+                "valid_from": None,
+                "valid_until": None,
+                "confidence": 0.9,
+                "weight": 0.8,
+                "metadata": "{}",
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-02T00:00:00+00:00",
+            },
+            "type": "KNOWS",
+        }
+
+        rel_data_2 = {
+            "props": {
+                "id": str(rel_id_2),
+                "namespace_id": str(uuid4()),
+                "description": "rel2",
+                "properties": "{}",
+                "source_document_ids": [],
+                "source_chunk_ids": [],
+                "valid_from": None,
+                "valid_until": None,
+                "confidence": 0.85,
+                "weight": 0.75,
+                "metadata": "{}",
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-02T00:00:00+00:00",
+            },
+            "type": "COLLABORATES_WITH",
+        }
+
+        async def mock_work(tx):
+            return [
+                {
+                    "eid": str(entity_id),
+                    "neighbors": [{"id": str(neighbor_id), "name": "neighbor"}],
+                    # Two relationships on the same path (depth=2)
+                    "rels": [[rel_data_1, rel_data_2]],
+                }
+            ]
+
+        session.execute_read = AsyncMock(side_effect=mock_work)
+
+        backend = Neo4jBackend.from_driver(driver, query_timeout=1.0)
+        result = await backend.get_neighborhoods_batch([entity_id])
+
+        rels = result[entity_id]["relationships"]
+        assert len(rels) == 2
+        assert rels[0]["id"] == str(rel_id_1)
+        assert rels[1]["id"] == str(rel_id_2)
+        assert rels[0]["relationship_type"] == "KNOWS"
+        assert rels[1]["relationship_type"] == "COLLABORATES_WITH"
+
+    @pytest.mark.asyncio
+    async def test_handles_none_relationship_values(self) -> None:
+        """None/falsy relationship values are skipped safely."""
+        driver, session = _make_neo4j_driver()
+
+        entity_id = uuid4()
+
+        rel_data = {
+            "props": {
+                "id": str(uuid4()),
+                "namespace_id": str(uuid4()),
+                "description": "rel",
+                "properties": "{}",
+                "source_document_ids": [],
+                "source_chunk_ids": [],
+                "valid_from": None,
+                "valid_until": None,
+                "confidence": 0.9,
+                "weight": 0.8,
+                "metadata": "{}",
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-02T00:00:00+00:00",
+            },
+            "type": "KNOWS",
+        }
+
+        async def mock_work(tx):
+            return [
+                {
+                    "eid": str(entity_id),
+                    "neighbors": [{"id": str(uuid4()), "name": "n"}],
+                    # Include a valid rel and then None/falsy values
+                    "rels": [[rel_data, None], None, []],
+                }
+            ]
+
+        session.execute_read = AsyncMock(side_effect=mock_work)
+
+        backend = Neo4jBackend.from_driver(driver, query_timeout=1.0)
+        result = await backend.get_neighborhoods_batch([entity_id])
+
+        # Only the valid rel should be in the result
+        assert len(result[entity_id]["relationships"]) == 1
+        assert result[entity_id]["relationships"][0]["relationship_type"] == "KNOWS"
+
+
 def _make_rel_props(**overrides: Any) -> dict[str, Any]:
     """Build a minimal post-fix relationship properties dict, with overrides."""
     props: dict[str, Any] = {

--- a/tests/unit/test_neo4j_backend.py
+++ b/tests/unit/test_neo4j_backend.py
@@ -562,6 +562,54 @@ class TestNeo4jBackendGetNeighborhoodsBatchDataHandling:
         assert len(result[entity_id]["relationships"]) == 1
         assert result[entity_id]["relationships"][0]["relationship_type"] == "KNOWS"
 
+    @pytest.mark.asyncio
+    async def test_raw_tuples_raise_attributeerror_regression(self) -> None:
+        """Regression lock: pre-fix raw tuples must raise, not silently corrupt.
+
+        If the Cypher query ever regresses to returning raw Relationship objects,
+        ``result.data()`` serializes them as 3-tuples. The consumer calls
+        ``r.get("props")``, which raises ``AttributeError`` on a tuple — surfacing
+        the regression instead of silently losing data.
+        """
+        driver, session = _make_neo4j_driver()
+        entity_id = uuid4()
+
+        pre_fix_tuple = ({"id": str(uuid4())}, "Relationship", {"id": str(uuid4())})
+
+        async def mock_work(tx):
+            return [
+                {
+                    "eid": str(entity_id),
+                    "neighbors": [],
+                    "rels": [[pre_fix_tuple]],
+                }
+            ]
+
+        session.execute_read = AsyncMock(side_effect=mock_work)
+        backend = Neo4jBackend.from_driver(driver, query_timeout=1.0)
+
+        with pytest.raises(AttributeError, match="get"):
+            await backend.get_neighborhoods_batch([entity_id])
+
+    @pytest.mark.asyncio
+    async def test_relationship_types_filter_completes_without_error(self) -> None:
+        """``relationship_types`` is accepted and the method completes."""
+        driver, session = _make_neo4j_driver()
+
+        async def mock_work(tx):
+            return []
+
+        session.execute_read = AsyncMock(side_effect=mock_work)
+        backend = Neo4jBackend.from_driver(driver, query_timeout=1.0)
+
+        result = await backend.get_neighborhoods_batch(
+            [uuid4()],
+            relationship_types=["KNOWS", "WORKS_WITH"],
+        )
+
+        assert result == {}
+        session.execute_read.assert_called_once()
+
 
 def _make_rel_props(**overrides: Any) -> dict[str, Any]:
     """Build a minimal post-fix relationship properties dict, with overrides."""


### PR DESCRIPTION
## Summary
- Fix silent data loss in `Neo4jBackend.get_neighborhoods_batch` where relationship properties were lost during serialization
- The Cypher query collected raw `Relationship` objects via variable-length paths (`[r*1..N]`), which the neo4j driver serialized as opaque 3-tuples through `result.data()`. `_element_to_dict` received these tuples and fell through to `{"_raw": str(element)}` stubs — silently discarding all properties (`id`, `namespace_id`, `description`, `confidence`, `weight`, `relationship_type`, etc.)
- Fix: project relationship properties and type in Cypher using list comprehension (`[rel IN r | {props: properties(rel), type: type(rel)}]`), then reconstruct dicts in the consumer code
- Same class of bug as DYT-2626 (which affected `get_entity_relationships`), but this one was silent — no `TypeError`, just corrupted data
- Also fix the same bug in `get_neighborhood` (singular) fallback query — same Cypher projection pattern
- Add regression test that pins the pre-fix tuple shape (raises `AttributeError` instead of silently corrupting)
- Add test for `relationship_types` filter parameter on batch queries
- Minor optimization: replace `dict()` copy + mutation with dict unpacking

## Test plan
- [x] Unit tests: 8 new tests covering populated dicts, property preservation, multiple entities, no neighbors, multi-hop paths, null handling, regression lock, and filter parameter
- [x] Integration test: `test_neo4j_get_neighborhoods_batch_integration.py` exercises full Cypher → driver → consumer path against real Neo4j (gated by `NEO4J_INTEGRATION_TEST=1`)
- [x] All 2545 tests pass, coverage 53% (above 46% threshold)
- [x] Grepped callers (`retriever.py`, `query/engine.py`) — none rely on `{"_raw": ...}` shape; relationships ARE consumed by `engine.py:1164-1168` for `graph_info.relationships_traversed`