### PR TITLE
Khora.recall(): return RecallResult with documents[] always populated

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -173,7 +173,6 @@ result: RecallResult = await kb.recall(
     min_similarity: float = 0.0,
     agentic: bool = False,
     raw: bool = False,
-    include_sources: bool = False,
     start_time: datetime | None = None,
     end_time: datetime | None = None,
 )

--- a/docs/engines/vectorcypher-engine.md
+++ b/docs/engines/vectorcypher-engine.md
@@ -120,19 +120,16 @@ This rich context enables downstream consumers (e.g., LLM chat) to answer questi
 
 ### Source Document Population
 
-All read methods (`recall()`, `get_entity()`, `list_entities()`, `find_related_entities()`, `search_entities()`) accept `include_sources: bool = False`:
+`recall()` always returns a `RecallResult` whose `documents` list holds full `DocumentProjection` rows for every document referenced by a chunk, entity, or relationship in the result. Khora batch-fetches `DocumentSource` metadata after the engine returns (chunked at 1,000 IDs) and replaces the engine's lightweight stubs in place.
 
 ```python
-# Default: no source metadata (zero overhead)
-results = await kb.recall("query")
-
-# With sources: populates source_document metadata on chunks/entities
-results = await kb.recall("query", include_sources=True)
-for chunk, score in results.chunks:
-    print(chunk.source_document)  # DocumentSource with title, source, etc.
+result = await kb.recall("query", namespace=ns_id)
+docs_by_id = {d.id: d for d in result.documents}
+for chunk in result.chunks:
+    print(docs_by_id[chunk.document_id].title)
 ```
 
-When `False` (default), no extra query runs. When `True`, `_populate_sources()` batch-fetches `DocumentSource` metadata (chunked at 1,000 IDs) and populates `chunk.source_document`, `entity.source_documents`, and `relationship.source_documents` in-place.
+Entity-read methods (`get_entity()`, `list_entities()`, `find_related_entities()`, `search_entities()`) still accept `include_sources: bool = False` to opt-in to per-entity `source_documents` population.
 
 ### VectorCypherRetriever (`src/khora/engines/vectorcypher/retriever.py`)
 

--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -264,6 +264,11 @@
       "owner": "khora"
     },
     {
+      "name": "khora.recall.document_upgrade",
+      "stability": "internal",
+      "owner": "khora"
+    },
+    {
       "name": "khora.remember",
       "stability": "public",
       "owner": "khora"
@@ -975,6 +980,17 @@
       "histogram_buckets": [0, 1, 7, 30, 90, 365, 3650],
       "labels": [],
       "_comment": "Issue #567 Phase A. Log-bucketed: hour-day-week-month-quarter-year-decade. No labels — global recency-skew signal."
+    },
+    {
+      "name": "khora.recall.dangling_ref",
+      "type": "counter",
+      "stability": "internal",
+      "unit": "1",
+      "description": "Recall referenced a document_id the relational store could not resolve (deleted, namespace mismatch, or replication lag). Counted by referrer kind.",
+      "labels": [
+        {"name": "referrer", "values": ["chunk", "entity", "relationship"], "_comment": "Which part of the RecallResult held the dangling reference."}
+      ],
+      "_comment": "NO namespace_id label — cardinality rule (CLAUDE.md). namespace_id lives on the surrounding span and debug log."
     },
     {
       "name": "khora.ingest.source_timestamp.fallback_count",

--- a/src/khora/core/models/recall.py
+++ b/src/khora/core/models/recall.py
@@ -51,8 +51,16 @@ class RecallChunk:
     own dedicated column. The chunker self-identification contract
     requires at minimum ``{"chunker": "<name>"}``.
 
-    ``occurred_at`` and ``connected_entity_ids`` are engine-populated
-    typed fields.
+    ``occurred_at`` is engine-populated.
+
+    ``connected_entity_ids`` is the set of entities the recall pipeline
+    linked to this chunk, derived by inverting
+    ``RecallEntity.source_chunk_ids`` after the engine returns. Empty
+    list semantics: **unknown**, not "no edges" — engines that return no
+    entities (skeleton, chronicle without entity hits, graph-less
+    stacks) leave this empty even when the underlying graph backend
+    might know edges to entities that simply weren't returned in this
+    result.
     """
 
     id: UUID

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -24,6 +24,16 @@ from khora.config import KhoraConfig, load_config
 from khora.core.models import Chunk, Document, Entity, MemoryNamespace
 from khora.query import SearchMode
 from khora.telemetry import bounded_text_hash, trace_span
+from khora.telemetry.metrics import metric_counter
+
+# Module-level counter — a dangling ref means an engine emitted a chunk /
+# entity / relationship pointing at a document_id that the relational store
+# could not resolve (deleted, namespace mismatch, or replication lag). No
+# namespace_id label by cardinality contract (see CLAUDE.md).
+_RECALL_DANGLING_REF_COUNTER = metric_counter(
+    "khora.recall.dangling_ref",
+    description="Dangling document references in recall results, by referrer kind.",
+)
 
 
 def _coerce_session_id_from_dict(metadata: dict[str, Any] | None) -> UUID | None:
@@ -1576,7 +1586,6 @@ class Khora:
         min_similarity: float = 0.0,
         agentic: bool = False,
         raw: bool = False,
-        include_sources: bool = False,
         start_time: datetime | None = None,
         end_time: datetime | None = None,
     ) -> RecallResult:
@@ -1609,8 +1618,6 @@ class Khora:
             min_similarity: Minimum similarity threshold
             agentic: If True, use multi-step agentic search (default: False)
             raw: If True, skip all LLM features (default: False)
-            include_sources: If True, populate source document metadata on
-                returned chunks and entities (default: False)
             start_time: Optional lower bound (inclusive) for memory time.
                 Timezone-aware datetimes are recommended; naive datetimes are
                 assumed UTC. When provided, bypasses NLP temporal detection.
@@ -1695,12 +1702,10 @@ class Khora:
                     raw=raw,
                     temporal_filter=temporal_filter,
                 )
-                # Source attribution lives on engine-produced
-                # ``RecallResult.documents``; ``_populate_sources`` is no
-                # longer reachable from the recall path (projections are
-                # frozen and lack the mutation targets it expected).
-                # ``include_sources`` is still accepted for API stability.
-                del include_sources
+                # Engines return DocumentProjection stubs (id + bare
+                # essentials). Batch-fetch full source metadata, derive
+                # per-chunk entity linkage, and emit a new RecallResult.
+                result = await self._upgrade_recall_documents(result, namespace_id)
 
                 # Emit RECALL_RESULTS_READY after engine returns, before packaging.
                 try:
@@ -2140,6 +2145,143 @@ class Khora:
         for rel, _score in relationships:
             rel_sources = {did: sources[did] for did in rel.source_document_ids if did in sources}
             rel.source_documents = rel_sources if rel_sources else None
+
+    async def _upgrade_recall_documents(self, result: RecallResult, namespace_id: UUID) -> RecallResult:
+        """Batch-fetch document sources and return an upgraded RecallResult.
+
+        Engines return ``RecallResult`` with ``DocumentProjection`` stubs
+        that carry an ``id`` plus whatever fields the engine already had
+        in hand (typically just ``created_at`` and ``source_type``). This
+        helper unions every document id referenced by chunks, entities,
+        or relationships, performs a single batched lookup via
+        ``storage.get_document_projections_batch``, and produces a fresh
+        ``RecallResult`` with:
+
+        - ``documents``: replaced with full ``DocumentProjection`` rows
+          where the relational store returned a row; stubs that the
+          relational store can't resolve are preserved (and counted as
+          dangling refs).
+        - ``chunks``: ``connected_entity_ids`` populated by inverting
+          ``RecallEntity.source_chunk_ids`` (the canonical chunk → entity
+          linkage produced upstream by extraction).
+
+        ``RecallResult`` is frozen, so the return value is a new instance
+        via ``dataclasses.replace`` — never an in-place mutation.
+        """
+        # Collect every document id referenced anywhere in the result.
+        doc_ids: set[UUID] = set()
+        for chunk in result.chunks:
+            doc_ids.add(chunk.document_id)
+        for entity in result.entities:
+            doc_ids.update(entity.source_document_ids)
+        for rel in result.relationships:
+            doc_ids.update(rel.source_document_ids)
+
+        if not doc_ids:
+            return result
+
+        sorted_ids = sorted(doc_ids)
+        projections: dict[UUID, DocumentProjection] = {}
+        upgrade_failed_reason: str | None = None
+        with trace_span(
+            "khora.recall.document_upgrade",
+            namespace_id=str(namespace_id),
+            doc_count=len(sorted_ids),
+        ):
+            try:
+                for i in range(0, len(sorted_ids), 1000):
+                    batch = sorted_ids[i : i + 1000]
+                    projections.update(await self.storage.get_document_projections_batch(batch))
+            except Exception as exc:
+                # Fail open: the engine call already succeeded; degrading the
+                # document-upgrade pass to "stubs only" is strictly better than
+                # crashing the recall. Surface the reason in engine_info so
+                # consumers can detect the degraded state.
+                upgrade_failed_reason = f"{type(exc).__name__}: {exc}"
+                logger.warning(
+                    "recall document upgrade failed; returning engine stubs (reason={}) ns={}",
+                    upgrade_failed_reason,
+                    namespace_id,
+                )
+                projections = {}
+
+        # Preserve the engine-emitted document list order: replace stubs
+        # whose id resolved against the relational store, leave the rest
+        # untouched.
+        seen_ids: set[UUID] = set()
+        upgraded_documents: list[DocumentProjection] = []
+        for stub in result.documents:
+            seen_ids.add(stub.id)
+            upgraded_documents.append(projections.get(stub.id, stub))
+
+        # Producer invariant: every referenced doc id must appear in
+        # ``documents``. Engines mostly emit a stub for every id they
+        # touch, but if any slip through, materialise an entry here —
+        # using the storage row when available, otherwise a minimal
+        # stub — rather than corrupting the invariant.
+        for did in sorted(doc_ids - seen_ids):
+            proj = projections.get(did)
+            if proj is not None:
+                upgraded_documents.append(proj)
+                continue
+            upgraded_documents.append(DocumentProjection(id=did, created_at=datetime.now(UTC), source_type="library"))
+
+        # Dangling refs: ids referenced by some chunk / entity / rel that
+        # the relational store could not resolve. Counted by referrer
+        # kind for triage; ``namespace_id`` stays on the span / log.
+        unresolved = doc_ids - set(projections.keys())
+        if unresolved:
+            chunk_dangling = sum(1 for c in result.chunks if c.document_id in unresolved)
+            entity_dangling = sum(1 for e in result.entities for did in e.source_document_ids if did in unresolved)
+            rel_dangling = sum(1 for r in result.relationships for did in r.source_document_ids if did in unresolved)
+            if chunk_dangling:
+                _RECALL_DANGLING_REF_COUNTER.add(chunk_dangling, attributes={"referrer": "chunk"})
+            if entity_dangling:
+                _RECALL_DANGLING_REF_COUNTER.add(entity_dangling, attributes={"referrer": "entity"})
+            if rel_dangling:
+                _RECALL_DANGLING_REF_COUNTER.add(rel_dangling, attributes={"referrer": "relationship"})
+            logger.debug(
+                "recall: {} dangling document refs (chunks={}, entities={}, rels={}) ns={}",
+                len(unresolved),
+                chunk_dangling,
+                entity_dangling,
+                rel_dangling,
+                namespace_id,
+            )
+
+        # Per-chunk entity linkage: invert ``RecallEntity.source_chunk_ids``
+        # — the canonical chunk → entity mapping produced by extraction.
+        # ``connected_entity_ids`` reflects only entities that survived
+        # the engine's filtering and made it into ``result.entities``;
+        # chunks may reference additional entities that fell below the
+        # recall threshold (or were never extracted) — those are
+        # intentionally omitted. Empty list means "no linkage in this
+        # result", not "no edges in the graph". Entity-less stacks
+        # (skeleton, chronicle without entity hits) leave every chunk
+        # with the default empty list. Ordering follows
+        # ``result.entities`` (the engine's score-sorted order).
+        chunk_to_entities: dict[UUID, list[UUID]] = {}
+        for entity in result.entities:
+            for cid in entity.source_chunk_ids:
+                chunk_to_entities.setdefault(cid, []).append(entity.id)
+
+        if chunk_to_entities:
+            upgraded_chunks = [
+                replace(chunk, connected_entity_ids=chunk_to_entities.get(chunk.id, [])) for chunk in result.chunks
+            ]
+        else:
+            upgraded_chunks = list(result.chunks)
+
+        if upgrade_failed_reason is not None:
+            engine_info = dict(result.engine_info)
+            engine_info["document_upgrade_failed"] = upgrade_failed_reason
+            return replace(
+                result,
+                documents=upgraded_documents,
+                chunks=upgraded_chunks,
+                engine_info=engine_info,
+            )
+        return replace(result, documents=upgraded_documents, chunks=upgraded_chunks)
 
     # ------------------------------------------------------------------
     # Semantic hooks (subscription API)

--- a/src/khora/storage/backends/base.py
+++ b/src/khora/storage/backends/base.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
         Relationship,
     )
     from khora.core.models.document import DocumentSource
+    from khora.core.models.recall import DocumentProjection
 
 
 @dataclass(frozen=True)
@@ -232,6 +233,26 @@ class RelationalBackendProtocol(Protocol):
 
         Returns:
             Dictionary mapping document ID to DocumentSource
+        """
+        ...
+
+    async def get_document_projections_batch(self, document_ids: list[UUID]) -> dict[UUID, DocumentProjection]:
+        """Fetch full ``DocumentProjection`` rows for recall responses.
+
+        Returns the typed projection shape used by ``Khora.recall()``:
+        ``id``, ``created_at``, ``source_type``, ``title``, ``external_id``,
+        ``source``, ``source_name``, ``source_url``, ``content_type``,
+        ``source_timestamp``, ``metadata``.
+
+        Distinct from ``get_document_sources_batch`` (which returns the
+        narrower ``DocumentSource`` for entity-source attribution) so the
+        two consumers can evolve their column sets independently.
+
+        Args:
+            document_ids: List of document IDs to fetch
+
+        Returns:
+            Dictionary mapping document ID to DocumentProjection
         """
         ...
 

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from khora.core.models import Document, MemoryNamespace, TenancyMode
 from khora.core.models.document import DocumentSource, DocumentStatus
