### PR TITLE
DYT-3605: honor API-supplied time bounds in recall (no sparse-results fallback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Khora are documented here.
 
 Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were internal (no git tags).
 
+## [Unreleased] — Recall API time bounds honored
+
+### Fixed — API-supplied `temporal_filter` no longer dropped (DYT-3605)
+
+Callers passing an explicit `temporal_filter` to `MemoryLake.recall()` had their bounds silently bypassed in two places:
+
+* **vectorcypher**: when `temporal_filter` was provided, the auto-detection branch (which also synthesizes the `TemporalSignal` consumed by the retriever's skip-fallback / version-filter / recency-weighting logic) was skipped entirely. The retriever then saw `temporal_signal=None` and applied none of the temporal-aware behavior the caller had asked for, including the sparse-results fallback that re-runs the search without the time bound.
+* **graphrag**: same shape — the auto-detect block was guarded by `temporal_filter is None`, so the resulting `RecallResult.metadata` was missing `temporal_category` / `temporal_confidence` for API-bounded queries.
+
+Both engines now synthesize an `EXPLICIT`-category `TemporalSignal` with `confidence=1.0` and `source="api"` when `temporal_filter` is supplied, so downstream behavior is consistent regardless of whether the bounds came from the caller or were detected from the query string. The new `source="api"` value joins the existing `"dictionary"` / `"semantic"` / `"none"` set on the `temporal_detect` span — telemetry contract unchanged (span attributes are not enumerated). graphrag's `apply_recency_bias` remains untouched on the API path: `EXPLICIT` does not match the `RECENCY`/`STATE_QUERY` guard, preserving existing behavior for API callers.
+
+---
+
 ## [Unreleased] — Connector throughput restoration
 
 ### Performance — restore pre-0.9.0 LiteLLM throughput (DYT-3599)

--- a/src/khora/engines/graphrag/engine.py
+++ b/src/khora/engines/graphrag/engine.py
@@ -377,16 +377,31 @@ class GraphRAGEngine:
 
         # Auto-detect temporal category when no explicit filter and not raw mode
         temporal_signal: TemporalSignal | None = None
-        if temporal_filter is None and not raw:
-            detector = TemporalDetector()
-            temporal_signal = detector.detect(query)
-            params = get_retrieval_params(temporal_signal)
+        if not raw:
+            if temporal_filter is not None:
+                # API-asserted bounds: synthesize an EXPLICIT signal so metadata
+                # reporting (temporal_category / temporal_confidence) is consistent
+                # with the vectorcypher engine. source="api" disambiguates the
+                # path. EXPLICIT does not match the RECENCY/STATE_QUERY guard, so
+                # apply_recency_bias remains untouched (preserves existing behavior
+                # for API callers).
+                temporal_signal = TemporalSignal(
+                    is_temporal=True,
+                    category=TemporalCategory.EXPLICIT,
+                    confidence=1.0,
+                    source="api",
+                    temporal_filter=temporal_filter,
+                )
+            else:
+                detector = TemporalDetector()
+                temporal_signal = detector.detect(query)
+                params = get_retrieval_params(temporal_signal)
 
-            if temporal_signal.is_temporal:
-                config.enable_temporal_detection = True
-            if temporal_signal.category in (TemporalCategory.RECENCY, TemporalCategory.STATE_QUERY):
-                config.apply_recency_bias = True
-                config.recency_weight = params.recency_weight
+                if temporal_signal.is_temporal:
+                    config.enable_temporal_detection = True
+                if temporal_signal.category in (TemporalCategory.RECENCY, TemporalCategory.STATE_QUERY):
+                    config.apply_recency_bias = True
+                    config.recency_weight = params.recency_weight
 
         # Resolve relative dates ("last 7 days") to SQL-pushdown filter
         # for RECENCY / STATE_QUERY categories when no explicit filter exists.

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -51,7 +51,7 @@ from khora.telemetry import trace, trace_span
 from .dual_nodes import DualNodeManager, EntityChunkLink
 from .retriever import RetrieverConfig, VectorCypherRetriever
 from .router import QueryComplexityRouter, RouterConfig
-from .temporal_detection import TemporalDetector, TemporalSignal
+from .temporal_detection import TemporalCategory, TemporalDetector, TemporalSignal
 
 if TYPE_CHECKING:
     from neo4j import AsyncDriver
@@ -1683,12 +1683,30 @@ class VectorCypherEngine:
         # even in raw mode — raw skips LLM enrichment but temporal category
         # detection is critical for recency weighting and sort order.
         temporal_signal: TemporalSignal | None = None
-        if temporal_filter is None:
+        if temporal_filter is not None:
+            # API-asserted bounds: synthesize an EXPLICIT signal so downstream
+            # behavior (skip-fallback in retriever, version filter, recency
+            # weighting) treats the caller-supplied predicate as a high-confidence
+            # temporal intent. source="api" disambiguates from
+            # "dictionary"/"semantic"/"none" in traces.
+            temporal_signal = TemporalSignal(
+                is_temporal=True,
+                category=TemporalCategory.EXPLICIT,
+                confidence=1.0,
+                source="api",
+                temporal_filter=temporal_filter,
+            )
+            with trace_span("khora.vectorcypher.temporal_detect") as td_span:
+                td_span.set_attribute("category", temporal_signal.category.value)
+                td_span.set_attribute("confidence", temporal_signal.confidence)
+                td_span.set_attribute("source", temporal_signal.source)
+        else:
             with trace_span("khora.vectorcypher.temporal_detect") as td_span:
                 detector = TemporalDetector()
                 temporal_signal = detector.detect(query)
                 td_span.set_attribute("category", temporal_signal.category.value)
                 td_span.set_attribute("confidence", temporal_signal.confidence)
+                td_span.set_attribute("source", temporal_signal.source)
                 # EXPLICIT category produces a date-range TemporalFilter for pushdown
                 if temporal_signal.temporal_filter is not None:
                     temporal_filter = temporal_signal.temporal_filter

--- a/tests/unit/engines/test_graphrag_engine.py
+++ b/tests/unit/engines/test_graphrag_engine.py
@@ -1,0 +1,83 @@
+"""Unit tests for the GraphRAG engine recall path."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from khora.memory_lake import RecallResult
+
+
+def _mock_khora_config() -> MagicMock:
+    """Create a mock KhoraConfig sufficient for GraphRAGEngine construction."""
+    config = MagicMock()
+    config.get_postgresql_url.return_value = "postgresql://localhost/test"
+    config.get_neo4j_url.return_value = None
+    config.get_neo4j_user.return_value = None
+    config.get_neo4j_password.return_value = None
+    config.get_neo4j_database.return_value = None
+    config.get_graph_config.return_value = None
+    config.get_vector_config.return_value = None
+    config.storage.postgresql_pool_size = 5
+    config.storage.postgresql_max_overflow = 10
+    config.storage.embedding_dimension = 1536
+    config.llm.model = "gpt-4o-mini"
+    config.llm.embedding_model = "text-embedding-3-small"
+    config.llm.embedding_dimension = 1536
+    config.llm.timeout = 30
+    config.llm.max_retries = 3
+    config.llm.extraction_model = None
+    config.llm.max_concurrent_llm_calls = 5
+    config.pipeline.chunking_strategy = "recursive"
+    config.pipeline.chunk_size = 1000
+    config.pipeline.chunk_overlap = 200
+    config.pipeline.extract_entities = True
+    config.telemetry_database_url = None
+    config.telemetry_service_name = "test"
+    return config
+
+
+@pytest.mark.unit
+class TestGraphRAGEngineApiTemporalFilter:
+    """DYT-3605: API-supplied temporal_filter synthesizes an EXPLICIT signal
+    and propagates to recall metadata as temporal_category/temporal_confidence."""
+
+    @pytest.mark.asyncio
+    async def test_recall_with_api_temporal_filter_metadata_reports_explicit(self) -> None:
+        """When recall() is invoked with a temporal_filter, the resulting
+        RecallResult.metadata must report temporal_category="explicit" and
+        temporal_confidence=1.0 — even though the engine never ran the
+        dictionary/semantic detector."""
+        from khora.engines.graphrag.engine import GraphRAGEngine
+        from khora.engines.skeleton.backends import TemporalFilter
+        from khora.query.engine import QueryResult
+
+        engine = GraphRAGEngine(_mock_khora_config())
+        engine._connected = True
+        engine._storage = AsyncMock()
+        engine._embedder = AsyncMock()
+
+        query_engine = MagicMock()
+        query_result = QueryResult(
+            chunks=[],
+            entities=[],
+            metadata={"engine": "graphrag"},
+        )
+        query_engine.query = AsyncMock(return_value=query_result)
+        engine._query_engine = query_engine
+
+        # Bounds chosen so any in-window chunk would sit strictly in
+        # [occurred_after, occurred_before) — occurred_before is exclusive.
+        tf = TemporalFilter(
+            occurred_after=datetime(2025, 1, 1, tzinfo=UTC),
+            occurred_before=datetime(2025, 6, 1, tzinfo=UTC),
+        )
+
+        result = await engine.recall("anything", uuid4(), temporal_filter=tf)
+
+        assert isinstance(result, RecallResult)
+        assert result.metadata["temporal_category"] == "explicit"
+        assert result.metadata["temporal_confidence"] == 1.0

--- a/tests/unit/engines/test_vectorcypher_engine.py
+++ b/tests/unit/engines/test_vectorcypher_engine.py
@@ -2029,3 +2029,111 @@ class TestProcessDocumentWindowing:
         engine._storage.update_document.assert_awaited_once()
         persisted_doc = engine._storage.update_document.await_args.args[0]
         assert persisted_doc.relationship_count == rels
+
+
+@pytest.mark.unit
+class TestVectorCypherEngineApiTemporalFilter:
+    """DYT-3605: API-supplied temporal_filter synthesizes an EXPLICIT signal."""
+
+    @pytest.fixture
+    def engine_with_mocked_retriever(self) -> VectorCypherEngine:
+        """Engine wired with a retriever whose retrieve() is an AsyncMock."""
+        from khora.engines.vectorcypher.retriever import VectorCypherResult
+        from khora.engines.vectorcypher.router import QueryComplexity, RoutingDecision
+
+        config = MagicMock()
+        config.get_postgresql_url.return_value = "postgresql://localhost/test"
+        config.get_neo4j_url.return_value = "bolt://localhost:7687"
+        config.get_neo4j_user.return_value = "neo4j"
+        config.get_neo4j_password.return_value = "password"
+        config.get_neo4j_database.return_value = "neo4j"
+        config.get_graph_config.return_value = MagicMock()
+        config.get_vector_config.return_value = MagicMock()
+        config.storage.postgresql_pool_size = 5
+        config.storage.postgresql_max_overflow = 10
+        config.storage.embedding_dimension = 1536
+
+        engine = VectorCypherEngine(config)
+        engine._connected = True
+        engine._storage = AsyncMock()
+        engine._temporal_store = AsyncMock()
+        engine._embedder = AsyncMock()
+        engine._dual_nodes = AsyncMock()
+        engine._neo4j_driver = AsyncMock()
+
+        routing = RoutingDecision(
+            complexity=QueryComplexity.SIMPLE,
+            use_graph=False,
+            graph_depth=0,
+            confidence=0.8,
+            reasoning="test",
+        )
+        chunk = Chunk(
+            id=uuid4(),
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="A chunk with enough content to pass the validation threshold for recall.",
+        )
+        retriever_result = VectorCypherResult(
+            chunks=[(chunk, 0.9)],
+            entities=[],
+            routing_decision=routing,
+            metadata={"search_mode": "simple_vector"},
+        )
+
+        engine._retriever = MagicMock()
+        engine._retriever._config = MagicMock()
+        engine._retriever._config.hybrid_alpha = 0.7
+        engine._retriever.retrieve = AsyncMock(return_value=retriever_result)
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_recall_with_api_temporal_filter_synthesizes_explicit_signal(
+        self, engine_with_mocked_retriever: VectorCypherEngine
+    ) -> None:
+        """When recall() is called with an API-supplied temporal_filter, the engine
+        must synthesize a TemporalSignal with category=EXPLICIT, source="api",
+        confidence=1.0, and forward it (along with the original filter) to the
+        retriever — bypassing the dictionary/semantic temporal detector entirely.
+        """
+        from khora.engines.skeleton.backends import TemporalFilter
+        from khora.engines.vectorcypher.temporal_detection import TemporalCategory
+
+        # occurred_before is exclusive in pgvector; using two distinct dates.
+        tf = TemporalFilter(
+            occurred_after=datetime(2025, 1, 1, tzinfo=UTC),
+            occurred_before=datetime(2025, 6, 1, tzinfo=UTC),
+        )
+
+        ns_id = uuid4()
+        await engine_with_mocked_retriever.recall("anything", ns_id, temporal_filter=tf)
+
+        engine_with_mocked_retriever._retriever.retrieve.assert_awaited_once()
+        kwargs = engine_with_mocked_retriever._retriever.retrieve.await_args.kwargs
+
+        # The API filter is forwarded verbatim alongside the synthesized signal.
+        assert kwargs["temporal_filter"] is tf
+        signal = kwargs["temporal_signal"]
+        assert signal is not None
+        assert signal.category == TemporalCategory.EXPLICIT
+        assert signal.source == "api"
+        assert signal.confidence == 1.0
+        assert signal.is_temporal is True
+        assert signal.temporal_filter is tf
+
+    @pytest.mark.asyncio
+    async def test_recall_without_temporal_filter_runs_detector(
+        self, engine_with_mocked_retriever: VectorCypherEngine
+    ) -> None:
+        """Regression: when recall() is called WITHOUT temporal_filter, the engine
+        must run the existing temporal detector (signal source != "api")."""
+        ns_id = uuid4()
+        await engine_with_mocked_retriever.recall("what did we do last week", ns_id)
+
+        engine_with_mocked_retriever._retriever.retrieve.assert_awaited_once()
+        kwargs = engine_with_mocked_retriever._retriever.retrieve.await_args.kwargs
+
+        signal = kwargs["temporal_signal"]
+        assert signal is not None
+        # Detector path produces "dictionary" / "semantic" / "none" — never "api".
+        assert signal.source != "api"

--- a/tests/unit/engines/test_vectorcypher_retriever.py
+++ b/tests/unit/engines/test_vectorcypher_retriever.py
@@ -1022,3 +1022,130 @@ class TestLLMRerankConfidenceGate:
         assert retriever._should_skip_llm_rerank(top_score=0.8, gap=0.25) is False
         # top=0.9 ≥ 0.85 AND gap=0.25 ≥ 0.2 → decisive gate fires
         assert retriever._should_skip_llm_rerank(top_score=0.9, gap=0.25) is True
+
+
+@pytest.mark.unit
+class TestExplicitTemporalSignalSkipsFallback:
+    """DYT-3605: when the caller asserts an EXPLICIT temporal_signal carrying a
+    parsed date filter, the retriever's "sparse-results" re-run-without-filter
+    fallback (engine.py-side, line ~754) MUST be skipped. Sparse results are
+    the correct signal in this path — the data may simply not exist in that
+    time window, which feeds downstream abstention."""
+
+    @pytest.mark.asyncio
+    async def test_explicit_temporal_signal_skips_sparse_results_fallback(self) -> None:
+        from datetime import datetime
+        from unittest.mock import patch
+
+        from khora.engines.skeleton.backends import TemporalFilter
+        from khora.engines.vectorcypher.temporal_detection import (
+            TemporalCategory,
+            TemporalSignal,
+        )
+
+        ns_id = uuid4()
+
+        # ── Fixture wiring (mirrors TestGracefulDegradation.retriever) ────────
+        vector_store = AsyncMock()
+        neo4j_driver = AsyncMock()
+        embedder = AsyncMock()
+        embedder.embed = AsyncMock(return_value=[0.1] * 1536)
+        embedder.model_name = "test-model"
+        embedder.dimension = 1536
+
+        # Mock vector store search (used by _vector_search_chunks under the hood)
+        chunk_id = uuid4()
+        doc_id = uuid4()
+        mock_result = MagicMock()
+        mock_result.chunk = MagicMock()
+        mock_result.chunk.id = chunk_id
+        mock_result.chunk.namespace_id = ns_id
+        mock_result.chunk.content = "in-window chunk"
+        mock_result.chunk.document_id = doc_id
+        mock_result.chunk.occurred_at = None
+        mock_result.chunk.created_at = None
+        mock_result.chunk.metadata = {}
+        mock_result.combined_score = 0.85
+        mock_result.similarity = 0.85
+        # Single result: well below limit // 2 = 5, so the fallback condition
+        # (sparse results) WOULD trigger if not gated by EXPLICIT.
+        vector_store.search = AsyncMock(return_value=[mock_result])
+
+        storage = AsyncMock()
+        entry_entity_id = uuid4()
+        storage.search_similar_entities = AsyncMock(return_value=[(entry_entity_id, 0.9)])
+        storage.get_entities_batch = AsyncMock(return_value={})
+
+        # Disable session-aware search to avoid the parallel session-fanout
+        # path — that path issues additional _vector_search_chunks calls and
+        # would muddy the call-count assertion.
+        config = RetrieverConfig(
+            query_cache_ttl_seconds=0,
+            enable_session_aware_search=False,
+        )
+        retriever = VectorCypherRetriever(
+            vector_store=vector_store,
+            neo4j_driver=neo4j_driver,
+            embedder=embedder,
+            config=config,
+            storage=storage,
+        )
+
+        # Route to MODERATE (use_graph=True) so the sparse-fallback site at
+        # retriever.py:754 is reachable.
+        retriever._router = MagicMock()
+        retriever._router.route = AsyncMock(
+            return_value=RoutingDecision(
+                complexity=QueryComplexity.MODERATE,
+                use_graph=True,
+                graph_depth=2,
+                confidence=0.8,
+                reasoning="moderate",
+            )
+        )
+        retriever._router.compute_adaptive_depth = MagicMock(return_value=2)
+
+        # Stub out graph-touching helpers so _vectorcypher_retrieve completes
+        # cleanly without exercising Neo4j internals.
+        retriever._cypher_expand = AsyncMock(return_value=({}, {}))
+        retriever._fetch_chunks_from_entities = AsyncMock(return_value=[])
+        retriever._version_filter_entities = AsyncMock(return_value=[])
+
+        # Build the EXPLICIT signal: API-style with a parsed date filter.
+        # occurred_before is exclusive in pgvector — bounds chosen so any
+        # in-window timestamp would sit strictly inside [after, before).
+        tf = TemporalFilter(
+            occurred_after=datetime(2025, 1, 1, tzinfo=UTC),
+            occurred_before=datetime(2025, 6, 1, tzinfo=UTC),
+        )
+        temporal_signal = TemporalSignal(
+            is_temporal=True,
+            category=TemporalCategory.EXPLICIT,
+            confidence=1.0,
+            source="api",
+            temporal_filter=tf,
+        )
+
+        # Spy on _vector_search_chunks while preserving its real behavior.
+        original = retriever._vector_search_chunks
+        spy = AsyncMock(wraps=original)
+        with patch.object(retriever, "_vector_search_chunks", spy):
+            await retriever.retrieve(
+                "what happened in early 2025",
+                ns_id,
+                temporal_filter=tf,
+                temporal_signal=temporal_signal,
+                limit=10,
+            )
+
+        # Sparse-results fallback re-runs _vector_search_chunks with
+        # temporal_filter=None when triggered. The EXPLICIT-with-date guard
+        # MUST suppress that re-run — exactly one call, with the original
+        # filter intact.
+        assert spy.await_count == 1, (
+            f"_vector_search_chunks was called {spy.await_count} times; the "
+            "EXPLICIT-with-date guard should have suppressed the sparse-"
+            "results fallback re-run."
+        )
+        forwarded_filter = spy.await_args.kwargs["temporal_filter"]
+        assert forwarded_filter is tf


### PR DESCRIPTION
## Summary

Fix [DYT-3605](https://linear.app/deyta/issue/DYT-3605) (root cause of [IGR-150](https://linear.app/deyta/issue/IGR-150/peras-recall-returned-chunk-out-of-the-data-filter)): `MemoryLake.recall(start_time, end_time)` was silently dropping API-supplied time bounds whenever the time-filtered first pass returned fewer than `limit // 2` chunks. The sparse-results fallback at `retriever.py:749` is gated by `is_explicit_with_date`, which checks `temporal_signal.category == EXPLICIT` — but `temporal_signal` was only built by the natural-language detector, which is skipped when the caller provides explicit dates. So the guard never fired for API callers.

## Fix (Option A: alias API path to EXPLICIT)

Synthesize a `TemporalSignal(category=EXPLICIT, source="api", confidence=1.0, temporal_filter=temporal_filter)` from the caller-supplied filter so all downstream gates that key on `category == EXPLICIT` fire correctly:
- skip-fallback guard at `retriever.py:749` ✓
- bi-temporal version filter at `retriever.py:640` ✓
- `RETRIEVAL_PARAMS[EXPLICIT]` recency weighting ✓
- graphrag metadata reporting (`temporal_category`, `temporal_confidence`)

Changes:
- `src/khora/engines/vectorcypher/engine.py` — synthesize EXPLICIT signal on API path; emit `khora.vectorcypher.temporal_detect` span with `category`/`confidence`/`source` attributes; preserve detector path verbatim (with added `source` attribute for parity).
- `src/khora/engines/graphrag/engine.py` — same parity for observability symmetry. EXPLICIT does not match the RECENCY/STATE_QUERY guard, so `apply_recency_bias` remains untouched on the API path (preserves existing behavior for API callers).
- New `source="api"` value (free-form `str` field — no enum update needed).

## Test plan

- [x] Unit tests pass (`uv run pytest tests/unit/ -q --no-cov -n auto`): 2941 passed, 195 skipped
- [x] Engine unit tests (`uv run pytest tests/unit/engines/ -q --no-cov`): 610 passed
- [x] Telemetry contract drift gate (`uv run pytest tests/unit/telemetry/test_contract.py -q --no-cov`): 10 passed
- [x] Lint (`uv run ruff check . && uv run ruff format --check .`): clean
- [ ] Integration tests via CI (Docker stack required — postgres + neo4j)

New tests cover:
- `tests/unit/engines/test_vectorcypher_engine.py::test_recall_with_api_temporal_filter_synthesizes_explicit_signal` — engine builds EXPLICIT signal with `source="api"`, `confidence=1.0`, original filter preserved.
- `tests/unit/engines/test_vectorcypher_engine.py` — regression: detector still runs when `temporal_filter is None`.
- `tests/unit/engines/test_vectorcypher_retriever.py::test_explicit_temporal_signal_skips_sparse_results_fallback` — `_vector_search_chunks` called exactly once (not twice with `temporal_filter=None`) when sparse results would otherwise trigger the fallback.
- `tests/unit/engines/test_graphrag_engine.py` (new file) — graphrag metadata reports `temporal_category="explicit"`, `temporal_confidence=1.0` for API-bound calls.

## Out of scope (separate tickets)

- Entity-side searches that ignore `temporal_filter` (`pgvector.search_similar_entities`, `khora.neo4j.get_entity_neighborhoods`).
- BM25 chunk channel ignoring `temporal_filter` (`_bm25_search_chunks`).
- Future `BOUNDED` category with `recency_weight=0.0` to replace EXPLICIT's `recency_weight=0.3` for API callers.