### PR TITLE
Add explicit source_timestamp kwarg to remember/remember_batch/submit_batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 
 ## [Unreleased]
 
+### Added
+
+- **Explicit `source_timestamp` kwarg on `Khora.remember()`, `Khora.remember_batch()`, and `Khora.submit_batch()`.** Callers can now pass `source_timestamp: datetime | None` directly instead of relying on the metadata-derived fallback. Per-doc dict key (`source_timestamp`) on `remember_batch` / `submit_batch` overrides the top-level kwarg for that document, mirroring the existing `source_type` / `source_name` / `source_url` pattern. When the kwarg is provided, it wins over the metadata-based fallback (`sent_at` / `occurred_at` / `created_at` / ...); when omitted, the existing fallback in `_extract_source_timestamp` is preserved unchanged.
+
 ### Security
 
 - **CI security gate allowlist for unfixable upstream CVEs.** pip-audit

--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -1027,6 +1027,7 @@ class ChronicleEngine:
         source_type: str = "library",
         source_name: str | None = None,
         source_url: str | None = None,
+        source_timestamp: datetime | None = None,
         metadata: dict[str, Any] | None = None,
         skill_name: str = "general_entities",
         entity_types: list[str],
@@ -1095,6 +1096,7 @@ class ChronicleEngine:
             source_type=source_type,
             source_name=source_name or None,
             source_url=source_url or None,
+            source_timestamp=source_timestamp,
             checksum=checksum,
             size_bytes=len(content.encode("utf-8")),
             metadata=dict(metadata or {}),
@@ -2295,6 +2297,7 @@ class ChronicleEngine:
         source_type: str = "library",
         source_name: str | None = None,
         source_url: str | None = None,
+        source_timestamp: datetime | None = None,
         extraction_batch_size: int | None = None,
         extraction_max_tokens: int | None = None,
     ) -> BatchResult:
@@ -2347,6 +2350,7 @@ class ChronicleEngine:
                 "source_type": doc_data.get("source_type", source_type),
                 "source_name": doc_data.get("source_name", source_name),
                 "source_url": doc_data.get("source_url", source_url),
+                "source_timestamp": doc_data.get("source_timestamp", source_timestamp),
                 "metadata": doc_data.get("metadata", {}),
             }
             if extraction_config_hash is not None:

--- a/src/khora/engines/protocol.py
+++ b/src/khora/engines/protocol.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from datetime import datetime
     from uuid import UUID
 
     from khora.core.models import Document, Entity, MemoryNamespace
@@ -57,6 +58,7 @@ class MemoryEngineProtocol(Protocol):
         source_type: str = "library",
         source_name: str | None = None,
         source_url: str | None = None,
+        source_timestamp: datetime | None = None,
         metadata: dict[str, Any] | None = None,
         skill_name: str = "general_entities",
         entity_types: list[str],
@@ -76,6 +78,8 @@ class MemoryEngineProtocol(Protocol):
             source_type: Provenance category (e.g. "library", "api", "file").
             source_name: Optional provider-level identifier (e.g. "slack", "linear").
             source_url: Optional original-source URL.
+            source_timestamp: Optional original-source timestamp. When provided,
+                persists directly to ``Document.source_timestamp``.
             metadata: Optional metadata
             skill_name: Extraction skill to use
             entity_types: Required entity types to extract
@@ -159,15 +163,16 @@ class MemoryEngineProtocol(Protocol):
         source_type: str = "library",
         source_name: str | None = None,
         source_url: str | None = None,
+        source_timestamp: datetime | None = None,
     ) -> BatchResult:
         """Store multiple documents with automatic optimization.
 
         Args:
             documents: List of document dicts with keys: content, title, source,
-                source_type, source_name, source_url, metadata, external_id
-                (optional caller-supplied external identifier). Top-level
-                source_type/source_name/source_url per-doc keys override the
-                corresponding kwargs.
+                source_type, source_name, source_url, source_timestamp, metadata,
+                external_id (optional caller-supplied external identifier).
+                Top-level source_type/source_name/source_url/source_timestamp
+                per-doc keys override the corresponding kwargs.
             namespace_id: Target namespace UUID
             skill_name: Extraction skill to use
             max_concurrent: Maximum concurrent document processing

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -228,6 +228,7 @@ class SkeletonConstructionEngine:
         source_type: str = "library",
         source_name: str | None = None,
         source_url: str | None = None,
+        source_timestamp: datetime | None = None,
         metadata: dict[str, Any] | None = None,
         skill_name: str = "general_entities",
         occurred_at: datetime | None = None,
@@ -282,6 +283,7 @@ class SkeletonConstructionEngine:
             source_type=source_type,
             source_name=source_name or None,
             source_url=source_url or None,
+            source_timestamp=source_timestamp,
             checksum=checksum,
             size_bytes=len(content.encode("utf-8")),
             metadata=dict(metadata or {}),
@@ -687,6 +689,7 @@ class SkeletonConstructionEngine:
         source_type: str = "library",
         source_name: str | None = None,
         source_url: str | None = None,
+        source_timestamp: datetime | None = None,
         bulk_mode: bool = False,
     ) -> BatchResult:
         """Store multiple documents with staged batch pipeline.
