### PR TITLE
DYT-3032: Drop PyMuPDF; stub PDF branch of extract_if_needed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Docker Compose is always available. Always run `make test` before opening a PR. 
 - `storage/backends/surrealdb/` — Unified SurrealDB backend
 - `db/models.py` — SQLAlchemy ORM (UUID columns use `as_uuid=True`)
 - `_accel.py` — Rust/NumPy acceleration (MMR, cosine, pagerank, entity resolution, community detection, temporal)
-- `extraction/binary_readers.py` — PDF/xlsx/docx/parquet readers consumed by khora-cli (stable boundary)
+- `extraction/binary_readers.py` — xlsx/docx/parquet readers consumed by khora-cli (stable boundary; `.pdf` now raises `NotImplementedError` — preprocess upstream or use khora-cli)
 - `pipelines/flows/ingest.py` — Document ingestion pipeline (3-phase: stage → enrich → expand)
 - `db/migrations/env.py` — Alembic with advisory locking
 - `config/schema.py` — `KhoraConfig` Pydantic settings (storage, LLM, pipeline, query, tenancy)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,7 @@ Programmatic values take priority over environment variables.
 | `weaviate` | Weaviate vector store | `weaviate-client>=4.20.1` |
 | `sqlite` | SQLite embedded relational + vector | `aiosqlite>=0.20.0` |
 | `lancedb` | LanceDB embedded vector store | `lancedb>=0.17.0`, `pyarrow` |
-| `binary-readers` | PDF / docx / xlsx readers (used by khora-cli and downstream ingestors) | `pymupdf`, `openpyxl`, `python-docx` |
+| `binary-readers` | docx / xlsx readers (used by khora-cli and downstream ingestors). PDF extraction was removed — preprocess PDFs upstream. | `openpyxl`, `python-docx` |
 | `parquet` | Parquet readers | `pyarrow>=18.0.0` |
 | `nlp` | spaCy-based sentence splitting | `spacy>=3.8` |
 | `logfire` | Logfire integration + Neo4j pool OTel metrics | `logfire>=4.0` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ reranking = [
     "sentence-transformers>=3.0.0",
 ]
 # Binary file readers (PDF, Excel, Word text extraction) — used by khora-cli and downstream consumers
-binary-readers = ["pymupdf>=1.25.0", "openpyxl>=3.1.0", "python-docx>=1.1.0"]
+binary-readers = ["openpyxl>=3.1.0", "python-docx>=1.1.0"]
 # Parquet file support (used by khora-cli and downstream consumers)
 parquet = ["pyarrow>=18.0.0"]
 # Accelerated CPU operations (numpy for cosine sim, rapidfuzz for string matching)

--- a/src/khora/extraction/binary_readers.py
+++ b/src/khora/extraction/binary_readers.py
@@ -1,12 +1,16 @@
 """Binary format extraction for ingestion.
 
-Converts PDF, Excel, Word, and Parquet binary formats to text/markdown so
-they can be fed into the standard text-ingest pipeline.  All extractors
-are optional — they degrade gracefully with a warning when dependencies
-are missing.
+Converts Excel, Word, and Parquet binary formats to text/markdown so they
+can be fed into the standard text-ingest pipeline.  Extractors degrade
+gracefully with a warning when optional dependencies are missing.
 
-Install: ``pip install khora[binary-readers]`` for pymupdf + openpyxl +
-python-docx, and ``pip install khora[parquet]`` for pyarrow.
+PDF extraction was removed from khora to eliminate an AGPL-3.0 dependency
+(PyMuPDF).  Callers passing a ``.pdf`` path to :func:`extract_if_needed`
+get a :class:`NotImplementedError` — preprocess PDFs upstream or use
+``khora-cli``'s PDF preprocessing.
+
+Install: ``pip install khora[binary-readers]`` for openpyxl + python-docx,
+and ``pip install khora[parquet]`` for pyarrow.
 """
 
 from __future__ import annotations
