### PR TITLE
Strip remaining khora-cli URL wrapping from CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -623,7 +623,7 @@ Two deferred decisions for v0.10 address the embedded warts:
 - Codified the khora public API surface consumed by downstream packages (genesis, khora-benchmarks, khora-explorer, khora-cli).
 
 ### Removed
-- `khora` console script and CLI subcommands (`extract`, `search`) — moved to [khora-cli](https://github.com/DeytaHQ/khora-cli). Install with `uv pip install khora-cli` and run `uv run khora-cli extract` / `uv run khora-cli search`.
+- `khora` console script and CLI subcommands (`extract`, `search`) — moved to khora-cli. Install with `uv pip install khora-cli` and run `uv run khora-cli extract` / `uv run khora-cli search`.
 - `khora ontology` CLI subcommands (moved to khora-explorer)
 - `khora.discovery` package (moved to khora-explorer)
 - `khora.cli` package (entire subtree — `extract`, `search`, `_common`)


### PR DESCRIPTION
## Summary
- Removes the markdown URL wrapping around the khora-cli reference in the v0.5.0 removed-features section of CHANGELOG.md, replacing \`[khora-cli](https://github.com/DeytaHQ/khora-cli)\` with plain text \`khora-cli\`
- Fixes a regression where sibling package names were wrapped with external links in the changelog

## Test plan
- [ ] No code changes — documentation/changelog only
- [ ] \`make format\` passes (confirmed)
- [ ] \`make lint\` passes (confirmed)
- [ ] \`make test\` passes (2 pre-existing flaky SurrealDB tests fail in full suite but pass in isolation, unrelated to this change)