### PR TITLE
fix(vectorcypher): persist chunker_info end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 
 ## [Unreleased]
 
+### Fixed
+
+- vectorcypher: persist `chunker_info` end-to-end so recall surfaces the chunker self-identification dict instead of `{}`.
+
 ## [0.16.2] - Fork-safe integrations + vectorcypher proxy fix + Hermes adapter
 
 Patch release on top of v0.16.1. Two production-impacting fixes (fork-safe integration globals; `Khora.recall()` `AttributeError` on session-less corpora introduced by the v0.16.0 namespace proxy), plus the Hermes memory-provider adapter and the env-var naming consolidation that already landed on `main` since v0.16.1.

--- a/src/khora/db/migrations/versions/038_khora_chunks_chunker_info.py
+++ b/src/khora/db/migrations/versions/038_khora_chunks_chunker_info.py
@@ -97,8 +97,8 @@ def _assert_pg_version_ok() -> None:
         )
 
 
-def _upgrade_impl() -> bool:
-    """Perform the schema change. Returns True if the column was added."""
+def _upgrade_impl() -> None:
+    """Perform the schema change."""
     bind = op.get_bind()
     inspector = sa.inspect(bind)
     if not inspector.has_table("khora_chunks"):
@@ -111,7 +111,7 @@ def _upgrade_impl() -> bool:
         # the updated ``khora_chunks_table`` definition. The migration is
         # still required for existing production deployments where
         # ``khora_chunks`` was created before this column existed.
-        return False
+        return
 
     is_pg = _is_postgres()
 
@@ -144,21 +144,18 @@ def _upgrade_impl() -> bool:
                 server_default=sa.text("'{}'"),
             ),
         )
-    return True
 
 
 def upgrade() -> None:
     start = time.monotonic()
-    applied = False
     try:
-        applied = _upgrade_impl()
+        _upgrade_impl()
     except OperationalError as exc:
         duration_ms = int((time.monotonic() - start) * 1000)
         logger.bind(
             migration_id=revision,
             duration_ms=duration_ms,
             lock_timeout_tripped=_is_lock_timeout(exc),
-            applied=False,
         ).error("khora.migration.applied")
         # Bare ``raise`` re-raises the active exception with the original
         # traceback preserved. env.py's wrapping context.begin_transaction()
@@ -170,7 +167,6 @@ def upgrade() -> None:
         migration_id=revision,
         duration_ms=duration_ms,
         lock_timeout_tripped=False,
-        applied=applied,
     ).info("khora.migration.applied")
 
 

