### PR TITLE
Mark neo4j_user as repr=False in StorageConfig

### DIFF
--- a/src/khora/storage/factory.py
+++ b/src/khora/storage/factory.py
@@ -115,7 +115,7 @@ class StorageConfig:
         ]
         | None
     ) = field(default=None, repr=False)
-    neo4j_user: str = "neo4j"
+    neo4j_user: str = field(default="neo4j", repr=False)
     neo4j_password: Annotated[
         str,
         AllowSecretTyping(

--- a/tests/unit/test_storage_factory.py
+++ b/tests/unit/test_storage_factory.py
@@ -324,6 +324,7 @@ class TestStorageConfigRepr:
         "pgvector_url",
         "neo4j_url",
         "neo4j_password",
+        "neo4j_user",
         "event_store_url",
     ]
 
@@ -333,6 +334,7 @@ class TestStorageConfigRepr:
             pgvector_url="postgresql+asyncpg://user:secret@host/db",
             neo4j_url="bolt://user:secret@host:7687",
             neo4j_password="hunter2",
+            neo4j_user="testuser",
             event_store_url="postgresql+asyncpg://user:secret@host/events",
         )
 


### PR DESCRIPTION
## Summary
- Marks `neo4j_user` field in `StorageConfig` with `repr=False` so it is excluded from the default `__repr__` output, preventing accidental leakage of usernames in logs or debug output
- Adds `neo4j_user` to the existing `test_storage_config_sensitive_fields_excluded_from_repr` test to ensure the field stays redacted

## Test plan
- [x] Unit tests pass (`make test` — unit suite clean)
- [x] `neo4j_user` confirmed excluded from `StorageConfig.__repr__` output
- [x] Lint and format checks pass