### PR TITLE
Emit canonical engine_info keys on the vectorcypher path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 
 ## [Unreleased]
 
+### Added
+
+- **vectorcypher: emit canonical `engine_info` keys**. `RecallResult.engine_info` from `VectorCypherEngine.recall()` now includes five engine-agnostic canonical keys alongside the existing engine-specific telemetry: `mode` (from the `SearchMode` argument), `channels_used` (subset of `{"vector", "graph", "bm25"}` derived from per-channel chunk counts), `rrf_k` (from `vc_config.fusion_rrf_k`), `temporal_signal` (`{category, source}` dict, defaults to `{"category": "none", "source": "none"}` when no signal detected), and `abstention_signals` (4 boolean flags + `combined_score` + `should_abstain`, same shape as chronicle). Two new metrics: `khora.vectorcypher.abstention_signal` (counter) and `khora.vectorcypher.abstention_combined_score` (histogram). Chronicle's `_compute_abstention_signals` refactored to delegate to the shared `khora.core.recall_abstention.compute_abstention_signals` helper — chronicle's output and metric emission are unchanged.
+
 ## [0.16.3] - Recall response shape fixes + chunker_info persistence
 
 Patch release on top of v0.16.2. Two end-to-end recall-contract fixes (chunker self-identification now round-trips on vectorcypher; unset optional strings serialize as `null` rather than `""`) plus a CVE-allowlist trim as `litellm` SSTI is no longer load-bearing on the pinned version.