--- a/src/khora/db/migrations/versions/038_khora_chunks_chunker_info.py
+++ b/src/khora/db/migrations/versions/038_khora_chunks_chunker_info.py
@@ -1,0 +1,182 @@
+"""Add chunker_info to khora_chunks.
+
+Revision ID: 038_khora_chunks_chunker_info
+Revises: 037_recall_response_format
+Create Date: 2026-05-21
+
+Schema changes:
+
+* ``khora_chunks.chunker_info`` ``JSONB`` NOT NULL DEFAULT ``'{}'::jsonb`` —
+  per-chunk metadata describing which chunker produced the chunk and
+  with what params. Mirrors the ``chunks.chunker_info`` column added in
+  migration 037, scoped to the temporal-store table managed by the
+  vectorcypher engine.
+
+PostgreSQL version requirement: ``chunker_info JSONB NOT NULL DEFAULT
+'{}'::jsonb`` relies on the PG ≥11 ``ADD COLUMN ... NOT NULL DEFAULT``
+fast-path to avoid a full ``khora_chunks`` table rewrite. The upgrade
+asserts ``server_version_num >= 110000`` and raises on older Postgres
+so we fail fast instead of silently triggering a multi-hour rewrite.
+
+Lock-timeout safety: a Postgres-only ``SET lock_timeout = '5s'`` is
+issued **before any DDL** so the ``ADD COLUMN`` AccessExclusiveLock
+acquisition is bounded. The setting is scoped to the migration's
+enclosing transaction (env.py wraps the whole upgrade in a single
+transaction; the SET expires at COMMIT). On lock-timeout the upgrade
+logs ``khora.migration.applied`` at ERROR with
+``lock_timeout_tripped=True`` (detected by the Postgres SQLSTATE
+``55P03`` / ``lock_not_available`` on the
+``OperationalError.orig.pgcode`` — any other ``OperationalError``
+class logs ``lock_timeout_tripped=False`` so dashboards don't conflate
+deadlocks / connection drops / syntax errors with the lock-timeout
+signal). Either path re-raises so Alembic rolls back the transaction.
+
+Cross-dialect: the sqlite_lance fixture stack runs the full Alembic
+chain. The Postgres ``JSONB`` type is replaced with portable ``sa.JSON``
+(TEXT-backed) on SQLite, mirroring migration 037's pattern.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from loguru import logger
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.exc import OperationalError
+
+revision: str = "038_khora_chunks_chunker_info"
+down_revision: str | Sequence[str] | None = "037_recall_response_format"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_MIN_PG_VERSION = 110000  # PG 11 — chunker_info NOT NULL DEFAULT fast-path
+
+# PostgreSQL SQLSTATE for "lock_not_available" — what `lock_timeout` raises
+# when an acquisition exceeds the configured timeout.
+_PG_LOCK_NOT_AVAILABLE = "55P03"
+
+
+def _is_postgres() -> bool:
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def _is_lock_timeout(exc: OperationalError) -> bool:
+    """Distinguish a real lock_timeout trip from any other OperationalError.
+
+    OperationalError is a broad SQLAlchemy class — it wraps deadlocks,
+    connection drops, syntax errors, server shutdowns, AND lock_timeout
+    failures. The structured log field ``lock_timeout_tripped`` must
+    only be True for the latter so monitoring dashboards aren't misled.
+    """
+    orig = getattr(exc, "orig", None)
+    if orig is None:
+        return False
+    return getattr(orig, "pgcode", None) == _PG_LOCK_NOT_AVAILABLE
+
+
+def _assert_pg_version_ok() -> None:
+    """Fail fast if Postgres is older than 11.
+
+    ``khora_chunks.chunker_info NOT NULL DEFAULT '{}'::jsonb`` triggers
+    a full table rewrite on PG ≤ 10 — a multi-hour outage on a large
+    khora_chunks table. The hosted version meets this; we assert here
+    so a misconfigured deploy fails in seconds rather than silently
+    rewriting.
+    """
+    bind = op.get_bind()
+    version_num = bind.execute(sa.text("SELECT current_setting('server_version_num')::int")).scalar()
+    if version_num is None or int(version_num) < _MIN_PG_VERSION:
+        raise RuntimeError(
+            f"Migration {revision} requires PostgreSQL >= 11 "
+            f"(server_version_num >= {_MIN_PG_VERSION}); got {version_num}. "
+            "The khora_chunks.chunker_info NOT NULL DEFAULT fast-path requires PG 11+."
+        )
+
+
+def _upgrade_impl() -> bool:
+    """Perform the schema change. Returns True if the column was added."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("khora_chunks"):
+        # ``khora_chunks`` is created at runtime by the vectorcypher
+        # ``PgVectorTemporalStore.connect()`` (via ``metadata.create_all``)
+        # and by ``SQLiteLanceTemporalStore``'s DDL — it is not part of the
+        # Alembic-managed schema. On fresh deploys and on the sqlite_lance
+        # test fixture the table doesn't exist when the chain runs; in that
+        # case the new column lands when the runtime creates the table from
+        # the updated ``khora_chunks_table`` definition. The migration is
+        # still required for existing production deployments where
+        # ``khora_chunks`` was created before this column existed.
+        return False
+
+    is_pg = _is_postgres()
+
+    if is_pg:
+        _assert_pg_version_ok()
+        # Bound the ADD COLUMN AccessExclusiveLock acquisition — a stuck
+        # pg_stat_activity entry on khora_chunks cannot stall the deploy
+        # past 5 seconds. Issued before any DDL.
+        op.execute("SET lock_timeout = '5s'")
+
+        op.add_column(
+            "khora_chunks",
+            sa.Column(
+                "chunker_info",
+                JSONB,
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+        )
+    else:
+        # SQLite: Postgres JSONB is unrenderable. Use sa.JSON (TEXT-backed)
+        # with a JSON literal default — mirrors migration 037's pattern for
+        # the corresponding ``chunks.chunker_info`` column.
+        op.add_column(
+            "khora_chunks",
+            sa.Column(
+                "chunker_info",
+                sa.JSON,
+                nullable=False,
+                server_default=sa.text("'{}'"),
+            ),
+        )
+    return True
+
+
+def upgrade() -> None:
+    start = time.monotonic()
+    applied = False
+    try:
+        applied = _upgrade_impl()
+    except OperationalError as exc:
+        duration_ms = int((time.monotonic() - start) * 1000)
+        logger.bind(
+            migration_id=revision,
+            duration_ms=duration_ms,
+            lock_timeout_tripped=_is_lock_timeout(exc),
+            applied=False,
+        ).error("khora.migration.applied")
+        # Bare ``raise`` re-raises the active exception with the original
+        # traceback preserved. env.py's wrapping context.begin_transaction()
+        # rolls back all DDL from this revision.
+        raise
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+    logger.bind(
+        migration_id=revision,
+        duration_ms=duration_ms,
+        lock_timeout_tripped=False,
+        applied=applied,
+    ).info("khora.migration.applied")
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("khora_chunks"):
+        return
+    op.drop_column("khora_chunks", "chunker_info")

--- a/src/khora/engines/skeleton/backends/__init__.py
+++ b/src/khora/engines/skeleton/backends/__init__.py
@@ -38,6 +38,7 @@ class TemporalChunk:
     tags: list[str] = field(default_factory=list)
     confidence: float = 1.0
     metadata: dict[str, Any] = field(default_factory=dict)
+    chunker_info: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/src/khora/engines/skeleton/backends/pgvector.py
+++ b/src/khora/engines/skeleton/backends/pgvector.py
@@ -66,6 +66,12 @@ khora_chunks_table = Table(
     Column("tags", ARRAY(String), default=[]),
     Column("confidence", Float, default=1.0),
     Column("metadata", JSONB, default=dict),
+    Column(
+        "chunker_info",
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+    ),
     # Full-text search
     Column("content_tsv", TSVECTOR, nullable=True),
     # Indexes are defined below
@@ -212,6 +218,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
                 tags=chunk.tags or [],
                 confidence=chunk.confidence,
                 metadata=chunk.metadata or {},
+                chunker_info=chunk.chunker_info or {},
             )
             await session.execute(stmt)
             await session.commit()
@@ -243,6 +250,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
                     "tags": chunk.tags or [],
                     "confidence": chunk.confidence,
                     "metadata": chunk.metadata or {},
+                    "chunker_info": chunk.chunker_info or {},
                 }
             )
 
@@ -598,7 +606,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
             namespace_id=row.namespace_id,
             document_id=row.document_id,
             content=row.content,
-            embedding=list(row.embedding) if hasattr(row, "embedding") and row.embedding is not None else None,
+            embedding=(list(row.embedding) if hasattr(row, "embedding") and row.embedding is not None else None),
             occurred_at=row.occurred_at,
             created_at=row.created_at,
             source_system=row.source_system,
@@ -607,6 +615,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
             tags=list(row.tags) if row.tags is not None else [],
             confidence=row.confidence or 1.0,
             metadata=row.metadata or {},
+            chunker_info=dict(row.chunker_info) if row.chunker_info else {},
         )
 
     async def health_check(self) -> dict[str, Any]:

--- a/src/khora/engines/skeleton/backends/sqlite_lance.py
+++ b/src/khora/engines/skeleton/backends/sqlite_lance.py
@@ -70,7 +70,8 @@ _KHORA_CHUNKS_SCHEMA: tuple[str, ...] = (
         channel TEXT,
         tags TEXT NOT NULL DEFAULT '[]',
         confidence REAL NOT NULL DEFAULT 1.0,
-        metadata TEXT NOT NULL DEFAULT '{}'
+        metadata TEXT NOT NULL DEFAULT '{}',
+        chunker_info TEXT NOT NULL DEFAULT '{}'
     )
     """,
     "CREATE INDEX IF NOT EXISTS ix_khora_chunks_namespace ON khora_chunks(namespace_id)",
@@ -238,6 +239,7 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
                     to_json_text(c.tags or []),
                     float(c.confidence) if c.confidence is not None else 1.0,
                     to_json_text(c.metadata or {}),
+                    to_json_text(c.chunker_info or {}),
                 )
             )
             if c.embedding:
@@ -254,8 +256,8 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         await self._sqlite.executemany(
             "INSERT INTO khora_chunks "
             "(id, namespace_id, document_id, content, occurred_at, created_at, "
-            "source_system, author, channel, tags, confidence, metadata) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "source_system, author, channel, tags, confidence, metadata, chunker_info) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             sqlite_rows,
         )
         await self._sqlite.commit()
@@ -633,6 +635,7 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
             tags_list = []
 
         meta = from_json_text(row["metadata"]) if row["metadata"] else {}
+        chunker_info = from_json_text(row["chunker_info"]) if row["chunker_info"] else {}
 
         return TemporalChunk(
             id=UUID(row["id"]),
@@ -648,6 +651,7 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
             tags=tags_list,
             confidence=row["confidence"] if row["confidence"] is not None else 1.0,
             metadata=meta,
+            chunker_info=chunker_info,
         )
 
     # ------------------------------------------------------------------

--- a/src/khora/engines/skeleton/backends/surrealdb.py
+++ b/src/khora/engines/skeleton/backends/surrealdb.py
@@ -75,6 +75,7 @@ DEFINE FIELD IF NOT EXISTS channel ON temporal_chunk TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS tags ON temporal_chunk TYPE option<array<string>>;
 DEFINE FIELD IF NOT EXISTS confidence ON temporal_chunk TYPE float DEFAULT 1.0;
 DEFINE FIELD IF NOT EXISTS metadata_ ON temporal_chunk FLEXIBLE TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS chunker_info ON temporal_chunk FLEXIBLE TYPE object DEFAULT {};
 
 DEFINE INDEX IF NOT EXISTS idx_tc_namespace ON temporal_chunk FIELDS namespace;
 DEFINE INDEX IF NOT EXISTS idx_tc_document ON temporal_chunk FIELDS document;
@@ -198,7 +199,8 @@ class SurrealDBTemporalStore(TemporalVectorStore):
             "channel = $channel, "
             "tags = $tags, "
             "confidence = $confidence, "
-            "metadata_ = $metadata_"
+            "metadata_ = $metadata_, "
+            "chunker_info = $chunker_info"
         )
         bindings = self._chunk_to_bindings(chunk, chunk_id)
         bindings["chunk_rid"] = _rid("temporal_chunk", chunk_id)
@@ -224,7 +226,7 @@ class SurrealDBTemporalStore(TemporalVectorStore):
                     "namespace": _rid("memory_namespace", chunk.namespace_id),
                     "document": _rid("document", chunk.document_id),
                     "content": chunk.content,
-                    "embedding": list(chunk.embedding) if chunk.embedding is not None else None,
+                    "embedding": (list(chunk.embedding) if chunk.embedding is not None else None),
                     "occurred_at": chunk.occurred_at,
                     "created_at": (chunk.created_at or datetime.now(UTC)),
                     "source_system": chunk.source_system,
@@ -233,6 +235,7 @@ class SurrealDBTemporalStore(TemporalVectorStore):
                     "tags": _ensure_list(chunk.tags),
                     "confidence": chunk.confidence,
                     "metadata_": chunk.metadata or {},
+                    "chunker_info": chunk.chunker_info or {},
                 }
             )
 
@@ -357,7 +360,11 @@ class SurrealDBTemporalStore(TemporalVectorStore):
         # Vector search (fetch extra for fusion if hybrid)
         vector_limit = limit * 2 if hybrid else limit
         vector_results = await self._vector_search(
-            filter_clauses, filter_bindings, query_embedding, vector_limit, min_similarity
+            filter_clauses,
+            filter_bindings,
+            query_embedding,
+            vector_limit,
+            min_similarity,
         )
 
         if hybrid and query_text:
@@ -561,6 +568,7 @@ class SurrealDBTemporalStore(TemporalVectorStore):
             "tags": _ensure_list(chunk.tags),
             "confidence": chunk.confidence,
             "metadata_": chunk.metadata or {},
+            "chunker_info": chunk.chunker_info or {},
         }
 
     @staticmethod
@@ -583,6 +591,10 @@ class SurrealDBTemporalStore(TemporalVectorStore):
         if not isinstance(meta, dict):
             meta = {}
 
+        chunker_info = row.get("chunker_info") or {}
+        if not isinstance(chunker_info, dict):
+            chunker_info = {}
+
         return TemporalChunk(
             id=chunk_id,
             namespace_id=namespace_id,
@@ -597,6 +609,7 @@ class SurrealDBTemporalStore(TemporalVectorStore):
             tags=tags,
             confidence=float(row.get("confidence", 1.0)),
             metadata=meta,
+            chunker_info=chunker_info,
         )
 
     @staticmethod

--- a/src/khora/engines/vectorcypher/dual_nodes.py
+++ b/src/khora/engines/vectorcypher/dual_nodes.py
@@ -14,6 +14,7 @@ This structure enables efficient retrieval by:
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -182,7 +183,8 @@ class DualNodeManager:
             author: $author,
             channel: $channel,
             confidence: $confidence,
-            metadata: $metadata
+            metadata: $metadata,
+            chunker_info: $chunker_info
         })
         RETURN c.id AS id
         """
@@ -199,6 +201,7 @@ class DualNodeManager:
             channel=chunk.channel,
             confidence=chunk.confidence,
             metadata=serialize_dict(chunk.metadata or {}),
+            chunker_info=json.dumps(chunk.chunker_info or {}),
         )
 
         async with self._session() as session:
@@ -250,6 +253,7 @@ class DualNodeManager:
                     "channel": chunk.channel,
                     "confidence": chunk.confidence,
                     "metadata": serialize_dict(chunk.metadata or {}),
+                    "chunker_info": json.dumps(chunk.chunker_info or {}),
                 }
             )
 
@@ -266,7 +270,8 @@ class DualNodeManager:
             author: chunk.author,
             channel: chunk.channel,
             confidence: chunk.confidence,
