### PR TITLE
DYT-3156: Add shared aiohttp session for LiteLLM calls

### DIFF
--- a/src/khora/config/llm.py
+++ b/src/khora/config/llm.py
@@ -175,8 +175,6 @@ def configure_litellm(config: LiteLLMConfig | None = None) -> None:
     Args:
         config: LiteLLM configuration (uses defaults if None)
     """
-    global _shared_aiohttp_session
-
     try:
         import litellm
     except ImportError:
@@ -205,9 +203,19 @@ def configure_litellm(config: LiteLLMConfig | None = None) -> None:
         elif "gemini" in config.model.lower():
             os.environ.setdefault("GOOGLE_API_KEY", api_key)
 
-    # Create a shared aiohttp session to prevent connection pool leak.
-    # litellm.aclient_session / global overrides are ignored by actual call paths;
-    # the only reliable mechanism is passing shared_session per call.
+    logger.info(f"LiteLLM configured with model: {config.model}")
+
+
+async def _init_shared_session() -> None:
+    """Create the shared aiohttp session for litellm calls if not already created.
+
+    Must be called from an async context (e.g. engine connect()) so that
+    aiohttp.ClientSession is instantiated inside a running coroutine.
+    The guard prevents session leaks on repeated connect() calls.
+    """
+    global _shared_aiohttp_session
+    if _shared_aiohttp_session is not None:
+        return
     try:
         import aiohttp
 
@@ -219,8 +227,6 @@ def configure_litellm(config: LiteLLMConfig | None = None) -> None:
         logger.debug("Shared aiohttp session created for litellm calls")
     except ImportError:
         logger.debug("aiohttp not available, skipping shared session creation")
-
-    logger.info(f"LiteLLM configured with model: {config.model}")
 
 
 def get_shared_session() -> Any:

--- a/src/khora/config/llm.py
+++ b/src/khora/config/llm.py
@@ -163,6 +163,9 @@ class LiteLLMConfig(BaseModel):
         return key
 
 
+_shared_aiohttp_session: Any = None
+
+
 def configure_litellm(config: LiteLLMConfig | None = None) -> None:
     """Configure LiteLLM with the given configuration.
 
