### PR TITLE
chunkers: self-identify in ChunkResult metadata; drop stale context_text refs

### DIFF
--- a/docs/engines/chronicle-engine.md
+++ b/docs/engines/chronicle-engine.md
@@ -99,7 +99,8 @@ async def main():
             "What is Alice's current position on release cadence?",
             namespace=ns.namespace_id,
         )
-        print(result.context_text)
+        for chunk in result.chunks:
+            print(chunk.content)
 
 asyncio.run(main())
 ```

--- a/docs/engines/vectorcypher-engine.md
+++ b/docs/engines/vectorcypher-engine.md
@@ -111,12 +111,14 @@ async with Khora("postgresql://...", engine="vectorcypher") as kb:
 
 ### RecallResult Context
 
-`recall()` returns `RecallResult` objects whose `context_text` field includes:
-- **Chunk content** — The matching text passages
-- **Entity data** — Names, types, descriptions of entities mentioned in matching chunks
-- **Relationship data** — Connections between entities in the result set
+`recall()` returns `RecallResult` objects whose typed projections expose:
+- **`chunks`** — Matching text passages as `RecallChunk` entries (`chunk.content`)
+- **`entities`** — Entities mentioned in matching chunks
+- **`relationships`** — Connections between entities in the result set
 
-This rich context enables downstream consumers (e.g., LLM chat) to answer questions about relationships without additional queries.
+Callers that need a flat context string for an LLM can compose one from
+`chunk.content` plus the `format_entity_section` / `format_relationship_section`
+helpers — no additional queries required.
 
 ### Source Document Population
 

--- a/src/khora/extraction/chunkers/base.py
+++ b/src/khora/extraction/chunkers/base.py
@@ -32,7 +32,11 @@ def _get_tiktoken_encoding() -> _tiktoken.Encoding | None:
 
 @dataclass
 class ChunkResult:
-    """Result of chunking a document."""
+    """Result of chunking a document.
+
+    Every chunker MUST stamp ``metadata["chunker"]`` with its registered
+    strategy name (``"fixed"``, ``"recursive"``, ``"semantic"``, ``"conversation"``).
+    """
 
     content: str
     index: int

--- a/src/khora/extraction/chunkers/conversation.py
+++ b/src/khora/extraction/chunkers/conversation.py
@@ -330,7 +330,7 @@ class ConversationChunker(Chunker):
         thread_ts = next((m.thread_ts for m in messages if m.thread_ts), None)
 
         metadata: dict[str, Any] = {
-            "source_type": "slack_conversation",
+            "chunker": "conversation",
             "channel": channel,
             "thread_ts": thread_ts,
             "session_id": session_id,

--- a/src/khora/extraction/chunkers/fixed.py
+++ b/src/khora/extraction/chunkers/fixed.py
@@ -59,6 +59,7 @@ class FixedChunker(Chunker):
                     start_char=start_char,
                     end_char=end_char,
                     token_count=len(chunk_tokens),
+                    metadata={"chunker": "fixed"},
                 )
             )
 
@@ -96,6 +97,7 @@ class FixedChunker(Chunker):
                         start_char=start,
                         end_char=end,
                         token_count=len(chunk_text) // 4,
+                        metadata={"chunker": "fixed"},
                     )
                 )
                 chunk_index += 1

--- a/src/khora/extraction/chunkers/recursive.py
+++ b/src/khora/extraction/chunkers/recursive.py
@@ -161,4 +161,5 @@ class RecursiveChunker(Chunker):
             start_char=max(0, start_char),
             end_char=end_char,
             token_count=self.count_tokens(content),
+            metadata={"chunker": "recursive"},
         )

--- a/src/khora/extraction/chunkers/semantic.py
+++ b/src/khora/extraction/chunkers/semantic.py
@@ -206,4 +206,5 @@ class SemanticChunker(Chunker):
             start_char=start_char,
             end_char=end_char,
             token_count=self.count_tokens(content),
+            metadata={"chunker": "semantic"},
         )

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -1619,8 +1619,9 @@ class Khora:
 
         Returns:
             RecallResult with matched memories.  When using the VectorCypher
-            engine, ``relationships`` contains scored relationship tuples and
-            ``context_text`` includes a ``--- Relationships ---`` section.
+            engine, ``relationships`` contains scored relationship tuples
+            that callers can render via the ``format_relationship_section``
+            helper alongside chunk content.
 
         Raises:
             ValueError: If both ``start_time`` and ``end_time`` are provided

--- a/tests/integration/matrix/test_vectorcypher_sqlite_lance.py
+++ b/tests/integration/matrix/test_vectorcypher_sqlite_lance.py
@@ -240,7 +240,7 @@ async def _remember(
 
 
 async def test_vc_remember_recall_roundtrip(kb: Khora, namespace_id: UUID) -> None:
-    """Ingest 3 docs, recall, assert ingested text appears in ``context_text``."""
+    """Ingest 3 docs, recall, assert ingested text appears in ``result.chunks[*].content``."""
     contents = [
         "Alice met Bob at the Python conference in Berlin.",
         "Carol presented research on graph databases at the same event.",

--- a/tests/unit/integrations/llamaindex/test_coverage_push.py
+++ b/tests/unit/integrations/llamaindex/test_coverage_push.py
@@ -132,7 +132,6 @@ def _mk_kb(**recall_attrs: Any) -> Any:
     recall_result = MagicMock(
         chunks=recall_attrs.get("chunks", []),
         entities=recall_attrs.get("entities", []),
-        context_text=recall_attrs.get("context_text", ""),
         metadata=recall_attrs.get("metadata", {}),
     )
     kb.recall = AsyncMock(return_value=recall_result)
@@ -199,11 +198,11 @@ async def test_memory_aget_joins_chunk_content_into_envelope() -> None:
     assert out.startswith("<khora_memory>")
 
 
-async def test_memory_aget_returns_empty_when_recall_has_no_context_and_no_chunks() -> None:
-    """No context_text + no chunks → empty payload (no envelope)."""
+async def test_memory_aget_returns_empty_when_recall_returns_no_chunks() -> None:
+    """No chunks → empty payload (no envelope)."""
     from khora.integrations.llamaindex import KhoraMemoryBlock
 
-    kb = _mk_kb(chunks=[], context_text="")
+    kb = _mk_kb(chunks=[])
     block = KhoraMemoryBlock(kb=kb, namespace_id=uuid4())
     out = await block.aget(messages=[ChatMessage(role="user", content="why?")])
     assert out == ""

--- a/tests/unit/integrations/openai_agents/test_hooks.py
+++ b/tests/unit/integrations/openai_agents/test_hooks.py
@@ -28,7 +28,6 @@ class _RecallResultStub:
     query: str = ""
     namespace_id: UUID = field(default_factory=uuid4)
     entities: list[Any] = field(default_factory=list)
-    context_text: str = ""
     metadata: dict[str, Any] = field(default_factory=dict)
 
 

--- a/tests/unit/integrations/openai_agents/test_hooks_coverage.py
+++ b/tests/unit/integrations/openai_agents/test_hooks_coverage.py
@@ -162,7 +162,6 @@ async def test_on_agent_start_picks_run_input_when_top_level_input_empty() -> No
         query: str = ""
         namespace_id: UUID = field(default_factory=uuid4)
         entities: list[Any] = field(default_factory=list)
-        context_text: str = ""
         metadata: dict[str, Any] = field(default_factory=dict)
 
     kb.recall.return_value = _Stub()
@@ -192,7 +191,6 @@ async def test_on_agent_start_skips_when_recall_returns_no_chunks() -> None:
         query: str = ""
         namespace_id: Any = field(default_factory=uuid4)
         entities: list[Any] = field(default_factory=list)
-        context_text: str = ""
         metadata: dict[str, Any] = field(default_factory=dict)
 
     kb.recall.return_value = _Stub()  # empty chunks

--- a/tests/unit/test_chunkers.py
+++ b/tests/unit/test_chunkers.py
@@ -9,6 +9,7 @@ from khora.extraction.chunkers import (
     ChunkResult,
     FixedChunker,
     RecursiveChunker,
+    SemanticChunker,
     create_chunker,
 )
 
@@ -237,3 +238,32 @@ class TestChunkerBase:
         """Test that negative overlap raises ValueError."""
         with pytest.raises(ValueError, match="chunk_overlap must be non-negative"):
             FixedChunker(chunk_size=100, chunk_overlap=-1)
+
+
+class TestChunkerSelfId:
+    """Every chunker stamps ``metadata["chunker"]`` with its registered name."""
+
+    def test_fixed_chunker_self_id(self) -> None:
+        chunker = FixedChunker(chunk_size=100, chunk_overlap=20)
+        chunks = chunker.chunk("Hello world, this is a fixed-chunker test.")
+        assert chunks
+        assert all(c.metadata["chunker"] == "fixed" for c in chunks)
+
+    def test_fixed_chunker_self_id_char_fallback(self) -> None:
+        """Char-fallback path (overlap >= effective token chunk) also stamps the name."""
+        chunker = FixedChunker(chunk_size=20, chunk_overlap=10)
+        chunks = chunker.chunk("A" * 200)
+        assert chunks
+        assert all(c.metadata["chunker"] == "fixed" for c in chunks)
+
+    def test_recursive_chunker_self_id(self) -> None:
+        chunker = RecursiveChunker(chunk_size=50, chunk_overlap=10)
+        chunks = chunker.chunk("First paragraph.\n\nSecond paragraph.\n\nThird paragraph.")
+        assert chunks
+        assert all(c.metadata["chunker"] == "recursive" for c in chunks)
+
+    def test_semantic_chunker_self_id(self) -> None:
+        chunker = SemanticChunker(chunk_size=80, chunk_overlap=10)
+        chunks = chunker.chunk("Sentence one. Sentence two. Sentence three. Sentence four.")
+        assert chunks
+        assert all(c.metadata["chunker"] == "semantic" for c in chunks)

--- a/tests/unit/test_context_text_entities.py
+++ b/tests/unit/test_context_text_entities.py
@@ -1,10 +1,9 @@
-"""Tests for entity and relationship inclusion in context_text.
+"""Tests for the ``format_entity_section`` and ``format_relationship_section`` helpers.
 
-Verifies that RecallResult.context_text includes an entity section
-when entities are present in the recall result.
-
-Verifies relationship formatting in context_text and RecallResult
-relationship support.
+Verifies that the entity-section formatter renders entities (name, type,
+description) and de-duplicates by ID, and that the relationship-section
+formatter renders source/type/target/description tuples. Callers compose
+these alongside ``chunk.content`` to build an LLM context string.
 """
 
 from __future__ import annotations
@@ -21,7 +20,7 @@ from khora.query.engine import format_entity_section, format_relationship_sectio
 
 @pytest.mark.unit
 class TestGetContextTextIncludesEntities:
-    """Verify that entity data appears in RecallResult.context_text."""
+    """Verify that entity data appears when callers compose a context string."""
 
     def test_chunks_and_entities(self) -> None:
         """When both chunks and entities are present, context_text has both."""

--- a/tests/unit/test_conversation_chunker.py
+++ b/tests/unit/test_conversation_chunker.py
@@ -238,7 +238,7 @@ class TestConversationChunker:
         chunker = ConversationChunker(config=ConversationChunkerConfig(min_group_size=1))
         results = chunker.chunk_messages(msgs)
         meta = results[0].metadata
-        assert meta["source_type"] == "slack_conversation"
+        assert meta["chunker"] == "conversation"
         assert meta["channel"] == "dev"
         assert meta["message_count"] == 1
         assert "time_start" in meta

--- a/tests/unit/test_message_extract.py
+++ b/tests/unit/test_message_extract.py
@@ -15,7 +15,7 @@ def _sample_chunk():
     line2 = "[10:01] bob: hi there"
     content = f"{line1}\n{line2}"
     metadata = {
-        "source_type": "slack_conversation",
+        "chunker": "conversation",
         "messages": [
             {
                 "id": "m1",


### PR DESCRIPTION
## Summary

- **Chunker self-identification.** Every `ChunkResult.metadata` now carries `"chunker": <strategy-name>`, matching the names registered in `khora.extraction.chunkers.create_chunker()`: `"fixed"`, `"recursive"`, `"semantic"`, `"conversation"`. The `ChunkResult` docstring documents the contract.
- **Conversation chunker key rename.** `"source_type": "slack_conversation"` is replaced with `"chunker": "conversation"`. All other conversation metadata keys (`channel`, `thread_ts`, `session_id`, `message_count`, `time_start`, `time_end`, `authors`, optional `messages`) are unchanged.
- **`context_text` cleanup.** Server-side `context_text` generation was already removed when the typed recall projection landed. This PR strips remaining stale references in `khora.recall()`'s docstring, the two engine docs, and dead `context_text` stubs in integration-test fixtures (openai-agents hooks, llamaindex coverage, sqlite_lance matrix test, the `test_context_text_entities` module docstring).
- **Tests.** New `TestChunkerSelfId` class asserts the registered name for each of fixed (token + char fallback paths), recursive, and semantic. Existing conversation-chunker assertion and the `test_message_extract` fixture migrate to the new key.

The skeleton engine already emits `engine_info["engine"] = "skeleton"` from a prior merge; no engine code is touched by this PR.

## Test plan

- [x] `make format` — clean (672 files unchanged).
- [x] `make lint` — exit 0 (only pre-existing `ty` warnings on unrelated `_accel.py`).
- [x] `make test` — 5853 passed / 35 skipped under the unit+integration+e2e suite. 4 pre-existing xdist-parallel flakes in unrelated tests (`chronicle.test_router_and_fusion`, `storage.test_protocol_compliance[sqlite_lance]`, `integrations.test_no_eager_imports[*]`) all pass serially.
- [x] Coverage: 71% (gate is 65%).
- [ ] CI green on this PR.