### PR TITLE
DYT-2670: Add remap_source_document_ids_batch() to Neo4j backend

### DIFF
--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -656,6 +656,8 @@ class Neo4jBackend(GraphBackendBase):
         #          LLM prompt examples, expansion modules (relationship_inferrer,
         #          cross_tool_unifier).
         rel_indexes = [
+            # type-independent relationship id index (used by remap, get, delete)
+            "CREATE INDEX rel_id IF NOT EXISTS FOR ()-[r]-() ON (r.id)",
             # --- namespace_id on all known relationship types ---
             # Core / general
             "CREATE INDEX rel_namespace IF NOT EXISTS FOR ()-[r:RELATES_TO]-() ON (r.namespace_id)",

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -2680,3 +2680,45 @@ RETURN current.id AS id
 
         async with self._session() as session:
             return await session.execute_read(_work)
+
+    async def remap_source_document_ids_batch(
+        self,
+        *,
+        entity_survivors: list[dict[str, str]],
+        relationship_survivors: list[dict[str, str]],
+    ) -> None:
+        """Remap source_document_ids for entities and relationships after dedup."""
+
+        if entity_survivors:
+
+            async def _remap_entities(tx: AsyncManagedTransaction) -> None:
+                query = """
+                UNWIND $survivors AS s
+                MATCH (e:Entity {id: s.entity_id})
+                WITH e, s, [x IN coalesce(e.source_document_ids, []) WHERE x <> s.old_doc_id] AS filtered
+                SET e.source_document_ids = CASE
+                  WHEN size(filtered) < size(coalesce(e.source_document_ids, [])) THEN filtered + [s.new_doc_id]
+                  ELSE coalesce(e.source_document_ids, [])
+                END
+                """
+                await tx.run(query, survivors=entity_survivors)
+
+            async with self._session() as session:
+                await session.execute_write(_remap_entities)
+
+        if relationship_survivors:
+
+            async def _remap_relationships(tx: AsyncManagedTransaction) -> None:
+                query = """
+                UNWIND $survivors AS s
+                MATCH ()-[rel {id: s.relationship_id}]-()
+                WITH rel, s, [x IN coalesce(rel.source_document_ids, []) WHERE x <> s.old_doc_id] AS filtered
+                SET rel.source_document_ids = CASE
+                  WHEN size(filtered) < size(coalesce(rel.source_document_ids, [])) THEN filtered + [s.new_doc_id]
+                  ELSE coalesce(rel.source_document_ids, [])
+                END
+                """
+                await tx.run(query, survivors=relationship_survivors)
+
+            async with self._session() as session:
+                await session.execute_write(_remap_relationships)

--- a/tests/integration/test_neo4j_remap_source_document_ids_integration.py
+++ b/tests/integration/test_neo4j_remap_source_document_ids_integration.py
@@ -1,0 +1,274 @@
+"""Real-Neo4j integration tests for ``Neo4jBackend.remap_source_document_ids_batch`` (DYT-2670).
+
+Verifies that source_document_ids arrays on entities and relationships are
+correctly remapped (old doc UUID swapped for new) against a running Neo4j
+instance.
+
+How to run locally:
+
+    make dev  # starts postgres + neo4j via docker compose
+    NEO4J_INTEGRATION_TEST=1 uv run pytest \
+        tests/integration/test_neo4j_remap_source_document_ids_integration.py -v
+
+Connection parameters are read from env vars with sensible defaults that
+match the ``make dev`` compose stack:
+
+    KHORA_NEO4J_URL       (default: bolt://localhost:7687)
+    KHORA_NEO4J_USERNAME  (default: neo4j)
+    KHORA_NEO4J_PASSWORD  (default: password)
+"""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+
+from khora.core.models.entity import Entity, Relationship
+from khora.storage.backends.neo4j import Neo4jBackend
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("NEO4J_INTEGRATION_TEST"),
+    reason="set NEO4J_INTEGRATION_TEST=1 to run against real Neo4j (requires make dev)",
+)
+class TestNeo4jRemapSourceDocumentIdsIntegration:
+    """End-to-end tests for remap_source_document_ids_batch against a real Neo4j."""
+
+    @pytest.mark.asyncio
+    async def test_entity_remap_happy_path(self) -> None:
+        """Remap replaces old_doc_id with new_doc_id in entity source_document_ids."""
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        namespace_id = uuid4()
+        doc_a, doc_b, doc_c = uuid4(), uuid4(), uuid4()
+        entity = Entity(
+            namespace_id=namespace_id,
+            name=f"entity-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="test entity",
+            source_document_ids=[doc_a, doc_b],
+        )
+
+        try:
+            await backend.create_entity(entity)
+
+            await backend.remap_source_document_ids_batch(
+                entity_survivors=[
+                    {
+                        "entity_id": str(entity.id),
+                        "old_doc_id": str(doc_a),
+                        "new_doc_id": str(doc_c),
+                    }
+                ],
+                relationship_survivors=[],
+            )
+
+            got = await backend.get_entity(entity.id)
+            assert got is not None
+            doc_ids = got.source_document_ids
+            assert len(doc_ids) == 2
+            assert doc_b in doc_ids
+            assert doc_c in doc_ids
+            assert doc_a not in doc_ids
+        finally:
+            try:
+                await backend.delete_entity(entity.id)
+            except Exception:  # noqa: BLE001
+                pass
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_entity_remap_old_doc_not_in_array(self) -> None:
+        """Remap with old_doc_id absent from array leaves source_document_ids unchanged."""
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        namespace_id = uuid4()
+        doc_a, doc_b, doc_x = uuid4(), uuid4(), uuid4()
+        entity = Entity(
+            namespace_id=namespace_id,
+            name=f"entity-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="test entity",
+            source_document_ids=[doc_a, doc_b],
+        )
+
+        try:
+            await backend.create_entity(entity)
+
+            await backend.remap_source_document_ids_batch(
+                entity_survivors=[
+                    {
+                        "entity_id": str(entity.id),
+                        "old_doc_id": str(doc_x),
+                        "new_doc_id": str(uuid4()),
+                    }
+                ],
+                relationship_survivors=[],
+            )
+
+            got = await backend.get_entity(entity.id)
+            assert got is not None
+            doc_ids = got.source_document_ids
+            assert len(doc_ids) == 2
+            assert doc_a in doc_ids
+            assert doc_b in doc_ids
+        finally:
+            try:
+                await backend.delete_entity(entity.id)
+            except Exception:  # noqa: BLE001
+                pass
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_relationship_remap_happy_path(self) -> None:
+        """Remap replaces old_doc_id with new_doc_id in relationship source_document_ids."""
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        namespace_id = uuid4()
+        doc_a, doc_b, doc_c = uuid4(), uuid4(), uuid4()
+        entity_a = Entity(
+            namespace_id=namespace_id,
+            name=f"entity-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="entity a",
+        )
+        entity_b = Entity(
+            namespace_id=namespace_id,
+            name=f"entity-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="entity b",
+        )
+        relationship = Relationship(
+            namespace_id=namespace_id,
+            source_entity_id=entity_a.id,
+            target_entity_id=entity_b.id,
+            relationship_type="KNOWS",
+            description="a knows b",
+            source_document_ids=[doc_a, doc_b],
+        )
+
+        try:
+            await backend.create_entity(entity_a)
+            await backend.create_entity(entity_b)
+            await backend.create_relationship(relationship)
+
+            await backend.remap_source_document_ids_batch(
+                entity_survivors=[],
+                relationship_survivors=[
+                    {
+                        "relationship_id": str(relationship.id),
+                        "old_doc_id": str(doc_a),
+                        "new_doc_id": str(doc_c),
+                    }
+                ],
+            )
+
+            got = await backend.get_relationship(relationship.id)
+            assert got is not None
+            doc_ids = got.source_document_ids
+            assert len(doc_ids) == 2
+            assert doc_b in doc_ids
+            assert doc_c in doc_ids
+            assert doc_a not in doc_ids
+        finally:
+            try:
+                await backend.delete_relationship(relationship.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_a.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_b.id)
+            except Exception:  # noqa: BLE001
+                pass
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_relationship_remap_old_doc_not_in_array(self) -> None:
+        """Remap with old_doc_id absent from array leaves relationship source_document_ids unchanged."""
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        namespace_id = uuid4()
+        doc_a, doc_b, doc_x = uuid4(), uuid4(), uuid4()
+        entity_a = Entity(
+            namespace_id=namespace_id,
+            name=f"entity-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="entity a",
+        )
+        entity_b = Entity(
+            namespace_id=namespace_id,
+            name=f"entity-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="entity b",
+        )
+        relationship = Relationship(
+            namespace_id=namespace_id,
+            source_entity_id=entity_a.id,
+            target_entity_id=entity_b.id,
+            relationship_type="KNOWS",
+            description="a knows b",
+            source_document_ids=[doc_a, doc_b],
+        )
+
+        try:
+            await backend.create_entity(entity_a)
+            await backend.create_entity(entity_b)
+            await backend.create_relationship(relationship)
+
+            await backend.remap_source_document_ids_batch(
+                entity_survivors=[],
+                relationship_survivors=[
+                    {
+                        "relationship_id": str(relationship.id),
+                        "old_doc_id": str(doc_x),
+                        "new_doc_id": str(uuid4()),
+                    }
+                ],
+            )
+
+            got = await backend.get_relationship(relationship.id)
+            assert got is not None
+            doc_ids = got.source_document_ids
+            assert len(doc_ids) == 2
+            assert doc_a in doc_ids
+            assert doc_b in doc_ids
+        finally:
+            try:
+                await backend.delete_relationship(relationship.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_a.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_b.id)
+            except Exception:  # noqa: BLE001
+                pass
+            await backend.disconnect()

