### PR TITLE
Fix exception chain leaking unredacted DSN via __cause__

### DIFF
--- a/src/khora/db/migrations/env.py
+++ b/src/khora/db/migrations/env.py
@@ -277,14 +277,18 @@ async def run_async_migrations() -> None:
             # Re-raise with redacted message. Try to preserve the original
             # exception type, but some SQLAlchemy / asyncpg exception types
             # require multiple positional args (e.g. NoSuchModuleError(name))
-            # — passing just the redacted message would raise TypeError and
-            # lose the original traceback. Fall back to RuntimeError chained
-            # via ``from exc`` so the original is still reachable via
-            # ``__cause__``.
+            # — passing just the redacted message would raise TypeError.
+            # Fall back to RuntimeError with ``from None`` so the unredacted
+            # DSN is not retained in __cause__ and captured by observability
+            # tools (Logfire, Sentry, traceback.print_exception).
             try:
                 redacted_exc = type(exc)(redacted)
             except TypeError:
-                raise RuntimeError(redacted) from exc
+                logger.debug(
+                    "Migration error type (original suppressed for DSN redaction): %s",
+                    type(exc).__name__,
+                )
+                raise RuntimeError(redacted) from None
             raise redacted_exc.with_traceback(exc.__traceback__) from None
         raise
 

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -798,6 +798,58 @@ class TestRunAsyncMigrations:
         mock_conn.run_sync.assert_called_once_with(env.do_run_migrations)
         mock_engine.dispose.assert_awaited_once()
 
+    @pytest.mark.unit
+    async def test_dsn_redaction_suppresses_cause_chain(self):
+        """TypeError fallback raises RuntimeError from None — __cause__ must not leak DSN.
+
+        When exception type reconstruction raises TypeError (e.g. NoSuchModuleError),
+        the fallback RuntimeError must use ``from None`` so the unredacted DSN is not
+        retained in __cause__ and captured by Logfire / Sentry / traceback.print_exception.
+        """
+        env = _load_env_functions()
+        env.config.attributes["database_url"] = "postgresql://user:secret@host/db"
+
+        class _MultiArgError(Exception):
+            """Simulates an exception type that requires >1 positional arg."""
+
+            def __init__(self, name: str, extra: str) -> None:
+                super().__init__(name, extra)
+
+        dsn_error = _MultiArgError(
+            "postgresql://user:secret@host/db",
+            "some extra arg",
+        )
+        mock_engine, mock_conn = self._mock_async_engine()
+        mock_conn.run_sync.side_effect = dsn_error
+
+        with patch.object(env, "create_async_engine", return_value=mock_engine):
+            with pytest.raises(RuntimeError) as exc_info:
+                await env.run_async_migrations()
+
+        raised = exc_info.value
+        # __cause__ must be None — DSN must not leak via exception chain
+        assert raised.__cause__ is None, "__cause__ must be suppressed (from None)"
+        # The redacted message must not contain the plaintext credential
+        assert "secret" not in str(raised)
+
+    @pytest.mark.unit
+    async def test_dsn_redaction_normal_exception_type_preserved(self):
+        """When exception type can be reconstructed, original type is preserved with redacted message."""
+        env = _load_env_functions()
+        env.config.attributes["database_url"] = "postgresql://user:secret@host/db"
+
+        dsn_error = ValueError("postgresql://user:secret@host/db")
+        mock_engine, mock_conn = self._mock_async_engine()
+        mock_conn.run_sync.side_effect = dsn_error
+
+        with patch.object(env, "create_async_engine", return_value=mock_engine):
+            with pytest.raises(ValueError) as exc_info:
+                await env.run_async_migrations()
+
+        raised = exc_info.value
+        assert raised.__cause__ is None
+        assert "secret" not in str(raised)
+
 
 # ---------------------------------------------------------------------------
 # env.py — do_run_migrations ahead-detection

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -822,15 +822,20 @@ class TestRunAsyncMigrations:
         mock_engine, mock_conn = self._mock_async_engine()
         mock_conn.run_sync.side_effect = dsn_error
 
-        with patch.object(env, "create_async_engine", return_value=mock_engine):
-            with pytest.raises(RuntimeError) as exc_info:
-                await env.run_async_migrations()
+        with patch.object(env, "logger") as mock_logger:
+            with patch.object(env, "create_async_engine", return_value=mock_engine):
+                with pytest.raises(RuntimeError) as exc_info:
+                    await env.run_async_migrations()
 
         raised = exc_info.value
         # __cause__ must be None — DSN must not leak via exception chain
         assert raised.__cause__ is None, "__cause__ must be suppressed (from None)"
         # The redacted message must not contain the plaintext credential
         assert "secret" not in str(raised)
+        # logger.debug must only log the type name, not the exception message or DSN
+        mock_logger.debug.assert_called_once()
+        debug_args = " ".join(str(a) for a in mock_logger.debug.call_args[0])
+        assert "secret" not in debug_args, "logger.debug must not log unredacted DSN"
 
     @pytest.mark.unit
     async def test_dsn_redaction_normal_exception_type_preserved(self):


### PR DESCRIPTION
## Summary
- Changed `RuntimeError` fallback in migration DSN redaction from `raise RuntimeError(redacted) from exc` to `raise RuntimeError(redacted) from None` — this suppresses `__cause__` so the unredacted DSN is not retained in the exception chain
- When the original exception type cannot be reconstructed (e.g. `NoSuchModuleError` requiring >1 positional arg), `logger.debug` now logs only the exception type name (not the message or DSN) before raising the sanitized fallback
- Adds two regression tests: one verifying that `__cause__ is None` in the TypeError-fallback path, and one verifying the normal (reconstructible) exception type path preserves the redacted message

## Test plan
- [x] Unit tests pass (`uv run pytest tests/unit/ -q` — 3418 passed)
- [x] `test_dsn_redaction_suppresses_cause_chain`: asserts `__cause__ is None` and that neither the raised message nor the `logger.debug` call contains the plaintext credential
- [x] `test_dsn_redaction_normal_exception_type_preserved`: asserts the original exception type is preserved with the redacted message and `__cause__ is None`
- [x] Lint and format clean (`make format && make lint`)