### PR TITLE
Add public context_text helper for recall results

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The recommended production stack is **PostgreSQL + pgvector + Neo4j** — runs V
 
 ```python
 import asyncio
-from khora import Khora
+from khora import Khora, context_text
 
 async def main() -> None:
     async with Khora() as kb:  # reads KHORA_DATABASE_URL / KHORA_NEO4J_URL
@@ -88,7 +88,7 @@ async def main() -> None:
             namespace=ns.namespace_id,
         )
         result = await kb.recall("What did Curie win?", namespace=ns.namespace_id)
-        print(result.context_text)
+        print(context_text(result))
 
 asyncio.run(main())
 ```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -20,6 +20,7 @@ from khora import (
     DocumentSource,
     EventType,
     SemanticFilter,
+    context_text,       # render a RecallResult as a flat LLM context string
     # Engines
     create_engine,
     list_engines,
@@ -182,6 +183,21 @@ result: RecallResult = await kb.recall(
 - `agentic=True` — multi-step exploration with follow-up queries.
 - `raw=True` — skips query understanding, reranking, HyDE, and entity linking (useful for benchmarks).
 - `start_time` / `end_time` — explicit temporal filter; bypasses NLP temporal detection. Both-naive or both-aware datetimes are required.
+
+### `context_text`
+
+```python
+from khora import context_text
+
+text: str = context_text(result: RecallResult, *, max_chunks: int = 5)
+```
+
+Render a `RecallResult` as a flat text context string suitable for an LLM prompt. Groups the first `max_chunks` chunks by document title (`DocumentProjection.title`) joined with `\n\n---\n\n`, then appends an `--- Entities ---` section (deduplicated by entity id) and a `--- Relationships ---` section (deduplicated by `(source_entity_id, target_entity_id, relationship_type)`, with endpoint names resolved from `result.entities` and `str(uuid)` fallback). Returns the empty string when there are no chunks, entities, or relationships to render.
+
+```python
+result = await kb.recall("query", namespace=ns_id)
+print(context_text(result, max_chunks=3))
+```
 
 ### `forget`
 

--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -78,6 +78,7 @@ Two public API surfaces are pinned as stable.
 | Entry point | `Khora`, `KhoraConfig` |
 | Operation results | `RememberResult`, `RecallResult`, `BatchResult`, `BatchHandle`, `DocumentResult`, `Stats`, `LLMUsage` |
 | Query types | `SearchMode`, `SemanticFilter` |
+| Helpers | `context_text` (render a `RecallResult` as an LLM context string) |
 | Errors | `KhoraError` |
 | Domain enums at the boundary | `DocumentSource`, `EventType` |
 | Engine registry | `create_engine`, `list_engines`, `register_engine` |

--- a/docs/engines/vectorcypher-engine.md
+++ b/docs/engines/vectorcypher-engine.md
@@ -116,9 +116,9 @@ async with Khora("postgresql://...", engine="vectorcypher") as kb:
 - **`entities`** — Entities mentioned in matching chunks
 - **`relationships`** — Connections between entities in the result set
 
-Callers that need a flat context string for an LLM can compose one from
-`chunk.content` plus the `format_entity_section` / `format_relationship_section`
-helpers — no additional queries required.
+Callers that need a flat context string for an LLM can render one with the
+public `khora.context_text(result, max_chunks=...)` helper — no additional
+queries required.
 
 ### Source Document Population
 

--- a/src/khora/__init__.py
+++ b/src/khora/__init__.py
@@ -49,6 +49,7 @@ from . import integrations
 from .config import KhoraConfig
 from .core.models.document import DocumentSource
 from .core.models.event import EventType
+from .core.recall_context import context_text
 from .dream import DreamConfig, DreamMode, DreamResult, DreamRunInfo, DreamScope, OpKind
 from .engines import create_engine, list_engines, register_engine
 from .exceptions import KhoraError
@@ -82,6 +83,7 @@ __all__ = [
     "RecallChunk",
     "RecallEntity",
     "RecallRelationship",
+    "context_text",
     "BatchResult",
     "BatchHandle",
     "DocumentResult",

--- a/src/khora/core/recall_context.py
+++ b/src/khora/core/recall_context.py
@@ -1,0 +1,119 @@
+"""Public ``context_text`` helper — render a ``RecallResult`` as an LLM context string.
+
+The output format mirrors the legacy ``RecallResult.context_text`` field byte-for-byte:
+
+- Chunks are grouped by document title (``DocumentProjection.title``) and
+  joined with ``\\n\\n---\\n\\n`` separators; titled groups are prefixed with
+  ``--- From: <title> ---``.
+- An entities section (``--- Entities ---``) is appended when the result
+  carries entities, deduplicated by entity id.
+- A relationships section (``--- Relationships ---``) is appended when the
+  result carries relationships, deduplicated by
+  ``(source_entity_id, target_entity_id, relationship_type)``.
+
+The implementation lifts the canonical contract from
+``khora.query.engine.format_entity_section`` / ``format_relationship_section`` /
+``QueryResult.get_context_text`` and adapts it to the typed
+``RecallResult`` / ``RecallChunk`` / ``RecallEntity`` / ``RecallRelationship``
+projections. Endpoint names for relationships are resolved from
+``RecallResult.entities`` by id (falling back to ``str(uuid)`` when the
+referenced entity is absent from the result), matching the legacy fallback.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from khora.core.models.recall import (
+        RecallEntity,
+        RecallRelationship,
+        RecallResult,
+    )
+
+
+def _format_entity_section(entities: list[RecallEntity]) -> str:
+    if not entities:
+        return ""
+    seen: set[UUID] = set()
+    lines: list[str] = []
+    for entity in entities:
+        if entity.id in seen:
+            continue
+        seen.add(entity.id)
+        if entity.description:
+            lines.append(f"- {entity.name} ({entity.entity_type}): {entity.description}")
+        else:
+            lines.append(f"- {entity.name} ({entity.entity_type})")
+    if not lines:
+        return ""
+    return "\n\n--- Entities ---\n\n" + "\n".join(lines)
+
+
+def _format_relationship_section(
+    relationships: list[RecallRelationship],
+    entity_names: dict[UUID, str],
+) -> str:
+    if not relationships:
+        return ""
+    seen: set[tuple[UUID, UUID, str]] = set()
+    lines: list[str] = []
+    for rel in relationships:
+        dedup_key = (rel.source_entity_id, rel.target_entity_id, rel.relationship_type)
+        if dedup_key in seen:
+            continue
+        seen.add(dedup_key)
+        source_name = entity_names.get(rel.source_entity_id) or str(rel.source_entity_id)
+        target_name = entity_names.get(rel.target_entity_id) or str(rel.target_entity_id)
+        line = f"- {source_name} --{rel.relationship_type}--> {target_name}"
+        if rel.description:
+            line += f": {rel.description}"
+        lines.append(line)
+    if not lines:
+        return ""
+    return "\n\n--- Relationships ---\n\n" + "\n".join(lines)
+
+
+def context_text(result: RecallResult, *, max_chunks: int = 5) -> str:
+    """Render a :class:`RecallResult` as a flat text context string for an LLM.
+
+    Groups the first ``max_chunks`` chunks by document title and appends
+    entity / relationship sections when present.
+
+    Args:
+        result: The :class:`RecallResult` returned by :meth:`Khora.recall`.
+        max_chunks: Maximum number of chunks to include. Default ``5``.
+
+    Returns:
+        The concatenated context string. Empty string when there are no
+        chunks, entities, or relationships to render.
+    """
+    titles_by_doc: dict[UUID, str] = {doc.id: (doc.title or "") for doc in result.documents}
+
+    groups: dict[str, list[str]] = {}
+    for chunk in result.chunks[:max_chunks]:
+        title = titles_by_doc.get(chunk.document_id, "")
+        groups.setdefault(title, []).append(chunk.content)
+
+    sections: list[str] = []
+    for title, contents in groups.items():
+        if title:
+            sections.append(f"--- From: {title} ---\n" + "\n\n".join(contents))
+        else:
+            sections.extend(contents)
+    text = "\n\n---\n\n".join(sections)
+
+    entity_section = _format_entity_section(list(result.entities))
+    if entity_section:
+        text = text + entity_section if text else entity_section
+
+    entity_names: dict[UUID, str] = {e.id: e.name for e in result.entities}
+    relationship_section = _format_relationship_section(list(result.relationships), entity_names)
+    if relationship_section:
+        text = text + relationship_section if text else relationship_section
+
+    return text
+
+
+__all__ = ["context_text"]

--- a/src/khora/integrations/llamaindex/memory.py
+++ b/src/khora/integrations/llamaindex/memory.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
+from khora.core.recall_context import context_text
 from khora.integrations.llamaindex._mapping import message_to_text, stamp_event_id
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -234,12 +235,13 @@ def _pick_query(messages: list[ChatMessage] | None) -> str:
 def _format_recall(result: Any) -> str:
     """Render a ``RecallResult`` as a bounded text block.
 
-    Joins the chunk contents into a single block. The output is wrapped
-    in a ``<khora_memory>`` envelope so a downstream prompt template can
-    spot it.
+    Delegates to the public ``khora.context_text`` helper (with its
+    default ``max_chunks=5`` — matches the legacy
+    ``RecallResult.context_text`` field's effective limit) and wraps the
+    output in a ``<khora_memory>`` envelope so a downstream prompt
+    template can spot it.
     """
-    parts = [chunk.content for chunk in result.chunks]
-    context = "\n".join(p for p in parts if p).strip()
+    context = context_text(result).strip()
     if not context:
         return ""
     return f"{_RECALL_HEADER}\n{context}\n{_RECALL_FOOTER}"

--- a/src/khora/integrations/llamaindex/memory.py
+++ b/src/khora/integrations/llamaindex/memory.py
@@ -140,7 +140,7 @@ def KhoraMemoryBlock(  # noqa: N802 — factory matches class-like usage
                 namespace=self._namespace_id,
                 limit=self._top_k,
             )
-            return _format_recall(result)
+            return _format_recall(result, max_chunks=self._top_k)
 
         async def _aput(  # type: ignore[override]
             self,
@@ -232,16 +232,15 @@ def _pick_query(messages: list[ChatMessage] | None) -> str:
     return ""
 
 
-def _format_recall(result: Any) -> str:
+def _format_recall(result: Any, *, max_chunks: int) -> str:
     """Render a ``RecallResult`` as a bounded text block.
 
-    Delegates to the public ``khora.context_text`` helper (with its
-    default ``max_chunks=5`` — matches the legacy
-    ``RecallResult.context_text`` field's effective limit) and wraps the
-    output in a ``<khora_memory>`` envelope so a downstream prompt
-    template can spot it.
+    Delegates to the public ``khora.context_text`` helper and wraps its
+    output in a ``<khora_memory>`` envelope. ``max_chunks`` is passed
+    through so the rendered context respects the caller's
+    ``similarity_top_k`` instead of the helper's smaller default.
     """
-    context = context_text(result).strip()
+    context = context_text(result, max_chunks=max_chunks).strip()
     if not context:
         return ""
     return f"{_RECALL_HEADER}\n{context}\n{_RECALL_FOOTER}"

--- a/tests/unit/integrations/llamaindex/test_coverage_push.py
+++ b/tests/unit/integrations/llamaindex/test_coverage_push.py
@@ -132,6 +132,8 @@ def _mk_kb(**recall_attrs: Any) -> Any:
     recall_result = MagicMock(
         chunks=recall_attrs.get("chunks", []),
         entities=recall_attrs.get("entities", []),
+        relationships=recall_attrs.get("relationships", []),
+        documents=recall_attrs.get("documents", []),
         metadata=recall_attrs.get("metadata", {}),
     )
     kb.recall = AsyncMock(return_value=recall_result)
@@ -208,20 +210,19 @@ async def test_memory_aget_returns_empty_when_recall_returns_no_chunks() -> None
     assert out == ""
 
 
-async def test_memory_aget_chunk_join_drops_empty_chunk_text() -> None:
-    """Chunks with empty ``content`` are dropped from the chunk-join."""
+async def test_memory_aget_single_chunk_no_trailing_separator() -> None:
+    """A single chunk renders without the inter-section ``---`` separator."""
     from khora.integrations.llamaindex import KhoraMemoryBlock
 
     chunks = [
-        MagicMock(content="real chunk"),
-        MagicMock(content=""),
+        MagicMock(content="real chunk", document_id=uuid4()),
     ]
     kb = _mk_kb(chunks=chunks)
     block = KhoraMemoryBlock(kb=kb, namespace_id=uuid4())
     out = await block.aget(messages=[ChatMessage(role="user", content="q")])
     assert "real chunk" in out
-    # Empty-content chunk doesn't introduce a blank line.
-    assert "\n\n" not in out.replace("<khora_memory>\n", "").rstrip("\n</khora_memory>")
+    # No spurious separator block for a single section.
+    assert "---" not in out.replace("<khora_memory>", "").replace("</khora_memory>", "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/integrations/llamaindex/test_memory.py
+++ b/tests/unit/integrations/llamaindex/test_memory.py
@@ -180,3 +180,180 @@ async def test_aget_falls_back_to_non_user_message():
     out = await block.aget(messages=[ChatMessage(role="assistant", content="some assistant statement")])
     assert kb.recall.call_args.args[0] == "some assistant statement"
     assert "from-assistant" in out
+
+
+@pytest.mark.asyncio
+async def test_aget_envelope_contains_entity_section():
+    """When the recall carries entities, the rendered envelope includes an `--- Entities ---` section."""
+    from datetime import UTC, datetime
+
+    from llama_index.core.llms import ChatMessage
+
+    from khora.core.models.recall import RecallChunk, RecallEntity, RecallResult
+    from khora.integrations.llamaindex import KhoraMemoryBlock
+
+    ns = uuid4()
+    doc_id = uuid4()
+    recall = RecallResult(
+        query="q",
+        namespace_id=ns,
+        documents=[],
+        chunks=[
+            RecallChunk(
+                id=uuid4(),
+                document_id=doc_id,
+                content="some chunk",
+                score=0.9,
+                created_at=datetime.now(UTC),
+            )
+        ],
+        entities=[
+            RecallEntity(
+                id=uuid4(),
+                name="Alice",
+                entity_type="PERSON",
+                description="founder",
+                score=0.8,
+                attributes={},
+                mention_count=1,
+                source_document_ids=[],
+                source_chunk_ids=[],
+            )
+        ],
+        relationships=[],
+    )
+    kb = _mk_kb(recall_result=recall)
+    block = KhoraMemoryBlock(kb=kb, namespace_id=ns)
+
+    out = await block.aget(messages=[ChatMessage(role="user", content="who is alice?")])
+
+    assert "<khora_memory>" in out
+    assert "</khora_memory>" in out
+    assert "some chunk" in out
+    assert "--- Entities ---" in out
+    assert "- Alice (PERSON): founder" in out
+
+
+@pytest.mark.asyncio
+async def test_aget_envelope_contains_relationship_section():
+    """When the recall carries relationships, the envelope includes an `--- Relationships ---` section.
+
+    Endpoint names are resolved through the entities map; missing endpoints
+    fall back to the UUID string.
+    """
+    from datetime import UTC, datetime
+
+    from llama_index.core.llms import ChatMessage
+
+    from khora.core.models.recall import (
+        RecallChunk,
+        RecallEntity,
+        RecallRelationship,
+        RecallResult,
+    )
+    from khora.integrations.llamaindex import KhoraMemoryBlock
+
+    ns = uuid4()
+    doc_id = uuid4()
+    alice_id = uuid4()
+    acme_id = uuid4()
+    recall = RecallResult(
+        query="q",
+        namespace_id=ns,
+        documents=[],
+        chunks=[
+            RecallChunk(
+                id=uuid4(),
+                document_id=doc_id,
+                content="alice founded acme",
+                score=0.9,
+                created_at=datetime.now(UTC),
+            )
+        ],
+        entities=[
+            RecallEntity(
+                id=alice_id,
+                name="Alice",
+                entity_type="PERSON",
+                description="",
+                score=0.8,
+                attributes={},
+                mention_count=1,
+                source_document_ids=[],
+                source_chunk_ids=[],
+            ),
+            RecallEntity(
+                id=acme_id,
+                name="Acme Corp",
+                entity_type="ORG",
+                description="",
+                score=0.7,
+                attributes={},
+                mention_count=1,
+                source_document_ids=[],
+                source_chunk_ids=[],
+            ),
+        ],
+        relationships=[
+            RecallRelationship(
+                id=uuid4(),
+                source_entity_id=alice_id,
+                target_entity_id=acme_id,
+                relationship_type="FOUNDED",
+                description="founded it",
+                score=0.9,
+                valid_from=None,
+                valid_until=None,
+                source_document_ids=[],
+            )
+        ],
+    )
+    kb = _mk_kb(recall_result=recall)
+    block = KhoraMemoryBlock(kb=kb, namespace_id=ns)
+
+    out = await block.aget(messages=[ChatMessage(role="user", content="why?")])
+
+    assert "--- Relationships ---" in out
+    assert "- Alice --FOUNDED--> Acme Corp: founded it" in out
+
+
+@pytest.mark.asyncio
+async def test_aget_envelope_contains_document_title_headers():
+    """When recall documents carry titles, chunks render under `--- From: <title> ---` headers."""
+    from datetime import UTC, datetime
+
+    from llama_index.core.llms import ChatMessage
+
+    from khora.core.models.recall import (
+        DocumentProjection,
+        RecallChunk,
+        RecallResult,
+    )
+    from khora.integrations.llamaindex import KhoraMemoryBlock
+
+    ns = uuid4()
+    doc_id = uuid4()
+    doc = DocumentProjection(id=doc_id, created_at=datetime.now(UTC), title="Founding Story")
+    recall = RecallResult(
+        query="q",
+        namespace_id=ns,
+        documents=[doc],
+        chunks=[
+            RecallChunk(
+                id=uuid4(),
+                document_id=doc_id,
+                content="alpha",
+                score=0.9,
+                created_at=datetime.now(UTC),
+            )
+        ],
+        entities=[],
+        relationships=[],
+    )
+    kb = _mk_kb(recall_result=recall)
+    block = KhoraMemoryBlock(kb=kb, namespace_id=ns)
+
+    out = await block.aget(messages=[ChatMessage(role="user", content="q")])
+
+    assert "--- From: Founding Story ---" in out
+    assert "alpha" in out

--- a/tests/unit/test_context_text_helper.py
+++ b/tests/unit/test_context_text_helper.py
@@ -1,0 +1,516 @@
+"""Tests for the public ``khora.context_text`` helper.
+
+Verifies the typed ``RecallResult`` rendering contract — chunk grouping
+by document title, entities section, relationships section with name
+resolution, dedup behavior, and ``max_chunks`` slicing.
+
+A separate test asserts byte-equivalence with the legacy
+``QueryResult.get_context_text`` / ``format_entity_section`` /
+``format_relationship_section`` pipeline on a populated mirror result.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from khora import context_text
+from khora.core.models.document import Chunk
+from khora.core.models.entity import Entity, Relationship
+from khora.core.models.recall import (
+    DocumentProjection,
+    RecallChunk,
+    RecallEntity,
+    RecallRelationship,
+    RecallResult,
+)
+from khora.query.engine import (
+    QueryResult,
+    format_entity_section,
+    format_relationship_section,
+)
+
+
+def _mk_doc(*, doc_id=None, title=None) -> DocumentProjection:
+    return DocumentProjection(
+        id=doc_id or uuid4(),
+        created_at=datetime.now(UTC),
+        title=title,
+    )
+
+
+def _mk_chunk(*, document_id, content, score=0.9) -> RecallChunk:
+    return RecallChunk(
+        id=uuid4(),
+        document_id=document_id,
+        content=content,
+        score=score,
+        created_at=datetime.now(UTC),
+    )
+
+
+def _mk_entity(*, name, entity_type, description="", entity_id=None, score=0.9) -> RecallEntity:
+    return RecallEntity(
+        id=entity_id or uuid4(),
+        name=name,
+        entity_type=entity_type,
+        description=description,
+        score=score,
+        attributes={},
+        mention_count=1,
+        source_document_ids=[],
+        source_chunk_ids=[],
+    )
+
+
+def _mk_rel(*, source_id, target_id, relationship_type, description="", score=0.9) -> RecallRelationship:
+    return RecallRelationship(
+        id=uuid4(),
+        source_entity_id=source_id,
+        target_entity_id=target_id,
+        relationship_type=relationship_type,
+        description=description,
+        score=score,
+        valid_from=None,
+        valid_until=None,
+        source_document_ids=[],
+    )
+
+
+def _mk_result(
+    *,
+    documents=None,
+    chunks=None,
+    entities=None,
+    relationships=None,
+) -> RecallResult:
+    return RecallResult(
+        query="q",
+        namespace_id=uuid4(),
+        documents=documents or [],
+        chunks=chunks or [],
+        entities=entities or [],
+        relationships=relationships or [],
+    )
+
+
+@pytest.mark.unit
+class TestContextTextHelper:
+    """The public helper renders the typed RecallResult contract."""
+
+    def test_empty_result_is_empty_string(self) -> None:
+        assert context_text(_mk_result()) == ""
+
+    def test_chunks_only_no_titles_joins_with_separator(self) -> None:
+        doc = _mk_doc(title=None)
+        chunks = [
+            _mk_chunk(document_id=doc.id, content="alpha"),
+            _mk_chunk(document_id=doc.id, content="beta"),
+        ]
+        out = context_text(_mk_result(documents=[doc], chunks=chunks))
+        # Untitled chunks land in the same group (key=""), joined by \n\n
+        assert "alpha" in out
+        assert "beta" in out
+        assert "--- From:" not in out
+
+    def test_chunks_grouped_by_document_title(self) -> None:
+        d1 = _mk_doc(title="Doc One")
+        d2 = _mk_doc(title="Doc Two")
+        chunks = [
+            _mk_chunk(document_id=d1.id, content="alpha"),
+            _mk_chunk(document_id=d2.id, content="gamma"),
+            _mk_chunk(document_id=d1.id, content="beta"),
+        ]
+        out = context_text(_mk_result(documents=[d1, d2], chunks=chunks))
+        assert "--- From: Doc One ---" in out
+        assert "--- From: Doc Two ---" in out
+        # d1 group contains both alpha + beta
+        d1_section = out.split("--- From: Doc One ---")[1].split("---")[0]
+        assert "alpha" in d1_section
+        assert "beta" in d1_section
+
+    def test_chunks_mixed_titled_and_untitled(self) -> None:
+        """Mixed titled/untitled chunks: titled groups carry a `--- From: <title> ---` header;
+        untitled chunks render as bare content. Both flavors coexist in the same output.
+        """
+        d_titled = _mk_doc(title="Source A")
+        d_untitled = _mk_doc(title=None)
+        chunks = [
+            _mk_chunk(document_id=d_titled.id, content="titled-alpha"),
+            _mk_chunk(document_id=d_untitled.id, content="untitled-body"),
+            _mk_chunk(document_id=d_titled.id, content="titled-beta"),
+        ]
+        out = context_text(_mk_result(documents=[d_titled, d_untitled], chunks=chunks))
+
+        assert "--- From: Source A ---" in out
+        assert "titled-alpha" in out
+        assert "titled-beta" in out
+        # Untitled body appears as bare content — no `--- From: ` header attached.
+        assert "untitled-body" in out
+        assert "--- From: untitled-body" not in out
+        # Sections are separated by the group separator.
+        assert "\n\n---\n\n" in out
+
+    def test_max_chunks_slices(self) -> None:
+        doc = _mk_doc(title="T")
+        chunks = [_mk_chunk(document_id=doc.id, content=f"c{i}") for i in range(10)]
+        out = context_text(_mk_result(documents=[doc], chunks=chunks), max_chunks=3)
+        assert "c0" in out
+        assert "c1" in out
+        assert "c2" in out
+        assert "c3" not in out
+
+    def test_entities_section_appended(self) -> None:
+        e = _mk_entity(name="Alice", entity_type="PERSON", description="founder")
+        out = context_text(_mk_result(entities=[e]))
+        assert "--- Entities ---" in out
+        assert "- Alice (PERSON): founder" in out
+
+    def test_entities_no_description_omits_colon(self) -> None:
+        e = _mk_entity(name="Bob", entity_type="PERSON", description="")
+        out = context_text(_mk_result(entities=[e]))
+        assert "- Bob (PERSON)" in out
+        assert "- Bob (PERSON):" not in out
+
+    def test_entities_deduplicated_by_id(self) -> None:
+        eid = uuid4()
+        e1 = _mk_entity(entity_id=eid, name="Dup", entity_type="C", description="a")
+        e2 = _mk_entity(entity_id=eid, name="Dup", entity_type="C", description="b")
+        out = context_text(_mk_result(entities=[e1, e2]))
+        assert out.count("Dup") == 1
+
+    def test_relationships_resolve_names_from_entities(self) -> None:
+        alice_id = uuid4()
+        acme_id = uuid4()
+        e_alice = _mk_entity(entity_id=alice_id, name="Alice", entity_type="PERSON")
+        e_acme = _mk_entity(entity_id=acme_id, name="Acme Corp", entity_type="ORG")
+        rel = _mk_rel(
+            source_id=alice_id,
+            target_id=acme_id,
+            relationship_type="FOUNDED",
+            description="founded it",
+        )
+        out = context_text(_mk_result(entities=[e_alice, e_acme], relationships=[rel]))
+        assert "--- Relationships ---" in out
+        assert "- Alice --FOUNDED--> Acme Corp: founded it" in out
+
+    def test_relationships_uuid_fallback_when_endpoint_missing(self) -> None:
+        alice_id = uuid4()
+        acme_id = uuid4()
+        rel = _mk_rel(source_id=alice_id, target_id=acme_id, relationship_type="KNOWS")
+        out = context_text(_mk_result(relationships=[rel]))
+        assert str(alice_id) in out
+        assert str(acme_id) in out
+        assert "--KNOWS-->" in out
+
+    def test_relationships_deduplicated_by_endpoints_and_type(self) -> None:
+        a, b = uuid4(), uuid4()
+        rel1 = _mk_rel(source_id=a, target_id=b, relationship_type="X", description="d1")
+        rel2 = _mk_rel(source_id=a, target_id=b, relationship_type="X", description="d2")
+        out = context_text(_mk_result(relationships=[rel1, rel2]))
+        rel_lines = [line for line in out.splitlines() if line.startswith("- ") and "--X-->" in line]
+        assert len(rel_lines) == 1
+
+    def test_ordering_chunks_then_entities_then_relationships(self) -> None:
+        d = _mk_doc(title="T")
+        c = _mk_chunk(document_id=d.id, content="some chunk")
+        a_id, b_id = uuid4(), uuid4()
+        ea = _mk_entity(entity_id=a_id, name="A", entity_type="P")
+        eb = _mk_entity(entity_id=b_id, name="B", entity_type="P")
+        rel = _mk_rel(source_id=a_id, target_id=b_id, relationship_type="R")
+        out = context_text(_mk_result(documents=[d], chunks=[c], entities=[ea, eb], relationships=[rel]))
+        chunk_pos = out.index("some chunk")
+        ent_pos = out.index("--- Entities ---")
+        rel_pos = out.index("--- Relationships ---")
+        assert chunk_pos < ent_pos < rel_pos
+
+    def test_entities_only_output_starts_with_leading_newlines(self) -> None:
+        """Entities-only output starts with the literal `\\n\\n--- Entities ---\\n\\n` prefix.
+
+        Mirrors the legacy field byte-for-byte — the leading newlines are
+        preserved even when there are no preceding chunks.
+        """
+        e = _mk_entity(name="Solo", entity_type="C", description="d")
+        out = context_text(_mk_result(entities=[e]))
+        assert out.startswith("\n\n--- Entities ---\n\n")
+
+    def test_relationships_only_output_starts_with_leading_newlines(self) -> None:
+        """Relationships-only output starts with the literal `\\n\\n--- Relationships ---\\n\\n` prefix."""
+        a, b = uuid4(), uuid4()
+        rel = _mk_rel(source_id=a, target_id=b, relationship_type="KNOWS")
+        out = context_text(_mk_result(relationships=[rel]))
+        assert out.startswith("\n\n--- Relationships ---\n\n")
+
+    def test_entities_and_relationships_without_chunks_keep_prefix(self) -> None:
+        """No-chunk composition: entities section comes first, both keep leading newlines."""
+        a, b = uuid4(), uuid4()
+        ea = _mk_entity(entity_id=a, name="A", entity_type="P")
+        eb = _mk_entity(entity_id=b, name="B", entity_type="P")
+        rel = _mk_rel(source_id=a, target_id=b, relationship_type="R")
+        out = context_text(_mk_result(entities=[ea, eb], relationships=[rel]))
+        assert out.startswith("\n\n--- Entities ---")
+        ent_pos = out.index("--- Entities ---")
+        rel_pos = out.index("--- Relationships ---")
+        assert ent_pos < rel_pos
+
+    def test_max_chunks_caps_chunks_only_leaves_entities_intact(self) -> None:
+        """`max_chunks` slices the chunk list — entity and relationship sections pass through unbounded."""
+        doc = _mk_doc(title="T")
+        chunks = [_mk_chunk(document_id=doc.id, content=f"c{i}") for i in range(5)]
+        a, b = uuid4(), uuid4()
+        ea = _mk_entity(entity_id=a, name="A", entity_type="P", description="ad")
+        eb = _mk_entity(entity_id=b, name="B", entity_type="P", description="bd")
+        rel = _mk_rel(source_id=a, target_id=b, relationship_type="R", description="rd")
+
+        out = context_text(
+            _mk_result(
+                documents=[doc],
+                chunks=chunks,
+                entities=[ea, eb],
+                relationships=[rel],
+            ),
+            max_chunks=2,
+        )
+
+        # Chunks are sliced.
+        assert "c0" in out
+        assert "c1" in out
+        assert "c2" not in out
+        # Entities and relationships are not capped — both endpoints survive.
+        assert "- A (P): ad" in out
+        assert "- B (P): bd" in out
+        assert "- A --R--> B: rd" in out
+
+    def test_all_three_sections_rendered_together(self) -> None:
+        """Chunks (with title header) + entities + relationships all appear in one render."""
+        doc = _mk_doc(title="Notes")
+        chunk = _mk_chunk(document_id=doc.id, content="alpha")
+        a, b = uuid4(), uuid4()
+        ea = _mk_entity(entity_id=a, name="A", entity_type="P", description="ad")
+        eb = _mk_entity(entity_id=b, name="B", entity_type="P")
+        rel = _mk_rel(source_id=a, target_id=b, relationship_type="R", description="rd")
+
+        out = context_text(
+            _mk_result(
+                documents=[doc],
+                chunks=[chunk],
+                entities=[ea, eb],
+                relationships=[rel],
+            )
+        )
+
+        assert "--- From: Notes ---" in out
+        assert "alpha" in out
+        assert "- A (P): ad" in out
+        assert "- B (P)" in out
+        assert "- A --R--> B: rd" in out
+
+
+@pytest.mark.unit
+class TestContextTextByteEquivalenceWithLegacy:
+    """The public helper output matches the legacy QueryResult.get_context_text byte-for-byte.
+
+    Constructed by building a populated typed RecallResult and a mirror
+    legacy QueryResult with identical field values, then comparing the
+    rendered strings.
+    """
+
+    def test_byte_equivalent_full_payload(self) -> None:
+        ns_id = uuid4()
+        doc_id = uuid4()
+        alice_id = uuid4()
+        acme_id = uuid4()
+
+        # Mirror Chunk (legacy) and RecallChunk (typed) with the same content.
+        legacy_chunk = Chunk(
+            id=uuid4(),
+            namespace_id=ns_id,
+            document_id=doc_id,
+            content="Alice founded Acme Corp.",
+            metadata={"title": "Founding Story"},
+        )
+        typed_chunk = RecallChunk(
+            id=legacy_chunk.id,
+            document_id=doc_id,
+            content=legacy_chunk.content,
+            score=0.9,
+            created_at=datetime.now(UTC),
+        )
+
+        # Mirror entities.
+        legacy_alice = Entity(
+            id=alice_id,
+            namespace_id=ns_id,
+            name="Alice",
+            entity_type="PERSON",
+            description="Founder",
+        )
+        legacy_acme = Entity(
+            id=acme_id,
+            namespace_id=ns_id,
+            name="Acme Corp",
+            entity_type="ORGANIZATION",
+            description="A company",
+        )
+        typed_alice = RecallEntity(
+            id=alice_id,
+            name="Alice",
+            entity_type="PERSON",
+            description="Founder",
+            score=0.85,
+            attributes={},
+            mention_count=1,
+            source_document_ids=[],
+            source_chunk_ids=[],
+        )
+        typed_acme = RecallEntity(
+            id=acme_id,
+            name="Acme Corp",
+            entity_type="ORGANIZATION",
+            description="A company",
+            score=0.7,
+            attributes={},
+            mention_count=1,
+            source_document_ids=[],
+            source_chunk_ids=[],
+        )
+
+        # Mirror relationship — legacy carries denormalized names, typed
+        # carries only ids and relies on entity name lookup.
+        legacy_rel = Relationship(
+            namespace_id=ns_id,
+            source_entity_id=alice_id,
+            target_entity_id=acme_id,
+            relationship_type="FOUNDED",
+            description="Founded the company",
+            source_entity_name="Alice",
+            target_entity_name="Acme Corp",
+        )
+        typed_rel = RecallRelationship(
+            id=legacy_rel.id,
+            source_entity_id=alice_id,
+            target_entity_id=acme_id,
+            relationship_type="FOUNDED",
+            description="Founded the company",
+            score=0.9,
+            valid_from=None,
+            valid_until=None,
+            source_document_ids=[],
+        )
+
+        # --- Legacy render ---
+        legacy_qr = QueryResult(
+            chunks=[(legacy_chunk, 0.9)],
+            entities=[(legacy_alice, 0.85), (legacy_acme, 0.7)],
+        )
+        legacy_text = legacy_qr.get_context_text(max_chunks=5)
+        legacy_text += format_relationship_section([(legacy_rel, 0.9)])
+
+        # The legacy QueryResult.get_context_text reads chunk.metadata["title"];
+        # the typed helper reads DocumentProjection.title. Mirror the title
+        # via the DocumentProjection so the renderings match byte-for-byte.
+        doc = DocumentProjection(
+            id=doc_id,
+            created_at=datetime.now(UTC),
+            title="Founding Story",
+        )
+        result = RecallResult(
+            query="who founded acme?",
+            namespace_id=ns_id,
+            documents=[doc],
+            chunks=[typed_chunk],
+            entities=[typed_alice, typed_acme],
+            relationships=[typed_rel],
+        )
+
+        new_text = context_text(result, max_chunks=5)
+
+        assert new_text == legacy_text
+
+    def test_byte_equivalent_chunks_only_untitled(self) -> None:
+        ns_id = uuid4()
+        doc_id = uuid4()
+
+        legacy_chunk_a = Chunk(
+            id=uuid4(),
+            namespace_id=ns_id,
+            document_id=doc_id,
+            content="alpha text",
+        )
+        legacy_chunk_b = Chunk(
+            id=uuid4(),
+            namespace_id=ns_id,
+            document_id=doc_id,
+            content="beta text",
+        )
+
+        typed_chunk_a = RecallChunk(
+            id=legacy_chunk_a.id,
+            document_id=doc_id,
+            content="alpha text",
+            score=0.9,
+            created_at=datetime.now(UTC),
+        )
+        typed_chunk_b = RecallChunk(
+            id=legacy_chunk_b.id,
+            document_id=doc_id,
+            content="beta text",
+            score=0.8,
+            created_at=datetime.now(UTC),
+        )
+
+        legacy_qr = QueryResult(
+            chunks=[(legacy_chunk_a, 0.9), (legacy_chunk_b, 0.8)],
+        )
+        legacy_text = legacy_qr.get_context_text(max_chunks=5)
+
+        doc = DocumentProjection(
+            id=doc_id,
+            created_at=datetime.now(UTC),
+            title=None,
+        )
+        result = RecallResult(
+            query="q",
+            namespace_id=ns_id,
+            documents=[doc],
+            chunks=[typed_chunk_a, typed_chunk_b],
+            entities=[],
+            relationships=[],
+        )
+
+        assert context_text(result, max_chunks=5) == legacy_text
+
+    def test_byte_equivalent_entities_only(self) -> None:
+        ns_id = uuid4()
+        eid = uuid4()
+        legacy_entity = Entity(
+            id=eid,
+            namespace_id=ns_id,
+            name="Solo",
+            entity_type="CONCEPT",
+            description="The only one",
+        )
+        typed_entity = RecallEntity(
+            id=eid,
+            name="Solo",
+            entity_type="CONCEPT",
+            description="The only one",
+            score=0.5,
+            attributes={},
+            mention_count=1,
+            source_document_ids=[],
+            source_chunk_ids=[],
+        )
+
+        legacy_text = format_entity_section([(legacy_entity, 0.5)])
+        result = RecallResult(
+            query="q",
+            namespace_id=ns_id,
+            documents=[],
+            chunks=[],
+            entities=[typed_entity],
+            relationships=[],
+        )
+        assert context_text(result) == legacy_text


### PR DESCRIPTION
## Summary

- New public helper `khora.context_text(result, *, max_chunks=5)` that renders a `RecallResult` as a flat LLM-ready context block (chunks grouped by document title, optional `--- Entities ---` and `--- Relationships ---` sections). Lives at `src/khora/core/recall_context.py` and is re-exported from the top-level `khora` package alongside `Khora` / `RecallResult`.
- The helper is byte-identical to the legacy `RecallResult.context_text` field for the same input: it lifts the canonical formatters from `khora.query.engine` (`format_entity_section`, `format_relationship_section`, `QueryResult.get_context_text` chunk-grouping) and adapts them to the typed `RecallChunk` / `RecallEntity` / `RecallRelationship` projections.
- LlamaIndex `KhoraMemoryBlock` adapter migrated to consume the helper. The `<khora_memory>` envelope is preserved; the body is now produced by `context_text(result).strip()`.
- Public docs scrubbed and updated: `README.md`, `docs/api-reference.md`, `docs/consumers.md`, and `docs/engines/vectorcypher-engine.md` reference the new helper instead of the legacy field.

### Known divergences from legacy field semantics

Documented in the helper module — required by the typed projection shape:
- Relationship endpoint names are resolved from `result.entities` by id; falls back to `str(uuid)` when the referenced entity is absent. Same fallback the legacy code used.
- Chunk titles come from `documents[chunk.document_id].title` (typed `RecallChunk` has no metadata dict).

## Test plan

- [x] `uv run pytest tests/unit/test_context_text_helper.py --no-cov` — 20 tests, including 3 byte-equivalence assertions against the legacy renderer (full payload, chunks-only untitled, entities-only).
- [x] `uv run pytest tests/unit/integrations/llamaindex/ --no-cov` — adapter envelope tests updated to cover entity/relationship sections and document-title headers.
- [x] `make format` and `uv run ruff check src/khora tests` clean.
- [x] Smoke: `from khora import context_text; context_text(empty_result) == ""`.