### PR TITLE
Re-type credential and DSN fields as SecretStr

### DIFF
--- a/src/khora/config/_secrets.py
+++ b/src/khora/config/_secrets.py
@@ -1,0 +1,36 @@
+"""Secret-redaction helpers for log / exception output.
+
+Local implementation mirroring the ``deyta_core.adr084.redact_dsn`` signature
+from ADR-084. Khora is OSS and does not (yet) depend on deyta-core; when
+DYT-3993 lands the deyta-core footprint, callers can switch the import over
+without changing semantics.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Matches the userinfo segment of a URI: ``://user:password@``. Captures
+# nothing — substitution replaces the whole match with ``://[REDACTED]@``.
+# Pattern verbatim from ADR-084 §🤝.
+_DSN_USERINFO_RE = re.compile(r"://[\w\-.]+:[^@/]+@")
+
+
+def redact_dsn(text: str) -> str:
+    """Return ``text`` with any DSN userinfo replaced by ``[REDACTED]``.
+
+    The pattern matches ``scheme://user:password@`` segments and replaces the
+    ``user:password`` part. Strings without an embedded DSN are returned
+    unchanged.
+
+    >>> redact_dsn("postgresql://alice:hunter2@db:5432/app")
+    'postgresql://[REDACTED]@db:5432/app'
+    >>> redact_dsn("no secret here")
+    'no secret here'
+    """
+    if not text:
+        return text
+    return _DSN_USERINFO_RE.sub("://[REDACTED]@", text)
+
+
+__all__ = ["redact_dsn"]

--- a/src/khora/config/_secrets.py
+++ b/src/khora/config/_secrets.py
@@ -1,10 +1,4 @@
-"""Secret-redaction helpers for log / exception output.
-
-Local implementation mirroring the ``deyta_core.adr084.redact_dsn`` signature
-from ADR-084. Khora is OSS and does not (yet) depend on deyta-core; when
-DYT-3993 lands the deyta-core footprint, callers can switch the import over
-without changing semantics.
-"""
+"""Secret-redaction helpers for log / exception output."""
 
 from __future__ import annotations
 
@@ -12,7 +6,6 @@ import re
 
 # Matches the userinfo segment of a URI: ``://user:password@``. Captures
 # nothing — substitution replaces the whole match with ``://[REDACTED]@``.
-# Pattern verbatim from ADR-084 §🤝.
 _DSN_USERINFO_RE = re.compile(r"://[\w\-.]+:[^@/]+@")
 
 

--- a/src/khora/config/schema.py
+++ b/src/khora/config/schema.py
@@ -8,8 +8,24 @@ from typing import Annotated, Any, Literal
 from urllib.parse import urlparse
 
 import yaml
-from pydantic import BaseModel, Discriminator, Field, Tag, field_validator, model_validator
+from pydantic import BaseModel, Discriminator, Field, SecretStr, Tag, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+def _secret_value(value: SecretStr | str | None, default: str = "") -> str:
+    """Return the plain-text value of a ``SecretStr`` (or pass-through ``str``).
+
+    ADR-084 boundary helper: storage-backend engine factories unwrap
+    ``SecretStr`` exactly once when handing credentials to the underlying
+    driver. Accepts ``str`` as a back-compat fallback so legacy call sites
+    that still pass plain strings continue to work during the migration
+    window.
+    """
+    if value is None:
+        return default
+    if isinstance(value, SecretStr):
+        return value.get_secret_value()
+    return value
 
 
 @dataclass
@@ -18,7 +34,7 @@ class ParsedNeo4jUrl:
 
     url: str  # URL without credentials (bolt://host:port)
     user: str
-    password: str
+    password: SecretStr
     database: str
 
     @classmethod
@@ -26,7 +42,7 @@ class ParsedNeo4jUrl:
         cls,
         url: str,
         default_user: str = "neo4j",
-        default_password: str = "",
+        default_password: SecretStr | str = "",
         default_database: str = "neo4j",
     ) -> ParsedNeo4jUrl:
         """Parse a Neo4j URL with optional embedded credentials.
@@ -44,7 +60,12 @@ class ParsedNeo4jUrl:
 
         # Extract user and password from URL
         user = parsed.username or default_user
-        password = parsed.password or default_password
+        if parsed.password:
+            password: SecretStr = SecretStr(parsed.password)
+        elif isinstance(default_password, SecretStr):
+            password = default_password
+        else:
+            password = SecretStr(default_password)
 
         # Extract database from path (e.g., /mydb -> mydb)
         database = parsed.path.lstrip("/") if parsed.path and parsed.path != "/" else default_database
@@ -69,7 +90,7 @@ class Neo4jConfig(BaseModel):
     backend: Literal["neo4j"] = "neo4j"
     url: str | None = Field(default=None, description="Neo4j connection URL (bolt:// or neo4j://)")
     user: str = Field(default="neo4j", description="Neo4j username")
-    password: str = Field(default="", description="Neo4j password")
+    password: SecretStr = Field(default=SecretStr(""), description="Neo4j password")
     database: str = Field(default="neo4j", description="Neo4j database name")
     max_connection_pool_size: int = Field(default=100, description="Neo4j connection pool size")
     connection_acquisition_timeout: float = Field(
@@ -151,7 +172,7 @@ class MemgraphConfig(BaseModel):
     backend: Literal["memgraph"] = "memgraph"
     url: str | None = Field(default=None, description="Memgraph connection URL (bolt://)")
     user: str = Field(default="memgraph", description="Memgraph username")
-    password: str = Field(default="", description="Memgraph password")
+    password: SecretStr = Field(default=SecretStr(""), description="Memgraph password")
 
 
 class NeptuneConfig(BaseModel):
@@ -164,7 +185,7 @@ class NeptuneConfig(BaseModel):
     backend: Literal["neptune"] = "neptune"
     url: str | None = Field(default=None, description="Neptune Bolt endpoint (bolt://cluster:8182)")
     user: str = Field(default="", description="Username (empty for IAM auth)")
-    password: str = Field(default="", description="Password (empty for IAM auth)")
+    password: SecretStr = Field(default=SecretStr(""), description="Password (empty for IAM auth)")
     iam_auth: bool = Field(default=False, description="Use AWS IAM SigV4 authentication")
     aws_region: str = Field(default="us-east-1", description="AWS region for IAM auth signing")
     max_connection_pool_size: int = Field(default=100, description="Bolt connection pool size (Neptune max: 1000)")
@@ -184,7 +205,7 @@ class SurrealDBConfig(BaseModel):
     namespace: str = Field(default="khora", description="SurrealDB namespace")
     database: str = Field(default="default", description="SurrealDB database")
     user: str = Field(default="root", description="SurrealDB username")
-    password: str = Field(default="root", description="SurrealDB password")
+    password: SecretStr = Field(default=SecretStr("root"), description="SurrealDB password")
     embedding_dimension: int = Field(default=1536, description="Embedding vector dimension")
     sync_data: bool = Field(default=True, description="Enable SURREAL_SYNC_DATA for crash-safe writes")
 
@@ -286,7 +307,7 @@ class SurrealDBVectorConfig(BaseModel):
     namespace: str = Field(default="khora", description="SurrealDB namespace")
     database: str = Field(default="default", description="SurrealDB database")
     user: str = Field(default="root", description="SurrealDB username")
-    password: str = Field(default="root", description="SurrealDB password")
+    password: SecretStr = Field(default=SecretStr("root"), description="SurrealDB password")
     embedding_dimension: int = Field(default=1536, description="Embedding vector dimension")
 
 
@@ -352,7 +373,7 @@ class StorageSettings(BaseSettings):
     )
 
     # PostgreSQL (relational)
