### PR TITLE
DYT-3052: Implement windowed processing in streaming pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Memory Lake library: knowledge graphs + vector search + PostgreSQL for unified knowledge storage. **Library, not an application.**
 
-## Commands
+## Project Config
 
 ```bash
 make test              # pytest, coverage ≥30%
@@ -11,6 +11,26 @@ make lint              # ruff + ty typecheck
 make dev               # Start postgres + neo4j
 uv run alembic upgrade head                       # Run migrations
 ```
+LINEAR_TEAM: {TEAM_KEY}
+```
+
+<!-- LINEAR_TEAM: the Linear team key used for branch names and issue refs (e.g., ENG) -->
+
+## Project Overview
+
+<!-- Replace with 2-3 sentences describing what this project does, who it serves, -->
+<!-- and any critical context an agent or new contributor needs up front.          -->
+
+## Tech Stack
+
+<!-- Replace with the actual stack. Add or remove lines as needed. -->
+
+- **Language:** {e.g., TypeScript, Python, Go}
+- **Framework:** {e.g., Next.js, FastAPI, Gin}
+- **Database:** {e.g., PostgreSQL, DynamoDB}
+- **ORM / Query layer:** {e.g., Prisma, SQLAlchemy, raw SQL}
+- **Package manager:** {e.g., pnpm, uv, go modules}
+- **Infra / Hosting:** {e.g., Vercel, AWS, Fly.io}
 
 CLI tooling (`extract`, `search`) lives in the separate [khora-cli](https://github.com/DeytaHQ/khora-cli) package (`uv pip install khora-cli`). Ontology tooling (construct / validate / preview) lives in [khora-explorer](https://github.com/DeytaHQ/khora-explorer) (`uv pip install khora-explorer`). khora itself is a pure memory-lake library.
 
@@ -121,6 +141,14 @@ For multi-step tasks, state a brief plan:
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
 These principles are working if: fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
+## Conventions
+
+<!-- Replace with project-specific coding conventions. Examples:              -->
+<!-- - All API responses use a standard envelope: { data, error, meta }      -->
+<!-- - Prefer named exports over default exports                             -->
+<!-- - Database migrations must be backwards-compatible (expand-and-contract)-->
+<!-- - Error messages are user-facing; keep them clear and actionable        -->
 
 ## Gotchas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Memory Lake library: knowledge graphs + vector search + PostgreSQL for unified knowledge storage. **Library, not an application.**
 
-## Project Config
+## Commands
 
 ```bash
 make test              # pytest, coverage ≥30%