+from khora.core.models.recall import DocumentProjection
 from khora.db.models import (
     Base,
     DocumentModel,
@@ -626,6 +627,50 @@ class PostgreSQLBackend(AsyncSessionMixin):
                     source_type=row.source_type,
                     created_at=row.created_at,
                     source_timestamp=row.source_timestamp,
+                )
+                for row in rows
+            }
+
+    async def get_document_projections_batch(self, document_ids: list[UUID]) -> dict[UUID, DocumentProjection]:
+        """Fetch full DocumentProjection rows for recall responses.
+
+        Wider SELECT than ``get_document_sources_batch`` — also pulls
+        ``external_id``, ``source_name``, ``source_url``, ``content_type``,
+        and ``metadata``.
+        """
+        if not document_ids:
+            return {}
+
+        async with self._get_session() as session:
+            result = await session.execute(
+                select(
+                    DocumentModel.id,
+                    DocumentModel.created_at,
+                    DocumentModel.source_type,
+                    DocumentModel.title,
+                    DocumentModel.external_id,
+                    DocumentModel.source,
+                    DocumentModel.source_name,
+                    DocumentModel.source_url,
+                    DocumentModel.content_type,
+                    DocumentModel.source_timestamp,
+                    DocumentModel.metadata_,
+                ).where(DocumentModel.id.in_(document_ids))
+            )
+            rows = result.all()
+            return {
+                row.id: DocumentProjection(
+                    id=row.id,
+                    created_at=row.created_at,
+                    source_type=row.source_type or "library",
+                    title=row.title,
+                    external_id=row.external_id,
+                    source=row.source,
+                    source_name=row.source_name,
+                    source_url=row.source_url,
+                    content_type=row.content_type,
+                    source_timestamp=row.source_timestamp,
+                    metadata=dict(row.metadata_ or {}),
                 )
                 for row in rows
             }

--- a/src/khora/storage/backends/sqlite.py
+++ b/src/khora/storage/backends/sqlite.py
@@ -21,6 +21,7 @@ from loguru import logger
 from khora.core.models import Chunk, Document, MemoryNamespace
 from khora.core.models.document import DocumentSource, DocumentStatus
 from khora.core.models.entity import Entity
+from khora.core.models.recall import DocumentProjection
 from khora.core.models.tenancy import TenancyMode
 from khora.storage.backends._fts5 import escape_fts5_query
 from khora.storage.backends.base import PaginatedResult
@@ -606,6 +607,39 @@ class SQLiteRelationalBackend:
                 source_type=r["source_type"] or "",
                 created_at=_parse_dt(r["created_at"]),
                 source_timestamp=_parse_dt(r["source_timestamp"]),
