### PR TITLE
DYT-3075: submit_batch re-processes existing PENDING/FAILED documents

### DIFF
--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -896,6 +896,27 @@ class VectorCypherEngine:
             max_chunks_in_flight=max_chunks_in_flight,
         )
 
+    async def clear_document_extraction_state(self, document_id: UUID, namespace_id: UUID) -> None:
+        """Clear partial extraction state (khora_chunks + :Chunk nodes) for a FAILED document.
+
+        Called by submit_batch before re-queuing a previously-FAILED document to prevent
+        duplicate chunks accumulating on retry (ADR-068 self-heal path, H1 fix).
+
+        Best-effort: logs and ignores storage errors so that cleanup failures do not
+        block re-processing.
+        """
+        temporal_store = self._get_temporal_store()
+        dual_nodes = self._get_dual_nodes()
+        try:
+            await temporal_store.delete_chunks_by_document(document_id, namespace_id)
+        except Exception as exc:
+            logger.warning(f"submit_batch cleanup: could not clear khora_chunks for document {document_id}: {exc}")
+        if dual_nodes is not None:
+            try:
+                await dual_nodes.delete_chunks_by_document(document_id, namespace_id)
+            except Exception as exc:
+                logger.warning(f"submit_batch cleanup: could not clear :Chunk nodes for document {document_id}: {exc}")
+
     async def _run_skeleton_extraction(
         self,
         chunks: list[TemporalChunk],

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -111,6 +111,8 @@ class DocumentResult:
     entities_extracted: int = 0
     relationships_created: int = 0
     llm_usage: list[LLMUsage] = field(default_factory=list)
+    skipped: bool = False
+    """True when the document was already COMPLETED and re-processing was skipped."""
 
 
 @dataclass
@@ -673,18 +675,80 @@ class MemoryLake:
             handle._mark_done()
             return handle
 
+        from khora.core.models.document import DocumentStatus
+
         namespace_id = await self._resolve_namespace(namespace)
         storage = self.storage
 
         # Persist all documents as PENDING before returning the handle.
         # This satisfies the durability contract — if the process crashes after
         # submit_batch() returns, the PENDING records survive for recovery.
+        #
+        # ADR-068 Decision 1 — self-healing for existing documents:
+        # Instead of failing on duplicate external_id, detect and dispatch:
+        #   PENDING   → skip insert, re-queue for processing (self-heal stalled docs)
+        #   COMPLETED → skip entirely, report success (already done)
+        #   FAILED    → reset to PENDING + update content, re-queue for processing
         pending_docs: list[Document] = []
         pending_doc_data: list[dict[str, Any]] = []
         pre_failed_docs: list[tuple[Document, str]] = []
+        pre_completed_docs: list[Document] = []
+
+        # Batch-lookup existing documents by external_id to avoid N serial queries.
+        all_external_ids = [d.get("external_id") for d in documents if d.get("external_id")]
+        existing_by_ext_id: dict[str, Document] = {}
+        if all_external_ids:
+            existing_by_ext_id = await storage.get_documents_by_external_ids(namespace_id, all_external_ids)
+
         for doc_data in documents:
             content = doc_data.get("content", "")
             checksum = hashlib.sha256(content.encode("utf-8")).hexdigest()
+            external_id = doc_data.get("external_id")
+            existing = existing_by_ext_id.get(external_id) if external_id else None
+
+            if existing is not None:
+                if existing.status == DocumentStatus.COMPLETED:
+                    # Already fully processed — skip re-insertion, report as skipped.
+                    logger.debug(
+                        f"submit_batch: document already COMPLETED, skipping "
+                        f"(external_id={external_id!r}, doc_id={existing.id})"
+                    )
+                    pre_completed_docs.append(existing)
+                    continue
+
+                # PENDING, FAILED, PROCESSING, or ARCHIVED: reset to PENDING and re-process.
+                # Update content + metadata so the re-run uses the latest submitted values
+                # (fixes empty-source issue observed in soak test — DYT-3075).
+                prior_status = existing.status
+                existing.content = content
+                existing.metadata = DocumentMetadata(
+                    title=doc_data.get("title", ""),
+                    source=doc_data.get("source", ""),
+                    source_type="api",
+                    checksum=checksum,
+                    size_bytes=len(content.encode("utf-8")),
+                    custom=doc_data.get("metadata") or {},
+                )
+                existing.status = DocumentStatus.PENDING
+                existing.extraction_config_hash = extraction_config_hash
+                existing.error_message = None
+                logger.debug(
+                    f"submit_batch: re-queuing existing {prior_status.value} document "
+                    f"(external_id={external_id!r}, doc_id={existing.id})"
+                )
+                try:
+                    await storage.update_document(existing)
+                    pending_docs.append(existing)
+                    pending_doc_data.append(doc_data)
+                except Exception as exc:
+                    logger.warning(
+                        f"submit_batch: could not update document record "
+                        f"(external_id={external_id!r}): {exc}"
+                    )
+                    pre_failed_docs.append((existing, str(exc)))
+                continue
+
+            # No existing document — normal insert path.
             doc = Document(
                 namespace_id=namespace_id,
                 content=content,
@@ -697,7 +761,7 @@ class MemoryLake:
                     custom=doc_data.get("metadata") or {},
                 ),
                 extraction_config_hash=extraction_config_hash,
-                external_id=doc_data.get("external_id"),
+                external_id=external_id,
             )
             try:
                 doc = await storage.create_document(doc)