--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -961,6 +961,18 @@
       "unit": "1"
     },
     {
+      "name": "khora.vectorcypher.abstention_signal",
+      "type": "counter",
+      "stability": "public",
+      "unit": ""
+    },
+    {
+      "name": "khora.vectorcypher.abstention_combined_score",
+      "type": "histogram",
+      "stability": "public",
+      "unit": "1"
+    },
+    {
       "name": "khora.memory.recall.duration",
       "type": "histogram",
       "stability": "public",

--- a/src/khora/core/__init__.py
+++ b/src/khora/core/__init__.py
@@ -6,6 +6,7 @@ from .models.document import Chunk, Document
 from .models.entity import Entity, Episode, Relationship
 from .models.event import EventType, MemoryEvent
 from .models.tenancy import MemoryNamespace, TenancyMode
+from .recall_abstention import compute_abstention_signals
 
 __all__ = [
     # Tenancy
@@ -21,4 +22,6 @@ __all__ = [
     # Event
     "MemoryEvent",
     "EventType",
+    # Recall helpers
+    "compute_abstention_signals",
 ]

--- a/src/khora/core/recall_abstention.py
+++ b/src/khora/core/recall_abstention.py
@@ -1,0 +1,52 @@
+"""Recall-result abstention-signal computation.
+
+Pure function consumed by both the chronicle and vectorcypher engines to
+produce the ``abstention_signals`` sub-dict carried in
+``RecallResult.engine_info``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def compute_abstention_signals(
+    *,
+    chunk_count: int,
+    top_chunk_score: float,
+    entity_count: int,
+    min_chunks: int = 1,
+    min_top_score: float = 0.3,
+    combined_threshold: float = 0.5,
+) -> dict[str, Any]:
+    """Compute passive abstention signals for downstream answer-generation.
+
+    Args:
+        chunk_count: Number of chunks returned by the engine.
+        top_chunk_score: Score of the top-ranked chunk (0.0 if none).
+        entity_count: Number of entities returned by the engine.
+        min_chunks: Chunk count below which ``chunks_below_min`` fires.
+        min_top_score: Top-chunk score below which ``top_score_low`` fires.
+        combined_threshold: Combined-score threshold at or above which
+            ``should_abstain`` is True.
+
+    Returns:
+        Dict with four boolean signal flags, a weighted ``combined_score``
+        in [0.0, 1.0], and a ``should_abstain`` convenience flag. Shape and
+        weighting match ``ChronicleEngine._compute_abstention_signals``.
+    """
+    entities_empty = entity_count == 0
+    chunks_empty = chunk_count == 0
+    chunks_below_min = chunk_count < min_chunks
+    top_score_low = top_chunk_score < min_top_score
+
+    combined = 0.3 * float(entities_empty) + 0.4 * float(chunks_below_min) + 0.3 * float(top_score_low)
+
+    return {
+        "entities_empty": entities_empty,
+        "chunks_empty": chunks_empty,
+        "chunks_below_min": chunks_below_min,
+        "top_score_low": top_score_low,
+        "combined_score": combined,
+        "should_abstain": combined >= combined_threshold,
+    }

--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -41,6 +41,7 @@ from khora.core.models.recall import (
     RecallChunk,
     RecallEntity,
 )
+from khora.core.recall_abstention import compute_abstention_signals
 from khora.engines._storage_config import build_storage_config
 from khora.engines.chronicle.compression import (
     FactExtractor,
@@ -1624,44 +1625,29 @@ class ChronicleEngine:
     ) -> dict[str, Any]:
         """Compute passive abstention signals for downstream answer-generation.
 
-        Returns a dict with four boolean flags, a combined float score, and
-        a convenience ``should_abstain`` flag derived from the configured
-        threshold.  Pure function over ``chunks`` and ``entities`` — does
-        not touch storage.  See ``ChronicleEngine.__init__`` for the
-        tunable thresholds.
+        See ``ChronicleEngine.__init__`` for the tunable thresholds.
         """
-        entities_empty = len(entities) == 0
-        chunks_empty = len(chunks) == 0
-        chunks_below_min = len(chunks) < self._abstention_min_chunks
         top_score = chunks[0][1] if chunks else 0.0
-        top_score_low = top_score < self._abstention_min_top_score
+        signals = compute_abstention_signals(
+            chunk_count=len(chunks),
+            top_chunk_score=top_score,
+            entity_count=len(entities),
+            min_chunks=self._abstention_min_chunks,
+            min_top_score=self._abstention_min_top_score,
+            combined_threshold=self._abstention_combined_threshold,
+        )
 
-        # Weighted boolean signals: any one fires → 0.3-0.4; all three → 1.0.
-        # chunks_below_min is weighted highest because zero/few chunks is the
-        # strongest signal that retrieval failed.
-        combined = 0.3 * float(entities_empty) + 0.4 * float(chunks_below_min) + 0.3 * float(top_score_low)
-
-        # Aggregate metrics (Phase 4). Per-signal counter increments
-        # 0-4 times per recall; histogram observed once per recall. Both are
-        # aggregate-only — no namespace_id label (cardinality safety).
-        if entities_empty:
+        if signals["entities_empty"]:
             _ABSTENTION_SIGNAL_COUNTER.add(1, attributes={"signal": "entities_empty"})
-        if chunks_empty:
+        if signals["chunks_empty"]:
             _ABSTENTION_SIGNAL_COUNTER.add(1, attributes={"signal": "chunks_empty"})
-        if chunks_below_min:
+        if signals["chunks_below_min"]:
             _ABSTENTION_SIGNAL_COUNTER.add(1, attributes={"signal": "chunks_below_min"})
-        if top_score_low:
+        if signals["top_score_low"]:
             _ABSTENTION_SIGNAL_COUNTER.add(1, attributes={"signal": "top_score_low"})
-        _ABSTENTION_COMBINED_SCORE_HISTOGRAM.record(combined)
+        _ABSTENTION_COMBINED_SCORE_HISTOGRAM.record(signals["combined_score"])
 
-        return {
-            "entities_empty": entities_empty,
-            "chunks_empty": chunks_empty,
-            "chunks_below_min": chunks_below_min,
-            "top_score_low": top_score_low,
-            "combined_score": combined,
-            "should_abstain": combined >= self._abstention_combined_threshold,
-        }
+        return signals
 
     # ------------------------------------------------------------------
     # Retrieval channels (Phase 2)

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -42,6 +42,7 @@ from khora.core.models.recall import (
     RecallEntity,
     RecallRelationship,
 )
+from khora.core.recall_abstention import compute_abstention_signals
 from khora.engines._storage_config import build_storage_config
 from khora.engines.skeleton.backends import TemporalChunk, TemporalFilter, create_temporal_store
 from khora.engines.skeleton.skeleton import SkeletonIndexer
@@ -50,6 +51,7 @@ from khora.khora import BatchResult, RecallResult, RememberResult, Stats
 from khora.query import SearchMode
 from khora.storage import StorageConfig, create_storage_coordinator
 from khora.telemetry import trace, trace_span
+from khora.telemetry.metrics import metric_counter, metric_histogram
 
 from .dual_nodes import DualNodeManager, EntityChunkLink
 from .retriever import RetrieverConfig, VectorCypherRetriever
@@ -63,6 +65,17 @@ if TYPE_CHECKING:
     from khora.extraction.skills import ExpertiseConfig
     from khora.khora import _GlobalChunkSemaphore
     from khora.storage import StorageCoordinator
+
+
+_VC_ABSTENTION_SIGNAL_COUNTER = metric_counter(
+    "khora.vectorcypher.abstention_signal",
+    description="VectorCypher abstention signal firings, by signal name.",
+)
+_VC_ABSTENTION_COMBINED_SCORE_HISTOGRAM = metric_histogram(
+    "khora.vectorcypher.abstention_combined_score",
+    unit="1",
+    description="VectorCypher abstention combined-score (0.0=confident, 1.0=should-abstain).",
+)
 
 
 def _ensure_tags(value: Any) -> list[str]:
@@ -1936,6 +1949,36 @@ class VectorCypherEngine:
                 seen_doc_ids.add(did)
                 documents.append(DocumentProjection(id=did, created_at=datetime.now(UTC), source_type="library"))
 
+        # Canonical engine_info keys for the recall response.
+        top_chunk_score = validated_chunks[0][1] if validated_chunks else 0.0
+        abstention_signals = compute_abstention_signals(
+            chunk_count=len(validated_chunks),
+            top_chunk_score=top_chunk_score,
+            entity_count=len(recall_entities),
+            # Hardcoded to ChronicleEngine defaults — same passive-signal semantics.
+            min_chunks=1,
+            min_top_score=0.3,
+            combined_threshold=0.5,
+        )
+
+        if abstention_signals["entities_empty"]:
+            _VC_ABSTENTION_SIGNAL_COUNTER.add(1, attributes={"signal": "entities_empty"})
+        if abstention_signals["chunks_empty"]:
+            _VC_ABSTENTION_SIGNAL_COUNTER.add(1, attributes={"signal": "chunks_empty"})
+        if abstention_signals["chunks_below_min"]:
+            _VC_ABSTENTION_SIGNAL_COUNTER.add(1, attributes={"signal": "chunks_below_min"})
+        if abstention_signals["top_score_low"]:
+            _VC_ABSTENTION_SIGNAL_COUNTER.add(1, attributes={"signal": "top_score_low"})
+        _VC_ABSTENTION_COMBINED_SCORE_HISTOGRAM.record(abstention_signals["combined_score"])
+
+        channels_used: list[str] = []
+        if result.metadata.get("vector_chunk_count", 0) > 0:
+            channels_used.append("vector")
+        if result.metadata.get("graph_chunk_count", 0) > 0:
+            channels_used.append("graph")
+        if result.metadata.get("bm25_chunk_count", 0) > 0:
+            channels_used.append("bm25")
+
         return RecallResult(
             query=query,
             namespace_id=namespace_id,
@@ -1945,6 +1988,15 @@ class VectorCypherEngine:
             relationships=recall_relationships,
             engine_info={
                 "engine": "vectorcypher",
+                "mode": mode.value,
+                "channels_used": channels_used,
+                "rrf_k": self._vc_config.fusion_rrf_k,
+                "temporal_signal": (
+                    {"category": temporal_signal.category.value, "source": temporal_signal.source}
+                    if temporal_signal is not None
+                    else {"category": "none", "source": "none"}
+                ),
+                "abstention_signals": abstention_signals,
                 "routing": result.routing_decision.complexity.value,
                 "use_graph": result.routing_decision.use_graph,
                 "graph_depth": result.routing_decision.graph_depth,

--- a/tests/unit/core/test_recall_abstention.py
+++ b/tests/unit/core/test_recall_abstention.py
@@ -1,0 +1,122 @@
+"""Unit tests for ``khora.core.recall_abstention.compute_abstention_signals``.
+
+Scenarios pin the formula, flag set, and ``should_abstain`` boundary; the
+chronicle and vectorcypher engines both delegate to this helper, so the
+public contract lives here.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from khora.core.recall_abstention import compute_abstention_signals
+
+
+@pytest.mark.unit
+class TestComputeAbstentionSignals:
+    def test_all_signals_fire_when_nothing_retrieved(self) -> None:
+        """chunk_count=0, entity_count=0, top_chunk_score=0.0 → every flag True,
+        combined_score == 1.0, should_abstain True."""
+        result = compute_abstention_signals(
+            chunk_count=0,
+            top_chunk_score=0.0,
+            entity_count=0,
+        )
+
+        assert result["entities_empty"] is True
+        assert result["chunks_empty"] is True
+        assert result["chunks_below_min"] is True
+        assert result["top_score_low"] is True
+        assert math.isclose(result["combined_score"], 1.0)
+        assert result["should_abstain"] is True
+
+    def test_no_signals_fire_when_retrieval_is_healthy(self) -> None:
+        """chunk_count=5, entity_count=3, top_chunk_score=0.9 (defaults) →
+        every flag False, combined_score == 0.0, should_abstain False."""
+        result = compute_abstention_signals(
+            chunk_count=5,
+            top_chunk_score=0.9,
+            entity_count=3,
+        )
+
+        assert result["entities_empty"] is False
+        assert result["chunks_empty"] is False
+        assert result["chunks_below_min"] is False
+        assert result["top_score_low"] is False
+        assert math.isclose(result["combined_score"], 0.0)
+        assert result["should_abstain"] is False
+
+    def test_chunks_empty_but_entities_present_does_not_abstain(self) -> None:
+        """chunk_count=0, entity_count=5, top_chunk_score=0.9 → chunks_empty
+        and chunks_below_min True, entities_empty and top_score_low False,
+        combined_score == 0.4 (only chunks_below_min weight fires),
+        should_abstain False (0.4 < 0.5 default threshold)."""
+        result = compute_abstention_signals(
+            chunk_count=0,
+            top_chunk_score=0.9,
+            entity_count=5,
+        )
+
+        assert result["entities_empty"] is False
+        assert result["chunks_empty"] is True
+        assert result["chunks_below_min"] is True
+        assert result["top_score_low"] is False
+        assert result["combined_score"] == pytest.approx(0.4)
+        assert result["should_abstain"] is False
+
+    def test_low_score_and_no_entities_triggers_abstain(self) -> None:
+        """chunk_count=2, entity_count=0, top_chunk_score=0.2 →
+        entities_empty and top_score_low True, chunks_empty and chunks_below_min
+        False (since 2 >= min_chunks=1), combined_score == 0.6,
+        should_abstain True (0.6 >= 0.5 default threshold)."""
+        result = compute_abstention_signals(
+            chunk_count=2,
+            top_chunk_score=0.2,
+            entity_count=0,
+        )
+
+        assert result["entities_empty"] is True
+        assert result["chunks_empty"] is False
+        assert result["chunks_below_min"] is False
+        assert result["top_score_low"] is True
+        assert result["combined_score"] == pytest.approx(0.6)
+        assert result["should_abstain"] is True
+
+    def test_custom_thresholds_round_trip(self) -> None:
+        """Custom (min_chunks=3, min_top_score=0.5, combined_threshold=0.7)
+        with chunk_count=2, entity_count=0, top_chunk_score=0.4 fires
+        entities_empty, chunks_below_min, top_score_low; combined_score == 1.0;
+        should_abstain True (only because combined_threshold=0.7 < 1.0)."""
+        result = compute_abstention_signals(
+            chunk_count=2,
+            top_chunk_score=0.4,
+            entity_count=0,
+            min_chunks=3,
+            min_top_score=0.5,
+            combined_threshold=0.7,
+        )
+
+        assert result["entities_empty"] is True
+        assert result["chunks_empty"] is False
+        assert result["chunks_below_min"] is True
+        assert result["top_score_low"] is True
+        assert math.isclose(result["combined_score"], 1.0)
+        # Threshold-bound assertion: combined_score (1.0) >= combined_threshold (0.7).
+        assert result["should_abstain"] is True
+
+    def test_custom_combined_threshold_blocks_abstention(self) -> None:
+        """Same flag profile as scenario 4 (combined_score == 0.6), but a
+        custom combined_threshold=0.7 flips should_abstain to False — proving
+        the threshold parameter is actually wired through rather than
+        hardcoded against the 0.5 default."""
+        result = compute_abstention_signals(
+            chunk_count=2,
+            top_chunk_score=0.2,
+            entity_count=0,
+            combined_threshold=0.7,
+        )
+
+        assert result["combined_score"] == pytest.approx(0.6)
+        assert result["should_abstain"] is False

--- a/tests/unit/engines/vectorcypher/test_engine_info_canonical.py
+++ b/tests/unit/engines/vectorcypher/test_engine_info_canonical.py
@@ -1,0 +1,211 @@
+"""Canonical ``engine_info`` schema test for ``VectorCypherEngine.recall()``.
+
+Pins the contract for the canonical keys emitted by the vectorcypher path:
+
+    engine, mode, channels_used, rrf_k, temporal_signal, abstention_signals
+
+Existing engine_info keys (``routing``, ``use_graph``, ``graph_depth``,
+``raw_chunk_count``, ``validated_chunk_count``, ``temporal_category``,
+``temporal_confidence``, ``is_temporal``, ``retrieval_mean_score``,
+``retrieval_score_variance``, ``retrieval_top_score_gap``) MUST remain —
+the canonical keys are added, not a replacement.
+
+Mirrors the mock-at-the-retriever-boundary pattern from
+``test_engine_coverage.py::TestRecallContextFormatting`` so no live
+Neo4j / Postgres / Lance is required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from khora.core.models import Chunk, Entity, Relationship
+from khora.engines.vectorcypher.engine import VectorCypherEngine
+from khora.engines.vectorcypher.retriever import VectorCypherResult
+from khora.engines.vectorcypher.router import QueryComplexity, RoutingDecision
+from khora.query import SearchMode
+
+
+def _make_config() -> MagicMock:
+    config = MagicMock()
+    config.get_postgresql_url.return_value = "postgresql://localhost/test"
+    config.get_neo4j_url.return_value = "bolt://localhost:7687"
+    config.get_neo4j_user.return_value = "neo4j"
+    config.get_neo4j_password.return_value = "password"
+    config.get_neo4j_database.return_value = "neo4j"
+    config.get_graph_config.return_value = MagicMock()
+    config.get_vector_config.return_value = MagicMock()
+    config.storage.postgresql_pool_size = 5
+    config.storage.postgresql_max_overflow = 10
+    config.storage.embedding_dimension = 1536
+    config.llm.model = "gpt-4o-mini"
+    config.llm.timeout = 30
+    config.pipeline.extract_entities = True
+    config.pipeline.chunking_strategy = "recursive"
+    config.pipeline.chunk_size = 1000
+    config.pipeline.chunk_overlap = 200
+    config.telemetry_database_url = None
+    config.telemetry_service_name = "test"
+    return config
+
+
+def _make_connected_engine() -> VectorCypherEngine:
+    engine = VectorCypherEngine(_make_config())
+    engine._connected = True
+    engine._storage = AsyncMock()
+    engine._temporal_store = AsyncMock()
+    engine._embedder = AsyncMock()
+    engine._dual_nodes = AsyncMock()
+    engine._retriever = AsyncMock()
+    engine._router = MagicMock()
+    engine._neo4j_driver = AsyncMock()
+    return engine
+
+
+def _make_populated_engine() -> VectorCypherEngine:
+    """Engine with a mocked retriever that returns one chunk + one entity +
+    one relationship — enough for ``result.chunks`` to be non-empty and for
+    the canonical keys to be populated."""
+    engine = _make_connected_engine()
+
+    routing = RoutingDecision(
+        complexity=QueryComplexity.SIMPLE,
+        use_graph=False,
+        graph_depth=0,
+        confidence=0.8,
+        reasoning="test",
+    )
+    chunk = Chunk(
+        id=uuid4(),
+        namespace_id=uuid4(),
+        document_id=uuid4(),
+        content="Long enough content for the validation pass to keep this chunk in results",
+    )
+    entity = Entity(name="Alice", entity_type="PERSON", description="An engineer")
+    relationship = Relationship(
+        relationship_type="KNOWS",
+        source_entity_name="Alice",
+        target_entity_name="Bob",
+        description="works with",
+    )
+    retriever_result = VectorCypherResult(
+        chunks=[(chunk, 0.9)],
+        entities=[(entity, 0.9)],
+        relationships=[(relationship, 0.7)],
+        routing_decision=routing,
+        metadata={"vector_chunk_count": 1, "graph_chunk_count": 0, "bm25_chunk_count": 0},
+    )
+    engine._retriever.retrieve = AsyncMock(return_value=retriever_result)
+    return engine
+
+
+@pytest.mark.unit
+class TestEngineInfoCanonicalKeys:
+    """Canonical engine_info contract for vectorcypher recall."""
+
+    @pytest.mark.asyncio
+    async def test_all_six_canonical_keys_present(self) -> None:
+        engine = _make_populated_engine()
+        result = await engine.recall("q", uuid4(), mode=SearchMode.HYBRID)
+
+        # 1. All 6 canonical keys must be present.
+        for key in ("engine", "mode", "channels_used", "rrf_k", "temporal_signal", "abstention_signals"):
+            assert key in result.engine_info, f"canonical key missing: {key!r}"
+
+    @pytest.mark.asyncio
+    async def test_engine_field_is_vectorcypher(self) -> None:
+        engine = _make_populated_engine()
+        result = await engine.recall("q", uuid4(), mode=SearchMode.HYBRID)
+        # 2. engine_info["engine"] == "vectorcypher".
+        assert result.engine_info["engine"] == "vectorcypher"
+
+    @pytest.mark.asyncio
+    async def test_mode_echoes_search_mode_value(self) -> None:
+        engine = _make_populated_engine()
+        result = await engine.recall("q", uuid4(), mode=SearchMode.HYBRID)
+        # 3. engine_info["mode"] echoes the passed SearchMode.value.
+        assert result.engine_info["mode"] == SearchMode.HYBRID.value
+
+    @pytest.mark.asyncio
+    async def test_temporal_signal_is_dict_with_category_and_source(self) -> None:
+        engine = _make_populated_engine()
+        result = await engine.recall("q", uuid4(), mode=SearchMode.HYBRID)
+        # 4. engine_info["temporal_signal"] is a dict with both category (str)
+        #    and source (str) keys.
+        ts = result.engine_info["temporal_signal"]
+        assert isinstance(ts, dict)
+        assert "category" in ts
+        assert "source" in ts
+        assert isinstance(ts["category"], str)
+        assert isinstance(ts["source"], str)
+
+    @pytest.mark.asyncio
+    async def test_abstention_signals_shape(self) -> None:
+        engine = _make_populated_engine()
+        result = await engine.recall("q", uuid4(), mode=SearchMode.HYBRID)
+        # 5. engine_info["abstention_signals"] is a 6-key dict with the
+        #    expected types.
+        signals = result.engine_info["abstention_signals"]
+        assert isinstance(signals, dict)
+        expected_keys = {
+            "entities_empty",
+            "chunks_empty",
+            "chunks_below_min",
+            "top_score_low",
+            "combined_score",
+            "should_abstain",
+        }
+        assert set(signals.keys()) == expected_keys
+        assert isinstance(signals["entities_empty"], bool)
+        assert isinstance(signals["chunks_empty"], bool)
+        assert isinstance(signals["chunks_below_min"], bool)
+        assert isinstance(signals["top_score_low"], bool)
+        assert isinstance(signals["combined_score"], float)
+        assert isinstance(signals["should_abstain"], bool)
+
+    @pytest.mark.asyncio
+    async def test_channels_used_is_constrained_string_list(self) -> None:
+        engine = _make_populated_engine()
+        result = await engine.recall("q", uuid4(), mode=SearchMode.HYBRID)
+        # 6. engine_info["channels_used"] is a list[str] of {vector, graph, bm25}.
+        channels = result.engine_info["channels_used"]
+        assert isinstance(channels, list)
+        allowed = {"vector", "graph", "bm25"}
+        for channel in channels:
+            assert isinstance(channel, str)
+            assert channel in allowed, f"unexpected channel: {channel!r}"
+
+    @pytest.mark.asyncio
+    async def test_rrf_k_matches_config(self) -> None:
+        engine = _make_populated_engine()
+        result = await engine.recall("q", uuid4(), mode=SearchMode.HYBRID)
+        # 7. engine_info["rrf_k"] is an int matching engine._vc_config.fusion_rrf_k.
+        rrf_k = result.engine_info["rrf_k"]
+        assert isinstance(rrf_k, int)
+        assert rrf_k == engine._vc_config.fusion_rrf_k
+
+    @pytest.mark.asyncio
+    async def test_existing_keys_still_present(self) -> None:
+        """Canonical keys add to ``engine_info``; existing keys must remain."""
+        engine = _make_populated_engine()
+        result = await engine.recall("q", uuid4(), mode=SearchMode.HYBRID)
+
+        # Existing keys per the ticket — the addition didn't replace them.
+        existing_keys = [
+            "routing",
+            "use_graph",
+            "graph_depth",
+            "raw_chunk_count",
+            "validated_chunk_count",
+            "temporal_category",
+            "temporal_confidence",
+            "is_temporal",
+            "retrieval_mean_score",
+            "retrieval_score_variance",
+            "retrieval_top_score_gap",
+        ]
+        for key in existing_keys:
+            assert key in result.engine_info, f"existing engine_info key missing after canonical add: {key!r}"


### PR DESCRIPTION
## Summary

`RecallResult.engine_info` returned by `VectorCypherEngine.recall()` now exposes five engine-agnostic canonical keys alongside the existing engine-specific telemetry:

- `mode` — `SearchMode.value` (`"vector" | "graph" | "hybrid" | "all"`)
- `channels_used` — `list[str]` subset of `{"vector", "graph", "bm25"}`, derived from per-channel chunk counts in `result.metadata`
- `rrf_k` — from `vc_config.fusion_rrf_k`
- `temporal_signal` — `{category, source}` dict (defaults to `{"category": "none", "source": "none"}` when no signal detected)
- `abstention_signals` — 4 boolean flags + `combined_score` (float) + `should_abstain` (bool)

### Implementation

- Extracts the shared abstention-signal computation into a new `khora.core.recall_abstention.compute_abstention_signals` pure helper consumed by both engines.
- Chronicle's `_compute_abstention_signals` refactored to delegate to the helper. Method signature, return shape, and metric emission unchanged (regression-verified by 12 existing chronicle abstention tests).
- Vectorcypher emits two new metrics in the same shape as chronicle's: `khora.vectorcypher.abstention_signal` (counter) and `khora.vectorcypher.abstention_combined_score` (histogram). Neither carries `namespace_id` (cardinality safety per the project telemetry rule).
- `docs/telemetry-contract.json` updated with both new metrics.
- `CHANGELOG.md` updated under `## [Unreleased] / ### Added`.

### Out of scope

Skeleton engine; renaming chronicle's existing `abstention_*` metrics; changing chronicle's existing `engine_info["channels"]` dict to `channels_used`; threshold configurability on vectorcypher (hardcoded to chronicle defaults `min_chunks=1, min_top_score=0.3, combined_threshold=0.5`).

## Test plan

- [x] `make format` clean
- [x] `make lint` clean (warnings pre-existing on `main`)
- [x] New unit tests: `tests/unit/core/test_recall_abstention.py` — 6 tests covering the truth-table scenarios + a custom-threshold round-trip case
- [x] New unit tests: `tests/unit/engines/vectorcypher/test_engine_info_canonical.py` — 8 tests covering all canonical-key assertions + existing-keys-preserved check
- [x] Regression: `tests/unit/engines/chronicle/ -k abstention` — 12 pre-existing tests pass unchanged
- [x] Telemetry contract gate: `tests/unit/telemetry/test_contract.py` — 14 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)