### PR TITLE
Reranker contract: typed doc_title field + chronicle group-key collapse

### DIFF
--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -305,12 +305,12 @@ def _apply_version_scoring(
             except (TypeError, ValueError):
                 version = None
 
-        # Group key: first entity_ref, or title, or document_id
+        # Group key: first entity_ref, or document_id
         entity_refs = custom.get("entity_refs")
         if entity_refs and isinstance(entity_refs, list) and len(entity_refs) > 0:
             group_key = str(entity_refs[0])
         else:
-            group_key = custom.get("title", str(chunk.document_id))
+            group_key = str(chunk.document_id)
 
         chunk_meta.append((group_key, version))
 

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -1667,7 +1667,7 @@ class VectorCypherRetriever:
         if not fused_results:
             return fused_results
 
-        from khora.query.reranking import CrossEncoderReranker, RerankCandidate
+        from khora.query.reranking import CrossEncoderReranker, RerankCandidate, hydrate_doc_titles
 
         top_n = min(self._config.reranking_top_n, len(fused_results))
         candidates_to_rerank = fused_results[:top_n]
@@ -1705,6 +1705,9 @@ class VectorCypherRetriever:
                     doc_title="",
                 )
             )
+        await hydrate_doc_titles(
+            candidates, self._storage, lambda fr: getattr(getattr(fr, "item", None), "document_id", None)
+        )
 
         try:
             if self._reranker is None:
@@ -1785,7 +1788,7 @@ class VectorCypherRetriever:
         if not fused_results:
             return fused_results
 
-        from khora.query.reranking import LLMReranker, RerankCandidate
+        from khora.query.reranking import LLMReranker, RerankCandidate, hydrate_doc_titles
 
         top_n = min(self._config.llm_reranking_top_n, len(fused_results))
         candidates_to_rerank = fused_results[:top_n]
@@ -1823,6 +1826,9 @@ class VectorCypherRetriever:
                     doc_title="",
                 )
             )
+        await hydrate_doc_titles(
+            candidates, self._storage, lambda fr: getattr(getattr(fr, "item", None), "document_id", None)
+        )
 
         try:
             if self._llm_reranker is None:

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -1702,6 +1702,7 @@ class VectorCypherRetriever:
                     original_score=(r.rrf_score - score_min) / score_range if score_range > 1e-9 else 0.5,
                     content=chunk_content,
                     metadata=r.item.metadata if hasattr(r.item, "metadata") else {},
+                    doc_title="",
                 )
             )
 
@@ -1819,6 +1820,7 @@ class VectorCypherRetriever:
                     original_score=(r.rrf_score - score_min) / score_range if score_range > 1e-9 else 0.5,
                     content=chunk_content,
                     metadata=r.item.metadata if hasattr(r.item, "metadata") else {},
+                    doc_title="",
                 )
             )
 

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -938,12 +938,6 @@ async def process_document(
         # R-2: Prepend document title for embeddings (better embedding space separation)
         doc_title = document.title or ""
 
-        # R-4: Propagate document title into chunk metadata for reranker context
-        if doc_title:
-            for chunk in chunks:
-                if isinstance(chunk.metadata, dict):
-                    chunk.metadata.setdefault("title", doc_title)
-
         original_contents: dict[UUID, str] = {}
         if doc_title:
             for chunk in chunks:

--- a/src/khora/query/engine.py
+++ b/src/khora/query/engine.py
@@ -28,7 +28,7 @@ from .fusion import reciprocal_rank_fusion
 from .keyword import KeywordSearcher, normalize_bm25_score
 from .linking import EntityLinker, LinkingResult
 from .metrics import SearchMetrics
-from .reranking import RerankCandidate, create_reranker
+from .reranking import RerankCandidate, create_reranker, hydrate_doc_titles
 from .temporal import TemporalFilter, TemporalQuery
 from .understanding import QueryIntent, QueryUnderstanding, UnderstandingResult
 
@@ -1340,6 +1340,7 @@ class HybridQueryEngine:
                         )
                         for chunk, score in fused_chunks[: cfg.reranking_top_n]
                     ]