@@ -710,13 +774,17 @@ class MemoryLake:
                 )
                 pre_failed_docs.append((doc, str(exc)))
 
-        handle = BatchHandle(batch_id=uuid4(), total=len(pending_docs) + len(pre_failed_docs))
+        handle = BatchHandle(
+            batch_id=uuid4(),
+            total=len(pending_docs) + len(pre_failed_docs) + len(pre_completed_docs),
+        )
         task = asyncio.create_task(
             self._submit_batch_worker(
                 handle,
                 pending_docs,
                 pending_doc_data,
                 pre_failed_docs,
+                pre_completed_docs,
                 on_result,
                 namespace_id=namespace_id,
                 skill_name=skill_name,
@@ -739,6 +807,7 @@ class MemoryLake:
         pending_docs: list[Document],
         doc_data_list: list[dict[str, Any]],
         pre_failed_docs: list[tuple[Document, str]],
+        pre_completed_docs: list[Document],
         on_result: Callable[[int, int, DocumentResult], None],
         *,
         namespace_id: UUID,
@@ -769,6 +838,19 @@ class MemoryLake:
                     namespace_id=namespace_id,
                     success=False,
                     error=err,
+                )
+            )
+
+        # Fire skipped results for documents already COMPLETED (ADR-068 self-heal).
+        for doc in pre_completed_docs:
+            _fire_result(
+                DocumentResult(
+                    document_id=doc.id,
+                    namespace_id=namespace_id,
+                    success=True,
+                    skipped=True,
+                    chunks_created=doc.chunk_count,
+                    entities_extracted=doc.entity_count,
                 )
             )
 

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -698,12 +698,34 @@ class MemoryLake:
         all_external_ids = [d.get("external_id") for d in documents if d.get("external_id")]
         existing_by_ext_id: dict[str, Document] = {}
         if all_external_ids:
-            existing_by_ext_id = await storage.get_documents_by_external_ids(namespace_id, all_external_ids)
+            try:
+                existing_by_ext_id = await storage.get_documents_by_external_ids(namespace_id, all_external_ids)
+            except Exception as exc:
+                # M2: Fall through to the normal insert path if the lookup fails.
+                logger.warning(
+                    f"submit_batch: could not look up existing documents by external_id "
+                    f"({exc}); treating all as new inserts"
+                )
+                existing_by_ext_id = {}
+
+        seen_external_ids: set[str] = set()
+        pre_failed_doc_ids: set[UUID] = set()
 
         for doc_data in documents:
             content = doc_data.get("content", "")
             checksum = hashlib.sha256(content.encode("utf-8")).hexdigest()
             external_id = doc_data.get("external_id")