-    postgresql_url: str | None = Field(default=None, description="PostgreSQL connection URL")
+    postgresql_url: SecretStr | None = Field(default=None, description="PostgreSQL connection URL")
     postgresql_pool_size: int = Field(default=50, description="PostgreSQL connection pool size")
     postgresql_max_overflow: int = Field(default=30, description="PostgreSQL max overflow connections")
     postgresql_pool_pre_ping: bool = Field(
@@ -367,11 +388,11 @@ class StorageSettings(BaseSettings):
     vector: VectorConfig = Field(default_factory=PgVectorConfig, description="Vector backend configuration")
 
     # Legacy flat fields — kept for backwards compatibility
-    pgvector_url: str | None = Field(default=None, description="[deprecated] pgvector connection URL")
+    pgvector_url: SecretStr | None = Field(default=None, description="[deprecated] pgvector connection URL")
     embedding_dimension: int = Field(default=1536, description="[deprecated] Embedding vector dimension")
-    neo4j_url: str | None = Field(default=None, description="[deprecated] Neo4j connection URL")
+    neo4j_url: SecretStr | None = Field(default=None, description="[deprecated] Neo4j connection URL")
     neo4j_user: str = Field(default="neo4j", description="[deprecated] Neo4j username")
-    neo4j_password: str = Field(default="", description="[deprecated] Neo4j password")
+    neo4j_password: SecretStr = Field(default=SecretStr(""), description="[deprecated] Neo4j password")
     neo4j_database: str = Field(default="neo4j", description="[deprecated] Neo4j database name")
 
     # HNSW index tuning
@@ -871,11 +892,11 @@ class KhoraConfig(BaseSettings):
     # Database for Khora internal state (shortcuts for storage.* URLs)
     # These can be set via KHORA_DATABASE_URL and KHORA_NEO4J_URL environment variables
     # Programmatic values take priority over environment variables
-    database_url: str | None = Field(
+    database_url: SecretStr | None = Field(
         default=None,
         description="PostgreSQL URL for Khora database (shortcut for storage.postgresql_url)",
     )
-    neo4j_url: str | None = Field(
+    neo4j_url: SecretStr | None = Field(
         default=None,
         description="Neo4j URL for graph storage (shortcut for storage.neo4j_url)",
     )
@@ -911,7 +932,7 @@ class KhoraConfig(BaseSettings):
     hooks: Any = Field(default=None, description="Semantic hooks configuration (SemanticHooksConfig)")
 
     # Telemetry
-    telemetry_database_url: str | None = Field(
+    telemetry_database_url: SecretStr | None = Field(
         default=None,
         description="PostgreSQL URL for telemetry database (set KHORA_TELEMETRY_DATABASE_URL to enable)",
     )
@@ -943,17 +964,39 @@ class KhoraConfig(BaseSettings):
         return cls.model_validate(data or {})
 
     def get_postgresql_url(self) -> str | None:
-        """Get PostgreSQL URL from config."""
-        return self.storage.postgresql_url or self.database_url
+        """Get PostgreSQL URL from config (plaintext, for driver consumption).
+
+        Boundary unwrap for ``SecretStr`` per ADR-084: callers receive a plain
+        string suitable for handing to SQLAlchemy / asyncpg. Returns ``None``
+        when neither ``storage.postgresql_url`` nor ``database_url`` is set.
+        """
+        if self.storage.postgresql_url is not None:
+            return _secret_value(self.storage.postgresql_url) or None
+        if self.database_url is not None:
+            return _secret_value(self.database_url) or None
+        return None
 
     def _get_raw_neo4j_url(self) -> str | None:
-        """Get raw Neo4j URL (may contain credentials)."""
+        """Get raw Neo4j URL (may contain credentials).
+
+        Boundary unwrap for ``SecretStr`` per ADR-084. Callers feed this URL
+        into ``ParsedNeo4jUrl.parse`` (which itself splits the URL into
+        cleaned-URL + credentials before forwarding to the driver).
+        """
         # Check new-style graph config first
         graph = self.storage.graph
         if isinstance(graph, Neo4jConfig) and graph.url:
             return graph.url
         # Fall back to legacy fields
-        return self.storage.neo4j_url or self.neo4j_url
+        if self.storage.neo4j_url is not None:
+            value = _secret_value(self.storage.neo4j_url)
+            if value:
+                return value
+        if self.neo4j_url is not None:
+            value = _secret_value(self.neo4j_url)
+            if value:
+                return value
+        return None
 
     def _parse_neo4j_url(self) -> ParsedNeo4jUrl | None:
         """Parse Neo4j URL and extract components."""
@@ -997,7 +1040,9 @@ class KhoraConfig(BaseSettings):
         return self.storage.neo4j_user
 
     def get_neo4j_password(self) -> str:
-        """Get Neo4j password.
+        """Get Neo4j password (plaintext, for driver consumption).
+
+        Boundary unwrap for ``SecretStr`` per ADR-084.
 
         Precedence: password embedded in ``Neo4jConfig.url`` (or the legacy
         ``neo4j_url``) wins. Otherwise, falls back to the separately-configured
@@ -1006,11 +1051,11 @@ class KhoraConfig(BaseSettings):
         """
         parsed = self._parse_neo4j_url()
         if parsed:
-            return parsed.password
+            return parsed.password.get_secret_value()
         graph = self.storage.graph
         if isinstance(graph, Neo4jConfig):
-            return graph.password
-        return self.storage.neo4j_password
+            return graph.password.get_secret_value()
+        return _secret_value(self.storage.neo4j_password)
 
     def get_neo4j_database(self) -> str:
         """Get Neo4j database name.
@@ -1060,8 +1105,10 @@ class KhoraConfig(BaseSettings):
         """
         vector = self.storage.vector
         if isinstance(vector, PgVectorConfig) and not vector.url:
-            # Populate from legacy fields
-            url = self.storage.pgvector_url or self.get_postgresql_url()
+            # Populate from legacy fields. ``pgvector_url`` is ``SecretStr`` post
+            # ADR-084 re-typing; ``PgVectorConfig.url`` remains a plain ``str``
+            # at the backend boundary, so unwrap here.
+            url = _secret_value(self.storage.pgvector_url) or self.get_postgresql_url()
             return PgVectorConfig(
                 url=url,
                 embedding_dimension=self.storage.embedding_dimension,

--- a/src/khora/config/schema.py
+++ b/src/khora/config/schema.py
@@ -88,7 +88,7 @@ class Neo4jConfig(BaseModel):
     """Neo4j graph backend configuration."""
 
     backend: Literal["neo4j"] = "neo4j"
-    url: str | None = Field(default=None, description="Neo4j connection URL (bolt:// or neo4j://)")
+    url: SecretStr | None = Field(default=None, description="Neo4j connection URL (bolt:// or neo4j://)")
     user: str = Field(default="neo4j", description="Neo4j username")
     password: SecretStr = Field(default=SecretStr(""), description="Neo4j password")
     database: str = Field(default="neo4j", description="Neo4j database name")
@@ -170,7 +170,7 @@ class MemgraphConfig(BaseModel):
     """Memgraph graph backend configuration."""
 
     backend: Literal["memgraph"] = "memgraph"
-    url: str | None = Field(default=None, description="Memgraph connection URL (bolt://)")
+    url: SecretStr | None = Field(default=None, description="Memgraph connection URL (bolt://)")
     user: str = Field(default="memgraph", description="Memgraph username")
     password: SecretStr = Field(default=SecretStr(""), description="Memgraph password")
 
@@ -183,7 +183,7 @@ class NeptuneConfig(BaseModel):
     """
 
     backend: Literal["neptune"] = "neptune"
-    url: str | None = Field(default=None, description="Neptune Bolt endpoint (bolt://cluster:8182)")
+    url: SecretStr | None = Field(default=None, description="Neptune Bolt endpoint (bolt://cluster:8182)")
     user: str = Field(default="", description="Username (empty for IAM auth)")
     password: SecretStr = Field(default=SecretStr(""), description="Password (empty for IAM auth)")
     iam_auth: bool = Field(default=False, description="Use AWS IAM SigV4 authentication")
@@ -200,7 +200,7 @@ class SurrealDBConfig(BaseModel):
 
     backend: Literal["surrealdb"] = "surrealdb"
     mode: str = Field(default="memory", description="Connection mode: memory, embedded, or remote")
-    url: str | None = Field(default=None, description="SurrealDB WebSocket URL (for remote mode)")
+    url: SecretStr | None = Field(default=None, description="SurrealDB WebSocket URL (for remote mode)")
     path: str | None = Field(default=None, description="Database file path (for embedded mode)")
     namespace: str = Field(default="khora", description="SurrealDB namespace")
     database: str = Field(default="default", description="SurrealDB database")
@@ -258,7 +258,7 @@ class AGEConfig(BaseModel):
     """
 
     backend: Literal["age"] = "age"
-    url: str | None = Field(default=None, description="PostgreSQL URL (can share with relational backend)")
+    url: SecretStr | None = Field(default=None, description="PostgreSQL URL (can share with relational backend)")
     graph_name: str = Field(default="khora_graph", description="Name of the AGE graph")
     pool_size: int = Field(default=10, description="Connection pool size")
     max_overflow: int = Field(default=20, description="Max overflow connections")
@@ -290,7 +290,7 @@ class PgVectorConfig(BaseModel):
     """pgvector vector backend configuration."""
 
     backend: Literal["pgvector"] = "pgvector"
-    url: str | None = Field(default=None, description="pgvector connection URL")
+    url: SecretStr | None = Field(default=None, description="pgvector connection URL")
     embedding_dimension: int = Field(default=1536, description="Embedding vector dimension")
 
 
@@ -302,7 +302,7 @@ class SurrealDBVectorConfig(BaseModel):
 
     backend: Literal["surrealdb"] = "surrealdb"
     mode: str = Field(default="memory", description="Connection mode: memory, embedded, or remote")
-    url: str | None = Field(default=None, description="SurrealDB WebSocket URL (for remote mode)")
+    url: SecretStr | None = Field(default=None, description="SurrealDB WebSocket URL (for remote mode)")
     path: str | None = Field(default=None, description="Database file path (for embedded mode)")
     namespace: str = Field(default="khora", description="SurrealDB namespace")
     database: str = Field(default="default", description="SurrealDB database")
@@ -986,7 +986,7 @@ class KhoraConfig(BaseSettings):
         # Check new-style graph config first
         graph = self.storage.graph
         if isinstance(graph, Neo4jConfig) and graph.url:
-            return graph.url
+            return _secret_value(graph.url) or None
         # Fall back to legacy fields
         if self.storage.neo4j_url is not None:
             value = _secret_value(self.storage.neo4j_url)
@@ -1105,9 +1105,9 @@ class KhoraConfig(BaseSettings):
         """
         vector = self.storage.vector
         if isinstance(vector, PgVectorConfig) and not vector.url:
-            # Populate from legacy fields. ``pgvector_url`` is ``SecretStr`` post
-            # ADR-084 re-typing; ``PgVectorConfig.url`` remains a plain ``str``
-            # at the backend boundary, so unwrap here.
+            # Populate from legacy fields. Both ``pgvector_url`` and
+            # ``PgVectorConfig.url`` are ``SecretStr`` post ADR-084 re-typing;
+            # unwrap the legacy field here so Pydantic re-wraps consistently.
             url = _secret_value(self.storage.pgvector_url) or self.get_postgresql_url()
             return PgVectorConfig(
                 url=url,

--- a/src/khora/config/schema.py
+++ b/src/khora/config/schema.py
@@ -15,11 +15,10 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 def _secret_value(value: SecretStr | str | None, default: str = "") -> str:
     """Return the plain-text value of a ``SecretStr`` (or pass-through ``str``).
 
-    ADR-084 boundary helper: storage-backend engine factories unwrap
-    ``SecretStr`` exactly once when handing credentials to the underlying
-    driver. Accepts ``str`` as a back-compat fallback so legacy call sites
-    that still pass plain strings continue to work during the migration
-    window.
+    Storage-backend engine factories unwrap ``SecretStr`` exactly once when
+    handing credentials to the underlying driver. Accepts ``str`` as a
+    back-compat fallback so legacy call sites that still pass plain strings
+    continue to work during the migration window.
     """
     if value is None:
         return default
@@ -966,9 +965,9 @@ class KhoraConfig(BaseSettings):
     def get_postgresql_url(self) -> str | None:
         """Get PostgreSQL URL from config (plaintext, for driver consumption).
 
-        Boundary unwrap for ``SecretStr`` per ADR-084: callers receive a plain
-        string suitable for handing to SQLAlchemy / asyncpg. Returns ``None``
-        when neither ``storage.postgresql_url`` nor ``database_url`` is set.
+        Boundary unwrap for ``SecretStr``: callers receive a plain string
+        suitable for handing to SQLAlchemy / asyncpg. Returns ``None`` when
+        neither ``storage.postgresql_url`` nor ``database_url`` is set.
         """
         if self.storage.postgresql_url is not None:
             return _secret_value(self.storage.postgresql_url) or None
@@ -979,8 +978,8 @@ class KhoraConfig(BaseSettings):
     def _get_raw_neo4j_url(self) -> str | None:
         """Get raw Neo4j URL (may contain credentials).
 
-        Boundary unwrap for ``SecretStr`` per ADR-084. Callers feed this URL
-        into ``ParsedNeo4jUrl.parse`` (which itself splits the URL into
+        Boundary unwrap for ``SecretStr``. Callers feed this URL into
+        ``ParsedNeo4jUrl.parse`` (which itself splits the URL into
         cleaned-URL + credentials before forwarding to the driver).
         """
         # Check new-style graph config first
@@ -1042,7 +1041,7 @@ class KhoraConfig(BaseSettings):
     def get_neo4j_password(self) -> str:
         """Get Neo4j password (plaintext, for driver consumption).
 
-        Boundary unwrap for ``SecretStr`` per ADR-084.
+        Boundary unwrap for ``SecretStr``.
 
         Precedence: password embedded in ``Neo4jConfig.url`` (or the legacy
         ``neo4j_url``) wins. Otherwise, falls back to the separately-configured
@@ -1106,8 +1105,8 @@ class KhoraConfig(BaseSettings):
         vector = self.storage.vector
         if isinstance(vector, PgVectorConfig) and not vector.url:
             # Populate from legacy fields. Both ``pgvector_url`` and
-            # ``PgVectorConfig.url`` are ``SecretStr`` post ADR-084 re-typing;
-            # unwrap the legacy field here so Pydantic re-wraps consistently.
+            # ``PgVectorConfig.url`` are ``SecretStr``; unwrap the legacy
+            # field here so Pydantic re-wraps consistently.
             url = _secret_value(self.storage.pgvector_url) or self.get_postgresql_url()
             return PgVectorConfig(
                 url=url,

--- a/src/khora/db/migrations/env.py
+++ b/src/khora/db/migrations/env.py
@@ -274,8 +274,18 @@ async def run_async_migrations() -> None:
     except Exception as exc:
         redacted = redact_dsn(str(exc))
         if redacted != str(exc):
-            # Re-raise with redacted message; preserve original type & traceback.
-            raise type(exc)(redacted).with_traceback(exc.__traceback__) from None
+            # Re-raise with redacted message. Try to preserve the original
+            # exception type, but some SQLAlchemy / asyncpg exception types
+            # require multiple positional args (e.g. NoSuchModuleError(name))
+            # — passing just the redacted message would raise TypeError and
+            # lose the original traceback. Fall back to RuntimeError chained
+            # via ``from exc`` so the original is still reachable via
+            # ``__cause__``.
+            try:
+                redacted_exc = type(exc)(redacted)
+            except TypeError:
+                raise RuntimeError(redacted) from exc
+            raise redacted_exc.with_traceback(exc.__traceback__) from None
         raise
 
 

--- a/src/khora/db/migrations/env.py
+++ b/src/khora/db/migrations/env.py
@@ -243,9 +243,9 @@ def run_migrations_offline() -> None:
 async def run_async_migrations() -> None:
     """Run migrations in 'online' mode with async engine.
 
-    ADR-084 §⚠️ Edge Cases: connection-setup errors raised by the underlying
-    driver often embed the plaintext DSN (asyncpg in particular formats the
-    full ``postgresql://user:pass@host/db`` string into its
+    Connection-setup errors raised by the underlying driver often embed the
+    plaintext DSN (asyncpg in particular formats the full
+    ``postgresql://user:pass@host/db`` string into its
     ``InvalidPasswordError`` / ``CannotConnectNowError`` messages). Wrap the
     exception path with ``redact_dsn`` so the userinfo segment never reaches
     log sinks or Logfire span attributes.

--- a/src/khora/db/migrations/env.py
+++ b/src/khora/db/migrations/env.py
@@ -17,6 +17,7 @@ from sqlalchemy import Column, MetaData, PrimaryKeyConstraint, String, Table, po
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import create_async_engine
 
+from khora.config._secrets import redact_dsn
 from khora.db.models import Base
 from khora.db.session import _DatabaseAheadError
 
@@ -240,24 +241,42 @@ def run_migrations_offline() -> None:
 
 
 async def run_async_migrations() -> None:
-    """Run migrations in 'online' mode with async engine."""
+    """Run migrations in 'online' mode with async engine.
+
+    ADR-084 §⚠️ Edge Cases: connection-setup errors raised by the underlying
+    driver often embed the plaintext DSN (asyncpg in particular formats the
+    full ``postgresql://user:pass@host/db`` string into its
+    ``InvalidPasswordError`` / ``CannotConnectNowError`` messages). Wrap the
+    exception path with ``redact_dsn`` so the userinfo segment never reaches
+    log sinks or Logfire span attributes.
+    """
     url = _get_url()
-    connectable = create_async_engine(url, poolclass=pool.NullPool)
+    try:
+        connectable = create_async_engine(url, poolclass=pool.NullPool)
 
-    async with connectable.connect() as connection:
-        # SQLite: enable foreign keys so FK constraints behave consistently
-        # with Postgres during batch ALTER operations.
-        if connection.dialect.name == "sqlite":
-            await connection.execute(text("PRAGMA foreign_keys = ON"))
-        await connection.run_sync(do_run_migrations)
-        # Explicitly commit — Alembic's "non-transactional DDL" path on SQLite
-        # doesn't issue COMMIT, and SQLAlchemy's async connection does not
-        # auto-commit on close. Without this, all DDL is lost. Safe on Postgres:
-        # the surrounding context.begin_transaction() already commits, and this
-        # is a no-op after commit.
-        await connection.commit()
+        async with connectable.connect() as connection:
+            # SQLite: enable foreign keys so FK constraints behave consistently
+            # with Postgres during batch ALTER operations.
+            if connection.dialect.name == "sqlite":
+                await connection.execute(text("PRAGMA foreign_keys = ON"))
+            await connection.run_sync(do_run_migrations)
+            # Explicitly commit — Alembic's "non-transactional DDL" path on SQLite
+            # doesn't issue COMMIT, and SQLAlchemy's async connection does not
+            # auto-commit on close. Without this, all DDL is lost. Safe on Postgres:
+            # the surrounding context.begin_transaction() already commits, and this
+            # is a no-op after commit.
+            await connection.commit()
 
-    await connectable.dispose()
+        await connectable.dispose()
+    except _DatabaseAheadError:
+        # Sentinel: no DSN content, propagate unchanged for the session.py handler.
+        raise
+    except Exception as exc:
+        redacted = redact_dsn(str(exc))
+        if redacted != str(exc):
+            # Re-raise with redacted message; preserve original type & traceback.
+            raise type(exc)(redacted).with_traceback(exc.__traceback__) from None
+        raise
 
 
 def run_migrations_online() -> None:

--- a/src/khora/db/session.py
+++ b/src/khora/db/session.py
@@ -253,14 +253,19 @@ def _run_migrations_sync(database_url: str | None = None) -> MigrationResult:
             skipped=True,
         )
     except Exception as e:
+        # ADR-084 §⚠️: scrub plaintext DSN userinfo from error messages before
+        # they hit logs or the returned MigrationResult.error string.
+        from khora.config._secrets import redact_dsn
+
         elapsed = time.monotonic() - start
-        logger.error("Migration failed: {}", e)
+        redacted_msg = redact_dsn(str(e))
+        logger.error("Migration failed: {}", redacted_msg)
         return MigrationResult(
             success=False,
             target_revision=None,
             current_revision=None,
             elapsed_seconds=elapsed,
-            error=f"{type(e).__name__}: {e}",
+            error=f"{type(e).__name__}: {redacted_msg}",
         )
 
 

--- a/src/khora/db/session.py
+++ b/src/khora/db/session.py
@@ -253,8 +253,8 @@ def _run_migrations_sync(database_url: str | None = None) -> MigrationResult:
             skipped=True,
         )
     except Exception as e:
-        # ADR-084 §⚠️: scrub plaintext DSN userinfo from error messages before
-        # they hit logs or the returned MigrationResult.error string.
+        # Scrub plaintext DSN userinfo from error messages before they hit
+        # logs or the returned MigrationResult.error string.
         from khora.config._secrets import redact_dsn
 
         elapsed = time.monotonic() - start

--- a/src/khora/engines/skeleton/backends/surrealdb.py
+++ b/src/khora/engines/skeleton/backends/surrealdb.py
@@ -125,8 +125,8 @@ class SurrealDBTemporalStore(TemporalVectorStore):
                     "or pass surrealdb_config explicitly."
                 )
 
-            # ADR-084 boundary: SurrealDBConfig.url and .password are SecretStr;
-            # unwrap exactly here so the driver receives plaintext.
+            # SurrealDBConfig.url and .password are SecretStr; unwrap exactly
+            # here so the driver receives plaintext.
             from pydantic import SecretStr as _SecretStr
 
             surreal_url = surreal_cfg.url

--- a/src/khora/engines/skeleton/backends/surrealdb.py
+++ b/src/khora/engines/skeleton/backends/surrealdb.py
@@ -125,14 +125,24 @@ class SurrealDBTemporalStore(TemporalVectorStore):
                     "or pass surrealdb_config explicitly."
                 )
 
+            # ADR-084 boundary: SurrealDBConfig.url and .password are SecretStr;
+            # unwrap exactly here so the driver receives plaintext.
+            from pydantic import SecretStr as _SecretStr
+
+            surreal_url = surreal_cfg.url
+            if isinstance(surreal_url, _SecretStr):
+                surreal_url = surreal_url.get_secret_value()
+            surreal_password = surreal_cfg.password
+            if isinstance(surreal_password, _SecretStr):
+                surreal_password = surreal_password.get_secret_value()
             self._conn = SurrealDBConnection(
                 mode=surreal_cfg.mode,
                 path=surreal_cfg.path,
-                url=surreal_cfg.url,
+                url=surreal_url,
                 namespace=surreal_cfg.namespace,
                 database=surreal_cfg.database,
                 user=surreal_cfg.user,
-                password=surreal_cfg.password,
+                password=surreal_password,
                 sync_data=surreal_cfg.sync_data,
             )
         self._connected = False

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -428,8 +428,8 @@ class Khora:
                 db_path = self._config.storage.sqlite_lance.db_path
                 db_url = f"sqlite+aiosqlite:///{db_path}"
             else:
-                # ADR-084 boundary: database_url is a SecretStr; unwrap for the
-                # Alembic runner (it forwards into SQLAlchemy create_async_engine).
+                # database_url is a SecretStr; unwrap for the Alembic runner
+                # (it forwards into SQLAlchemy create_async_engine).
                 db_url = self._config.database_url.get_secret_value() if self._config.database_url is not None else None
             result = await _run_migrations(db_url)
             if not result.success:

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -385,7 +385,9 @@ class Khora:
             self._config = load_config()
             # Apply overrides if provided
             if graph_url:
-                self._config.neo4j_url = graph_url
+                from pydantic import SecretStr as _SecretStr
+
+                self._config.neo4j_url = _SecretStr(graph_url)
             if embedding_model != "text-embedding-3-small":
                 self._config.llm.embedding_model = embedding_model
 
@@ -426,7 +428,9 @@ class Khora:
                 db_path = self._config.storage.sqlite_lance.db_path
                 db_url = f"sqlite+aiosqlite:///{db_path}"
             else:
-                db_url = self._config.database_url
+                # ADR-084 boundary: database_url is a SecretStr; unwrap for the
+                # Alembic runner (it forwards into SQLAlchemy create_async_engine).
+                db_url = self._config.database_url.get_secret_value() if self._config.database_url is not None else None
             result = await _run_migrations(db_url)
             if not result.success:
                 raise RuntimeError(f"Database migration failed: {result.error}")

--- a/src/khora/storage/backends/age.py
+++ b/src/khora/storage/backends/age.py
@@ -62,9 +62,18 @@ class AGEBackend(GraphBackendBase):
 
     @classmethod
     def from_config(cls, config: Any) -> AGEBackend:
-        """Create an AGEBackend from an AGEConfig object."""
+        """Create an AGEBackend from an AGEConfig object.
+
+        ADR-084 boundary: if ``config.url`` is a ``SecretStr`` it is unwrapped
+        exactly here so the SQLAlchemy engine receives a plaintext DSN.
+        """
+        from pydantic import SecretStr
+
+        url = config.url or ""
+        if isinstance(url, SecretStr):
+            url = url.get_secret_value()
         return cls(
-            database_url=config.url or "",
+            database_url=url,
             graph_name=getattr(config, "graph_name", "khora_graph"),
             pool_size=getattr(config, "pool_size", 10),
             max_overflow=getattr(config, "max_overflow", 20),

--- a/src/khora/storage/backends/age.py
+++ b/src/khora/storage/backends/age.py
@@ -64,8 +64,8 @@ class AGEBackend(GraphBackendBase):
     def from_config(cls, config: Any) -> AGEBackend:
         """Create an AGEBackend from an AGEConfig object.
 
-        ADR-084 boundary: if ``config.url`` is a ``SecretStr`` it is unwrapped
-        exactly here so the SQLAlchemy engine receives a plaintext DSN.
+        If ``config.url`` is a ``SecretStr`` it is unwrapped exactly here so
+        the SQLAlchemy engine receives a plaintext DSN.
         """
         from pydantic import SecretStr
 

--- a/src/khora/storage/backends/memgraph.py
+++ b/src/khora/storage/backends/memgraph.py
@@ -52,11 +52,20 @@ class MemgraphBackend(GraphBackendBase):
 
     @classmethod
     def from_config(cls, config: Any) -> MemgraphBackend:
-        """Create a MemgraphBackend from a MemgraphConfig object."""
+        """Create a MemgraphBackend from a MemgraphConfig object.
+
+        ADR-084 boundary: ``config.password`` is unwrapped from ``SecretStr``
+        here so the driver receives a plaintext credential.
+        """
+        from pydantic import SecretStr
+
+        password = config.password
+        if isinstance(password, SecretStr):
+            password = password.get_secret_value()
         return cls(
             url=config.url or "bolt://localhost:7687",
             user=config.user,
-            password=config.password,
+            password=password,
         )
 
     # ------------------------------------------------------------------

--- a/src/khora/storage/backends/memgraph.py
+++ b/src/khora/storage/backends/memgraph.py
@@ -54,8 +54,8 @@ class MemgraphBackend(GraphBackendBase):
     def from_config(cls, config: Any) -> MemgraphBackend:
         """Create a MemgraphBackend from a MemgraphConfig object.
 
-        ADR-084 boundary: ``config.password`` and ``config.url`` are unwrapped
-        from ``SecretStr`` here so the driver receives plaintext.
+        ``config.password`` and ``config.url`` are unwrapped from
+        ``SecretStr`` here so the driver receives plaintext.
         """
         from pydantic import SecretStr
 

--- a/src/khora/storage/backends/memgraph.py
+++ b/src/khora/storage/backends/memgraph.py
@@ -54,16 +54,19 @@ class MemgraphBackend(GraphBackendBase):
     def from_config(cls, config: Any) -> MemgraphBackend:
         """Create a MemgraphBackend from a MemgraphConfig object.
 
-        ADR-084 boundary: ``config.password`` is unwrapped from ``SecretStr``
-        here so the driver receives a plaintext credential.
+        ADR-084 boundary: ``config.password`` and ``config.url`` are unwrapped
+        from ``SecretStr`` here so the driver receives plaintext.
         """
         from pydantic import SecretStr
 
         password = config.password
         if isinstance(password, SecretStr):
             password = password.get_secret_value()
+        url = config.url
+        if isinstance(url, SecretStr):
+            url = url.get_secret_value()
         return cls(
-            url=config.url or "bolt://localhost:7687",
+            url=url or "bolt://localhost:7687",
             user=config.user,
             password=password,
         )

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -478,9 +478,9 @@ class Neo4jBackend(GraphBackendBase):
     def from_config(cls, config: Any) -> Neo4jBackend:
         """Create a Neo4jBackend from a Neo4jConfig object.
 
-        ADR-084 boundary: ``config.password`` and ``config.url`` are
-        ``pydantic.SecretStr`` (or a plain ``str`` if a non-Pydantic dataclass
-        is passed). Unwrap exactly here so the driver receives plaintext.
+        ``config.password`` and ``config.url`` are ``pydantic.SecretStr``
+        (or a plain ``str`` if a non-Pydantic dataclass is passed). Unwrap
+        exactly here so the driver receives plaintext.
         """
         from pydantic import SecretStr
 

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -476,11 +476,21 @@ class Neo4jBackend(GraphBackendBase):
 
     @classmethod
     def from_config(cls, config: Any) -> Neo4jBackend:
-        """Create a Neo4jBackend from a Neo4jConfig object."""
+        """Create a Neo4jBackend from a Neo4jConfig object.
+
+        ADR-084 boundary: ``config.password`` is a ``pydantic.SecretStr`` (or a
+        plain ``str`` if a non-Pydantic dataclass is passed). Unwrap exactly
+        here so the driver receives the plaintext credential.
+        """
+        from pydantic import SecretStr
+
+        password = config.password
+        if isinstance(password, SecretStr):
+            password = password.get_secret_value()
         return cls(
             url=config.url or "",
             user=config.user,
-            password=config.password,
+            password=password,
             database=config.database,
             max_connection_pool_size=getattr(config, "max_connection_pool_size", 100),
             connection_acquisition_timeout=getattr(config, "connection_acquisition_timeout", 60.0),

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -478,17 +478,20 @@ class Neo4jBackend(GraphBackendBase):
     def from_config(cls, config: Any) -> Neo4jBackend:
         """Create a Neo4jBackend from a Neo4jConfig object.
 
-        ADR-084 boundary: ``config.password`` is a ``pydantic.SecretStr`` (or a
-        plain ``str`` if a non-Pydantic dataclass is passed). Unwrap exactly
-        here so the driver receives the plaintext credential.
+        ADR-084 boundary: ``config.password`` and ``config.url`` are
+        ``pydantic.SecretStr`` (or a plain ``str`` if a non-Pydantic dataclass
+        is passed). Unwrap exactly here so the driver receives plaintext.
         """
         from pydantic import SecretStr
 
         password = config.password
         if isinstance(password, SecretStr):
             password = password.get_secret_value()
+        url = config.url
+        if isinstance(url, SecretStr):
+            url = url.get_secret_value()
         return cls(
-            url=config.url or "",
+            url=url or "",
             user=config.user,
             password=password,
             database=config.database,

--- a/src/khora/storage/backends/neptune.py
+++ b/src/khora/storage/backends/neptune.py
@@ -60,11 +60,20 @@ class NeptuneBackend(GraphBackendBase):
 
     @classmethod
     def from_config(cls, config: Any) -> NeptuneBackend:
-        """Create a NeptuneBackend from a NeptuneConfig object."""
+        """Create a NeptuneBackend from a NeptuneConfig object.
+
+        ADR-084 boundary: ``config.password`` is unwrapped from ``SecretStr``
+        here so the driver receives a plaintext credential.
+        """
+        from pydantic import SecretStr
+
+        password = config.password
+        if isinstance(password, SecretStr):
+            password = password.get_secret_value()
         return cls(
             url=config.url or "bolt://localhost:8182",
             user=config.user,
-            password=config.password,
+            password=password,
             iam_auth=config.iam_auth,
             aws_region=config.aws_region,
             max_connection_pool_size=config.max_connection_pool_size,

--- a/src/khora/storage/backends/neptune.py
+++ b/src/khora/storage/backends/neptune.py
@@ -62,8 +62,8 @@ class NeptuneBackend(GraphBackendBase):
     def from_config(cls, config: Any) -> NeptuneBackend:
         """Create a NeptuneBackend from a NeptuneConfig object.
 
-        ADR-084 boundary: ``config.password`` and ``config.url`` are unwrapped
-        from ``SecretStr`` here so the driver receives plaintext.
+        ``config.password`` and ``config.url`` are unwrapped from
+        ``SecretStr`` here so the driver receives plaintext.
         """
         from pydantic import SecretStr
 

--- a/src/khora/storage/backends/neptune.py
+++ b/src/khora/storage/backends/neptune.py
@@ -62,16 +62,19 @@ class NeptuneBackend(GraphBackendBase):
     def from_config(cls, config: Any) -> NeptuneBackend:
         """Create a NeptuneBackend from a NeptuneConfig object.
 
-        ADR-084 boundary: ``config.password`` is unwrapped from ``SecretStr``
-        here so the driver receives a plaintext credential.
+        ADR-084 boundary: ``config.password`` and ``config.url`` are unwrapped
+        from ``SecretStr`` here so the driver receives plaintext.
         """
         from pydantic import SecretStr
 
         password = config.password
         if isinstance(password, SecretStr):
             password = password.get_secret_value()
+        url = config.url
+        if isinstance(url, SecretStr):
+            url = url.get_secret_value()
         return cls(
-            url=config.url or "bolt://localhost:8182",
+            url=url or "bolt://localhost:8182",
             user=config.user,
             password=password,
             iam_auth=config.iam_auth,

--- a/src/khora/storage/backends/surrealdb/event_store.py
+++ b/src/khora/storage/backends/surrealdb/event_store.py
@@ -62,6 +62,11 @@ class SurrealDBEventStoreAdapter:
         ``password``.  All are optional and fall back to SurrealDBConnection
         defaults.
         """
+        from pydantic import SecretStr
+
+        password = config.get("password", "root")
+        if isinstance(password, SecretStr):
+            password = password.get_secret_value()
         conn = SurrealDBConnection(
             mode=config.get("mode", "memory"),
             path=config.get("path"),
@@ -69,7 +74,7 @@ class SurrealDBEventStoreAdapter:
             namespace=config.get("namespace", "khora"),
             database=config.get("database", "default"),
             user=config.get("user", "root"),
-            password=config.get("password", "root"),
+            password=password,
         )
         return cls(connection=conn)
 

--- a/src/khora/storage/backends/surrealdb/graph.py
+++ b/src/khora/storage/backends/surrealdb/graph.py
@@ -192,13 +192,23 @@ class SurrealDBGraphAdapter:
 
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> SurrealDBGraphAdapter:
-        """Create an adapter from a configuration dictionary."""
+        """Create an adapter from a configuration dictionary.
+
+        ADR-084 boundary: ``password`` is unwrapped from
+        ``pydantic.SecretStr`` if needed so the driver receives a plaintext
+        credential.
+        """
+        from pydantic import SecretStr
+
         from khora.storage.backends.surrealdb.connection import SurrealDBConnection
 
         conn_kwargs: dict[str, Any] = {}
         for key in ("mode", "path", "url", "namespace", "database", "user", "password"):
             if key in config:
-                conn_kwargs[key] = config[key]
+                value = config[key]
+                if key == "password" and isinstance(value, SecretStr):
+                    value = value.get_secret_value()
+                conn_kwargs[key] = value
 
         connection = SurrealDBConnection(**conn_kwargs)
         return cls(connection)

--- a/src/khora/storage/backends/surrealdb/graph.py
+++ b/src/khora/storage/backends/surrealdb/graph.py
@@ -194,9 +194,8 @@ class SurrealDBGraphAdapter:
     def from_config(cls, config: dict[str, Any]) -> SurrealDBGraphAdapter:
         """Create an adapter from a configuration dictionary.
 
-        ADR-084 boundary: ``password`` is unwrapped from
-        ``pydantic.SecretStr`` if needed so the driver receives a plaintext
-        credential.
+        ``password`` is unwrapped from ``pydantic.SecretStr`` if needed so
+        the driver receives a plaintext credential.
         """
         from pydantic import SecretStr
 

--- a/src/khora/storage/backends/surrealdb/relational.py
+++ b/src/khora/storage/backends/surrealdb/relational.py
@@ -53,6 +53,11 @@ class SurrealDBRelationalAdapter:
         ``password``.  All are optional and fall back to SurrealDBConnection
         defaults.
         """
+        from pydantic import SecretStr
+
+        password = config.get("password", "root")
+        if isinstance(password, SecretStr):
+            password = password.get_secret_value()
         conn = SurrealDBConnection(
             mode=config.get("mode", "memory"),
             path=config.get("path"),
@@ -60,7 +65,7 @@ class SurrealDBRelationalAdapter:
             namespace=config.get("namespace", "khora"),
             database=config.get("database", "default"),
             user=config.get("user", "root"),
-            password=config.get("password", "root"),
+            password=password,
         )
         return cls(connection=conn)
 

--- a/src/khora/storage/backends/surrealdb/vector.py
+++ b/src/khora/storage/backends/surrealdb/vector.py
@@ -62,14 +62,21 @@ class SurrealDBVectorAdapter:
         """Create an adapter from a configuration dictionary.
 
         Expected keys mirror :class:`SurrealDBConnection` init args, plus
-        optional ``hnsw_ef_search``.
+        optional ``hnsw_ef_search``. ADR-084 boundary: ``password`` is
+        unwrapped from ``pydantic.SecretStr`` if needed so the driver
+        receives a plaintext credential.
         """
+        from pydantic import SecretStr
+
         from khora.storage.backends.surrealdb.connection import SurrealDBConnection
 
         conn_kwargs: dict[str, Any] = {}
         for key in ("mode", "path", "url", "namespace", "database", "user", "password"):
             if key in config:
-                conn_kwargs[key] = config[key]
+                value = config[key]
+                if key == "password" and isinstance(value, SecretStr):
+                    value = value.get_secret_value()
+                conn_kwargs[key] = value
 
         connection = SurrealDBConnection(**conn_kwargs)
         return cls(connection, hnsw_ef_search=config.get("hnsw_ef_search", 100))

--- a/src/khora/storage/backends/surrealdb/vector.py
+++ b/src/khora/storage/backends/surrealdb/vector.py
@@ -62,9 +62,9 @@ class SurrealDBVectorAdapter:
         """Create an adapter from a configuration dictionary.
 
         Expected keys mirror :class:`SurrealDBConnection` init args, plus
-        optional ``hnsw_ef_search``. ADR-084 boundary: ``password`` and
-        ``url`` are unwrapped from ``pydantic.SecretStr`` if needed so the
-        driver receives plaintext credentials / DSN.
+        optional ``hnsw_ef_search``. ``password`` and ``url`` are unwrapped
+        from ``pydantic.SecretStr`` if needed so the driver receives
+        plaintext credentials / DSN.
         """
         from pydantic import SecretStr
 

--- a/src/khora/storage/backends/surrealdb/vector.py
+++ b/src/khora/storage/backends/surrealdb/vector.py
@@ -62,9 +62,9 @@ class SurrealDBVectorAdapter:
         """Create an adapter from a configuration dictionary.
 
         Expected keys mirror :class:`SurrealDBConnection` init args, plus
-        optional ``hnsw_ef_search``. ADR-084 boundary: ``password`` is
-        unwrapped from ``pydantic.SecretStr`` if needed so the driver
-        receives a plaintext credential.
+        optional ``hnsw_ef_search``. ADR-084 boundary: ``password`` and
+        ``url`` are unwrapped from ``pydantic.SecretStr`` if needed so the
+        driver receives plaintext credentials / DSN.
         """
         from pydantic import SecretStr
 
@@ -74,7 +74,7 @@ class SurrealDBVectorAdapter:
         for key in ("mode", "path", "url", "namespace", "database", "user", "password"):
             if key in config:
                 value = config[key]
-                if key == "password" and isinstance(value, SecretStr):
+                if key in ("password", "url") and isinstance(value, SecretStr):
                     value = value.get_secret_value()
                 conn_kwargs[key] = value
 

--- a/src/khora/storage/factory.py
+++ b/src/khora/storage/factory.py
@@ -395,12 +395,19 @@ class StorageFactory:
 
             # Create a shared SurrealDB connection for all four adapters
             try:
+                # ADR-084 boundary: SurrealDBConfig.password is a SecretStr;
+                # unwrap exactly here so the driver receives the plaintext.
+                from pydantic import SecretStr as _SecretStr
+
                 from .backends.surrealdb.connection import SurrealDBConnection
                 from .backends.surrealdb.event_store import SurrealDBEventStoreAdapter
                 from .backends.surrealdb.graph import SurrealDBGraphAdapter
                 from .backends.surrealdb.relational import SurrealDBRelationalAdapter
                 from .backends.surrealdb.vector import SurrealDBVectorAdapter
 
+                surreal_password = getattr(surreal_config, "password", "root")
+                if isinstance(surreal_password, _SecretStr):
+                    surreal_password = surreal_password.get_secret_value()
                 conn = SurrealDBConnection(
                     mode=getattr(surreal_config, "mode", "memory"),
                     path=getattr(surreal_config, "path", None),
@@ -408,7 +415,7 @@ class StorageFactory:
                     namespace=getattr(surreal_config, "namespace", "khora"),
                     database=getattr(surreal_config, "database", "default"),
                     user=getattr(surreal_config, "user", "root"),
-                    password=getattr(surreal_config, "password", "root"),
+                    password=surreal_password,
                     sync_data=getattr(surreal_config, "sync_data", True),
                 )
                 return StorageCoordinator(

--- a/src/khora/storage/factory.py
+++ b/src/khora/storage/factory.py
@@ -239,7 +239,12 @@ class StorageFactory:
             backend_name = getattr(vector_config, "backend", None)
             if backend_name == "pgvector":
                 # PgVectorBackend has a specialized constructor
+                # ADR-084 boundary: PgVectorConfig.url is a SecretStr; unwrap here.
+                from pydantic import SecretStr as _SecretStr
+
                 url = getattr(vector_config, "url", None)
+                if isinstance(url, _SecretStr):
+                    url = url.get_secret_value()
                 if not url:
                     logger.warning("pgvector URL not configured, vector backend disabled")
                     return None
@@ -324,13 +329,23 @@ class StorageFactory:
         role: str,
     ) -> Any | None:
         """Create a backend instance from registry via lazy import + from_config()."""
+        from pydantic import SecretStr as _SecretStr
+
+        def _surrealdb_cache_key(cfg: Any) -> str:
+            # ADR-084: unwrap SecretStr url so cache keys are plain strings.
+            raw_url = getattr(cfg, "url", None)
+            if isinstance(raw_url, _SecretStr):
+                raw_url = raw_url.get_secret_value()
+            url = raw_url or ""
+            path = getattr(cfg, "path", None) or ""
+            mode = getattr(cfg, "mode", "memory")
+            return f"surrealdb:{mode}:{url}:{path}"
+
         if backend_name == "surrealdb":
             # SurrealDB dual-role: reuse instance for same endpoint
-            url = getattr(config, "url", None) or ""
-            path = getattr(config, "path", None) or ""
-            mode = getattr(config, "mode", "memory")
-            cache_key = f"surrealdb:{mode}:{url}:{path}"
+            cache_key = _surrealdb_cache_key(config)
             if cache_key in _surrealdb_instances:
+                mode = getattr(config, "mode", "memory")
                 logger.info(f"Reusing SurrealDB instance for {role} role (mode={mode})")
                 return _surrealdb_instances[cache_key]
 
@@ -346,10 +361,7 @@ class StorageFactory:
         instance = cls.from_config(config)
 
         if backend_name == "surrealdb":
-            url = getattr(config, "url", None) or ""
-            path = getattr(config, "path", None) or ""
-            mode = getattr(config, "mode", "memory")
-            _surrealdb_instances[f"surrealdb:{mode}:{url}:{path}"] = instance
+            _surrealdb_instances[_surrealdb_cache_key(config)] = instance
 
         return instance
 
@@ -408,10 +420,13 @@ class StorageFactory:
                 surreal_password = getattr(surreal_config, "password", "root")
                 if isinstance(surreal_password, _SecretStr):
                     surreal_password = surreal_password.get_secret_value()
+                surreal_url = getattr(surreal_config, "url", None)
+                if isinstance(surreal_url, _SecretStr):
+                    surreal_url = surreal_url.get_secret_value()
                 conn = SurrealDBConnection(
                     mode=getattr(surreal_config, "mode", "memory"),
                     path=getattr(surreal_config, "path", None),
-                    url=getattr(surreal_config, "url", None),
+                    url=surreal_url,
                     namespace=getattr(surreal_config, "namespace", "khora"),
                     database=getattr(surreal_config, "database", "default"),
                     user=getattr(surreal_config, "user", "root"),

--- a/src/khora/storage/factory.py
+++ b/src/khora/storage/factory.py
@@ -239,7 +239,7 @@ class StorageFactory:
             backend_name = getattr(vector_config, "backend", None)
             if backend_name == "pgvector":
                 # PgVectorBackend has a specialized constructor
-                # ADR-084 boundary: PgVectorConfig.url is a SecretStr; unwrap here.
+                # PgVectorConfig.url is a SecretStr; unwrap here.
                 from pydantic import SecretStr as _SecretStr
 
                 url = getattr(vector_config, "url", None)
@@ -332,7 +332,7 @@ class StorageFactory:
         from pydantic import SecretStr as _SecretStr
 
         def _surrealdb_cache_key(cfg: Any) -> str:
-            # ADR-084: unwrap SecretStr url so cache keys are plain strings.
+            # Unwrap SecretStr url so cache keys are plain strings.
             raw_url = getattr(cfg, "url", None)
             if isinstance(raw_url, _SecretStr):
                 raw_url = raw_url.get_secret_value()
@@ -407,8 +407,8 @@ class StorageFactory:
 
             # Create a shared SurrealDB connection for all four adapters
             try:
-                # ADR-084 boundary: SurrealDBConfig.password is a SecretStr;
-                # unwrap exactly here so the driver receives the plaintext.
+                # SurrealDBConfig.password is a SecretStr; unwrap exactly
+                # here so the driver receives the plaintext.
                 from pydantic import SecretStr as _SecretStr
 
                 from .backends.surrealdb.connection import SurrealDBConnection

--- a/src/khora/telemetry/__init__.py
+++ b/src/khora/telemetry/__init__.py
@@ -90,7 +90,10 @@ async def init_telemetry(config: TelemetryConfig | None = None) -> TelemetryColl
 
     from .session import create_telemetry_engine
 
-    engine = create_telemetry_engine(config.database_url)
+    # ADR-084 boundary: TelemetryConfig.database_url is a SecretStr; unwrap
+    # exactly here so the SQLAlchemy engine receives the plaintext DSN.
+    database_url = config.database_url.get_secret_value()
+    engine = create_telemetry_engine(database_url)
     _collector = TelemetryCollector(
         engine,
         service_name=config.service_name,

--- a/src/khora/telemetry/__init__.py
+++ b/src/khora/telemetry/__init__.py
@@ -90,8 +90,8 @@ async def init_telemetry(config: TelemetryConfig | None = None) -> TelemetryColl
 
     from .session import create_telemetry_engine
 
-    # ADR-084 boundary: TelemetryConfig.database_url is a SecretStr; unwrap
-    # exactly here so the SQLAlchemy engine receives the plaintext DSN.
+    # TelemetryConfig.database_url is a SecretStr; unwrap exactly here so
+    # the SQLAlchemy engine receives the plaintext DSN.
     database_url = config.database_url.get_secret_value()
     engine = create_telemetry_engine(database_url)
     _collector = TelemetryCollector(

--- a/src/khora/telemetry/config.py
+++ b/src/khora/telemetry/config.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import os
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SecretStr
 
 
 class TelemetryConfig(BaseModel):
     """Configuration for the telemetry subsystem."""
 
-    database_url: str | None = Field(
+    database_url: SecretStr | None = Field(
         default=None,
-        description="PostgreSQL URL for telemetry database",
+        description="PostgreSQL URL for telemetry database (ADR-084 SecretStr)",
     )
     service_name: str = Field(
         default="khora",

--- a/src/khora/telemetry/config.py
+++ b/src/khora/telemetry/config.py
@@ -12,7 +12,7 @@ class TelemetryConfig(BaseModel):
 
     database_url: SecretStr | None = Field(
         default=None,
-        description="PostgreSQL URL for telemetry database (ADR-084 SecretStr)",
+        description="PostgreSQL URL for telemetry database (SecretStr)",
     )
     service_name: str = Field(
         default="khora",

--- a/tests/unit/test_adr084_secret_typing.py
+++ b/tests/unit/test_adr084_secret_typing.py
@@ -23,6 +23,7 @@ from pydantic import SecretStr
 from khora.config._secrets import redact_dsn
 from khora.config.schema import (
     KhoraConfig,
+    LLMSettings,
     MemgraphConfig,
     Neo4jConfig,
     NeptuneConfig,
@@ -112,6 +113,52 @@ class TestSecretStrFieldTypes:
         parsed = ParsedNeo4jUrl.parse("bolt://user:hunter2@h:7687")
         assert isinstance(parsed.password, SecretStr)
         assert parsed.password.get_secret_value() == "hunter2"
+
+    def test_neo4j_config_url_is_secretstr(self) -> None:
+        cfg = Neo4jConfig(url="bolt://user:hunter2@h:7687")
+        assert isinstance(cfg.url, SecretStr)
+        assert cfg.url.get_secret_value() == "bolt://user:hunter2@h:7687"
+
+    def test_memgraph_config_url_is_secretstr(self) -> None:
+        cfg = MemgraphConfig(url="bolt://user:hunter2@h:7687")
+        assert isinstance(cfg.url, SecretStr)
+        assert cfg.url.get_secret_value() == "bolt://user:hunter2@h:7687"
+
+    def test_neptune_config_url_is_secretstr(self) -> None:
+        cfg = NeptuneConfig(url="bolt://user:hunter2@h:8182")
+        assert isinstance(cfg.url, SecretStr)
+        assert cfg.url.get_secret_value() == "bolt://user:hunter2@h:8182"
+
+    def test_surrealdb_config_url_is_secretstr(self) -> None:
+        cfg = SurrealDBConfig(url="ws://user:hunter2@h:8000")
+        assert isinstance(cfg.url, SecretStr)
+        assert cfg.url.get_secret_value() == "ws://user:hunter2@h:8000"
+
+    def test_surrealdb_vector_config_url_is_secretstr(self) -> None:
+        cfg = SurrealDBVectorConfig(url="ws://user:hunter2@h:8000")
+        assert isinstance(cfg.url, SecretStr)
+        assert cfg.url.get_secret_value() == "ws://user:hunter2@h:8000"
+
+    def test_llm_settings_has_no_v1_scope_secret_fields(self) -> None:
+        """v1-scope guard: LLMSettings carries no secret-typed fields today.
+
+        ``LLMSettings.api_key_env`` is an env-var-name pointer (per ADR-084
+        §📌 baseline scope-inflation note), so it stays plain ``str``. If a
+        future refactor adds an in-scope field (e.g. ``api_key: str``), this
+        test must be updated to either re-type it as ``SecretStr`` or to
+        explicitly carve it out — locking down the v1-scope boundary in
+        the test surface so the change cannot land silently.
+        """
+        settings = LLMSettings()
+        # api_key_env is a pointer (env-var name), not a secret value.
+        assert isinstance(settings.api_key_env, str)
+        # Enumerate every field and assert nothing has slipped into v1-scope
+        # without being typed as SecretStr.
+        for name, field in LLMSettings.model_fields.items():
+            assert field.annotation is not SecretStr, (
+                f"LLMSettings.{name} is typed as SecretStr — update this v1-scope "
+                "guard test (it is now in-scope and must be enumerated explicitly)."
+            )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_adr084_secret_typing.py
+++ b/tests/unit/test_adr084_secret_typing.py
@@ -1,0 +1,221 @@
+"""ADR-084 v1-scope SecretStr re-typing — contract tests.
+
+Covers:
+
+* every v1-scope Pydantic password / DSN field is typed as
+  :class:`pydantic.SecretStr` (or ``SecretStr | None``).
+* ``repr()`` and ``model_dump_json()`` of those fields never leak the
+  underlying plaintext.
+* the local ``khora.config._secrets.redact_dsn`` helper scrubs ``user:pass@``
+  userinfo from arbitrary text.
+* migration-error wrapping in ``khora.db.session._run_migrations_sync``
+  routes through ``redact_dsn`` so plaintext DSNs cannot reach the returned
+  ``MigrationResult.error`` string.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import SecretStr
+
+from khora.config._secrets import redact_dsn
+from khora.config.schema import (
+    KhoraConfig,
+    MemgraphConfig,
+    Neo4jConfig,
+    NeptuneConfig,
+    ParsedNeo4jUrl,
+    StorageSettings,
+    SurrealDBConfig,
+    SurrealDBVectorConfig,
+)
+from khora.telemetry.config import TelemetryConfig
+
+
+@pytest.mark.unit
+class TestSecretStrFieldTypes:
+    """Every v1-scope Pydantic password / DSN field is typed as SecretStr."""
+
+    def test_neo4j_config_password_is_secretstr(self) -> None:
+        cfg = Neo4jConfig(password="hunter2")
+        assert isinstance(cfg.password, SecretStr)
+        assert cfg.password.get_secret_value() == "hunter2"
+
+    def test_memgraph_config_password_is_secretstr(self) -> None:
+        cfg = MemgraphConfig(password="hunter2")
+        assert isinstance(cfg.password, SecretStr)
+        assert cfg.password.get_secret_value() == "hunter2"
+
+    def test_neptune_config_password_is_secretstr(self) -> None:
+        cfg = NeptuneConfig(password="hunter2")
+        assert isinstance(cfg.password, SecretStr)
+        assert cfg.password.get_secret_value() == "hunter2"
+
+    def test_surrealdb_config_password_is_secretstr(self) -> None:
+        cfg = SurrealDBConfig(password="hunter2")
+        assert isinstance(cfg.password, SecretStr)
+        assert cfg.password.get_secret_value() == "hunter2"
+
+    def test_surrealdb_vector_config_password_is_secretstr(self) -> None:
+        cfg = SurrealDBVectorConfig(password="hunter2")
+        assert isinstance(cfg.password, SecretStr)
+        assert cfg.password.get_secret_value() == "hunter2"
+
+    def test_storage_settings_neo4j_password_is_secretstr(self) -> None:
+        settings = StorageSettings(neo4j_password="hunter2")
+        assert isinstance(settings.neo4j_password, SecretStr)
+        assert settings.neo4j_password.get_secret_value() == "hunter2"
+
+    def test_storage_settings_postgresql_url_is_secretstr(self) -> None:
+        settings = StorageSettings(postgresql_url="postgresql://u:p@h/d")
+        assert isinstance(settings.postgresql_url, SecretStr)
+        assert settings.postgresql_url.get_secret_value() == "postgresql://u:p@h/d"
+
+    def test_storage_settings_pgvector_url_is_secretstr(self) -> None:
+        settings = StorageSettings(pgvector_url="postgresql://u:p@h/d")
+        assert isinstance(settings.pgvector_url, SecretStr)
+        assert settings.pgvector_url.get_secret_value() == "postgresql://u:p@h/d"
+
+    def test_storage_settings_neo4j_url_is_secretstr(self) -> None:
+        # Construct without legacy migration kicking in (no neo4j_user/password
+        # to avoid the legacy → new-style graph migration that consumes
+        # ``neo4j_url``).
+        settings = StorageSettings.model_construct(
+            neo4j_url=SecretStr("bolt://u:p@h:7687"),
+        )
+        assert isinstance(settings.neo4j_url, SecretStr)
+        assert settings.neo4j_url.get_secret_value() == "bolt://u:p@h:7687"
+
+    def test_khora_config_database_url_is_secretstr(self) -> None:
+        cfg = KhoraConfig(database_url="postgresql://u:p@h/d")
+        assert isinstance(cfg.database_url, SecretStr)
+        assert cfg.database_url.get_secret_value() == "postgresql://u:p@h/d"
+
+    def test_khora_config_neo4j_url_is_secretstr(self) -> None:
+        cfg = KhoraConfig(neo4j_url="bolt://u:p@h:7687")
+        assert isinstance(cfg.neo4j_url, SecretStr)
+        assert cfg.neo4j_url.get_secret_value() == "bolt://u:p@h:7687"
+
+    def test_khora_config_telemetry_database_url_is_secretstr(self) -> None:
+        cfg = KhoraConfig(telemetry_database_url="postgresql://u:p@h/t")
+        assert isinstance(cfg.telemetry_database_url, SecretStr)
+        assert cfg.telemetry_database_url.get_secret_value() == "postgresql://u:p@h/t"
+
+    def test_telemetry_config_database_url_is_secretstr(self) -> None:
+        cfg = TelemetryConfig(database_url="postgresql://u:p@h/t")
+        assert isinstance(cfg.database_url, SecretStr)
+        assert cfg.database_url.get_secret_value() == "postgresql://u:p@h/t"
+
+    def test_parsed_neo4j_url_password_is_secretstr(self) -> None:
+        parsed = ParsedNeo4jUrl.parse("bolt://user:hunter2@h:7687")
+        assert isinstance(parsed.password, SecretStr)
+        assert parsed.password.get_secret_value() == "hunter2"
+
+
+@pytest.mark.unit
+class TestNoPlaintextLeakInReprOrJson:
+    """SecretStr fields must not leak the plaintext in ``repr`` / JSON dump."""
+
+    def test_neo4j_config_repr_redacts(self) -> None:
+        cfg = Neo4jConfig(url="bolt://localhost:7687", password="hunter2")
+        assert "hunter2" not in repr(cfg)
+        # SecretStr's masked repr is the deliberate hint that redaction happened.
+        assert "**********" in repr(cfg)
+
+    def test_khora_config_database_url_repr_redacts(self) -> None:
+        cfg = KhoraConfig(database_url="postgresql://alice:hunter2@db:5432/app")
+        # Whole DSN, including userinfo, is wrapped — SecretStr masks the
+        # entire string, not just the userinfo.
+        assert "hunter2" not in repr(cfg)
+        assert "alice" not in repr(cfg)
+
+    def test_storage_settings_json_dump_redacts(self) -> None:
+        settings = StorageSettings(neo4j_password="hunter2", postgresql_url="postgresql://u:p@h/d")
+        # ``model_dump_json`` masks SecretStr by default
+        dumped = json.loads(settings.model_dump_json())
+        assert dumped["neo4j_password"] != "hunter2"
+        assert dumped["postgresql_url"] != "postgresql://u:p@h/d"
+
+
+@pytest.mark.unit
+class TestRedactDsn:
+    """``redact_dsn`` scrubs userinfo from DSN-shaped strings."""
+
+    @pytest.mark.parametrize(
+        ("inp", "expected"),
+        [
+            (
+                "postgresql://alice:hunter2@db:5432/app",
+                "postgresql://[REDACTED]@db:5432/app",
+            ),
+            (
+                "postgresql+asyncpg://u:p@h/d",
+                "postgresql+asyncpg://[REDACTED]@h/d",
+            ),
+            (
+                "bolt://neo4j:hunter2@cluster.example.com:7687",
+                "bolt://[REDACTED]@cluster.example.com:7687",
+            ),
+            # No userinfo → unchanged
+            ("postgresql://localhost:5432/app", "postgresql://localhost:5432/app"),
+            # Empty / non-DSN strings → unchanged
+            ("", ""),
+            ("just some text", "just some text"),
+        ],
+    )
+    def test_redact_dsn_cases(self, inp: str, expected: str) -> None:
+        assert redact_dsn(inp) == expected
+
+    def test_redact_dsn_inside_error_message(self) -> None:
+        """Mimics how driver errors embed the DSN in their message."""
+        msg = (
+            "connection failed: could not translate host name "
+            "for postgresql://alice:hunter2@db:5432/app (Name or service not known)"
+        )
+        out = redact_dsn(msg)
+        assert "hunter2" not in out
+        assert "alice" not in out
+        assert "[REDACTED]" in out
+
+
+@pytest.mark.unit
+class TestMigrationErrorRedaction:
+    """``_run_migrations_sync`` redacts DSN userinfo from the returned error."""
+
+    def test_invalid_url_error_is_redacted(self) -> None:
+        """A bogus URL surfaces a driver error containing the userinfo; the
+        wrapper must scrub it before returning the :class:`MigrationResult`.
+
+        We exercise the sync helper directly so the test stays in-process and
+        does not need a real database.
+        """
+        from khora.db.session import _run_migrations_sync
+
+        # An unsupported scheme + embedded credentials triggers SQLAlchemy's
+        # ``NoSuchModuleError`` (or equivalent) — the message includes the URL.
+        url = "definitely-not-a-real-scheme://alice:hunter2@localhost/db"
+        result = _run_migrations_sync(database_url=url)
+        assert result.success is False
+        assert result.error is not None
+        assert "hunter2" not in result.error
+        assert "alice" not in result.error
+
+    def test_no_url_returns_explicit_error(self) -> None:
+        """When no URL is passed and the env var is unset, the helper returns a
+        descriptive error that does not contain any DSN userinfo.
+        """
+        import os
+
+        from khora.db.session import _run_migrations_sync
+
+        prev = os.environ.pop("KHORA_DATABASE_URL", None)
+        try:
+            result = _run_migrations_sync(database_url=None)
+        finally:
+            if prev is not None:
+                os.environ["KHORA_DATABASE_URL"] = prev
+        assert result.success is False
+        assert result.error is not None
+        assert "@" not in result.error  # no userinfo at all

--- a/tests/unit/test_age_backend.py
+++ b/tests/unit/test_age_backend.py
@@ -294,7 +294,7 @@ class TestAGEConfig:
             pool_size=5,
             max_overflow=10,
         )
-        assert config.url == "postgresql://localhost:5432/khora"
+        assert config.url.get_secret_value() == "postgresql://localhost:5432/khora"
         assert config.graph_name == "my_graph"
         assert config.pool_size == 5
         assert config.max_overflow == 10

--- a/tests/unit/test_config_backends.py
+++ b/tests/unit/test_config_backends.py
@@ -27,10 +27,10 @@ class TestStorageSettingsBackwardsCompat:
             neo4j_database="mydb",
         )
         assert isinstance(settings.graph, Neo4jConfig)
-        # ADR-084: url is SecretStr — unwrap to compare plaintext.
+        # url is SecretStr — unwrap to compare plaintext.
         assert settings.graph.url.get_secret_value() == "bolt://localhost:7687"
         assert settings.graph.user == "admin"
-        # ADR-084: password is SecretStr — unwrap to compare plaintext.
+        # password is SecretStr — unwrap to compare plaintext.
         assert settings.graph.password.get_secret_value() == "secret"
         assert settings.graph.database == "mydb"
 
@@ -186,7 +186,7 @@ class TestKhoraConfigGraphHelpers:
         assert isinstance(graph, Neo4jConfig)
         assert graph.url.get_secret_value() == "bolt://localhost:7687"
         assert graph.user == "neo4j"
-        # ADR-084: password is SecretStr — unwrap to compare plaintext.
+        # password is SecretStr — unwrap to compare plaintext.
         assert graph.password.get_secret_value() == "pass"
 
     def test_get_graph_config_kuzu(self):
@@ -283,7 +283,7 @@ class TestParsedNeo4jUrl:
 
     def test_parse_respects_default_password_when_url_has_none(self) -> None:
         parsed = ParsedNeo4jUrl.parse("bolt://localhost:7687", default_password="fallbackpass")
-        # ADR-084: ParsedNeo4jUrl.password is SecretStr — unwrap to compare.
+        # ParsedNeo4jUrl.password is SecretStr — unwrap to compare.
         assert parsed.password.get_secret_value() == "fallbackpass"
 
     def test_parse_embedded_password_overrides_default(self) -> None:

--- a/tests/unit/test_config_backends.py
+++ b/tests/unit/test_config_backends.py
@@ -27,7 +27,8 @@ class TestStorageSettingsBackwardsCompat:
             neo4j_database="mydb",
         )
         assert isinstance(settings.graph, Neo4jConfig)
-        assert settings.graph.url == "bolt://localhost:7687"
+        # ADR-084: url is SecretStr — unwrap to compare plaintext.
+        assert settings.graph.url.get_secret_value() == "bolt://localhost:7687"
         assert settings.graph.user == "admin"
         # ADR-084: password is SecretStr — unwrap to compare plaintext.
         assert settings.graph.password.get_secret_value() == "secret"
@@ -39,7 +40,7 @@ class TestStorageSettingsBackwardsCompat:
             embedding_dimension=768,
         )
         assert isinstance(settings.vector, PgVectorConfig)
-        assert settings.vector.url == "postgresql://localhost:5432/vectors"
+        assert settings.vector.url.get_secret_value() == "postgresql://localhost:5432/vectors"
         assert settings.vector.embedding_dimension == 768
 
     def test_new_style_graph_config_takes_precedence(self):
@@ -78,7 +79,7 @@ class TestDiscriminatedUnionParsing:
             }
         )
         assert isinstance(settings.graph, MemgraphConfig)
-        assert settings.graph.url == "bolt://mg:7687"
+        assert settings.graph.url.get_secret_value() == "bolt://mg:7687"
 
     def test_neptune_config_from_dict(self):
         settings = StorageSettings.model_validate(
@@ -108,7 +109,7 @@ class TestDiscriminatedUnionParsing:
             }
         )
         assert isinstance(settings.graph, AGEConfig)
-        assert settings.graph.url == "postgresql://localhost:5432/khora"
+        assert settings.graph.url.get_secret_value() == "postgresql://localhost:5432/khora"
         assert settings.graph.graph_name == "my_graph"
 
     def test_pgvector_is_default_vector_backend(self):
@@ -183,7 +184,7 @@ class TestKhoraConfigGraphHelpers:
         )
         graph = config.get_graph_config()
         assert isinstance(graph, Neo4jConfig)
-        assert graph.url == "bolt://localhost:7687"
+        assert graph.url.get_secret_value() == "bolt://localhost:7687"
         assert graph.user == "neo4j"
         # ADR-084: password is SecretStr — unwrap to compare plaintext.
         assert graph.password.get_secret_value() == "pass"
@@ -204,7 +205,7 @@ class TestKhoraConfigGraphHelpers:
         )
         vector = config.get_vector_config()
         assert isinstance(vector, PgVectorConfig)
-        assert vector.url == "postgresql://localhost:5432/khora"
+        assert vector.url.get_secret_value() == "postgresql://localhost:5432/khora"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_config_backends.py
+++ b/tests/unit/test_config_backends.py
@@ -29,7 +29,8 @@ class TestStorageSettingsBackwardsCompat:
         assert isinstance(settings.graph, Neo4jConfig)
         assert settings.graph.url == "bolt://localhost:7687"
         assert settings.graph.user == "admin"
-        assert settings.graph.password == "secret"
+        # ADR-084: password is SecretStr — unwrap to compare plaintext.
+        assert settings.graph.password.get_secret_value() == "secret"
         assert settings.graph.database == "mydb"
 
     def test_legacy_pgvector_fields_migrated(self):
@@ -184,7 +185,8 @@ class TestKhoraConfigGraphHelpers:
         assert isinstance(graph, Neo4jConfig)
         assert graph.url == "bolt://localhost:7687"
         assert graph.user == "neo4j"
-        assert graph.password == "pass"
+        # ADR-084: password is SecretStr — unwrap to compare plaintext.
+        assert graph.password.get_secret_value() == "pass"
 
     def test_get_graph_config_kuzu(self):
         config = KhoraConfig(
@@ -280,18 +282,19 @@ class TestParsedNeo4jUrl:
 
     def test_parse_respects_default_password_when_url_has_none(self) -> None:
         parsed = ParsedNeo4jUrl.parse("bolt://localhost:7687", default_password="fallbackpass")
-        assert parsed.password == "fallbackpass"
+        # ADR-084: ParsedNeo4jUrl.password is SecretStr — unwrap to compare.
+        assert parsed.password.get_secret_value() == "fallbackpass"
 
     def test_parse_embedded_password_overrides_default(self) -> None:
         parsed = ParsedNeo4jUrl.parse("bolt://user:embedded@localhost:7687", default_password="fallback")
-        assert parsed.password == "embedded"
+        assert parsed.password.get_secret_value() == "embedded"
 
     def test_parse_neo4j_scheme_preserved(self) -> None:
         """``neo4j://`` routing URLs are parsed and reconstructed with scheme intact."""
         parsed = ParsedNeo4jUrl.parse("neo4j://user:pass@cluster.example.com:7687")
         assert parsed.url == "neo4j://cluster.example.com:7687"
         assert parsed.user == "user"
-        assert parsed.password == "pass"
+        assert parsed.password.get_secret_value() == "pass"
 
     def test_parse_explicit_empty_password_falls_through_to_default(self) -> None:
         """A URL like ``bolt://user:@host:7687`` (trailing colon, no password)
@@ -301,6 +304,6 @@ class TestParsedNeo4jUrl:
         most servers, so falling through to a configured default is the
         sensible behavior.
         """
-        parsed = ParsedNeo4jUrl.parse("bolt://user:@localhost:7687", default_password="fallback")
+        parsed = ParsedNeo4jUrl.parse("bolt://user:@localhost:7687", default_password="fallback")  # noqa: E501
         assert parsed.user == "user"
-        assert parsed.password == "fallback"
+        assert parsed.password.get_secret_value() == "fallback"

--- a/tests/unit/test_khora.py
+++ b/tests/unit/test_khora.py
@@ -110,7 +110,7 @@ class TestKhoraInit:
         kb = Khora(cfg)
 
         assert kb._config is cfg
-        assert kb._config.database_url == "postgresql://test"
+        assert kb._config.database_url.get_secret_value() == "postgresql://test"
 
     def test_init_with_storage_config(self) -> None:
         """Init with explicit storage_config uses it directly."""
@@ -912,7 +912,7 @@ class TestSimplifiedConstructor:
             kb = Khora("postgresql://localhost/mydb")
             mock_load.assert_not_called()
 
-        assert kb._config.database_url == "postgresql://localhost/mydb"
+        assert kb._config.database_url.get_secret_value() == "postgresql://localhost/mydb"
 
     def test_init_with_database_url_and_graph_url(self) -> None:
         """Init with both database and graph URLs."""
@@ -922,8 +922,8 @@ class TestSimplifiedConstructor:
                 graph_url="bolt://localhost:7687",
             )
 
-        assert kb._config.database_url == "postgresql://localhost/mydb"
-        assert kb._config.neo4j_url == "bolt://localhost:7687"
+        assert kb._config.database_url.get_secret_value() == "postgresql://localhost/mydb"
+        assert kb._config.neo4j_url.get_secret_value() == "bolt://localhost:7687"
 
     def test_init_with_custom_embedding_model(self) -> None:
         """Init with custom embedding model."""
@@ -944,7 +944,7 @@ class TestSimplifiedConstructor:
         kb = Khora(cfg)
 
         assert kb._config is cfg
-        assert kb._config.database_url == "postgresql://test"
+        assert kb._config.database_url.get_secret_value() == "postgresql://test"
 
     def test_init_with_none_loads_from_env(self) -> None:
         """Init with None loads config from env/file."""
@@ -961,7 +961,7 @@ class TestSimplifiedConstructor:
         with patch("khora.khora.load_config", return_value=mock_cfg):
             kb = Khora(graph_url="bolt://custom:7687")
 
-        assert kb._config.neo4j_url == "bolt://custom:7687"
+        assert kb._config.neo4j_url.get_secret_value() == "bolt://custom:7687"
 
     def test_init_with_engine_parameter(self) -> None:
         """Init with explicit engine parameter."""

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -29,8 +29,8 @@ def _mock_config() -> MagicMock:
     from pydantic import SecretStr
 
     cfg = MagicMock()
-    # ADR-084: database_url is SecretStr on KhoraConfig; tests must mock the
-    # same type so unwrap call sites (Khora.connect()) don't AttributeError.
+    # database_url is SecretStr on KhoraConfig; tests must mock the same type
+    # so unwrap call sites (Khora.connect()) don't AttributeError.
     cfg.database_url = SecretStr("postgresql://localhost/testdb")
     cfg.llm.embedding_model = "text-embedding-3-small"
     return cfg

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -26,8 +26,12 @@ _MIGRATIONS_DIR = Path(khora.db.migrations.__file__).parent
 
 def _mock_config() -> MagicMock:
     """Minimal mock KhoraConfig for Khora tests."""
+    from pydantic import SecretStr
+
     cfg = MagicMock()
-    cfg.database_url = "postgresql://localhost/testdb"
+    # ADR-084: database_url is SecretStr on KhoraConfig; tests must mock the
+    # same type so unwrap call sites (Khora.connect()) don't AttributeError.
+    cfg.database_url = SecretStr("postgresql://localhost/testdb")
     cfg.llm.embedding_model = "text-embedding-3-small"
     return cfg
 

--- a/tests/unit/test_secret_typing.py
+++ b/tests/unit/test_secret_typing.py
@@ -1,8 +1,8 @@
-"""ADR-084 v1-scope SecretStr re-typing — contract tests.
+"""SecretStr re-typing — contract tests.
 
 Covers:
 
-* every v1-scope Pydantic password / DSN field is typed as
+* every Pydantic password / DSN field is typed as
   :class:`pydantic.SecretStr` (or ``SecretStr | None``).
 * ``repr()`` and ``model_dump_json()`` of those fields never leak the
   underlying plaintext.
@@ -37,7 +37,7 @@ from khora.telemetry.config import TelemetryConfig
 
 @pytest.mark.unit
 class TestSecretStrFieldTypes:
-    """Every v1-scope Pydantic password / DSN field is typed as SecretStr."""
+    """Every Pydantic password / DSN field is typed as SecretStr."""
 
     def test_neo4j_config_password_is_secretstr(self) -> None:
         cfg = Neo4jConfig(password="hunter2")
@@ -139,15 +139,14 @@ class TestSecretStrFieldTypes:
         assert isinstance(cfg.url, SecretStr)
         assert cfg.url.get_secret_value() == "ws://user:hunter2@h:8000"
 
-    def test_llm_settings_has_no_v1_scope_secret_fields(self) -> None:
-        """v1-scope guard: LLMSettings carries no secret-typed fields today.
+    def test_llm_settings_has_no_secret_fields(self) -> None:
+        """Guard: LLMSettings carries no secret-typed fields today.
 
-        ``LLMSettings.api_key_env`` is an env-var-name pointer (per ADR-084
-        §📌 baseline scope-inflation note), so it stays plain ``str``. If a
-        future refactor adds an in-scope field (e.g. ``api_key: str``), this
-        test must be updated to either re-type it as ``SecretStr`` or to
-        explicitly carve it out — locking down the v1-scope boundary in
-        the test surface so the change cannot land silently.
+        ``LLMSettings.api_key_env`` is an env-var-name pointer, so it stays
+        plain ``str``. If a future refactor adds an in-scope field (e.g.
+        ``api_key: str``), this test must be updated to either re-type it as
+        ``SecretStr`` or to explicitly carve it out — locking down the
+        boundary in the test surface so the change cannot land silently.
         """
         settings = LLMSettings()
         # api_key_env is a pointer (env-var name), not a secret value.
@@ -156,8 +155,8 @@ class TestSecretStrFieldTypes:
         # without being typed as SecretStr.
         for name, field in LLMSettings.model_fields.items():
             assert field.annotation is not SecretStr, (
-                f"LLMSettings.{name} is typed as SecretStr — update this v1-scope "
-                "guard test (it is now in-scope and must be enumerated explicitly)."
+                f"LLMSettings.{name} is typed as SecretStr — update this guard "
+                "test (it is now in-scope and must be enumerated explicitly)."
             )
 
 

--- a/tests/unit/test_surrealdb_backend.py
+++ b/tests/unit/test_surrealdb_backend.py
@@ -139,7 +139,8 @@ class TestSurrealDBConfig:
 
         cfg = SurrealDBConfig(mode="remote", url="ws://localhost:8000")
         assert cfg.mode == "remote"
-        assert cfg.url == "ws://localhost:8000"
+        # ADR-084: url is SecretStr — unwrap to compare plaintext.
+        assert cfg.url.get_secret_value() == "ws://localhost:8000"
 
     def test_config_in_graph_union(self) -> None:
         from khora.config.schema import StorageSettings
@@ -174,7 +175,7 @@ class TestSurrealDBConfig:
         cfg = SurrealDBConfig(mode="remote", url="ws://localhost:8000")
         settings = StorageSettings(backend="surrealdb", surrealdb=cfg)
         assert settings.surrealdb is not None
-        assert settings.surrealdb.url == "ws://localhost:8000"
+        assert settings.surrealdb.url.get_secret_value() == "ws://localhost:8000"
 
     def test_vector_config_union(self) -> None:
         from khora.config.schema import SurrealDBVectorConfig

--- a/tests/unit/test_surrealdb_backend.py
+++ b/tests/unit/test_surrealdb_backend.py
@@ -153,7 +153,8 @@ class TestSurrealDBConfig:
 
         cfg = SurrealDBConfig()
         assert cfg.user == "root"
-        assert cfg.password == "root"
+        # ADR-084: password is SecretStr — unwrap to compare plaintext.
+        assert cfg.password.get_secret_value() == "root"
 
     def test_storage_backend_field(self) -> None:
         from khora.config.schema import StorageSettings

--- a/tests/unit/test_surrealdb_backend.py
+++ b/tests/unit/test_surrealdb_backend.py
@@ -139,7 +139,7 @@ class TestSurrealDBConfig:
 
         cfg = SurrealDBConfig(mode="remote", url="ws://localhost:8000")
         assert cfg.mode == "remote"
-        # ADR-084: url is SecretStr — unwrap to compare plaintext.
+        # url is SecretStr — unwrap to compare plaintext.
         assert cfg.url.get_secret_value() == "ws://localhost:8000"
 
     def test_config_in_graph_union(self) -> None:
@@ -154,7 +154,7 @@ class TestSurrealDBConfig:
 
         cfg = SurrealDBConfig()
         assert cfg.user == "root"
-        # ADR-084: password is SecretStr — unwrap to compare plaintext.
+        # password is SecretStr — unwrap to compare plaintext.
         assert cfg.password.get_secret_value() == "root"
 
     def test_storage_backend_field(self) -> None:

--- a/tests/unit/test_telemetry_collector.py
+++ b/tests/unit/test_telemetry_collector.py
@@ -60,7 +60,7 @@ class TestTelemetryConfig:
     def test_from_env_with_url(self):
         with patch.dict("os.environ", {"KHORA_TELEMETRY_DATABASE_URL": "postgresql://localhost/telemetry"}):
             cfg = TelemetryConfig.from_env()
-            # ADR-084: database_url is SecretStr — unwrap to compare plaintext.
+            # database_url is SecretStr — unwrap to compare plaintext.
             assert cfg.database_url.get_secret_value() == "postgresql://localhost/telemetry"
 
     def test_from_env_custom_service(self):

--- a/tests/unit/test_telemetry_collector.py
+++ b/tests/unit/test_telemetry_collector.py
@@ -60,7 +60,8 @@ class TestTelemetryConfig:
     def test_from_env_with_url(self):
         with patch.dict("os.environ", {"KHORA_TELEMETRY_DATABASE_URL": "postgresql://localhost/telemetry"}):
             cfg = TelemetryConfig.from_env()
-            assert cfg.database_url == "postgresql://localhost/telemetry"
+            # ADR-084: database_url is SecretStr — unwrap to compare plaintext.
+            assert cfg.database_url.get_secret_value() == "postgresql://localhost/telemetry"
 
     def test_from_env_custom_service(self):
         with patch.dict("os.environ", {"KHORA_TELEMETRY_SERVICE_NAME": "genesis"}):


### PR DESCRIPTION
## Summary
- Re-type credential and connection-URL fields across storage and telemetry config as `pydantic.SecretStr`, preventing accidental leakage via logs / repr.
- Add `_secret_value()` boundary helper in `khora.config._secrets` and use it inside each backend's engine/driver factory to unwrap `SecretStr` exactly once at the driver edge (Neo4j, Memgraph, Neptune, AGE, SurrealDB graph/relational/vector/event_store, Postgres session, Alembic env, telemetry collector).
- Update `ParsedNeo4jUrl` to carry a `SecretStr` password; accept `SecretStr | str` for back-compat at the parse boundary.
- Cover the contract with `tests/unit/test_secret_typing.py` plus targeted updates to backend, migration, and telemetry tests.

## Test plan
- [x] `make format`
- [x] `make lint`
- [x] `make test` (3038 passed, 195 skipped; one pre-existing collection error in `sqlite_lance/test_embedding_defense.py` due to missing optional `pyarrow` dep, unrelated to this branch)
- [ ] Manual verification: confirm secrets render as `'**********'` in logged config and that backend connections still authenticate