### PR TITLE
fix(vectorcypher): stamp co-occurrence edges with chunk + document provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 
 ## [Unreleased]
 
+### Fixed
+
+- **vectorcypher: stamp co-occurrence edges with chunk + document provenance.** `_build_cooccurrence_relationships` now takes the originating `chunks: list[Chunk]` argument and sets `source_chunk_ids=[chunk_id]` / `source_document_ids=[chunk.document_id]` on every ASSOCIATED_WITH edge it emits, matching the sibling builder in `pipelines/flows/ingest.py`. Previously the four call sites in `engines/vectorcypher/engine.py` (standard create-path, skeleton-deferred, multi-stage extraction, batch path) persisted co-occurrence relationships to Neo4j with empty provenance arrays, leaving downstream provenance/expansion queries unable to trace these edges back to their source chunks or documents. If an entity's `source_chunk_ids` references a chunk that is not in the passed list (shouldn't happen via normal extraction paths), the builder logs a warning and falls back to an empty `source_document_ids` list rather than crashing.
+
 ### Added
 
 - **vectorcypher: emit canonical `engine_info` keys**. `RecallResult.engine_info` from `VectorCypherEngine.recall()` now includes five engine-agnostic canonical keys alongside the existing engine-specific telemetry: `mode` (from the `SearchMode` argument), `channels_used` (subset of `{"vector", "graph", "bm25"}` derived from per-channel chunk counts), `rrf_k` (from `vc_config.fusion_rrf_k`), `temporal_signal` (`{category, source}` dict, defaults to `{"category": "none", "source": "none"}` when no signal detected), and `abstention_signals` (4 boolean flags + `combined_score` + `should_abstain`, same shape as chronicle). Two new metrics: `khora.vectorcypher.abstention_signal` (counter) and `khora.vectorcypher.abstention_combined_score` (histogram). Chronicle's `_compute_abstention_signals` refactored to delegate to the shared `khora.core.recall_abstention.compute_abstention_signals` helper — chronicle's output and metric emission are unchanged.

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -161,6 +161,7 @@ def _bfs_distances_from(seed: UUID, relationships: list[Any]) -> dict[UUID, int]
 
 def _build_cooccurrence_relationships(
     entities: list[Entity],
+    chunks: list[Chunk],
     namespace_id: UUID,
     existing_relationships: list[Relationship],
 ) -> list[Relationship]:
@@ -169,12 +170,18 @@ def _build_cooccurrence_relationships(
     This mirrors the co-occurrence logic in ``pipelines/flows/ingest.py:369-405``
     to ensure VectorCypher builds equally dense graphs.  Capped at
     ``_MAX_COOCCURRENCE_PER_CHUNK`` per chunk to prevent quadratic explosion.
+
+    ``chunks`` carries the (chunk_id → document_id) mapping used to stamp
+    provenance (``source_chunk_ids`` / ``source_document_ids``) on each new
+    edge.
     """
     # Build chunk → entities map
     chunk_entity_map: dict[UUID, list[Entity]] = {}
     for entity in entities:
         for chunk_id in entity.source_chunk_ids:
             chunk_entity_map.setdefault(chunk_id, []).append(entity)
+
+    chunk_to_doc: dict[UUID, UUID] = {c.id: c.document_id for c in chunks}
 
     # Collect existing pairs to avoid duplicates
     existing_pairs: set[tuple[UUID, UUID]] = set()
@@ -186,6 +193,15 @@ def _build_cooccurrence_relationships(
     for chunk_id, chunk_entities in chunk_entity_map.items():
         if len(chunk_entities) < 2:
             continue
+        document_id = chunk_to_doc.get(chunk_id)
+        if document_id is None:
+            logger.warning(
+                f"VectorCypher co-occurrence: chunk {chunk_id} missing from chunks list; "
+                "relationship will have empty source_document_ids"
+            )
+            source_document_ids: list[UUID] = []
+        else:
+            source_document_ids = [document_id]
         chunk_count = 0
         for i, e1 in enumerate(chunk_entities):
             for e2 in chunk_entities[i + 1 :]:
@@ -201,6 +217,8 @@ def _build_cooccurrence_relationships(
                         namespace_id=namespace_id,
                         description="Co-occurs in same chunk",
                         properties={},
+                        source_chunk_ids=[chunk_id],
+                        source_document_ids=list(source_document_ids),
                         confidence=0.4,
                     )
                 )
@@ -1193,7 +1211,7 @@ class VectorCypherEngine:
             await storage.upsert_entities_batch(namespace_id, entities)
 
             # Create co-occurrence relationships between entities in the same chunk
-            cooccurrence_rels = _build_cooccurrence_relationships(entities, namespace_id, relationships)
+            cooccurrence_rels = _build_cooccurrence_relationships(entities, chunk_objects, namespace_id, relationships)
             if cooccurrence_rels:
                 relationships = list(relationships) + cooccurrence_rels
 
@@ -1329,7 +1347,7 @@ class VectorCypherEngine:
             entity.embedding_model = embedder.model_name
 
         # Create co-occurrence relationships between entities in the same chunk
-        cooccurrence_rels = _build_cooccurrence_relationships(entities, namespace_id, relationships)
+        cooccurrence_rels = _build_cooccurrence_relationships(entities, chunk_objects, namespace_id, relationships)
         if cooccurrence_rels:
             relationships = list(relationships) + cooccurrence_rels
 
@@ -1509,7 +1527,9 @@ class VectorCypherEngine:
                     new_entities = list(extracted_entities)
                     new_relationships = list(extracted_relationships)
 
-                    cooccurrence_rels = _build_cooccurrence_relationships(new_entities, namespace_id, new_relationships)
+                    cooccurrence_rels = _build_cooccurrence_relationships(
+                        new_entities, new_chunks, namespace_id, new_relationships
+                    )
                     if cooccurrence_rels:
                         new_relationships.extend(cooccurrence_rels)
 
@@ -2737,7 +2757,7 @@ class VectorCypherEngine:
 
                         # Co-occurrence relationships
                         cooccurrence_rels = _build_cooccurrence_relationships(
-                            all_entities, namespace_id, all_relationships
+                            all_entities, all_core_chunk_objects, namespace_id, all_relationships
                         )
                         if cooccurrence_rels:
                             all_relationships.extend(cooccurrence_rels)

--- a/tests/integration/matrix/test_vectorcypher_sqlite_lance.py
+++ b/tests/integration/matrix/test_vectorcypher_sqlite_lance.py
@@ -518,6 +518,46 @@ async def test_vc_dual_node_persistence(kb: Khora, namespace_id: UUID) -> None:
     assert rels, "expected at least one relationship after dual-node write"
 
 
+async def test_vc_cooccurrence_carries_source_document_ids(kb: Khora, namespace_id: UUID) -> None:
+    """ASSOCIATED_WITH co-occurrence edges round-trip with ``source_document_ids``.
+
+    Ingest a single doc that yields ≥2 entities in one chunk → VC's
+    ``_build_cooccurrence_relationships`` synthesizes an
+    ``ASSOCIATED_WITH`` edge between them.  Read the edge back from the
+    embedded graph and assert its provenance is populated — both
+    ``source_chunk_ids`` (which chunk produced the pair) and
+    ``source_document_ids`` (which document that chunk belongs to).
+    """
+    _plan_extraction(
+        "Marie Curie",
+        entities=[("Marie Curie", "PERSON"), ("radium", "CONCEPT")],
+    )
+    r = await _remember(
+        kb,
+        namespace_id=namespace_id,
+        content="Marie Curie discovered radium and polonium in 1898.",
+    )
+
+    coord = kb._engine._storage  # type: ignore[union-attr]
+    row_ns_id = await coord.resolve_namespace(namespace_id)
+    rels = await coord.graph.list_relationships(row_ns_id, limit=100)
+
+    cooccurrence_rels = [rel for rel in rels if rel.relationship_type == "ASSOCIATED_WITH"]
+    assert cooccurrence_rels, (
+        f"expected at least one ASSOCIATED_WITH co-occurrence edge, got types: "
+        f"{sorted({rel.relationship_type for rel in rels})}"
+    )
+    for rel in cooccurrence_rels:
+        assert rel.source_document_ids, (
+            f"ASSOCIATED_WITH edge {rel.id} has empty source_document_ids — provenance regression"
+        )
+        assert r.document_id in rel.source_document_ids, f"expected {r.document_id} in {rel.source_document_ids}"
+        assert rel.source_chunk_ids, (
+            f"ASSOCIATED_WITH edge {rel.id} has empty source_chunk_ids — "
+            f"co-occurrence edges should know which chunk they came from"
+        )
+
+
 @pytest.mark.xfail(
     strict=False,
     reason=(

--- a/tests/unit/engines/vectorcypher/test_cooccurrence.py
+++ b/tests/unit/engines/vectorcypher/test_cooccurrence.py
@@ -1,0 +1,185 @@
+"""Provenance tests for VectorCypher's ``_build_cooccurrence_relationships``.
+
+The builder's signature takes a ``chunks: list[Chunk]`` argument so each
+emitted ``ASSOCIATED_WITH`` edge can carry ``source_chunk_ids`` /
+``source_document_ids`` provenance back to the chunk (and document) it
+was synthesized from.
+
+These tests pin the provenance contract — the cap and pair-dedup
+behaviour is covered separately in
+``test_engine_coverage.py::TestBuildCooccurrenceRelationships``; this
+module focuses on the new fields.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from loguru import logger as loguru_logger
+
+from khora.core.models import Chunk, Entity, Relationship
+from khora.engines.vectorcypher.engine import (
+    _MAX_COOCCURRENCE_PER_CHUNK,
+    _build_cooccurrence_relationships,
+)
+
+
+def _chunk(document_id=None) -> Chunk:
+    """Make a Chunk with a fresh id, attached to ``document_id`` (or a fresh doc)."""
+    return Chunk(document_id=document_id or uuid4())
+
+
+@pytest.mark.unit
+class TestCooccurrenceProvenance:
+    def test_source_document_ids_populated_for_single_chunk(self) -> None:
+        """Pair from one chunk gets that chunk's id + its document's id stamped on."""
+        ns = uuid4()
+        doc = uuid4()
+        chunk = Chunk(document_id=doc)
+        e_a = Entity(name="A", entity_type="PERSON", source_chunk_ids=[chunk.id])
+        e_b = Entity(name="B", entity_type="PERSON", source_chunk_ids=[chunk.id])
+
+        rels = _build_cooccurrence_relationships([e_a, e_b], [chunk], ns, [])
+
+        assert len(rels) == 1
+        rel = rels[0]
+        assert rel.source_chunk_ids == [chunk.id]
+        assert rel.source_document_ids == [doc]
+
+    def test_multi_chunk_pair_dedup_keeps_first_seen_chunk(self) -> None:
+        """When A,B co-occur in two chunks, exactly one edge is emitted and it
+        carries the FIRST chunk's (and document's) provenance.
+
+        Pair-dedup uses ``existing_pairs.add(pair)`` after the first emission,
+        so the second chunk's iteration short-circuits before producing a
+        duplicate edge.  The first-seen chunk's id/document_id wins.
+        """
+        ns = uuid4()
+        d1, d2 = uuid4(), uuid4()
+        chunk_x = Chunk(document_id=d1)
+        chunk_y = Chunk(document_id=d2)
+        e_a = Entity(
+            name="A",
+            entity_type="PERSON",
+            source_chunk_ids=[chunk_x.id, chunk_y.id],
+        )
+        e_b = Entity(
+            name="B",
+            entity_type="PERSON",
+            source_chunk_ids=[chunk_x.id, chunk_y.id],
+        )
+
+        rels = _build_cooccurrence_relationships([e_a, e_b], [chunk_x, chunk_y], ns, [])
+
+        # Pair-dedup → exactly one edge survives.
+        assert len(rels) == 1
+        rel = rels[0]
+        # The first chunk iterated (whichever the dict ordering hands back
+        # first; in CPython 3.7+ that is insertion order from entity's
+        # source_chunk_ids, so chunk_x) wins the provenance race.
+        assert rel.source_chunk_ids == [chunk_x.id]
+        assert rel.source_document_ids == [d1]
+
+    def test_chunk_without_doc_fallback_emits_warning(self) -> None:
+        """Entity references a chunk_id not present in ``chunks`` → relationship
+        is still created with empty ``source_document_ids`` and a loguru
+        WARNING is emitted.
+
+        This is the defensive fallback path: extraction-time entity
+        ``source_chunk_ids`` should always be a subset of the chunks passed
+        in, but we must not crash if a caller passes mismatched inputs.
+        """
+        ns = uuid4()
+        missing_chunk_id = uuid4()
+        e_a = Entity(name="A", entity_type="PERSON", source_chunk_ids=[missing_chunk_id])
+        e_b = Entity(name="B", entity_type="PERSON", source_chunk_ids=[missing_chunk_id])
+
+        records: list[str] = []
+        sink_id = loguru_logger.add(lambda msg: records.append(str(msg)), level="WARNING")
+        try:
+            # chunks is empty — missing_chunk_id is not in the map.
+            rels = _build_cooccurrence_relationships([e_a, e_b], [], ns, [])
+        finally:
+            loguru_logger.remove(sink_id)
+
+        assert len(rels) == 1
+        rel = rels[0]
+        assert rel.source_document_ids == []
+        # The chunk_id we DO know about (the one the entity references) is
+        # still recorded — only the document mapping is missing.
+        assert rel.source_chunk_ids == [missing_chunk_id]
+        assert any("missing from chunks list" in m and str(missing_chunk_id) in m for m in records), (
+            f"expected warning about missing chunk, got: {records}"
+        )
+
+    def test_no_duplicate_pairs_across_chunks(self) -> None:
+        """Two entities sharing two chunks must produce exactly one edge.
+
+        This is the dedup invariant — duplicate ``(min(id), max(id))``
+        pairs across chunks must collapse.  Without dedup the builder
+        would emit two ``ASSOCIATED_WITH`` edges between A and B (one
+        per chunk), bloating the graph.
+        """
+        ns = uuid4()
+        chunk_x = Chunk(document_id=uuid4())
+        chunk_y = Chunk(document_id=uuid4())
+        e_a = Entity(
+            name="A",
+            entity_type="PERSON",
+            source_chunk_ids=[chunk_x.id, chunk_y.id],
+        )
+        e_b = Entity(
+            name="B",
+            entity_type="PERSON",
+            source_chunk_ids=[chunk_x.id, chunk_y.id],
+        )
+
+        rels = _build_cooccurrence_relationships([e_a, e_b], [chunk_x, chunk_y], ns, [])
+
+        assert len(rels) == 1, (
+            f"expected pair-dedup → 1 edge, got {len(rels)}: {[(r.source_entity_id, r.target_entity_id) for r in rels]}"
+        )
+
+    def test_max_cooccurrence_per_chunk_cap_respected(self) -> None:
+        """``_MAX_COOCCURRENCE_PER_CHUNK`` caps the pair count per chunk.
+
+        10 entities in a single chunk → C(10,2) = 45 raw pairs.  The cap
+        must keep emissions at exactly ``_MAX_COOCCURRENCE_PER_CHUNK``.
+        """
+        ns = uuid4()
+        chunk = Chunk(document_id=uuid4())
+        entities = [Entity(name=f"E{i}", entity_type="CONCEPT", source_chunk_ids=[chunk.id]) for i in range(10)]
+
+        rels = _build_cooccurrence_relationships(entities, [chunk], ns, [])
+
+        assert len(rels) == _MAX_COOCCURRENCE_PER_CHUNK, (
+            f"expected cap at {_MAX_COOCCURRENCE_PER_CHUNK}, got {len(rels)}"
+        )
+        # Even the capped edges carry provenance.
+        for rel in rels:
+            assert rel.source_chunk_ids == [chunk.id]
+            assert rel.source_document_ids == [chunk.document_id]
+
+    def test_existing_pair_skipped_does_not_emit_provenance(self) -> None:
+        """If a pair already exists in ``existing_relationships``, the
+        co-occurrence builder skips it entirely — no edge, no provenance.
+
+        Guards against the bug where the builder would emit a duplicate
+        edge with new provenance, overwriting the original extraction
+        relationship's source link.
+        """
+        ns = uuid4()
+        chunk = Chunk(document_id=uuid4())
+        e_a = Entity(name="A", entity_type="PERSON", source_chunk_ids=[chunk.id])
+        e_b = Entity(name="B", entity_type="PERSON", source_chunk_ids=[chunk.id])
+        existing = Relationship(
+            source_entity_id=e_b.id,
+            target_entity_id=e_a.id,
+            relationship_type="KNOWS",
+            namespace_id=ns,
+        )
+
+        rels = _build_cooccurrence_relationships([e_a, e_b], [chunk], ns, [existing])
+
+        assert rels == []

--- a/tests/unit/engines/vectorcypher/test_engine_coverage.py
+++ b/tests/unit/engines/vectorcypher/test_engine_coverage.py
@@ -32,7 +32,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from khora.core.models import Entity, Relationship
+from khora.core.models import Chunk, Entity, Relationship
 from khora.engines.vectorcypher.engine import (
     VectorCypherConfig,
     VectorCypherEngine,
@@ -156,17 +156,21 @@ class TestBfsDistancesFromExtra:
 class TestBuildCooccurrenceRelationships:
     def test_no_pairs_when_single_entity_per_chunk(self) -> None:
         ns = uuid4()
+        doc = uuid4()
         chunk = uuid4()
         e1 = Entity(name="A", entity_type="PERSON", source_chunk_ids=[chunk])
-        rels = _build_cooccurrence_relationships([e1], ns, [])
+        chunks = [Chunk(id=chunk, namespace_id=ns, document_id=doc)]
+        rels = _build_cooccurrence_relationships([e1], chunks, ns, [])
         assert rels == []
 
     def test_pairs_created_for_shared_chunk(self) -> None:
         ns = uuid4()
+        doc = uuid4()
         chunk = uuid4()
         e1 = Entity(name="A", entity_type="PERSON", source_chunk_ids=[chunk])
         e2 = Entity(name="B", entity_type="PERSON", source_chunk_ids=[chunk])
-        rels = _build_cooccurrence_relationships([e1, e2], ns, [])
+        chunks = [Chunk(id=chunk, namespace_id=ns, document_id=doc)]
+        rels = _build_cooccurrence_relationships([e1, e2], chunks, ns, [])
         assert len(rels) == 1
         assert rels[0].relationship_type == "ASSOCIATED_WITH"
         assert rels[0].namespace_id == ns
@@ -176,6 +180,7 @@ class TestBuildCooccurrenceRelationships:
 
     def test_existing_pair_skipped(self) -> None:
         ns = uuid4()
+        doc = uuid4()
         chunk = uuid4()
         e1 = Entity(name="A", entity_type="PERSON", source_chunk_ids=[chunk])
         e2 = Entity(name="B", entity_type="PERSON", source_chunk_ids=[chunk])
@@ -186,16 +191,19 @@ class TestBuildCooccurrenceRelationships:
             relationship_type="KNOWS",
             namespace_id=ns,
         )
-        rels = _build_cooccurrence_relationships([e1, e2], ns, [existing])
+        chunks = [Chunk(id=chunk, namespace_id=ns, document_id=doc)]
+        rels = _build_cooccurrence_relationships([e1, e2], chunks, ns, [existing])
         assert rels == []
 
     def test_per_chunk_cap(self) -> None:
         """Co-occurrence is capped at 15 pairs per chunk to prevent quadratic explosion."""
         ns = uuid4()
+        doc = uuid4()
         chunk = uuid4()
         # 7 entities in a single chunk → C(7,2)=21 raw pairs, capped at 15
         entities = [Entity(name=f"E{i}", entity_type="X", source_chunk_ids=[chunk]) for i in range(7)]
-        rels = _build_cooccurrence_relationships(entities, ns, [])
+        chunks = [Chunk(id=chunk, namespace_id=ns, document_id=doc)]
+        rels = _build_cooccurrence_relationships(entities, chunks, ns, [])
         assert len(rels) == 15
 
 


### PR DESCRIPTION
## Summary

- Extends `_build_cooccurrence_relationships` in `src/khora/engines/vectorcypher/engine.py` to accept `chunks: list[Chunk]` and populate `source_chunk_ids=[chunk_id]` / `source_document_ids=[chunk.document_id]` on every `ASSOCIATED_WITH` edge it emits. Matches the sibling builder in `pipelines/flows/ingest.py`, which already set these fields.
- Updates all four in-tree call sites (standard create-path, skeleton-deferred, multi-stage extraction, batch path) to pass their locally-scoped chunk list.
- Defensive fallback: if an entity's `source_chunk_ids` references a chunk that is not in the passed chunks list (should not happen on normal extraction flows), the builder logs a `logger.warning` and emits the edge with empty `source_document_ids` rather than crashing.

Before this fix, every VectorCypher-engine co-occurrence relationship was persisted to Neo4j with empty `source_document_ids` / `source_chunk_ids`, breaking the implicit guarantee that every relationship knows which document it came from. New ingestions get correct provenance immediately; existing data self-heals as customers re-ingest (no backfill migration is part of this PR — intentionally out of scope).

`src/khora/pipelines/flows/ingest.py` (the correct reference impl), chronicle, and skeleton engines are untouched.

## Test plan

- [x] 5 new unit tests in `tests/unit/engines/vectorcypher/test_cooccurrence.py` covering the provenance contract: single-chunk population, multi-chunk pair-dedup first-seen-wins, chunk-without-doc fallback emits warning, no duplicate pairs across chunks, `_MAX_COOCCURRENCE_PER_CHUNK` cap respected (plus a defensive existing-pair-skipped check). All pass.
- [x] Existing `test_engine_coverage.py::TestBuildCooccurrenceRelationships` updated to the new signature. All pass.
- [x] Integration test added at `tests/integration/matrix/test_vectorcypher_sqlite_lance.py::test_vc_cooccurrence_carries_source_document_ids`: ingests a document, verifies the round-tripped `ASSOCIATED_WITH` edges carry both `source_document_ids` and `source_chunk_ids`. Passes.
- [x] `make format` clean. `make lint` exits 0 (only pre-existing `_accel.py` type-shim warnings; no new findings).
- [x] `make test-unit` passes for `tests/unit/engines/vectorcypher/` (198 tests).