+
+            # M4: Skip duplicate external_ids within the same batch.
+            if external_id:
+                if external_id in seen_external_ids:
+                    logger.warning(
+                        f"submit_batch: duplicate external_id in batch, skipping subsequent occurrence "
+                        f"(external_id={external_id!r})"
+                    )
+                    continue
+                seen_external_ids.add(external_id)
+
             existing = existing_by_ext_id.get(external_id) if external_id else None
 
             if existing is not None:
@@ -716,10 +738,23 @@ class MemoryLake:
                     pre_completed_docs.append(existing)
                     continue
 
-                # PENDING, FAILED, PROCESSING, or ARCHIVED: reset to PENDING and re-process.
+                # M1: PROCESSING means an active worker holds this doc — skip to avoid race.
+                if existing.status == DocumentStatus.PROCESSING:
+                    logger.warning(
+                        f"submit_batch: document is PROCESSING, skipping re-queue to avoid race "
+                        f"(external_id={external_id!r}, doc_id={existing.id})"
+                    )
+                    pre_completed_docs.append(existing)
+                    continue
+
+                # PENDING, FAILED, or ARCHIVED: reset to PENDING and re-process.
                 # Update content + metadata so the re-run uses the latest submitted values
                 # (fixes empty-source issue observed in soak test — DYT-3075).
                 prior_status = existing.status
+                # H1: Track FAILED docs — they may have partial extraction state that
+                # must be cleared before re-processing to prevent duplicate chunks.
+                if prior_status == DocumentStatus.FAILED:
+                    pre_failed_doc_ids.add(existing.id)
                 existing.content = content
                 existing.metadata = DocumentMetadata(
                     title=doc_data.get("title", ""),
@@ -742,8 +777,7 @@ class MemoryLake:
                     pending_doc_data.append(doc_data)
                 except Exception as exc:
                     logger.warning(
-                        f"submit_batch: could not update document record "
-                        f"(external_id={external_id!r}): {exc}"
+                        f"submit_batch: could not update document record (external_id={external_id!r}): {exc}"
                     )
                     pre_failed_docs.append((existing, str(exc)))
                 continue
@@ -795,6 +829,7 @@ class MemoryLake:
                 chunk_strategy=chunk_strategy,
                 max_chunks_in_flight=max_chunks_in_flight,
                 max_concurrent=max_concurrent,
+                pre_failed_doc_ids=pre_failed_doc_ids,
             )
         )
         self._bg_tasks.add(task)
@@ -819,6 +854,7 @@ class MemoryLake:
         chunk_strategy: ChunkStrategy | None,
         max_chunks_in_flight: int | None,
         max_concurrent: int,
+        pre_failed_doc_ids: set[UUID],
     ) -> None:
         """Background worker that processes pre-staged PENDING documents."""
         storage = self.storage
@@ -882,6 +918,21 @@ class MemoryLake:
             from khora.telemetry.context import collect_usage, start_usage_collection
 
             async with sem:
+                # H1: Clear partial extraction state for previously-FAILED documents
+                # before re-processing to prevent duplicate chunks/entities on retry.
+                if doc.id in pre_failed_doc_ids:
+                    if storage.vector is not None:
+                        try:
+                            await storage.vector.delete_chunks_by_document(doc.id)
+                        except Exception as exc:
+                            logger.warning(f"submit_batch: could not clear chunks table for {doc.id}: {exc}")
+                    clear_fn = getattr(engine, "clear_document_extraction_state", None)
+                    if clear_fn is not None:
+                        try:
+                            await clear_fn(doc.id, namespace_id)
+                        except Exception as exc:
+                            logger.warning(f"submit_batch: could not clear extraction state for {doc.id}: {exc}")
+
                 start_usage_collection()
                 try:
                     doc_metadata = doc_data.get("metadata") or {}

--- a/tests/unit/test_memory_lake.py
+++ b/tests/unit/test_memory_lake.py
@@ -1662,6 +1662,8 @@ def _make_lake_with_staged_support(ns_id):
 
     lake._engine._storage.create_document = AsyncMock(side_effect=_fake_create_document)
     lake._engine._storage.update_document = AsyncMock(side_effect=lambda doc: doc)
