### PR TITLE
Docs: scrub internal service references

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Khora is a knowledge memory library for long-horizon AI agents, with pluggable r
 
 Khora is a **library, not an application**. Tooling lives in sibling packages (coming soon...):
 
-- [khora-service](https://github.com/DeytaHQ/khora-service) — runs Khora as a long-lived service.
-- [khora-explorer](https://github.com/DeytaHQ/khora-explorer) — tooling for ontology construction and exploration.
+- khora-cli (to be released soon) — CLI tooling for extraction and search.
+- khora-explorer (to be released soon) — tooling for ontology construction and exploration.
 
 ## Install
 
@@ -115,7 +115,7 @@ Start at [docs/README.md](docs/README.md). Key entry points:
 - [Architecture](docs/architecture/overview.md) — how the pieces fit.
 - [Engines](docs/engines/engine-comparison.md) — VectorCypher, Skeleton, Chronicle.
 - [Migrations](docs/migrations.md) — Alembic workflow for library users.
-- [Downstream consumers](docs/consumers.md) — how khora-cli, khora-explorer, and khora-benchmarks consume khora.
+- [Downstream consumers](docs/consumers.md) — sibling packages and integration guide.
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ Khora is a knowledge memory library. This directory contains everything beyond t
 - [Configuration](configuration.md) — `KHORA_*` environment variables, `KhoraConfig`, installation extras.
 - [API reference](api-reference.md) — public `Khora` methods and result types.
 - [Migrations](migrations.md) — Alembic workflow for library users (PostgreSQL backends only).
-- [Consumers](consumers.md) — how downstream packages (khora-cli, khora-explorer, khora-benchmarks) use khora.
+- [Consumers](consumers.md) — how downstream packages (e.g. khora-cli, khora-explorer) use khora.
 
 ## Architecture
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -239,7 +239,7 @@ A custom engine **must** implement the full `MemoryEngineProtocol` from `src/kho
 
 ## Expertise
 
-`ExpertiseConfig` is a stable sibling API maintained in coordination with khora-explorer and khora-benchmarks.
+`ExpertiseConfig` is a stable sibling API maintained in coordination with khora-explorer.
 
 ```python
 from khora import ExpertiseConfig, EntityTypeConfig, RelationshipTypeConfig
@@ -285,6 +285,6 @@ except KhoraError as exc:
 
 ## Stability guarantee
 
-Symbols imported from the top-level `khora` namespace and `khora.extraction.skills` are stable. Additive changes land in minor releases; breaking changes require a major version bump and coordinated release with khora-benchmarks, khora-explorer, and khora-cli.
+Symbols imported from the top-level `khora` namespace and `khora.extraction.skills` are stable. Additive changes land in minor releases; breaking changes require a major version bump and coordinated release with khora-cli and khora-explorer.
 
 Private imports (`khora.engines.vectorcypher`, `khora.query.engine`, `khora.pipelines.flows`, etc.) are **not** stable and can change between minor versions.

--- a/docs/engines/hybrid-search.md
+++ b/docs/engines/hybrid-search.md
@@ -439,7 +439,7 @@ KHORA_QUERY_DEFAULT_LIMIT=10
 KHORA_QUERY_MIN_SIMILARITY=0.0
 ```
 
-### Via Genesis YAML
+### Via YAML
 
 ```yaml
 query:

--- a/docs/engines/skeleton-engine.md
+++ b/docs/engines/skeleton-engine.md
@@ -387,10 +387,10 @@ KHORA_QUERY_HYBRID_ALPHA=0.7
 KHORA_QUERY_RECENCY_DECAY_DAYS=30
 ```
 
-### Via Genesis YAML
+### Via YAML
 
 ```yaml
-# config/skeleton/genesis.yaml
+# config/skeleton/khora.yaml
 engine:
   name: skeleton
   backend: pgvector

--- a/docs/engines/vectorcypher-engine.md
+++ b/docs/engines/vectorcypher-engine.md
@@ -472,10 +472,10 @@ KHORA_NEO4J_PASSWORD=password
 KHORA_ENGINE_NAME=vectorcypher
 ```
 
-### Via Genesis YAML
+### Via YAML
 
 ```yaml
-# config/vectorcypher/genesis.yaml
+# config/vectorcypher/khora.yaml
 engine:
   name: vectorcypher
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -4,7 +4,7 @@ Khora ships its own Alembic migrations bundled inside the package at `src/khora/
 
 ## Who runs migrations?
 
-Library consumers (genesis, khora-cli, khora-benchmarks, custom services) need Khora's schema to exist before calling `Khora()`. Two options:
+Library consumers (e.g. khora-cli and custom services) need Khora's schema to exist before calling `Khora()`. Two options:
 
 ### 1. Let Khora run them for you
 

--- a/docs/telemetry-contract.md
+++ b/docs/telemetry-contract.md
@@ -31,7 +31,7 @@ telemetry public surface. It is enforced by
 
 - **public** — appears in dashboards, alerts, or downstream code that we
   don't control. Cannot break without a coordinated major version bump
-  (genesis, khora-benchmarks, khora-cli, khora-explorer).
+  across downstream consumers (e.g. khora-cli, khora-explorer).
 - **internal** — emitted today, but the names are not part of the public
   contract. Rename freely; just keep this file in sync with the codebase.
 
@@ -61,9 +61,8 @@ not bump it.
 
 ## OSS implication
 
-khora and anima are independent OSS packages. Per
-[architectural decision], we do **not** extract a shared
-`deyta-telemetry` library. Each package owns its own
-`telemetry-contract.json` and its own drift gate. Downstream consumers
-may rely on the names tagged `public` in this file remaining stable
-within a major version line.
+khora owns its own `telemetry-contract.json` and its own drift gate;
+related OSS packages are expected to do the same rather than depend on
+a shared telemetry library. Downstream consumers may rely on the names
+tagged `public` in this file remaining stable within a major version
+line.

--- a/docs/telemetry-contract.md
+++ b/docs/telemetry-contract.md
@@ -10,7 +10,7 @@ telemetry public surface. It is enforced by
   removals, or signature changes require a major version bump.
 - **`event_types`** — Pydantic models (`LLMEvent`, `StorageEvent`,
   `PipelineEvent`) with their full field set. These rows ship to Postgres and
-  are read by downstream tooling (Poros / Peras cost tracking, dashboards).
+  are read by downstream tooling (cost tracking, dashboards).
   Adding a field with a default is non-breaking; removing or renaming a
   field is breaking.
 - **`collector_methods`** — the recording surface

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,9 +86,9 @@ all-backends = [
 reranking = [
     "sentence-transformers>=3.0.0",
 ]
-# Binary file readers (PDF, Excel, Word text extraction) — used by khora-cli and downstream consumers
+# Binary file readers (PDF, Excel, Word text extraction) — used by khora-cli
 binary-readers = ["pymupdf>=1.25.0", "openpyxl>=3.1.0", "python-docx>=1.1.0"]
-# Parquet file support (used by khora-cli and downstream consumers)
+# Parquet file support (used by khora-cli)
 parquet = ["pyarrow>=18.0.0"]
 # Accelerated CPU operations (numpy for cosine sim, rapidfuzz for string matching)
 accel = [
@@ -126,8 +126,8 @@ raw-options.local_scheme = "no-local-version"
 packages = ["src/khora"]
 
 # Sdist excludes dev-only tree.  ``.claude/docs/workflow.md`` is an absolute
-# symlink into the TTOJ repo on developer machines; tarfile rejects absolute
-# symlinks during sdist creation, so the whole .claude/ tree is excluded.
+# symlink on some developer machines; tarfile rejects absolute symlinks
+# during sdist creation, so the whole .claude/ tree is excluded.
 [tool.hatch.build.targets.sdist]
 exclude = [
     ".claude",

--- a/scripts/bench_logger_enqueue.py
+++ b/scripts/bench_logger_enqueue.py
@@ -27,7 +27,7 @@ Six scenarios across two sink types and three duty cycles:
   rotating-file rotation events, anything making real syscalls).
 * **handler/slow**: ``slow-sink`` plus a 5ms ``await asyncio.sleep`` between
   batches, modelling a request handler doing other async work between log
-  bursts. This is the realistic Khora / Peras workload. Without *some* idle
+  bursts. This is the realistic Khora workload. Without *some* idle
   time for the background thread to drain, ``slow-sink`` applies sustained
   backpressure through the IPC pipe and enqueue's wins evaporate.
 

--- a/src/khora/config/llm.py
+++ b/src/khora/config/llm.py
@@ -1,7 +1,7 @@
 """LiteLLM configuration for unified LLM access.
 
 Provides a unified interface to all LLM providers (OpenAI, Anthropic, Google, etc.)
-with fallbacks and routing. Based on the memoryman/potemkin pattern.
+with fallbacks and routing.
 """
 
 from __future__ import annotations
@@ -139,7 +139,7 @@ class LiteLLMConfig(BaseModel):
         description="Total cap on simultaneous connections in the shared "
         "aiohttp session, summed across all hosts. Default 200 covers a "
         "Khora mixing OpenAI + Anthropic + reranker hosts at the "
-        "concurrency genesis configures.",
+        "concurrency the caller configures.",
     )
     max_connections_per_host: int = Field(
         default=0,

--- a/src/khora/core/models/schemas.py
+++ b/src/khora/core/models/schemas.py
@@ -135,8 +135,8 @@ def register_attribute_schema(
 ) -> None:
     """Register a Pydantic attribute schema for an entity type.
 
-    Downstream projects (e.g. genesis) use this to add domain-specific
-    schemas without modifying khora core.
+    Downstream projects use this to add domain-specific schemas without
+    modifying khora core.
 
     Args:
         entity_type: Canonical entity type name (e.g. "TICKET")

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -350,7 +350,7 @@ class VectorCypherEngine:
             neo4j_url = self._config.get_neo4j_url()
             if not neo4j_url:
                 raise ValueError(
-                    "Neo4j URL is required for VectorCypher engine. Set GENESIS_NEO4J_URL or configure graph_config."
+                    "Neo4j URL is required for VectorCypher engine. Set KHORA_NEO4J_URL or configure graph_config."
                 )
 
             neo4j_cfg = self._config.get_graph_config()
@@ -1522,9 +1522,9 @@ class VectorCypherEngine:
         #    source_chunk_ids, so without this step survivor entities keep
         #    retired chunk UUIDs and net-new entities accumulate stale UUIDs
         #    from prior documents. Downstream consumers that read
-        #    ``len(entity.source_chunk_ids)`` as a mention count (Poros /
-        #    Peras per DYT-645; genesis analytics) would double-count across
-        #    replaces. SET is idempotent; safe for both survivors and net-new.
+        #    ``len(entity.source_chunk_ids)`` as a mention count would
+        #    double-count across replaces. SET is idempotent; safe for both
+        #    survivors and net-new.
         graph = storage.graph
         reset_source_chunk_ids = getattr(graph, "reset_entity_source_chunk_ids_batch", None) if graph else None
         if reset_source_chunk_ids is not None and new_entities:

--- a/src/khora/extraction/skills/base.py
+++ b/src/khora/extraction/skills/base.py
@@ -613,12 +613,11 @@ class ExtractionSkill:
         )
 
 
-# Public API contract. Downstream consumers (khora-explorer,
-# genesis, khora-benchmarks) depend on these symbols. Changes to any class
-# listed here — renaming fields, removing fields, or changing field types —
-# require a major version bump and prior coordination. Additive changes
-# (new optional fields with defaults) are permitted in patch/minor releases
-# provided from_dict round-trips existing payloads.
+# Public API contract. Downstream consumers depend on these symbols.
+# Changes to any class listed here — renaming fields, removing fields, or
+# changing field types — require a major version bump and prior coordination.
+# Additive changes (new optional fields with defaults) are permitted in
+# patch/minor releases provided from_dict round-trips existing payloads.
 __all__ = [
     # Stable expertise configuration
     "ExpertiseConfig",

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -91,8 +91,8 @@ if TYPE_CHECKING:
     from khora.storage import StorageConfig, StorageCoordinator
 
 
-# DYT-645: LLMUsage is a public API type consumed by Poros (DYT-650) and Peras (DYT-651).
-# Changes to field names or types require coordination with those projects.
+# LLMUsage is a public API type consumed by external cost-tracking integrations.
+# Changes to field names or types require a coordinated release.
 @dataclass(slots=True, frozen=True)
 class LLMUsage:
     """A single LLM API call's token usage.
@@ -509,7 +509,7 @@ class Khora:
             if _is_undefined_table_error(exc):
                 # Fresh DB — `memory_namespaces` hasn't been created yet, so there
                 # are no namespaces and therefore no orphaned PENDING docs. Common
-                # path on per-run ephemeral databases (e.g. khora-benchmarks-service).
+                # path on per-run ephemeral databases.
                 logger.debug(
                     "pending_processor: skipping orphan recovery on fresh DB (memory_namespaces table not yet created)"
                 )

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -1523,7 +1523,7 @@ async def ingest_documents(
     _staging_elapsed = _batch_time.perf_counter() - _staging_t0
 
     # Build mapping from staged doc ID to original dict for per-doc overrides
-    # (e.g. _skill_name, _extraction_context set by callers like Genesis)
+    # (e.g. _skill_name, _extraction_context set by callers)
     doc_originals: dict[UUID, dict[str, Any]] = {}
     for orig, staged in zip(documents, staged_results):
         if staged is not None:

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -151,8 +151,8 @@ class PgVectorBackend(AsyncSessionMixin):
             elif not await self._check_halfvec_indexes():
                 self._halfvec_available = False
                 # Distinguish "fresh DB, migrations not run yet" (benign — common path
-                # for ephemeral per-run databases like khora-benchmarks-service) from
-                # "tables exist but indexes are missing" (real misconfiguration).
+                # for ephemeral per-run databases) from "tables exist but indexes are
+                # missing" (real misconfiguration).
                 if not await self._halfvec_target_tables_exist():
                     logger.info(
                         "halfvec HNSW indexes not yet created (fresh DB) — using full-precision "


### PR DESCRIPTION
## Summary

Scrub references to internal/unreleased sibling services from khora's docs, source comments, and one user-facing error message before open-sourcing.

- **Docs (8 files):** `README.md`, `docs/README.md`, `docs/api-reference.md`, `docs/migrations.md`, `docs/telemetry-contract.md`, `docs/engines/{hybrid-search,skeleton-engine,vectorcypher-engine}.md` — replace internal references with neutral phrasing; mark `khora-cli` / `khora-explorer` as "(to be released soon)".
- **Source comments (7 files):** `src/khora/{config/llm,core/models/schemas,engines/vectorcypher/engine,extraction/skills/base,khora,pipelines/flows/ingest,storage/backends/pgvector}.py` — strip references to internal services; no behavioural changes.
- **One non-comment edit:** `engines/vectorcypher/engine.py:353` error message `GENESIS_NEO4J_URL` → `KHORA_NEO4J_URL`. String-literal only — `get_neo4j_url()` already resolves to `KHORA_NEO4J_URL`.
- **Build metadata:** `pyproject.toml` and `scripts/bench_logger_enqueue.py` comments.

## Test plan

- [x] `make format` — clean
- [x] `make lint` — clean (pre-existing ty warnings only)
- [x] `make test` — 3205 passed, 8 skipped, coverage 59.11%