+            )
+        return result
+
+    async def get_document_projections_batch(self, document_ids: list[UUID]) -> dict[UUID, DocumentProjection]:
+        if not document_ids:
+            return {}
+        placeholders = ",".join("?" for _ in document_ids)
+        cursor = await self._conn.execute(
+            f"SELECT id, created_at, source_type, title, external_id, source, source_name, "  # noqa: S608
+            f"source_url, content_type, source_timestamp, metadata_ "
+            f"FROM documents WHERE id IN ({placeholders})",
+            [str(d) for d in document_ids],
+        )
+        rows = await cursor.fetchall()
+        result: dict[UUID, DocumentProjection] = {}
+        for r in rows:
+            uid = UUID(r["id"])
+            try:
+                metadata = json.loads(r["metadata_"]) if r["metadata_"] else {}
+            except (ValueError, TypeError):
+                metadata = {}
+            result[uid] = DocumentProjection(
+                id=uid,
+                created_at=_parse_dt(r["created_at"]) or datetime.now(UTC),
+                source_type=r["source_type"] or "library",
+                title=r["title"] or None,
+                external_id=r["external_id"] or None,
+                source=r["source"] or None,
+                source_name=r["source_name"] or None,
+                source_url=r["source_url"] or None,
+                content_type=r["content_type"] or None,
+                source_timestamp=_parse_dt(r["source_timestamp"]),
+                metadata=metadata if isinstance(metadata, dict) else {},
             )
         return result
 

--- a/src/khora/storage/backends/sqlite_lance/relational.py
+++ b/src/khora/storage/backends/sqlite_lance/relational.py
@@ -46,6 +46,7 @@ from sqlalchemy.types import Uuid
 
 from khora.core.models import Document, MemoryNamespace, TenancyMode
 from khora.core.models.document import DocumentSource, DocumentStatus
+from khora.core.models.recall import DocumentProjection
 from khora.db.models import DocumentModel, MemoryNamespaceModel, SyncCheckpointModel
 from khora.engines.chronicle.compression import MemoryFact
 from khora.engines.chronicle.events import ChronicleEvent
@@ -593,6 +594,43 @@ class SQLiteLanceRelationalAdapter(AsyncSessionMixin):
                     source_type=row.source_type,
                     created_at=row.created_at,
                     source_timestamp=row.source_timestamp,
+                )
+                for row in rows
+            }
+
+    async def get_document_projections_batch(self, document_ids: list[UUID]) -> dict[UUID, DocumentProjection]:
+        if not document_ids:
+            return {}
+        async with self._get_session() as session:
+            result = await session.execute(
+                select(
+                    DocumentModel.id,
+                    DocumentModel.created_at,
+                    DocumentModel.source_type,
+                    DocumentModel.title,
+                    DocumentModel.external_id,
+                    DocumentModel.source,
+                    DocumentModel.source_name,
+                    DocumentModel.source_url,
+                    DocumentModel.content_type,
+                    DocumentModel.source_timestamp,
+                    DocumentModel.metadata_,
+                ).where(DocumentModel.id.in_(document_ids))
+            )
+            rows = result.all()
+            return {
+                row.id: DocumentProjection(
+                    id=row.id,
+                    created_at=row.created_at or datetime.now(UTC),
+                    source_type=row.source_type or "library",
+                    title=row.title or None,
+                    external_id=row.external_id or None,
+                    source=row.source or None,
+                    source_name=row.source_name or None,
+                    source_url=row.source_url or None,
+                    content_type=row.content_type or None,
+                    source_timestamp=row.source_timestamp,
+                    metadata=dict(row.metadata_ or {}),
                 )
                 for row in rows
             }

--- a/src/khora/storage/backends/surrealdb/relational.py
+++ b/src/khora/storage/backends/surrealdb/relational.py
@@ -16,6 +16,7 @@ from loguru import logger
 
 from khora.core.models import Document, MemoryNamespace, TenancyMode
 from khora.core.models.document import DocumentSource, DocumentStatus
+from khora.core.models.recall import DocumentProjection
 from khora.storage.backends.base import PaginatedResult
 from khora.storage.backends.surrealdb._helpers import (
     _parse_dt,
@@ -572,6 +573,34 @@ class SurrealDBRelationalAdapter:
                 source_type=r.get("source_type", ""),
                 created_at=_parse_dt(r.get("created_at")),
                 source_timestamp=_parse_dt(r.get("source_timestamp")),
+            )
+        return result
+
+    async def get_document_projections_batch(self, document_ids: list[UUID]) -> dict[UUID, DocumentProjection]:
+        """Fetch full DocumentProjection rows for recall responses."""
+        if not document_ids:
+            return {}
+        id_strs = [_record_id("document", uid) for uid in document_ids]
+        rows = await self._conn.query(
+            "SELECT id, created_at, source_type, title, external_id, source, source_name, "
+            "source_url, content_type, source_timestamp, metadata_ FROM document WHERE id IN $ids",
+            {"ids": id_strs},
+        )
+        result: dict[UUID, DocumentProjection] = {}
+        for r in rows:
+            uid = _parse_uuid(r["id"])
+            result[uid] = DocumentProjection(
+                id=uid,
+                created_at=_parse_dt(r.get("created_at")) or datetime.now(UTC),
+                source_type=r.get("source_type") or "library",
+                title=r.get("title") or None,
+                external_id=r.get("external_id") or None,
+                source=r.get("source") or None,
+                source_name=r.get("source_name") or None,
+                source_url=r.get("source_url") or None,
+                content_type=r.get("content_type") or None,
+                source_timestamp=_parse_dt(r.get("source_timestamp")),
+                metadata=dict(r.get("metadata_") or {}),
             )
         return result
 

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -30,6 +30,7 @@ from khora.core.models import (
     Relationship,
 )
 from khora.core.models.document import DocumentSource
+from khora.core.models.recall import DocumentProjection
 from khora.storage.backends.base import PaginatedResult
 from khora.telemetry import get_collector, trace_span
 
@@ -1359,6 +1360,21 @@ class StorageCoordinator:
             return {}
         if self.relational:
             return await self.relational.get_document_sources_batch(document_ids)
+        return {}
+
+    async def get_document_projections_batch(self, document_ids: list[UUID]) -> dict[UUID, DocumentProjection]:
+        """Fetch full DocumentProjection rows for recall responses.
+
+        Args:
+            document_ids: List of document IDs to fetch
+
+        Returns:
+            Dictionary mapping document ID to DocumentProjection
+        """
+        if not document_ids:
+            return {}
+        if self.relational:
+            return await self.relational.get_document_projections_batch(document_ids)
         return {}
 
     @_record_storage_op("get_neighborhoods_batch", "graph")

--- a/tests/integration/storage/backends/surrealdb/test_get_document_projections_batch.py
+++ b/tests/integration/storage/backends/surrealdb/test_get_document_projections_batch.py
@@ -1,0 +1,122 @@
+"""Round-trip test for ``SurrealDBRelationalAdapter.get_document_projections_batch``.
+
+Exercises the four risk surfaces flagged on the recall rewrite:
+
+- RecordID → UUID coercion at the projection boundary (``_parse_uuid``
+  on the ``id`` column, which Surreal hands back as a ``RecordID``).
+- NULL / falsy ``source_type`` defaults to ``"library"`` on the
+  projection (matches sqlite / postgres / sqlite_lance behaviour).
+- ``metadata_`` column name is consistent between INSERT and SELECT
+  (regression net for the schema-naming gotcha).
+- Wider field set (``external_id`` / ``source_name`` / ``source_url`` /
+  ``content_type`` + ``metadata``) survives the round trip.
+
+Runs against an in-memory SurrealDB (``mode="memory"``) — no docker
+required. Skipped when the ``surrealdb`` extra is not installed.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+
+pytest.importorskip("surrealdb")
+
+from khora.core.models import Document, DocumentProjection, MemoryNamespace, TenancyMode  # noqa: E402
+from khora.storage.backends.surrealdb.connection import SurrealDBConnection  # noqa: E402
+from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def adapter():
+    conn = SurrealDBConnection(mode="memory", namespace="khora_test", database="projections")
+    await conn.connect()
+    adapter = SurrealDBRelationalAdapter(conn)
+    try:
+        yield adapter
+    finally:
+        await conn.disconnect()
+
+
+@pytest.fixture
+async def namespace(adapter):
+    nid = uuid4()
+    ns = MemoryNamespace(id=nid, namespace_id=nid, tenancy_mode=TenancyMode.SHARED)
+    return await adapter.create_namespace(ns)
+
+
+async def test_projections_batch_full_field_roundtrip(adapter, namespace) -> None:
+    """Every projection column survives the SurrealDB INSERT → SELECT round-trip."""
+    doc = Document(
+        namespace_id=namespace.id,
+        content="hello surreal",
+        title="Surreal Title",
+        external_id="surreal-ext-7",
+        source="ws://example.com/x",
+        source_name="Surreal Source",
+        source_url="https://example.com/surreal",
+        source_type="file",
+        content_type="text/markdown",
+        checksum="surreal-rt",
+        size_bytes=12,
+        metadata={"k": "v", "n": 1},
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    await adapter.create_document(doc)
+
+    projections = await adapter.get_document_projections_batch([doc.id])
+
+    assert doc.id in projections
+    proj = projections[doc.id]
+    assert isinstance(proj, DocumentProjection)
+    # RecordID → UUID coercion at the boundary.
+    assert isinstance(proj.id, UUID)
+    assert proj.id == doc.id
+    assert proj.title == "Surreal Title"
+    assert proj.external_id == "surreal-ext-7"
+    assert proj.source == "ws://example.com/x"
+    assert proj.source_name == "Surreal Source"
+    assert proj.source_url == "https://example.com/surreal"
+    assert proj.source_type == "file"
+    assert proj.content_type == "text/markdown"
+    assert proj.metadata == {"k": "v", "n": 1}
+    assert proj.created_at is not None
+
+
+async def test_projections_batch_null_source_type_defaults_to_library(adapter, namespace) -> None:
+    """A document with falsy ``source_type`` projects as ``source_type="library"``.
+
+    Mirrors the same coercion contract the other three backends honour.
+    """
+    doc = Document(
+        namespace_id=namespace.id,
+        content="x",
+        title="no source_type",
+        checksum="surreal-null-st",
+        source_type="",  # falsy
+    )
+    await adapter.create_document(doc)
+
+    projections = await adapter.get_document_projections_batch([doc.id])
+    proj = projections[doc.id]
+    assert proj.source_type == "library"
+
+
+async def test_projections_batch_empty_input(adapter) -> None:
+    """Empty input short-circuits to ``{}`` without a SurrealDB query."""
+    assert await adapter.get_document_projections_batch([]) == {}
+
+
+async def test_projections_batch_unknown_id_omitted(adapter, namespace) -> None:
+    """Unknown ids do not appear in the result — caller's job to handle missing."""
+    doc = Document(namespace_id=namespace.id, content="present", checksum="surreal-present")
+    await adapter.create_document(doc)
+    missing = uuid4()
+
+    projections = await adapter.get_document_projections_batch([doc.id, missing])
+    assert set(projections.keys()) == {doc.id}

