### PR TITLE
Suppress credential fields from StorageConfig repr

### DIFF
--- a/src/khora/storage/factory.py
+++ b/src/khora/storage/factory.py
@@ -86,7 +86,7 @@ class StorageConfig:
             ),
         ]
         | None
-    ) = None
+    ) = field(default=None, repr=False)
     postgresql_echo: bool = False
     postgresql_pool_size: int = 10
     postgresql_max_overflow: int = 20
@@ -101,7 +101,7 @@ class StorageConfig:
             ),
         ]
         | None
-    ) = None
+    ) = field(default=None, repr=False)
     pgvector_embedding_dimension: int = 1536
     pgvector_use_halfvec: bool = True
 
@@ -114,14 +114,14 @@ class StorageConfig:
             ),
         ]
         | None
-    ) = None
+    ) = field(default=None, repr=False)
     neo4j_user: str = "neo4j"
     neo4j_password: Annotated[
         str,
         AllowSecretTyping(
             reason="legacy factory intermediary; holds post-boundary plain string from KhoraConfig.get_neo4j_password()"
         ),
-    ] = ""
+    ] = field(default="", repr=False)
     neo4j_database: str = "neo4j"
 
     # New-style backend configs (Pydantic models from config/schema.py)
@@ -142,7 +142,7 @@ class StorageConfig:
             ),
         ]
         | None
-    ) = None
+    ) = field(default=None, repr=False)
 
     @classmethod
     def from_dict(cls, config: dict[str, Any]) -> StorageConfig:

--- a/src/khora/storage/factory.py
+++ b/src/khora/storage/factory.py
@@ -125,13 +125,13 @@ class StorageConfig:
     neo4j_database: str = "neo4j"
 
     # New-style backend configs (Pydantic models from config/schema.py)
-    graph_config: Any = None  # GraphConfig union type
-    vector_config: Any = None  # VectorConfig union type
+    graph_config: Any = field(default=None, repr=False)  # GraphConfig union type
+    vector_config: Any = field(default=None, repr=False)  # VectorConfig union type
 
     # Unified backend selector
     backend: str = "postgres"  # "postgres" (traditional), "surrealdb", or "sqlite_lance"
-    surrealdb_config: Any = None  # SurrealDBConfig from config/schema.py
-    sqlite_lance_config: Any = None  # SQLiteLanceConfig from config/schema.py
+    surrealdb_config: Any = field(default=None, repr=False)  # SurrealDBConfig from config/schema.py
+    sqlite_lance_config: Any = field(default=None, repr=False)  # SQLiteLanceConfig from config/schema.py
 
     # Event store configuration (uses PostgreSQL by default)
     event_store_url: (

--- a/tests/unit/test_storage_factory.py
+++ b/tests/unit/test_storage_factory.py
@@ -314,3 +314,47 @@ class TestPoolPrePing:
 
         config = KhoraConfig(storage={"postgresql_pool_pre_ping": True})
         assert config.storage.postgresql_pool_pre_ping is True
+
+
+class TestStorageConfigRepr:
+    """repr must not expose credential fields."""
+
+    _CREDENTIAL_FIELDS = [
+        "postgresql_url",
+        "pgvector_url",
+        "neo4j_url",
+        "neo4j_password",
+        "event_store_url",
+    ]
+
+    def _make_config(self) -> StorageConfig:
+        return StorageConfig(
+            postgresql_url="postgresql+asyncpg://user:secret@host/db",
+            pgvector_url="postgresql+asyncpg://user:secret@host/db",
+            neo4j_url="bolt://user:secret@host:7687",
+            neo4j_password="hunter2",
+            event_store_url="postgresql+asyncpg://user:secret@host/events",
+        )
+
+    def test_credential_fields_absent_from_repr(self):
+        config = self._make_config()
+        r = repr(config)
+        for field_name in self._CREDENTIAL_FIELDS:
+            assert field_name not in r, f"repr should not include {field_name!r}"
+
+    def test_secret_values_absent_from_repr(self):
+        config = self._make_config()
+        r = repr(config)
+        assert "secret" not in r
+        assert "hunter2" not in r
+
+    def test_non_credential_fields_present_in_repr(self):
+        config = StorageConfig(postgresql_echo=True, neo4j_database="mydb")
+        r = repr(config)
+        assert "postgresql_echo" in r
+        assert "neo4j_database" in r
+
+    def test_field_values_still_accessible(self):
+        config = self._make_config()
+        assert config.postgresql_url == "postgresql+asyncpg://user:secret@host/db"
+        assert config.neo4j_password == "hunter2"

--- a/tests/unit/test_storage_factory.py
+++ b/tests/unit/test_storage_factory.py
@@ -358,3 +358,19 @@ class TestStorageConfigRepr:
         config = self._make_config()
         assert config.postgresql_url == "postgresql+asyncpg://user:secret@host/db"
         assert config.neo4j_password == "hunter2"
+
+    def test_new_style_config_fields_absent_from_repr(self):
+        from khora.config.schema import SurrealDBConfig
+
+        sdb_cfg = SurrealDBConfig(
+            mode="remote",
+            url="ws://user:topsecret@host:8000/rpc",
+            password="topsecret",
+        )
+        config = StorageConfig(backend="surrealdb", surrealdb_config=sdb_cfg)
+        r = repr(config)
+        assert "surrealdb_config" not in r
+        assert "graph_config" not in r
+        assert "vector_config" not in r
+        assert "sqlite_lance_config" not in r
+        assert "topsecret" not in r


### PR DESCRIPTION
## Summary
- `StorageConfig` dataclass fields that hold credentials (`postgresql_url`, `pgvector_url`, `neo4j_url`, `neo4j_password`, `event_store_url`, `graph_config`, `vector_config`, `surrealdb_config`, `sqlite_lance_config`) were previously included in the default `__repr__`, leaking plaintext secrets into logs, debug output, and exception tracebacks
- Fixed by adding `field(default=..., repr=False)` to each credential-bearing field so they are silently omitted from `repr()` output while remaining fully accessible via attribute access
- Non-sensitive fields (`postgresql_echo`, `neo4j_database`, `backend`, etc.) continue to appear in repr for debuggability

## Test plan
- [x] Unit tests pass (3416 passed, 207 skipped)
- [x] `TestStorageConfigRepr` — new test class covering: credential field names absent from repr, secret values absent from repr, non-credential fields still visible, attribute access unaffected, new-style config objects excluded
- [x] `make format` and `make lint` clean