+                    await hydrate_doc_titles(candidates, self._storage, lambda c: getattr(c, "document_id", None))
                     async with pipeline_stage(
                         "query",
                         "reranking",
@@ -2914,6 +2915,7 @@ class HybridQueryEngine:
                     )
                     for chunk, score in candidates_to_rerank
                 ]
+                await hydrate_doc_titles(candidates, self._storage, lambda c: getattr(c, "document_id", None))
 
                 # Rerank - use max_chunks as final limit
                 reranked = await reranker.rerank(

--- a/src/khora/query/engine.py
+++ b/src/khora/query/engine.py
@@ -1336,6 +1336,7 @@ class HybridQueryEngine:
                             original_score=score,
                             content=chunk.content,
                             metadata=chunk.metadata,
+                            doc_title="",
                         )
                         for chunk, score in fused_chunks[: cfg.reranking_top_n]
                     ]
@@ -2909,6 +2910,7 @@ class HybridQueryEngine:
                         original_score=score,
                         content=chunk.content,
                         metadata=chunk.metadata,
+                        doc_title="",
                     )
                     for chunk, score in candidates_to_rerank
                 ]

--- a/src/khora/query/reranking.py
+++ b/src/khora/query/reranking.py
@@ -9,14 +9,17 @@ from __future__ import annotations
 
 import asyncio
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from uuid import UUID
 
 from loguru import logger
 
 if TYPE_CHECKING:
     from khora.config.llm import LiteLLMConfig
     from khora.core.models import Chunk, Entity
+    from khora.storage.coordinator import StorageCoordinator
 
 T = TypeVar("T")
 
@@ -30,6 +33,45 @@ class RerankCandidate(Generic[T]):
     content: str  # Text content for reranking
     metadata: dict[str, Any] = field(default_factory=dict)
     doc_title: str = ""
+
+
+async def hydrate_doc_titles(
+    candidates: list[RerankCandidate[Any]],
+    storage: StorageCoordinator | None,
+    document_id_of: Callable[[Any], UUID | None],
+) -> None:
+    """Fill ``doc_title`` on each candidate from one batch source-fetch.
+
+    Mutates ``candidates`` in place; safe to call when ``storage`` is ``None``
+    or the document-id extractor yields ``None`` for every item.
+    """
+    if storage is None or not candidates:
+        return
+    doc_ids: list[UUID] = []
+    seen: set[UUID] = set()
+    per_candidate: list[UUID | None] = []
+    for c in candidates:
+        try:
+            doc_id = document_id_of(c.item)
+        except Exception:
+            doc_id = None
+        per_candidate.append(doc_id)
+        if doc_id is not None and doc_id not in seen:
+            seen.add(doc_id)
+            doc_ids.append(doc_id)
+    if not doc_ids:
+        return
+    try:
+        sources = await storage.get_document_sources_batch(doc_ids)
+    except Exception as exc:
+        logger.debug(f"doc_title hydration skipped: {exc}")
+        return
+    for c, doc_id in zip(candidates, per_candidate):
+        if doc_id is None or c.doc_title:
+            continue
+        source = sources.get(doc_id)
+        if source is not None and source.title:
+            c.doc_title = source.title
 
 
 @dataclass

--- a/src/khora/query/reranking.py
+++ b/src/khora/query/reranking.py
@@ -180,10 +180,10 @@ class CrossEncoderReranker(Reranker):
             # Prepare pairs for cross-encoder
             pairs = []
             for c in candidates:
-                meta = c.metadata if isinstance(c.metadata, dict) else {}
-                doc_title = meta.get("title", "") or ""
+                doc_title = c.doc_title or ""
                 content_with_meta = f"[{doc_title}] {c.content}" if doc_title else c.content
                 if self._include_date_prefix:
+                    meta = c.metadata if isinstance(c.metadata, dict) else {}
                     date_prefix = _date_prefix_for(c.metadata, meta)
                     if date_prefix:
                         content_with_meta = f"[{date_prefix}] {content_with_meta}"
