### PR TITLE
DYT-2997: Restore LICENSE to verbatim Apache-2.0 text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -137,8 +138,8 @@
 
    6. Trademarks. This License does not grant permission to use the trade
       names, trademarks, service marks, or product names of the Licensor,
-      except as required for describing the origin of the Work and
-      reproducing the content of the NOTICE file.
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
    7. Disclaimer of Warranty. Unless required by applicable law or
       agreed to in writing, Licensor provides the Work (and each
@@ -163,15 +164,15 @@
       has been advised of the possibility of such damages.
 
    9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may accept and charge a
-      fee for acceptance of support, warranty, indemnity, or other liability
-      obligations and/or rights consistent with this License. However, in
-      accepting such obligations, You may act only on Your own behalf and on
-      Your sole responsibility, not on behalf of any other Contributor, and
-      only if You agree to indemnify, defend, and hold each Contributor
-      harmless for any liability incurred by, or claims asserted against,
-      such Contributor by reason of your accepting any such warranty or
-      additional liability.
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
 


### PR DESCRIPTION
## Summary

- Restores `LICENSE` to the canonical Apache-2.0 text (from https://www.apache.org/licenses/LICENSE-2.0).
- Fixes two clauses that had been reworded: §4 "Redistribution" ("reasonable and customary use in describing the origin") and §9 "Accepting Warranty or Additional Liability" ("You may choose to offer, and charge a fee for, acceptance of support...").
- `NOTICE` is unchanged and carries the AllTheData Inc. copyright claim, which is where Apache-2.0 requires it.

Modifying the license text while still claiming "Apache-2.0" is not permitted by the license itself; this is a prerequisite for the first public PyPI release.

Linear: [DYT-2997](https://linear.app/deyta/issue/DYT-2997/restore-license-to-verbatim-apache-20-text)

## Test plan

- [x] `diff <canonical Apache-2.0 from apache.org> LICENSE` returns only the "How to apply" appendix copyright-line difference (which is the applier-filled placeholder, not a license-text divergence).
- [x] `NOTICE` still contains the AllTheData Inc. copyright.
- [x] No source code changes; no functional impact on build, tests, or runtime.