+    # No pre-existing docs by default — each test can override as needed.
+    lake._engine._storage.get_documents_by_external_ids = AsyncMock(return_value={})
 
     async def _fake_process_staged(doc, **kwargs):
         return (2, 1, 0)  # chunks, entities, rels
@@ -2184,13 +2186,19 @@ class TestSubmitBatch:
         assert handle.is_done
 
     @pytest.mark.asyncio
-    async def test_external_id_collision_produces_error_result(self) -> None:
-        """If create_document raises (e.g. IntegrityError), on_result receives success=False."""
+    async def test_create_document_error_fallback_produces_error_result(self) -> None:
+        """If get_documents_by_external_ids finds nothing and create_document raises, on_result receives success=False.
+
+        This covers the race-condition path: external_id not found in lookup,
+        then a concurrent insert causes the create to fail.
+        """
         from sqlalchemy.exc import IntegrityError
 
         ns_id = uuid4()
         lake = _make_lake(connected=True)
         lake._engine._storage.resolve_namespace = AsyncMock(return_value=ns_id)
+        # No existing doc found by external_id lookup
+        lake._engine._storage.get_documents_by_external_ids = AsyncMock(return_value={})
 
         def _raise_integrity(doc):
             raise IntegrityError("INSERT", {}, Exception("unique constraint"))
@@ -2216,3 +2224,146 @@ class TestSubmitBatch:
         assert len(results) == 1
         assert results[0].success is False
         assert handle.failed == 1
