### PR TITLE
DYT-3736: Migrate legacy uppercase document_status values to lowercase

### DIFF
--- a/src/khora/db/migrations/versions/027_migrate_uppercase_document_status.py
+++ b/src/khora/db/migrations/versions/027_migrate_uppercase_document_status.py
@@ -36,13 +36,7 @@ def upgrade() -> None:
     """Normalise uppercase document_status rows to lowercase. Postgres-only."""
     if op.get_bind().dialect.name != "postgresql":
         return
-    op.execute(
-        text(
-            "UPDATE documents "
-            "SET status = LOWER(status::text)::document_status "
-            "WHERE status::text ~ '[A-Z]'"
-        )
-    )
+    op.execute(text("UPDATE documents SET status = LOWER(status::text)::document_status WHERE status::text ~ '[A-Z]'"))
 
 
 def downgrade() -> None:

--- a/src/khora/db/migrations/versions/027_migrate_uppercase_document_status.py
+++ b/src/khora/db/migrations/versions/027_migrate_uppercase_document_status.py
@@ -1,0 +1,49 @@
+"""Migrate legacy uppercase document_status values to lowercase.
+
+Revision ID: 027_migrate_uppercase_document_status
+Revises: 026_widen_alembic_version_column
+Create Date: 2026-05-05
+
+DYT-3736: Staging contains ~19 000 rows with uppercase status values
+(PENDING, PROCESSING, COMPLETED, FAILED, ARCHIVED) written by an early
+Khora version that used enum .name instead of .value. The canonical
+DocumentStatus enum defines lowercase values only. This migration
+normalises all uppercase rows to their lowercase equivalents.
+
+The lowercase enum values already exist (migration 014 added 'pending'
+and 'archived'; 000 created 'processing', 'completed', 'failed'), so
+this is a pure data update — no ALTER TYPE is needed.
+
+PostgreSQL does not support DROP VALUE from an enum, so the uppercase
+variants remain defined in the type but are now unused.
+
+Idempotent: re-running is safe (the WHERE clause matches zero rows when
+all statuses are already lowercase).
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "027_migrate_uppercase_document_status"
+down_revision: str | Sequence[str] | None = "026_widen_alembic_version_column"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Normalise uppercase document_status rows to lowercase. Postgres-only."""
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    op.execute(
+        text(
+            "UPDATE documents "
+            "SET status = LOWER(status::text)::document_status "
+            "WHERE status::text ~ '[A-Z]'"
+        )
+    )
+
+
+def downgrade() -> None:
+    """No-op — we cannot recover which rows were originally uppercase."""

--- a/tests/unit/db/test_migration_027_migrate_uppercase_document_status.py
+++ b/tests/unit/db/test_migration_027_migrate_uppercase_document_status.py
@@ -1,0 +1,81 @@
+"""DYT-3736: ``027_migrate_uppercase_document_status``.
+
+Pins the three branches of the migration:
+
+1. SQLite is a no-op (no ENUM type, nothing to fix).
+2. PostgreSQL executes an UPDATE that lowercases uppercase status rows.
+3. Downgrade is a no-op (cannot recover original uppercase state).
+"""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def migration():
+    return importlib.import_module(
+        "khora.db.migrations.versions.027_migrate_uppercase_document_status"
+    )
+
+
+class TestRevisionMetadata:
+    def test_revision_id(self, migration) -> None:
+        assert migration.revision == "027_migrate_uppercase_document_status"
+
+    def test_down_revision(self, migration) -> None:
+        assert migration.down_revision == "026_widen_alembic_version_column"
+
+
+class TestUpgrade:
+    def test_sqlite_is_noop(self, migration) -> None:
+        """SQLite has no ENUM type — return early without any SQL."""
+        bind = MagicMock()
+        bind.dialect.name = "sqlite"
+        with (
+            patch.object(migration.op, "get_bind", return_value=bind),
+            patch.object(migration.op, "execute") as exec_mock,
+        ):
+            migration.upgrade()
+        exec_mock.assert_not_called()
+
+    def test_postgres_executes_update(self, migration) -> None:
+        """PostgreSQL path issues an UPDATE to lowercase uppercase status rows."""
+        bind = MagicMock()
+        bind.dialect.name = "postgresql"
+        with (
+            patch.object(migration.op, "get_bind", return_value=bind),
+            patch.object(migration.op, "execute") as exec_mock,
+        ):
+            migration.upgrade()
+        exec_mock.assert_called_once()
+
+    def test_postgres_update_sql_is_correct(self, migration) -> None:
+        """Verify the UPDATE uses LOWER() cast and filters on uppercase chars."""
+        bind = MagicMock()
+        bind.dialect.name = "postgresql"
+        with (
+            patch.object(migration.op, "get_bind", return_value=bind),
+            patch.object(migration.op, "execute") as exec_mock,
+        ):
+            migration.upgrade()
+        sql = str(exec_mock.call_args.args[0])
+        assert "UPDATE documents" in sql
+        assert "LOWER(status::text)::document_status" in sql
+        assert "[A-Z]" in sql
+
+
+class TestDowngrade:
+    def test_is_noop(self, migration) -> None:
+        """Downgrade cannot restore original uppercase values — it is a no-op."""
+        bind = MagicMock()
+        bind.dialect.name = "postgresql"
+        with (
+            patch.object(migration.op, "get_bind", return_value=bind),
+            patch.object(migration.op, "execute") as exec_mock,
+        ):
+            migration.downgrade()
+        exec_mock.assert_not_called()