@@ -20,14 +24,6 @@ from loguru import logger
 # ---------------------------------------------------------------------------
 # Optional dependency detection
 # ---------------------------------------------------------------------------
-
-_HAS_PYMUPDF = False
-try:
-    import pymupdf  # noqa: F401
-
-    _HAS_PYMUPDF = True
-except ImportError:
-    pass
 
 _HAS_OPENPYXL = False
 try:
@@ -55,47 +51,27 @@ except ImportError:
 
 
 # ---------------------------------------------------------------------------
-# Extractors
+# PDF sentinel
 # ---------------------------------------------------------------------------
 
+_PDF_REMOVED_MESSAGE = (
+    "khora no longer includes PDF parsing. "
+    "Preprocess PDFs upstream (e.g. extract text to a .txt or .md file) "
+    "or use khora-cli's PDF preprocessing, then pass the extracted text to remember()."
+)
 
-def extract_pdf_text(path: Path) -> str:
-    """Extract text content from a PDF file.
 
-    Uses pymupdf (PyMuPDF) for fast text extraction.
-    Returns empty string if pymupdf is not installed.
+def _pdf_not_supported(path: Path) -> str:
+    """Stub raised when a caller dispatches a ``.pdf`` path.
+
+    PDF parsing was removed from khora; see module docstring.
     """
-    if not _HAS_PYMUPDF:
-        logger.warning(f"pymupdf not installed — cannot extract text from {path.name}. Install: pip install pymupdf")
-        return ""
+    raise NotImplementedError(_PDF_REMOVED_MESSAGE)
 
-    import pymupdf
 
-    try:
-        doc = pymupdf.open(str(path))
-        pages: list[str] = []
-        for page in doc:
-            text = page.get_text()
-            if text.strip():
-                pages.append(text)
-        page_count = doc.page_count
-        doc.close()
-
-        full_text = "\n\n---\n\n".join(pages)
-
-        # Check for scanned PDFs (very little text per page)
-        if page_count > 0:
-            chars_per_page = len(full_text) / page_count
-            if chars_per_page < 50:
-                logger.warning(
-                    f"{path.name}: ~{chars_per_page:.0f} chars/page — "
-                    "possibly a scanned PDF (OCR not supported, text may be incomplete)"
-                )
-
-        return full_text
-    except Exception as e:
-        logger.error(f"PDF extraction failed for {path.name}: {e}")
-        return ""
+# ---------------------------------------------------------------------------
+# Extractors
+# ---------------------------------------------------------------------------
 
 
 def extract_xlsx_text(path: Path) -> str:
@@ -200,7 +176,7 @@ def extract_parquet_text(path: Path) -> str:
 
 #: Map of file extensions to extraction functions
 _EXTRACTORS: dict[str, callable] = {
-    ".pdf": extract_pdf_text,
+    ".pdf": _pdf_not_supported,
     ".xlsx": extract_xlsx_text,
     ".xls": extract_xls_text,
     ".docx": extract_docx_text,
@@ -215,8 +191,8 @@ def get_extraction_warning(path: Path) -> str | None:
     given file extension.  Returns ``None`` when everything looks fine.
     """
     ext = path.suffix.lower()
-    if ext == ".pdf" and not _HAS_PYMUPDF:
-        return f"Cannot extract text from {path.name} — install pymupdf: pip install pymupdf"
+    if ext == ".pdf":
+        return f"Cannot extract text from {path.name} — {_PDF_REMOVED_MESSAGE}"
     if ext in (".xlsx", ".xls") and not _HAS_OPENPYXL:
         return f"Cannot extract text from {path.name} — install openpyxl: pip install openpyxl"
     if ext == ".docx" and not _HAS_DOCX:
@@ -232,6 +208,9 @@ def extract_if_needed(path: Path) -> Path | None:
     If extraction succeeds, writes a `{name}_extracted.md` file alongside
     the original and returns the path to it.  Returns None if no
     extraction was needed or if it failed.