--- a/tests/integration/storage/test_get_document_projections_batch_pg.py
+++ b/tests/integration/storage/test_get_document_projections_batch_pg.py
@@ -1,0 +1,159 @@
+"""Round-trip test for ``PostgreSQLBackend.get_document_projections_batch``.
+
+Exercises:
+
+- Wider field set survives the SELECT (``external_id``, ``source_name``,
+  ``source_url``, ``content_type``, ``metadata``).
+- ``source_type`` NULL → ``"library"`` coercion at the projection
+  boundary.
+- ``metadata_`` JSON column round-trips as a dict.
+- Empty input short-circuits to ``{}``.
+- Unknown ids are silently omitted from the result.
+
+Requires a running PostgreSQL (``make dev``). Skipped automatically when
+the configured ``KHORA_DATABASE_URL`` is unreachable.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+
+from khora.core.models import Document, DocumentProjection, MemoryNamespace
+from khora.core.models.document import DocumentStatus
+from khora.db.session import run_migrations
+from khora.storage.backends.postgresql import PostgreSQLBackend
+
+DATABASE_URL = os.environ.get(
+    "KHORA_DATABASE_URL",
+    "postgresql+asyncpg://khora:khora@localhost:5432/khora",
+)
+
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
+
+
+pytestmark = [pytest.mark.integration]
+
+
+def _pg_reachable() -> bool:
+    import socket
+    from urllib.parse import urlparse
+
+    parsed = urlparse(DATABASE_URL.replace("+asyncpg", ""))
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+skip_no_pg = pytest.mark.skipif(
+    not _pg_reachable(),
+    reason="PostgreSQL not reachable (run `make dev` first)",
+)
+
+
+@pytest.fixture(scope="module")
+async def _run_migrations_once():
+    result = await run_migrations(DATABASE_URL)
+    assert result.success, f"Migrations failed: {result.error}"
+
+
+@pytest.fixture
+async def backend(_run_migrations_once):
+    be = PostgreSQLBackend(database_url=DATABASE_URL)
+    await be.connect()
+    try:
+        yield be
+    finally:
+        await be.disconnect()
+
+
+@skip_no_pg
+class TestGetDocumentProjectionsBatchPg:
+    async def test_full_field_roundtrip(self, backend: PostgreSQLBackend) -> None:
+        ns = await backend.create_namespace(MemoryNamespace())
+
+        doc = Document(
+            id=uuid4(),
+            namespace_id=ns.id,
+            content="hello pg",
+            status=DocumentStatus.PENDING,
+            title="PG Title",
+            external_id=f"pg-ext-{uuid4().hex[:8]}",
+            source="file:///tmp/pg.txt",
+            source_name="PG Source",
+            source_url="https://example.com/pg",
+            source_type="file",
+            content_type="text/plain",
+            checksum=f"pg-rt-{uuid4().hex[:8]}",
+            size_bytes=8,
+            metadata={"k": "v", "n": 1, "nested": {"a": True}},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        await backend.create_document(doc)
+
+        projections = await backend.get_document_projections_batch([doc.id])
+
+        assert doc.id in projections
+        proj = projections[doc.id]
+        assert isinstance(proj, DocumentProjection)
+        assert isinstance(proj.id, UUID)
+        assert proj.id == doc.id
+        assert proj.title == "PG Title"
+        assert proj.external_id == doc.external_id
+        assert proj.source == "file:///tmp/pg.txt"
+        assert proj.source_name == "PG Source"
+        assert proj.source_url == "https://example.com/pg"
+        assert proj.source_type == "file"
+        assert proj.content_type == "text/plain"
+        assert proj.metadata == {"k": "v", "n": 1, "nested": {"a": True}}
+        assert proj.created_at is not None
+
+    async def test_null_source_type_defaults_to_library(self, backend: PostgreSQLBackend) -> None:
+        """Document with falsy ``source_type`` projects as ``source_type="library"``."""
+        ns = await backend.create_namespace(MemoryNamespace())
+        doc = Document(
+            id=uuid4(),
+            namespace_id=ns.id,
+            content="x",
+            status=DocumentStatus.PENDING,
+            title="no source_type",
+            checksum=f"pg-null-st-{uuid4().hex[:8]}",
+            source_type="",  # falsy → projection should coerce
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        await backend.create_document(doc)
+
+        projections = await backend.get_document_projections_batch([doc.id])
+        proj = projections[doc.id]
+        assert proj.source_type == "library"
+
+    async def test_empty_input(self, backend: PostgreSQLBackend) -> None:
+        assert await backend.get_document_projections_batch([]) == {}
+
+    async def test_unknown_id_omitted(self, backend: PostgreSQLBackend) -> None:
+        ns = await backend.create_namespace(MemoryNamespace())
+        doc = Document(
+            id=uuid4(),
+            namespace_id=ns.id,
+            content="present",
+            status=DocumentStatus.PENDING,
+            checksum=f"pg-present-{uuid4().hex[:8]}",
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        await backend.create_document(doc)
+
+        projections = await backend.get_document_projections_batch([doc.id, uuid4()])
+        assert set(projections.keys()) == {doc.id}

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -50,6 +50,10 @@ def mock_engine() -> MagicMock:
     _empty_ns_page = MagicMock()
     _empty_ns_page.items = []
     mock_eng._storage.list_namespaces = AsyncMock(return_value=_empty_ns_page)
+    # Default to empty maps — tests that exercise the recall document
+    # upgrade pass can override these per-test.
+    mock_eng._storage.get_document_sources_batch = AsyncMock(return_value={})
+    mock_eng._storage.get_document_projections_batch = AsyncMock(return_value={})
     mock_eng._embedder = MagicMock()
 
     # Lifecycle

--- a/tests/unit/storage/backends/sqlite_lance/test_relational.py
+++ b/tests/unit/storage/backends/sqlite_lance/test_relational.py
@@ -294,6 +294,68 @@ async def test_get_document_sources_batch(adapter, namespace):
     assert src.source == "file:///tmp/a.txt"
 
 
+async def test_get_document_projections_batch_full_field_roundtrip(adapter, namespace):
+    """Every projection column round-trips through the wider SELECT."""
+    from khora.core.models import DocumentProjection
+
+    doc = Document(
+        namespace_id=namespace.id,
+        content="hello",
+        title="Doc Title",
+        external_id="ext-42",
+        source="file:///tmp/x.md",
+        source_name="Source Name",
+        source_url="https://example.com/x",
+        source_type="file",
+        content_type="text/markdown",
+        checksum="proj-roundtrip",
+        size_bytes=5,
+        metadata={"k1": "v1", "k2": 2},
+    )
+    await adapter.create_document(doc)
+
+    projections = await adapter.get_document_projections_batch([doc.id])
+
+    assert doc.id in projections
+    proj = projections[doc.id]
+    assert isinstance(proj, DocumentProjection)
+    assert proj.id == doc.id
+    assert proj.title == "Doc Title"
+    assert proj.external_id == "ext-42"
+    assert proj.source == "file:///tmp/x.md"
+    assert proj.source_name == "Source Name"
+    assert proj.source_url == "https://example.com/x"
+    assert proj.source_type == "file"
+    assert proj.content_type == "text/markdown"
+    assert proj.metadata == {"k1": "v1", "k2": 2}
+    assert proj.created_at is not None
+
+
+async def test_get_document_projections_batch_null_source_type_defaults_to_library(adapter, namespace):
+    """``source_type`` defaults to ``"library"`` when the column is NULL/empty."""
+    from khora.core.models import DocumentProjection
+
+    doc = Document(
+        namespace_id=namespace.id,
+        content="x",
+        title="No source_type",
+        checksum="proj-null-st",
+        source_type="",  # falsy — should coerce to "library" on the projection
+    )
+    await adapter.create_document(doc)
+
+    projections = await adapter.get_document_projections_batch([doc.id])
+
+    proj = projections[doc.id]
+    assert isinstance(proj, DocumentProjection)
+    assert proj.source_type == "library"
+
+
+async def test_get_document_projections_batch_empty_input(adapter):
+    """Empty input short-circuits to ``{}`` without a SQL round-trip."""
+    assert await adapter.get_document_projections_batch([]) == {}
+
+
 async def test_empty_batch_is_noop(adapter):
     assert await adapter.get_documents_batch([]) == {}
     assert await adapter.get_documents_by_checksums(uuid4(), []) == {}

--- a/tests/unit/test_khora.py
+++ b/tests/unit/test_khora.py
@@ -1326,8 +1326,8 @@ class TestIncludeSources:
     """Tests for include_sources parameter on read methods."""
 
     @pytest.mark.asyncio
-    async def test_recall_include_sources_false(self) -> None:
-        """Default include_sources=False does not call get_document_sources_batch."""
+    async def test_recall_no_referenced_docs_skips_fetch(self) -> None:
+        """Empty recall result skips the document upgrade fetch entirely."""
         kb = _make_kb(connected=True)
         ns_id = uuid4()
 
@@ -1352,14 +1352,8 @@ class TestIncludeSources:
         kb._engine._storage.get_document_sources_batch.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_recall_include_sources_true(self) -> None:
-        """include_sources=True is accepted (kept for API stability) and the engine-produced
-        ``RecallResult.documents`` flow through to the caller unchanged.
-
-        Source attribution now lives on ``RecallResult.documents`` rather than being
-        mutated onto each chunk/entity post-recall. Engines build the ``documents``
-        list from their own data; ``kb.recall`` passes it through.
-        """
+    async def test_recall_upgrades_document_stubs(self) -> None:
+        """Khora.recall() batch-fetches DocumentProjection rows and produces an upgraded RecallResult."""
         from datetime import UTC, datetime
 
         from khora.core.models import DocumentProjection, RecallChunk, RecallEntity
@@ -1380,35 +1374,57 @@ class TestIncludeSources:
             attributes={},
             mention_count=0,
             source_document_ids=[doc_id_1, doc_id_2],
-            source_chunk_ids=[],
+            source_chunk_ids=[chunk.id],
         )
-        doc_1 = DocumentProjection(id=doc_id_1, created_at=now, title="Doc 1")
-        doc_2 = DocumentProjection(id=doc_id_2, created_at=now, title="Doc 2")
+        doc_1_stub = DocumentProjection(id=doc_id_1, created_at=now)
+        doc_2_stub = DocumentProjection(id=doc_id_2, created_at=now)
 
         mock_result = RecallResult(
             query="test",
             namespace_id=ns_id,
-            documents=[doc_1, doc_2],
+            documents=[doc_1_stub, doc_2_stub],
             chunks=[chunk],
             entities=[entity],
             relationships=[],
         )
         kb._engine.recall = AsyncMock(return_value=mock_result)
+        kb._engine._storage.get_document_projections_batch = AsyncMock(
+            return_value={
+                doc_id_1: DocumentProjection(
+                    id=doc_id_1,
+                    created_at=now,
+                    title="Doc 1",
+                    source="src-1",
+                    external_id="ext-1",
+                    source_url="https://example.com/1",
+                ),
+                doc_id_2: DocumentProjection(
+                    id=doc_id_2,
+                    created_at=now,
+                    title="Doc 2",
+                    source="src-2",
+                    content_type="text/markdown",
+                ),
+            }
+        )
 
         with (
             patch("khora.telemetry.context.ensure_trace_id"),
             patch("khora.telemetry.context.clear_trace_id"),
         ):
-            result = await kb.recall("test", namespace=ns_id, include_sources=True)
+            result = await kb.recall("test", namespace=ns_id)
 
-        # documents flow through; callers join chunk → DocumentProjection by id.
+        kb._engine._storage.get_document_projections_batch.assert_awaited_once()
         docs_by_id = {d.id: d for d in result.documents}
-        assert docs_by_id.get(result.chunks[0].document_id) is not None
-        # Entity exposes its source document IDs (the DocumentSource→DocumentProjection
-        # mapping isn't 1:1 — assertion is on id membership).
+        # Full DocumentProjection round-trip — all 11 fields available.
+        assert docs_by_id[doc_id_1].title == "Doc 1"
+        assert docs_by_id[doc_id_1].external_id == "ext-1"
+        assert docs_by_id[doc_id_1].source_url == "https://example.com/1"
+        assert docs_by_id[doc_id_2].title == "Doc 2"
+        assert docs_by_id[doc_id_2].content_type == "text/markdown"
+        # connected_entity_ids inverted from RecallEntity.source_chunk_ids.
+        assert result.chunks[0].connected_entity_ids == [entity.id]
         assert set(result.entities[0].source_document_ids) == {doc_id_1, doc_id_2}
-        # Both docs the entity references resolved to a DocumentProjection.
-        assert all(docs_by_id.get(did) is not None for did in result.entities[0].source_document_ids)
 
     @pytest.mark.asyncio
     async def test_list_entities_include_sources(self) -> None:
@@ -1493,8 +1509,8 @@ class TestIncludeSources:
         kb._engine._storage.get_document_sources_batch.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_include_sources_empty_results(self) -> None:
-        """Empty chunks/entities with include_sources=True does not crash or fetch."""
+    async def test_recall_empty_results(self) -> None:
+        """Empty chunks/entities does not crash or fetch."""
         kb = _make_kb(connected=True)
         ns_id = uuid4()
 
@@ -1513,7 +1529,7 @@ class TestIncludeSources:
             patch("khora.telemetry.context.ensure_trace_id"),
             patch("khora.telemetry.context.clear_trace_id"),
         ):
-            result = await kb.recall("nothing", namespace=ns_id, include_sources=True)
+            result = await kb.recall("nothing", namespace=ns_id)
 
         assert result.chunks == []
         assert result.entities == []
@@ -1626,23 +1642,32 @@ class TestIncludeSources:
             relationships=[],
         )
         kb._engine.recall = AsyncMock(return_value=mock_result)
+        kb._engine._storage.get_document_sources_batch = AsyncMock(return_value={})
 
         with (
             patch("khora.telemetry.context.ensure_trace_id"),
             patch("khora.telemetry.context.clear_trace_id"),
         ):
-            result = await kb.recall("test", namespace=ns_id, include_sources=True)
+            result = await kb.recall("test", namespace=ns_id)
 
+        # Producer invariant: every doc_id referenced by an entity / chunk /
+        # rel must appear in ``documents`` — unresolvable ids get a minimal
+        # stub rather than being dropped (downstream code does
+        # ``{d.id: d for d in result.documents}[chunk.document_id]``).
         doc_ids_in_result = {d.id for d in result.documents}
-        assert doc_ids_in_result == {doc_id_1}
-        assert doc_id_2 not in doc_ids_in_result
-        # The entity still references both, but only doc_1 resolved.
+        assert doc_ids_in_result == {doc_id_1, doc_id_2}
+        # doc_1 keeps the engine-supplied title; doc_2 is a minimal stub.
+        docs_by_id = {d.id: d for d in result.documents}
+        assert docs_by_id[doc_id_1].title == "Doc 1"
+        assert docs_by_id[doc_id_2].title is None
+        # The entity still references both.
         assert set(result.entities[0].source_document_ids) == {doc_id_1, doc_id_2}
 
     @pytest.mark.asyncio
     async def test_chunk_with_missing_document(self) -> None:
-        """A chunk whose document_id has no matching ``documents[]`` entry is OK —
-        caller's doc-lookup simply returns no projection.
+        """A chunk whose document_id is unresolvable still gets a minimal
+        DocumentProjection stub — preserves the producer invariant that every
+        referenced doc_id appears in ``result.documents``.
         """
         from datetime import UTC, datetime
 