@@ -172,6 +175,8 @@ def configure_litellm(config: LiteLLMConfig | None = None) -> None:
     Args:
         config: LiteLLM configuration (uses defaults if None)
     """
+    global _shared_aiohttp_session
+
     try:
         import litellm
     except ImportError:
@@ -200,7 +205,36 @@ def configure_litellm(config: LiteLLMConfig | None = None) -> None:
         elif "gemini" in config.model.lower():
             os.environ.setdefault("GOOGLE_API_KEY", api_key)
 
+    # Create a shared aiohttp session to prevent connection pool leak.
+    # litellm.aclient_session / global overrides are ignored by actual call paths;
+    # the only reliable mechanism is passing shared_session per call.
+    try:
+        import aiohttp
+
+        connector = aiohttp.TCPConnector(limit=20, limit_per_host=10, keepalive_timeout=30)
+        _shared_aiohttp_session = aiohttp.ClientSession(
+            connector=connector,
+            timeout=aiohttp.ClientTimeout(total=600),
+        )
+        logger.debug("Shared aiohttp session created for litellm calls")
+    except ImportError:
+        logger.debug("aiohttp not available, skipping shared session creation")
+
     logger.info(f"LiteLLM configured with model: {config.model}")
+
+
+def get_shared_session() -> Any:
+    """Return the shared aiohttp session for litellm calls, or None if not initialised."""
+    return _shared_aiohttp_session
+
+
+async def close_shared_session() -> None:
+    """Close the shared aiohttp session. Call on engine/app shutdown."""
+    global _shared_aiohttp_session
+    if _shared_aiohttp_session is not None:
+        await _shared_aiohttp_session.close()
+        _shared_aiohttp_session = None
+        logger.debug("Shared aiohttp session closed")
 
 
 def create_litellm_router(config: LiteLLMConfig) -> Any:

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -410,9 +410,10 @@ class VectorCypherEngine:
             timeout=self._config.llm.timeout,
             max_retries=self._config.llm.max_retries,
         )
-        from khora.config.llm import configure_litellm
+        from khora.config.llm import _init_shared_session, configure_litellm
 
         configure_litellm(llm_config)
+        await _init_shared_session()
         self._embedder = LiteLLMEmbedder.from_config(llm_config)
 
         # Initialize dual node manager (Neo4j only — SurrealDB uses graph adapter).

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -410,6 +410,9 @@ class VectorCypherEngine:
             timeout=self._config.llm.timeout,
             max_retries=self._config.llm.max_retries,
         )
+        from khora.config.llm import configure_litellm
+
+        configure_litellm(llm_config)
         self._embedder = LiteLLMEmbedder.from_config(llm_config)
 
         # Initialize dual node manager (Neo4j only — SurrealDB uses graph adapter).
@@ -497,6 +500,11 @@ class VectorCypherEngine:
             return
 
         logger.info("Disconnecting VectorCypher engine...")
+
+        # Close shared aiohttp session used by litellm calls
+        from khora.config.llm import close_shared_session
+
+        await close_shared_session()
 
         # Shutdown telemetry
         from khora.telemetry import shutdown_telemetry

--- a/src/khora/extraction/embedders/litellm.py
+++ b/src/khora/extraction/embedders/litellm.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential
 
+from khora.config.llm import get_shared_session
 from khora.telemetry import trace_span
 
 from .base import Embedder
@@ -399,8 +400,6 @@ class LiteLLMEmbedder(Embedder):
                     req_span.set_attribute("timeout", self._timeout)
 
                     _t0 = _time.perf_counter()
-                    from khora.config.llm import get_shared_session
-
                     response = await litellm.aembedding(
                         model=self._model,
                         input=sanitized,

--- a/src/khora/extraction/embedders/litellm.py
+++ b/src/khora/extraction/embedders/litellm.py
@@ -399,11 +399,14 @@ class LiteLLMEmbedder(Embedder):
                     req_span.set_attribute("timeout", self._timeout)
 
                     _t0 = _time.perf_counter()
+                    from khora.config.llm import get_shared_session
+
                     response = await litellm.aembedding(
                         model=self._model,
                         input=sanitized,
                         timeout=self._timeout,
                         dimensions=self._dimension,
+                        shared_session=get_shared_session(),
                     )
                     _latency = (_time.perf_counter() - _t0) * 1000
                     req_span.set_attribute("latency_ms", round(_latency, 2))

--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -765,6 +765,8 @@ class LLMEntityExtractor(EntityExtractor):
                         effective_max_tokens = self._max_tokens
 
                         with trace_span("khora.extraction.llm_call", model=self._model, call_type="single"):
+                            from khora.config.llm import get_shared_session
+
                             response = await litellm.acompletion(
                                 model=self._model,
                                 messages=[
@@ -776,6 +778,7 @@ class LLMEntityExtractor(EntityExtractor):
                                 timeout=self._timeout,
                                 num_retries=0,
                                 response_format=self._get_response_format(),
+                                shared_session=get_shared_session(),
                             )
                         _latency = (_time.perf_counter() - _t0) * 1000
                         self._log_rate_limit_headers(response)
@@ -909,6 +912,8 @@ class LLMEntityExtractor(EntityExtractor):
 
                 _t0 = _time.perf_counter()
                 with trace_span("khora.extraction.llm_call", model=self._model, call_type="relationship_second_pass"):
+                    from khora.config.llm import get_shared_session
+
                     response = await litellm.acompletion(
                         model=self._model,
                         messages=[
@@ -919,6 +924,7 @@ class LLMEntityExtractor(EntityExtractor):
                         max_tokens=self._max_tokens,
                         timeout=self._timeout,
                         response_format=self._get_response_format(),
+                        shared_session=get_shared_session(),
                     )
                 _latency = (_time.perf_counter() - _t0) * 1000
                 self._log_rate_limit_headers(response)
@@ -1675,6 +1681,8 @@ Return ONLY valid JSON, no other text."""
                             call_type="multi_batch",
                             batch_size=len(texts),
                         ):
