### PR TITLE
DYT-3712: Redact credential URLs from engine/connection log messages

### DIFF
--- a/src/khora/engines/skeleton/backends/weaviate.py
+++ b/src/khora/engines/skeleton/backends/weaviate.py
@@ -21,6 +21,7 @@ from khora.engines.skeleton.backends import (
     TemporalSearchResult,
     TemporalVectorStore,
 )
+from khora.storage._log_safe import _safe_url_for_log
 
 if TYPE_CHECKING:
     from khora.config import KhoraConfig
@@ -93,7 +94,7 @@ class WeaviateTemporalStore(TemporalVectorStore):
             logger.info(f"Created Weaviate collection: {COLLECTION_NAME}")
 
         self._connected = True
-        logger.info(f"WeaviateTemporalStore connected to {self._weaviate_url}")
+        logger.info("WeaviateTemporalStore connected to {url}", url=_safe_url_for_log(self._weaviate_url))
 
     async def disconnect(self) -> None:
         """Disconnect from Weaviate."""

--- a/src/khora/storage/_log_safe.py
+++ b/src/khora/storage/_log_safe.py
@@ -1,0 +1,12 @@
+from urllib.parse import urlparse
+
+
+def _safe_url_for_log(url: str) -> str:
+    """Render URL with credentials redacted, suitable for log messages."""
+    parsed = urlparse(url)
+    if not (parsed.username or parsed.password):
+        return url
+    host = parsed.hostname or ""
+    if parsed.port:
+        host = f"{host}:{parsed.port}"
+    return parsed._replace(netloc=f"<redacted>@{host}").geturl()

--- a/src/khora/storage/backends/memgraph.py
+++ b/src/khora/storage/backends/memgraph.py
@@ -26,6 +26,8 @@ from khora.storage.backends.mixins import (
     serialize_dict,
 )
 
+from .._log_safe import _safe_url_for_log
+
 
 class MemgraphBackend(GraphBackendBase):
     """Memgraph graph backend using the neo4j Python driver over Bolt.
@@ -67,7 +69,7 @@ class MemgraphBackend(GraphBackendBase):
 
         from neo4j import AsyncGraphDatabase
 
-        logger.info(f"Connecting to Memgraph at {self._url}...")
+        logger.info("Connecting to Memgraph at {url}...", url=_safe_url_for_log(self._url))
         self._driver = AsyncGraphDatabase.driver(
             self._url,
             auth=(self._user, self._password),

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -30,6 +30,8 @@ from khora.storage.backends.mixins import element_to_dict as _element_to_dict
 from khora.storage.backends.mixins import serialize_dict as _serialize_dict
 from khora.telemetry import trace, trace_span
 
+from .._log_safe import _safe_url_for_log
+
 # Neo4j relationship labels must be valid identifiers: letters, digits, underscores.
 # LLM-generated types like "at-risk" or "works for" need sanitizing.
 _NEO4J_LABEL_RE = _re.compile(r"[^A-Za-z0-9_]")
@@ -561,7 +563,7 @@ class Neo4jBackend(GraphBackendBase):
             self._start_pool_sampler()
             return
 
-        logger.info(f"Connecting to Neo4j at {self._url}...")
+        logger.info("Connecting to Neo4j at {url}...", url=_safe_url_for_log(self._url))
         self._driver = AsyncGraphDatabase.driver(
             self._url,
             auth=(self._user, self._password),

--- a/src/khora/storage/backends/neptune.py
+++ b/src/khora/storage/backends/neptune.py
@@ -27,6 +27,8 @@ from khora.storage.backends.mixins import (
     serialize_dict,
 )
 
+from .._log_safe import _safe_url_for_log
+
 
 class NeptuneBackend(GraphBackendBase):
     """AWS Neptune graph backend using the neo4j Python driver over Bolt.
@@ -108,7 +110,7 @@ class NeptuneBackend(GraphBackendBase):
         else:
             auth = (self._user, self._password) if self._user else None
 
