### PR TITLE
Sanitize internal ticket citations in comments and docs (OSS prep)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,7 @@ jobs:
       # Why not sed at release time? `sed` on the runner's pyproject.toml leaves
       # the working tree dirty. setuptools_scm/hatch-vcs treats `dirty` at a tag
       # as "ahead of tag" → bumps to next-patch.dev0 (e.g. 0.10.4.dev0 instead
-      # of 0.10.3). This was the bug in DYT-4029.
+      # of 0.10.3). This is the bug we are working around.
 
       # hatch-vcs reads the version from the most recent git tag automatically.
       # Produces both dist/*.whl and dist/*.tar.gz for upload.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,9 +157,8 @@ deprecation shim was higher than the breaking-change cost of a hard removal.
   from `khora` at the top level (preferred) or `khora.khora` (submodule).
 - **No deprecation shim.** `from khora import MemoryLake` and
   `from khora.memory_lake import …` raise `ImportError` on 0.10.0+.
-  Downstream consumers (`genesis`, `khora-benchmarks`) migrate via
-  coordinated PRs after this release (DYT-3967). Both
-  pre-pinned `khora<0.10` to avoid Renovate auto-bumps.
+  Downstream consumers migrate via coordinated PRs after this release.
+  Both pre-pinned `khora<0.10` to avoid Renovate auto-bumps.
 - **LLM prompts** in `khora.query.understanding` now say "knowledge base"
   instead of "memory lake" (`COMPREHENSIVE_UNDERSTANDING_PROMPT`,
   `LIGHTWEIGHT_UNDERSTANDING_PROMPT`). Sent verbatim to the LLM.