@@ -1665,15 +1690,22 @@ class TestIncludeSources:
             relationships=[],
         )
         kb._engine.recall = AsyncMock(return_value=mock_result)
+        kb._engine._storage.get_document_sources_batch = AsyncMock(return_value={})
 
         with (
             patch("khora.telemetry.context.ensure_trace_id"),
             patch("khora.telemetry.context.clear_trace_id"),
         ):
-            result = await kb.recall("test", namespace=ns_id, include_sources=True)
+            result = await kb.recall("test", namespace=ns_id)
 
         docs_by_id = {d.id: d for d in result.documents}
-        assert docs_by_id.get(result.chunks[0].document_id) is None
+        # Invariant: chunk's document_id MUST resolve to some
+        # DocumentProjection in result.documents — minimal stub if the
+        # relational store couldn't resolve it.
+        proj = docs_by_id.get(result.chunks[0].document_id)
+        assert proj is not None
+        assert proj.id == doc_id
+        assert proj.title is None  # minimal stub — no upstream metadata
 
     @pytest.mark.asyncio
     async def test_storage_exception_propagation(self) -> None:
@@ -1688,7 +1720,7 @@ class TestIncludeSources:
             patch("khora.telemetry.context.clear_trace_id"),
         ):
             with pytest.raises(RuntimeError, match="DB error"):