--- a/tests/integration/test_neo4j_remap_source_document_ids_integration.py
+++ b/tests/integration/test_neo4j_remap_source_document_ids_integration.py
@@ -133,6 +133,132 @@ class TestNeo4jRemapSourceDocumentIdsIntegration:
             await backend.disconnect()
 
     @pytest.mark.asyncio
+    async def test_entity_remap_deduplicates_old_doc_id(self) -> None:
+        """Remap removes all occurrences of old_doc_id and appends one new_doc_id."""
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        namespace_id = uuid4()
+        doc_a, doc_b, doc_c = uuid4(), uuid4(), uuid4()
+        entity = Entity(
+            namespace_id=namespace_id,
+            name=f"entity-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="test entity",
+            source_document_ids=[doc_a, doc_a, doc_b],
+        )
+
+        try:
+            await backend.create_entity(entity)
+
+            await backend.remap_source_document_ids_batch(
+                entity_survivors=[
+                    {
+                        "entity_id": str(entity.id),
+                        "old_doc_id": str(doc_a),
+                        "new_doc_id": str(doc_c),
+                    }
+                ],
+                relationship_survivors=[],
+            )
+
+            got = await backend.get_entity(entity.id)
+            assert got is not None
+            doc_ids = got.source_document_ids
+            assert len(doc_ids) == 2
+            assert doc_b in doc_ids
+            assert doc_c in doc_ids
+            assert doc_a not in doc_ids
+        finally:
+            try:
+                await backend.delete_entity(entity.id)
+            except Exception:  # noqa: BLE001
+                pass
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_entity_remap_multiple_survivors_in_batch(self) -> None:
+        """Remap handles multiple survivors in a single batch call."""
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        namespace_id = uuid4()
+        doc_a, doc_b, doc_c, doc_d, doc_e, doc_f = (
+            uuid4(),
+            uuid4(),
+            uuid4(),
+            uuid4(),
+            uuid4(),
+            uuid4(),
+        )
+        entity_1 = Entity(
+            namespace_id=namespace_id,
+            name=f"entity-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="test entity 1",
+            source_document_ids=[doc_a, doc_b],
+        )
+        entity_2 = Entity(
+            namespace_id=namespace_id,
+            name=f"entity-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            description="test entity 2",
+            source_document_ids=[doc_c, doc_d],
+        )
+
+        try:
+            await backend.create_entity(entity_1)
+            await backend.create_entity(entity_2)
+
+            await backend.remap_source_document_ids_batch(
+                entity_survivors=[
+                    {
+                        "entity_id": str(entity_1.id),
+                        "old_doc_id": str(doc_a),
+                        "new_doc_id": str(doc_e),
+                    },
+                    {
+                        "entity_id": str(entity_2.id),
+                        "old_doc_id": str(doc_c),
+                        "new_doc_id": str(doc_f),
+                    },
+                ],
+                relationship_survivors=[],
+            )
+
+            got_1 = await backend.get_entity(entity_1.id)
+            assert got_1 is not None
+            doc_ids_1 = got_1.source_document_ids
+            assert len(doc_ids_1) == 2
+            assert doc_b in doc_ids_1
+            assert doc_e in doc_ids_1
+
+            got_2 = await backend.get_entity(entity_2.id)
+            assert got_2 is not None
+            doc_ids_2 = got_2.source_document_ids
+            assert len(doc_ids_2) == 2
+            assert doc_d in doc_ids_2
+            assert doc_f in doc_ids_2
+        finally:
+            try:
+                await backend.delete_entity(entity_1.id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await backend.delete_entity(entity_2.id)
+            except Exception:  # noqa: BLE001
+                pass
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
     async def test_relationship_remap_happy_path(self) -> None:
         """Remap replaces old_doc_id with new_doc_id in relationship source_document_ids."""
         url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")


### PR DESCRIPTION
## Summary
- Add `remap_source_document_ids_batch()` method to `Neo4jBackend` for swapping old doc UUIDs with new ones in `source_document_ids` arrays on entities and relationships (ADR-056 decision #5)
- Handles both entity and relationship survivors in a single call, skipping empty lists
- Uses `CASE` guard to prevent spurious appends when `old_doc_id` is not in the array
- Adds `COALESCE` for null-safety on `source_document_ids` arrays
- Integration tests covering all 4 acceptance criteria: entity happy path, entity no-match, relationship happy path, relationship no-match

## Test plan
- [x] Unit tests pass (2508 passed)
- [x] Ruff format + check pass
- [ ] Integration tests pass (`NEO4J_INTEGRATION_TEST=1 uv run pytest tests/integration/test_neo4j_remap_source_document_ids_integration.py -v`)