### PR TITLE
DYT-3170: Change submit_batch default max_concurrent from 1 to 20

### DIFF
--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -784,7 +784,7 @@ class MemoryLake:
         extraction_config_hash: str | None = None,
         chunk_strategy: ChunkStrategy | None = None,
         max_chunks_in_flight: int | None = None,
-        max_concurrent: int = 10,
+        max_concurrent: int = 20,
         reprocess_archived: bool = False,
     ) -> BatchHandle:
         """Submit documents for deferred background processing.
@@ -817,7 +817,7 @@ class MemoryLake:
             max_chunks_in_flight: Maximum chunks processed per window. Controls
                 memory usage during background processing. None = unbounded.
             max_concurrent: Maximum documents to process concurrently in background
-                (default: 10).
+                (default: 20).
             reprocess_archived: If True, ARCHIVED documents are reset to PENDING
                 and re-processed like FAILED documents. If False (default), ARCHIVED
                 documents are skipped with a warning — preserving intentional

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -784,7 +784,7 @@ class MemoryLake:
         extraction_config_hash: str | None = None,
         chunk_strategy: ChunkStrategy | None = None,
         max_chunks_in_flight: int | None = None,
-        max_concurrent: int = 20,
+        max_concurrent: int = 10,
         reprocess_archived: bool = False,
     ) -> BatchHandle:
         """Submit documents for deferred background processing.
@@ -817,7 +817,7 @@ class MemoryLake:
             max_chunks_in_flight: Maximum chunks processed per window. Controls
                 memory usage during background processing. None = unbounded.
             max_concurrent: Maximum documents to process concurrently in background
-                (default: 1 — sequential processing).
+                (default: 10).
             reprocess_archived: If True, ARCHIVED documents are reset to PENDING
                 and re-processed like FAILED documents. If False (default), ARCHIVED
                 documents are skipped with a warning — preserving intentional

--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -784,7 +784,7 @@ class MemoryLake:
         extraction_config_hash: str | None = None,
         chunk_strategy: ChunkStrategy | None = None,
         max_chunks_in_flight: int | None = None,
-        max_concurrent: int = 1,
+        max_concurrent: int = 20,
         reprocess_archived: bool = False,
     ) -> BatchHandle:
         """Submit documents for deferred background processing.


### PR DESCRIPTION
## Summary
- Change `submit_batch()` default `max_concurrent` from 1 (sequential) to 20, aligning with the documented intent that batch processing should utilize concurrency by default
- The previous default of 1 forced sequential processing unless callers explicitly opted in, which was inconsistent with the batch processing use case

## Test plan
- [x] Unit tests pass (2723 passed)
- [x] Lint and format checks pass
- [x] Coverage threshold met (52.72% ≥ 46%)
- Verify downstream callers that rely on `submit_batch()` default are not negatively impacted by increased concurrency