### PR TITLE
DYT-2672: Promote (namespace_id, external_id) partial index to UNIQUE

### DIFF
--- a/docs/data-models/documents-chunks.md
+++ b/docs/data-models/documents-chunks.md
@@ -294,7 +294,7 @@ CREATE TABLE documents (
 CREATE INDEX idx_documents_namespace ON documents(namespace_id);
 CREATE INDEX idx_documents_status ON documents(namespace_id, status);
 CREATE INDEX idx_documents_checksum ON documents(namespace_id, (metadata->>'checksum'));
-CREATE INDEX ix_documents_namespace_external_id
+CREATE UNIQUE INDEX ix_documents_namespace_external_id_unique
     ON documents(namespace_id, external_id) WHERE external_id IS NOT NULL;
 ```
 

--- a/src/khora/db/migrations/versions/022_promote_external_id_index_unique.py
+++ b/src/khora/db/migrations/versions/022_promote_external_id_index_unique.py
@@ -7,6 +7,12 @@ Create Date: 2026-04-21
 DYT-2672: Promote the partial composite index (namespace_id, external_id)
 WHERE external_id IS NOT NULL to a UNIQUE constraint, enabling idempotent
 upsert-by-external_id.
+
+Uses CREATE/DROP INDEX CONCURRENTLY on PostgreSQL (cannot run inside a
+transaction), so each index operation uses an autocommit block.  Invalid
+indexes left behind by interrupted builds are detected via
+pg_index.indisvalid, dropped, and recreated.  SQLite uses the standard
+transactional approach (no CONCURRENTLY support).
 """
 
 from collections.abc import Sequence
@@ -20,18 +26,52 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
+def _drop_invalid_index(index_name: str) -> None:
+    """Drop an index if it exists and is marked invalid (indisvalid = false).
+
+    An invalid index is left behind when CREATE INDEX CONCURRENTLY is
+    interrupted.  We must remove it before re-creating, because
+    IF NOT EXISTS will skip creation even for invalid indexes.
+    """
+    conn = op.get_bind()
+    is_invalid = conn.execute(
+        text(
+            "SELECT EXISTS ("
+            "  SELECT 1 FROM pg_class c"
+            "  JOIN pg_index i ON i.indexrelid = c.oid"
+            "  WHERE c.relname = :name AND NOT i.indisvalid"
+            ")"
+        ),
+        {"name": index_name},
+    ).scalar()
+    if is_invalid:
+        with op.get_context().autocommit_block():
+            op.execute(text(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}"))
+
+
 def upgrade() -> None:
     """Replace non-unique partial index with a UNIQUE partial index."""
-    op.drop_index("ix_documents_namespace_external_id", table_name="documents")
     if op.get_bind().dialect.name == "postgresql":
-        op.create_index(
-            "ix_documents_namespace_external_id_unique",
-            "documents",
-            ["namespace_id", "external_id"],
-            unique=True,
-            postgresql_where=text("external_id IS NOT NULL"),
-        )
+        # Drop old non-unique index concurrently
+        with op.get_context().autocommit_block():
+            op.execute(text("DROP INDEX CONCURRENTLY IF EXISTS ix_documents_namespace_external_id"))
+
+        # Clean up any invalid index from interrupted previous build
+        _drop_invalid_index("ix_documents_namespace_external_id_unique")
+
+        # Create new unique partial index concurrently
+        with op.get_context().autocommit_block():
+            op.execute(
+                text(
+                    "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS"
+                    " ix_documents_namespace_external_id_unique"
+                    " ON documents (namespace_id, external_id)"
+                    " WHERE external_id IS NOT NULL"
+                )
+            )
     else:
+        # SQLite: no CONCURRENTLY, use transactional approach
+        op.drop_index("ix_documents_namespace_external_id", table_name="documents")
         op.create_index(
             "ix_documents_namespace_external_id_unique",
             "documents",
@@ -43,15 +83,23 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Restore original non-unique partial index."""
-    op.drop_index("ix_documents_namespace_external_id_unique", table_name="documents")
     if op.get_bind().dialect.name == "postgresql":
-        op.create_index(
-            "ix_documents_namespace_external_id",
-            "documents",
-            ["namespace_id", "external_id"],
-            postgresql_where=text("external_id IS NOT NULL"),
-        )
+        with op.get_context().autocommit_block():
+            op.execute(text("DROP INDEX CONCURRENTLY IF EXISTS ix_documents_namespace_external_id_unique"))
+
+        _drop_invalid_index("ix_documents_namespace_external_id")
+
+        with op.get_context().autocommit_block():
+            op.execute(
+                text(
+                    "CREATE INDEX CONCURRENTLY IF NOT EXISTS"
+                    " ix_documents_namespace_external_id"
+                    " ON documents (namespace_id, external_id)"
+                    " WHERE external_id IS NOT NULL"
+                )
+            )
     else:
+        op.drop_index("ix_documents_namespace_external_id_unique", table_name="documents")
         op.create_index(
             "ix_documents_namespace_external_id",
             "documents",

--- a/src/khora/db/migrations/versions/022_promote_external_id_index_unique.py
+++ b/src/khora/db/migrations/versions/022_promote_external_id_index_unique.py
@@ -1,0 +1,60 @@
+"""Promote external_id partial index to UNIQUE.
+
+Revision ID: 022_promote_external_id_index_unique
+Revises: 021_add_document_external_id
+Create Date: 2026-04-21
+
+DYT-2672: Promote the partial composite index (namespace_id, external_id)
+WHERE external_id IS NOT NULL to a UNIQUE constraint, enabling idempotent
+upsert-by-external_id.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "022_promote_external_id_index_unique"
+down_revision: str | Sequence[str] | None = "021_add_document_external_id"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Replace non-unique partial index with a UNIQUE partial index."""
+    op.drop_index("ix_documents_namespace_external_id", table_name="documents")
+    if op.get_bind().dialect.name == "postgresql":
+        op.create_index(
+            "ix_documents_namespace_external_id_unique",
+            "documents",
+            ["namespace_id", "external_id"],
+            unique=True,
+            postgresql_where=text("external_id IS NOT NULL"),
+        )
+    else:
+        op.create_index(
+            "ix_documents_namespace_external_id_unique",
+            "documents",
+            ["namespace_id", "external_id"],
+            unique=True,
+            sqlite_where=text("external_id IS NOT NULL"),
+        )
+
+
+def downgrade() -> None:
+    """Restore original non-unique partial index."""
+    op.drop_index("ix_documents_namespace_external_id_unique", table_name="documents")
+    if op.get_bind().dialect.name == "postgresql":
+        op.create_index(
+            "ix_documents_namespace_external_id",
+            "documents",
+            ["namespace_id", "external_id"],
+            postgresql_where=text("external_id IS NOT NULL"),
+        )
+    else:
+        op.create_index(
+            "ix_documents_namespace_external_id",
+            "documents",
+            ["namespace_id", "external_id"],
+            sqlite_where=text("external_id IS NOT NULL"),
+        )

--- a/src/khora/db/models.py
+++ b/src/khora/db/models.py
@@ -179,9 +179,10 @@ class DocumentModel(Base):
         Index("ix_documents_namespace_source_type", "namespace_id", "source_type"),
         Index("ix_documents_namespace_created_at", "namespace_id", "created_at"),
         Index(
-            "ix_documents_namespace_external_id",
+            "ix_documents_namespace_external_id_unique",
             "namespace_id",
             "external_id",
+            unique=True,
             postgresql_where=text("external_id IS NOT NULL"),
         ),
     )

--- a/tests/integration/test_unique_external_id.py
+++ b/tests/integration/test_unique_external_id.py
@@ -116,7 +116,7 @@ class TestUniqueExternalId:
                 ns = await _create_namespace(session)
                 ext_id = f"dup-{uuid4().hex[:8]}"
                 await _insert_document(session, ns.id, external_id=ext_id)
-                with pytest.raises(IntegrityError):
+                with pytest.raises(IntegrityError, match=r"ix_documents_namespace_external_id_unique"):
                     await _insert_document(session, ns.id, external_id=ext_id)
 
     async def test_concurrent_insert_same_external_id_raises(
@@ -176,7 +176,7 @@ class TestUniqueExternalId:
             async with session.begin():
                 ns = await _create_namespace(session)
                 await _insert_document(session, ns.id, external_id="")
-                with pytest.raises(IntegrityError):
+                with pytest.raises(IntegrityError, match=r"ix_documents_namespace_external_id_unique"):
                     await _insert_document(session, ns.id, external_id="")
 
     async def test_same_external_id_different_namespace_allowed(

--- a/tests/integration/test_unique_external_id.py
+++ b/tests/integration/test_unique_external_id.py
@@ -1,0 +1,195 @@
+"""Integration tests for the unique (namespace_id, external_id) partial index (DYT-2672).
+
+Validates migration 022 which promotes the partial composite index on
+(namespace_id, external_id) WHERE external_id IS NOT NULL to UNIQUE.
+
+Requires a running PostgreSQL instance (``make dev``).
+
+Connection parameters (env overrides, sensible ``make dev`` defaults)::
+
+    KHORA_DATABASE_URL  (default: postgresql+asyncpg://khora:khora@localhost:5432/khora)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import AsyncIterator
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from khora.db.models import DocumentModel, MemoryNamespaceModel
+from khora.db.session import run_migrations
+
+DATABASE_URL = os.environ.get(
+    "KHORA_DATABASE_URL",
+    "postgresql+asyncpg://khora:khora@localhost:5432/khora",
+)
+
+# Normalize to asyncpg driver
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
+
+pytestmark = [pytest.mark.integration]
+
+
+def _pg_reachable() -> bool:
+    """Quick TCP check to see if PostgreSQL is listening."""
+    import socket
+    from urllib.parse import urlparse
+
+    parsed = urlparse(DATABASE_URL.replace("+asyncpg", ""))
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+skip_no_pg = pytest.mark.skipif(
+    not _pg_reachable(),
+    reason="PostgreSQL not reachable (run `make dev` first)",
+)
+
+
+@pytest.fixture(scope="module")
+async def _run_migrations_once():
+    """Run Alembic migrations once for the entire module."""
+    result = await run_migrations(DATABASE_URL)
+    assert result.success, f"Migrations failed: {result.error}"
+
+
+@pytest.fixture
+async def session_factory(_run_migrations_once) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    """Create a disposable engine + session factory per test."""
+    engine = create_async_engine(DATABASE_URL)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+async def _create_namespace(session: AsyncSession) -> MemoryNamespaceModel:
+    """Insert a fresh namespace and return it."""
+    ns_id = uuid4()
+    ns = MemoryNamespaceModel(id=ns_id, namespace_id=ns_id)
+    session.add(ns)
+    await session.flush()
+    return ns
+
+
+async def _insert_document(
+    session: AsyncSession,
+    namespace_id,
+    *,
+    external_id: str | None = None,
+) -> DocumentModel:
+    """Insert a minimal document row."""
+    doc = DocumentModel(
+        id=uuid4(),
+        namespace_id=namespace_id,
+        content="test content",
+        external_id=external_id,
+    )
+    session.add(doc)
+    await session.flush()
+    return doc
+
+
+@skip_no_pg
+class TestUniqueExternalId:
+    """Tests for the UNIQUE partial index on (namespace_id, external_id)."""
+
+    async def test_duplicate_external_id_raises_integrity_error(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Two documents with the same (namespace_id, external_id) must raise IntegrityError."""
+        async with session_factory() as session:
+            async with session.begin():
+                ns = await _create_namespace(session)
+                ext_id = f"dup-{uuid4().hex[:8]}"
+                await _insert_document(session, ns.id, external_id=ext_id)
+                with pytest.raises(IntegrityError):
+                    await _insert_document(session, ns.id, external_id=ext_id)
+
+    async def test_concurrent_insert_same_external_id_raises(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Concurrent inserts for the same (namespace_id, external_id) — at least one must fail."""
+        # Pre-create namespace in its own transaction so both tasks can see it.
+        async with session_factory() as session:
+            async with session.begin():
+                ns = await _create_namespace(session)
+
+        ns_id = ns.id
+        ext_id = f"conc-{uuid4().hex[:8]}"
+        errors: list[Exception] = []
+
+        async def _insert(factory: async_sessionmaker[AsyncSession]) -> None:
+            async with factory() as sess:
+                async with sess.begin():
+                    doc = DocumentModel(
+                        id=uuid4(),
+                        namespace_id=ns_id,
+                        content="concurrent",
+                        external_id=ext_id,
+                    )
+                    sess.add(doc)
+
+        tasks = [_insert(session_factory), _insert(session_factory)]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        errors = [r for r in results if isinstance(r, Exception)]
+
+        # At least one must fail with IntegrityError
+        assert any(isinstance(e, IntegrityError) for e in errors), (
+            f"Expected at least one IntegrityError, got: {errors}"
+        )
+
+    async def test_null_external_id_allows_duplicates(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """NULL external_id is excluded from the partial index — duplicates are fine."""
+        async with session_factory() as session:
+            async with session.begin():
+                ns = await _create_namespace(session)
+                doc1 = await _insert_document(session, ns.id, external_id=None)
+                doc2 = await _insert_document(session, ns.id, external_id=None)
+
+        # Both rows persisted with distinct IDs
+        assert doc1.id != doc2.id
+
+    async def test_empty_string_external_id_triggers_unique_constraint(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Empty string is NOT NULL — the partial index covers it, so duplicates must fail."""
+        async with session_factory() as session:
+            async with session.begin():
+                ns = await _create_namespace(session)
+                await _insert_document(session, ns.id, external_id="")
+                with pytest.raises(IntegrityError):
+                    await _insert_document(session, ns.id, external_id="")
+
+    async def test_same_external_id_different_namespace_allowed(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """The same external_id in different namespaces must be allowed."""
+        async with session_factory() as session:
+            async with session.begin():
+                ns1 = await _create_namespace(session)
+                ns2 = await _create_namespace(session)
+                ext_id = f"cross-ns-{uuid4().hex[:8]}"
+                doc1 = await _insert_document(session, ns1.id, external_id=ext_id)
+                doc2 = await _insert_document(session, ns2.id, external_id=ext_id)
+
+        assert doc1.id != doc2.id

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -408,14 +408,14 @@ class TestMigrationPackageStructure:
         assert env_path.exists(), f"env.py not found at {env_path}"
 
     @pytest.mark.unit
-    def test_versions_dir_has_22_files(self):
-        """versions/ directory contains 22 migration files."""
+    def test_versions_dir_has_23_files(self):
+        """versions/ directory contains 23 migration files."""
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
         # Filter out __pycache__ and __init__
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
-        assert len(migration_files) == 22, (
-            f"Expected 22 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
+        assert len(migration_files) == 23, (
+            f"Expected 23 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
         )
 
     @pytest.mark.unit

--- a/tests/unit/test_sqlite_migrations.py
+++ b/tests/unit/test_sqlite_migrations.py
@@ -77,7 +77,7 @@ class TestSqliteMigrations:
                     # Version table must point at head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
                     version = result.scalar()
-                    assert version == "021_add_document_external_id"
+                    assert version == "022_promote_external_id_index_unique"
             finally:
                 await engine.dispose()
 


### PR DESCRIPTION
## Summary
- Add Alembic migration 022 that drops the non-unique partial index `ix_documents_namespace_external_id` and creates a UNIQUE partial index `ix_documents_namespace_external_id_unique` on `(namespace_id, external_id) WHERE external_id IS NOT NULL`
- Update `Document.__table_args__` in `db/models.py` to reflect `unique=True` on the index definition
- Add integration tests covering: duplicate rejection, concurrent insert race (at least one `IntegrityError`), NULL passthrough (partial index excludes NULLs), cross-namespace allowance, and empty-string edge case
- Update existing test assertions for new migration count (22 → 23) and head revision

## Context
Part of ADR-056 (Document Update Lifecycle Phase 2), decision #7. The UNIQUE constraint backstops the caller-owned concurrency model — it turns the worst-case duplicate-external-id race into a deterministic `IntegrityError` instead of silently creating duplicates.

**Migration fails on pre-existing duplicates by design.** Consumers must deduplicate affected namespaces and re-ingest before running this migration (see ticket for details).

## Test plan
- [x] Unit tests pass (2525 passed, 166 skipped)
- [x] Coverage ≥ 30% (52.15%)
- [x] Migration chain contiguity test passes
- [x] SQLite migration head revision test updated and passes
- [x] Migration file count test updated and passes
- [ ] Integration tests pass with PostgreSQL (`make dev` + `pytest -m integration`)