@@ -830,6 +833,7 @@ class SkeletonConstructionEngine:
                     source_type=doc_data.get("source_type", source_type),
                     source_name=doc_data.get("source_name", source_name) or None,
                     source_url=doc_data.get("source_url", source_url) or None,
+                    source_timestamp=doc_data.get("source_timestamp", source_timestamp),
                     checksum=checksum,
                     size_bytes=len(content.encode("utf-8")),
                     metadata=dict(doc_metadata),

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -677,6 +677,7 @@ class VectorCypherEngine:
         source_type: str = "library",
         source_name: str | None = None,
         source_url: str | None = None,
+        source_timestamp: datetime | None = None,
         metadata: dict[str, Any] | None = None,
         skill_name: str = "general_entities",
         expertise: ExpertiseConfig | str | None = None,
@@ -738,6 +739,7 @@ class VectorCypherEngine:
                     source_type=source_type,
                     source_name=source_name,
                     source_url=source_url,
+                    source_timestamp=source_timestamp,
                     metadata=metadata,
                     skill_name=skill_name,
                     expertise=expertise,
@@ -772,6 +774,7 @@ class VectorCypherEngine:
             source_type=source_type,
             source_name=source_name or None,
             source_url=source_url or None,
+            source_timestamp=source_timestamp,
             checksum=checksum,
             size_bytes=len(content.encode("utf-8")),
             metadata=dict(metadata or {}),
@@ -800,6 +803,7 @@ class VectorCypherEngine:
                 namespace_id=namespace_id,
                 title=title,
                 source=source,
+                source_timestamp=source_timestamp,
                 metadata=metadata,
                 skill_name=skill_name,
                 expertise=expertise,
@@ -1333,6 +1337,7 @@ class VectorCypherEngine:
         source_type: str = "library",
         source_name: str | None = None,
         source_url: str | None = None,
+        source_timestamp: datetime | None = None,
         metadata: dict[str, Any] | None,
         skill_name: str,
         expertise: ExpertiseConfig | str | None,
@@ -1397,7 +1402,7 @@ class VectorCypherEngine:
             extraction_config_hash=extraction_config_hash,
             external_id=external_id,
             created_at=existing.created_at,
-            source_timestamp=existing.source_timestamp,
+            source_timestamp=source_timestamp if source_timestamp is not None else existing.source_timestamp,
             processed_at=existing.processed_at,
             session_id=_coerce_session_id_from_metadata(metadata) or existing.session_id,
         )
@@ -2083,6 +2088,7 @@ class VectorCypherEngine:
         source_type: str = "library",
         source_name: str | None = None,
         source_url: str | None = None,
