### PR TITLE
DYT-2669: Add retire_orphaned_relationships_batch() to Neo4j backend

### DIFF
--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -14,7 +14,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from copy import copy
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, TypedDict
 from uuid import UUID, uuid4
 
 from loguru import logger
@@ -1855,13 +1855,20 @@ class Neo4jBackend(GraphBackendBase):
             deleted = await session.execute_write(_delete)
             return deleted > 0
 
+    class RetirementRow(TypedDict):
+        """A row for retire_orphaned_relationships_batch()."""
+
+        relationship_id: UUID
+        old_doc_id: UUID
+        retired_at: datetime
+
     @trace(
         "khora.neo4j.retire_orphaned_relationships_batch",
         result=lambda r: {"retired_count": r},
     )
     async def retire_orphaned_relationships_batch(
         self,
-        retirement_rows: list[dict[str, Any]],
+        retirement_rows: list[RetirementRow],
     ) -> int:
         """Soft-retire orphaned relationships by stamping valid_until in-place.
 
@@ -1873,6 +1880,10 @@ class Neo4jBackend(GraphBackendBase):
             relationship_id: UUID — the relationship to retire
             old_doc_id: UUID — the document being replaced
             retired_at: datetime — timestamp for valid_until / updated_at
+
+        Returns:
+            Number of relationships actually retired (sole-sourced matches only),
+            not the number of rows attempted.
         """
         if not retirement_rows:
             return 0

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -1856,6 +1856,55 @@ class Neo4jBackend(GraphBackendBase):
             return deleted > 0
 
     @trace(
+        "khora.neo4j.retire_orphaned_relationships_batch",
+        result=lambda r: {"retired_count": r},
+    )
+    async def retire_orphaned_relationships_batch(
+        self,
+        retirement_rows: list[dict[str, Any]],
+    ) -> int:
+        """Soft-retire orphaned relationships by stamping valid_until in-place.
+
+        Only mutates relationships whose sole source was the replaced document
+        (size(source_document_ids) = 1). Multi-sourced relationships are left
+        untouched for separate survivor cleanup.
+
+        Each row must contain:
+            relationship_id: UUID — the relationship to retire
+            old_doc_id: UUID — the document being replaced
+            retired_at: datetime — timestamp for valid_until / updated_at
+        """
+        if not retirement_rows:
+            return 0
+        rows = [
+            {
+                "relationship_id": str(r["relationship_id"]),
+                "old_doc_id": str(r["old_doc_id"]),
+                "retired_at": r["retired_at"].isoformat(),
+            }
+            for r in retirement_rows
+        ]
+
+        async def _retire(tx: AsyncManagedTransaction) -> int:
+            result = await tx.run(
+                """
+                UNWIND $retirement_rows AS r
+                MATCH ()-[rel {id: r.relationship_id}]-()
+                WHERE size(rel.source_document_ids) = 1
+                  AND r.old_doc_id IN rel.source_document_ids
+                SET rel.valid_until = r.retired_at,
+                    rel.updated_at = r.retired_at
+                RETURN count(DISTINCT rel) AS retired
+                """,
+                retirement_rows=rows,
+            )
+            record = await result.single()
+            return record["retired"] if record else 0
+
+        async with self._session() as session:
+            return await session.execute_write(_retire)
+
+    @trace(
         "khora.neo4j.get_entity_relationships",
         include={"entity_id", "direction"},
         result=lambda r: {"result_count": len(r)},

--- a/tests/integration/test_neo4j_retire_relationships_integration.py
+++ b/tests/integration/test_neo4j_retire_relationships_integration.py
@@ -1,0 +1,262 @@
+"""Real-Neo4j integration test for ``Neo4jBackend.retire_orphaned_relationships_batch`` (DYT-2669).
+
+This test exercises the full Cypher retire path against a running Neo4j
+instance, verifying that sole-sourced relationships are soft-retired
+(valid_until stamped) while multi-sourced or wrong-doc relationships
+are left untouched.
+
+How to run locally:
+
+    make dev  # starts postgres + neo4j via docker compose
+    NEO4J_INTEGRATION_TEST=1 uv run pytest \
+        tests/integration/test_neo4j_retire_relationships_integration.py -v
+
+Connection parameters are read from env vars with sensible defaults that
+match the ``make dev`` compose stack:
+
+    KHORA_NEO4J_URL       (default: bolt://localhost:7687)
+    KHORA_NEO4J_USERNAME  (default: neo4j)
+    KHORA_NEO4J_PASSWORD  (default: password)
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from khora.core.models.entity import Entity, Relationship
+from khora.storage.backends.neo4j import Neo4jBackend
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("NEO4J_INTEGRATION_TEST"),
+    reason="set NEO4J_INTEGRATION_TEST=1 to run against real Neo4j (requires make dev)",
+)
+class TestNeo4jRetireOrphanedRelationshipsBatch:
+    """End-to-end tests for retire_orphaned_relationships_batch against a real Neo4j."""
+
+    @pytest.mark.asyncio
+    async def test_sole_sourced_relationship_is_retired(self) -> None:
+        """A relationship with exactly one source doc matching old_doc_id is retired."""
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        namespace_id = uuid4()
+        doc_id = uuid4()
+        entity_a = Entity(
+            namespace_id=namespace_id,
+            name=f"alice-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="Alice",
+        )
+        entity_b = Entity(
+            namespace_id=namespace_id,
+            name=f"bob-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="Bob",
+        )
+        relationship = Relationship(
+            namespace_id=namespace_id,
+            source_entity_id=entity_a.id,
+            target_entity_id=entity_b.id,
+            relationship_type="KNOWS",
+            description="alice knows bob",
+            source_document_ids=[doc_id],
+            confidence=0.9,
+            weight=0.75,
+        )
+
+        try:
+            await backend.create_entity(entity_a)
+            await backend.create_entity(entity_b)
+            await backend.create_relationship(relationship)
+
+            retired_at = datetime.now(UTC)
+            count = await backend.retire_orphaned_relationships_batch(
+                [
+                    {
+                        "relationship_id": relationship.id,
+                        "old_doc_id": doc_id,
+                        "retired_at": retired_at,
+                    }
+                ]
+            )
+
+            assert count == 1
+
+            rel = await backend.get_relationship(relationship.id)
+            assert rel is not None
+            assert rel.valid_until is not None
+            assert rel.valid_until.isoformat() == retired_at.isoformat()
+            assert rel.updated_at.isoformat() == retired_at.isoformat()
+            # Other properties must be unchanged
+            assert rel.description == "alice knows bob"
+            assert rel.confidence == 0.9
+            assert rel.weight == 0.75
+            assert len(rel.source_document_ids) == 1
+        finally:
+            try:
+                await backend.delete_relationship(relationship.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_a.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_b.id)
+            except Exception:  # noqa: BLE001
+                pass
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_multi_sourced_relationship_not_retired(self) -> None:
+        """A relationship with multiple source docs is NOT retired."""
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        namespace_id = uuid4()
+        doc_id = uuid4()
+        other_doc_id = uuid4()
+        entity_a = Entity(
+            namespace_id=namespace_id,
+            name=f"carol-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="Carol",
+        )
+        entity_b = Entity(
+            namespace_id=namespace_id,
+            name=f"dave-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="Dave",
+        )
+        relationship = Relationship(
+            namespace_id=namespace_id,
+            source_entity_id=entity_a.id,
+            target_entity_id=entity_b.id,
+            relationship_type="WORKS_WITH",
+            description="carol works with dave",
+            source_document_ids=[doc_id, other_doc_id],
+            confidence=0.8,
+            weight=0.6,
+        )
+
+        try:
+            await backend.create_entity(entity_a)
+            await backend.create_entity(entity_b)
+            await backend.create_relationship(relationship)
+
+            retired_at = datetime.now(UTC)
+            count = await backend.retire_orphaned_relationships_batch(
+                [
+                    {
+                        "relationship_id": relationship.id,
+                        "old_doc_id": doc_id,
+                        "retired_at": retired_at,
+                    }
+                ]
+            )
+
+            assert count == 0
+
+            rel = await backend.get_relationship(relationship.id)
+            assert rel is not None
+            assert rel.valid_until is None
+        finally:
+            try:
+                await backend.delete_relationship(relationship.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_a.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_b.id)
+            except Exception:  # noqa: BLE001
+                pass
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_wrong_doc_id_not_retired(self) -> None:
+        """A sole-sourced relationship is NOT retired when old_doc_id doesn't match."""
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        namespace_id = uuid4()
+        doc_id = uuid4()
+        wrong_doc_id = uuid4()
+        entity_a = Entity(
+            namespace_id=namespace_id,
+            name=f"eve-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="Eve",
+        )
+        entity_b = Entity(
+            namespace_id=namespace_id,
+            name=f"frank-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="Frank",
+        )
+        relationship = Relationship(
+            namespace_id=namespace_id,
+            source_entity_id=entity_a.id,
+            target_entity_id=entity_b.id,
+            relationship_type="MANAGES",
+            description="eve manages frank",
+            source_document_ids=[doc_id],
+            confidence=0.95,
+            weight=0.5,
+        )
+
+        try:
+            await backend.create_entity(entity_a)
+            await backend.create_entity(entity_b)
+            await backend.create_relationship(relationship)
+
+            retired_at = datetime.now(UTC)
+            count = await backend.retire_orphaned_relationships_batch(
+                [
+                    {
+                        "relationship_id": relationship.id,
+                        "old_doc_id": wrong_doc_id,
+                        "retired_at": retired_at,
+                    }
+                ]
+            )
+
+            assert count == 0
+
+            rel = await backend.get_relationship(relationship.id)
+            assert rel is not None
+            assert rel.valid_until is None
+        finally:
+            try:
+                await backend.delete_relationship(relationship.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_a.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_b.id)
+            except Exception:  # noqa: BLE001
+                pass
+            await backend.disconnect()

--- a/tests/integration/test_neo4j_retire_relationships_integration.py
+++ b/tests/integration/test_neo4j_retire_relationships_integration.py
@@ -95,8 +95,8 @@ class TestNeo4jRetireOrphanedRelationshipsBatch:
             rel = await backend.get_relationship(relationship.id)
             assert rel is not None
             assert rel.valid_until is not None
-            assert rel.valid_until.isoformat() == retired_at.isoformat()
-            assert rel.updated_at.isoformat() == retired_at.isoformat()
+            assert rel.valid_until == retired_at
+            assert rel.updated_at == retired_at
             # Other properties must be unchanged
             assert rel.description == "alice knows bob"
             assert rel.confidence == 0.9
@@ -246,6 +246,130 @@ class TestNeo4jRetireOrphanedRelationshipsBatch:
             rel = await backend.get_relationship(relationship.id)
             assert rel is not None
             assert rel.valid_until is None
+        finally:
+            try:
+                await backend.delete_relationship(relationship.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_a.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_b.id)
+            except Exception:  # noqa: BLE001
+                pass
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_empty_batch_returns_zero(self) -> None:
+        """An empty batch should return 0 without touching Neo4j."""
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        try:
+            count = await backend.retire_orphaned_relationships_batch([])
+            assert count == 0
+        finally:
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_relationship_id_returns_zero(self) -> None:
+        """A non-existent relationship ID should silently return 0."""
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        try:
+            count = await backend.retire_orphaned_relationships_batch(
+                [
+                    {
+                        "relationship_id": uuid4(),
+                        "old_doc_id": uuid4(),
+                        "retired_at": datetime.now(UTC),
+                    }
+                ]
+            )
+            assert count == 0
+        finally:
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_already_retired_relationship_is_restamped(self) -> None:
+        """Re-retiring an already-retired relationship updates the timestamp."""
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        namespace_id = uuid4()
+        doc_id = uuid4()
+        entity_a = Entity(
+            namespace_id=namespace_id,
+            name=f"grace-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="Grace",
+        )
+        entity_b = Entity(
+            namespace_id=namespace_id,
+            name=f"heidi-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="Heidi",
+        )
+        relationship = Relationship(
+            namespace_id=namespace_id,
+            source_entity_id=entity_a.id,
+            target_entity_id=entity_b.id,
+            relationship_type="MENTORS",
+            description="grace mentors heidi",
+            source_document_ids=[doc_id],
+            confidence=0.85,
+            weight=0.7,
+        )
+
+        try:
+            await backend.create_entity(entity_a)
+            await backend.create_entity(entity_b)
+            await backend.create_relationship(relationship)
+
+            # First retirement
+            first_retired_at = datetime.now(UTC)
+            count1 = await backend.retire_orphaned_relationships_batch(
+                [
+                    {
+                        "relationship_id": relationship.id,
+                        "old_doc_id": doc_id,
+                        "retired_at": first_retired_at,
+                    }
+                ]
+            )
+            assert count1 == 1
+
+            # Second retirement with later timestamp
+            second_retired_at = datetime.now(UTC)
+            count2 = await backend.retire_orphaned_relationships_batch(
+                [
+                    {
+                        "relationship_id": relationship.id,
+                        "old_doc_id": doc_id,
+                        "retired_at": second_retired_at,
+                    }
+                ]
+            )
+            assert count2 == 1
+
+            rel = await backend.get_relationship(relationship.id)
+            assert rel is not None
+            assert rel.valid_until == second_retired_at
         finally:
             try:
                 await backend.delete_relationship(relationship.id)


### PR DESCRIPTION
## Summary
- Add `retire_orphaned_relationships_batch()` method to `Neo4jBackend` that soft-retires relationships by stamping `valid_until` and `updated_at` in-place (ADR-056, decision #4)
- Only mutates relationships whose sole source was the replaced document (`size(source_document_ids) = 1`); multi-sourced relationships are left untouched
- Cypher uses `UNWIND` batch pattern with `count(DISTINCT rel)` to avoid double-counting from undirected match
- Integration tests cover all 3 acceptance criteria: sole-sourced retirement, multi-sourced skip, wrong-doc-id skip

## Test plan
- [x] Unit tests pass (2536 passed, 53% coverage)
- [x] Lint and format clean (`ruff check`, `ruff format`)
- [ ] Integration tests pass against real Neo4j (`NEO4J_INTEGRATION_TEST=1 uv run pytest tests/integration/test_neo4j_retire_relationships_integration.py -v`)
- [ ] Manual: `make dev` → run integration test → verify sole-sourced relationship gets `valid_until` stamped