+
+    Raises :class:`NotImplementedError` for ``.pdf`` inputs: PDF parsing
+    was removed from khora; preprocess PDFs upstream.
     """
     ext = path.suffix.lower()
     extractor = _EXTRACTORS.get(ext)

--- a/tests/unit/test_binary_readers.py
+++ b/tests/unit/test_binary_readers.py
@@ -1,0 +1,53 @@
+"""Tests for extraction.binary_readers.
+
+Focus is on the PDF-removal boundary per DYT-3032: callers hitting a .pdf
+path should get a clear ``NotImplementedError``, and ``get_extraction_warning``
+should surface the same message for pre-flight checks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from khora.extraction.binary_readers import (
+    _PDF_REMOVED_MESSAGE,
+    extract_if_needed,
+    get_extraction_warning,
+)
+
+
+def test_extract_if_needed_raises_on_pdf(tmp_path: Path) -> None:
+    pdf = tmp_path / "example.pdf"
+    pdf.write_bytes(b"%PDF-1.4 not a real pdf")
+
+    with pytest.raises(NotImplementedError) as exc:
+        extract_if_needed(pdf)
+
+    assert _PDF_REMOVED_MESSAGE in str(exc.value)
+
+
+def test_extract_if_needed_returns_none_for_unknown_extension(tmp_path: Path) -> None:
+    """Unknown extensions are still a silent no-op — only .pdf changed."""
+    unknown = tmp_path / "example.unknown"
+    unknown.write_text("text")
+
+    assert extract_if_needed(unknown) is None
+
+
+def test_get_extraction_warning_for_pdf_mentions_removal(tmp_path: Path) -> None:
+    pdf = tmp_path / "example.pdf"
+    pdf.touch()
+
+    warning = get_extraction_warning(pdf)
+    assert warning is not None
+    assert _PDF_REMOVED_MESSAGE in warning
+
+
+def test_get_extraction_warning_none_for_clean_path(tmp_path: Path) -> None:
+    """No warning for an extension that has no registered extractor."""
+    plain = tmp_path / "example.txt"
+    plain.touch()
+
+    assert get_extraction_warning(plain) is None

