### PR TITLE
fix: pgvector.upsert_entities_batch reports is_new=True for existing entities (#719)

### DIFF
--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from loguru import logger
-from sqlalchemy import delete, func, select, text, update
+from sqlalchemy import delete, func, literal_column, select, text, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 from tenacity import AsyncRetrying, retry_if_exception, stop_after_attempt, wait_exponential
 
@@ -898,7 +898,10 @@ class PgVectorBackend(AsyncSessionMixin):
         deadlocks when multiple documents share entities.  Upserts for
         different namespaces proceed in parallel without contention.
 
-        Returns list of (entity, is_new) tuples (is_new is approximate).
+        Returns list of (entity, is_new) tuples. `is_new` is computed via
+        ``RETURNING (xmax = 0)``: ``xmax = 0`` indicates a true insert, while
+        a non-zero ``xmax`` means the ``ON CONFLICT DO UPDATE`` path acquired
+        a row lock on the existing row.
         """
         if not entities:
             return []
@@ -909,6 +912,7 @@ class PgVectorBackend(AsyncSessionMixin):
             # Sort by (namespace_id, name, entity_type) to ensure consistent lock ordering
             sorted_entities = sorted(entities, key=lambda e: (str(e.namespace_id), e.name, str(e.entity_type)))
             lock_key2 = _namespace_lock_key(namespace_id)
+            is_new_map: dict[tuple[str, str], bool] = {}
 
             async with self._get_session() as session:
                 # Acquire namespace-scoped advisory lock for the duration of this
@@ -959,13 +963,44 @@ class PgVectorBackend(AsyncSessionMixin):
                             "metadata": stmt.excluded.metadata,
                             "updated_at": stmt.excluded.updated_at,
                         },
+                    ).returning(
+                        EntityModel.name,
+                        EntityModel.entity_type,
+                        literal_column("(xmax = 0)").label("is_new"),
                     )
-                    await session.execute(stmt)
+                    result = await session.execute(stmt)
+                    for row in result:
+                        key = (row.name, row.entity_type)
+                        if key in is_new_map:
+                            logger.warning(
+                                "upsert_entities_batch: duplicate (name, entity_type) "
+                                "in input batch; is_new for first occurrence may be inaccurate "
+                                "(name={name!r}, entity_type={entity_type!r}, namespace_id={namespace_id})",
+                                name=row.name,
+                                entity_type=row.entity_type,
+                                namespace_id=namespace_id,
+                            )
+                        is_new_map[key] = bool(row.is_new)
 
                 # Single commit for all sub-batches under the advisory lock
                 await session.commit()
 
-            return [(entity, True) for entity in sorted_entities]
+            results: list[tuple] = []
+            for entity in sorted_entities:
+                key = (entity.name, entity.entity_type)
+                if key in is_new_map:
+                    results.append((entity, is_new_map[key]))
+                else:
+                    logger.warning(
+                        "upsert_entities_batch: entity missing from RETURNING; "
+                        "falling back to is_new=True "
+                        "(name={name!r}, entity_type={entity_type!r}, namespace_id={namespace_id})",
+                        name=entity.name,
+                        entity_type=entity.entity_type,
+                        namespace_id=namespace_id,
+                    )
+                    results.append((entity, True))
+            return results
 
         return await _retry_on_deadlock(_do_upsert)
 

--- a/tests/integration/storage/test_pgvector_upsert_is_new.py
+++ b/tests/integration/storage/test_pgvector_upsert_is_new.py
@@ -1,0 +1,174 @@
+"""Integration test for `PgVectorBackend.upsert_entities_batch` is_new tracking.
+
+Regression test for GitHub issue #719. Prior to the fix, the pgvector
+backend returned ``is_new=True`` for every entity — even on the second
+upsert of the same ``(namespace_id, name, entity_type)`` — because the
+function hard-coded ``return [(entity, True) for entity in sorted_entities]``.
+
+The Neo4j adapter's parametrized compliance test
+(``tests/unit/storage/backends/test_protocol_compliance.py::test_upsert_entities_batch_new_vs_existing``)
+runs against the ``graph_backend`` fixture only, so this gap on the
+vector adapter went undetected. This test closes that gap by exercising
+pgvector directly against a real PostgreSQL.
+
+The fix uses ``RETURNING (xmax = 0) AS is_new`` to discriminate true
+inserts from ``ON CONFLICT DO UPDATE`` paths.
+
+Requires a running PostgreSQL instance from this repo's compose stack
+(``make dev``); port ``5434`` per ``compose.yaml``. Set
+``KHORA_DATABASE_URL`` to override.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from khora.core.models import Entity, MemoryNamespace
+from khora.db.session import run_migrations
+from khora.storage.backends.pgvector import PgVectorBackend
+from khora.storage.backends.postgresql import PostgreSQLBackend
+
+DATABASE_URL = os.environ.get(
+    "KHORA_DATABASE_URL",
+    "postgresql+asyncpg://khora:khora@localhost:5434/khora",
+)
+
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
+
+pytestmark = [pytest.mark.integration]
+
+
+def _pg_reachable() -> bool:
+    import socket
+    from urllib.parse import urlparse
+
+    parsed = urlparse(DATABASE_URL.replace("+asyncpg", ""))
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+skip_no_pg = pytest.mark.skipif(
+    not _pg_reachable(),
+    reason="PostgreSQL not reachable (run `make dev` first)",
+)
+
+
+@pytest.fixture(scope="module")
+async def _run_migrations_once():
+    result = await run_migrations(DATABASE_URL)
+    assert result.success, f"Migrations failed: {result.error}"
+
+
+@pytest.fixture
+async def relational(_run_migrations_once):
+    be = PostgreSQLBackend(database_url=DATABASE_URL)
+    await be.connect()
+    yield be
+    await be.disconnect()
+
+
+@pytest.fixture
+async def vector_backend(_run_migrations_once):
+    # Match the production embedding dimension; entity rows allow NULL embeddings,
+    # so the actual vector dim does not affect this test.
+    be = PgVectorBackend(database_url=DATABASE_URL, embedding_dimension=4)
+    await be.connect()
+    yield be
+    await be.disconnect()
+
+
+def _make_entity(namespace_id, *, name: str, entity_type: str = "PERSON") -> Entity:
+    """Build a fresh Entity. Each call returns a new ``id``; the natural key
+    ``(namespace_id, name, entity_type)`` is what drives the ON CONFLICT path."""
+    return Entity(
+        id=uuid4(),
+        namespace_id=namespace_id,
+        name=name,
+        entity_type=entity_type,
+        description="",
+        attributes={},
+        embedding=None,
+        embedding_model="",
+        mention_count=1,
+        confidence=1.0,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+@skip_no_pg
+class TestPgVectorUpsertIsNew:
+    """Regression coverage for issue #719 — pgvector ``is_new`` semantics."""
+
+    async def test_upsert_entities_batch_new_vs_existing(
+        self, relational: PostgreSQLBackend, vector_backend: PgVectorBackend
+    ) -> None:
+        ns = await relational.create_namespace(MemoryNamespace())
+
+        # Seed 3 entities — all must report is_new=True.
+        seed = [_make_entity(ns.id, name=f"S{i}") for i in range(3)]
+        seeded = await vector_backend.upsert_entities_batch(ns.id, seed)
+        assert all(is_new for _, is_new in seeded), f"expected all True on initial upsert, got {[f for _, f in seeded]}"
+
+        # Mix 2 new + 3 colliding-by-(name, entity_type). Use fresh Entity
+        # instances with new uuids — mirrors issue #719's repro where every
+        # ingest pass mints fresh entity objects but the natural key collides.
+        new = [_make_entity(ns.id, name=f"N{i}") for i in range(2)]
+        collide = [_make_entity(ns.id, name=f"S{i}") for i in range(3)]
+        results = await vector_backend.upsert_entities_batch(ns.id, new + collide)
+
+        # The backend sorts internally by (namespace_id, name, entity_type),
+        # so check the flag per-entity by name rather than positional order.
+        flags = {e.name: is_new for e, is_new in results}
+        assert flags == {
+            "N0": True,
+            "N1": True,
+            "S0": False,
+            "S1": False,
+            "S2": False,
+        }, f"is_new map wrong on second pass: {flags}"
+
+        # Row count: 5 total (3 seeded + 2 net new). MERGE semantics preserved.
+        assert await vector_backend.count_entities(ns.id) == 5
+
+    async def test_upsert_entities_batch_empty(self, vector_backend: PgVectorBackend) -> None:
+        assert await vector_backend.upsert_entities_batch(uuid4(), []) == []
+
+    async def test_upsert_entities_batch_crosses_sub_batch_boundary(
+        self, relational: PostgreSQLBackend, vector_backend: PgVectorBackend
+    ) -> None:
+        """``is_new`` must remain correct across multiple sub-batches.
+
+        ``upsert_entities_batch`` chunks input by ``batch_size`` while holding
+        the namespace advisory lock for the full transaction. The fix builds
+        ``is_new_map`` incrementally across sub-batches; this test guards
+        against bugs that would reset the map per sub-batch or otherwise
+        lose track of seen rows across the chunk boundary.
+
+        Uses a small ``batch_size=2`` so 5 entities span 3 sub-batches.
+        """
+        ns = await relational.create_namespace(MemoryNamespace())
+
+        seed = [_make_entity(ns.id, name=f"X{i}") for i in range(5)]
+        seeded = await vector_backend.upsert_entities_batch(ns.id, seed, batch_size=2)
+        assert [is_new for _, is_new in seeded] == [True] * 5
+
+        # All 5 collide across the chunk boundary on the second pass.
+        collide = [_make_entity(ns.id, name=f"X{i}") for i in range(5)]
+        results = await vector_backend.upsert_entities_batch(ns.id, collide, batch_size=2)
+        flags = {e.name: is_new for e, is_new in results}
+        assert flags == {f"X{i}": False for i in range(5)}, f"is_new across sub-batches wrong: {flags}"
+
+        assert await vector_backend.count_entities(ns.id) == 5


### PR DESCRIPTION
## Summary

- `PgVectorBackend.upsert_entities_batch` hardcoded `(entity, True)` for every entity, even ones already present in the namespace. The Neo4j adapter for the same inputs correctly distinguished insert vs. update, so the two halves of the dual-write disagreed on `is_new`.
- Replaced the hardcoded return with `RETURNING (xmax = 0) AS is_new` piggybacked on the existing `INSERT ... ON CONFLICT DO UPDATE`. `xmax = 0` is PostgreSQL's natural insert-vs-update discriminator: pure inserts leave it zero, the ON CONFLICT DO UPDATE path sets it to the current transaction's xid. No extra round-trip.
- Accumulate the RETURNING rows into a `(name, entity_type) -> is_new` map across all sub-batches under the existing namespace advisory lock, then build the return list against `sorted_entities`. Defensive `logger.warning` calls cover the missing-from-RETURNING fallback and intra-batch-duplicate edge cases surfaced by review.
- Added an integration test (`tests/integration/storage/test_pgvector_upsert_is_new.py`) covering the issue's repro (fresh UUIDs, colliding name+type), the empty-input short-circuit, and a cross-sub-batch-boundary case (`batch_size=2` over 5 entities) to verify `is_new` accumulates correctly across multiple statements inside one transaction. The protocol-compliance test that caught the bug on graph backends only runs against the `graph_backend` fixture — pgvector is the *vector* adapter, which is why this regressed unnoticed.

## Impact

- **pgvector-only stacks**: `pipelines/flows/ingest.py:1286` (`needs_embedding = is_new or not entity.embedding`) stops triggering on every existing entity, eliminating wasted embedding-model calls.
- **Coordinator counters** (`storage/coordinator.py:652-653`) and **ingest event types** (`ingest.py:1248`: `entity.created` vs `entity.updated`) now reflect reality.
- **Dual-stack (pgvector + Neo4j)** consumers were shielded today because the coordinator returns Neo4j's results; this fixes direct vector-adapter callers and brings the two halves into agreement.

## Test plan

- [x] `uv run pytest tests/integration/storage/test_pgvector_upsert_is_new.py -v` — all 3 tests pass against the fix
- [x] Regression gate verified: tests 1 and 3 fail against the unfixed backend (per QA's `git stash` run during development)
- [x] `make format && make lint` clean
- [ ] Full `make test` runs in CI (local run blocked by docker-compose port conflicts with another project; CI's stack is isolated)
- [ ] Manual: issue #719's repro script prints `vector=[True, False] graph=[True, False]` after merge

Fixes #719