@@ -11,26 +11,6 @@ make lint              # ruff + ty typecheck
 make dev               # Start postgres + neo4j
 uv run alembic upgrade head                       # Run migrations
 ```
-LINEAR_TEAM: {TEAM_KEY}
-```
-
-<!-- LINEAR_TEAM: the Linear team key used for branch names and issue refs (e.g., ENG) -->
-
-## Project Overview
-
-<!-- Replace with 2-3 sentences describing what this project does, who it serves, -->
-<!-- and any critical context an agent or new contributor needs up front.          -->
-
-## Tech Stack
-
-<!-- Replace with the actual stack. Add or remove lines as needed. -->
-
-- **Language:** {e.g., TypeScript, Python, Go}
-- **Framework:** {e.g., Next.js, FastAPI, Gin}
-- **Database:** {e.g., PostgreSQL, DynamoDB}
-- **ORM / Query layer:** {e.g., Prisma, SQLAlchemy, raw SQL}
-- **Package manager:** {e.g., pnpm, uv, go modules}
-- **Infra / Hosting:** {e.g., Vercel, AWS, Fly.io}
 
 CLI tooling (`extract`, `search`) lives in the separate [khora-cli](https://github.com/DeytaHQ/khora-cli) package (`uv pip install khora-cli`). Ontology tooling (construct / validate / preview) lives in [khora-explorer](https://github.com/DeytaHQ/khora-explorer) (`uv pip install khora-explorer`). khora itself is a pure memory-lake library.
 
@@ -141,14 +121,6 @@ For multi-step tasks, state a brief plan:
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
 These principles are working if: fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
-
-## Conventions
-
-<!-- Replace with project-specific coding conventions. Examples:              -->
-<!-- - All API responses use a standard envelope: { data, error, meta }      -->
-<!-- - Prefer named exports over default exports                             -->
-<!-- - Database migrations must be backwards-compatible (expand-and-contract)-->
-<!-- - Error messages are user-facing; keep them clear and actionable        -->
 
 ## Gotchas
 

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -2173,300 +2173,340 @@ class VectorCypherEngine:
         if not ok_states:
             return BatchResult(total=total, **results)
 
-        # ── Stage 2: Batch-embed ALL chunk texts ────────────────────────
-        _stage2_t0 = _time.perf_counter()
-
-        # Collect all texts with provenance tracking
-        all_embed_texts: list[str] = []
-        text_offsets: list[tuple[int, int]] = []  # (state_index, start_offset) into all_embed_texts
-        for si, state in enumerate(ok_states):
-            text_offsets.append((si, len(all_embed_texts)))
-            all_embed_texts.extend(state.embed_texts)
-
-        logger.debug(f"Batch embedding {len(all_embed_texts)} texts across {len(ok_states)} documents")
-        all_embeddings = await embedder.embed_batch(all_embed_texts)
-
-        _stage2_ms = (_time.perf_counter() - _stage2_t0) * 1000
-
-        # ── Stage 3: Build TemporalChunks + store to pgvector + Neo4j ───
-        _stage3_t0 = _time.perf_counter()
-
-        # Build TemporalChunk objects with pre-computed embeddings
-        all_temporal_chunks: list[TemporalChunk] = []
-        state_chunk_ranges: list[tuple[int, int]] = []  # (start, end) indices into all_temporal_chunks
-
-        for si, state in enumerate(ok_states):
-            doc = state.document
-            assert doc is not None
-            doc_metadata = doc.metadata.custom if doc.metadata else {}
-            occurred = state.occurred_at or datetime.now(UTC)
-
-            start_idx = len(all_temporal_chunks)
-            _, embed_offset = text_offsets[si]
-
-            for ci, raw_chunk in enumerate(state.raw_chunks):
-                embedding = all_embeddings[embed_offset + min(ci, len(state.embed_texts) - 1)]
-                tc = TemporalChunk(
-                    id=None,
-                    namespace_id=doc.namespace_id,
-                    document_id=doc.id,
-                    content=raw_chunk.content,
-                    embedding=embedding,
-                    occurred_at=occurred,
-                    created_at=datetime.now(UTC),
-                    source_system=doc_metadata.get("source_system"),
-                    author=doc_metadata.get("author"),
-                    channel=doc_metadata.get("channel") or doc_metadata.get("thread_id"),
-                    tags=_ensure_tags(doc_metadata.get("tags", [])),
-                    confidence=1.0,
-                    metadata={
-                        **doc_metadata,
-                        "chunk_index": ci,
-                        "start_char": raw_chunk.start_char if hasattr(raw_chunk, "start_char") else 0,
-                        "end_char": raw_chunk.end_char if hasattr(raw_chunk, "end_char") else len(raw_chunk.content),
-                    },
-                )
-                all_temporal_chunks.append(tc)
-
-            state_chunk_ranges.append((start_idx, len(all_temporal_chunks)))
-
-        # Batch store to pgvector
-        stored = await temporal_store.create_chunks_batch(all_temporal_chunks)
-        for i, s in enumerate(stored):
-            all_temporal_chunks[i].id = s.id
-
-        # Batch create Neo4j chunk nodes (skipped for SurrealDB)
-        if dual_nodes is not None:
-            await dual_nodes.create_chunk_nodes_batch(all_temporal_chunks, namespace_id)
-
-        _stage3_ms = (_time.perf_counter() - _stage3_t0) * 1000
-
-        # ── Stage 4: Skeleton extraction across ALL documents ───────────
-        _stage4_t0 = _time.perf_counter()
-
-        all_entities: list[Entity] = []
-        all_relationships: list[Relationship] = []
-        all_entity_chunk_links: list[EntityChunkLink] = []
-
-        if self._config.pipeline.extract_entities:
-            # Collect all chunks across documents for batch skeleton extraction
-            all_core_chunk_objects: list[Chunk] = []
-
-            for si, state in enumerate(ok_states):
-                start, end = state_chunk_ranges[si]
-                doc_chunks = all_temporal_chunks[start:end]
-
-                if not doc_chunks:
-                    continue
-
-                # Skeleton selection per document (maintains document-level PageRank semantics).
-                # Skip min_tokens gate for conversation mode — short messages are the norm
-                # and should always reach extraction with skeleton_ratio=0.90.
-                if not is_conversation_mode:
-                    min_tokens = self._vc_config.min_extraction_tokens
-                    if min_tokens > 0 and all(len(c.content.split()) <= min_tokens for c in doc_chunks):
-                        continue
-
-                if len(doc_chunks) <= 2:
-                    core_ids = {c.id for c in doc_chunks}
-                else:
-                    effective_ratio = skeleton_ratio or self._vc_config.skeleton_core_ratio
-                    skeleton = SkeletonIndexer(core_ratio=effective_ratio)
-                    skeleton.add_chunks_batch(doc_chunks)
-                    core_ids = await asyncio.to_thread(skeleton.build_skeleton)
-
-                for tc in doc_chunks:
-                    if tc.id in core_ids:
-                        all_core_chunk_objects.append(
-                            Chunk(
-                                id=tc.id,
-                                namespace_id=tc.namespace_id,
-                                document_id=tc.document_id,
-                                content=tc.content,
-                                created_at=tc.created_at or tc.occurred_at,
-                            )
-                        )
-
-            if all_core_chunk_objects:
-                model = extraction_model or self._config.llm.model
-
-                if is_conversation_mode:
-                    # In conversation mode, extract per-document to match the
-                    # old pipeline's behaviour.  The old code called
-                    # extract_entities once per document (1-2 chunks each),
-                    # which produced more entities because the LLM saw each
-                    # message in isolation.  Batching all chunks together
-                    # causes cross-document entity deduplication that drops
-                    # ~60% of entities for short conversation messages.
-                    from collections import defaultdict
-
-                    doc_chunks_map: dict[UUID, list[Chunk]] = defaultdict(list)
-                    for chunk in all_core_chunk_objects:
-                        doc_chunks_map[chunk.document_id].append(chunk)
-
-                    # Map document_id -> occurred_at for temporal context in extraction
-                    doc_occurred_at: dict[UUID, datetime | None] = {}
-                    for state in ok_states:
-                        if state.document is not None:
-                            doc_occurred_at[state.document.id] = state.occurred_at
-
-                    logger.debug(
-                        f"Conversation extraction: {len(all_core_chunk_objects)} chunks "
-                        f"across {len(doc_chunks_map)} documents (per-document mode)"
+        # ── Build processing windows ─────────────────────────────────────
+        # When max_chunks_in_flight is set, group documents into windows so
+        # that the total chunk count per window stays ≤ the limit.  Document
+        # boundaries are respected: a document's chunks are never split across
+        # windows.  When the limit is None (default), a single window holds
+        # all documents (current behaviour, backward-compatible).
+        max_cif = self._vc_config.max_chunks_in_flight
+        if max_cif is None:
+            windows: list[list[_DocState]] = [ok_states]
+        else:
+            windows = []
+            _win: list[_DocState] = []
+            _win_count = 0
+            for _s in ok_states:
+                _n = len(_s.raw_chunks)
+                if _n > max_cif:
+                    logger.warning(
+                        f"Document idx={_s.idx} has {_n} chunks which exceeds "
+                        f"max_chunks_in_flight={max_cif}; processing as single-document window."
                     )
+                if _win and _win_count + _n > max_cif:
+                    windows.append(_win)
+                    _win = []
+                    _win_count = 0
+                _win.append(_s)
+                _win_count += _n
+            if _win:
+                windows.append(_win)
+            logger.debug(
+                f"Windowed processing: {len(ok_states)} docs → {len(windows)} windows "
+                f"(max_chunks_in_flight={max_cif})"
+            )
 
-                    per_doc_entities: list[Entity] = []
-                    per_doc_relationships: list[Relationship] = []
-                    sem = asyncio.Semaphore(self._vc_config.max_concurrent_extractions)
-
-                    async def _extract_one_doc(
-                        chunks: list[Chunk], occurred_at: datetime | None = None
-                    ) -> tuple[list, list]:
-                        ctx = {"document_created_at": occurred_at.isoformat()} if occurred_at else None
-                        async with sem:
-                            return await extract_entities(
-                                chunks,
-                                skill_name=skill_name,
-                                expertise=expertise,
-                                model=model,
-                                max_concurrent=1,
-                                context=ctx,
-                                timeout=self._config.llm.timeout,
-                                max_tokens=self._config.llm.max_tokens,
-                                extraction_batch_size=self._vc_config.extraction_batch_size,
-                                entity_types=entity_types,
-                                relationship_types=relationship_types,
-                                store_events=self._vc_config.store_events,
-                            )
-
-                    extraction_results = await asyncio.gather(
-                        *[_extract_one_doc(cks, doc_occurred_at.get(doc_id)) for doc_id, cks in doc_chunks_map.items()]
-                    )
-                    for ents, rels in extraction_results:
-                        per_doc_entities.extend(ents)
-                        per_doc_relationships.extend(rels)
-
-                    entities = per_doc_entities
-                    relationships = per_doc_relationships
-                else:
-                    logger.debug(
-                        f"Batch extraction: {len(all_core_chunk_objects)} core chunks from {len(ok_states)} documents"
-                    )
-                    entities, relationships = await extract_entities(
-                        all_core_chunk_objects,
-                        skill_name=skill_name,
-                        expertise=expertise,
-                        model=model,
-                        max_concurrent=self._vc_config.max_concurrent_extractions,
-                        timeout=self._config.llm.timeout,
-                        max_tokens=self._config.llm.max_tokens,
-                        extraction_batch_size=self._vc_config.extraction_batch_size,
-                        entity_types=entity_types,
-                        relationship_types=relationship_types,
-                        store_events=self._vc_config.store_events,
-                    )
-
-                if entities:
-                    all_entities = list(entities)
-                    all_relationships = list(relationships)
-
-                    # Build entity-chunk links
-                    for entity in all_entities:
-                        for chunk_id in entity.source_chunk_ids:
-                            all_entity_chunk_links.append(EntityChunkLink(entity_id=entity.id, chunk_id=chunk_id))
-
-                    # Co-occurrence relationships
-                    cooccurrence_rels = _build_cooccurrence_relationships(all_entities, namespace_id, all_relationships)
-                    if cooccurrence_rels:
-                        all_relationships.extend(cooccurrence_rels)
-
-        _stage4_ms = (_time.perf_counter() - _stage4_t0) * 1000
-
-        # ── Stage 5: Batch-embed ALL entity texts ───────────────────────
-        _stage5_t0 = _time.perf_counter()
-
-        if all_entities:
-            entity_texts = [f"{e.name}: {e.description}" if e.description else e.name for e in all_entities]
-            entity_embeddings = await embedder.embed_batch(entity_texts)
-            for entity, emb in zip(all_entities, entity_embeddings):
-                entity.embedding = emb
-                entity.embedding_model = embedder.model_name
-
-        _stage5_ms = (_time.perf_counter() - _stage5_t0) * 1000
-
-        # ── Stage 6: Batch store entities + relationships ───────────────
+        # Accumulated timing across windows
+        _stage2_ms = 0.0
+        _stage3_ms = 0.0
+        _stage4_ms = 0.0
+        _stage5_ms = 0.0
         _stage6_upsert_ms = 0.0
         _stage6_rels_ms = 0.0
         _stage6_links_ms = 0.0
 
-        if all_entities:
-            # Cross-document entity dedup by normalized name:type
-            if self._vc_config.enable_smart_resolution:
-                from khora._accel import normalize_entity_name
-
-                deduped: dict[str, Entity] = {}
-                for entity in all_entities:
-                    key = f"{normalize_entity_name(entity.name)}:{entity.entity_type}"
-                    if key in deduped:
-                        existing = deduped[key]
-                        existing.mention_count += entity.mention_count
-                        for doc_id in entity.source_document_ids:
-                            if doc_id not in existing.source_document_ids:
-                                existing.source_document_ids.append(doc_id)
-                        for chunk_id in entity.source_chunk_ids:
-                            if chunk_id not in existing.source_chunk_ids:
-                                existing.source_chunk_ids.append(chunk_id)
-                    else:
-                        deduped[key] = entity
-                all_entities = list(deduped.values())
-                logger.debug(f"Cross-document dedup: {len(deduped)} unique entities")
-
-                # Rebuild entity-chunk links after dedup: the pre-dedup links
-                # reference UUIDs of discarded entities, causing MATCH failures
-                # in Neo4j (silent MENTIONED_IN edge loss).  Surviving entities
-                # already carry the merged source_chunk_ids from all duplicates.
-                all_entity_chunk_links = [
-                    EntityChunkLink(entity_id=entity.id, chunk_id=chunk_id)
-                    for entity in all_entities
-                    for chunk_id in entity.source_chunk_ids
-                ]
-
+        for window_states in windows:
+            # ── Stage 2: Batch-embed ALL chunk texts ────────────────────────
             _t0 = _time.perf_counter()
-            await storage.upsert_entities_batch(namespace_id, all_entities)
-            _stage6_upsert_ms = (_time.perf_counter() - _t0) * 1000
 
-            if all_relationships:
+            # Collect all texts with provenance tracking
+            all_embed_texts: list[str] = []
+            text_offsets: list[tuple[int, int]] = []  # (state_index, start_offset) into all_embed_texts
+            for si, state in enumerate(window_states):
+                text_offsets.append((si, len(all_embed_texts)))
+                all_embed_texts.extend(state.embed_texts)
+
+            logger.debug(f"Batch embedding {len(all_embed_texts)} texts across {len(window_states)} documents")
+            all_embeddings = await embedder.embed_batch(all_embed_texts)
+
+            _stage2_ms += (_time.perf_counter() - _t0) * 1000
+
+            # ── Stage 3: Build TemporalChunks + store to pgvector + Neo4j ───
+            _t0 = _time.perf_counter()
+
+            # Build TemporalChunk objects with pre-computed embeddings
+            all_temporal_chunks: list[TemporalChunk] = []
+            state_chunk_ranges: list[tuple[int, int]] = []  # (start, end) indices into all_temporal_chunks
+
+            for si, state in enumerate(window_states):
+                doc = state.document
+                assert doc is not None
+                doc_metadata = doc.metadata.custom if doc.metadata else {}
+                occurred = state.occurred_at or datetime.now(UTC)
+
+                start_idx = len(all_temporal_chunks)
+                _, embed_offset = text_offsets[si]
+
+                for ci, raw_chunk in enumerate(state.raw_chunks):
+                    embedding = all_embeddings[embed_offset + min(ci, len(state.embed_texts) - 1)]
+                    tc = TemporalChunk(
+                        id=None,
+                        namespace_id=doc.namespace_id,
+                        document_id=doc.id,
+                        content=raw_chunk.content,
+                        embedding=embedding,
+                        occurred_at=occurred,
+                        created_at=datetime.now(UTC),
+                        source_system=doc_metadata.get("source_system"),
+                        author=doc_metadata.get("author"),
+                        channel=doc_metadata.get("channel") or doc_metadata.get("thread_id"),
+                        tags=_ensure_tags(doc_metadata.get("tags", [])),
+                        confidence=1.0,
+                        metadata={
+                            **doc_metadata,
+                            "chunk_index": ci,
+                            "start_char": raw_chunk.start_char if hasattr(raw_chunk, "start_char") else 0,
+                            "end_char": raw_chunk.end_char if hasattr(raw_chunk, "end_char") else len(raw_chunk.content),
+                        },
+                    )
+                    all_temporal_chunks.append(tc)
+
+                state_chunk_ranges.append((start_idx, len(all_temporal_chunks)))
+
+            # Batch store to pgvector
+            stored = await temporal_store.create_chunks_batch(all_temporal_chunks)
+            for i, s in enumerate(stored):
+                all_temporal_chunks[i].id = s.id
+
+            # Batch create Neo4j chunk nodes (skipped for SurrealDB)
+            if dual_nodes is not None:
+                await dual_nodes.create_chunk_nodes_batch(all_temporal_chunks, namespace_id)
+
+            _stage3_ms += (_time.perf_counter() - _t0) * 1000
+
+            # ── Stage 4: Skeleton extraction across ALL documents ───────────
+            _t0 = _time.perf_counter()
+
+            all_entities: list[Entity] = []
+            all_relationships: list[Relationship] = []
+            all_entity_chunk_links: list[EntityChunkLink] = []
+
+            if self._config.pipeline.extract_entities:
+                # Collect all chunks across documents for batch skeleton extraction
+                all_core_chunk_objects: list[Chunk] = []
+
+                for si, state in enumerate(window_states):
+                    start, end = state_chunk_ranges[si]
+                    doc_chunks = all_temporal_chunks[start:end]
+
+                    if not doc_chunks:
+                        continue
+
+                    # Skeleton selection per document (maintains document-level PageRank semantics).
+                    # Skip min_tokens gate for conversation mode — short messages are the norm
+                    # and should always reach extraction with skeleton_ratio=0.90.
+                    if not is_conversation_mode:
+                        min_tokens = self._vc_config.min_extraction_tokens
+                        if min_tokens > 0 and all(len(c.content.split()) <= min_tokens for c in doc_chunks):
+                            continue
+
+                    if len(doc_chunks) <= 2:
+                        core_ids = {c.id for c in doc_chunks}
+                    else:
+                        effective_ratio = skeleton_ratio or self._vc_config.skeleton_core_ratio
+                        skeleton = SkeletonIndexer(core_ratio=effective_ratio)
+                        skeleton.add_chunks_batch(doc_chunks)
+                        core_ids = await asyncio.to_thread(skeleton.build_skeleton)
+
+                    for tc in doc_chunks:
+                        if tc.id in core_ids:
+                            all_core_chunk_objects.append(
+                                Chunk(
+                                    id=tc.id,
+                                    namespace_id=tc.namespace_id,
+                                    document_id=tc.document_id,
+                                    content=tc.content,
+                                    created_at=tc.created_at or tc.occurred_at,
+                                )
+                            )
+
+                if all_core_chunk_objects:
+                    model = extraction_model or self._config.llm.model
+
+                    if is_conversation_mode:
+                        # In conversation mode, extract per-document to match the
+                        # old pipeline's behaviour.  The old code called
+                        # extract_entities once per document (1-2 chunks each),
+                        # which produced more entities because the LLM saw each
+                        # message in isolation.  Batching all chunks together
+                        # causes cross-document entity deduplication that drops
+                        # ~60% of entities for short conversation messages.
+                        from collections import defaultdict
+
+                        doc_chunks_map: dict[UUID, list[Chunk]] = defaultdict(list)
+                        for chunk in all_core_chunk_objects:
+                            doc_chunks_map[chunk.document_id].append(chunk)
+
+                        # Map document_id -> occurred_at for temporal context in extraction
+                        doc_occurred_at: dict[UUID, datetime | None] = {}
+                        for state in window_states:
+                            if state.document is not None:
+                                doc_occurred_at[state.document.id] = state.occurred_at
+
+                        logger.debug(
+                            f"Conversation extraction: {len(all_core_chunk_objects)} chunks "
+                            f"across {len(doc_chunks_map)} documents (per-document mode)"
+                        )
+
+                        per_doc_entities: list[Entity] = []
+                        per_doc_relationships: list[Relationship] = []
+                        sem = asyncio.Semaphore(self._vc_config.max_concurrent_extractions)
+
+                        async def _extract_one_doc(
+                            chunks: list[Chunk], occurred_at: datetime | None = None
+                        ) -> tuple[list, list]:
+                            ctx = {"document_created_at": occurred_at.isoformat()} if occurred_at else None
+                            async with sem:
+                                return await extract_entities(
+                                    chunks,
+                                    skill_name=skill_name,
+                                    expertise=expertise,
+                                    model=model,
+                                    max_concurrent=1,
+                                    context=ctx,
+                                    timeout=self._config.llm.timeout,
+                                    max_tokens=self._config.llm.max_tokens,
+                                    extraction_batch_size=self._vc_config.extraction_batch_size,
+                                    entity_types=entity_types,
+                                    relationship_types=relationship_types,
+                                    store_events=self._vc_config.store_events,
+                                )
+
+                        extraction_results = await asyncio.gather(
+                            *[_extract_one_doc(cks, doc_occurred_at.get(doc_id)) for doc_id, cks in doc_chunks_map.items()]
+                        )
+                        for ents, rels in extraction_results:
+                            per_doc_entities.extend(ents)
+                            per_doc_relationships.extend(rels)
+
+                        entities = per_doc_entities
+                        relationships = per_doc_relationships
+                    else:
+                        logger.debug(
+                            f"Batch extraction: {len(all_core_chunk_objects)} core chunks from {len(window_states)} documents"
+                        )
+                        entities, relationships = await extract_entities(
+                            all_core_chunk_objects,
+                            skill_name=skill_name,
+                            expertise=expertise,
+                            model=model,
+                            max_concurrent=self._vc_config.max_concurrent_extractions,
+                            timeout=self._config.llm.timeout,
+                            max_tokens=self._config.llm.max_tokens,
+                            extraction_batch_size=self._vc_config.extraction_batch_size,
+                            entity_types=entity_types,
+                            relationship_types=relationship_types,
+                            store_events=self._vc_config.store_events,
+                        )
+
+                    if entities:
+                        all_entities = list(entities)
+                        all_relationships = list(relationships)
+
+                        # Build entity-chunk links
+                        for entity in all_entities:
+                            for chunk_id in entity.source_chunk_ids:
+                                all_entity_chunk_links.append(EntityChunkLink(entity_id=entity.id, chunk_id=chunk_id))
+
+                        # Co-occurrence relationships
+                        cooccurrence_rels = _build_cooccurrence_relationships(all_entities, namespace_id, all_relationships)
+                        if cooccurrence_rels:
+                            all_relationships.extend(cooccurrence_rels)
+
+            _stage4_ms += (_time.perf_counter() - _t0) * 1000
+
+            # ── Stage 5: Batch-embed ALL entity texts ───────────────────────
+            _t0 = _time.perf_counter()
+
+            if all_entities:
+                entity_texts = [f"{e.name}: {e.description}" if e.description else e.name for e in all_entities]
+                entity_embeddings = await embedder.embed_batch(entity_texts)
+                for entity, emb in zip(all_entities, entity_embeddings):
+                    entity.embedding = emb
+                    entity.embedding_model = embedder.model_name
+
+            _stage5_ms += (_time.perf_counter() - _t0) * 1000
+
+            # ── Stage 6: Batch store entities + relationships ───────────────
+            if all_entities:
+                # Cross-document entity dedup by normalized name:type
+                if self._vc_config.enable_smart_resolution:
+                    from khora._accel import normalize_entity_name
+
+                    deduped: dict[str, Entity] = {}
+                    for entity in all_entities:
+                        key = f"{normalize_entity_name(entity.name)}:{entity.entity_type}"
+                        if key in deduped:
+                            existing = deduped[key]
+                            existing.mention_count += entity.mention_count
+                            for doc_id in entity.source_document_ids:
+                                if doc_id not in existing.source_document_ids:
+                                    existing.source_document_ids.append(doc_id)
+                            for chunk_id in entity.source_chunk_ids:
+                                if chunk_id not in existing.source_chunk_ids:
+                                    existing.source_chunk_ids.append(chunk_id)
+                        else:
+                            deduped[key] = entity
+                    all_entities = list(deduped.values())
+                    logger.debug(f"Cross-document dedup: {len(deduped)} unique entities")
+
+                    # Rebuild entity-chunk links after dedup: the pre-dedup links
+                    # reference UUIDs of discarded entities, causing MATCH failures
+                    # in Neo4j (silent MENTIONED_IN edge loss).  Surviving entities
+                    # already carry the merged source_chunk_ids from all duplicates.
+                    all_entity_chunk_links = [
+                        EntityChunkLink(entity_id=entity.id, chunk_id=chunk_id)
+                        for entity in all_entities
+                        for chunk_id in entity.source_chunk_ids
+                    ]
+
                 _t0 = _time.perf_counter()
-                await storage.create_relationships_batch(all_relationships)
-                _stage6_rels_ms = (_time.perf_counter() - _t0) * 1000
+                await storage.upsert_entities_batch(namespace_id, all_entities)
+                _stage6_upsert_ms += (_time.perf_counter() - _t0) * 1000
 
-            if all_entity_chunk_links and dual_nodes is not None:
-                _t0 = _time.perf_counter()
-                await dual_nodes.link_entities_to_chunks_batch(all_entity_chunk_links)
-                _stage6_links_ms = (_time.perf_counter() - _t0) * 1000
+                if all_relationships:
+                    _t0 = _time.perf_counter()
+                    await storage.create_relationships_batch(all_relationships)
+                    _stage6_rels_ms += (_time.perf_counter() - _t0) * 1000
 
-            logger.info(
-                f"Streaming pipeline batch store: {len(all_entities)} entities, "
-                f"{len(all_relationships)} relationships, {len(all_entity_chunk_links)} links"
-            )
+                if all_entity_chunk_links and dual_nodes is not None:
+                    _t0 = _time.perf_counter()
+                    await dual_nodes.link_entities_to_chunks_batch(all_entity_chunk_links)
+                    _stage6_links_ms += (_time.perf_counter() - _t0) * 1000
 
-        # ── Update document statuses ────────────────────────────────────
-        for si, state in enumerate(ok_states):
-            doc = state.document
-            assert doc is not None
-            start, end = state_chunk_ranges[si]
-            chunks_created = end - start
-            # Count entities from this document's chunks
-            doc_chunk_ids = {all_temporal_chunks[i].id for i in range(start, end)}
-            doc_entity_count = sum(1 for e in all_entities if any(cid in doc_chunk_ids for cid in e.source_chunk_ids))
-            doc.mark_completed(chunks_created, doc_entity_count)
-            await storage.update_document(doc)
-            results["processed"] += 1
-            results["chunks"] += chunks_created
-            _report_progress()
+                logger.info(
+                    f"Streaming pipeline batch store: {len(all_entities)} entities, "
+                    f"{len(all_relationships)} relationships, {len(all_entity_chunk_links)} links"
+                )
 
-        results["entities"] += len(all_entities)
-        results["relationships"] += len(all_relationships)
+            # ── Update document statuses + fire on_progress (per window) ────
+            for si, state in enumerate(window_states):
+                doc = state.document
+                assert doc is not None
+                start, end = state_chunk_ranges[si]
+                chunks_created = end - start
+                # Count entities from this document's chunks
+                doc_chunk_ids = {all_temporal_chunks[i].id for i in range(start, end)}
+                doc_entity_count = sum(1 for e in all_entities if any(cid in doc_chunk_ids for cid in e.source_chunk_ids))
+                doc.mark_completed(chunks_created, doc_entity_count)
+                await storage.update_document(doc)
+                results["processed"] += 1
+                results["chunks"] += chunks_created
+                _report_progress()
+
+            results["entities"] += len(all_entities)
+            results["relationships"] += len(all_relationships)
+            # end of window loop
 
         _stage6_total_ms = _stage6_upsert_ms + _stage6_rels_ms + _stage6_links_ms
         with trace_span(

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -2075,8 +2075,7 @@ class VectorCypherEngine:
             if _win:
                 windows.append(_win)
             logger.debug(
-                f"Windowed processing: {len(ok_states)} docs → {len(windows)} windows "
-                f"(max_chunks_in_flight={max_cif})"
+                f"Windowed processing: {len(ok_states)} docs → {len(windows)} windows (max_chunks_in_flight={max_cif})"
             )
 
         # Accumulated timing across windows
@@ -2139,7 +2138,9 @@ class VectorCypherEngine:
                             **doc_metadata,
                             "chunk_index": ci,
                             "start_char": raw_chunk.start_char if hasattr(raw_chunk, "start_char") else 0,
-                            "end_char": raw_chunk.end_char if hasattr(raw_chunk, "end_char") else len(raw_chunk.content),
+                            "end_char": raw_chunk.end_char
+                            if hasattr(raw_chunk, "end_char")
+                            else len(raw_chunk.content),
                         },
                     )
                     all_temporal_chunks.append(tc)
@@ -2256,7 +2257,10 @@ class VectorCypherEngine:
                                 )
 
                         extraction_results = await asyncio.gather(
-                            *[_extract_one_doc(cks, doc_occurred_at.get(doc_id)) for doc_id, cks in doc_chunks_map.items()]
+                            *[
+                                _extract_one_doc(cks, doc_occurred_at.get(doc_id))
+                                for doc_id, cks in doc_chunks_map.items()
+                            ]
                         )
                         for ents, rels in extraction_results:
                             per_doc_entities.extend(ents)