--- a/tests/unit/db/test_migration_027_migrate_uppercase_document_status.py
+++ b/tests/unit/db/test_migration_027_migrate_uppercase_document_status.py
@@ -17,9 +17,7 @@ import pytest
 
 @pytest.fixture
 def migration():
-    return importlib.import_module(
-        "khora.db.migrations.versions.027_migrate_uppercase_document_status"
-    )
+    return importlib.import_module("khora.db.migrations.versions.027_migrate_uppercase_document_status")
 
 
 class TestRevisionMetadata:

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -408,14 +408,14 @@ class TestMigrationPackageStructure:
         assert env_path.exists(), f"env.py not found at {env_path}"
 
     @pytest.mark.unit
-    def test_versions_dir_has_27_files(self):
-        """versions/ directory contains 27 migration files."""
+    def test_versions_dir_has_28_files(self):
+        """versions/ directory contains 28 migration files."""
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
         # Filter out __pycache__ and __init__
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
-        assert len(migration_files) == 27, (
-            f"Expected 27 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
+        assert len(migration_files) == 28, (
+            f"Expected 28 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
         )
 
     @pytest.mark.unit

--- a/tests/unit/test_sqlite_migrations.py
+++ b/tests/unit/test_sqlite_migrations.py
@@ -80,7 +80,7 @@ class TestSqliteMigrations:
                     # Version table must point at head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
                     version = result.scalar()
-                    assert version == "026_widen_alembic_version_column"
+                    assert version == "027_migrate_uppercase_document_status"
             finally:
                 await engine.dispose()
 


### PR DESCRIPTION
## Summary
- Adds Alembic migration `027_migrate_uppercase_document_status` that normalises any legacy uppercase `document_status` enum values (e.g. `PENDING`, `PROCESSING`, `COMPLETED`, `FAILED`) to their lowercase equivalents (`pending`, `processing`, `completed`, `failed`) via a single `UPDATE` with a regex guard (`~ '[A-Z]'`)
- Migration is a no-op on databases that already have all-lowercase values, and the `downgrade()` path is intentionally a no-op (data loss is acceptable; reverting to uppercase would require external knowledge of which rows were touched)
- Registers the migration revision in `test_migration_bundling.py` and `test_sqlite_migrations.py` so the bundling gate and SQLite smoke-test stay green
- Adds a dedicated unit-test module (`test_migration_027_migrate_uppercase_document_status.py`) that verifies revision metadata, the SQLite upgrade/downgrade path, and the update SQL logic with mocked `op`/`text`

## Test plan
- [x] Unit tests pass (`make test` — 29 passed, 99 skipped)
- [x] Migration bundling gate updated (`test_migration_bundling.py`)
- [x] SQLite smoke-test updated (`test_sqlite_migrations.py`)
- [x] Dedicated unit tests for migration 027 added and passing
- [ ] Integration tests (require live PostgreSQL) — covered by CI