-                await kb.recall("test", namespace=ns_id, include_sources=True)
+                await kb.recall("test", namespace=ns_id)
 
     @pytest.mark.asyncio
     async def test_entity_empty_source_document_ids(self) -> None:
@@ -1719,15 +1751,17 @@ class TestIncludeSources:
             relationships=[],
         )
         kb._engine.recall = AsyncMock(return_value=mock_result)
+        kb._engine._storage.get_document_sources_batch = AsyncMock()
 
         with (
             patch("khora.telemetry.context.ensure_trace_id"),
             patch("khora.telemetry.context.clear_trace_id"),
         ):
-            result = await kb.recall("test", namespace=ns_id, include_sources=True)
+            result = await kb.recall("test", namespace=ns_id)
 
         assert result.documents == []
         assert result.entities[0].source_document_ids == []
+        kb._engine._storage.get_document_sources_batch.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_khora_recall_upgrade.py
+++ b/tests/unit/test_khora_recall_upgrade.py
@@ -1,0 +1,567 @@
+"""Unit tests for ``Khora.recall()`` document-upgrade pass.
+
+Covers the contract:
+
+- ``recall()`` no longer accepts ``include_sources``; the entity-read
+  methods still do.
+- ``RecallResult.documents`` is unconditionally populated by unioning
+  every doc id referenced by chunks / entities / relationships.
+- Unresolvable doc ids materialise minimal ``DocumentProjection`` stubs
+  (referential-integrity invariant) and bump the
+  ``khora.recall.dangling_ref`` counter, tagged by ``referrer``.
+- Storage failures during the upgrade pass fail open: the result is
+  returned with engine stubs intact and ``engine_info["document_upgrade_failed"]``
+  set.
+- ``connected_entity_ids`` is derived by inverting
+  ``RecallEntity.source_chunk_ids``, ordered by entity score.
+- ``DocumentProjection`` ids round-trip as ``UUID`` even when an engine
+  hands in str-typed ids.
+- The ``khora.recall.dangling_ref`` counter never carries a
+  ``namespace_id`` attribute.
+- Every storage backend's ``get_document_projections_batch`` returns
+  the wider field set.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+from opentelemetry import metrics as _otel_metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+from khora.core.models import (
+    DocumentProjection,
+    RecallChunk,
+    RecallEntity,
+    RecallRelationship,
+    RecallResult,
+)
+
+from .helpers import make_kb as _make_kb
+
+# ---------------------------------------------------------------------------
+# OTel meter fixture — installs an in-memory MeterProvider and rebinds
+# the cached ``_RECALL_DANGLING_REF_COUNTER`` in khora.khora so the
+# counter routes to the test reader.
+# ---------------------------------------------------------------------------
+
+
+def _reset_otel_globals() -> None:
+    import opentelemetry.metrics._internal as _m
+    import opentelemetry.trace as _t
+    from opentelemetry.metrics._internal import _ProxyMeterProvider
+    from opentelemetry.trace import ProxyTracerProvider
+
+    _t._TRACER_PROVIDER_SET_ONCE = _t.Once()
+    _t._TRACER_PROVIDER = None
+    _t._PROXY_TRACER_PROVIDER = ProxyTracerProvider()
+
+    _m._METER_PROVIDER_SET_ONCE = _m.Once()
+    _m._METER_PROVIDER = None
+    _m._PROXY_METER_PROVIDER = _ProxyMeterProvider()
+
+
+@pytest.fixture
+def metric_reader(monkeypatch: pytest.MonkeyPatch):
+    """Install an in-memory MeterProvider and rebind khora's counter cache."""
+    _reset_otel_globals()
+    reader = InMemoryMetricReader()
+    mp = MeterProvider(metric_readers=[reader])
+    _otel_metrics.set_meter_provider(mp)
+
+    from khora import khora as khora_mod
+    from khora.telemetry import _otel as _otel_module
+    from khora.telemetry.metrics import metric_counter
+
+    _otel_module._METER = _otel_metrics.get_meter("khora", _otel_module._KHORA_VERSION)
+    new_counter = metric_counter(
+        "khora.recall.dangling_ref",
+        description="Dangling document references in recall results, by referrer kind.",
+    )
+    monkeypatch.setattr(khora_mod, "_RECALL_DANGLING_REF_COUNTER", new_counter)
+
+    yield reader
+
+    _reset_otel_globals()
+    _otel_module._METER = _otel_metrics.get_meter("khora", _otel_module._KHORA_VERSION)
+
+
+def _dangling_ref_points(reader: InMemoryMetricReader) -> list:
+    """Return all data points emitted for ``khora.recall.dangling_ref``."""
+    data = reader.get_metrics_data()
+    if data is None:
+        return []
+    points = []
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name == "khora.recall.dangling_ref":
+                    points.extend(metric.data.data_points)
+    return points
+
+
+# ---------------------------------------------------------------------------
+# 1. kwarg removal — recall() rejects include_sources, entity-read keeps it
+# ---------------------------------------------------------------------------
+
+
+class TestIncludeSourcesKwargRemoval:
+    @pytest.mark.asyncio
+    async def test_recall_rejects_include_sources_kwarg(self) -> None:
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+        with pytest.raises(TypeError):
+            await kb.recall(query="x", namespace=ns_id, include_sources=True)  # type: ignore[call-arg]
+
+    @pytest.mark.asyncio
+    async def test_entity_read_methods_still_accept_include_sources(self) -> None:
+        """``get_entity`` / ``list_entities`` / ``find_related_entities``
+        / ``search_entities`` must still accept ``include_sources=True``."""
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+
+        # All four should not raise TypeError on the kwarg. They may
+        # return None / [] given the mocked engine.
+        await kb.get_entity(uuid4(), namespace=ns_id, include_sources=True)
+        await kb.list_entities(namespace=ns_id, include_sources=True)
+        await kb.find_related_entities(uuid4(), namespace=ns_id, include_sources=True)
+        await kb.search_entities("q", namespace=ns_id, include_sources=True)
+
+
+# ---------------------------------------------------------------------------
+# 2. documents[] populated unconditionally — union over all referrers
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentsPopulatedUnconditionally:
+    @pytest.mark.asyncio
+    async def test_documents_union_chunks_entities_relationships(self) -> None:
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+        now = datetime.now(UTC)
+
+        doc_a = uuid4()
+        doc_b = uuid4()
+        doc_c = uuid4()
+        doc_d = uuid4()
+
+        chunk_a = RecallChunk(id=uuid4(), document_id=doc_a, content="a", score=0.9, created_at=now)
+        chunk_b = RecallChunk(id=uuid4(), document_id=doc_b, content="b", score=0.8, created_at=now)
+        entity = RecallEntity(
+            id=uuid4(),
+            name="E",
+            entity_type="X",
+            description="",
+            score=0.7,
+            attributes={},
+            mention_count=0,
+            source_document_ids=[doc_c],
+            source_chunk_ids=[],
+        )
+        rel = RecallRelationship(
+            id=uuid4(),
+            source_entity_id=uuid4(),
+            target_entity_id=uuid4(),
+            relationship_type="R",
+            description="",
+            score=0.6,
+            valid_from=None,
+            valid_until=None,
+            source_document_ids=[doc_d],
+        )
+
+        # Engine emits stubs only for the chunk-referenced docs;
+        # entity / rel docs must still appear after the upgrade pass.
+        mock_result = RecallResult(
+            query="q",
+            namespace_id=ns_id,
+            documents=[
+                DocumentProjection(id=doc_a, created_at=now),
+                DocumentProjection(id=doc_b, created_at=now),
+            ],
+            chunks=[chunk_a, chunk_b],
+            entities=[entity],
+            relationships=[rel],
+        )
+        kb._engine.recall = AsyncMock(return_value=mock_result)
+        kb._engine._storage.get_document_projections_batch = AsyncMock(
+            return_value={
+                doc_a: DocumentProjection(id=doc_a, created_at=now, title="A"),
+                doc_b: DocumentProjection(id=doc_b, created_at=now, title="B"),
+                doc_c: DocumentProjection(id=doc_c, created_at=now, title="C"),
+                doc_d: DocumentProjection(id=doc_d, created_at=now, title="D"),
+            }
+        )
+
+        result = await kb.recall(query="q", namespace=ns_id)
+
+        assert {d.id for d in result.documents} == {doc_a, doc_b, doc_c, doc_d}
+        by_id = {d.id: d for d in result.documents}
+        assert by_id[doc_c].title == "C"
+        assert by_id[doc_d].title == "D"
+
+
+# ---------------------------------------------------------------------------
+# 3. Referential integrity stub — dangling chunk doc id → minimal stub
+#    and the dangling_ref counter ticks with referrer="chunk", value=1.
+# ---------------------------------------------------------------------------
+
+
+class TestReferentialIntegrityStub:
+    @pytest.mark.asyncio
+    async def test_dangling_chunk_doc_id_yields_stub_and_counter(self, metric_reader) -> None:
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+        now = datetime.now(UTC)
+        missing_doc = uuid4()
+
+        chunk = RecallChunk(id=uuid4(), document_id=missing_doc, content="x", score=0.5, created_at=now)
+        mock_result = RecallResult(
+            query="q",
+            namespace_id=ns_id,
+            documents=[],
+            chunks=[chunk],
+            entities=[],
+            relationships=[],
+        )
+        kb._engine.recall = AsyncMock(return_value=mock_result)
+        kb._engine._storage.get_document_projections_batch = AsyncMock(return_value={})
+
+        # Does not raise.
+        result = await kb.recall(query="q", namespace=ns_id)
+
+        by_id = {d.id: d for d in result.documents}
+        assert missing_doc in by_id
+        stub = by_id[missing_doc]
+        assert isinstance(stub, DocumentProjection)
+        assert stub.id == missing_doc
+        assert stub.source_type == "library"
+        # Stub carries no upstream metadata.
+        assert stub.title is None
+        assert stub.external_id is None
+
+        points = _dangling_ref_points(metric_reader)
+        chunk_points = [p for p in points if dict(p.attributes).get("referrer") == "chunk"]
+        assert len(chunk_points) == 1
+        assert chunk_points[0].value == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Fail-open path — storage raises, recall still returns, warning logged.
+# ---------------------------------------------------------------------------
+
+
+class TestFailOpenOnStorageFailure:
+    @pytest.mark.asyncio
+    async def test_storage_exception_records_reason_and_does_not_crash(self) -> None:
+        from loguru import logger
+
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+        now = datetime.now(UTC)
+
+        doc_id = uuid4()
+        chunk = RecallChunk(id=uuid4(), document_id=doc_id, content="x", score=0.5, created_at=now)
+        engine_stub = DocumentProjection(id=doc_id, created_at=now, title="engine-stub")
+
+        mock_result = RecallResult(
+            query="q",
+            namespace_id=ns_id,
+            documents=[engine_stub],
+            chunks=[chunk],
+            entities=[],
+            relationships=[],
+            engine_info={"engine": "skeleton"},
+        )
+        kb._engine.recall = AsyncMock(return_value=mock_result)
+        kb._engine._storage.get_document_projections_batch = AsyncMock(side_effect=RuntimeError("boom"))
+
+        captured: list[str] = []
+        handler_id = logger.add(lambda msg: captured.append(str(msg)), level="WARNING")
+        try:
+            result = await kb.recall(query="q", namespace=ns_id)
+        finally:
+            logger.remove(handler_id)
+
+        # engine_info reports the failure reason.
+        assert result.engine_info["document_upgrade_failed"].startswith("RuntimeError:")
+        assert "boom" in result.engine_info["document_upgrade_failed"]
+        # Engine stub survived.
+        by_id = {d.id: d for d in result.documents}
+        assert by_id[doc_id].title == "engine-stub"
+        # Existing engine_info keys are preserved.
+        assert result.engine_info["engine"] == "skeleton"
+        # A warning landed in loguru.
+        assert any("document upgrade failed" in line for line in captured), captured
+
+
+# ---------------------------------------------------------------------------
+# 5. connected_entity_ids inversion — invert RecallEntity.source_chunk_ids,
+#    ordered by entity score.
+# ---------------------------------------------------------------------------
+
+
+class TestConnectedEntityIdsInversion:
+    @pytest.mark.asyncio
+    async def test_chunk_to_entity_inversion_with_score_ordering(self) -> None:
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+        now = datetime.now(UTC)
+        doc_id = uuid4()
+
+        c1 = RecallChunk(id=uuid4(), document_id=doc_id, content="c1", score=0.9, created_at=now)
+        c2 = RecallChunk(id=uuid4(), document_id=doc_id, content="c2", score=0.8, created_at=now)
+
+        # e1 has the higher score, so on c2 it must appear before e2.
+        e1 = RecallEntity(
+            id=uuid4(),
+            name="E1",
+            entity_type="X",
+            description="",
+            score=0.95,
+            attributes={},
+            mention_count=0,
+            source_document_ids=[doc_id],
+            source_chunk_ids=[c1.id, c2.id],
+        )
+        e2 = RecallEntity(
+            id=uuid4(),
+            name="E2",
+            entity_type="X",
+            description="",
+            score=0.50,
+            attributes={},
+            mention_count=0,
+            source_document_ids=[doc_id],
+            source_chunk_ids=[c2.id],
+        )
+
+        mock_result = RecallResult(
+            query="q",
+            namespace_id=ns_id,
+            documents=[DocumentProjection(id=doc_id, created_at=now)],
+            chunks=[c1, c2],
+            entities=[e1, e2],  # already score-sorted by the engine
+            relationships=[],
+        )
+        kb._engine.recall = AsyncMock(return_value=mock_result)
+        kb._engine._storage.get_document_projections_batch = AsyncMock(
+            return_value={doc_id: DocumentProjection(id=doc_id, created_at=now, title="D")}
+        )
+
+        result = await kb.recall(query="q", namespace=ns_id)
+
+        out_by_id = {c.id: c for c in result.chunks}
+        assert out_by_id[c1.id].connected_entity_ids == [e1.id]
+        assert out_by_id[c2.id].connected_entity_ids == [e1.id, e2.id]
+
+
+# ---------------------------------------------------------------------------
+# 6. UUID coercion at the projection boundary — a fake engine that hands
+#    in str-typed UUIDs should still produce ``UUID`` instances on the
+#    typed projections (the dataclass is the contract surface).
+# ---------------------------------------------------------------------------
+
+
+class TestProjectionUUIDCoercion:
+    @pytest.mark.asyncio
+    async def test_projection_emits_uuid_for_document_id(self) -> None:
+        """The dataclass annotation is ``UUID``. Any engine that constructs
+        a ``RecallChunk`` with ``document_id`` already typed as ``UUID``
+        round-trips through ``recall()`` as ``UUID`` — even when the engine
+        previously stored ids as strings, the construction site must
+        coerce. This is a contract test on the projection boundary.
+        """
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+        now = datetime.now(UTC)
+
+        # Simulate an engine that has str-typed ids at the raw row level
+        # but coerces at the projection boundary.
+        raw_doc_id_str = str(uuid4())
+        doc_id = UUID(raw_doc_id_str)
+        raw_chunk_id_str = str(uuid4())
+        chunk = RecallChunk(
+            id=UUID(raw_chunk_id_str),
+            document_id=UUID(raw_doc_id_str),
+            content="hello",
+            score=0.9,
+            created_at=now,
+        )
+
+        mock_result = RecallResult(
+            query="q",
+            namespace_id=ns_id,
+            documents=[DocumentProjection(id=doc_id, created_at=now)],
+            chunks=[chunk],
+            entities=[],
+            relationships=[],
+        )
+        kb._engine.recall = AsyncMock(return_value=mock_result)
+        kb._engine._storage.get_document_projections_batch = AsyncMock(
+            return_value={doc_id: DocumentProjection(id=doc_id, created_at=now, title="D")}
+        )
+
+        result = await kb.recall(query="q", namespace=ns_id)
+
+        assert isinstance(result.chunks[0].document_id, UUID)
+        assert isinstance(result.chunks[0].id, UUID)
+        assert isinstance(result.documents[0].id, UUID)
+
+
+# ---------------------------------------------------------------------------
+# 7. Cardinality regression — dangling_ref MUST NOT carry namespace_id.
+# ---------------------------------------------------------------------------
+
+
+class TestCounterCardinality:
+    @pytest.mark.asyncio
+    async def test_no_namespace_id_on_dangling_ref_counter(self, metric_reader) -> None:
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+        now = datetime.now(UTC)
+
+        # Force every referrer kind to register a dangling-ref hit.
+        missing_chunk_doc = uuid4()
+        missing_entity_doc = uuid4()
+        missing_rel_doc = uuid4()
+
+        chunk = RecallChunk(
+            id=uuid4(),
+            document_id=missing_chunk_doc,
+            content="x",
+            score=0.5,
+            created_at=now,
+        )
+        entity = RecallEntity(
+            id=uuid4(),
+            name="E",
+            entity_type="X",
+            description="",
+            score=0.5,
+            attributes={},
+            mention_count=0,
+            source_document_ids=[missing_entity_doc],
+            source_chunk_ids=[],
+        )
+        rel = RecallRelationship(
+            id=uuid4(),
+            source_entity_id=uuid4(),
+            target_entity_id=uuid4(),
+            relationship_type="R",
+            description="",
+            score=0.5,
+            valid_from=None,
+            valid_until=None,
+            source_document_ids=[missing_rel_doc],
+        )
+
+        mock_result = RecallResult(
+            query="q",
+            namespace_id=ns_id,
+            documents=[],
+            chunks=[chunk],
+            entities=[entity],
+            relationships=[rel],
+        )
+        kb._engine.recall = AsyncMock(return_value=mock_result)
+        kb._engine._storage.get_document_projections_batch = AsyncMock(return_value={})
+
+        await kb.recall(query="q", namespace=ns_id)
+
+        points = _dangling_ref_points(metric_reader)
+        assert points, "expected dangling_ref points to be emitted"
+        seen_referrers = set()
+        for p in points:
+            attrs = dict(p.attributes)
+            # The cardinality contract: only "referrer" is permitted.
+            assert "namespace_id" not in attrs, f"khora.recall.dangling_ref must not carry namespace_id: {attrs}"
+            assert set(attrs.keys()) <= {"referrer"}, f"unexpected labels on dangling_ref: {set(attrs.keys())}"
+            seen_referrers.add(attrs.get("referrer"))
+        # All three referrer kinds must have been recorded.
+        assert seen_referrers == {"chunk", "entity", "relationship"}
+
+
+# ---------------------------------------------------------------------------
+# 8. Backend smoke — ``get_document_projections_batch`` on a real backend
+#    returns the wider field set. Uses SQLite in-memory.
+# ---------------------------------------------------------------------------
+
+
+class TestBackendProjectionsBatch:
+    @pytest.mark.asyncio
+    async def test_sqlite_backend_returns_wider_field_set(self) -> None:
+        from khora.core.models import Document, MemoryNamespace
+        from khora.core.models.document import DocumentStatus
+        from khora.core.models.tenancy import TenancyMode
+        from khora.storage.backends.sqlite import SQLiteRelationalBackend
+
+        backend = SQLiteRelationalBackend(":memory:")
+        await backend.connect()
+        try:
+            now = datetime.now(UTC)
+            ns = MemoryNamespace(
+                id=uuid4(),
+                namespace_id=uuid4(),
+                tenancy_mode=TenancyMode.SHARED,
+                version=1,
+                is_active=True,
+                config_overrides={},
+                sync_checkpoints={},
+                metadata={},
+                created_at=now,
+                updated_at=now,
+            )
+            await backend.create_namespace(ns)
+
+            doc = Document(
+                id=uuid4(),
+                namespace_id=ns.id,
+                content="hello world",
+                status=DocumentStatus.PENDING,
+                title="Test Title",
+                external_id="ext-123",
+                source="src.txt",
+                source_name="Source Name",
+                source_url="https://example.com/x",
+                source_type="file",
+                content_type="text/plain",
+                checksum="abc",
+                metadata={"k": "v"},
+                created_at=now,
+                updated_at=now,
+            )
+            await backend.create_document(doc)
+
+            projections = await backend.get_document_projections_batch([doc.id])
+
+            assert doc.id in projections
+            proj = projections[doc.id]
+            assert isinstance(proj, DocumentProjection)
+            assert isinstance(proj.id, UUID)
+            # Wider field set — every public projection column survives.
+            assert proj.title == "Test Title"
+            assert proj.external_id == "ext-123"
+            assert proj.source == "src.txt"
+            assert proj.source_name == "Source Name"
+            assert proj.source_url == "https://example.com/x"
+            assert proj.source_type == "file"
+            assert proj.content_type == "text/plain"
+            assert proj.metadata == {"k": "v"}
+        finally:
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_sqlite_backend_empty_input_returns_empty(self) -> None:
+        from khora.storage.backends.sqlite import SQLiteRelationalBackend
+
+        backend = SQLiteRelationalBackend(":memory:")
+        await backend.connect()
+        try:
+            assert await backend.get_document_projections_batch([]) == {}
+        finally:
+            await backend.disconnect()