-            metadata: chunk.metadata
+            metadata: chunk.metadata,
+            chunker_info: chunk.chunker_info
         })
         """
 
@@ -496,6 +501,7 @@ class DualNodeManager:
                c.document_id AS document_id,
                c.occurred_at AS occurred_at,
                c.metadata AS metadata,
+               c.chunker_info AS chunker_info,
                collect(DISTINCT e.id) AS entity_ids,
                sum(r.mention_count) AS total_mentions
         {order_clause}

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -947,6 +947,7 @@ class VectorCypherEngine:
                                 if hasattr(raw_chunk, "end_char")
                                 else len(raw_chunk.content),
                             },
+                            chunker_info=dict(raw_chunk.metadata),
                         )
                         temporal_chunks.append(temporal_chunk)
 
@@ -1140,6 +1141,7 @@ class VectorCypherEngine:
                         document_id=tc.document_id,
                         content=tc.content,
                         created_at=tc.created_at or tc.occurred_at,
+                        chunker_info=dict(tc.chunker_info or {}),
                     )
                 )
 
@@ -1282,6 +1284,7 @@ class VectorCypherEngine:
                 document_id=tc.document_id,
                 content=tc.content,
                 created_at=tc.created_at or tc.occurred_at,
+                chunker_info=dict(tc.chunker_info or {}),
             )
             for tc in core_temporal_chunks
         ]
@@ -1431,6 +1434,7 @@ class VectorCypherEngine:
                         start_char=getattr(raw_chunk, "start_char", 0),
                         end_char=getattr(raw_chunk, "end_char", len(raw_chunk.content)),
                         metadata={**new_doc_metadata, "chunk_index": i},
+                        chunker_info=dict(raw_chunk.metadata),
                         embedding=embedding,
                         embedding_model=embedder.model_name,
                         created_at=now,
@@ -1456,6 +1460,7 @@ class VectorCypherEngine:
                         embedding=c.embedding,
                         occurred_at=occurred_at,
                         created_at=c.created_at,
+                        chunker_info=dict(c.chunker_info or {}),
                     )
                     for c in new_chunks
                 ]
@@ -1531,6 +1536,7 @@ class VectorCypherEngine:
                         "start_char": c.start_char,
                         "end_char": c.end_char or len(c.content),
                     },
+                    chunker_info=dict(c.chunker_info or {}),
                 )
             )
 
@@ -2522,6 +2528,7 @@ class VectorCypherEngine:
                             if hasattr(raw_chunk, "end_char")
                             else len(raw_chunk.content),
                         },
+                        chunker_info=dict(raw_chunk.metadata),
                     )
                     all_temporal_chunks.append(tc)
 
@@ -2581,6 +2588,7 @@ class VectorCypherEngine:
                                     document_id=tc.document_id,
                                     content=tc.content,
                                     created_at=tc.created_at or tc.occurred_at,
+                                    chunker_info=dict(tc.chunker_info or {}),
                                 )
                             )
 

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -15,6 +15,7 @@ Performance optimizations:
 from __future__ import annotations
 
 import asyncio
+import json
 import math
 import os
 from dataclasses import dataclass, field
@@ -802,6 +803,11 @@ class VectorCypherRetriever:
                         document_id=UUID(c_data["document_id"]),
                         content=c_data.get("content", ""),
                         metadata={"occurred_at": c_data.get("occurred_at")},
+                        chunker_info=(
+                            json.loads(c_data["chunker_info"])
+                            if isinstance(c_data.get("chunker_info"), str)
+                            else (c_data.get("chunker_info") or {})
+                        ),
                     )
                     chunks.append((chunk, rank_score))
 
@@ -1936,6 +1942,7 @@ class VectorCypherRetriever:
                         "occurred_at": r.chunk.occurred_at.isoformat() if r.chunk.occurred_at else None,
                         **(r.chunk.metadata or {}),
                     },
+                    chunker_info=r.chunk.chunker_info or {},
                     created_at=r.chunk.created_at or r.chunk.occurred_at,
                 )
                 chunk_results.append((chunk, r.combined_score or r.similarity))
@@ -2496,6 +2503,7 @@ class VectorCypherRetriever:
                                     "total_mentions": 1,
                                     "entity_ids": [],
                                     "occurred_at": getattr(chunk, "source_timestamp", None),
+                                    "chunker_info": getattr(chunk, "chunker_info", None) or {},
                                 }
                             )
                 except Exception as e:
@@ -2522,6 +2530,11 @@ class VectorCypherRetriever:
                         "connected_entities": record.get("entity_ids", []),
                         **(record.get("metadata") or {}),
                     },
+                    chunker_info=(
+                        json.loads(record["chunker_info"])
+                        if isinstance(record.get("chunker_info"), str)
+                        else (record.get("chunker_info") or {})
+                    ),
                 )
                 results.append((chunk_id, score, chunk))
 
@@ -2578,6 +2591,7 @@ class VectorCypherRetriever:
                             "occurred_at": r.chunk.occurred_at.isoformat() if r.chunk.occurred_at else None,
                             **(r.chunk.metadata or {}),
                         },
+                        chunker_info=r.chunk.chunker_info or {},
                         created_at=r.chunk.created_at or r.chunk.occurred_at,
                     ),
                 )
@@ -2671,6 +2685,7 @@ class VectorCypherRetriever:
                                 ),
                                 **(getattr(chunk, "metadata", None) or {}),
                             },
+                            chunker_info=getattr(chunk, "chunker_info", None) or {},
                             created_at=getattr(chunk, "created_at", None) or getattr(chunk, "occurred_at", None),
                         ),
                     )

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -84,6 +84,26 @@ _NEO4J_TRANSIENT_ERRORS: tuple[type[Exception], ...] = (
 _BENCH_MODE: bool = os.environ.get("KHORA_BENCH_MODE", "").strip().lower() in {"true", "1", "yes"}
 
 
+def _decode_chunker_info(value: Any) -> dict[str, Any]:
+    """Normalize the value of ``chunker_info`` returned by a record dict.
+
+    Neo4j serializes ``chunker_info`` as a JSON string at write time (see
+    ``dual_nodes.create_chunk_nodes_batch``); other graph stores return
+    a native dict. A corrupted persisted value (direct DB tampering, a
+    half-finished migration) must not crash ``recall()`` — fall back to
+    an empty dict on ``json.JSONDecodeError``.
+    """
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return decoded if isinstance(decoded, dict) else {}
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
 @dataclass
 class VectorCypherResult:
     """Result from VectorCypher retrieval."""
@@ -803,11 +823,7 @@ class VectorCypherRetriever:
                         document_id=UUID(c_data["document_id"]),
                         content=c_data.get("content", ""),
                         metadata={"occurred_at": c_data.get("occurred_at")},
-                        chunker_info=(
-                            json.loads(c_data["chunker_info"])
-                            if isinstance(c_data.get("chunker_info"), str)
-                            else (c_data.get("chunker_info") or {})
-                        ),
+                        chunker_info=_decode_chunker_info(c_data.get("chunker_info")),
                     )
                     chunks.append((chunk, rank_score))
 
@@ -2530,11 +2546,7 @@ class VectorCypherRetriever:
                         "connected_entities": record.get("entity_ids", []),
                         **(record.get("metadata") or {}),
                     },
-                    chunker_info=(
-                        json.loads(record["chunker_info"])
-                        if isinstance(record.get("chunker_info"), str)
-                        else (record.get("chunker_info") or {})
-                    ),
+                    chunker_info=_decode_chunker_info(record.get("chunker_info")),
                 )
                 results.append((chunk_id, score, chunk))
 

--- a/tests/integration/db/test_migration_032_dream_runs.py
+++ b/tests/integration/db/test_migration_032_dream_runs.py
@@ -297,7 +297,7 @@ class TestMigration032OnSqlite:
                 async with engine.connect() as conn:
                     # Chain reached head (sanity).
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "037_recall_response_format"
+                    assert result.scalar() == "038_khora_chunks_chunker_info"
 
                     # khora_dream_runs MUST NOT exist on SQLite — embedded path
                     # mirrors checkpoint state via a JSONL file sink.

--- a/tests/integration/matrix/test_vectorcypher_chunker_info.py
+++ b/tests/integration/matrix/test_vectorcypher_chunker_info.py
@@ -1,0 +1,161 @@
+"""End-to-end ``chunker_info`` propagation on the VectorCypher embedded path.
+
+Pins the contract that the chunker's strategy identifier survives the
+full remember → store → recall round-trip on the production embedded
+stack (sqlite_lance + VectorCypher). The matching unit test in
+``tests/unit/engines/vectorcypher/test_chunker_info_propagation.py``
+verifies the engine-layer wiring; this test exercises the storage write
++ retriever read against a real (in-process) database and vector index.
+
+Why this test exists: a regression that drops ``chunker_info`` would not
+surface in the unit suite if the storage adapter quietly returns
+``None`` or fails to project the new column on read. End-to-end gives
+us confidence the entire chain — chunker → engine → temporal store →
+LanceDB/SQLite → retriever → ``RecallChunk.chunker_info`` — is intact.
+
+Shares no infrastructure with sibling tests beyond ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+try:
+    import aiosqlite  # noqa: F401
+    import lancedb  # noqa: F401
+
+    _HAS_EMBEDDED = True
+except ImportError:
+    _HAS_EMBEDDED = False
+
+from khora.config import KhoraConfig
+from khora.config.schema import SQLiteLanceConfig
+from khora.extraction.extractors.base import ExtractionResult
+from khora.extraction.skills import ExpertiseConfig
+from khora.khora import Khora
+
+EMBED_DIM = 32
+
+pytestmark = [
+    pytest.mark.embedded,
+    pytest.mark.integration,
+    pytest.mark.skipif(not _HAS_EMBEDDED, reason="aiosqlite/lancedb not installed"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Deterministic embedder + no-op extractor stubs (no OPENAI_API_KEY needed)
+# ---------------------------------------------------------------------------
+
+
+def _embed_for(text_in: str) -> list[float]:
+    seed = hashlib.sha256(text_in.encode("utf-8")).digest()
+    raw = [(seed[i % len(seed)] - 128) / 128.0 for i in range(EMBED_DIM)]
+    norm = sum(x * x for x in raw) ** 0.5 or 1.0
+    return [x / norm for x in raw]
+
+
+async def _stub_embed_batch(self: Any, texts: list[str]) -> list[list[float]]:
+    return [_embed_for(t) for t in texts]
+
+
+async def _stub_embed(self: Any, text_in: str) -> list[float]:
+    return _embed_for(text_in)
+
+
+async def _stub_extract_multi(self: Any, texts: list[str], **_kwargs: Any) -> list[ExtractionResult]:
+    # Entity extraction is irrelevant to this test; return empty results.
+    return [ExtractionResult() for _ in texts]
+
+
+@pytest.fixture(autouse=True)
+def _patch_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "khora.extraction.embedders.litellm.LiteLLMEmbedder.embed_batch",
+        _stub_embed_batch,
+    )
+    monkeypatch.setattr(
+        "khora.extraction.embedders.litellm.LiteLLMEmbedder.embed",
+        _stub_embed,
+    )
+    monkeypatch.setattr(
+        "khora.extraction.extractors.llm.LLMEntityExtractor.extract_multi",
+        _stub_extract_multi,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-test embedded Khora fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def kb(tmp_path: Path) -> AsyncIterator[Khora]:
+    config = KhoraConfig()
+    config.storage.backend = "sqlite_lance"
+    config.storage.sqlite_lance = SQLiteLanceConfig(
+        db_path=str(tmp_path / "khora.db"),
+        lance_path=str(tmp_path / "khora.lance"),
+        embedding_dimension=EMBED_DIM,
+    )
+    config.llm.embedding_dimension = EMBED_DIM
+    config.storage.embedding_dimension = EMBED_DIM
+    config.neo4j_url = None
+    config.pipelines.chunk_size = 1024
+    # Disable extraction — chunker_info is independent of entity extraction.
+    config.pipelines.extract_entities = False
+    config.pipelines.selective_extraction = False
+
+    kb = Khora(config, engine="vectorcypher", run_migrations=True)
+    await kb.connect()
+    try:
+        yield kb
+    finally:
+        try:
+            await kb.disconnect()
+        except Exception:
+            pass
+
+
+@pytest.fixture
+async def namespace_id(kb: Khora) -> UUID:
+    ns = await kb.create_namespace()
+    return ns.namespace_id
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+async def test_chunker_info_survives_remember_recall_roundtrip(kb: Khora, namespace_id: UUID) -> None:
+    """Every recalled chunk must carry a non-empty ``chunker_info`` with the strategy name."""
+    await kb.remember(
+        content="hello world from the VectorCypher embedded path",
+        namespace=namespace_id,
+        title="",
+        entity_types=[],
+        relationship_types=[],
+        expertise=ExpertiseConfig(name="chunker-info-roundtrip"),
+    )
+
+    result = await kb.recall("hello", namespace=namespace_id, limit=10)
+
+    assert result.chunks, "recall must return at least one chunk"
+    for chunk in result.chunks:
+        assert chunk.chunker_info, f"empty chunker_info on chunk {chunk.id}: {chunk.chunker_info!r}"
+        assert "chunker" in chunk.chunker_info, (
+            f"chunker_info missing 'chunker' key on chunk {chunk.id}: {chunk.chunker_info!r}"
+        )
+        # The configured default strategy is "recursive" (from KhoraConfig
+        # defaults), but we accept any registered chunker — this test is
+        # agnostic to which strategy the engine picked, only that the
+        # identifier propagated.
+        assert isinstance(chunk.chunker_info["chunker"], str)
+        assert chunk.chunker_info["chunker"], "chunker name must be a non-empty string"

--- a/tests/unit/engines/skeleton/backends/test_pgvector_coverage.py
+++ b/tests/unit/engines/skeleton/backends/test_pgvector_coverage.py
@@ -75,6 +75,7 @@ def _row(**kwargs) -> SimpleNamespace:
         tags=["urgent"],
         confidence=0.9,
         metadata={"chunk_index": 0},
+        chunker_info={},
     )
     base.update(kwargs)
     return SimpleNamespace(**base)

--- a/tests/unit/engines/vectorcypher/test_chunker_info_propagation.py
+++ b/tests/unit/engines/vectorcypher/test_chunker_info_propagation.py
@@ -1,0 +1,281 @@
+"""Unit tests for ``chunker_info`` propagation through the VectorCypher engine.
+
+The contract under test:
+
+* A chunker emits ``ChunkResult.metadata = {"chunker": "<strategy>", ...}``
+  (see ``khora.extraction.chunkers.base.ChunkResult`` docstring — every
+  chunker MUST stamp ``metadata["chunker"]`` with its strategy name).
+* The VectorCypher engine must copy that dict, verbatim, onto the
+  ``TemporalChunk.chunker_info`` field before handing the chunk to the
+  temporal store.
+
+These tests pin that wire at the engine boundary. They mock the storage,
+temporal store, dual-node, and embedder layers — no DB, no Neo4j, no
+LiteLLM. The single observable is the ``TemporalChunk`` list passed into
+``temporal_store.create_chunks_batch``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from khora.core.models.document import Document, DocumentStatus
+from khora.engines.skeleton.backends import TemporalChunk
+from khora.engines.vectorcypher.engine import VectorCypherEngine
+
+# ---------------------------------------------------------------------------
+# Stub chunker — emits ChunkResult-shaped objects with a known metadata dict
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubChunkResult:
+    """Duck-typed stand-in for ``ChunkResult``.
+
+    The engine reads ``content``, ``start_char``, ``end_char``, and
+    ``metadata``; we provide exactly those.
+    """
+
+    content: str
+    start_char: int = 0
+    end_char: int = 0
+    token_count: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class _StubChunker:
+    """Returns a fixed list of ``_StubChunkResult`` instances on ``chunk()``.
+
+    Mirrors the ``Chunker.chunk(text)`` contract from
+    ``khora.extraction.chunkers.base.Chunker``.
+    """
+
+    def __init__(self, results: list[_StubChunkResult]) -> None:
+        self._results = results
+
+    def chunk(self, text: str) -> list[_StubChunkResult]:
+        return list(self._results)
+
+
+# ---------------------------------------------------------------------------
+# Engine scaffolding (mirrors patterns in test_engine_coverage.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_config() -> MagicMock:
+    config = MagicMock()
+    config.get_postgresql_url.return_value = "postgresql://localhost/test"
+    config.get_neo4j_url.return_value = "bolt://localhost:7687"
+    config.get_neo4j_user.return_value = "neo4j"
+    config.get_neo4j_password.return_value = "password"
+    config.get_neo4j_database.return_value = "neo4j"
+    config.get_graph_config.return_value = MagicMock()
+    config.get_vector_config.return_value = MagicMock()
+    config.storage.postgresql_pool_size = 5
+    config.storage.postgresql_max_overflow = 10
+    config.storage.embedding_dimension = 4
+    config.llm.model = "gpt-4o-mini"
+    config.llm.timeout = 30
+    # Extraction off — we only care about the chunk-write path.
+    config.pipeline.extract_entities = False
+    config.pipeline.chunking_strategy = "fixed"
+    config.pipeline.chunk_size = 1000
+    config.pipeline.chunk_overlap = 0
+    config.telemetry_database_url = None
+    config.telemetry_service_name = "test"
+    return config
+
+
+def _make_connected_engine() -> VectorCypherEngine:
+    engine = VectorCypherEngine(_make_config())
+    engine._connected = True
+    engine._storage = AsyncMock()
+    engine._temporal_store = AsyncMock()
+    engine._embedder = AsyncMock()
+    engine._dual_nodes = AsyncMock()
+    engine._retriever = AsyncMock()
+    engine._router = MagicMock()
+    engine._neo4j_driver = AsyncMock()
+    return engine
+
+
+def _make_document(content: str = "hello world") -> Document:
+    return Document(
+        id=uuid4(),
+        namespace_id=uuid4(),
+        content=content,
+        status=DocumentStatus.PENDING,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestChunkerInfoPropagation:
+    """``ChunkResult.metadata`` must arrive on ``TemporalChunk.chunker_info``."""
+
+    @pytest.mark.asyncio
+    async def test_single_chunk_copies_chunker_metadata(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """One chunk in → one ``TemporalChunk`` out with matching ``chunker_info``."""
+        engine = _make_connected_engine()
+
+        marker = {"chunker": "fixed", "size": 100}
+        stub_chunker = _StubChunker(
+            [_StubChunkResult(content="hello world", start_char=0, end_char=11, metadata=marker)]
+        )
+        monkeypatch.setattr(
+            "khora.extraction.chunkers.create_chunker",
+            lambda *args, **kwargs: stub_chunker,
+        )
+
+        # Capture the TemporalChunks handed to the temporal store.
+        captured: list[list[TemporalChunk]] = []
+
+        async def _capture_create_chunks(chunks: list[TemporalChunk]) -> list[TemporalChunk]:
+            captured.append(list(chunks))
+            for c in chunks:
+                if c.id is None:
+                    c.id = uuid4()
+            return list(chunks)
+
+        engine._temporal_store.create_chunks_batch = AsyncMock(side_effect=_capture_create_chunks)
+        engine._dual_nodes.create_chunk_nodes_batch = AsyncMock(return_value=None)
+        engine._embedder.embed_batch = AsyncMock(return_value=[[0.0] * 4])
+        engine._embedder.model_name = "mock-embed"
+        engine._storage.update_document = AsyncMock(return_value=None)
+
+        document = _make_document(content="hello world")
+        from datetime import UTC, datetime
+
+        await engine._process_document(
+            document,
+            skill_name="default",
+            expertise=None,
+            extraction_model=None,
+            occurred_at=datetime.now(UTC),
+            entity_types=[],
+            relationship_types=[],
+        )
+
+        # Exactly one batch with one chunk.
+        assert len(captured) == 1, f"expected 1 batch call, got {len(captured)}"
+        assert len(captured[0]) == 1, f"expected 1 chunk in batch, got {len(captured[0])}"
+
+        temporal_chunk = captured[0][0]
+        assert isinstance(temporal_chunk, TemporalChunk)
+        # The contract: chunker_info is a (defensively copied) duplicate of
+        # ChunkResult.metadata.
+        assert temporal_chunk.chunker_info == marker, (
+            f"chunker_info mismatch: expected {marker}, got {temporal_chunk.chunker_info}"
+        )
+        # Defensive copy: mutating the original chunker metadata must not
+        # leak into the persisted TemporalChunk.
+        marker["after_persist"] = "leaked"
+        assert "after_persist" not in temporal_chunk.chunker_info, (
+            "chunker_info must be a copy of the chunker's metadata, not a shared reference"
+        )
+
+    @pytest.mark.asyncio
+    async def test_multiple_chunks_each_carry_their_own_chunker_info(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A multi-chunk document → each ``TemporalChunk`` carries its own dict."""
+        engine = _make_connected_engine()
+
+        results = [
+            _StubChunkResult(content=f"chunk {i}", start_char=i, end_char=i + 7, metadata={"chunker": "fixed", "i": i})
+            for i in range(3)
+        ]
+        stub_chunker = _StubChunker(results)
+        monkeypatch.setattr(
+            "khora.extraction.chunkers.create_chunker",
+            lambda *args, **kwargs: stub_chunker,
+        )
+
+        captured: list[list[TemporalChunk]] = []
+
+        async def _capture_create_chunks(chunks: list[TemporalChunk]) -> list[TemporalChunk]:
+            captured.append(list(chunks))
+            for c in chunks:
+                if c.id is None:
+                    c.id = uuid4()
+            return list(chunks)
+
+        engine._temporal_store.create_chunks_batch = AsyncMock(side_effect=_capture_create_chunks)
+        engine._dual_nodes.create_chunk_nodes_batch = AsyncMock(return_value=None)
+        engine._embedder.embed_batch = AsyncMock(return_value=[[0.0] * 4, [0.0] * 4, [0.0] * 4])
+        engine._embedder.model_name = "mock-embed"
+        engine._storage.update_document = AsyncMock(return_value=None)
+
+        document = _make_document(content="one two three")
+        from datetime import UTC, datetime
+
+        await engine._process_document(
+            document,
+            skill_name="default",
+            expertise=None,
+            extraction_model=None,
+            occurred_at=datetime.now(UTC),
+            entity_types=[],
+            relationship_types=[],
+        )
+
+        # All three chunks land in one batch on the default code path.
+        all_chunks = [c for batch in captured for c in batch]
+        assert len(all_chunks) == 3, f"expected 3 chunks, got {len(all_chunks)}"
+
+        for i, tc in enumerate(all_chunks):
+            assert tc.chunker_info == {"chunker": "fixed", "i": i}, (
+                f"chunk #{i} has unexpected chunker_info: {tc.chunker_info}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_empty_chunker_metadata_yields_empty_dict(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A chunker with empty ``metadata={}`` → ``chunker_info == {}`` (not None)."""
+        engine = _make_connected_engine()
+
+        stub_chunker = _StubChunker([_StubChunkResult(content="bare content", start_char=0, end_char=12, metadata={})])
+        monkeypatch.setattr(
+            "khora.extraction.chunkers.create_chunker",
+            lambda *args, **kwargs: stub_chunker,
+        )
+
+        captured: list[list[TemporalChunk]] = []
+
+        async def _capture_create_chunks(chunks: list[TemporalChunk]) -> list[TemporalChunk]:
+            captured.append(list(chunks))
+            for c in chunks:
+                if c.id is None:
+                    c.id = uuid4()
+            return list(chunks)
+
+        engine._temporal_store.create_chunks_batch = AsyncMock(side_effect=_capture_create_chunks)
+        engine._dual_nodes.create_chunk_nodes_batch = AsyncMock(return_value=None)
+        engine._embedder.embed_batch = AsyncMock(return_value=[[0.0] * 4])
+        engine._embedder.model_name = "mock-embed"
+        engine._storage.update_document = AsyncMock(return_value=None)
+
+        from datetime import UTC, datetime
+
+        await engine._process_document(
+            _make_document(content="bare content"),
+            skill_name="default",
+            expertise=None,
+            extraction_model=None,
+            occurred_at=datetime.now(UTC),
+            entity_types=[],
+            relationship_types=[],
+        )
+
+        all_chunks = [c for batch in captured for c in batch]
+        assert len(all_chunks) == 1
+        tc = all_chunks[0]
+        # Must be a dict (default_factory), never None.
+        assert tc.chunker_info == {}
+        assert isinstance(tc.chunker_info, dict)

--- a/tests/unit/engines/vectorcypher/test_chunker_info_read_paths.py
+++ b/tests/unit/engines/vectorcypher/test_chunker_info_read_paths.py
@@ -1,0 +1,137 @@
+"""Unit tests for the ``chunker_info`` read paths.
+
+The propagation contract has two boundaries that the engine-level
+:mod:`test_chunker_info_propagation` cannot reach without real Neo4j /
+SurrealDB infrastructure:
+
+* The VectorCypher retriever rebuilds :class:`Chunk` objects from Neo4j
+  record dicts at two sites (``c.chunker_info`` projection in the typed
+  entity fast path and the graph-search path). Neo4j stores
+  ``chunker_info`` as a JSON-encoded string at write time (see
+  :func:`dual_nodes.create_chunk_nodes_batch`); the read sites must
+  deserialize that string, while staying robust to native dicts and to
+  corrupted values that would otherwise crash ``recall()``.
+* The SurrealDB temporal store maps result rows to ``TemporalChunk``
+  via :meth:`_row_to_chunk`. ``chunker_info`` arrives there as a dict
+  (object-typed field) and must survive missing keys / wrong types.
+
+The two tests below pin the deserialization contract at each boundary
+without any cross-network dependencies.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from khora.engines.skeleton.backends.surrealdb import SurrealDBTemporalStore
+from khora.engines.vectorcypher.retriever import _decode_chunker_info
+
+# ---------------------------------------------------------------------------
+# Neo4j retriever boundary — ``_decode_chunker_info`` helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDecodeChunkerInfo:
+    """Pin the helper used at both Neo4j retriever sites."""
+
+    def test_native_dict_passes_through(self) -> None:
+        value = {"chunker": "fixed", "size": 100}
+        assert _decode_chunker_info(value) == value
+
+    def test_json_string_is_parsed(self) -> None:
+        # Neo4j stores chunker_info as a JSON string at write time.
+        result = _decode_chunker_info('{"chunker": "semantic"}')
+        assert result == {"chunker": "semantic"}
+
+    def test_none_yields_empty_dict(self) -> None:
+        assert _decode_chunker_info(None) == {}
+
+    def test_missing_key_default_is_empty_dict(self) -> None:
+        # The retriever calls _decode_chunker_info(record.get("chunker_info"));
+        # when the projection is missing entirely, .get returns None.
+        record: dict[str, object] = {}
+        assert _decode_chunker_info(record.get("chunker_info")) == {}
+
+    def test_malformed_json_does_not_raise(self) -> None:
+        # A corrupted persisted JSON string (direct DB tampering, a partial
+        # write) must not crash recall(). Fall back to {}.
+        assert _decode_chunker_info("{not valid json") == {}
+
+    def test_json_null_yields_empty_dict(self) -> None:
+        # 'null' parses to Python None, which is not a dict.
+        assert _decode_chunker_info("null") == {}
+
+    def test_json_array_yields_empty_dict(self) -> None:
+        # A JSON-array string parses to a list — also not a dict.
+        assert _decode_chunker_info('["chunker"]') == {}
+
+    def test_non_string_non_dict_yields_empty_dict(self) -> None:
+        assert _decode_chunker_info(42) == {}
+        assert _decode_chunker_info(0.5) == {}
+        assert _decode_chunker_info(True) == {}
+
+
+# ---------------------------------------------------------------------------
+# SurrealDB read boundary — ``_row_to_chunk``
+# ---------------------------------------------------------------------------
+
+
+def _surreal_row(**overrides: object) -> dict[str, object]:
+    """Build a minimal SurrealDB result row.
+
+    ``_row_to_chunk`` reads `id`, `namespace`, `document`, plus the
+    runtime fields. The UUID helpers tolerate non-record-id strings,
+    so a bare hex string suffices.
+    """
+    chunk_id = uuid4()
+    namespace_id = uuid4()
+    document_id = uuid4()
+    base: dict[str, object] = {
+        "id": str(chunk_id),
+        "namespace": str(namespace_id),
+        "document": str(document_id),
+        "content": "hello",
+        "embedding": None,
+        "occurred_at": None,
+        "created_at": None,
+        "source_system": None,
+        "author": None,
+        "channel": None,
+        "tags": None,
+        "confidence": 1.0,
+        "metadata_": {},
+        "chunker_info": {},
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.unit
+class TestSurrealDBRowToChunk:
+    """Pin the SurrealDB read-side mapping for ``chunker_info``."""
+
+    def test_dict_chunker_info_is_preserved(self) -> None:
+        row = _surreal_row(chunker_info={"chunker": "recursive", "max_chars": 500})
+        chunk = SurrealDBTemporalStore._row_to_chunk(row)
+        assert chunk.chunker_info == {"chunker": "recursive", "max_chars": 500}
+
+    def test_missing_chunker_info_defaults_to_empty_dict(self) -> None:
+        row = _surreal_row()
+        del row["chunker_info"]
+        chunk = SurrealDBTemporalStore._row_to_chunk(row)
+        assert chunk.chunker_info == {}
+
+    def test_none_chunker_info_defaults_to_empty_dict(self) -> None:
+        row = _surreal_row(chunker_info=None)
+        chunk = SurrealDBTemporalStore._row_to_chunk(row)
+        assert chunk.chunker_info == {}
+
+    def test_non_dict_chunker_info_defaults_to_empty_dict(self) -> None:
+        # SurrealDB declares the field as object-typed, but a corrupted
+        # write could land a string. The mapper must not crash.
+        row = _surreal_row(chunker_info="not-a-dict")
+        chunk = SurrealDBTemporalStore._row_to_chunk(row)
+        assert chunk.chunker_info == {}

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -442,14 +442,14 @@ class TestMigrationPackageStructure:
         assert env_path.exists(), f"env.py not found at {env_path}"
 
     @pytest.mark.unit
-    def test_versions_dir_has_38_files(self):
-        """versions/ directory contains 38 migration files."""
+    def test_versions_dir_has_39_files(self):
+        """versions/ directory contains 39 migration files."""
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
         # Filter out __pycache__ and __init__
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
-        assert len(migration_files) == 38, (
-            f"Expected 38 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
+        assert len(migration_files) == 39, (
+            f"Expected 39 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
         )
 
     @pytest.mark.unit

--- a/tests/unit/test_pgvector_row_to_chunk.py
+++ b/tests/unit/test_pgvector_row_to_chunk.py
@@ -33,6 +33,7 @@ def _make_row(embedding=None, tags=None):
         tags=tags,
         confidence=0.95,
         metadata={"key": "value"},
+        chunker_info={},
     )
 
 

--- a/tests/unit/test_sqlite_migrations.py
+++ b/tests/unit/test_sqlite_migrations.py
@@ -80,7 +80,7 @@ class TestSqliteMigrations:
                     # Version table must point at head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
                     version = result.scalar()
-                    assert version == "037_recall_response_format"
+                    assert version == "038_khora_chunks_chunker_info"
             finally:
                 await engine.dispose()
 


### PR DESCRIPTION
## Summary

On the vectorcypher engine path, the chunker self-identification dict (`{"chunker": "<strategy>", ...}` stamped by every chunker into `ChunkResult.metadata`) was dropped between the chunker and the temporal store, and re-defaulted to `{}` on read. Skeleton was already correct via the regular `chunks` table. This PR wires `chunker_info` end-to-end on the `khora_chunks` table so `recall().chunks[i].chunker_info` surfaces the real dict.

- `TemporalChunk` gains a `chunker_info: dict[str, Any]` field next to `metadata`.
- `khora_chunks` table definition (pgvector), DDL (sqlite_lance), and surrealdb temporal-store schema all carry the new column.
- New Alembic migration `038_khora_chunks_chunker_info` adds the column for production deployments where the table predates it. The migration skips on dialects where `khora_chunks` does not exist (fresh deploys, sqlite_lance fixture) — `metadata.create_all` / runtime DDL lands the column from the updated table definition in those cases.
- Vectorcypher engine: every `TemporalChunk(...)` site (single-doc, replace-doc, batch) now passes `chunker_info=dict(raw_chunk.metadata)`.
- Vectorcypher retriever: every `Chunk(...)` site projects `chunker_info` from its supplying record — Neo4j sites read the JSON string we stamp; `TemporalChunk` sites read the field directly. Cypher RETURN clauses for the Neo4j-record sites now include `c.chunker_info`.
- Neo4j Chunk-node writes serialize `chunker_info` as a JSON string in `dual_nodes.create_chunk_nodes_batch`.

## Test plan

- [x] `uv run pytest tests/unit/engines/vectorcypher/test_chunker_info_propagation.py` — 3 tests pinning the engine wiring (single chunk, multi-chunk independent dicts, empty-metadata fallback).
- [x] `uv run pytest tests/integration/db/test_migration_032_dream_runs.py` — migration-chain test updated to expect `038_khora_chunks_chunker_info` as head.
- [ ] New integration test `tests/integration/matrix/test_vectorcypher_chunker_info.py` runs under the matrix stack — gated on CI's matrix job.
- [ ] CI green (lint, format, test).