+        source_timestamp: datetime | None = None,
         bulk_mode: bool = False,
     ) -> BatchResult:
         """Store multiple documents with automatic optimization.
@@ -2140,6 +2146,7 @@ class VectorCypherEngine:
                 source_type=source_type,
                 source_name=source_name,
                 source_url=source_url,
+                source_timestamp=source_timestamp,
             )
         finally:
             if bulk_mode:
@@ -2166,6 +2173,7 @@ class VectorCypherEngine:
         source_type: str = "library",
         source_name: str | None = None,
         source_url: str | None = None,
+        source_timestamp: datetime | None = None,
     ) -> BatchResult:
         """Internal implementation of remember_batch (separated for bulk_mode wrapping)."""
         use_streaming = self._vc_config.streaming_pipeline
@@ -2187,6 +2195,7 @@ class VectorCypherEngine:
                 source_type=source_type,
                 source_name=source_name,
                 source_url=source_url,
+                source_timestamp=source_timestamp,
             )
 
         from khora.extraction.chunkers import create_chunker
@@ -2257,6 +2266,7 @@ class VectorCypherEngine:
                     source_type=doc_data.get("source_type", source_type),
                     source_name=doc_data.get("source_name", source_name),
                     source_url=doc_data.get("source_url", source_url),
+                    source_timestamp=doc_data.get("source_timestamp", source_timestamp),
                     metadata=doc_metadata,
                     skill_name=skill_name,
                     expertise=expertise,
@@ -2370,6 +2380,7 @@ class VectorCypherEngine:
                         source_type=doc_data.get("source_type", source_type),
                         source_name=doc_data.get("source_name", source_name) or None,
                         source_url=doc_data.get("source_url", source_url) or None,
+                        source_timestamp=doc_data.get("source_timestamp", source_timestamp),
                         metadata=dict(doc_metadata),
                         extraction_config_hash=extraction_config_hash,
                         external_id=doc_data.get("external_id"),
@@ -2832,6 +2843,7 @@ class VectorCypherEngine:
         source_type: str = "library",
         source_name: str | None = None,
         source_url: str | None = None,
+        source_timestamp: datetime | None = None,
     ) -> BatchResult:
         """Legacy per-document remember_batch (non-streaming pipeline)."""
         storage = self._get_storage()
@@ -2885,6 +2897,7 @@ class VectorCypherEngine:
                         source_type=doc_data.get("source_type", source_type),
                         source_name=doc_data.get("source_name", source_name),
                         source_url=doc_data.get("source_url", source_url),
+                        source_timestamp=doc_data.get("source_timestamp", source_timestamp),
                         metadata=doc_metadata,
                         skill_name=skill_name,
                         expertise=expertise,

--- a/src/khora/integrations/google_adk/_mapping.py
+++ b/src/khora/integrations/google_adk/_mapping.py
@@ -251,7 +251,7 @@ def event_to_remember_kwargs(
         # can rewrite ingested memory through `Khora.remember` directly.
         "entity_types": [],
         "relationship_types": [],
-        "source_timestamp_iso": iso_ts,  # consumed by the service, not by remember()
+        "source_timestamp": source_ts,
     }
 
 

--- a/src/khora/integrations/google_adk/memory_service.py
+++ b/src/khora/integrations/google_adk/memory_service.py
@@ -344,10 +344,6 @@ class KhoraMemoryService:
             merged.update(kwargs["metadata"])
             kwargs["metadata"] = merged
 
-        # ``source_timestamp_iso`` is a helper field for the service, not a
-        # ``Khora.remember`` parameter — strip before forwarding.
-        kwargs.pop("source_timestamp_iso", None)
-
         external_id = kwargs["external_id"]
         # Idempotency: if a document for this event already exists, forget
         # it first so we don't accumulate duplicate chunks on re-ingest.

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -1020,6 +1020,7 @@ class Khora:
         source_type: str = "library",
         source_name: str | None = None,
         source_url: str | None = None,
+        source_timestamp: datetime | None = None,
         metadata: dict[str, Any] | None = None,
         skill_name: str = "general_entities",
         entity_types: list[str],
@@ -1046,6 +1047,11 @@ class Khora:
             source_type: Provenance category (default "library").
             source_name: Optional provider-level identifier (e.g. "slack", "linear").
             source_url: Optional original-source URL.
+            source_timestamp: Optional original-source timestamp (when the content
+                was authored / occurred at the source). When provided, wins over
+                any timestamp derivable from ``metadata`` via the metadata-based
+                fallback (``sent_at`` / ``occurred_at`` / ``created_at`` / ...).
+                When omitted, the existing metadata-derived fallback is preserved.
             metadata: Optional metadata
             skill_name: Extraction skill to use
             entity_types: Required entity types to extract
@@ -1084,6 +1090,15 @@ class Khora:
             # without needing a dedicated kwarg on every engine's remember().
             if session_id is not None:
                 metadata = {**(metadata or {}), "session_id": str(session_id)}
+            # Stamp the explicit source_timestamp kwarg into the metadata dict
+            # under the canonical ``source_timestamp`` key so downstream code
+            # (ingest pipeline, engines that read metadata) sees the
+            # caller-provided value verbatim. Kwarg-wins-over-metadata-fallback
+            # semantics: existing ``sent_at`` / ``occurred_at`` / ``created_at``
+            # keys are not touched, so the metadata-derived fallback (see
+            # ``_extract_source_timestamp``) is preserved when the kwarg is None.
+            if source_timestamp is not None:
+                metadata = {**(metadata or {}), "source_timestamp": source_timestamp}
             with trace_span("khora.remember", namespace_id=str(namespace_id), content_length=len(content)):
                 # NOTE: expertise and extraction_config_hash are always forwarded,
                 # even when None. Custom engines registered via register_engine()
@@ -1096,6 +1111,7 @@ class Khora:
                     source_type=source_type,
                     source_name=source_name,
                     source_url=source_url,
+                    source_timestamp=source_timestamp,
                     metadata=metadata,
                     skill_name=skill_name,
                     entity_types=entity_types,
@@ -1127,6 +1143,7 @@ class Khora:
         source_type: str = "library",
         source_name: str | None = None,
         source_url: str | None = None,
+        source_timestamp: datetime | None = None,
         max_concurrent: int = 10,
         deduplicate: bool = True,
         infer_relationships: bool = True,
@@ -1159,6 +1176,7 @@ class Khora:
                 - source_type: str (optional) — overrides top-level kwarg per doc
                 - source_name: str (optional) — overrides top-level kwarg per doc
                 - source_url: str (optional) — overrides top-level kwarg per doc
+                - source_timestamp: datetime (optional) — overrides top-level kwarg per doc
                 - metadata: dict (optional)
                 - external_id: str (optional) — caller-supplied external identifier
             namespace: Namespace UUID (as UUID or string)
@@ -1166,6 +1184,10 @@ class Khora:
             source_type: Default provenance category for docs that don't supply one.
             source_name: Default provider identifier for docs that don't supply one.
             source_url: Default original-source URL for docs that don't supply one.
+            source_timestamp: Default original-source timestamp for docs that don't
+                supply one. When provided (top-level kwarg or per-doc), wins over
+                the metadata-derived fallback in the ingest pipeline; when omitted,
+                the existing fallback is preserved.
             max_concurrent: Maximum concurrent document processing
             deduplicate: Deduplicate entities across documents (default: True)
             infer_relationships: Infer relationships after ingestion (default: True)
@@ -1209,6 +1231,8 @@ class Khora:
                         doc_data["source_name"] = source_name
                     if "source_url" not in doc_data:
                         doc_data["source_url"] = source_url
+                    if "source_timestamp" not in doc_data:
+                        doc_data["source_timestamp"] = source_timestamp
                 # NOTE: see remember() comment re: custom engine compatibility
                 batch_kwargs: dict[str, Any] = dict(
                     skill_name=skill_name,
@@ -1224,6 +1248,7 @@ class Khora:
                     source_type=source_type,
                     source_name=source_name,
                     source_url=source_url,
+                    source_timestamp=source_timestamp,
                 )
                 if extraction_batch_size is not None:
                     batch_kwargs["extraction_batch_size"] = extraction_batch_size
@@ -1257,6 +1282,7 @@ class Khora:
         source_type: str = "library",
         source_name: str | None = None,
         source_url: str | None = None,
+        source_timestamp: datetime | None = None,
         entity_types: list[str],
         relationship_types: list[str],
         expertise: ExpertiseConfig | None = None,
@@ -1284,9 +1310,10 @@ class Khora:
 
         Args:
             documents: List of document dicts with 'content', 'title', 'source',
-                'source_type', 'source_name', 'source_url', 'metadata',
-                'external_id' keys. Per-doc source_type / source_name /
-                source_url override the top-level kwargs for that document.
+                'source_type', 'source_name', 'source_url', 'source_timestamp',
+                'metadata', 'external_id' keys. Per-doc source_type / source_name /
+                source_url / source_timestamp override the top-level kwargs for
+                that document.
             on_result: Synchronous callback(completed, total, DocumentResult)
                 invoked per document as processing completes.
             namespace: Namespace UUID (as UUID or string).
@@ -1294,6 +1321,10 @@ class Khora:
             source_type: Default provenance category (e.g. "library", "api").
             source_name: Default provider identifier (e.g. "slack", "linear").
             source_url: Default original-source URL.
+            source_timestamp: Default original-source timestamp for docs that
+                don't supply one. When provided (top-level kwarg or per-doc),
+                wins over the metadata-derived fallback when the document is
+                processed; when omitted, the existing fallback is preserved.
             entity_types: Required entity types to extract.
             relationship_types: Required relationship types to extract.
             expertise: Optional domain-specific extraction config.
@@ -1453,6 +1484,7 @@ class Khora:
                 existing.source_type = doc_data.get("source_type", source_type)
                 existing.source_name = doc_data.get("source_name", source_name) or None
                 existing.source_url = doc_data.get("source_url", source_url) or None
+                existing.source_timestamp = doc_data.get("source_timestamp", source_timestamp)
                 existing.checksum = checksum
                 existing.size_bytes = len(content.encode("utf-8"))
                 existing.metadata = doc_data.get("metadata") or {}
@@ -1489,6 +1521,7 @@ class Khora:
                 source_type=doc_data.get("source_type", source_type),
                 source_name=doc_data.get("source_name", source_name) or None,
                 source_url=doc_data.get("source_url", source_url) or None,
+                source_timestamp=doc_data.get("source_timestamp", source_timestamp),
                 checksum=checksum,
                 size_bytes=len(content.encode("utf-8")),
                 metadata=doc_data.get("metadata") or {},

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -1090,15 +1090,6 @@ class Khora:
             # without needing a dedicated kwarg on every engine's remember().
             if session_id is not None:
                 metadata = {**(metadata or {}), "session_id": str(session_id)}
-            # Stamp the explicit source_timestamp kwarg into the metadata dict
-            # under the canonical ``source_timestamp`` key so downstream code
-            # (ingest pipeline, engines that read metadata) sees the
-            # caller-provided value verbatim. Kwarg-wins-over-metadata-fallback
-            # semantics: existing ``sent_at`` / ``occurred_at`` / ``created_at``
-            # keys are not touched, so the metadata-derived fallback (see
-            # ``_extract_source_timestamp``) is preserved when the kwarg is None.
-            if source_timestamp is not None:
-                metadata = {**(metadata or {}), "source_timestamp": source_timestamp}
             with trace_span("khora.remember", namespace_id=str(namespace_id), content_length=len(content)):
                 # NOTE: expertise and extraction_config_hash are always forwarded,
                 # even when None. Custom engines registered via register_engine()

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -635,8 +635,11 @@ async def stage_document(
     # Extract custom metadata
     custom_metadata = doc_input.get("metadata", {})
 
-    # Use source timestamp if available, otherwise use current time
-    source_timestamp = _extract_source_timestamp(custom_metadata)
+    # Use source timestamp if available, otherwise use current time.
+    # Explicit doc_input["source_timestamp"] wins; otherwise fall back to the
+    # metadata-derived value (sent_at / occurred_at / created_at / ...).
+    _explicit_ts = doc_input.get("source_timestamp")
+    source_timestamp = _explicit_ts if _explicit_ts is not None else _extract_source_timestamp(custom_metadata)
     created_at = source_timestamp or datetime.now(UTC)
     session_id = _coerce_session_id(custom_metadata.get("session_id"))
 
@@ -714,7 +717,10 @@ async def stage_documents_batch(
         content = doc_input.get("content", "")
         custom_metadata = doc_input.get("metadata", {})
 
-        source_timestamp = _extract_source_timestamp(custom_metadata)
+        # Explicit doc_input["source_timestamp"] wins; otherwise fall back to
+        # the metadata-derived value (sent_at / occurred_at / created_at / ...).
+        _explicit_ts = doc_input.get("source_timestamp")
+        source_timestamp = _explicit_ts if _explicit_ts is not None else _extract_source_timestamp(custom_metadata)
         created_at = source_timestamp or datetime.now(UTC)
         session_id = _coerce_session_id(custom_metadata.get("session_id"))
 
@@ -786,7 +792,10 @@ async def _stage_all_documents(
         custom_metadata = doc_input.get("metadata", {})
         checksum = compute_checksum(content)
 
-        source_timestamp = _extract_source_timestamp(custom_metadata)
+        # Explicit doc_input["source_timestamp"] wins; otherwise fall back to
+        # the metadata-derived value (sent_at / occurred_at / created_at / ...).
+        _explicit_ts = doc_input.get("source_timestamp")
+        source_timestamp = _explicit_ts if _explicit_ts is not None else _extract_source_timestamp(custom_metadata)
         created_at = source_timestamp or datetime.now(UTC)
         session_id = _coerce_session_id(custom_metadata.get("session_id"))
 

--- a/tests/unit/test_khora.py
+++ b/tests/unit/test_khora.py
@@ -3972,3 +3972,345 @@ class TestProvenanceKwargsSubmitBatch:
         assert captured[0].source_type == "library"
         assert captured[0].source_name is None
         assert captured[0].source_url is None
+
+
+# ---------------------------------------------------------------------------
+# Provenance kwarg: source_timestamp
+# ---------------------------------------------------------------------------
+
+from datetime import UTC as _UTC  # noqa: E402
+
+_FIXED_SOURCE_TS = datetime(2024, 1, 15, 12, 0, tzinfo=_UTC)
+_OTHER_SOURCE_TS = datetime(2024, 6, 1, 8, 30, tzinfo=_UTC)
+
+
+def _engine_source_timestamp(call_kwargs: dict) -> object:
+    """Read the effective source_timestamp from an engine call.
+
+    The kwarg may be threaded either as a top-level ``source_timestamp`` kwarg
+    on the engine call (mirroring ``source_type``/``source_name``/``source_url``)
+    OR by stamping the value into ``metadata["source_timestamp"]`` so the
+    downstream ingest pipeline picks it up. Both are valid; this helper picks
+    whichever is populated so the tests assert the user-facing contract
+    (the engine receives the value), not a specific threading style.
+    """
+    if "source_timestamp" in call_kwargs and call_kwargs["source_timestamp"] is not None:
+        return call_kwargs["source_timestamp"]
+    metadata = call_kwargs.get("metadata") or {}
+    return metadata.get("source_timestamp")
+
+
+class TestSourceTimestampKwargRemember:
+    """Tests that remember() threads source_timestamp through to the engine."""
+
+    @pytest.mark.asyncio
+    async def test_remember_passes_explicit_source_timestamp(self) -> None:
+        """Explicit source_timestamp is forwarded to engine.remember()."""
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+
+        kb._engine.remember = AsyncMock(
+            return_value=RememberResult(
+                document_id=uuid4(),
+                namespace_id=ns_id,
+                chunks_created=1,
+                entities_extracted=0,
+                relationships_created=0,
+            )
+        )
+
+        with (
+            patch("khora.telemetry.context.ensure_trace_id"),
+            patch("khora.telemetry.context.clear_trace_id"),
+        ):
+            await kb.remember(
+                "content",
+                namespace=ns_id,
+                entity_types=["PERSON"],
+                relationship_types=["KNOWS"],
+                source_timestamp=_FIXED_SOURCE_TS,
+            )
+
+        kwargs = kb._engine.remember.call_args.kwargs
+        assert _engine_source_timestamp(kwargs) == _FIXED_SOURCE_TS
+
+    @pytest.mark.asyncio
+    async def test_remember_default_source_timestamp_is_none(self) -> None:
+        """Omitted source_timestamp reaches the engine as None; metadata is preserved
+        for the downstream _extract_source_timestamp fallback."""
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+
+        kb._engine.remember = AsyncMock(
+            return_value=RememberResult(
+                document_id=uuid4(),
+                namespace_id=ns_id,
+                chunks_created=0,
+                entities_extracted=0,
+                relationships_created=0,
+            )
+        )
+
+        with (
+            patch("khora.telemetry.context.ensure_trace_id"),
+            patch("khora.telemetry.context.clear_trace_id"),
+        ):
+            await kb.remember(
+                "content",
+                namespace=ns_id,
+                entity_types=["PERSON"],
+                relationship_types=["KNOWS"],
+                metadata={"created_at": "2024-01-15T12:00:00Z"},
+            )
+
+        kwargs = kb._engine.remember.call_args.kwargs
+        # No explicit kwarg was provided — engine sees no source_timestamp
+        # value, so the downstream pipeline runs _extract_source_timestamp
+        # against metadata (which still carries created_at verbatim).
+        assert _engine_source_timestamp(kwargs) is None
+        assert kwargs["metadata"]["created_at"] == "2024-01-15T12:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_remember_kwarg_wins_over_metadata_created_at(self) -> None:
+        """Both kwarg and metadata.created_at present → kwarg value reaches the engine."""
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+
+        kb._engine.remember = AsyncMock(
+            return_value=RememberResult(
+                document_id=uuid4(),
+                namespace_id=ns_id,
+                chunks_created=0,
+                entities_extracted=0,
+                relationships_created=0,
+            )
+        )
+
+        with (
+            patch("khora.telemetry.context.ensure_trace_id"),
+            patch("khora.telemetry.context.clear_trace_id"),
+        ):
+            await kb.remember(
+                "content",
+                namespace=ns_id,
+                entity_types=["PERSON"],
+                relationship_types=["KNOWS"],
+                metadata={"created_at": "2024-06-01T08:30:00+00:00"},
+                source_timestamp=_FIXED_SOURCE_TS,
+            )
+
+        kwargs = kb._engine.remember.call_args.kwargs
+        assert _engine_source_timestamp(kwargs) == _FIXED_SOURCE_TS
+
+
+class TestSourceTimestampKwargRememberBatch:
+    """Tests that remember_batch() stamps per-doc dicts with source_timestamp."""
+
+    @pytest.mark.asyncio
+    async def test_top_level_kwarg_applies_to_all_docs(self) -> None:
+        """Top-level source_timestamp is stamped onto every doc dict."""
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+
+        kb._engine.remember_batch = AsyncMock(
+            return_value=BatchResult(total=2, processed=2, skipped=0, failed=0, chunks=0, entities=0, relationships=0)
+        )
+
+        docs = [{"content": "doc one"}, {"content": "doc two"}]
+
+        with (
+            patch("khora.telemetry.context.ensure_trace_id"),
+            patch("khora.telemetry.context.clear_trace_id"),
+        ):
+            await kb.remember_batch(
+                docs,
+                namespace=ns_id,
+                entity_types=["PERSON"],
+                relationship_types=["KNOWS"],
+                source_timestamp=_FIXED_SOURCE_TS,
+            )
+
+        # Each doc dict is stamped in-place — this is what the engine /
+        # ingest pipeline consume per-document, matching the pattern used
+        # for source_type / source_name / source_url.
+        for doc in docs:
+            assert doc["source_timestamp"] == _FIXED_SOURCE_TS
+
+    @pytest.mark.asyncio
+    async def test_per_doc_dict_key_overrides_top_level(self) -> None:
+        """Mixed: doc-with-key keeps its own source_timestamp; doc-without inherits top-level."""
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+
+        kb._engine.remember_batch = AsyncMock(
+            return_value=BatchResult(total=2, processed=2, skipped=0, failed=0, chunks=0, entities=0, relationships=0)
+        )
+
+        docs = [
+            {"content": "doc with override", "source_timestamp": _OTHER_SOURCE_TS},
+            {"content": "doc without override"},
+        ]
+
+        with (
+            patch("khora.telemetry.context.ensure_trace_id"),
+            patch("khora.telemetry.context.clear_trace_id"),
+        ):
+            await kb.remember_batch(
+                docs,
+                namespace=ns_id,
+                entity_types=["PERSON"],
+                relationship_types=["KNOWS"],
+                source_timestamp=_FIXED_SOURCE_TS,
+            )
+
+        # Doc 0: per-doc key wins.
+        assert docs[0]["source_timestamp"] == _OTHER_SOURCE_TS
+        # Doc 1: gets the top-level fallback.
+        assert docs[1]["source_timestamp"] == _FIXED_SOURCE_TS
+
+    @pytest.mark.asyncio
+    async def test_defaults_when_neither_provided(self) -> None:
+        """No top-level kwarg + no per-doc key → source_timestamp defaults to None."""
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+
+        kb._engine.remember_batch = AsyncMock(
+            return_value=BatchResult(total=1, processed=1, skipped=0, failed=0, chunks=0, entities=0, relationships=0)
+        )
+
+        docs = [{"content": "doc"}]
+
+        with (
+            patch("khora.telemetry.context.ensure_trace_id"),
+            patch("khora.telemetry.context.clear_trace_id"),
+        ):
+            await kb.remember_batch(
+                docs,
+                namespace=ns_id,
+                entity_types=["PERSON"],
+                relationship_types=["KNOWS"],
+            )
+
+        assert docs[0]["source_timestamp"] is None
+
+
+class TestSourceTimestampKwargSubmitBatch:
+    """Tests that submit_batch() honors source_timestamp precedence."""
+
+    @pytest.mark.asyncio
+    async def test_top_level_kwarg_stamps_document(self) -> None:
+        """Top-level source_timestamp ends up on each persisted Document."""
+        ns_id = uuid4()
+        kb = _make_kb_with_staged_support(ns_id)
+
+        captured: list = []
+
+        async def _capture_create(doc):
+            captured.append(doc)
+            return doc
+
+        kb._engine._storage.create_document = AsyncMock(side_effect=_capture_create)
+
+        handle = await kb.submit_batch(
+            [{"content": "doc-1"}, {"content": "doc-2"}],
+            on_result=lambda c, t, r: None,
+            namespace=ns_id,
+            entity_types=["PERSON"],
+            relationship_types=["KNOWS"],
+            source_timestamp=_FIXED_SOURCE_TS,
+        )
+        await handle.wait()
+
+        assert len(captured) == 2
+        for doc in captured:
+            assert doc.source_timestamp == _FIXED_SOURCE_TS
+
+    @pytest.mark.asyncio
+    async def test_per_doc_key_overrides_top_level(self) -> None:
+        """Mixed batch: per-doc source_timestamp wins; others inherit top-level."""
+        ns_id = uuid4()
+        kb = _make_kb_with_staged_support(ns_id)
+
+        captured: list = []
+
+        async def _capture_create(doc):
+            captured.append(doc)
+            return doc
+
+        kb._engine._storage.create_document = AsyncMock(side_effect=_capture_create)
+
+        docs = [
+            {"content": "override", "source_timestamp": _OTHER_SOURCE_TS},
+            {"content": "inherit"},
+        ]
+
+        handle = await kb.submit_batch(
+            docs,
+            on_result=lambda c, t, r: None,
+            namespace=ns_id,
+            entity_types=["PERSON"],
+            relationship_types=["KNOWS"],
+            source_timestamp=_FIXED_SOURCE_TS,
+        )
+        await handle.wait()
+
+        assert len(captured) == 2
+        assert captured[0].source_timestamp == _OTHER_SOURCE_TS
+        assert captured[1].source_timestamp == _FIXED_SOURCE_TS
+
+    @pytest.mark.asyncio
+    async def test_kwarg_wins_over_metadata_created_at(self) -> None:
+        """Both kwarg and metadata.created_at present → kwarg value wins on the persisted Document."""
+        ns_id = uuid4()
+        kb = _make_kb_with_staged_support(ns_id)
+
+        captured: list = []
+
+        async def _capture_create(doc):
+            captured.append(doc)
+            return doc
+
+        kb._engine._storage.create_document = AsyncMock(side_effect=_capture_create)
+
+        # metadata.created_at would normally drive _extract_source_timestamp
+        # downstream; with the explicit kwarg present, the kwarg must win.
+        metadata_ts_str = "2024-06-01T08:30:00+00:00"
+
+        handle = await kb.submit_batch(
+            [{"content": "doc", "metadata": {"created_at": metadata_ts_str}}],
+            on_result=lambda c, t, r: None,
+            namespace=ns_id,
+            entity_types=["PERSON"],
+            relationship_types=["KNOWS"],
+            source_timestamp=_FIXED_SOURCE_TS,
+        )
+        await handle.wait()
+
+        assert len(captured) == 1
+        assert captured[0].source_timestamp == _FIXED_SOURCE_TS
+
+    @pytest.mark.asyncio
+    async def test_defaults_when_neither_provided(self) -> None:
+        """No top-level kwarg + no per-doc key → persisted Document.source_timestamp is None."""
+        ns_id = uuid4()
+        kb = _make_kb_with_staged_support(ns_id)
+
+        captured: list = []
+
+        async def _capture_create(doc):
+            captured.append(doc)
+            return doc
+
+        kb._engine._storage.create_document = AsyncMock(side_effect=_capture_create)
+
+        handle = await kb.submit_batch(
+            [{"content": "doc"}],
+            on_result=lambda c, t, r: None,
+            namespace=ns_id,
+            entity_types=["PERSON"],
+            relationship_types=["KNOWS"],
+        )
+        await handle.wait()
+
+        assert len(captured) == 1
+        assert captured[0].source_timestamp is None


### PR DESCRIPTION
## Summary

- Adds `source_timestamp: datetime | None = None` as a first-class kwarg on `Khora.remember()`, `Khora.remember_batch()`, and `Khora.submit_batch()`, mirroring the existing `source_type` / `source_name` / `source_url` pattern.
- When the kwarg is provided, it persists directly to `Document.source_timestamp`. When omitted, the existing metadata-derived fallback (`_extract_source_timestamp` on `sent_at` / `occurred_at` / `created_at` / ...) is preserved for backward compatibility, so existing callers see no behavior change.
- Threaded through `MemoryEngineProtocol`, `VectorCypherEngine`, `ChronicleEngine`, `SkeletonConstructionEngine`, and the ingest pipeline so all three public entry points land the kwarg-supplied timestamp on the persisted `DocumentModel`.
- The `google_adk` adapter now forwards the parsed ADK-event timestamp via the new kwarg instead of stuffing an ISO string in a helper metadata key (the prior `kwargs.pop("source_timestamp_iso", None)` strip is gone).
- `remember_batch()` / `submit_batch()` also accept `source_timestamp` as a per-doc dict key — the per-doc value wins over the top-level kwarg, matching the existing source-trio precedence.
- CHANGELOG entry added under the upcoming-release section.

## Test plan

- [x] `make format` clean
- [x] `make lint` passes (existing `ty` warnings unchanged)
- [x] 10 new unit tests in `tests/unit/test_khora.py` covering the four scenarios from the spec — kwarg explicit, per-doc dict variant, metadata fallback, and kwarg-wins-over-metadata — all green
- [x] Affected ingest-pipeline tests (`tests/unit/test_pipelines_ingest.py`) still pass — no regression in the fallback path
- [x] `google_adk` unit tests still pass
- [ ] Integration / e2e suites — verified via CI