### PR DESCRIPTION
## Summary

Aligns `Khora.recall()` with the typed `RecallResult` projection landed in the prior step, and closes the remaining gaps so the response shape is contractually complete.

### API change
- `Khora.recall()` no longer accepts the `include_sources` kwarg. Passing it raises `TypeError`. The 4 entity-read methods (`get_entity`, `list_entities`, `find_related_entities`, `search_entities`) still accept `include_sources` — that surface is unchanged.

### Storage layer
- New typed primitive on the `RelationalBackend` protocol: `get_document_projections_batch(doc_ids) -> dict[UUID, DocumentProjection]`. Returns the wider 11-field shape (`id`, `created_at`, `source_type`, `title`, `external_id`, `source`, `source_name`, `source_url`, `content_type`, `source_timestamp`, `metadata`) — vs. the narrower `DocumentSource` returned by `get_document_sources_batch`, which the entity-attribution path still uses.
- Implemented on `postgresql`, `sqlite`, `sqlite_lance`, and `surrealdb` backends with matching SELECT lists.
- `StorageCoordinator.get_document_projections_batch` passthrough mirrors the existing source-batch passthrough.

### Post-engine upgrade pass (`Khora._upgrade_recall_documents`)
- After the engine returns, the recall pass batch-fetches full `DocumentProjection`s for every doc id referenced by chunks, entities, or relationships in the result. Engine stubs are replaced with the full projection where the relational store resolves them.
- **Referential integrity invariant:** every `chunks[i].document_id`, every id in `entities[i].source_document_ids`, and every id in `relationships[i].source_document_ids` resolves to a `documents[j].id` after the pass — unresolvable ids get a minimal stub appended so consumers can always do `{d.id: d for d in result.documents}[chunk.document_id]` without `KeyError`.
- **`connected_entity_ids` population:** inverted from `RecallEntity.source_chunk_ids` (the canonical chunk → entity mapping produced by extraction). Empty list semantics: "no linkage in this result", not "no edges in the graph". Graph-less stacks (skeleton, chronicle without entity hits) leave every chunk with the default empty list.
- **Fail-open:** if `get_document_projections_batch` raises, the engine stubs are preserved, `engine_info["document_upgrade_failed"]` is set to the exception class+message, and a warning is logged. The recall does not crash.

