### PR TITLE
release: v0.15.3 lockstep bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 
 ## [Unreleased]
 
+## [0.15.3] — Typed recall projection; supersedes broken 0.15.2
+
+Supersedes 0.15.2, which shipped a `khora-accel==0.15.1` pin in the `[rust]` extra pointing at a never-published accel version, breaking `pip install khora[rust]==0.15.2`. v0.15.3 restores lockstep with the matching `khora-accel==0.15.3` pin.
+
 ### Changed
 
 - **`Khora.recall()` returns a typed projection — BREAKING.** `RecallResult` is rewritten as a JSON-serializable response projection at `khora.core.models.recall` (re-exported from `khora`). Migration:
@@ -24,6 +28,7 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 
 ### Fixed
 
+- **`pip install khora[rust]==0.15.2` failed to resolve.** The published 0.15.2 wheel hard-required `khora-accel==0.15.1`, but accel `0.15.1` was never published to PyPI (the lockstep `pyproject.toml` pin was not bumped in the 0.15.2 release commit). v0.15.3 ships matching `khora==0.15.3` + `khora-accel==0.15.3`. Yank 0.15.2 on PyPI.
 - Stale results from `Khora.recall()` after `remember`/`forget`. The in-process query result cache in the vectorcypher retriever held results for up to 5 minutes without invalidation on writes.
 - **vectorcypher entity-chunk fetch crashed on SurrealDB-only deployments** ([#754](https://github.com/DeytaHQ/khora/issues/754)). `VectorCypherRetriever._fetch_chunks_from_entities` falls back to the unified `self._storage` backend when no graph (`_dual_nodes`) is wired — the case for `backend=surrealdb` with the vectorcypher engine. The fallback built each `chunk_record` dict without a `document_id` key, but the downstream result-building loop unconditionally did `UUID(record["document_id"])`, producing an unhandled `KeyError` whenever any entity had source chunks. The fallback's `try/except` only wrapped the storage calls, not the consumer loop, so the error propagated upward and crashed recall calls routed through the entity-anchored channel. Now stamps `document_id` from the `Chunk.document_id` field returned by `storage.get_chunks_batch`. Regression covered in `tests/unit/engines/vectorcypher/test_fetch_chunks_surrealdb_fallback.py`.
 - **Entity-upsert advisory lock collided at ~65K namespaces** ([#738](https://github.com/DeytaHQ/khora/issues/738)). `_namespace_lock_key` folded the 128-bit `namespace_id` UUID down to a single signed `int4` via 4-way XOR, used as `key2` in `pg_advisory_xact_lock(KHOR, key2)`. Deployments with more than ~65K distinct namespaces (per-user / per-agent patterns under `khora.integrations.openai_agents`, `google_adk`, `crewai`, `langgraph`) hit birthday-paradox collisions — empirically observed at 120K in the issue's repro. Two namespaces sharing a folded key would serialize their entity upserts behind each other, producing tail-latency spikes on a random subset of namespaces. No data loss — the lock auto-released on commit and `_retry_on_deadlock` covered the contention. Replaced with `_namespace_lock_keys(...)` which fills both 32-bit slots of Postgres's two-int advisory-lock form from the full 128 bits of the UUID, giving ~2^64 effective lock-id entropy (birthday-safe at billions of namespaces). **Operators:** the legacy `0x4B484F52` ("KHOR") `classid` is no longer set on these locks — update any `pg_locks` dashboards that filter on it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ nlp = ["spacy>=3.8.0"]
 # LOCKSTEP: this pin must match rust/khora-accel/Cargo.toml's version exactly.
 # Bump both in the same PR. See CLAUDE.md → Version Bumps.
 rust = [
-    "khora-accel==0.15.1",
+    "khora-accel==0.15.3",
 ]
 # SurrealDB unified backend (graph + vector + relational in one DB)
 surrealdb = ["surrealdb>=2.0.0,<3.0"]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "khora-accel"
-version = "0.15.1"
+version = "0.15.3"
 dependencies = [
  "aho-corasick",
  "criterion",

--- a/rust/khora-accel/Cargo.toml
+++ b/rust/khora-accel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khora-accel"
-version = "0.15.1"
+version = "0.15.3"
 edition = "2024"
 rust-version = "1.85"
 description = "Rust-accelerated operations for Khora"


### PR DESCRIPTION
## Summary

- Bumps `khora-accel` Cargo version + the `[rust]`-extra lockstep pin to **0.15.3** (skipping 0.15.2 because accel 0.15.2 is already on PyPI).
- Regenerates `rust/Cargo.lock`.
- Promotes the existing `[Unreleased]` CHANGELOG entries to **`[0.15.3]`** and adds a Fixed bullet about the broken 0.15.2 wheel.

## Why

`khora==0.15.2` (published earlier today) hard-requires `khora-accel==0.15.1` in its `rust` extra, but accel `0.15.1` was never published to PyPI. The smoke-install gate caught it: https://github.com/DeytaHQ/khora/actions/runs/26096642898/job/76736722211. PyPI doesn't allow overwriting, so the fix is a fresh 0.15.3 release with a correct lockstep pin.

Root cause: the `khora-accel == X.Y.Z` pin in `pyproject.toml`'s `[rust]` extra was not bumped in the v0.15.2 release commit. The release workflow deliberately does NOT sed `pyproject.toml` at release time (would dirty the tree and hatch-vcs would emit `.devN`), so the lockstep pin must be correct in the committed source. See `CLAUDE.md` → Version Bumps.

## Follow-ups after merge

1. Tag and push: `git tag v0.15.3 && git push origin v0.15.3`
2. Yank `khora==0.15.2` on PyPI so installers stop landing on the broken wheel.
3. (Separate PR) Refresh `docs/RELEASE.md` — it still claims the workflow seds the `khora-accel` pin at release time, which was removed.

## Test plan

- [ ] CI green (release.yml's `verify-ci-green` gate requires it before the tag-push pipeline runs).
- [ ] After tag push: `pip install "khora[sqlite-lance,rust,otel]==0.15.3"` resolves cleanly in the smoke-install job.