### PR TITLE
IGR-114: remove vectorcypher in-process query result cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 
 ### Fixed
 
-- Stale results from `Khora.recall()` after `remember`/`forget` (IGR-114). The in-process query result cache in the vectorcypher retriever held results for up to 5 minutes without invalidation on writes.
+- Stale results from `Khora.recall()` after `remember`/`forget`. The in-process query result cache in the vectorcypher retriever held results for up to 5 minutes without invalidation on writes.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 
 ### Removed
 
-- `RetrieverConfig.query_cache_ttl_seconds` and `RetrieverConfig.query_cache_max_size` (also removed from `VectorCypherEngineConfig`). Callers that set these can drop them — they no longer have any effect.
+- `RetrieverConfig.query_cache_ttl_seconds` and `RetrieverConfig.query_cache_max_size` (also removed from `VectorCypherEngineConfig`). **Breaking:** passing these kwargs now raises `TypeError`. Drop them from your config.
 
 ## [0.15.1] — Security patch release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Khora are documented here.
 
 Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were internal (no git tags).
 
+## [Unreleased]
+
+### Fixed
+
+- Stale results from `Khora.recall()` after `remember`/`forget` (IGR-114). The in-process query result cache in the vectorcypher retriever held results for up to 5 minutes without invalidation on writes.
+
+### Removed
+
+- `RetrieverConfig.query_cache_ttl_seconds` and `RetrieverConfig.query_cache_max_size` (also removed from `VectorCypherEngineConfig`). Callers that set these can drop them — they no longer have any effect.
+
 ## [0.15.1] — Security patch release
 
 ### Security

--- a/docs/architecture/performance-optimization.md
+++ b/docs/architecture/performance-optimization.md
@@ -390,21 +390,6 @@ These higher limits are safe because Rust acceleration reduces per-operation CPU
 
 ## Phase 8: VectorCypher Query Optimizations (v0.3.5)
 
-### Query Result Caching
-
-The VectorCypher engine now caches query results with LRU eviction:
-
-```python
-from khora.engines.vectorcypher import VectorCypherConfig
-
-config = VectorCypherConfig(
-    query_cache_ttl_seconds=300,   # 5-minute TTL (default)
-    query_cache_max_size=100,      # Max cached entries (default)
-)
-```
-
-Cache key is `sha256(query + namespace_id + mode)`. The cache is checked at the start of the retriever pipeline and populated on completion. Any `remember()` or `forget()` call invalidates the cache for the affected namespace.
-
 ### Coherence Scoring
 
 A lightweight bigram coherence analysis is applied after RRF fusion to penalize word-shuffled confounders:

--- a/docs/engines/vectorcypher-engine.md
+++ b/docs/engines/vectorcypher-engine.md
@@ -175,11 +175,6 @@ class RetrieverConfig:
     # Entity expansion
     lazy_entity_expansion: bool = False  # Defer entity expansion until needed
 
-    # Query cache
-    query_cache_enabled: bool = True
-    query_cache_ttl: int = 300  # seconds
-    query_cache_max_size: int = 1000
-
     # Limits
     max_chunks: int = 50
     max_entities: int = 30

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,7 +11,6 @@ These improvements are focused on making Khora faster and more reliable for prod
 | Item | Why It Matters |
 |------|----------------|
 | **HNSW Index Support** | Done. Migration 005 rebuilds the vector index as HNSW with `ef_construction=128`. See [Performance Optimization](architecture/performance-optimization.md). |
-| **Query Result Caching** | Done. LRU cache with TTL (`max_size=100`, `ttl_seconds=300`) keyed on `sha256(query + namespace_id + mode)`. See [Performance Optimization](architecture/performance-optimization.md). |
 | **Coherence Scoring** | Done (v0.3.5). Bigram coherence scoring for confounder rejection in VectorCypher's RRF fusion (`coherence_weight=0.1`). |
 | **Streaming Pipeline** | Done (v0.3.2). `streaming_pipeline=True` default in `VectorCypherConfig`. |
 | **Incremental Index Updates** | Currently, adding new vectors requires rebuilding indexes. Incremental updates would make real-time ingestion practical. |

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -249,10 +249,6 @@ class VectorCypherConfig:
     temporal_recency_decay_days: int = 30
     recency_decay_type: str = "exponential"  # "linear" or "exponential"
 