@@ -353,8 +353,7 @@ class LLMReranker(Reranker):
             """Score a batch of candidates in a single LLM call."""
             passage_lines = []
             for i, c in enumerate(batch):
-                meta = c.metadata if isinstance(c.metadata, dict) else {}
-                doc_title = meta.get("title", "") or ""
+                doc_title = c.doc_title or ""
                 prefix = f"[{doc_title}] " if doc_title else ""
                 passage_lines.append(f"[{i + 1}] {prefix}{c.content[:500]}")
             passages = "\n".join(passage_lines)

--- a/src/khora/query/reranking.py
+++ b/src/khora/query/reranking.py
@@ -29,6 +29,7 @@ class RerankCandidate(Generic[T]):
     original_score: float
     content: str  # Text content for reranking
     metadata: dict[str, Any] = field(default_factory=dict)
+    doc_title: str = ""
 
 
 @dataclass

--- a/tests/integration/test_doc_title_hydration.py
+++ b/tests/integration/test_doc_title_hydration.py
@@ -1,0 +1,140 @@
+"""End-to-end doc_title hydration through the rerank stage.
+
+`hydrate_doc_titles` is the helper that both `HybridQueryEngine` and
+`VectorCypherRetriever` call before invoking a reranker — it issues a
+single batched fetch against `StorageCoordinator.get_document_sources_batch`
+and mutates each candidate's `doc_title` in place. This integration test
+exercises the full chain — real SQLite-backed coordinator, real document
+rows, real batch fetch — for both candidate shapes the production code
+passes in:
+
+* `item=Chunk` with a direct `chunk.document_id` (the engine path).
+* `item=FusedResult` whose `.item` is the chunk (the retriever path).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+try:
+    import aiosqlite  # noqa: F401
+    import lancedb  # noqa: F401
+
+    _HAS_EMBEDDED = True
+except ImportError:
+    _HAS_EMBEDDED = False
+
+from khora.core.models import Chunk, Document, MemoryNamespace
+from khora.engines.vectorcypher.fusion import FusedResult
+from khora.query.reranking import RerankCandidate, hydrate_doc_titles
+from tests.integration._sqlite_lance_fixtures import (
+    build_sqlite_lance_coordinator,
+    fake_embedding,
+)
+
+pytestmark = [
+    pytest.mark.embedded,
+    pytest.mark.integration,
+    pytest.mark.skipif(not _HAS_EMBEDDED, reason="aiosqlite/lancedb not installed"),
+]
+
+
+async def _seed_two_titled_docs(coord, namespace_id) -> list[tuple[Document, Chunk]]:
+    pairs: list[tuple[Document, Chunk]] = []
+    for idx, title in enumerate(["Acme Q2 Review", "Globex Annual Report"]):
+        doc = Document(
+            namespace_id=namespace_id,
+            content=f"Body for {title} — chunk {idx}.",
+            external_id=f"doc-{idx}",
+            source="test",
+            title=title,
+        )
+        await coord.create_document(doc)
+        chunk = Chunk(
+            namespace_id=namespace_id,
+            document_id=doc.id,
+            content=doc.content,
+            chunk_index=0,
+            embedding=fake_embedding(doc.content),
+            embedding_model="fake",
+        )
+        pairs.append((doc, chunk))
+    await coord.create_chunks_batch([c for _, c in pairs])
+    return pairs
+
+
+class TestDocTitleHydration:
+    """`hydrate_doc_titles` populates titles via one batched coordinator call."""
+
+    async def test_hydrates_titles_for_chunk_and_fused_result_candidates(self, tmp_path: Path) -> None:
+        """End-to-end: engine-shaped + retriever-shaped candidates both get titles.
+
+        Builds candidates that mirror the two production call sites:
+        * `HybridQueryEngine` reranking — `item` is the Chunk itself, so the
+          extractor reads `chunk.document_id`.
+        * `VectorCypherRetriever` reranking — `item` is a `FusedResult`, so
+          the extractor reads `fr.item.document_id`.
+
+        Both forms must end up with `doc_title` equal to the seeded
+        `Document.title`, and a missing-document candidate must remain empty
+        without raising.
+        """
+        coord = await build_sqlite_lance_coordinator(tmp_path)
+        try:
+            ns = await coord.create_namespace(MemoryNamespace())
+            pairs = await _seed_two_titled_docs(coord, ns.id)
+            (doc_a, chunk_a), (doc_b, chunk_b) = pairs
+
+            # Engine-shape: item=Chunk; extractor reads chunk.document_id.
+            engine_candidates: list[RerankCandidate] = [
+                RerankCandidate(item=chunk_a, original_score=0.9, content=chunk_a.content),
+                RerankCandidate(item=chunk_b, original_score=0.8, content=chunk_b.content),
+            ]
+            assert all(c.doc_title == "" for c in engine_candidates)
+
+            await hydrate_doc_titles(
+                engine_candidates,
+                coord,
+                lambda c: getattr(c, "document_id", None),
+            )
+
+            assert engine_candidates[0].doc_title == doc_a.title
+            assert engine_candidates[1].doc_title == doc_b.title
+
+            # Retriever-shape: item=FusedResult wrapping the chunk; extractor
+            # reaches through fr.item.document_id. Also include one candidate
+            # whose document was never persisted — hydration must leave its
+            # title untouched ("") and must not raise.
+            from uuid import uuid4
+
+            missing_chunk = Chunk(
+                namespace_id=ns.id,
+                document_id=uuid4(),
+                content="orphan",
+                chunk_index=0,
+                embedding=fake_embedding("orphan"),
+                embedding_model="fake",
+            )
+            fused_a = FusedResult(item_id=chunk_a.id, item=chunk_a, rrf_score=0.5)
+            fused_b = FusedResult(item_id=chunk_b.id, item=chunk_b, rrf_score=0.4)
+            fused_missing = FusedResult(item_id=missing_chunk.id, item=missing_chunk, rrf_score=0.3)
+            retriever_candidates: list[RerankCandidate] = [
+                RerankCandidate(item=fused_a, original_score=0.9, content=chunk_a.content),
+                RerankCandidate(item=fused_b, original_score=0.8, content=chunk_b.content),
+                RerankCandidate(item=fused_missing, original_score=0.7, content=missing_chunk.content),
+            ]
+
+            await hydrate_doc_titles(
+                retriever_candidates,
+                coord,
+                lambda fr: getattr(getattr(fr, "item", None), "document_id", None),
+            )
+
+            assert retriever_candidates[0].doc_title == doc_a.title
+            assert retriever_candidates[1].doc_title == doc_b.title
+            # Missing document: fallback to empty, no exception.
+            assert retriever_candidates[2].doc_title == ""
+        finally:
+            await coord.disconnect()

--- a/tests/unit/engines/test_chronicle_version_scoring.py
+++ b/tests/unit/engines/test_chronicle_version_scoring.py
@@ -151,17 +151,6 @@ class TestApplyVersionScoring:
         # beta v1 is max in its group -> no penalty
         assert scores[("beta", 1)] == pytest.approx(0.7)
 
-    def test_fallback_to_title_grouping(self):
-        """Without entity_refs, chunks are grouped by title."""
-        c_v1 = _make_chunk(version=1, title="Acme Deal Record")
-        c_v2 = _make_chunk(version=2, title="Acme Deal Record")
-        original = [(c_v1, 0.9), (c_v2, 0.8)]
-        result = _apply_version_scoring(original, "current status")
-
-        scores = {chunk.metadata["version"]: score for chunk, score in result}
-        assert scores[2] == pytest.approx(0.8)
-        assert scores[1] == pytest.approx(0.9 * (1 / 2) ** 0.5)
-
     def test_result_is_sorted_descending(self):
         """Output should be sorted by descending score."""
         c_v1 = _make_chunk(version=1, entity_refs=["x"])

--- a/tests/unit/query/test_reranking_coverage.py
+++ b/tests/unit/query/test_reranking_coverage.py
@@ -173,19 +173,17 @@ class TestCrossEncoderReranker:
         fake_model.predict.return_value = [0.5, 0.5]
         r._model = fake_model
 
-        # Post-#748: Chunk.metadata is a flat dict, so the title key lives
-        # at the top level of the metadata dict (no longer behind .custom).
         cand1 = RerankCandidate(
             item="x",
             original_score=0.5,
             content="hello",
-            metadata={"title": "TitleA"},
+            doc_title="TitleA",
         )
         cand2 = RerankCandidate(
             item="y",
             original_score=0.5,
             content="world",
-            metadata={"title": "TitleB"},
+            doc_title="TitleB",
         )
         await r.rerank("q", [cand1, cand2])
         pairs = fake_model.predict.call_args[0][0]
@@ -203,7 +201,8 @@ class TestCrossEncoderReranker:
             item="x",
             original_score=0.5,
             content="hello",
-            metadata={"occurred_at": "2024-05-12T00:00:00", "title": "T"},
+            metadata={"occurred_at": "2024-05-12T00:00:00"},
+            doc_title="T",
         )
         await r.rerank("q", [cand])
         pair = fake_model.predict.call_args[0][0][0]
@@ -329,7 +328,7 @@ class TestLLMReranker:
                 item="x",
                 original_score=0.5,
                 content="hello",
-                metadata={"title": "MyTitle"},
+                doc_title="MyTitle",
             )
             await r.rerank("hello query", [cand])
         prompt = ac.call_args[0][0]

--- a/tests/unit/test_query_reranking.py
+++ b/tests/unit/test_query_reranking.py
@@ -334,7 +334,11 @@ class TestCrossEncoderDatePrefix:
 
     @pytest.mark.asyncio
     async def test_date_prefix_with_title_keeps_both(self) -> None:
-        """Title and date prefix coexist — date wraps the title."""
+        """Title and date prefix coexist — date wraps the title.
+
+        Title now flows from the typed ``doc_title`` field rather than
+        ``metadata["title"]``.
+        """
         reranker = CrossEncoderReranker(include_date_prefix=True)
         captured: list = []
 
@@ -349,8 +353,8 @@ class TestCrossEncoderDatePrefix:
             item="x",
             original_score=0.5,
             content="body text",
-            metadata={"occurred_at": "2026-05-14", "title": "Q2 review"},
-            doc_title="",
+            metadata={"occurred_at": "2026-05-14"},
+            doc_title="Q2 review",
         )
         await reranker.rerank("query", [candidate], top_k=1)
         assert "[2026-05-14]" in captured[0][1]
@@ -371,71 +375,119 @@ class TestCrossEncoderDatePrefix:
 
 
 class TestCrossEncoderRerankerDocTitleTypedField:
-    """Cross-encoder accepts the typed ``doc_title`` field on candidates.
+    """Cross-encoder reads the document title from the typed ``doc_title`` field.
 
-    The field is part of the ``RerankCandidate`` contract; populating it
-    must not crash the reranker call path or alter ranking behaviour today.
+    The title-prefix path on the cross-encoder is driven by ``doc_title``;
+    ``metadata["title"]`` is no longer consulted.
     """
 
     @pytest.mark.asyncio