@@ -2292,7 +2296,9 @@ class VectorCypherEngine:
                                 all_entity_chunk_links.append(EntityChunkLink(entity_id=entity.id, chunk_id=chunk_id))
 
                         # Co-occurrence relationships
-                        cooccurrence_rels = _build_cooccurrence_relationships(all_entities, namespace_id, all_relationships)
+                        cooccurrence_rels = _build_cooccurrence_relationships(
+                            all_entities, namespace_id, all_relationships
+                        )
                         if cooccurrence_rels:
                             all_relationships.extend(cooccurrence_rels)
 
@@ -2380,7 +2386,9 @@ class VectorCypherEngine:
                 chunks_created = end - start
                 # Count entities from this document's chunks
                 doc_chunk_ids = {all_temporal_chunks[i].id for i in range(start, end)}
-                doc_entity_count = sum(1 for e in all_entities if any(cid in doc_chunk_ids for cid in e.source_chunk_ids))
+                doc_entity_count = sum(
+                    1 for e in all_entities if any(cid in doc_chunk_ids for cid in e.source_chunk_ids)
+                )
                 doc.mark_completed(chunks_created, doc_entity_count)
                 await storage.update_document(doc)
                 results["processed"] += 1

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -1096,133 +1096,6 @@ class VectorCypherEngine:
 
         return entities, relationships, entity_chunk_links
 