-    # Query caching
-    query_cache_ttl_seconds: int = 300  # 5 min TTL
-    query_cache_max_size: int = 100
-
     # Extraction concurrency (aligned with ingest pipeline's default of 20)
     max_concurrent_extractions: int = 20
 
@@ -544,8 +540,6 @@ class VectorCypherEngine:
             recency_decay_type=self._vc_config.recency_decay_type,
             min_entity_similarity=self._vc_config.retriever_min_entity_similarity,
             hybrid_alpha=self._vc_config.fusion_hybrid_alpha,
-            query_cache_ttl_seconds=self._vc_config.query_cache_ttl_seconds,
-            query_cache_max_size=self._vc_config.query_cache_max_size,
             lazy_entity_expansion=self._vc_config.lazy_entity_expansion,
             skeleton_core_ratio=self._vc_config.skeleton_core_ratio,
             enable_session_aware_search=self._vc_config.enable_session_aware_search,

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -15,10 +15,8 @@ Performance optimizations:
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import math
 import os
-import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal
@@ -191,10 +189,6 @@ class RetrieverConfig:
     # Search thresholds
     min_entity_similarity: float = 0.3
     hybrid_alpha: float = 0.7
-
-    # Query caching
-    query_cache_ttl_seconds: int = 0  # 0 = disabled
-    query_cache_max_size: int = 100
 
     # Lazy entity expansion
     lazy_entity_expansion: bool = False
@@ -379,11 +373,6 @@ class VectorCypherRetriever:
             else None
         )
 
-        # Query result cache (LRU + TTL)
-        self._cache: dict[str, tuple[float, VectorCypherResult]] = {}
-        self._cache_ttl = self._config.query_cache_ttl_seconds
-        self._cache_max_size = self._config.query_cache_max_size
-
         # Lazy entity expansion cache: chunk_id -> expansion_score (0 = no match)
         self._expansion_cache: dict[UUID, float] = {}
 
@@ -535,23 +524,6 @@ class VectorCypherRetriever:
                     vetoed=anti_recency_veto,
                 )
 
-            # Cache check
-            cache_key = ""
-            if self._cache_ttl > 0:
-                cache_key = hashlib.md5(
-                    f"{query}:{namespace_id}:{temporal_filter}:{graph_depth}:{limit}".encode(),
-                    usedforsecurity=False,
-                ).hexdigest()
-
-                if cache_key in self._cache:
-                    cached_time, cached_result = self._cache[cache_key]
-                    if time.monotonic() - cached_time < self._cache_ttl:
-                        cached_result.metadata["cache_hit"] = True
-                        span.set_attribute("cache_hit", True)
-                        return cached_result
-                    else:
-                        del self._cache[cache_key]
-
             # Step 1: Route query to determine strategy
             with trace_span("khora.vectorcypher.route") as route_span:
                 routing = await self._router.route(query, temporal_signal=temporal_signal)
@@ -632,13 +604,6 @@ class VectorCypherRetriever:
                         recency_floor=params.recency_floor,
                         temporal_signal=temporal_signal,
                     )
-
-            # Store in cache
-            if self._cache_ttl > 0 and cache_key:
-                if len(self._cache) >= self._cache_max_size:
-                    oldest_key = min(self._cache, key=lambda k: self._cache[k][0])
-                    del self._cache[oldest_key]
-                self._cache[cache_key] = (time.monotonic(), result)
 
             span.set_attribute("chunk_count", len(result.chunks))
             span.set_attribute("entity_count", len(result.entities))

