### PR TITLE
DYT-3395: Fix _parse_response ↔ _extract_json_from_text infinite recursion

### DIFF
--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -2079,7 +2079,11 @@ Return ONLY valid JSON, no other text."""
         if json_match:
             try:
                 data = json.loads(json_match.group())
-                return self._parse_response(json.dumps(data))
+                # Pass dict directly — _parse_response accepts dicts and skips
+                # json.loads. Re-serializing with json.dumps would re-enter
+                # _parse_response as a string, risking mutual recursion if
+                # _strip_json_fences mangles the output back into invalid JSON.
+                return self._parse_response(data)
             except json.JSONDecodeError:
                 pass
 

--- a/tests/unit/test_extraction_llm.py
+++ b/tests/unit/test_extraction_llm.py
@@ -152,6 +152,31 @@ class TestExtractJsonFromText:
         assert len(result.entities) == 0
         assert "raw_response" in result.metadata
 
+    def test_no_mutual_recursion_with_parse_response(self) -> None:
+        """_extract_json_from_text must not recurse via _parse_response.
+
+        Regression test for DYT-3395: when _extract_json_from_text called
+        _parse_response(json.dumps(data)), re-serialization could produce
+        a string that _strip_json_fences/_repair_json mangled back into
+        invalid JSON, causing _parse_response → _extract_json_from_text →
+        _parse_response → ... → RecursionError.
+        """
+        import sys
+
+        extractor = LLMEntityExtractor()
+        # Truncated JSON that has a valid subset: regex will match {"entities": []}
+        # from the wrapping, and the inner parse should NOT recurse.
+        text = '{"entities": [], "relationships": [{"source": "foo", "target": "ba'
+        old_limit = sys.getrecursionlimit()
+        # Set a low recursion limit so we catch infinite recursion fast
+        sys.setrecursionlimit(50)
+        try:
+            result = extractor._parse_response(text)
+            # Should return something (empty or partial), not blow the stack
+            assert isinstance(result, ExtractionResult)
+        finally:
+            sys.setrecursionlimit(old_limit)
+
 
 class TestFilterByConfidence:
     """Tests for _filter_by_confidence."""


### PR DESCRIPTION
## Summary
- Fix mutual recursion between `_parse_response` and `_extract_json_from_text` that causes `RecursionError: maximum recursion depth exceeded`
- `_extract_json_from_text` was re-serializing a parsed dict with `json.dumps` before passing to `_parse_response`, which re-parsed it as a string — if `_strip_json_fences`/`_repair_json` mangled it back to invalid JSON, the cycle repeated infinitely
- Fix: pass the dict directly (line 2082), since `_parse_response` already accepts dict input
- This killed the bridge poll loop in poros-staging — the asyncio task died silently on RecursionError while the pending processor kept running

## Test plan
- [x] Added regression test `test_no_mutual_recursion_with_parse_response` that sets recursion limit to 50 and verifies truncated JSON is handled without blowing the stack
- [x] All 50 unit tests pass