### PR TITLE
DYT-3787: Quiet benign per-run-DB diagnostics (memory_namespaces, halfvec HNSW)

### DIFF
--- a/src/khora/memory_lake.py
+++ b/src/khora/memory_lake.py
@@ -26,6 +26,22 @@ from khora.query import SearchMode
 from khora.telemetry import bounded_text_hash, trace_span
 
 
+def _is_undefined_table_error(exc: BaseException) -> bool:
+    """Return True if *exc* is (or wraps) a Postgres "undefined table" error.
+
+    SQLSTATE 42P01 is raised by asyncpg as ``UndefinedTableError`` and wrapped
+    by SQLAlchemy as ``ProgrammingError``. We don't import either type here to
+    avoid a hard dependency on the postgres backend at module-import time —
+    duck-type via the SQLSTATE attribute on the underlying driver exception.
+    """
+    for candidate in (exc, getattr(exc, "orig", None), getattr(exc, "__cause__", None)):
+        if candidate is None:
+            continue
+        if getattr(candidate, "sqlstate", None) == "42P01":
+            return True
+    return False
+
+
 class _GlobalChunkSemaphore:
     """Counting semaphore supporting bulk acquire/release for chunk windowing.
 
@@ -490,7 +506,15 @@ class MemoryLake:
         try:
             await self._enqueue_orphaned_pending_docs()
         except Exception as exc:
-            logger.error(f"pending_processor: orphan recovery failed: {exc}")
+            if _is_undefined_table_error(exc):
+                # Fresh DB — `memory_namespaces` hasn't been created yet, so there
+                # are no namespaces and therefore no orphaned PENDING docs. Common
+                # path on per-run ephemeral databases (e.g. khora-benchmarks-service).
+                logger.debug(
+                    "pending_processor: skipping orphan recovery on fresh DB (memory_namespaces table not yet created)"
+                )
+            else:
+                logger.error(f"pending_processor: orphan recovery failed: {exc}")
 
         # Phase 2: drain the queue with bounded concurrency.
         max_concurrent = self._config.pipelines.pending_processor_max_concurrent

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -150,10 +150,19 @@ class PgVectorBackend(AsyncSessionMixin):
                 logger.warning("halfvec requested but pgvector < 0.7.0 — falling back to full-precision vectors")
             elif not await self._check_halfvec_indexes():
                 self._halfvec_available = False
-                logger.warning(
-                    "halfvec HNSW indexes not found — falling back to full-precision vectors. "
-                    "Run migrations to create them."
-                )
+                # Distinguish "fresh DB, migrations not run yet" (benign — common path
+                # for ephemeral per-run databases like khora-benchmarks-service) from
+                # "tables exist but indexes are missing" (real misconfiguration).
+                if not await self._halfvec_target_tables_exist():
+                    logger.info(
+                        "halfvec HNSW indexes not yet created (fresh DB) — using full-precision "
+                        "vectors until migrations run"
+                    )
+                else:
+                    logger.warning(
+                        "halfvec HNSW indexes not found — falling back to full-precision vectors. "
+                        "Run migrations to create them."
+                    )
             else:
                 self._halfvec_available = True
                 logger.info("halfvec (float16) support detected — enabled for similarity search")
@@ -201,6 +210,30 @@ class PgVectorBackend(AsyncSessionMixin):
                 return (major, minor) >= (0, 7)
         except Exception as e:
             logger.debug(f"Failed to detect pgvector version: {e}")
+            return False
+
+    async def _halfvec_target_tables_exist(self) -> bool:
+        """Return True iff both ``chunks`` and ``entities`` tables exist.
+
+        Used to distinguish "fresh DB before migrations" (benign — vectors fall
+        back to full precision until tables are created) from "tables exist but
+        indexes were never built" (real misconfiguration worth a warning).
+        """
+        try:
+            async with self._get_session() as session:
+                result = await session.execute(
+                    text(
+                        "SELECT count(*) FROM pg_class c "
+                        "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                        "WHERE c.relkind = 'r' "
+                        "AND n.nspname = 'public' "
+                        "AND c.relname IN ('chunks', 'entities')"
+                    )
+                )
+                count = result.scalar_one_or_none() or 0
+                return count == 2
+        except Exception as e:
+            logger.debug(f"Failed to check halfvec target tables: {e}")
             return False
 
     async def _check_halfvec_indexes(self) -> bool:

--- a/tests/unit/test_memory_lake.py
+++ b/tests/unit/test_memory_lake.py
@@ -3501,3 +3501,52 @@ class TestPendingProcessor:
         assert params["skill_name"] == "custom_skill"
         assert params["entity_types"] == ["PERSON"]
         assert params["relationship_types"] == ["KNOWS"]
+
+
+# ---------------------------------------------------------------------------
+# DYT-3787: undefined-table detection for fresh-DB orphan recovery
+# ---------------------------------------------------------------------------
+
+
+class TestIsUndefinedTableError:
+    """Tests for `_is_undefined_table_error` — used by `_run_pending_processor`
+    to silence the "memory_namespaces does not exist" ERROR on fresh ephemeral
+    DBs (DYT-3787)."""
+
+    def test_detects_undefined_table_via_sqlstate_attribute(self) -> None:
+        from khora.memory_lake import _is_undefined_table_error
+
+        class _FakeAsyncpgError(Exception):
+            sqlstate = "42P01"
+
+        assert _is_undefined_table_error(_FakeAsyncpgError("relation does not exist")) is True
+
+    def test_detects_when_wrapped_via_orig(self) -> None:
+        """SQLAlchemy wraps the asyncpg exception under `.orig` — the helper
+        must look through the wrapper, not just the top-level exception."""
+        from khora.memory_lake import _is_undefined_table_error
+
+        class _AsyncpgError(Exception):
+            sqlstate = "42P01"
+
+        class _SQLAlchemyError(Exception):
+            def __init__(self, orig: Exception) -> None:
+                super().__init__(str(orig))
+                self.orig = orig
+
+        wrapped = _SQLAlchemyError(_AsyncpgError("table missing"))
+        assert _is_undefined_table_error(wrapped) is True
+
+    def test_returns_false_for_other_sqlstate(self) -> None:
+        """Other postgres errors (constraint violation, etc.) must not match."""
+        from khora.memory_lake import _is_undefined_table_error
+
+        class _OtherError(Exception):
+            sqlstate = "23505"  # unique_violation
+
+        assert _is_undefined_table_error(_OtherError("dup key")) is False
+
+    def test_returns_false_for_plain_exception(self) -> None:
+        from khora.memory_lake import _is_undefined_table_error
+
+        assert _is_undefined_table_error(RuntimeError("not a db error")) is False

--- a/tests/unit/test_pgvector_halfvec_diagnostics.py
+++ b/tests/unit/test_pgvector_halfvec_diagnostics.py
@@ -1,0 +1,76 @@
+"""Unit tests for the halfvec-index diagnostics on PgVectorBackend (DYT-3787).
+
+The connect path used to log a single WARNING — `halfvec HNSW indexes not found —
+falling back to full-precision vectors. Run migrations to create them.` — for
+both the "production DB missing migrations" case (real misconfiguration) and the
+"fresh ephemeral DB before any migrations have run" case (benign, common in
+khora-benchmarks-service per-run DBs).
+
+The new `_halfvec_target_tables_exist` helper distinguishes them so the two
+cases are logged at different levels.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from khora.storage.backends.pgvector import PgVectorBackend
+
+
+def _make_backend() -> PgVectorBackend:
+    """Construct a backend without touching the network / SQLAlchemy."""
+    return PgVectorBackend.__new__(PgVectorBackend)
+
+
+def _patch_session(backend: PgVectorBackend, scalar_value: Any) -> AsyncMock:
+    """Stub `_get_session` so that `session.execute(...).scalar_one_or_none()`
+    returns *scalar_value*."""
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=scalar_value)
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result)
+
+    cm = AsyncMock()
+    cm.__aenter__.return_value = session
+    cm.__aexit__.return_value = False
+    backend._get_session = MagicMock(return_value=cm)  # type: ignore[attr-defined]
+    return session
+
+
+@pytest.mark.asyncio
+async def test_halfvec_target_tables_exist_returns_true_when_both_tables_present() -> None:
+    backend = _make_backend()
+    _patch_session(backend, 2)
+    assert await backend._halfvec_target_tables_exist() is True
+
+
+@pytest.mark.asyncio
+async def test_halfvec_target_tables_exist_returns_false_when_no_tables() -> None:
+    """Fresh DB: pg_class returns 0 rows for chunks/entities."""
+    backend = _make_backend()
+    _patch_session(backend, 0)
+    assert await backend._halfvec_target_tables_exist() is False
+
+
+@pytest.mark.asyncio
+async def test_halfvec_target_tables_exist_returns_false_when_only_one_present() -> None:
+    """Partial schema (e.g. ``chunks`` exists but not ``entities``) is also a
+    "not ready yet" state — return False so the caller doesn't fire the WARN
+    that points the operator to a migration that won't fully recover the DB."""
+    backend = _make_backend()
+    _patch_session(backend, 1)
+    assert await backend._halfvec_target_tables_exist() is False
+
+
+@pytest.mark.asyncio
+async def test_halfvec_target_tables_exist_returns_false_on_db_error() -> None:
+    backend = _make_backend()
+    cm = AsyncMock()
+    cm.__aenter__.side_effect = RuntimeError("connection lost")
+    cm.__aexit__.return_value = False
+    backend._get_session = MagicMock(return_value=cm)  # type: ignore[attr-defined]
+
+    assert await backend._halfvec_target_tables_exist() is False