--- a/tests/unit/engines/test_rels_task_exception.py
+++ b/tests/unit/engines/test_rels_task_exception.py
@@ -71,7 +71,6 @@ def _make_retriever(
     storage.get_entities_batch = AsyncMock(return_value={entity_id_1: entity_1, entity_id_2: entity_2})
 
     config = RetrieverConfig(
-        query_cache_ttl_seconds=0,
         coherence_weight=0.0,
     )
 

--- a/tests/unit/engines/test_retriever_coverage_push.py
+++ b/tests/unit/engines/test_retriever_coverage_push.py
@@ -84,7 +84,7 @@ def _make_retriever(
         vector_store=vector_store if vector_store is not None else AsyncMock(),
         neo4j_driver=neo4j_driver if neo4j_driver is not None else AsyncMock(),
         embedder=AsyncMock(),
-        config=config or RetrieverConfig(query_cache_ttl_seconds=0),
+        config=config or RetrieverConfig(),
         storage=storage,
     )
 
@@ -327,7 +327,6 @@ class TestRecencyChannelChunks:
         c1 = _make_vector_store_chunk(embedding=emb)
         vstore.search_recent_chunks = AsyncMock(return_value=[(c1, None)])
         config = RetrieverConfig(
-            query_cache_ttl_seconds=0,
             temporal_query_relevance_floor=0.5,
         )
         retriever = _make_retriever(config=config, vector_store=vstore)
@@ -385,7 +384,6 @@ class TestApplyReranking:
         fused = [FusedResult(item=c, item_id=c.id, rrf_score=1.0 - 0.1 * i) for i, c in enumerate(chunks)]
 
         config = RetrieverConfig(
-            query_cache_ttl_seconds=0,
             reranking_top_n=3,
             reranking_blend_weight=0.7,
         )
@@ -540,7 +538,6 @@ class TestApplyLLMReranking:
         chunks = [_make_chunk(f"c{i}") for i in range(6)]
         fused = [FusedResult(item=c, item_id=c.id, rrf_score=1.0 - 0.1 * i) for i, c in enumerate(chunks)]
         config = RetrieverConfig(
-            query_cache_ttl_seconds=0,
             llm_reranking_top_n=3,
         )
         retriever = _make_retriever(config=config)
@@ -636,7 +633,6 @@ class TestApplyLLMReranking:
 class TestShouldSkipLlmRerank:
     def test_gap_gate_fires(self) -> None:
         config = RetrieverConfig(
-            query_cache_ttl_seconds=0,
             llm_reranking_confidence_threshold=0.1,
         )
         retriever = _make_retriever(config=config)
@@ -645,7 +641,6 @@ class TestShouldSkipLlmRerank:
 
     def test_decisive_winner_gate_fires(self) -> None:
         config = RetrieverConfig(
-            query_cache_ttl_seconds=0,
             llm_reranking_confidence_threshold=0.5,  # gap won't trigger
             llm_reranking_min_top_score=0.7,
             llm_reranking_decisive_gap=0.1,
@@ -656,7 +651,6 @@ class TestShouldSkipLlmRerank:
 
     def test_neither_gate_fires(self) -> None:
         config = RetrieverConfig(
-            query_cache_ttl_seconds=0,
             llm_reranking_confidence_threshold=0.5,
             llm_reranking_min_top_score=0.7,
             llm_reranking_decisive_gap=0.1,
@@ -1004,7 +998,6 @@ class TestCalculateRecencyScoresPerSource:
         """slack source → 3-day decay (fast), salesforce → 180 (slow); when same age
         the slack chunk decays faster."""
         config = RetrieverConfig(
-            query_cache_ttl_seconds=0,
             temporal_per_source_decay=True,
             temporal_reference_wall_clock=True,
             recency_decay_type="exponential",
@@ -1026,7 +1019,6 @@ class TestCalculateRecencyScoresPerSource:
     def test_per_source_decay_falls_back_to_default(self) -> None:
         """Unknown source_system → use the dict's ``_default`` key."""
         config = RetrieverConfig(
-            query_cache_ttl_seconds=0,
             temporal_per_source_decay=True,
             temporal_reference_wall_clock=True,
             recency_decay_type="exponential",
@@ -1044,7 +1036,6 @@ class TestCalculateRecencyScoresPerSource:
     def test_per_source_decay_default_missing_falls_back_to_config(self) -> None:
         """If ``_default`` key is absent → use config.recency_decay_days."""
         config = RetrieverConfig(
-            query_cache_ttl_seconds=0,
             temporal_per_source_decay=True,
             temporal_reference_wall_clock=True,
             recency_decay_type="exponential",
@@ -1063,7 +1054,6 @@ class TestCalculateRecencyScoresPerSource:
     def test_pathological_zero_decay_falls_back(self) -> None:
         """Decay=0 would div-by-zero → falls back to config.recency_decay_days."""
         config = RetrieverConfig(
-            query_cache_ttl_seconds=0,
             temporal_per_source_decay=True,
             temporal_reference_wall_clock=True,
             recency_decay_type="exponential",
@@ -1081,7 +1071,6 @@ class TestCalculateRecencyScoresPerSource:
     def test_linear_decay_path(self) -> None:
         """The ``linear`` decay branch is independent from per-source."""
         config = RetrieverConfig(
-            query_cache_ttl_seconds=0,
             temporal_reference_wall_clock=True,
             recency_decay_type="linear",
             recency_decay_days=10,
@@ -1104,7 +1093,6 @@ class TestCalculateRecencyScoresPerSource:
     def test_reference_mode_override(self) -> None:
         """explicit reference_mode kwarg wins over config."""
         config = RetrieverConfig(
-            query_cache_ttl_seconds=0,
             temporal_reference_wall_clock=False,
         )
         retriever = _make_retriever(config=config)
@@ -1134,7 +1122,7 @@ class TestRetrieveBackendGate:
             vector_store=AsyncMock(),
             neo4j_driver=None,
             embedder=AsyncMock(),
-            config=RetrieverConfig(query_cache_ttl_seconds=0),
+            config=RetrieverConfig(),
             backend="sqlite_lance",
         )
         from khora.engines.skeleton.backends import TemporalFilter
@@ -1152,7 +1140,6 @@ class TestPprRetrievalPath:
         calls ppr_retrieve_chunks instead of _fetch_chunks_from_entities."""
         ns = uuid4()
         config = RetrieverConfig(
-            query_cache_ttl_seconds=0,
             enable_ppr_retrieval=True,
             ppr_damping=0.85,
             ppr_max_iter=10,
@@ -1335,7 +1322,7 @@ class TestCypherExpand:
             vector_store=AsyncMock(),
             neo4j_driver=None,  # no dual_nodes
             embedder=AsyncMock(),
-            config=RetrieverConfig(query_cache_ttl_seconds=0),
+            config=RetrieverConfig(),
             storage=storage,
         )
         scores, info = await retriever._cypher_expand(entry_entity_ids=[seed], namespace_id=uuid4(), depth=2)
@@ -1361,7 +1348,7 @@ class TestCypherExpand:
 
     @pytest.mark.asyncio
     async def test_depth_is_clamped_to_max(self) -> None:
-        retriever = _make_retriever(config=RetrieverConfig(query_cache_ttl_seconds=0, max_depth=3))
+        retriever = _make_retriever(config=RetrieverConfig(max_depth=3))
         retriever._dual_nodes = MagicMock()
         retriever._dual_nodes.get_entity_neighborhoods = AsyncMock(return_value={})
         await retriever._cypher_expand(
@@ -1417,7 +1404,7 @@ class TestFetchChunksFromEntities:
             vector_store=AsyncMock(),
             neo4j_driver=None,
             embedder=AsyncMock(),
-            config=RetrieverConfig(query_cache_ttl_seconds=0),
+            config=RetrieverConfig(),
             storage=None,
         )
         result = await retriever._fetch_chunks_from_entities(
@@ -1436,7 +1423,7 @@ class TestFetchChunksFromEntities:
             vector_store=AsyncMock(),
             neo4j_driver=None,
             embedder=AsyncMock(),
-            config=RetrieverConfig(query_cache_ttl_seconds=0),
+            config=RetrieverConfig(),
             storage=storage,
         )
         result = await retriever._fetch_chunks_from_entities(
@@ -1564,7 +1551,7 @@ class TestSimpleRetrievePaths:
                 ("new content", newer, None),
             ]
         )
-        config = RetrieverConfig(query_cache_ttl_seconds=0)
+        config = RetrieverConfig()
         retriever = VectorCypherRetriever(
             vector_store=vstore,
             neo4j_driver=AsyncMock(),
@@ -1600,7 +1587,7 @@ class TestSimpleRetrievePaths:
             vector_store=vstore,
             neo4j_driver=AsyncMock(),
             embedder=AsyncMock(),
-            config=RetrieverConfig(query_cache_ttl_seconds=0),
+            config=RetrieverConfig(),
         )
         routing = RoutingDecision(
             complexity=QueryComplexity.SIMPLE,
@@ -1631,7 +1618,6 @@ class TestSimpleRetrievePaths:
         storage.search_fulltext_chunks = AsyncMock(return_value=[(bm25_chunk, 0.9)])
 
         config = RetrieverConfig(
-            query_cache_ttl_seconds=0,
             enable_bm25_channel=True,
             bm25_top_k=10,
         )
@@ -1668,7 +1654,6 @@ class TestSimpleRetrievePaths:
         storage.search_fulltext_chunks = AsyncMock(side_effect=RuntimeError("ft down"))
 
         config = RetrieverConfig(
-            query_cache_ttl_seconds=0,
             enable_bm25_channel=True,
         )
         retriever = VectorCypherRetriever(
@@ -1712,7 +1697,7 @@ class TestSimpleRetrievePaths:
             vector_store=vstore,
             neo4j_driver=AsyncMock(),
             embedder=AsyncMock(),
-            config=RetrieverConfig(query_cache_ttl_seconds=0),
+            config=RetrieverConfig(),
         )
         routing = RoutingDecision(
             complexity=QueryComplexity.SIMPLE,
@@ -1748,7 +1733,6 @@ class TestRetrieveAntiRecencyVeto:
         """When the floor flag is on and the query contains "ever" / "all time",
         synthesis is vetoed and the resulting metadata reflects the veto."""
         config = RetrieverConfig(
-            query_cache_ttl_seconds=0,
             temporal_recency_floor_enabled=True,
         )
         vector_store = AsyncMock()

--- a/tests/unit/engines/test_temporal_phase_a_retriever.py
+++ b/tests/unit/engines/test_temporal_phase_a_retriever.py
@@ -227,7 +227,6 @@ def synth_retriever() -> VectorCypherRetriever:
 
     cfg = RetrieverConfig(
         temporal_recency_floor_enabled=True,
-        query_cache_ttl_seconds=0,
     )
     retriever = VectorCypherRetriever(
         vector_store=vector_store,
@@ -323,7 +322,6 @@ class TestSyntheticRecencyFilter:
 
         cfg = RetrieverConfig(
             temporal_recency_floor_enabled=False,
-            query_cache_ttl_seconds=0,
         )
         retriever = VectorCypherRetriever(
             vector_store=vector_store,

--- a/tests/unit/engines/test_vectorcypher_engine.py
+++ b/tests/unit/engines/test_vectorcypher_engine.py
@@ -39,8 +39,6 @@ class TestVectorCypherConfig:
         assert config.temporal_recency_weight == 0.2
         assert config.temporal_recency_decay_days == 30
         assert config.recency_decay_type == "exponential"
-        assert config.query_cache_ttl_seconds == 300
-        assert config.query_cache_max_size == 100
         assert config.streaming_pipeline is True
         assert config.enable_smart_resolution is True
         assert config.lazy_entity_expansion is True
@@ -56,14 +54,12 @@ class TestVectorCypherConfig:
             graph_default_depth=3,
             fusion_vector_weight=0.7,
             fusion_graph_weight=0.3,
-            query_cache_ttl_seconds=300,
         )
         assert config.routing_enabled is False
         assert config.skeleton_core_ratio == 0.5
         assert config.graph_default_depth == 3
         assert config.fusion_vector_weight == 0.7
         assert config.fusion_graph_weight == 0.3
-        assert config.query_cache_ttl_seconds == 300
 
 
 class TestExtractionQualityMetrics:

--- a/tests/unit/engines/test_vectorcypher_retriever.py
+++ b/tests/unit/engines/test_vectorcypher_retriever.py
@@ -40,8 +40,6 @@ class TestRetrieverConfig:
         assert config.recency_decay_type == "exponential"
         assert config.min_entity_similarity == 0.3
         assert config.hybrid_alpha == 0.7
-        assert config.query_cache_ttl_seconds == 0
-        assert config.query_cache_max_size == 100
         assert config.lazy_entity_expansion is False
         assert config.enable_session_aware_search is True
         assert config.max_chunks == 50
@@ -56,7 +54,6 @@ class TestRetrieverConfig:
             vector_weight=0.7,
             graph_weight=0.3,
             recency_weight=0.0,
-            query_cache_ttl_seconds=300,
         )
         assert config.default_depth == 3
         assert config.max_depth == 5
@@ -64,7 +61,6 @@ class TestRetrieverConfig:
         assert config.vector_weight == 0.7
         assert config.graph_weight == 0.3
         assert config.recency_weight == 0.0
-        assert config.query_cache_ttl_seconds == 300
 
     def test_session_aware_search_enabled(self) -> None:
         """Test enabling session-aware search."""
@@ -129,7 +125,6 @@ class TestRetrieverInit:
         )
 
         assert retriever._config.default_depth == 2
-        assert retriever._cache == {}
 
     def test_init_custom_config(self) -> None:
         """Test retriever initialization with custom config."""
@@ -222,7 +217,7 @@ class TestRetrieverSimpleRetrieve:
         mock_result.similarity = 0.85
         vector_store.search = AsyncMock(return_value=[mock_result])
 
-        config = RetrieverConfig(query_cache_ttl_seconds=0)
+        config = RetrieverConfig()
 
         retriever = VectorCypherRetriever(
             vector_store=vector_store,
@@ -428,24 +423,6 @@ class TestRetrieverRecencyScores:
 
 
 @pytest.mark.unit
-class TestRetrieverCaching:
-    """Tests for query result caching."""
-
-    @pytest.mark.asyncio
-    async def test_cache_disabled_by_default(self) -> None:
-        """Test that caching is disabled when ttl is 0."""
-        retriever = VectorCypherRetriever(
-            vector_store=AsyncMock(),
-            neo4j_driver=AsyncMock(),
-            embedder=AsyncMock(),
-            config=RetrieverConfig(query_cache_ttl_seconds=0),
-        )
-
-        assert retriever._cache_ttl == 0
-        assert retriever._cache == {}
-
-
-@pytest.mark.unit
 class TestSimpleRetrieveScoreNormalization:
     """Regression tests for: simple path score normalization.
 
@@ -541,7 +518,7 @@ class TestSimpleRetrieveScoreNormalization:
 
         vector_store.search = AsyncMock(return_value=mock_results)
 
-        config = RetrieverConfig(query_cache_ttl_seconds=0)
+        config = RetrieverConfig()
         retriever = VectorCypherRetriever(
             vector_store=vector_store,
             neo4j_driver=neo4j_driver,
@@ -601,7 +578,7 @@ class TestSimpleRetrieveScoreNormalization:
 
         vector_store.search = AsyncMock(return_value=[mock_result])
 
-        config = RetrieverConfig(query_cache_ttl_seconds=0)
+        config = RetrieverConfig()
         retriever = VectorCypherRetriever(
             vector_store=vector_store,
             neo4j_driver=AsyncMock(),
@@ -666,7 +643,7 @@ class TestGracefulDegradation:
         storage.search_similar_entities = AsyncMock(return_value=[(entry_entity_id, 0.9)])
         storage.get_entities_batch = AsyncMock(return_value={})
 
-        config = RetrieverConfig(query_cache_ttl_seconds=0)
+        config = RetrieverConfig()
 
         retriever = VectorCypherRetriever(
             vector_store=vector_store,
@@ -1080,7 +1057,6 @@ class TestExplicitTemporalSignalSkipsFallback:
         # path — that path issues additional _vector_search_chunks calls and
         # would muddy the call-count assertion.
         config = RetrieverConfig(
-            query_cache_ttl_seconds=0,
             enable_session_aware_search=False,
         )
         retriever = VectorCypherRetriever(


### PR DESCRIPTION
## Summary

Removes the in-process query result cache from VectorCypher retriever to fix stale results after memory updates (remember/forget). The MD5-keyed LRU cache held results for up to 5 minutes without invalidation on writes, causing `recall()` to return outdated chunks after `forget()`.

**Fixes:** IGR-114

## Changes

- Remove `RetrieverConfig.query_cache_ttl_seconds` and `query_cache_max_size` kwargs
- Remove config fields from `VectorCypherEngineConfig`
- Remove cache dictionary and TTL/eviction logic from `VectorCypherRetriever.__init__` and `retrieve()` method
- Update tests to remove cache-related assertions
- Update CHANGELOG and documentation

## Test Plan

- [x] Unit tests pass: 71/71 vectorcypher engine tests pass
- [x] Test coverage verified on modified retriever/engine code
- [x] No downstream breakage: integrations (crewai, langgraph, llamaindex, openai-agents) do not reference removed kwargs

## Note

**Devil's advocate review identified a secondary staleness vector:** the expansion cache (`_expansion_cache: dict[UUID chunk_id, float score]`) is still present and exhibits the same bug. A follow-up PR should clear this cache on `forget()` to prevent stale expansion scores from influencing subsequent queries. This PR focuses narrowly on the query-result cache per the dispatch prompt, but the expansion cache should be addressed in IGR-115.