### PR TITLE
DYT-3069: Add llm_usage to DocumentResult for submit_batch cost tracking

### DIFF
--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -831,7 +831,7 @@ class MemoryLake:
                         llm_usage=collect_usage(),
                     )
                 except Exception as exc:
-                    collect_usage()  # drain on error path — discard partial usage
+                    partial_usage = collect_usage()
                     logger.error(f"submit_batch: failed to process document {doc.id}: {exc}")
                     doc.mark_failed(str(exc))
                     try:
@@ -843,6 +843,7 @@ class MemoryLake:
                         namespace_id=namespace_id,
                         success=False,
                         error=str(exc),
+                        llm_usage=partial_usage,
                     )
                 _fire_result(result)
 

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -110,6 +110,7 @@ class DocumentResult:
     chunks_created: int = 0
     entities_extracted: int = 0
     relationships_created: int = 0
+    llm_usage: list[LLMUsage] = field(default_factory=list)
 
 
 @dataclass
@@ -796,7 +797,10 @@ class MemoryLake:
         sem = asyncio.Semaphore(max_concurrent)
 
         async def _process_one(doc: Document, doc_data: dict[str, Any]) -> None:
+            from khora.telemetry.context import collect_usage, start_usage_collection
+
             async with sem:
+                start_usage_collection()
                 try:
                     doc_metadata = doc_data.get("metadata") or {}
                     occurred_at_raw = doc_metadata.get("occurred_at")
@@ -824,8 +828,10 @@ class MemoryLake:
                         chunks_created=chunks,
                         entities_extracted=entities,
                         relationships_created=rels,
+                        llm_usage=collect_usage(),
                     )
                 except Exception as exc:
+                    collect_usage()  # drain on error path — discard partial usage
                     logger.error(f"submit_batch: failed to process document {doc.id}: {exc}")
                     doc.mark_failed(str(exc))
                     try:

--- a/tests/unit/test_memory_lake.py
+++ b/tests/unit/test_memory_lake.py
@@ -2029,6 +2029,100 @@ class TestSubmitBatch:
         assert ops == {"embedding", "entity_extraction"}
 
     @pytest.mark.asyncio
