### PR TITLE
Fix release.yml: use REST generate-notes for existing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,10 +348,11 @@ jobs:
             LATEST_FLAG="--latest"
           fi
           # Idempotent: if a release for this tag already exists (manual
-          # backfill or workflow re-run), update it in place instead of failing.
+          # backfill via the UI, or workflow re-run), leave it untouched —
+          # it may have been hand-edited for a reason — and just print it.
           if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG already exists; refreshing generated notes."
-            gh release edit "$TAG" --generate-notes $LATEST_FLAG
+            echo "Release $TAG already exists; leaving it untouched."
+            gh release view "$TAG"
           else
             gh release create "$TAG" --title "$TAG" --generate-notes $LATEST_FLAG
           fi


### PR DESCRIPTION
## Summary

- `gh release edit` has no `--generate-notes` flag (only `gh release create` does), so the idempotent branch in the `github-release` job crashed every time a release was created via the GitHub UI before the workflow ran.
- A pre-existing release may have been hand-edited for a reason, so refreshing it from the workflow is the wrong default. Instead, when the release already exists, log a notice, print its current state via `gh release view`, and exit cleanly.

Fixes #584.

## Test plan

- [ ] Tag a manual release via the GitHub UI before pushing the tag, then push the tag and confirm the `github-release` job logs "already exists; leaving it untouched", prints the current release, and exits 0.
- [ ] Confirm a fresh tag (no pre-existing release) still hits the `gh release create` path and publishes notes.