@@ -207,7 +206,7 @@ Both engines now synthesize an `EXPLICIT`-category `TemporalSignal` with `confid
 
 ### Performance — restore pre-0.9.0 LiteLLM throughput
 
-The shared aiohttp session introduced in DYT-3156 (v0.9.0) was created with hard-coded `TCPConnector(limit=20, limit_per_host=10)`. `limit_per_host=10` silently throttled all OpenAI / Anthropic / etc. requests to 10 in flight per host, regardless of caller-configured concurrency. Downstream services (e.g. Genesis with `max_concurrent_llm_calls=200`) regressed ~5–20× on wall-time after upgrading to 0.9.x because the shared session became the dominant ceiling on parallel LLM/embedding calls.
+The shared aiohttp session introduced in v0.9.0 was created with hard-coded `TCPConnector(limit=20, limit_per_host=10)`. `limit_per_host=10` silently throttled all OpenAI / Anthropic / etc. requests to 10 in flight per host, regardless of caller-configured concurrency. Downstream services (e.g. Genesis with `max_concurrent_llm_calls=200`) regressed ~5–20× on wall-time after upgrading to 0.9.x because the shared session became the dominant ceiling on parallel LLM/embedding calls.
 
 The connector is now configurable through `LiteLLMConfig` and `LLMSettings`:
 
@@ -242,7 +241,7 @@ Telemetry workstream (PRs #504–#509) shipped after the v0.9.1 tag. It hardens 
 
 ### Fixed
 
-- **`storage_events.namespace_id` 100% NULL since Feb 2026.** Restored namespace propagation through the storage telemetry path. The break had survived multiple releases because no operator dashboard was reading the column — DYT-3398 surfaced it during the Phase-0 audit. (#506)
+- **`storage_events.namespace_id` 100% NULL since Feb 2026.** Restored namespace propagation through the storage telemetry path. The break had survived multiple releases because no operator dashboard was reading the column — surfaced during the Phase-0 audit. (#506)
 
 ### OSS implication
 
@@ -281,14 +280,14 @@ See [docs/engines/engine-comparison.md](docs/engines/engine-comparison.md#produc
 - Chronicle channels (BM25 / semantic / temporal / entity) now share the same `created_after`/`created_before` bounds — fixes channel divergence that broke RRF fusion.
 - Recursive-CTE graph traversal switched from node-visited to edge-visited tracking (mirrors Neo4j `MATCH [*1..N]`).
 - `valid_until > now` filter inlined into both anchor and recursive arms of the CTE.
-- DYT-3555 / DYT-3556: Skeleton tag-cast and `occurred_at` parsing fixes (`Skeleton.remember()` parity with `remember_batch()`).
+- Skeleton tag-cast and `occurred_at` parsing fixes (`Skeleton.remember()` parity with `remember_batch()`).
 - Embedded compensating-delete-on-failure logging hardened.
 - (#485): LanceDB IVF-PQ index now retrains once the corpus grows past `retrain_factor × (rows at last training)`. Configurable via `KHORA_STORAGE_SQLITE_LANCE__RETRAIN_FACTOR` (default `2.0`). Fixes silent recall degradation as the corpus grows past the initial training threshold (5k rows). Set ≤ `1.0` to disable.
 
 ### Embedded warts (documented, not fixed)
 
 - **Partial atomicity in `coordinator.transaction()`** on embedded — only the SQL session is enrolled; LanceDB writes happen post-commit with compensating deletes.
-- **DYT-3550**: Point-in-time queries are not supported on the embedded stack. The CTE port does not implement PIT semantics. Tracked.
+- **Point-in-time queries** are not supported on the embedded stack. The CTE port does not implement PIT semantics. Tracked.
 - **FTS5 on chunks only** — entity-anchored recall falls back to `LIKE` / JSON-equality on embedded. Use the PostgreSQL stack for entity-heavy corpora.
 
 ### Deprecated

--- a/rust/khora-accel/src/temporal.rs
+++ b/rust/khora-accel/src/temporal.rs
@@ -185,7 +185,7 @@ pub fn detect_temporal_category(query: &str) -> u8 {
             " does it still", " is it still", " am i still", " do i still",
             "'s current ", " current job", " current role", " current position",
             " live now", " work now", " working now", " living now", " doing now",
-            // Enterprise domain patterns (DYT-2143/DYT-2145): compound current-state queries.
+            // Enterprise domain compound current-state query patterns.
             // Generic " current " was too broad — triggered on recency lookups like
             // "current quota" that work better without temporal intelligence.
             " current status", " current stage", " current state",
@@ -307,7 +307,7 @@ pub fn detect_temporal_category_with_confidence(query: &str) -> (u8, f64, Vec<St
             " does it still", " is it still", " am i still", " do i still",
             "'s current ", " current job", " current role", " current position",
             " live now", " work now", " working now", " living now", " doing now",
-            // Enterprise domain patterns (DYT-2143/DYT-2145)
+            // Enterprise domain patterns
             " current status", " current stage", " current state",
             " current health", " current deal", " current project",
             " current plan", " current team",

--- a/scripts/bench_logger_enqueue.py
+++ b/scripts/bench_logger_enqueue.py
@@ -1,6 +1,6 @@
 """Microbenchmark: loguru sync vs enqueue=True under an async event loop.
 
-This script reproduces the latent async-correctness bug fixed in DYT-2050.
+This script reproduces a latent async-correctness bug in loguru's enqueue model.
 A synchronous loguru sink (the default) blocks the calling thread during the
 write, which means inside ``async def`` code every ``logger.info(...)`` call
 stalls the event loop for the duration of the I/O. Switching the sink to

--- a/src/khora/_accel.py
+++ b/src/khora/_accel.py
@@ -1226,7 +1226,7 @@ TEMPORAL_DICTIONARY: dict[int, list[str]] = {
         " working now",
         " living now",
         " doing now",
-        # DYT-2143/DYT-2145: Enterprise domain compound current-state patterns.
+        # Enterprise domain compound current-state patterns.
         # Generic " current " was too broad — triggered on recency lookups.
         " current status",
         " current stage",

--- a/src/khora/config/schema.py
+++ b/src/khora/config/schema.py
@@ -621,7 +621,7 @@ class QuerySettings(BaseSettings):
     keyword_weight: float = Field(default=0.2, ge=0.0, le=1.0, description="Weight for keyword search in fusion")
 
     # Temporal settings.
-    # `recency_weight` and `recency_decay_days` were tightened in DYT-3780
+    # `recency_weight` and `recency_decay_days` were tightened
     # from (0.2, 30) to (0.35, 7) after BEAM 100K showed the four weakest
     # categories (event_ordering, contradiction_resolution, temporal_reasoning,
     # knowledge_update) all share a weak-recency / supersession root cause —

--- a/src/khora/db/models.py
+++ b/src/khora/db/models.py
@@ -490,7 +490,7 @@ class PermissionModel(Base):
     principal_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
 
     # The resource (what the permission applies to)
-    # Post-DYT-220: resource_type must always be 'namespace' (sole isolation boundary).
+    # resource_type must always be 'namespace' (sole isolation boundary).
     resource_type: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
     resource_id: Mapped[UUIDType] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
 

--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -1252,7 +1252,7 @@ class ChronicleEngine:
                 routing_complexity = "fallback"
 
         # Extract temporal bounds once and forward them to every channel.
-        # WHY: until DYT-3547 only the temporal channel honored these bounds,
+        # WHY: previously only the temporal channel honored these bounds,
         # so a 20-day-old chunk could leak through a 7-day window via the
         # semantic / BM25 / entity channels. Pgvector's search_similar and
         # search_fulltext already pushdown COALESCE(source_timestamp,

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -419,7 +419,7 @@ class Khora:
 
             # For the sqlite_lance embedded backend, derive a sqlite+aiosqlite URL
             # from the configured db_path so Alembic migrations target the same
-            # file the adapters use. DYT-2727 made the migrations dialect-aware.
+            # file the adapters use. The migrations are dialect-aware.
             db_url: str | None
             if (
                 getattr(self._config.storage, "backend", "postgres") == "sqlite_lance"

--- a/src/khora/logging_config.py
+++ b/src/khora/logging_config.py
@@ -17,9 +17,9 @@ from loguru import logger
 _drain_registered = False
 
 # Environment variable that, when set to a valid level name, raises the
-# verbosity of the ``neo4j`` stdlib logger at runtime. Added for DYT-2625 so
-# that operators can enable driver-internal DEBUG lines (pool acquire, TLS,
-# routing) without a code change. See README for accepted values.
+# verbosity of the ``neo4j`` stdlib logger at runtime. Lets operators
+# enable driver-internal DEBUG lines (pool acquire, TLS, routing) without
+# a code change. See README for accepted values.
 _NEO4J_LOG_LEVEL_ENV = "KHORA_NEO4J_LOG_LEVEL"
 _NEO4J_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
 

--- a/src/khora/storage/backends/sqlite_lance/event_store.py
+++ b/src/khora/storage/backends/sqlite_lance/event_store.py
@@ -2,7 +2,7 @@
 
 Append-only event log backed by the ``memory_events`` SQLite table
 (created by Alembic migration ``000_initial_schema`` under the
-dialect-gated path added in DYT-2727).  Implements
+dialect-gated path).  Implements
 :class:`~khora.storage.backends.base.EventStoreProtocol` without
 SQLAlchemy — direct aiosqlite against the shared
 :class:`EmbeddedStorageHandle`.

--- a/src/khora/storage/backends/sqlite_lance/graph.py
+++ b/src/khora/storage/backends/sqlite_lance/graph.py
@@ -614,7 +614,7 @@ class SQLiteLanceGraphAdapter(GraphBackendBase):
         #
         # ``visited`` tracks **edge ids**, not node ids — matches Neo4j's
         # ``MATCH [*1..N]`` semantics, which forbids reusing the same
-        # relationship rather than the same node.  See DYT-3548.
+        # relationship rather than the same node.
         sql = f"""
             WITH RECURSIVE walk(
                 edge_id, src, cur, depth, edge_ids, visited
@@ -784,7 +784,6 @@ class SQLiteLanceGraphAdapter(GraphBackendBase):
         # not the same node).  Without this, a cycle like A→B→C→A
         # makes the recursion fan out exponentially with depth, even
         # though ``DISTINCT`` masks the row count after the fact.
-        # See DYT-3548.
         sql = f"""
             WITH RECURSIVE walk(seed, cur, depth, direction, edge_id, visited) AS (
                 SELECT r.source_entity_id, r.target_entity_id, 1, 'out', r.id,

--- a/src/khora/storage/backends/sqlite_lance/relational.py
+++ b/src/khora/storage/backends/sqlite_lance/relational.py
@@ -7,8 +7,8 @@ the SQLite database file owned by :class:`EmbeddedStorageHandle` so that
 :meth:`StorageCoordinator.transaction` can share a single session across
 SQL-based adapters via the public ``_session_factory`` attribute.
 
-Schema creation is handled by Alembic (dialect-gated migrations from
-DYT-2727); this adapter assumes tables already exist.
+Schema creation is handled by Alembic (dialect-gated migrations);
+this adapter assumes tables already exist.
 """
 
 from __future__ import annotations

--- a/src/khora/storage/backends/sqlite_lance/schema.py
+++ b/src/khora/storage/backends/sqlite_lance/schema.py
@@ -3,8 +3,7 @@
 Defines the Arrow schemas for the chunks and entities vector tables and
 provides an idempotent ``ensure_lance_tables`` helper used during
 ``EmbeddedStorageHandle.connect``.  Table bodies and index creation
-beyond the core vector column are deferred to later tickets
-(DYT-2728/2729/2730/2731).
+beyond the core vector column are deferred to later work.
 """
 
 from __future__ import annotations

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -525,7 +525,7 @@ class StorageCoordinator:
         try:
             # 1. Prefetch old graph state and compute retire / survive sets
             #    BEFORE mutating anything.  Doing this up front keeps the
-            #    Python-side filter aligned with the Cypher in DYT-2668/2669.
+            #    Python-side filter aligned with the Cypher.
             fetch = getattr(self.graph, "fetch_document_extraction_state", None)
             if fetch is None:
                 old_entity_records: list[dict[str, Any]] = []

--- a/tests/integration/_sqlite_lance_fixtures.py
+++ b/tests/integration/_sqlite_lance_fixtures.py
@@ -26,7 +26,7 @@ async def build_sqlite_lance_coordinator(
 ) -> StorageCoordinator:
     """Construct a fully-migrated sqlite_lance coordinator in tmp_path.
 
-    Relies on the real Alembic-migrated schema — after DYT-2749 the raw
+    Relies on the real Alembic-migrated schema — the raw
     adapters align with the migrated column shape (``chunks.metadata``,
     no ``embedding`` column, external-content FTS5 driven by triggers,
     32-char hex UUIDs matching SQLAlchemy ``UUID(as_uuid=True)``), so no

--- a/tests/integration/matrix/test_chronicle_pg.py
+++ b/tests/integration/matrix/test_chronicle_pg.py
@@ -477,8 +477,8 @@ async def test_chronicle_entity_anchored_routing(kb: Khora, namespace_id: UUID) 
     """ "Who is Alice?" → ENTITY_ANCHORED routing classification.
 
     The router's classification depends on the heuristic match against the
-    query string — "Who is X?" is the canonical entity-anchored pattern
-    (see DYT-3147). When entity_anchored fires, the entity-channel RRF
+    query string — "Who is X?" is the canonical entity-anchored pattern.
+    When entity_anchored fires, the entity-channel RRF
     weight is doubled (engine.py:1232-1233). We can't easily inspect the
     weight without patching, so we assert the routing label only — the
     weight-doubling is covered by ``test_router_and_fusion.py``.

--- a/tests/integration/matrix/test_skeleton_pg.py
+++ b/tests/integration/matrix/test_skeleton_pg.py
@@ -265,7 +265,7 @@ async def _remember(
 async def _recall(kb: Khora, query: str, **kwargs: Any) -> Any:
     """Recall wrapper that pins ``mode=SearchMode.VECTOR`` for deterministic ranking.
 
-    Pre-DYT-3555 this was a workaround for the ``SearchMode.KEYWORD``
+    Originally this was a workaround for the ``SearchMode.KEYWORD``
     AttributeError on default HYBRID. Post-fix the wrapper still pins
     VECTOR so top-k ordering tests aren't affected by the BM25 blend
     weight (``hybrid_alpha=0.7`` under HYBRID). The default-HYBRID path
@@ -510,7 +510,7 @@ async def test_skeleton_recall_default_hybrid_mode(kb: Khora, namespace_id: UUID
     Pre-fix, ``SkeletonConstructionEngine.recall`` (engine.py:441) referenced
     a non-existent ``SearchMode.KEYWORD`` member, which crashed with
     ``AttributeError`` whenever ``mode != VECTOR`` (HYBRID is the Khora
-    default). DYT-3555 added ``KEYWORD`` to the enum, so this regression
+    default). The fix added ``KEYWORD`` to the enum, so this regression
     test now asserts the default path simply returns a ``RecallResult``.
     """
     await _remember(kb, namespace_id=namespace_id, content="alpha simple sentence")

--- a/tests/integration/matrix/test_skeleton_sqlite_lance.py
+++ b/tests/integration/matrix/test_skeleton_sqlite_lance.py
@@ -224,9 +224,10 @@ async def test_skeleton_remember_recall_roundtrip(kb: Khora, namespace_id: UUID)
 
     result = await _recall(kb, "falcon launch", namespace=namespace_id, limit=10)
 
-    # Skeleton reports its backend type in metadata. Once DYT-3561 lands,
-    # the value should be "lancedb" (or whatever name the new backend
-    # registers under) — assert non-empty rather than pin the string.
+    # Skeleton reports its backend type in metadata. Once the LanceDB-backed
+    # vector path lands, the value should be "lancedb" (or whatever name the
+    # new backend registers under) — assert non-empty rather than pin the
+    # string.
     assert result.metadata.get("backend") is not None
     assert len(result.chunks) >= 1, "expected at least one chunk back"
     assert "falcon" in result.context_text.lower()
@@ -281,7 +282,7 @@ async def test_skeleton_recall_top_k_ordering(kb: Khora, namespace_id: UUID) -> 
 @pytest.mark.xfail(
     strict=True,
     reason=(
-        "Engine-level namespace resolution gap (out of scope for DYT-3561): "
+        "Engine-level namespace resolution gap: "
         "the test fixture passes the stable ``ns.namespace_id`` straight to "
         "``engine.recall`` while ``kb.remember`` resolves it to the "
         "row-level ``id`` before persisting. ``khora_chunks.namespace_id`` "
@@ -294,9 +295,9 @@ async def test_skeleton_recall_top_k_ordering(kb: Khora, namespace_id: UUID) -> 
 async def test_skeleton_recall_with_metadata_filter(kb: Khora, namespace_id: UUID) -> None:
     """Tag filter restricts recall to chunks carrying the requested tag.
 
-    Unlike the PG sibling, the embedded path doesn't hit DYT-3556 (SQLite
-    serializes ``tags`` as JSON-text — no ``ARRAY(String).contains``
-    incompatibility). The current xfail tracks a separate engine-layer
+    Unlike the PG sibling, the embedded path doesn't hit the ARRAY
+    incompatibility (SQLite serializes ``tags`` as JSON-text — no
+    ``ARRAY(String).contains`` incompatibility). The current xfail tracks a separate engine-layer
     namespace-resolution gap surfaced by this test bypassing
     :meth:`Khora.recall` and calling ``engine.recall`` directly.
     """

--- a/tests/integration/matrix/test_vectorcypher_sqlite_lance.py
+++ b/tests/integration/matrix/test_vectorcypher_sqlite_lance.py
@@ -313,8 +313,8 @@ async def test_vc_entity_extraction(kb: Khora, namespace_id: UUID) -> None:
     strict=False,
     reason=(
         "VC's sync remember path does not rebind extraction-time entity IDs "
-        "to upsert-resolved IDs (DYT-3558 fixed this only in "
-        "pipelines/flows/ingest.py, not in vectorcypher/engine._run_skeleton_extraction). "
+        "to upsert-resolved IDs (fixed only in pipelines/flows/ingest.py, "
+        "not in vectorcypher/engine._run_skeleton_extraction). "
         "On sqlite_lance, that produces FOREIGN KEY failures when a second "
         "document re-mentions an entity from the first doc."
     ),
@@ -353,7 +353,7 @@ async def test_vc_two_hop_traversal(kb: Khora, namespace_id: UUID) -> None:
     text_blob = result.context_text + " ".join(c.content for c, _ in result.chunks)
     # The 2-hop reachable concept ("graph databases" via Bob→Carol) must
     # surface in the recall result. If this fails the CTE traversal is
-    # not crossing 2 hops — see DYT-3548.
+    # not crossing 2 hops.
     assert "graph databases" in text_blob.lower(), f"2-hop entity not surfaced; got context={text_blob[:300]!r}"
 
 
@@ -524,7 +524,7 @@ async def test_vc_dual_node_persistence(kb: Khora, namespace_id: UUID) -> None:
         "Same root cause as test_vc_two_hop_traversal: VC's sync remember "
         "does not rebind extraction-time entity IDs after upsert resolution, "
         "so a second doc re-mentioning a prior entity hits FOREIGN KEY on "
-        "create_relationships_batch. Tracked alongside DYT-3548/DYT-3549/DYT-3558."
+        "create_relationships_batch."
     ),
     raises=Exception,
 )
@@ -536,7 +536,7 @@ async def test_vc_prefer_current_via_cte(kb: Khora, namespace_id: UUID) -> None:
     SQLite-CTE traversal. R2 is the fix that makes
     ``prefer_current`` honor expired/invalidated edges in the CTE. Until
     that lands, the CTE happily walks expired edges, so this test is
-    expected to fail even after DYT-3560 wires the VC embedded path.
+    expected to fail until the VC embedded path is wired.
 
     The chain: B→C edge has ``valid_to`` in the past → with
     ``prefer_current=True`` it must be skipped → C ("polonium") is

--- a/tests/integration/test_neo4j_get_entity_relationships_integration.py
+++ b/tests/integration/test_neo4j_get_entity_relationships_integration.py
@@ -33,7 +33,7 @@ match the ``make dev`` compose stack:
     KHORA_NEO4J_USERNAME  (default: neo4j)
     KHORA_NEO4J_PASSWORD  (default: password)
 
-The test would fail on the pre-DYT-2626 code because the real driver's
+The test would fail on the pre-fix code because the real driver's
 ``.data()`` method serializes a ``RETURN r`` value as a 3-tuple
 ``(start_dict, rel_type, end_dict)`` — handing
 ``_record_to_relationship`` a tuple instead of a dict and raising

--- a/tests/unit/db/test_migration_026_widen_alembic_version.py
+++ b/tests/unit/db/test_migration_026_widen_alembic_version.py
@@ -1,4 +1,4 @@
-"""DYT-3545 / DYT-3546: ``026_widen_alembic_version_column``.
+"""``026_widen_alembic_version_column``.
 
 Pins the four branches of the migration so a future Alembic refactor
 doesn't silently re-introduce VARCHAR(32) and break long revision IDs:

--- a/tests/unit/engines/skeleton/test_occurred_at_metadata.py
+++ b/tests/unit/engines/skeleton/test_occurred_at_metadata.py
@@ -1,6 +1,6 @@
 """``Skeleton.remember`` honors ``metadata['occurred_at']``.
 
-Pre-DYT-3557 the single-doc ``remember()`` path silently dropped
+Previously the single-doc ``remember()`` path silently dropped
 ``metadata['occurred_at']`` and stamped chunks with ``datetime.now(UTC)``,
 while ``remember_batch`` (lines 746-752) parsed the same key. These tests
 pin the symmetry so the bug can't regress.

--- a/tests/unit/engines/test_dual_nodes.py
+++ b/tests/unit/engines/test_dual_nodes.py
@@ -677,7 +677,7 @@ class TestDualNodeManagerGetEntityNeighborhoodsTimeout:
     ) -> None:
         """On timeout, a dedicated trace_span is emitted with structured attrs.
 
-        Replaces the former ``TODO`` telemetry counter —
+        Replaces the former telemetry counter —
         operators can now alert on span name ``*.timeout`` in Logfire/OTEL
         and filter by ``timeout_s``, ``entity_count``, ``depth``, ``code``,
         and ``namespace_id`` attributes.

--- a/tests/unit/engines/test_skeleton_search_mode.py
+++ b/tests/unit/engines/test_skeleton_search_mode.py
@@ -81,7 +81,7 @@ def _build_engine_with_stubs() -> tuple[SkeletonConstructionEngine, AsyncMock]:
 async def test_recall_resolves_hybrid_alpha_per_mode(mode: SearchMode, expected_alpha: float) -> None:
     """Every SearchMode value must resolve a ``hybrid_alpha`` without crashing.
 
-    Pre-DYT-3555, ``mode=HYBRID`` (the Khora default) raised
+    Previously, ``mode=HYBRID`` (the Khora default) raised
     ``AttributeError: SearchMode has no attribute 'KEYWORD'`` because the
     ``elif`` RHS was evaluated whenever the ``if`` branch was False.
     """

--- a/tests/unit/engines/test_vectorcypher_occurred_at_metadata.py
+++ b/tests/unit/engines/test_vectorcypher_occurred_at_metadata.py
@@ -1,6 +1,6 @@
 """``VectorCypherEngine.remember`` honors ``metadata['occurred_at']``.
 
-Pre-DYT-3581 the single-doc ``remember()`` path silently dropped
+Previously the single-doc ``remember()`` path silently dropped
 ``metadata['occurred_at']`` and stamped chunks with ``datetime.now(UTC)``,
 while ``remember_batch`` (engine.py:2118-2120) parsed the same key. These
 tests pin the symmetry so the bug can't regress. Mirrors PR #484

--- a/tests/unit/storage/backends/sqlite_lance/test_graph.py
+++ b/tests/unit/storage/backends/sqlite_lance/test_graph.py
@@ -562,7 +562,7 @@ class TestTraversal:
         """A pair of nodes connected by two distinct directed edges
         (A→B via r1, B→A via r2) admits a legitimate 2-hop A→A path
         that traverses each edge exactly once.  Neo4j's ``MATCH [*1..N]``
-        forbids reusing **edges**, not nodes — the pre-DYT-3548 CTE
+        forbids reusing **edges**, not nodes — an earlier CTE
         tracked visited *nodes*, which incorrectly blocked the return
         walk into A and silently dropped this path."""
         ns = uuid4()
@@ -606,7 +606,7 @@ class TestTraversal:
         assert all(p[-1]["data"]["id"] == str(r3.id) for p in paths)
 
     async def test_get_neighborhoods_batch_cyclic_walk_is_bounded(self, adapter: SQLiteLanceGraphAdapter):
-        """Cycle A→B→A (2 parallel directed edges).  The pre-DYT-3548
+        """Cycle A→B→A (2 parallel directed edges).  An earlier
         ``get_neighborhoods_batch`` CTE had NO visited set at all, so
         the recursive arms re-traversed the cycle ``2^depth`` times
         before the trailing ``DISTINCT`` collapsed the rows.  The fix

--- a/tests/unit/storage/backends/sqlite_lance/test_relational.py
+++ b/tests/unit/storage/backends/sqlite_lance/test_relational.py
@@ -37,7 +37,7 @@ if _HAS_EMBEDDED:
 async def adapter(migrated_sqlite_db, tmp_path):
     """Migrated SQLite DB + connected relational adapter.
 
-    Uses the real Alembic migration chain (dialect-gated since DYT-2727)
+    Uses the real Alembic migration chain (dialect-gated)
     to validate that the adapter works against the production schema.
     """
     db_path = str(migrated_sqlite_db)

--- a/tests/unit/storage/backends/test_protocol_compliance.py
+++ b/tests/unit/storage/backends/test_protocol_compliance.py
@@ -91,7 +91,7 @@ async def _migrate(db_path: Path) -> None:
     The adapters speak the exact schema the migrations produce
     (``chunks.metadata``, no ``embedding`` column on ``chunks`` /
     ``entities``, external-content FTS5 with triggers, 32-char UUID
-    hex) after DYT-2749 — no reshape shim required.
+    hex) — no reshape shim required.
     """
     url = f"sqlite+aiosqlite:///{db_path}"
     result = await run_migrations(url)

--- a/tests/unit/storage/test_sqlite_lance_e2e.py
+++ b/tests/unit/storage/test_sqlite_lance_e2e.py
@@ -6,8 +6,8 @@ across four adapters (relational, graph, vector, event_store), Alembic
 migrations against the SQLite file, and backend health checks.
 
 Per-adapter write/read contracts are covered by the per-adapter test
-modules (DYT-2728..2731); a ``Khora.remember()`` round-trip will
-be added in DYT-2734 (integration tests).
+modules; a ``Khora.remember()`` round-trip will be added in integration
+tests.
 """
 
 from __future__ import annotations
@@ -39,7 +39,7 @@ async def coordinator(tmp_path: Path):
     db_path = str(tmp_path / "khora.db")
     lance_path = str(tmp_path / "khora.lance")
 
-    # DYT-2727 made these migrations dialect-aware; they work on SQLite.
+    # Migrations are dialect-aware; they work on SQLite.
     result = await run_migrations(f"sqlite+aiosqlite:///{db_path}")
     assert result.success, f"migration failed: {result.error}"
 

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,7 +1,7 @@
 """Tests for khora.logging_config — async-safety guards and sink setup.
 
-Added for DYT-2050 to close a coverage gap on setup_logging's enqueue=True
-sink configuration and the atexit drain guard. All tests fully mock the
+Covers setup_logging's enqueue=True sink configuration and the atexit
+drain guard. All tests fully mock the
 loguru logger, atexit.register, and logging.basicConfig so they do not
 mutate global process state.
 """

--- a/tests/unit/test_neo4j_pool_metrics_correctness.py
+++ b/tests/unit/test_neo4j_pool_metrics_correctness.py
@@ -692,7 +692,7 @@ class TestPoolSampler:
         scheduler jitter (two dropped ticks).
 
         Skipped by default (``@pytest.mark.slow``). To run:
-        ``uv run pytest -m slow tests/unit/test_neo4j_pool_metrics_dyt2624.py``.
+        ``uv run pytest -m slow tests/unit/test_neo4j_pool_metrics_correctness.py``.
         """
         driver = MagicMock()
         pool = MagicMock()


### PR DESCRIPTION
## Summary

Clause-level rewrites of internal ticket citations that the prior mechanical regex pass left behind.

- 17 in-prose / parenthetical ticket-citation rewrites across `.github/workflows/release.yml`, `scripts/`, `src/khora/**`, and `tests/**` — converted internal ticket references to generic phrasing while preserving the substance of each comment.
- 4 compound-token rewrites in `rust/khora-accel/src/temporal.rs` and `src/khora/_accel.py`.
- 1 filename rename: the Neo4j pool-metrics test file renamed to `tests/unit/test_neo4j_pool_metrics_correctness.py` (self-reference inside the file also updated).
- Cleans up residual `Pre-` / `Post-` / "tracked in …" ticket-prefix residue plus 5 `CHANGELOG.md` ticket references.

Post-edit invariant: a grep for the internal ticket-ID pattern returns no matches across tracked files.

Diff is text-only (32 files, +58/-60 lines) — comments, docstrings, CHANGELOG prose, and one filename. No production logic changes.

## Test plan

- [x] `make format` clean
- [x] `make lint` clean (`ruff check` + `ty` — passed; only pre-existing typecheck warnings unrelated to this diff)
- [x] Audit clean (self-audit, `review:database`, `review:test`, `review:docs`, bandit)
- [x] Renamed test file picked up under its new name (still exists at the new path; old path removed)
- [ ] CI green on the PR