+    async def test_failed_document_result_carries_partial_llm_usage(self) -> None:
+        """Failed DocumentResult includes any LLM usage recorded before the exception."""
+        from khora.memory_lake import LLMUsage
+        from khora.telemetry.context import record_usage
+
+        ns_id = uuid4()
+        lake = _make_lake(connected=True)
+        lake._engine._storage.resolve_namespace = AsyncMock(return_value=ns_id)
+        lake._engine._storage.create_document = AsyncMock(side_effect=lambda doc: doc)
+        lake._engine._storage.update_document = AsyncMock(side_effect=lambda doc: doc)
+
+        async def _process_with_usage_then_fail(doc, **kwargs):
+            record_usage(
+                LLMUsage(
+                    operation="embedding",
+                    model="text-embedding-3-small",
+                    prompt_tokens=10,
+                    completion_tokens=0,
+                    total_tokens=10,
+                    latency_ms=5.0,
+                )
+            )
+            raise RuntimeError("graph write failed")
+
+        lake._engine.process_staged_document = AsyncMock(side_effect=_process_with_usage_then_fail)
+
+        results: list[DocumentResult] = []
+
+        handle = await lake.submit_batch(
+            [{"content": "will fail after llm call"}],
+            on_result=lambda c, t, r: results.append(r),
+            namespace=ns_id,
+            entity_types=["PERSON"],
+            relationship_types=["KNOWS"],
+        )
+        await handle.wait()
+
+        assert len(results) == 1
+        assert results[0].success is False
+        assert len(results[0].llm_usage) == 1
+        assert results[0].llm_usage[0].operation == "embedding"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_documents_llm_usage_isolation(self) -> None:
+        """Each document's llm_usage contains only its own recorded entries."""
+        from khora.memory_lake import LLMUsage
+        from khora.telemetry.context import record_usage
+
+        ns_id = uuid4()
+        lake = _make_lake(connected=True)
+        lake._engine._storage.resolve_namespace = AsyncMock(return_value=ns_id)
+        lake._engine._storage.create_document = AsyncMock(side_effect=lambda doc: doc)
+
+        call_count = 0
+
+        async def _process_with_distinct_usage(doc, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            op = f"embedding_{call_count}"
+            record_usage(
+                LLMUsage(
+                    operation=op,
+                    model="text-embedding-3-small",
+                    prompt_tokens=call_count * 10,
+                    completion_tokens=0,
+                    total_tokens=call_count * 10,
+                    latency_ms=float(call_count),
+                )
+            )
+            return (1, 0, 0)
+
+        lake._engine.process_staged_document = AsyncMock(side_effect=_process_with_distinct_usage)
+
+        results: list[DocumentResult] = []
+
+        handle = await lake.submit_batch(
+            [{"content": "doc A"}, {"content": "doc B"}],
+            on_result=lambda c, t, r: results.append(r),
+            namespace=ns_id,
+            entity_types=["PERSON"],
+            relationship_types=["KNOWS"],
+            max_concurrent=2,
+        )
+        await handle.wait()
+
+        assert len(results) == 2
+        # Each result must have exactly one usage entry, not two
+        for r in results:
+            assert len(r.llm_usage) == 1
+        # The two results must have distinct operation names (no cross-contamination)
+        ops = {r.llm_usage[0].operation for r in results}
+        assert len(ops) == 2
+
+    @pytest.mark.asyncio
     async def test_failed_document_updates_storage_status(self) -> None:
         """When process_staged_document raises, the document is marked FAILED in storage."""
         from khora.core.models.document import DocumentStatus

--- a/tests/unit/test_memory_lake.py
+++ b/tests/unit/test_memory_lake.py
@@ -1977,6 +1977,58 @@ class TestSubmitBatch:
         assert results[0].relationships_created == 2
 
     @pytest.mark.asyncio
+    async def test_document_result_carries_llm_usage(self) -> None:
+        """DocumentResult.llm_usage is populated from usage recorded during processing."""
+        from khora.memory_lake import LLMUsage
+        from khora.telemetry.context import record_usage
+
+        ns_id = uuid4()
+        lake = _make_lake(connected=True)
+        lake._engine._storage.resolve_namespace = AsyncMock(return_value=ns_id)
+        lake._engine._storage.create_document = AsyncMock(side_effect=lambda doc: doc)
+
+        async def _process_with_usage(doc, **kwargs):
+            record_usage(
+                LLMUsage(
+                    operation="embedding",
+                    model="text-embedding-3-small",
+                    prompt_tokens=10,
+                    completion_tokens=0,
+                    total_tokens=10,
+                    latency_ms=5.0,
+                )
+            )
+            record_usage(
+                LLMUsage(
+                    operation="entity_extraction",
+                    model="gpt-4o",
+                    prompt_tokens=100,
+                    completion_tokens=50,
+                    total_tokens=150,
+                    latency_ms=200.0,
+                )
+            )
+            return (2, 1, 0)
+
+        lake._engine.process_staged_document = AsyncMock(side_effect=_process_with_usage)
+
+        results: list[DocumentResult] = []
+
+        handle = await lake.submit_batch(
+            [{"content": "doc with llm calls"}],
+            on_result=lambda c, t, r: results.append(r),
+            namespace=ns_id,
+            entity_types=["PERSON"],
+            relationship_types=["KNOWS"],
+        )
+        await handle.wait()
+
+        assert results[0].success is True
+        assert len(results[0].llm_usage) == 2
+        ops = {u.operation for u in results[0].llm_usage}
+        assert ops == {"embedding", "entity_extraction"}
+
+    @pytest.mark.asyncio
     async def test_failed_document_updates_storage_status(self) -> None:
         """When process_staged_document raises, the document is marked FAILED in storage."""
         from khora.core.models.document import DocumentStatus


### PR DESCRIPTION
## Summary
- Added `llm_usage` field to `DocumentResult` to surface per-document LLM token usage from `submit_batch` calls
- Accumulated `LLMUsage` across extraction steps and attached to each `DocumentResult` so callers can track costs per document
- Captured partial usage on error paths so failed documents also carry whatever usage was accumulated before the failure
- Added unit tests: happy-path accumulation, error-path partial capture, and concurrent isolation (no cross-document contamination)

## Test plan
- [x] `make format` passes (no changes needed)
- [x] `make test` passes (3 pre-existing failures on `main` unrelated to this change)
- [x] New unit tests cover: normal accumulation, error path with partial usage, concurrent document isolation