-        logger.info(f"Connecting to Neptune at {self._url}...")
+        logger.info("Connecting to Neptune at {url}...", url=_safe_url_for_log(self._url))
         self._driver = AsyncGraphDatabase.driver(
             self._url,
             auth=auth,

--- a/src/khora/storage/backends/sqlite_lance/relational.py
+++ b/src/khora/storage/backends/sqlite_lance/relational.py
@@ -32,6 +32,8 @@ from khora.db.models import DocumentModel, MemoryNamespaceModel, SyncCheckpointM
 from khora.storage.backends.base import PaginatedResult
 from khora.storage.backends.mixins import AsyncSessionMixin
 
+from ..._log_safe import _safe_url_for_log
+
 if TYPE_CHECKING:
     from .connection import EmbeddedStorageHandle
 
@@ -110,7 +112,7 @@ class SQLiteLanceRelationalAdapter(AsyncSessionMixin):
             return
 
         url = _build_sqlite_url(self._handle.config.db_path)
-        logger.info(f"Opening SQLAlchemy async engine for {url}")
+        logger.info("Opening SQLAlchemy async engine for {url}", url=_safe_url_for_log(url))
         self._engine = create_async_engine(url, future=True)
         _register_pragmas(self._engine)
         self._session_factory = async_sessionmaker(

--- a/src/khora/storage/backends/surrealdb/connection.py
+++ b/src/khora/storage/backends/surrealdb/connection.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from loguru import logger
 
+from ..._log_safe import _safe_url_for_log
+
 # Module-level lock prevents concurrent schema initialization from
 # multiple SurrealDBConnection instances (the StorageCoordinator
 # connects 4 backends in parallel, all sharing the same embedded DB).
@@ -89,7 +91,7 @@ class SurrealDBConnection:
         import surrealdb
 
         endpoint = self._build_endpoint()
-        logger.info(f"Connecting to SurrealDB ({self._mode}): {endpoint}")
+        logger.info(f"Connecting to SurrealDB ({self._mode}): {_safe_url_for_log(endpoint)}")
         # Use getattr to create the client so ty does not infer the union
         # return type of AsyncSurreal() (whose HTTP variant .connect(url)
         # has a required url param that conflicts with the WS variant).

--- a/src/khora/storage/factory.py
+++ b/src/khora/storage/factory.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
+from ._log_safe import _safe_url_for_log
 from .backends.pgvector import PgVectorBackend
 from .backends.postgresql import PostgreSQLBackend
 from .coordinator import StorageCoordinator
@@ -197,14 +198,14 @@ class StorageFactory:
                 max_overflow=max_overflow,
                 pool_pre_ping=pool_pre_ping,
             )
-            logger.debug(f"Created shared engine for {key}")
+            logger.debug("Created shared engine for {url}", url=_safe_url_for_log(key))
         return self._engine_cache[key]
 
     async def dispose_engines(self) -> None:
         """Dispose all cached engines."""
         for key, engine in self._engine_cache.items():
             await engine.dispose()
-            logger.debug(f"Disposed shared engine for {key}")
+            logger.debug("Disposed shared engine for {url}", url=_safe_url_for_log(key))
         self._engine_cache.clear()
 
     def create_relational_backend(self) -> PostgreSQLBackend | None:

--- a/tests/unit/storage/test_log_safe.py
+++ b/tests/unit/storage/test_log_safe.py
@@ -1,0 +1,42 @@
+import pytest
+
+from khora.storage._log_safe import _safe_url_for_log
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        # (a) URL with user + password
+        (
+            "postgresql+asyncpg://peras:ebesspyg7jl0kwkbglto@pgbouncer.example.net/peras",
+            "postgresql+asyncpg://<redacted>@pgbouncer.example.net/peras",
+        ),
+        # (b) URL with user only (no password)
+        (
+            "bolt://admin@neo4j.example.com:7687",
+            "bolt://<redacted>@neo4j.example.com:7687",
+        ),
+        # (c) URL with neither user nor password
+        (
+            "postgresql+asyncpg://pgbouncer.example.net/peras",
+            "postgresql+asyncpg://pgbouncer.example.net/peras",
+        ),
+        # (d) URL with non-default port
+        (
+            "bolt://user:secret@neo4j.example.com:7688",
+            "bolt://<redacted>@neo4j.example.com:7688",
+        ),
+        # (e) sqlite-style file: URL with no netloc — passthrough
+        (
+            "sqlite+aiosqlite:///path/to/khora.db",
+            "sqlite+aiosqlite:///path/to/khora.db",
+        ),
+        # file: URL passthrough
+        (
+            "file:///tmp/mydb",
+            "file:///tmp/mydb",
+        ),
+    ],
+)
+def test_safe_url_for_log(url: str, expected: str) -> None:
+    assert _safe_url_for_log(url) == expected


### PR DESCRIPTION
## Summary
- Added `_safe_url_for_log()` helper in `src/khora/storage/_log_safe.py` that strips username/password from connection URLs before they appear in log messages, replacing credentials with `<redacted>`
- Applied the helper across all storage backends that log connection URLs: Neo4j, Memgraph, Neptune, SurrealDB, SQLite+LanceDB relational layer, StorageFactory (shared engine cache), and Weaviate temporal store
- Passwords and usernames embedded in bolt://, postgresql+asyncpg://, and other URL schemes will no longer appear in plaintext in log output
- URLs without credentials are passed through unchanged

## Test plan
- [x] Unit tests pass (`tests/unit/storage/test_log_safe.py` — 6 parametrized cases covering user+password, user-only, no credentials, non-default port, sqlite file paths)
- [x] `make format` — clean
- [x] `make lint` — clean (ruff)
- [x] Full unit test suite passes (3142 tests)