### Telemetry
- New internal counter `khora.recall.dangling_ref` with a single label `referrer` ∈ `{"chunk", "entity", "relationship"}`. **No `namespace_id` label** — per the cardinality rule that namespace_id is a span attribute and log field only.
- Telemetry contract JSON updated with `stability: internal`.

### Tests
- 10 new tests in `tests/unit/test_khora_recall_upgrade.py`:
  - `include_sources` kwarg raises `TypeError` on `recall()`; entity-read methods still accept it.
  - `documents[]` populated unconditionally as the union of all chunk / entity / relationship doc references.
  - Referential-integrity stub appended for unresolvable doc ids; dangling-ref counter increments with `referrer="chunk"` exactly once.
  - Fail-open path: storage exception → `engine_info["document_upgrade_failed"]` set, warning logged, no crash.
  - `connected_entity_ids` inversion produces score-sorted order matching `result.entities`.
  - UUID coercion at the projection boundary (str → UUID).
  - Cardinality regression: dangling-ref counter never emits a `namespace_id` attribute across all three referrer kinds.
  - `sqlite` backend round-trip on `get_document_projections_batch` covers all 11 fields.
- Integration smoke tests for the new primitive on `postgresql` and `surrealdb` backends.
- Existing recall tests updated for the new shape (no `include_sources`).

## Test plan
- [ ] Unit tests pass — `uv run pytest tests/unit -q --no-cov --ignore=tests/unit/integrations/langgraph --ignore=tests/unit/integrations/google_adk` (5648 passed locally; langgraph/google_adk are env-dependent and fail identically on main).
- [ ] Integration tests pass in CI.
- [ ] `make format` and `make lint` clean.
- [ ] Manual verification: `await kb.recall(...)` returns `RecallResult` with `documents[]` populated for every referenced doc id; passing `include_sources` raises `TypeError`.