--- a/uv.lock
+++ b/uv.lock
@@ -1164,7 +1164,6 @@ all-backends = [
 ]
 binary-readers = [
     { name = "openpyxl" },
-    { name = "pymupdf" },
     { name = "python-docx" },
 ]
 dev = [
@@ -1293,7 +1292,6 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=18.0.0" },
     { name = "pyarrow", marker = "extra == 'sqlite-lance'", specifier = ">=18.0.0" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
-    { name = "pymupdf", marker = "extra == 'binary-readers'", specifier = ">=1.25.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -2389,22 +2387,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
-]
-
-[[package]]
-name = "pymupdf"
-version = "1.27.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/32/f6b645c51d79a188a4844140c5dabca7b487ad56c4be69c4bc782d0d11a9/pymupdf-1.27.2.2.tar.gz", hash = "sha256:ea8fdc3ab6671ca98f629d5ec3032d662c8cf1796b146996b7ad306ac7ed3335", size = 85354380, upload-time = "2026-03-20T09:47:58.386Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/88/d01992a50165e22dec057a1129826846c547feb4ba07f42720ac030ce438/pymupdf-1.27.2.2-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:800f43e60a6f01f644343c2213b8613db02eaf4f4ba235b417b3351fa99e01c0", size = 23987563, upload-time = "2026-03-19T12:35:42.989Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/0e/9f526bc1d49d8082eff0d1547a69d541a0c5a052e71da625559efaba46a6/pymupdf-1.27.2.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8e2e4299ef1ac0c9dff9be096cbd22783699673abecfa7c3f73173ae06421d73", size = 23263089, upload-time = "2026-03-20T09:44:16.982Z" },
-    { url = "https://files.pythonhosted.org/packages/42/be/984f0d6343935b5dd30afaed6be04fc753146bf55709e63ef28bf9ef7497/pymupdf-1.27.2.2-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c5e3d54922db1c7da844f1208ac1db05704770988752311f81dd36694ae0a07b", size = 24318817, upload-time = "2026-03-20T09:44:33.209Z" },
-    { url = "https://files.pythonhosted.org/packages/22/8e/85e9d9f11dbf34036eb1df283805ef6b885f2005a56d6533bb58ab0b8a11/pymupdf-1.27.2.2-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:892698c9768457eb0991c102c96a856c0a7062539371df5e6bee0816f3ef498e", size = 24948135, upload-time = "2026-03-20T09:44:51.012Z" },
-    { url = "https://files.pythonhosted.org/packages/db/e6/386edb017e5b93f1ab0bf6653ae32f3dd8dfc834ed770212e10ca62f4af9/pymupdf-1.27.2.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b4bbfa6ef347fade678771a93f6364971c51a2cdc44cd2400dc4eeed1ddb4e6", size = 25169585, upload-time = "2026-03-20T09:45:05.393Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/fd/f1ebe24fcd31aaea8b85b3a7ac4c3fc96e20388be5466ace27c9a3c546d9/pymupdf-1.27.2.2-cp310-abi3-win32.whl", hash = "sha256:0b8e924433b7e0bd46be820899300259235997d5a747638471fb2762baa8ee30", size = 18008861, upload-time = "2026-03-20T09:45:21.353Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/b6/2a9a8556000199bbf80a5915dcd15d550d1e5288894316445c54726aaf53/pymupdf-1.27.2.2-cp310-abi3-win_amd64.whl", hash = "sha256:09bb53f9486ccb5297030cbc2dbdae845ba1c3c5126e96eb2d16c4f118de0b5b", size = 19238032, upload-time = "2026-03-20T09:45:37.941Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/c6/e3e11c42f09b9c34ec332c0f37b817671b59ef4001895b854f0494092105/pymupdf-1.27.2.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:6cebfbbdfd219ebdebf4d8e3914624b2e3d3a844c43f4f76935822dd9b13cc12", size = 24985299, upload-time = "2026-03-20T09:45:53.26Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Removes `pymupdf` from `khora[binary-readers]` to eliminate the AGPL-3.0 copyleft obligation for downstream consumers of an Apache-2.0 library.
- `extract_if_needed()` raises `NotImplementedError` on `.pdf` inputs with a clear migration message (preprocess upstream or use khora-cli). The public API from ADR-024 is preserved — same function, same signature.
- Non-PDF extraction (xlsx, docx, parquet) unchanged.
- `get_extraction_warning()` surfaces the same removal notice for pre-flight checks.
- Updates CLAUDE.md and docs/configuration.md to reflect the narrowed extra.
- New `tests/unit/test_binary_readers.py` covers the `.pdf` `NotImplementedError` path and the preserved no-op-for-unknown-extension behavior.

Linear: [DYT-3032](https://linear.app/deyta/issue/DYT-3032)

Follow-up ticket for restoring PDF support post-launch via markitdown or Docling (MIT): [DYT-3033](https://linear.app/deyta/issue/DYT-3033).

Q.M of the PyPI publication proposal (Notion) chose path (b): stub PDFs now, restore post-launch via an MIT library.

## Test plan

- [x] `uv run pytest tests/unit/test_binary_readers.py` — 4 new tests pass
- [x] `uv run pytest tests/unit/` full suite — 2641 passed (skipping pre-existing `test_protocol_compliance.py` collection error that exists on main)
- [x] `make format` — no changes to binary_readers.py
- [x] `uv build` — wheel builds; pymupdf absent from resolved deps
- [x] `diff uv.lock` — only pymupdf package removed, no collateral changes

## Coordination note

ADR-024 names `extract_if_needed` as stable public API consumed by khora-cli. Informal courtesy check with @igor (authored DYT-1304 / DYT-2648) recommended before merging — khora-cli may want to vendor a stopgap parser so its own users aren't fully broken during the gap window.