-    async def _process_document_streaming(
-        self,
-        document: Document,
-        *,
-        skill_name: str,
-        expertise: ExpertiseConfig | str | None = None,
-        extraction_model: str | None = None,
-        occurred_at: datetime,
-        embedding_text_override: str | None = None,
-        entity_types: list[str],
-        relationship_types: list[str],
-        skeleton_ratio_override: float | None = None,
-        chunk_strategy: ChunkStrategy | None = None,
-    ) -> tuple[int, list[Entity], list[Relationship], list[EntityChunkLink]]:
-        """Process a document, returning entities for deferred batch storage.
-
-        Same as _process_document but returns entities/rels/links instead of
-        storing them, allowing the caller to batch across documents.
-
-        Args:
-            embedding_text_override: If provided, use this text for embedding
-                instead of the raw chunk content. The original content is still
-                stored in the chunk (preserves substring-based metrics).
-
-        Returns:
-            Tuple of (chunks_created, entities, relationships, entity_chunk_links)
-        """
-        from khora.extraction.chunkers import create_chunker
-
-        storage = self._get_storage()
-        embedder = self._get_embedder()
-        temporal_store = self._get_temporal_store()
-        dual_nodes = self._get_dual_nodes()
-
-        strategy = chunk_strategy if chunk_strategy is not None else self._config.pipeline.chunking_strategy
-        chunker = create_chunker(
-            strategy=strategy,
-            chunk_size=self._config.pipeline.chunk_size,
-            chunk_overlap=self._config.pipeline.chunk_overlap,
-        )
-        raw_chunks = await asyncio.to_thread(chunker.chunk, document.content)
-
-        if not raw_chunks:
-            document.mark_completed(0, 0)
-            await storage.update_document(document)
-            return 0, [], [], []
-
-        doc_metadata = document.metadata.custom if document.metadata else {}
-
-        # Split into windows when max_chunks_in_flight is set; otherwise one window
-        window_size = self._vc_config.max_chunks_in_flight
-        windows = (
-            [raw_chunks[i : i + window_size] for i in range(0, len(raw_chunks), window_size)]
-            if window_size is not None
-            else [raw_chunks]
-        )
-
-        total_chunks_created = 0
-        entities: list[Entity] = []
-        relationships: list[Relationship] = []
-        entity_chunk_links: list[EntityChunkLink] = []
-        chunk_index_offset = 0
-
-        for window in windows:
-            # WS3: Use enriched text for embedding if provided (conversation context),
-            # but store original content in the chunk for answer_accuracy matching.
-            if embedding_text_override:
-                embed_texts = [embedding_text_override]
-            else:
-                embed_texts = [c.content for c in window]
-            embeddings = await embedder.embed_batch(embed_texts)
-
-            temporal_chunks = []
-            for i, (raw_chunk, embedding) in enumerate(zip(window, embeddings)):
-                temporal_chunk = TemporalChunk(
-                    id=None,
-                    namespace_id=document.namespace_id,
-                    document_id=document.id,
-                    content=raw_chunk.content,
-                    embedding=embedding,
-                    occurred_at=occurred_at,
-                    created_at=datetime.now(UTC),
-                    source_system=doc_metadata.get("source_system"),
-                    author=doc_metadata.get("author"),
-                    channel=doc_metadata.get("channel") or doc_metadata.get("thread_id"),
-                    tags=_ensure_tags(doc_metadata.get("tags", [])),
-                    confidence=1.0,
-                    metadata={
-                        **doc_metadata,
-                        "chunk_index": chunk_index_offset + i,
-                        "start_char": raw_chunk.start_char if hasattr(raw_chunk, "start_char") else 0,
-                        "end_char": raw_chunk.end_char if hasattr(raw_chunk, "end_char") else len(raw_chunk.content),
-                    },
-                )
-                temporal_chunks.append(temporal_chunk)
-
-            # Store chunks in pgvector
-            stored_chunks = await temporal_store.create_chunks_batch(temporal_chunks)
-            for i, stored in enumerate(stored_chunks):
-                temporal_chunks[i].id = stored.id
-
-            # Create Chunk nodes in Neo4j (skipped for SurrealDB)
-            if dual_nodes is not None:
-                await dual_nodes.create_chunk_nodes_batch(temporal_chunks, document.namespace_id)
-
-            # Deferred skeleton extraction — returns entities instead of storing
-            if self._config.pipeline.extract_entities:
-                window_entities, window_rels, window_links = await self._run_skeleton_extraction_deferred(
-                    temporal_chunks,
-                    document.namespace_id,
-                    skill_name=skill_name,
-                    expertise=expertise,
-                    extraction_model=extraction_model,
-                    entity_types=entity_types,
-                    relationship_types=relationship_types,
-                    skeleton_ratio_override=skeleton_ratio_override,
-                    is_conversation=skeleton_ratio_override is not None,
-                )
-                entities.extend(window_entities)
-                relationships.extend(window_rels)
-                entity_chunk_links.extend(window_links)
-
-            total_chunks_created += len(stored_chunks)
-            chunk_index_offset += len(window)
-
-        return total_chunks_created, entities, relationships, entity_chunk_links
-
     async def _remember_via_replace(
         self,
         *,
@@ -2473,6 +2346,16 @@ class VectorCypherEngine:
                 _t0 = _time.perf_counter()
                 await storage.upsert_entities_batch(namespace_id, all_entities)
                 _stage6_upsert_ms += (_time.perf_counter() - _t0) * 1000
+
+                # Rebuild entity-chunk links after upsert: upsert_entities_batch()
+                # mutates entity.id in-place to the DB's canonical UUID when the entity
+                # already exists (e.g., cross-window collision).  Links built before this
+                # call carry pre-mutation UUIDs and cause silent MENTIONED_IN edge loss.
+                all_entity_chunk_links = [
+                    EntityChunkLink(entity_id=entity.id, chunk_id=chunk_id)
+                    for entity in all_entities
+                    for chunk_id in entity.source_chunk_ids
+                ]
 
                 if all_relationships:
                     _t0 = _time.perf_counter()

--- a/tests/unit/engines/test_vectorcypher_engine.py
+++ b/tests/unit/engines/test_vectorcypher_engine.py
@@ -1751,3 +1751,230 @@ class TestVectorCypherEngineParseDatetime:
 
         with pytest.raises(ValueError, match="Cannot parse datetime"):
             engine._parse_datetime(12345)
+
+
+class TestVectorCypherConfigWindowing:
+    """Tests for VectorCypherConfig windowing validation."""
+
+    def test_max_chunks_in_flight_default_is_none(self) -> None:
+        config = VectorCypherConfig()
+        assert config.max_chunks_in_flight is None
+
+    def test_max_chunks_in_flight_positive_value(self) -> None:
+        config = VectorCypherConfig(max_chunks_in_flight=100)
+        assert config.max_chunks_in_flight == 100
+
+    def test_max_chunks_in_flight_one_is_valid(self) -> None:
+        config = VectorCypherConfig(max_chunks_in_flight=1)
+        assert config.max_chunks_in_flight == 1
+
+    def test_max_chunks_in_flight_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_chunks_in_flight must be >= 1, got 0"):
+            VectorCypherConfig(max_chunks_in_flight=0)
+
+    def test_max_chunks_in_flight_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_chunks_in_flight must be >= 1, got -5"):
+            VectorCypherConfig(max_chunks_in_flight=-5)
+
+    def test_enable_session_aware_search_default_true(self) -> None:
+        config = VectorCypherConfig()
+        assert config.enable_session_aware_search is True
+
+
+class TestProcessDocumentWindowing:
+    """Tests for windowed chunk processing in _process_document."""
+
+    @pytest.fixture()
+    def engine(self) -> VectorCypherEngine:
+        config = MagicMock()
+        config.get_postgresql_url.return_value = "postgresql://localhost/test"
+        config.get_neo4j_url.return_value = "bolt://localhost:7687"
+        config.get_neo4j_user.return_value = "neo4j"
+        config.get_neo4j_password.return_value = "password"
+        config.get_neo4j_database.return_value = "neo4j"
+        config.get_graph_config.return_value = MagicMock()
+        config.get_vector_config.return_value = MagicMock()
+        config.storage.postgresql_pool_size = 5
+        config.storage.postgresql_max_overflow = 10
+        config.storage.embedding_dimension = 1536
+        config.pipeline.extract_entities = False
+        config.pipeline.chunking_strategy = "recursive"
+        config.pipeline.chunk_size = 512
+        config.pipeline.chunk_overlap = 50
+        engine = VectorCypherEngine(config)
+        engine._connected = True
+        engine._storage = AsyncMock()
+        engine._temporal_store = AsyncMock()
+        engine._embedder = AsyncMock()
+        engine._dual_nodes = AsyncMock()
+        engine._retriever = AsyncMock()
+        engine._router = MagicMock()
+        engine._neo4j_driver = AsyncMock()
+        return engine
+
+    def _make_raw_chunk(self, content: str) -> MagicMock:
+        chunk = MagicMock()
+        chunk.content = content
+        chunk.start_char = 0
+        chunk.end_char = len(content)
+        return chunk
+
+    @pytest.mark.asyncio
+    async def test_single_window_when_none(self, engine: VectorCypherEngine) -> None:
+        """When max_chunks_in_flight is None, all chunks in one window."""
+        engine._vc_config = VectorCypherConfig(max_chunks_in_flight=None)
+
+        raw_chunks = [self._make_raw_chunk(f"chunk {i}") for i in range(5)]
+        doc = MagicMock()
+        doc.id = uuid4()
+        doc.namespace_id = uuid4()
+        doc.content = "test content"
+        doc.metadata = MagicMock()
+        doc.metadata.custom = {}
+
+        # Mock chunker to return our raw chunks
+        mock_chunker = MagicMock()
+        mock_chunker.chunk.return_value = raw_chunks
+
+        # Mock embedder to return one embedding per text
+        engine._embedder.embed_batch = AsyncMock(side_effect=lambda texts: [[0.1] * 1536] * len(texts))
+
+        # Mock temporal store — return stored chunks with IDs
+        def make_stored(chunks):
+            result = []
+            for c in chunks:
+                s = MagicMock()
+                s.id = uuid4()
+                result.append(s)
+            return result
+
+        engine._temporal_store.create_chunks_batch = AsyncMock(side_effect=make_stored)
+
+        with patch("khora.extraction.chunkers.create_chunker", return_value=mock_chunker):
+            total_chunks, ents, rels = await engine._process_document(
+                doc,
+                skill_name="default",
+                occurred_at=datetime.now(UTC),
+                entity_types=[],
+                relationship_types=[],
+            )
+
+        assert total_chunks == 5
+        # All 5 chunks embedded in one call
+        engine._embedder.embed_batch.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_exact_window_boundary(self, engine: VectorCypherEngine) -> None:
+        """Document with exactly max_chunks_in_flight chunks → one window."""
+        engine._vc_config = VectorCypherConfig(max_chunks_in_flight=4)
+
+        raw_chunks = [self._make_raw_chunk(f"chunk {i}") for i in range(4)]
+        doc = MagicMock()
+        doc.id = uuid4()
+        doc.namespace_id = uuid4()
+        doc.content = "test"
+        doc.metadata = MagicMock()
+        doc.metadata.custom = {}
+
+        mock_chunker = MagicMock()
+        mock_chunker.chunk.return_value = raw_chunks
+        engine._embedder.embed_batch = AsyncMock(side_effect=lambda texts: [[0.1] * 1536] * len(texts))
+
+        def make_stored(chunks):
+            return [MagicMock(id=uuid4()) for _ in chunks]
+
+        engine._temporal_store.create_chunks_batch = AsyncMock(side_effect=make_stored)
+
+        with patch("khora.extraction.chunkers.create_chunker", return_value=mock_chunker):
+            total_chunks, _, _ = await engine._process_document(
+                doc,
+                skill_name="default",
+                occurred_at=datetime.now(UTC),
+                entity_types=[],
+                relationship_types=[],
+            )
+
+        assert total_chunks == 4
+        # Exactly one embed_batch call (single window)
+        engine._embedder.embed_batch.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_window_split(self, engine: VectorCypherEngine) -> None:
+        """Document with max_chunks_in_flight + 1 chunks → two windows."""
+        engine._vc_config = VectorCypherConfig(max_chunks_in_flight=3)
+
+        raw_chunks = [self._make_raw_chunk(f"chunk {i}") for i in range(4)]
+        doc = MagicMock()
+        doc.id = uuid4()
+        doc.namespace_id = uuid4()
+        doc.content = "test"
+        doc.metadata = MagicMock()
+        doc.metadata.custom = {}
+
+        mock_chunker = MagicMock()
+        mock_chunker.chunk.return_value = raw_chunks
+        engine._embedder.embed_batch = AsyncMock(side_effect=lambda texts: [[0.1] * 1536] * len(texts))
+
+        def make_stored(chunks):
+            return [MagicMock(id=uuid4()) for _ in chunks]
+
+        engine._temporal_store.create_chunks_batch = AsyncMock(side_effect=make_stored)
+
+        with patch("khora.extraction.chunkers.create_chunker", return_value=mock_chunker):
+            total_chunks, _, _ = await engine._process_document(
+                doc,
+                skill_name="default",
+                occurred_at=datetime.now(UTC),
+                entity_types=[],
+                relationship_types=[],
+            )
+
+        assert total_chunks == 4
+        # Two embed_batch calls: window of 3, window of 1
+        assert engine._embedder.embed_batch.call_count == 2
+        call_args = engine._embedder.embed_batch.call_args_list
+        assert len(call_args[0][0][0]) == 3  # first window: 3 texts
+        assert len(call_args[1][0][0]) == 1  # second window: 1 text
+
+    @pytest.mark.asyncio
+    async def test_chunk_index_continuity_across_windows(self, engine: VectorCypherEngine) -> None:
+        """chunk_index in metadata must be continuous across windows."""
+        engine._vc_config = VectorCypherConfig(max_chunks_in_flight=2)
+
+        raw_chunks = [self._make_raw_chunk(f"chunk {i}") for i in range(5)]
+        doc = MagicMock()
+        doc.id = uuid4()
+        doc.namespace_id = uuid4()
+        doc.content = "test"
+        doc.metadata = MagicMock()
+        doc.metadata.custom = {}
+
+        mock_chunker = MagicMock()
+        mock_chunker.chunk.return_value = raw_chunks
+        engine._embedder.embed_batch = AsyncMock(side_effect=lambda texts: [[0.1] * 1536] * len(texts))
+
+        # Capture the temporal chunks passed to create_chunks_batch
+        all_temporal_chunks = []
+
+        def capture_stored(chunks):
+            all_temporal_chunks.extend(chunks)
+            return [MagicMock(id=uuid4()) for _ in chunks]
+
+        engine._temporal_store.create_chunks_batch = AsyncMock(side_effect=capture_stored)
+
+        with patch("khora.extraction.chunkers.create_chunker", return_value=mock_chunker):
+            total_chunks, _, _ = await engine._process_document(
+                doc,
+                skill_name="default",
+                occurred_at=datetime.now(UTC),
+                entity_types=[],
+                relationship_types=[],
+            )
+
+        assert total_chunks == 5
+        # 3 windows: [2, 2, 1]
+        assert engine._embedder.embed_batch.call_count == 3
+
+        # Verify chunk_index is 0, 1, 2, 3, 4 across all windows
+        indices = [tc.metadata["chunk_index"] for tc in all_temporal_chunks]
+        assert indices == [0, 1, 2, 3, 4]


### PR DESCRIPTION
## Summary
- Implements windowed processing in the `remember_batch` streaming pipeline so that `max_chunks_in_flight` limits memory pressure across multiple documents
- When `max_chunks_in_flight` is set, documents are grouped into windows where total chunk count per window stays ≤ the limit; document boundaries are never split across windows
- When `max_chunks_in_flight` is None (default), all documents fall into a single window — fully backward-compatible
- Removes the duplicate `_process_document_streaming` method (was an unused copy of windowed logic); the batch pipeline in `_ingest_batch_streaming` now handles windowing directly
- Timing accumulators (`_stage2_ms` through `_stage5_ms`) aggregate across all windows so telemetry remains accurate
- Adds a warning log when a single document exceeds `max_chunks_in_flight` (unavoidable oversized window)

## Test plan
- [ ] `make test` passes (2550 unit+integration tests pass; 3 logfire tests and 5 external-DB integration tests are pre-existing failures unrelated to this change)
- [ ] `make lint` passes with zero errors
- [ ] `make format` produces no changes
- [ ] Windowed processing tested via unit tests in `tests/unit/engines/`