### PR TITLE
Broaden redact_dsn username class to [^:@/]+

### DIFF
--- a/src/khora/config/_secrets.py
+++ b/src/khora/config/_secrets.py
@@ -6,7 +6,7 @@ import re
 
 # Matches the userinfo segment of a URI: ``://user:password@``. Captures
 # nothing — substitution replaces the whole match with ``://[REDACTED]@``.
-_DSN_USERINFO_RE = re.compile(r"://[\w\-.]+:[^@/]+@")
+_DSN_USERINFO_RE = re.compile(r"://[^:@/]+:[^@/]+@")
 
 
 def redact_dsn(text: str) -> str:

--- a/tests/unit/test_secret_typing.py
+++ b/tests/unit/test_secret_typing.py
@@ -204,6 +204,22 @@ class TestRedactDsn:
                 "bolt://neo4j:hunter2@cluster.example.com:7687",
                 "bolt://[REDACTED]@cluster.example.com:7687",
             ),
+            # Non-standard userinfo characters (service-account-style ``+``,
+            # ``~``, and percent-encoded bytes) must still be scrubbed — the
+            # username class mirrors the password class (``[^:@/]+``) so any
+            # RFC-3986 userinfo char the URL parser accepts is redacted.
+            (
+                "postgresql://app+prod:hunter2@db:5432/app",
+                "postgresql://[REDACTED]@db:5432/app",
+            ),
+            (
+                "postgresql://user~name:hunter2@db:5432/app",
+                "postgresql://[REDACTED]@db:5432/app",
+            ),
+            (
+                "postgresql://a%2Bb:hunter2@db:5432/app",
+                "postgresql://[REDACTED]@db:5432/app",
+            ),
             # No userinfo → unchanged
             ("postgresql://localhost:5432/app", "postgresql://localhost:5432/app"),
             # Empty / non-DSN strings → unchanged


### PR DESCRIPTION
## Summary
- `_DSN_USERINFO_RE` previously restricted DSN usernames to `[\w\-.]+`, which fails to match RFC-3986 userinfo characters that PostgreSQL/asyncpg accept (e.g. `+`, `~`, percent-encoded bytes). When a DSN with such a username appeared in log lines, the regex did not match and the secret leaked through `redact_dsn` unredacted.
- Broaden the username class to `[^:@/]+`, mirroring the password class, so any character a URL parser would accept in userinfo is redacted.
- Add unit cases covering `+`, `~`, and percent-encoded usernames to lock the behavior in.

## Test plan
- [x] `uv run pytest tests/unit/test_secret_typing.py` (parametrized cases pass)
- [x] `make format` / `make lint`
- [x] `make test` (unit suite — 3238 passed)