### PR TITLE
Close secret-str migration window (semgrep WARNING → ERROR)

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,5 +1,5 @@
 # Detect str-typed secret-pattern fields in Pydantic models and dataclasses.
-# ADR-084 migration window closed (DYT-4001): all v1-scope fields retyped.
+# Migration window closed: all v1-scope fields retyped.
 # Severity ERROR: any new str-typed secret field blocks CI.
 rules:
   - id: secret-str-pydantic

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,13 +1,13 @@
 # Detect str-typed secret-pattern fields in Pydantic models and dataclasses.
-# Severity WARNING: CI reports findings without blocking while existing fields
-# are remediated. Flip both rules to ERROR once the backlog is clear.
+# ADR-084 migration window closed (DYT-4001): all v1-scope fields retyped.
+# Severity ERROR: any new str-typed secret field blocks CI.
 rules:
   - id: secret-str-pydantic
     message: >
       Secret-named field '$FIELD' is typed as plain str in a Pydantic model.
       Use pydantic.SecretStr, or annotate with AllowSecretTyping(reason="...")
       for deliberate exceptions.
-    severity: WARNING
+    severity: ERROR
     languages: [python]
     patterns:
       - pattern-either:
@@ -37,7 +37,7 @@ rules:
       Secret-named field '$FIELD' is typed as plain str in a dataclass.
       Use a wrapper type or Annotated[str, AllowSecretTyping(reason="...")] for
       deliberate exceptions.
-    severity: WARNING
+    severity: ERROR
     languages: [python]
     patterns:
       - pattern-either:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -312,6 +312,9 @@ dev = [
     "rapidfuzz>=3.14.3",  # For ty type checking of optional accel module
     "spacy>=3.8.11",
     "aiosqlite>=0.20.0",  # For SQLite backend tests
+    "pyarrow>=18.0.0",  # For sqlite-lance backend tests
+    "opentelemetry-sdk>=1.27.0",  # For OTel telemetry tests
+    "opentelemetry-exporter-otlp-proto-http>=1.27.0",  # For OTel exporter tests
     "psutil>=5.9.0",  # RSS sampling for soak harness
     "hypothesis>=6.140.0",  # property-based tests for retrieval invariants
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -7,11 +7,11 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-05-07T12:47:41.373018Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-urllib3 = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+urllib3 = { timestamp = "2026-05-14T12:47:41.373026Z", span = "PT0S" }
 
 [manifest]
 constraints = [
@@ -1306,8 +1306,11 @@ weaviate = [
 dev = [
     { name = "aiosqlite" },
     { name = "hypothesis" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
     { name = "prek" },
     { name = "psutil" },
+    { name = "pyarrow" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1396,8 +1399,11 @@ provides-extras = ["accel", "age", "all-backends", "binary-readers", "dev", "emb
 dev = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "hypothesis", specifier = ">=6.140.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.27.0" },
     { name = "prek", specifier = ">=0.3.3" },
     { name = "psutil", specifier = ">=5.9.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },


### PR DESCRIPTION
## Summary
- Closes the secret-str migration window: flips both \`secret-str-pydantic\` and \`secret-str-dataclass\` semgrep rules from \`WARNING\` to \`ERROR\` so any new plain-\`str\` secret field now blocks CI
- Updates the header comment in \`.semgrep.yml\` to reflect the closed window (all v1-scope fields have been retyped)
- Adds missing test dependencies (\`pyarrow>=18.0.0\`, \`opentelemetry-sdk>=1.27.0\`, \`opentelemetry-exporter-otlp-proto-http>=1.27.0\`) to \`pyproject.toml\` and \`uv.lock\`

## Test plan
- [x] \`make format\` — passes, no changes
- [x] \`make lint\` — passes (exit 0)
- [x] \`make test\` — 3222 passed, 195 skipped; 2 pre-existing failures in \`test_surrealdb_backend.py\` (test-ordering issue, not introduced by this branch, confirmed by running tests in isolation)