### PR TITLE
Sanitize test fixtures (log_safe, telemetry_collector)

### DIFF
--- a/tests/unit/storage/test_log_safe.py
+++ b/tests/unit/storage/test_log_safe.py
@@ -8,8 +8,8 @@ from khora.storage._log_safe import _safe_url_for_log
     [
         # (a) URL with user + password
         (
-            "postgresql+asyncpg://peras:ebesspyg7jl0kwkbglto@pgbouncer.example.net/peras",
-            "postgresql+asyncpg://<redacted>@pgbouncer.example.net/peras",
+            "postgresql+asyncpg://testuser:s3cret-fake-token@db.example.net/testdb",
+            "postgresql+asyncpg://<redacted>@db.example.net/testdb",
         ),
         # (b) URL with user only (no password)
         (
@@ -18,8 +18,8 @@ from khora.storage._log_safe import _safe_url_for_log
         ),
         # (c) URL with neither user nor password
         (
-            "postgresql+asyncpg://pgbouncer.example.net/peras",
-            "postgresql+asyncpg://pgbouncer.example.net/peras",
+            "postgresql+asyncpg://db.example.net/testdb",
+            "postgresql+asyncpg://db.example.net/testdb",
         ),
         # (d) URL with non-default port
         (

--- a/tests/unit/test_telemetry_collector.py
+++ b/tests/unit/test_telemetry_collector.py
@@ -64,9 +64,9 @@ class TestTelemetryConfig:
             assert cfg.database_url.get_secret_value() == "postgresql://localhost/telemetry"
 
     def test_from_env_custom_service(self):
-        with patch.dict("os.environ", {"KHORA_TELEMETRY_SERVICE_NAME": "genesis"}):
+        with patch.dict("os.environ", {"KHORA_TELEMETRY_SERVICE_NAME": "test-service"}):
             cfg = TelemetryConfig.from_env()
-            assert cfg.service_name == "genesis"
+            assert cfg.service_name == "test-service"
 
 
 # ---------------------------------------------------------------------------
@@ -127,10 +127,10 @@ class TestTelemetryCollector:
 
     def test_service_name_applied(self):
         engine = MagicMock()
-        collector = TelemetryCollector(engine, service_name="genesis")
+        collector = TelemetryCollector(engine, service_name="test-service")
         collector.record_llm_call(operation="chat")
         _, data = collector._buffer[0]
-        assert data["service_name"] == "genesis"
+        assert data["service_name"] == "test-service"
 
     @pytest.mark.asyncio
     async def test_flush_drains_buffer(self):


### PR DESCRIPTION
## Summary
- Sanitize internal references in two test fixtures.
- `tests/unit/storage/test_log_safe.py`: replace credential-shaped DSN with generic `testuser:s3cret-fake-token@db.example.net/testdb`. Replacement DSN is still credential-shaped so the `_safe_url_for_log` redaction assertion (`user:pass` → `<redacted>`) remains meaningful.
- `tests/unit/test_telemetry_collector.py`: replace internal service name with `test-service` at env-var input site, `TelemetryCollector(service_name=...)` and both round-trip assertions.
- Pure string-literal substitution in test fixtures: no `src/` changes, no API/contract surface touched, no logic changes.

## Test plan
- [x] `uv run pytest tests/unit/storage/test_log_safe.py tests/unit/test_telemetry_collector.py -q` — 24 passed
- [x] No remaining occurrences of the removed placeholder strings in `src/` or `tests/`