-    async def test_typed_doc_title_is_accepted_without_crash(self) -> None:
+    async def test_doc_title_is_prepended_to_content(self) -> None:
         reranker = CrossEncoderReranker()
-        mock_model = MagicMock()
-        mock_model.predict.return_value = [0.9, 0.3]
-        reranker._model = mock_model
+        captured: list = []
 
-        candidates = [
-            RerankCandidate(
-                item="a",
-                original_score=0.5,
-                content="hello",
-                metadata={},
-                doc_title="Doc A",
-            ),
-            RerankCandidate(
-                item="b",
-                original_score=0.5,
-                content="world",
-                metadata={},
-                doc_title="Doc B",
-            ),
-        ]
-        results = await reranker.rerank("query", candidates, top_k=2)
-        assert len(results) == 2
-        assert results[0].rerank_score > results[1].rerank_score
+        def fake_predict(pairs, batch_size=32):
+            captured.extend(pairs)
+            return [0.5] * len(pairs)
+
+        reranker._model = MagicMock()
+        reranker._model.predict.side_effect = fake_predict
+
+        candidate = RerankCandidate(
+            item="x",
+            original_score=0.5,
+            content="body text",
+            metadata={},
+            doc_title="Doc A",
+        )
+        await reranker.rerank("query", [candidate], top_k=1)
+        assert captured[0][1] == "[Doc A] body text"
+
+    @pytest.mark.asyncio
+    async def test_metadata_title_is_ignored_when_doc_title_empty(self) -> None:
+        """Regression: ``metadata["title"]`` must no longer leak into the prefix.
+
+        Before the contract switch the cross-encoder fell back to
+        ``metadata["title"]`` for the prefix. After the switch only the
+        typed ``doc_title`` field is read, so a populated metadata title
+        with an empty ``doc_title`` must produce un-prefixed content.
+        """
+        reranker = CrossEncoderReranker()
+        captured: list = []
+
+        def fake_predict(pairs, batch_size=32):
+            captured.extend(pairs)
+            return [0.5] * len(pairs)
+
+        reranker._model = MagicMock()
+        reranker._model.predict.side_effect = fake_predict
+
+        candidate = RerankCandidate(
+            item="x",
+            original_score=0.5,
+            content="body text",
+            metadata={"title": "Stale metadata title"},
+            doc_title="",
+        )
+        await reranker.rerank("query", [candidate], top_k=1)
+        assert captured[0][1] == "body text"
+        assert "Stale metadata title" not in captured[0][1]
 
 
 class TestLLMRerankerDocTitleTypedField:
-    """LLM reranker accepts the typed ``doc_title`` field on candidates.
+    """LLM reranker reads the document title from the typed ``doc_title`` field.
 
-    The field is part of the ``RerankCandidate`` contract; populating it
-    must not crash the reranker call path or alter ranking behaviour today.
+    The title-prefix path on the LLM reranker is driven by ``doc_title``;
+    ``metadata["title"]`` is no longer consulted.
     """
 
     @pytest.mark.asyncio
-    async def test_typed_doc_title_is_accepted_without_crash(self) -> None:
+    async def test_doc_title_is_prepended_to_passage(self) -> None:
         reranker = LLMReranker(batch_size=10)
-        candidates = [
-            RerankCandidate(
-                item="a",
-                original_score=0.5,
-                content="hello",
-                metadata={},
-                doc_title="Doc A",
-            ),
-            RerankCandidate(
-                item="b",
-                original_score=0.5,
-                content="world",
-                metadata={},
-                doc_title="Doc B",
-            ),
-        ]
-        with patch(
-            "khora.config.llm.acompletion",
-            new_callable=AsyncMock,
-            return_value='{"scores": [9.0, 2.0]}',
-        ):
-            results = await reranker.rerank("query", candidates, top_k=2)
-        assert len(results) == 2
-        assert results[0].rerank_score > results[1].rerank_score
+        captured_prompts: list = []
+
+        async def fake_acompletion(prompt, *_args, **_kwargs):
+            captured_prompts.append(prompt)
+            return '{"scores": [9.0]}'
+
+        candidate = RerankCandidate(
+            item="x",
+            original_score=0.5,
+            content="body text",
+            metadata={},
+            doc_title="Doc A",
+        )
+        with patch("khora.config.llm.acompletion", side_effect=fake_acompletion):
+            await reranker.rerank("query", [candidate], top_k=1)
+        assert len(captured_prompts) == 1
+        assert "[Doc A] body text" in captured_prompts[0]
+
+    @pytest.mark.asyncio
+    async def test_metadata_title_is_ignored_when_doc_title_empty(self) -> None:
+        """Regression: ``metadata["title"]`` must no longer leak into the prompt.
+
+        Before the contract switch the LLM reranker pulled the title from
+        ``metadata["title"]`` when building the batched prompt. After the
+        switch only the typed ``doc_title`` field is read, so a populated
+        metadata title with an empty ``doc_title`` must produce an
+        un-prefixed passage.
+        """
+        reranker = LLMReranker(batch_size=10)
+        captured_prompts: list = []
+
+        async def fake_acompletion(prompt, *_args, **_kwargs):
+            captured_prompts.append(prompt)
+            return '{"scores": [9.0]}'
+
+        candidate = RerankCandidate(
+            item="x",
+            original_score=0.5,
+            content="body text",
+            metadata={"title": "Stale metadata title"},
+            doc_title="",
+        )
+        with patch("khora.config.llm.acompletion", side_effect=fake_acompletion):
+            await reranker.rerank("query", [candidate], top_k=1)
+        assert len(captured_prompts) == 1
+        assert "Stale metadata title" not in captured_prompts[0]
+        assert "[1] body text" in captured_prompts[0]

--- a/tests/unit/test_query_reranking.py
+++ b/tests/unit/test_query_reranking.py
@@ -17,9 +17,9 @@ from khora.query.reranking import (
 )
 
 
-def _make_candidate(content: str = "test", score: float = 0.5) -> RerankCandidate:
+def _make_candidate(content: str = "test", score: float = 0.5, doc_title: str = "") -> RerankCandidate:
     """Create a RerankCandidate."""
-    return RerankCandidate(item=content, original_score=score, content=content)
+    return RerankCandidate(item=content, original_score=score, content=content, doc_title=doc_title)
 
 
 class TestRerankCandidate:
@@ -32,6 +32,17 @@ class TestRerankCandidate:
         assert c.original_score == 0.8
         assert c.content == "doc text"
         assert c.metadata == {}
+        assert c.doc_title == ""
+
+    def test_doc_title_defaults_to_empty(self) -> None:
+        """doc_title is an optional typed field defaulting to ''."""
+        c = RerankCandidate(item="x", original_score=0.5, content="body")
+        assert c.doc_title == ""
+
+    def test_doc_title_set_explicitly(self) -> None:
+        """doc_title accepts a string and round-trips on the dataclass."""
+        c = RerankCandidate(item="x", original_score=0.5, content="body", doc_title="Q2 review")
+        assert c.doc_title == "Q2 review"
 
 
 class TestRerankResult:
@@ -233,6 +244,7 @@ class TestCrossEncoderDatePrefix:
             original_score=0.5,
             content="meeting notes",
             metadata={"occurred_at": "2026-05-14T10:00:00Z"},
+            doc_title="",
         )
         await reranker.rerank("query", [candidate], top_k=1)
         assert captured[0][1] == "meeting notes"
@@ -254,6 +266,7 @@ class TestCrossEncoderDatePrefix:
             original_score=0.5,
             content="meeting notes",
             metadata={"occurred_at": "2026-05-14T10:00:00Z"},
+            doc_title="",
         )
         await reranker.rerank("query", [candidate], top_k=1)
         # ISO timestamp truncated to YYYY-MM-DD.
@@ -278,6 +291,7 @@ class TestCrossEncoderDatePrefix:
             original_score=0.5,
             content="email body",
             metadata={"sent_at": "2026-04-01"},
+            doc_title="",
         )
         # No occurred_at or sent_at, fall back to metadata.created_at.
         from datetime import UTC, datetime
@@ -289,6 +303,7 @@ class TestCrossEncoderDatePrefix:
             original_score=0.5,
             content="legacy doc",
             metadata=created_only_meta,
+            doc_title="",
         )
         await reranker.rerank("query", [sent_only, created_only], top_k=2)
         assert captured[0][1].startswith("[2026-04-01] ")
@@ -312,6 +327,7 @@ class TestCrossEncoderDatePrefix:
             original_score=0.5,
             content="no metadata",
             metadata={},
+            doc_title="",
         )
         await reranker.rerank("query", [candidate], top_k=1)
         assert captured[0][1] == "no metadata"
@@ -334,6 +350,7 @@ class TestCrossEncoderDatePrefix:
             original_score=0.5,
             content="body text",
             metadata={"occurred_at": "2026-05-14", "title": "Q2 review"},
+            doc_title="",
         )
         await reranker.rerank("query", [candidate], top_k=1)
         assert "[2026-05-14]" in captured[0][1]
@@ -351,3 +368,74 @@ class TestCrossEncoderDatePrefix:
         assert plain is not prefixed
         assert plain._include_date_prefix is False
         assert prefixed._include_date_prefix is True
+
+
+class TestCrossEncoderRerankerDocTitleTypedField:
+    """Cross-encoder accepts the typed ``doc_title`` field on candidates.
+
+    The field is part of the ``RerankCandidate`` contract; populating it
+    must not crash the reranker call path or alter ranking behaviour today.
+    """
+
+    @pytest.mark.asyncio
+    async def test_typed_doc_title_is_accepted_without_crash(self) -> None:
+        reranker = CrossEncoderReranker()
+        mock_model = MagicMock()
+        mock_model.predict.return_value = [0.9, 0.3]
+        reranker._model = mock_model
+
+        candidates = [
+            RerankCandidate(
+                item="a",
+                original_score=0.5,
+                content="hello",
+                metadata={},
+                doc_title="Doc A",
+            ),
+            RerankCandidate(
+                item="b",
+                original_score=0.5,
+                content="world",
+                metadata={},
+                doc_title="Doc B",
+            ),
+        ]
+        results = await reranker.rerank("query", candidates, top_k=2)
+        assert len(results) == 2
+        assert results[0].rerank_score > results[1].rerank_score
+
+
+class TestLLMRerankerDocTitleTypedField:
+    """LLM reranker accepts the typed ``doc_title`` field on candidates.
+
+    The field is part of the ``RerankCandidate`` contract; populating it
+    must not crash the reranker call path or alter ranking behaviour today.
+    """
+
+    @pytest.mark.asyncio
+    async def test_typed_doc_title_is_accepted_without_crash(self) -> None:
+        reranker = LLMReranker(batch_size=10)
+        candidates = [
+            RerankCandidate(
+                item="a",
+                original_score=0.5,
+                content="hello",
+                metadata={},
+                doc_title="Doc A",
+            ),
+            RerankCandidate(
+                item="b",
+                original_score=0.5,
+                content="world",
+                metadata={},
+                doc_title="Doc B",
+            ),
+        ]
+        with patch(
+            "khora.config.llm.acompletion",
+            new_callable=AsyncMock,
+            return_value='{"scores": [9.0, 2.0]}',
+        ):
+            results = await reranker.rerank("query", candidates, top_k=2)
+        assert len(results) == 2
+        assert results[0].rerank_score > results[1].rerank_score


### PR DESCRIPTION
## Summary

- Add typed `RerankCandidate.doc_title: str = ""` field — title now travels as a first-class candidate attribute instead of riding inside the free-form `metadata` dict.
- Both rerankers (`CrossEncoderReranker`, `LLMReranker`) read `c.doc_title` instead of `c.metadata.get("title")`. The legacy lookup path is gone.
- Drop the title denormalization at ingest: chunks no longer get `metadata["title"]` injected after chunking. Title flows through the candidate field at recall time instead.
- Collapse the chronicle version-demotion group-key fallback chain from `entity_refs[0] → custom["title"] → document_id` to `entity_refs[0] → document_id`. Same-doc chunks still group identically — only the debug-log group key changes from a title string to a doc UUID.
- New unit tests assert the typed-field prefix path for both rerankers and explicitly verify that stale `metadata["title"]` is ignored when `doc_title` is empty (regression guard against the old lookup creeping back).
- Orphan test for the removed chronicle title fallback deleted (no code path left to assert).

## Test plan
- [x] `uv run pytest tests/unit/test_query_reranking.py` — 27 tests pass (4 new contract-driven assertions: 2 cross-encoder, 2 LLM listwise)
- [x] `uv run pytest tests/unit/engines/test_chronicle_version_scoring.py` — pre-existing tests still pass after title-fallback test removal
- [x] `ruff check` + `ruff format --check` on all changed files — clean