### PR TITLE
Make Neo4j _record_to_relationship resilient to edges missing id/namespace_id

### DIFF
--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -2235,9 +2235,16 @@ RETURN count(r) AS updated
         self, rel: dict[str, Any], source_id: str, target_id: str, rel_type: str
     ) -> Relationship:
         """Convert a Neo4j relationship to a domain Relationship."""
+        rel_id = rel.get("id")
+        rel_ns = rel.get("namespace_id")
+        if rel_id is None or rel_ns is None:
+            logger.warning(
+                f"Relationship missing id/namespace_id (type={rel_type}, "
+                f"{source_id}->{target_id}); using synthesized identity"
+            )
         return Relationship(
-            id=UUID(rel["id"]),
-            namespace_id=UUID(rel["namespace_id"]),
+            id=UUID(rel_id) if rel_id else uuid4(),
+            namespace_id=UUID(rel_ns) if rel_ns else uuid4(),
             source_entity_id=UUID(source_id),
             target_entity_id=UUID(target_id),
             relationship_type=rel_type,

--- a/tests/unit/storage/backends/test_neo4j_coverage.py
+++ b/tests/unit/storage/backends/test_neo4j_coverage.py
@@ -31,7 +31,7 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -773,6 +773,78 @@ class TestRecordToRelationship:
         r = b._record_to_relationship(node, str(uuid4()), str(uuid4()), "KNOWS")
         assert r.valid_from == datetime(2024, 1, 1, tzinfo=UTC)
         assert r.valid_until == datetime(2024, 6, 1, tzinfo=UTC)
+
+    def test_missing_id_synthesizes_uuid_and_warns(self) -> None:
+        # Loguru intercept — capture WARNs via a custom sink.
+        from loguru import logger as loguru_logger
+
+        node = _rel_node()
+        del node["id"]
+        b = Neo4jBackend("bolt://localhost:7687")
+
+        records: list[str] = []
+        sink_id = loguru_logger.add(lambda msg: records.append(str(msg)), level="WARNING")
+        try:
+            r = b._record_to_relationship(node, str(uuid4()), str(uuid4()), "WORKS_FOR")
+        finally:
+            loguru_logger.remove(sink_id)
+
+        assert isinstance(r.id, UUID)
+        assert any("missing id/namespace_id" in m for m in records), records
+
+    def test_missing_namespace_id_synthesizes_uuid_and_warns(self) -> None:
+        from loguru import logger as loguru_logger
+
+        node = _rel_node()
+        del node["namespace_id"]
+        b = Neo4jBackend("bolt://localhost:7687")
+
+        records: list[str] = []
+        sink_id = loguru_logger.add(lambda msg: records.append(str(msg)), level="WARNING")
+        try:
+            r = b._record_to_relationship(node, str(uuid4()), str(uuid4()), "WORKS_FOR")
+        finally:
+            loguru_logger.remove(sink_id)
+
+        assert isinstance(r.namespace_id, UUID)
+        assert any("missing id/namespace_id" in m for m in records), records
+
+    def test_missing_both_synthesizes_uuids_and_warns(self) -> None:
+        from loguru import logger as loguru_logger
+
+        node = _rel_node()
+        del node["id"]
+        del node["namespace_id"]
+        b = Neo4jBackend("bolt://localhost:7687")
+
+        records: list[str] = []
+        sink_id = loguru_logger.add(lambda msg: records.append(str(msg)), level="WARNING")
+        try:
+            r = b._record_to_relationship(node, str(uuid4()), str(uuid4()), "WORKS_FOR")
+        finally:
+            loguru_logger.remove(sink_id)
+
+        assert isinstance(r.id, UUID)
+        assert isinstance(r.namespace_id, UUID)
+        assert any("missing id/namespace_id" in m for m in records), records
+
+    def test_well_formed_passthrough_no_warn(self) -> None:
+        from loguru import logger as loguru_logger
+
+        rel_id, ns_id = uuid4(), uuid4()
+        node = _rel_node(id=str(rel_id), namespace_id=str(ns_id))
+        b = Neo4jBackend("bolt://localhost:7687")
+
+        records: list[str] = []
+        sink_id = loguru_logger.add(lambda msg: records.append(str(msg)), level="WARNING")
+        try:
+            r = b._record_to_relationship(node, str(uuid4()), str(uuid4()), "WORKS_FOR")
+        finally:
+            loguru_logger.remove(sink_id)
+
+        assert r.id == rel_id
+        assert r.namespace_id == ns_id
+        assert not any("missing id/namespace_id" in m for m in records), records
 
 
 @pytest.mark.unit

--- a/tests/unit/test_neo4j_backend.py
+++ b/tests/unit/test_neo4j_backend.py
@@ -718,7 +718,7 @@ class TestNeo4jBackendGetEntityRelationships:
 
         backend = Neo4jBackend.from_driver(driver, query_timeout=None)
 
-        with pytest.raises(TypeError, match="tuple indices"):
+        with pytest.raises(AttributeError, match="'tuple' object has no attribute 'get'"):
             await backend.get_entity_relationships(entity_id, namespace_id=uuid4(), direction="outgoing")
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`Neo4jBackend._record_to_relationship` hard-subscripted `rel["id"]` / `rel["namespace_id"]` while every other field in the method used `rel.get(...)` with a default. A single relationship whose property map lacks those keys raised `KeyError`, and since it propagates out of the comprehension, **the entire `get_entity_relationships()` result was discarded** — one malformed edge wiped the whole entity-neighborhood response.

Edges can lack `id`/`namespace_id` because the write path (`create_relationships_batch`) sets them `ON CREATE` only — never backfilled on a MERGE-match, so legacy/partial edges are permanent landmines for the read path.

### Change

- `_record_to_relationship`: `rel.get("id")` / `rel.get("namespace_id")` with a synthesized `uuid4()` fallback and a single `WARN` when either is missing, mirroring the `.get()` resilience every other field already uses. The `Relationship` dataclass already defaults `id`/`namespace_id` to `field(default_factory=uuid4)`, so synthesized identity is consistent with the model contract. **No behavioural change for well-formed edges.**
- 4 unit tests covering missing-`id` / missing-`namespace_id` / missing-both (→ synthesized UUID identity + WARN) and well-formed (→ provided ids unchanged, no WARN).
- One regression-lock assertion updated `TypeError`→`AttributeError`: with `.get()` instead of `[]`, a raw tuple now surfaces `AttributeError` — the fail-loud intent is preserved.

### Out of scope (deferred follow-ups, tracked in #763)

- Write-path self-heal: `ON MATCH SET r.id = coalesce(...)` in `create_relationships_batch`.
- One-off Cypher backfill for existing property-less edges.

## Test plan

- [x] `tests/unit/test_neo4j_backend.py` + `tests/unit/storage/backends/test_neo4j_coverage.py`: 109 passed (incl. the 4 new tests + the updated regression-lock).
- [x] `make format` / `make lint` clean.
- [x] Full CI green (unit + integration).

Fixes #763