### PR TITLE
fix(vectorcypher): bypass NamespaceRequiredProxy for pool_backend

### DIFF
--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -330,9 +330,12 @@ class VectorCypherRetriever:
             config: Retriever configuration
             router_config: Router configuration (optional, for LLM routing etc.)
             storage: Storage coordinator for entity vector search via pgvector.
-                When ``storage.graph`` is a ``Neo4jBackend``, its ``_session``
+                When ``storage._graph`` is a ``Neo4jBackend``, its ``_session``
                 helper is forwarded to ``DualNodeManager`` so pool metrics
                 observe every Neo4j session opened through this retriever.
+                ``_graph`` (not the public ``graph`` proxy) is used because
+                the ``NamespaceRequiredProxy`` refuses dunder/private attribute
+                lookups — see ``khora.storage._namespace_proxy``.
             neo4j_query_timeout: Optional per-transaction timeout in seconds
                 forwarded to the underlying ``DualNodeManager`` to bound
                 ``get_entity_neighborhoods``. ``None`` disables the timeout.
@@ -359,7 +362,10 @@ class VectorCypherRetriever:
         self._router = QueryComplexityRouter(router_config)
         # Forward Neo4jBackend when available so pool metrics observe
         # all traversals driven from the retriever (see DualNodeManager).
-        pool_backend = getattr(storage, "graph", None) if storage else None
+        # Bypass the NamespaceRequiredProxy on ``storage.graph`` by reading
+        # ``_graph`` directly — the proxy refuses underscore-prefixed lookups
+        # (DualNodeManager._session would hit AttributeError('_session')).
+        pool_backend = getattr(storage, "_graph", None) if storage else None
         self._dual_nodes = (
             DualNodeManager(
                 neo4j_driver,

--- a/tests/unit/engines/test_vectorcypher_retriever.py
+++ b/tests/unit/engines/test_vectorcypher_retriever.py
@@ -187,6 +187,38 @@ class TestRetrieverInit:
 
         assert retriever._dual_nodes is None
 
+    def test_init_bypasses_namespace_proxy_for_pool_backend(self) -> None:
+        """``DualNodeManager.pool_backend`` must be the raw graph backend.
+
+        ``StorageCoordinator.graph`` returns a ``NamespaceRequiredProxy`` whose
+        ``__getattr__`` rejects any underscore-prefixed name — including
+        ``_session``. Reading the public attribute caused session-aware search
+        (and any other path that opens a Neo4j session through
+        ``DualNodeManager``) to die with ``AttributeError('_session')`` on
+        every recall once the proxy landed (#765).
+        """
+        from khora.storage.coordinator import StorageCoordinator
+
+        raw_graph = MagicMock(name="raw_graph_backend")
+        raw_graph._session = MagicMock(name="_session")
+        storage = StorageCoordinator()
+        storage.graph = raw_graph  # routes through proxy on assignment
+
+        # Sanity: the public attribute is now the proxy and refuses ``_session``.
+        assert storage.graph is not raw_graph
+        with pytest.raises(AttributeError):
+            storage.graph._session  # noqa: B018
+
+        retriever = VectorCypherRetriever(
+            vector_store=AsyncMock(),
+            neo4j_driver=AsyncMock(),
+            embedder=AsyncMock(),
+            storage=storage,
+        )
+
+        assert retriever._dual_nodes is not None
+        assert retriever._dual_nodes._pool_backend is raw_graph
+
 
 @pytest.mark.unit
 class TestRetrieverSimpleRetrieve:


### PR DESCRIPTION
## Summary

- `VectorCypherRetriever` was reading `storage.graph` (the deprecation proxy added in #765) and forwarding it to `DualNodeManager` as `pool_backend`. The proxy's `__getattr__` rejects underscore-prefixed lookups, so the first call to `DualNodeManager._session()` raised `AttributeError('_session')`.
- Session-discovery caught the first hit and logged a "falling back to global search" warning, but every other `DualNodeManager` callsite (`get_chunks_by_entities`, …) hit the same proxy and bubbled the error to `Khora.recall()` callers — affecting ~90% of queries on corpora ingested without session metadata.
- Switched to `storage._graph` to bypass the proxy, matching the internal-access pattern already used in `VectorCypherEngine.connect()` and documented in `khora.storage._namespace_proxy`.

Fixes #792.

## Test plan

- [x] `uv run pytest tests/unit/engines/test_vectorcypher_retriever.py` — 45 passed
- [x] `uv run pytest tests/unit/engines/ tests/unit/storage/` — 1800 passed
- [x] New regression test `test_init_bypasses_namespace_proxy_for_pool_backend` fails on unpatched code (verified via stash) and passes on the fix