+                            from khora.config.llm import get_shared_session
+
                             response = await litellm.acompletion(
                                 model=self._model,
                                 messages=[
@@ -1686,6 +1694,7 @@ Return ONLY valid JSON, no other text."""
                                 timeout=self._timeout,
                                 num_retries=0,
                                 response_format=self._get_multi_response_format(),
+                                shared_session=get_shared_session(),
                             )
                         _latency = (_time.perf_counter() - _t0) * 1000
                         self._log_rate_limit_headers(response)

--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 from tenacity import AsyncRetrying, stop_after_attempt, stop_after_delay, wait_exponential
 
+from khora.config.llm import get_shared_session
+
 from .base import (
     EntityExtractor,
     ExtractedEntity,
@@ -765,8 +767,6 @@ class LLMEntityExtractor(EntityExtractor):
                         effective_max_tokens = self._max_tokens
 
                         with trace_span("khora.extraction.llm_call", model=self._model, call_type="single"):
-                            from khora.config.llm import get_shared_session
-
                             response = await litellm.acompletion(
                                 model=self._model,
                                 messages=[
@@ -912,8 +912,6 @@ class LLMEntityExtractor(EntityExtractor):
 
                 _t0 = _time.perf_counter()
                 with trace_span("khora.extraction.llm_call", model=self._model, call_type="relationship_second_pass"):
-                    from khora.config.llm import get_shared_session
-
                     response = await litellm.acompletion(
                         model=self._model,
                         messages=[
@@ -1681,8 +1679,6 @@ Return ONLY valid JSON, no other text."""
                             call_type="multi_batch",
                             batch_size=len(texts),
                         ):
-                            from khora.config.llm import get_shared_session
-
                             response = await litellm.acompletion(
                                 model=self._model,
                                 messages=[

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -23,9 +23,7 @@ from khora.telemetry.logfire_integration import (
     install_neo4j_logfire_handler,
 )
 
-requires_logfire = pytest.mark.skipif(
-    not _HAS_LOGFIRE, reason="logfire not installed"
-)
+requires_logfire = pytest.mark.skipif(not _HAS_LOGFIRE, reason="logfire not installed")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -18,8 +18,13 @@ from khora import logging_config
 from khora.logging_config import apply_neo4j_log_level_from_env, setup_logging
 from khora.telemetry import logfire_integration
 from khora.telemetry.logfire_integration import (
+    _HAS_LOGFIRE,
     _NEO4J_LOGFIRE_HANDLER_MARK,
     install_neo4j_logfire_handler,
+)
+
+requires_logfire = pytest.mark.skipif(
+    not _HAS_LOGFIRE, reason="logfire not installed"
 )
 
 
@@ -252,6 +257,7 @@ def _reset_neo4j_handlers():
             neo4j_logger.removeHandler(h)
 
 
+@requires_logfire
 def test_install_neo4j_logfire_handler_attaches_when_env_set_and_logfire_available(
     monkeypatch: pytest.MonkeyPatch,
     _reset_neo4j_handlers: None,
@@ -297,6 +303,7 @@ def test_install_neo4j_logfire_handler_noop_when_logfire_unavailable(
     assert _marked_neo4j_handlers() == []
 
 
+@requires_logfire
 def test_install_neo4j_logfire_handler_idempotent(
     monkeypatch: pytest.MonkeyPatch,
     _reset_neo4j_handlers: None,
@@ -308,6 +315,7 @@ def test_install_neo4j_logfire_handler_idempotent(
     assert len(_marked_neo4j_handlers()) == 1
 
 
+@requires_logfire
 def test_setup_logging_installs_neo4j_logfire_handler_when_env_set(
     monkeypatch: pytest.MonkeyPatch,
     _reset_neo4j_logger_level: logging.Logger,


### PR DESCRIPTION
## Summary
- Adds a shared `aiohttp.ClientSession` for LiteLLM HTTP calls to prevent connection exhaustion under load (`src/khora/config/llm.py`)
- Wires the session into the VectorCypher engine and LiteLLM embedder/extractor call paths
- Fixes logfire-conditional tests that were failing when `logfire` is not installed by adding `@requires_logfire` skip markers

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass
- [x] `make format && make lint` clean