### PR DESCRIPTION
## Summary

Two distinct log messages fire on every per-run ephemeral DB used by `khora-benchmarks-service` (and any fresh-DB caller), drowning real signals in benign noise. Both are now silenced or downgraded only when we can prove the DB is fresh; production misconfigurations still log loudly.

### `memory_lake._run_pending_processor`
- Was logging at **ERROR** when `memory_namespaces` didn't exist on connect.
- Orphan recovery has nothing to do on a fresh DB, so this is benign.
- Now: detect via SQLSTATE `42P01` (looking through SQLAlchemy's `.orig` wrapper) and log at DEBUG. Other recovery failures still fire ERROR.

### `storage.backends.pgvector.connect`
- Was logging at **WARNING** ("halfvec HNSW indexes not found — run migrations") whenever indexes were missing — including on every fresh DB before any migrations had run.
- New helper `_halfvec_target_tables_exist()` distinguishes:
  - `chunks` and `entities` tables don't exist → fresh DB, log at INFO
  - tables exist but indexes don't → real misconfiguration, keep WARN

## Why

On smoke run `dc4b72e8` (2026-05-07): 1 `memory_namespaces does not exist` ERROR + 13 `halfvec HNSW indexes not found` WARNINGs per run, drowning the real ERRORs from beam_500k. Operators ignored both as known noise — exactly the pattern that hides real problems.

## Test plan
- [x] `pytest tests/unit/test_memory_lake.py tests/unit/test_pgvector_halfvec_diagnostics.py tests/unit/test_pgvector_row_to_chunk.py` — 159 passed (8 new)
- [x] `prek run --files <touched>` — clean (ruff, ruff-format, ty all pass)
- [ ] After merge: re-run a small smoke benchmark on skynet (`khora-benchmarks-service` per-run DB) and confirm:
  - `memory_namespaces does not exist` ERROR is gone (or moved to DEBUG)
  - `halfvec HNSW indexes not found` WARN is gone for the fresh-DB case (still fires for real misconfigured DBs)

## Out of scope
- Lazy halfvec index creation (would silence the warning entirely but changes runtime behavior — separate ticket if desired).
- Running khora's full migration set against per-run DBs from the service side (workaround that masks the bug — explicitly rejected in favor of fixing diagnostics here).