+
+    @pytest.mark.asyncio
+    async def test_pending_external_id_requeues_for_processing(self) -> None:
+        """PENDING document with same external_id is re-queued, not failed (DYT-3075)."""
+        from khora.core.models.document import Document, DocumentStatus
+
+        ns_id = uuid4()
+        lake = _make_lake(connected=True)
+        lake._engine._storage.resolve_namespace = AsyncMock(return_value=ns_id)
+
+        existing_doc = Document(namespace_id=ns_id, content="old content", external_id="ext-pending")
+        existing_doc.status = DocumentStatus.PENDING
+
+        lake._engine._storage.get_documents_by_external_ids = AsyncMock(
+            return_value={"ext-pending": existing_doc}
+        )
+        lake._engine._storage.update_document = AsyncMock(side_effect=lambda doc: doc)
+
+        async def _fake_process(doc, **kwargs):
+            return (3, 2, 1)
+
+        lake._engine.process_staged_document = AsyncMock(side_effect=_fake_process)
+
+        results: list[DocumentResult] = []
+
+        handle = await lake.submit_batch(
+            [{"content": "new content", "external_id": "ext-pending", "source": "updated-source"}],
+            on_result=lambda c, t, r: results.append(r),
+            namespace=ns_id,
+            entity_types=["PERSON"],
+            relationship_types=["KNOWS"],
+        )
+        await handle.wait()
+
+        # create_document must NOT be called — we reuse the existing doc
+        lake._engine._storage.create_document.assert_not_called()
+        # update_document IS called to reset status + content
+        lake._engine._storage.update_document.assert_called_once()
+        updated = lake._engine._storage.update_document.call_args[0][0]
+        assert updated.status == DocumentStatus.PENDING
+        assert updated.content == "new content"
+        assert updated.metadata.source == "updated-source"
+
+        assert len(results) == 1
+        assert results[0].success is True
+        assert results[0].skipped is False
+        assert results[0].chunks_created == 3
+        assert handle.failed == 0
+
+    @pytest.mark.asyncio
+    async def test_completed_external_id_reported_as_skipped(self) -> None:
+        """COMPLETED document with same external_id is skipped, not re-processed (DYT-3075)."""
+        from khora.core.models.document import Document, DocumentStatus
+
+        ns_id = uuid4()
+        lake = _make_lake(connected=True)
+        lake._engine._storage.resolve_namespace = AsyncMock(return_value=ns_id)
+
+        existing_doc = Document(namespace_id=ns_id, content="done", external_id="ext-done")
+        existing_doc.status = DocumentStatus.COMPLETED
+        existing_doc.chunk_count = 5
+        existing_doc.entity_count = 3
+
+        lake._engine._storage.get_documents_by_external_ids = AsyncMock(
+            return_value={"ext-done": existing_doc}
+        )
+
+        async def _fake_process(doc, **kwargs):
+            return (1, 1, 0)
+
+        lake._engine.process_staged_document = AsyncMock(side_effect=_fake_process)
+
+        results: list[DocumentResult] = []
+
+        handle = await lake.submit_batch(
+            [{"content": "done", "external_id": "ext-done"}],
+            on_result=lambda c, t, r: results.append(r),
+            namespace=ns_id,
+            entity_types=["PERSON"],
+            relationship_types=["KNOWS"],
+        )
+        await handle.wait()
+
+        # Neither create nor update should be called
+        lake._engine._storage.create_document.assert_not_called()
+        # process_staged_document not called for skipped doc
+        lake._engine.process_staged_document.assert_not_called()
+
+        assert len(results) == 1
+        assert results[0].success is True
+        assert results[0].skipped is True
+        assert results[0].chunks_created == 5
+        assert results[0].entities_extracted == 3
+        assert handle.failed == 0
+
+    @pytest.mark.asyncio
+    async def test_failed_external_id_resets_to_pending_and_reprocesses(self) -> None:
+        """FAILED document with same external_id is reset to PENDING and re-processed (DYT-3075)."""
+        from khora.core.models.document import Document, DocumentStatus
+
+        ns_id = uuid4()
+        lake = _make_lake(connected=True)
+        lake._engine._storage.resolve_namespace = AsyncMock(return_value=ns_id)
+
+        existing_doc = Document(namespace_id=ns_id, content="bad content", external_id="ext-failed")
+        existing_doc.status = DocumentStatus.FAILED
+        existing_doc.error_message = "previous error"
+
+        lake._engine._storage.get_documents_by_external_ids = AsyncMock(
+            return_value={"ext-failed": existing_doc}
+        )
+        lake._engine._storage.update_document = AsyncMock(side_effect=lambda doc: doc)
+
+        async def _fake_process(doc, **kwargs):
+            return (2, 1, 0)
+
+        lake._engine.process_staged_document = AsyncMock(side_effect=_fake_process)
+
+        results: list[DocumentResult] = []
+
+        handle = await lake.submit_batch(
+            [{"content": "fixed content", "external_id": "ext-failed", "source": "fixed-source"}],
+            on_result=lambda c, t, r: results.append(r),
+            namespace=ns_id,
+            entity_types=["PERSON"],
+            relationship_types=["KNOWS"],
+        )
+        await handle.wait()
+
+        # update_document called to reset status and update content
+        lake._engine._storage.update_document.assert_called_once()
+        updated = lake._engine._storage.update_document.call_args[0][0]
+        assert updated.status == DocumentStatus.PENDING
+        assert updated.content == "fixed content"
+        assert updated.error_message is None
+
+        # Document was re-processed
+        lake._engine.process_staged_document.assert_called_once()
+
+        assert len(results) == 1
+        assert results[0].success is True
+        assert results[0].skipped is False
+        assert handle.failed == 0

--- a/tests/unit/test_memory_lake.py
+++ b/tests/unit/test_memory_lake.py
@@ -2237,9 +2237,7 @@ class TestSubmitBatch:
         existing_doc = Document(namespace_id=ns_id, content="old content", external_id="ext-pending")
         existing_doc.status = DocumentStatus.PENDING
 
-        lake._engine._storage.get_documents_by_external_ids = AsyncMock(
-            return_value={"ext-pending": existing_doc}
-        )
+        lake._engine._storage.get_documents_by_external_ids = AsyncMock(return_value={"ext-pending": existing_doc})
         lake._engine._storage.update_document = AsyncMock(side_effect=lambda doc: doc)
 
         async def _fake_process(doc, **kwargs):
@@ -2287,9 +2285,7 @@ class TestSubmitBatch:
         existing_doc.chunk_count = 5
         existing_doc.entity_count = 3
 
-        lake._engine._storage.get_documents_by_external_ids = AsyncMock(
-            return_value={"ext-done": existing_doc}
-        )
+        lake._engine._storage.get_documents_by_external_ids = AsyncMock(return_value={"ext-done": existing_doc})
 
         async def _fake_process(doc, **kwargs):
             return (1, 1, 0)
