### PR TITLE
DYT-2667: Add optional session param to delete_chunks_by_document

### DIFF
--- a/src/khora/storage/backends/base.py
+++ b/src/khora/storage/backends/base.py
@@ -281,7 +281,12 @@ class VectorBackendProtocol(Protocol):
 
     @abstractmethod
     async def delete_chunks_by_document(self, document_id: UUID, *, session: AsyncSession | None = None) -> int:
-        """Delete all chunks for a document."""
+        """Delete all chunks for a document.
+
+        When *session* is provided the caller owns the transaction —
+        no commit is issued.  When ``None``, a private session is used
+        and committed automatically.
+        """
         ...
 
     @abstractmethod

--- a/src/khora/storage/backends/base.py
+++ b/src/khora/storage/backends/base.py
@@ -15,6 +15,8 @@ from uuid import UUID
 T = TypeVar("T")
 
 if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
     from khora.core.models import (
         Chunk,
         Document,
@@ -278,7 +280,7 @@ class VectorBackendProtocol(Protocol):
         ...
 
     @abstractmethod
-    async def delete_chunks_by_document(self, document_id: UUID) -> int:
+    async def delete_chunks_by_document(self, document_id: UUID, *, session: AsyncSession | None = None) -> int:
         """Delete all chunks for a document."""
         ...
 

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -357,7 +357,12 @@ class PgVectorBackend(AsyncSessionMixin):
             return [self._chunk_model_to_domain(m) for m in result.scalars().all()]
 
     async def delete_chunks_by_document(self, document_id: UUID, *, session: AsyncSession | None = None) -> int:
-        """Delete all chunks for a document."""
+        """Delete all chunks for a document.
+
+        When *session* is provided the caller owns the transaction —
+        no commit is issued.  When ``None``, a private session is used
+        and committed automatically.
+        """
         if session is not None:
             result = await session.execute(delete(ChunkModel).where(ChunkModel.document_id == document_id))
             return result.rowcount  # type: ignore[unresolved-attribute]

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -356,11 +356,14 @@ class PgVectorBackend(AsyncSessionMixin):
             )
             return [self._chunk_model_to_domain(m) for m in result.scalars().all()]
 
-    async def delete_chunks_by_document(self, document_id: UUID) -> int:
+    async def delete_chunks_by_document(self, document_id: UUID, *, session: AsyncSession | None = None) -> int:
         """Delete all chunks for a document."""
-        async with self._get_session() as session:
+        if session is not None:
             result = await session.execute(delete(ChunkModel).where(ChunkModel.document_id == document_id))
-            await session.commit()
+            return result.rowcount  # type: ignore[unresolved-attribute]
+        async with self._get_session() as own_session:
+            result = await own_session.execute(delete(ChunkModel).where(ChunkModel.document_id == document_id))
+            await own_session.commit()
             return result.rowcount  # type: ignore[unresolved-attribute]
 
     def _cosine_similarity(self, embedding_col, query_embedding: list[float]):

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -212,3 +212,78 @@ class TestBackendSessionParam:
         mock_session.add.assert_called_once()
         mock_session.flush.assert_awaited_once()
         mock_session.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pgvector_delete_chunks_by_document_with_session(self):
+        """delete_chunks_by_document uses provided session without committing."""
+        from uuid import uuid4
+
+        from khora.storage.backends.pgvector import PgVectorBackend
+
+        backend = PgVectorBackend("postgresql+asyncpg://test")
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.rowcount = 5
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        doc_id = uuid4()
+        count = await backend.delete_chunks_by_document(doc_id, session=mock_session)
+
+        assert count == 5
+        mock_session.execute.assert_awaited_once()
+        mock_session.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pgvector_delete_chunks_by_document_without_session(self):
+        """delete_chunks_by_document opens own session and commits when no session provided."""
+        from uuid import uuid4
+
+        from khora.storage.backends.pgvector import PgVectorBackend
+
+        backend = PgVectorBackend("postgresql+asyncpg://test")
+
+        mock_result = MagicMock()
+        mock_result.rowcount = 3
+
+        mock_own_session = AsyncMock()
+        mock_own_session.execute = AsyncMock(return_value=mock_result)
+        mock_own_session.__aenter__ = AsyncMock(return_value=mock_own_session)
+        mock_own_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(backend, "_get_session", return_value=mock_own_session):
+            doc_id = uuid4()
+            count = await backend.delete_chunks_by_document(doc_id)
+
+        assert count == 3
+        mock_own_session.execute.assert_awaited_once()
+        mock_own_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_pgvector_delete_chunks_by_document_no_chunks(self):
+        """delete_chunks_by_document returns 0 when document has no chunks."""
+        from uuid import uuid4
+
+        from khora.storage.backends.pgvector import PgVectorBackend
+
+        backend = PgVectorBackend("postgresql+asyncpg://test")
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.rowcount = 0
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        count = await backend.delete_chunks_by_document(uuid4(), session=mock_session)
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_pgvector_delete_chunks_by_document_error_propagates(self):
+        """delete_chunks_by_document propagates execute errors."""
+        from uuid import uuid4
+
+        from khora.storage.backends.pgvector import PgVectorBackend
+
+        backend = PgVectorBackend("postgresql+asyncpg://test")
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(side_effect=RuntimeError("connection lost"))
+
+        with pytest.raises(RuntimeError, match="connection lost"):
+            await backend.delete_chunks_by_document(uuid4(), session=mock_session)


### PR DESCRIPTION
## Summary
- Add an optional `session` keyword-only parameter to `delete_chunks_by_document()` in both the `VectorBackendProtocol` (base.py) and the `PgVectorBackend` implementation (pgvector.py)
- When a caller-provided `AsyncSession` is passed, the method uses it directly without committing — allowing the delete to participate in an outer transaction
- When no session is passed, the method creates and commits its own session as before (backward-compatible)
- Follows the existing pattern used by `create_chunk()` and `create_chunks_batch()`

## Test plan
- [x] All 2536 existing tests pass (no regressions)
- [x] Ruff format and lint checks pass
- [ ] Manual verification: call `delete_chunks_by_document(doc_id, session=txn_session)` within a coordinator transaction to confirm it participates in the outer transaction without independent commit