### PR TITLE
DYT-3158: Reduce embedding cache memory footprint

### DIFF
--- a/src/khora/config/llm.py
+++ b/src/khora/config/llm.py
@@ -111,6 +111,15 @@ class LiteLLMConfig(BaseModel):
         "and long texts get small batches, keeping API response "
         "payloads under ~2MB.",
     )
+    embed_cache_max_size: int = Field(
+        default=50000,
+        ge=0,
+        description=(
+            "Maximum number of embeddings to cache in memory (0 to disable). "
+            "Each entry uses ~13 KB (numpy float64 array). "
+            "At 50,000 entries: ~650 MB. Tune for container memory budget."
+        ),
+    )
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> LiteLLMConfig:

--- a/src/khora/extraction/embedders/litellm.py
+++ b/src/khora/extraction/embedders/litellm.py
@@ -7,7 +7,7 @@ import re
 import time as _time_mod
 from collections import OrderedDict
 from hashlib import sha256
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential
@@ -15,6 +15,13 @@ from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential
 from khora.telemetry import trace_span
 
 from .base import Embedder
+
+try:
+    import numpy as np
+
+    _HAS_NUMPY = True
+except ImportError:
+    _HAS_NUMPY = False
 
 if TYPE_CHECKING:
     from khora.config import LiteLLMConfig
@@ -109,7 +116,9 @@ class LiteLLMEmbedder(Embedder):
                 Dynamically sizes batches so short texts get large batches
                 and long texts get small batches, keeping API response
                 payloads under ~2MB to avoid HTTP transfer corruption.
-            cache_max_size: Maximum cached embeddings (0 to disable)
+            cache_max_size: Maximum cached embeddings (0 to disable). Each entry
+                uses ~13 KB (numpy float64) when numpy is available, or ~50 KB
+                (Python list[float]) otherwise. At 50,000 entries: ~650 MB.
             embed_concurrency: Maximum concurrent embedding sub-batch API calls
             retry_wait: Base wait time (seconds) for exponential backoff between retries
             cache_ttl_hours: Cache entry TTL in hours (None = no expiry)
@@ -123,7 +132,8 @@ class LiteLLMEmbedder(Embedder):
         self._max_batch_tokens = max_batch_tokens
         self._embed_concurrency = embed_concurrency
         self._retry_wait = retry_wait
-        self._cache: OrderedDict[str, tuple[list[float], float]] = OrderedDict()
+        # Stores numpy arrays when numpy is available (~13 KB/entry vs ~50 KB for list[float])
+        self._cache: OrderedDict[str, tuple[Any, float]] = OrderedDict()
         self._cache_max_size = cache_max_size
         self._cache_ttl_seconds: float | None = cache_ttl_hours * 3600.0 if cache_ttl_hours is not None else None
         self._cache_hits = 0
@@ -157,7 +167,7 @@ class LiteLLMEmbedder(Embedder):
                     return None
             self._cache.move_to_end(key)
             self._cache_hits += 1
-            return embedding
+            return embedding.tolist() if _HAS_NUMPY and hasattr(embedding, "tolist") else embedding
         self._cache_misses += 1
         return None
 
@@ -166,7 +176,9 @@ class LiteLLMEmbedder(Embedder):
         if not self._cache_max_size:
             return
         key = key or self._cache_key(text)
-        self._cache[key] = (embedding, _time_mod.monotonic())
+        # Store as numpy float64 array when available: ~13 KB/entry vs ~50 KB for list[float]
+        stored: Any = np.array(embedding, dtype=np.float64) if _HAS_NUMPY else embedding
+        self._cache[key] = (stored, _time_mod.monotonic())
         self._cache.move_to_end(key)
         while len(self._cache) > self._cache_max_size:
             self._cache.popitem(last=False)
@@ -199,6 +211,7 @@ class LiteLLMEmbedder(Embedder):
             embed_concurrency=config.embed_concurrency,
             batch_size=getattr(config, "embed_batch_size", 200),
             max_batch_tokens=getattr(config, "embed_batch_tokens", 50_000),
+            cache_max_size=getattr(config, "embed_cache_max_size", 50000),
         )
 
     @property


### PR DESCRIPTION
## Summary
- Added `embed_cache_max_size` config field to `LiteLLMConfig` with a default of 50,000 entries and clear memory-budget documentation (~13 KB/entry with numpy, ~650 MB at default)
- Changed the embedding cache to store `numpy.float64` arrays instead of `list[float]` when numpy is available (~13 KB/entry vs ~50 KB), reducing memory footprint by ~4×
- Added a graceful fallback: when numpy is not installed, the cache falls back to `list[float]` storage transparently
- Updated docstrings and type annotations to reflect the new storage format

## Test plan
- [ ] Unit tests pass (`make test`)
- [ ] Integration tests pass
- [ ] Manual verification: instantiate `LiteLLMEmbedder` with numpy present and confirm cached embeddings return correct `list[float]` values; verify memory usage is ~4× lower than before