@@ -2332,9 +2328,7 @@ class TestSubmitBatch:
         existing_doc.status = DocumentStatus.FAILED
         existing_doc.error_message = "previous error"
 
-        lake._engine._storage.get_documents_by_external_ids = AsyncMock(
-            return_value={"ext-failed": existing_doc}
-        )
+        lake._engine._storage.get_documents_by_external_ids = AsyncMock(return_value={"ext-failed": existing_doc})
         lake._engine._storage.update_document = AsyncMock(side_effect=lambda doc: doc)
 
         async def _fake_process(doc, **kwargs):
@@ -2367,3 +2361,155 @@ class TestSubmitBatch:
         assert results[0].success is True
         assert results[0].skipped is False
         assert handle.failed == 0
+
+    @pytest.mark.asyncio
+    async def test_failed_external_id_clears_prior_state_before_reprocess(self) -> None:
+        """For a FAILED doc, clear_document_extraction_state is called before re-processing (H1)."""
+        from khora.core.models.document import Document, DocumentStatus
+
+        ns_id = uuid4()
+        lake = _make_lake(connected=True)
+        lake._engine._storage.resolve_namespace = AsyncMock(return_value=ns_id)
+
+        existing_doc = Document(namespace_id=ns_id, content="bad content", external_id="ext-failed-h1")
+        existing_doc.status = DocumentStatus.FAILED
+        existing_doc.error_message = "previous error"
+
+        lake._engine._storage.get_documents_by_external_ids = AsyncMock(return_value={"ext-failed-h1": existing_doc})
+        lake._engine._storage.update_document = AsyncMock(side_effect=lambda doc: doc)
+
+        clear_calls: list[tuple] = []
+
+        async def _fake_clear(doc_id, ns_id_arg):
+            clear_calls.append((doc_id, ns_id_arg))
+
+        lake._engine.clear_document_extraction_state = AsyncMock(side_effect=_fake_clear)
+
+        async def _fake_process(doc, **kwargs):
+            return (2, 1, 0)
+
+        lake._engine.process_staged_document = AsyncMock(side_effect=_fake_process)
+
+        handle = await lake.submit_batch(
+            [{"content": "fixed content", "external_id": "ext-failed-h1"}],
+            on_result=lambda c, t, r: None,
+            namespace=ns_id,
+            entity_types=["PERSON"],
+            relationship_types=["KNOWS"],
+        )
+        await handle.wait()
+
+        # Cleanup was called before re-processing
+        lake._engine.clear_document_extraction_state.assert_called_once_with(existing_doc.id, ns_id)
+        # Document was re-processed
+        lake._engine.process_staged_document.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_processing_external_id_skipped_to_avoid_race(self) -> None:
+        """PROCESSING document with same external_id is skipped to avoid race condition (M1)."""
+        from khora.core.models.document import Document, DocumentStatus
+
+        ns_id = uuid4()
+        lake = _make_lake(connected=True)
+        lake._engine._storage.resolve_namespace = AsyncMock(return_value=ns_id)
+
+        existing_doc = Document(namespace_id=ns_id, content="in progress", external_id="ext-proc")
+        existing_doc.status = DocumentStatus.PROCESSING
+
+        lake._engine._storage.get_documents_by_external_ids = AsyncMock(return_value={"ext-proc": existing_doc})
+
+        async def _fake_process(doc, **kwargs):
+            return (1, 0, 0)
+
+        lake._engine.process_staged_document = AsyncMock(side_effect=_fake_process)
+
+        results: list[DocumentResult] = []
+
+        handle = await lake.submit_batch(
+            [{"content": "new content", "external_id": "ext-proc"}],
+            on_result=lambda c, t, r: results.append(r),
+            namespace=ns_id,
+            entity_types=["PERSON"],
+            relationship_types=["KNOWS"],
+        )
+        await handle.wait()
+
+        # PROCESSING doc skipped — not re-processed and not created
+        lake._engine.process_staged_document.assert_not_called()
+        lake._engine._storage.create_document.assert_not_called()
+        lake._engine._storage.update_document.assert_not_called()
+
+        assert len(results) == 1
+        assert results[0].success is True
+        assert results[0].skipped is True
+
+    @pytest.mark.asyncio
+    async def test_lookup_failure_falls_back_to_create(self) -> None:
+        """If get_documents_by_external_ids raises, submit_batch treats all docs as new inserts (M2)."""
+        ns_id = uuid4()
+        lake = _make_lake(connected=True)
+        lake._engine._storage.resolve_namespace = AsyncMock(return_value=ns_id)
+        lake._engine._storage.get_documents_by_external_ids = AsyncMock(side_effect=RuntimeError("DB timeout"))
+
+        async def _fake_create(doc):
+            return doc
+
+        lake._engine._storage.create_document = AsyncMock(side_effect=_fake_create)
+
+        async def _fake_process(doc, **kwargs):
+            return (2, 1, 0)
+
+        lake._engine.process_staged_document = AsyncMock(side_effect=_fake_process)
+
+        results: list[DocumentResult] = []
+
+        handle = await lake.submit_batch(
+            [{"content": "new doc", "external_id": "ext-new-m2"}],
+            on_result=lambda c, t, r: results.append(r),
+            namespace=ns_id,
+            entity_types=["PERSON"],
+            relationship_types=["KNOWS"],
+        )
+        await handle.wait()
+
+        # Falls back to create path
+        lake._engine._storage.create_document.assert_called_once()
+        assert len(results) == 1
+        assert results[0].success is True
+
+    @pytest.mark.asyncio
+    async def test_duplicate_external_id_in_batch_skips_second(self) -> None:
+        """When the same external_id appears twice in a batch, the second is skipped (M4)."""
+        ns_id = uuid4()
+        lake = _make_lake(connected=True)
+        lake._engine._storage.resolve_namespace = AsyncMock(return_value=ns_id)
+        lake._engine._storage.get_documents_by_external_ids = AsyncMock(return_value={})
+
+        async def _fake_create(doc):
+            return doc
+
+        lake._engine._storage.create_document = AsyncMock(side_effect=_fake_create)
+
+        async def _fake_process(doc, **kwargs):
+            return (2, 1, 0)
+
+        lake._engine.process_staged_document = AsyncMock(side_effect=_fake_process)
+
+        results: list[DocumentResult] = []
+
+        handle = await lake.submit_batch(
+            [
+                {"content": "first content", "external_id": "ext-dup"},
+                {"content": "second content", "external_id": "ext-dup"},  # duplicate
+            ],
+            on_result=lambda c, t, r: results.append(r),
+            namespace=ns_id,
+            entity_types=["PERSON"],
+            relationship_types=["KNOWS"],
+        )
+        await handle.wait()
+
+        # Only one document created (second was skipped)
+        lake._engine._storage.create_document.assert_called_once()
+        assert len(results) == 1
+        assert results[0].success is True


### PR DESCRIPTION
## Summary
- **PENDING documents**: `submit_batch` now detects existing PENDING documents by `external_id` and re-queues them for processing instead of failing on duplicate insert (self-heal for stalled docs)
- **COMPLETED documents**: `submit_batch` skips re-insertion for already-completed documents and reports them as skipped (`BatchSubmitResult.skipped=True`)
- **FAILED documents**: `submit_batch` resets status to PENDING, updates content/checksum, clears partial extraction state (chunks + graph nodes), and re-queues for re-processing
- **Batch deduplication**: duplicate `external_id` values within the same batch are deduplicated with a warning log
- Added `clear_document_extraction_state()` to the vectorcypher engine to remove stale chunks before retry (best-effort, logs and ignores storage errors)
- Added `skipped: bool` field to `BatchDocumentResult` to distinguish skipped-completed from newly-queued documents

## Test plan
- [x] Unit tests for all three state transitions (PENDING→re-queue, COMPLETED→skip, FAILED→reset+re-queue) added in `tests/unit/test_memory_lake.py`
- [x] Batch deduplication unit test added
- [x] `make format` passes (ruff format + ruff check)
- [x] `make test` passes — 2596 passed, 236 skipped (3 pre-existing failures in `test_logging_config.py` unrelated to this PR)