### PR TITLE
fix(vectorcypher): surface LLM rerank skip + add llm_reranking_mode override

### DIFF
--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -973,6 +973,18 @@
       "unit": "1"
     },
     {
+      "name": "khora.vectorcypher.llm_reranking.skipped_total",
+      "type": "counter",
+      "stability": "internal",
+      "unit": "1",
+      "owner": "vectorcypher",
+      "description": "Number of times the VectorCypher LLM rerank step was skipped, by reason. Surfaces the discoverability bug from issue #814 — when enable_llm_reranking=True but the gate fires, this counter increments so operators can see the skip without scraping DEBUG logs.",
+      "labels": [
+        {"name": "reason", "values": ["not_temporal", "no_version_metadata", "decisive_winner"]}
+      ],
+      "_comment": "Issue #814. NO namespace_id label — cardinality rule."
+    },
+    {
       "name": "khora.memory.recall.duration",
       "type": "histogram",
       "stability": "public",

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -21,7 +21,7 @@ import time as _time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID
 
 from loguru import logger
@@ -334,11 +334,28 @@ class VectorCypherConfig:
     reranking_top_n: int = 50  # How many candidates to feed to the cross-encoder
     reranking_blend_weight: float = 0.7  # Rerank vs original score blend (passed to reranker)
 
-    # LLM reranking (applied after cross-encoder, only for temporal queries)
+    # LLM reranking (applied after cross-encoder, only for temporal queries).
+    #
+    # When ``enable_llm_reranking=True``, the retriever still applies a
+    # version-metadata precondition by default — if no chunk in the top
+    # candidates carries ``metadata["version"]`` (the enterprise temporal
+    # signal), the LLM rerank step is skipped because PR #364 showed it
+    # regresses MRR on conversational benchmarks (LongMemEval / LoCoMo).
+    # Set ``llm_reranking_mode="always"`` to disable that precondition and
+    # force LLM rerank on every temporal query (the "decisive winner"
+    # latency optimization still applies).
     enable_llm_reranking: bool = False
     llm_reranking_model: str = "gpt-4o-mini"
     llm_reranking_top_n: int = 5
     llm_reranking_confidence_threshold: float = 0.1
+    # ``"auto"`` (default) — gate LLM rerank on the version-metadata
+    # precondition (current behavior). The first time the gate fires for
+    # a given namespace, a one-time WARNING is emitted so users who opted
+    # in to ``enable_llm_reranking=True`` discover why the LLM is not
+    # being invoked.
+    # ``"always"`` — skip the version-metadata precondition; LLM rerank
+    # runs on every temporal query (subject to the decisive-winner skip).
+    llm_reranking_mode: Literal["auto", "always"] = "auto"
 
 
 class VectorCypherEngine:
@@ -590,6 +607,7 @@ class VectorCypherEngine:
             llm_reranking_model=self._vc_config.llm_reranking_model,
             llm_reranking_top_n=self._vc_config.llm_reranking_top_n,
             llm_reranking_confidence_threshold=self._vc_config.llm_reranking_confidence_threshold,
+            llm_reranking_mode=self._vc_config.llm_reranking_mode,
             # Issue #567 Phase A — pull temporal flags from KhoraConfig.query.
             # All default OFF; operators opt in per-namespace.
             temporal_reference_wall_clock=self._config.query.temporal_reference_wall_clock,

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -38,6 +38,7 @@ except ImportError:
 
 from khora.core.models import Chunk, Entity, Relationship
 from khora.telemetry import bounded_text_hash, trace_span
+from khora.telemetry.metrics import metric_counter
 
 from .dual_nodes import DualNodeManager
 from .fusion import (
@@ -82,6 +83,19 @@ _NEO4J_TRANSIENT_ERRORS: tuple[type[Exception], ...] = (
 # Read once at import to avoid an env lookup per recency-score computation
 # on the hot path. Set ``KHORA_BENCH_MODE=true|1|yes`` to enable.
 _BENCH_MODE: bool = os.environ.get("KHORA_BENCH_MODE", "").strip().lower() in {"true", "1", "yes"}
+
+
+# LLM rerank skip counter (issue #814). Tracks how often the LLM rerank
+# step is skipped, broken down by reason. No ``namespace_id`` label —
+# cardinality rule (see CLAUDE.md). Module-level so the meter provider
+# can de-duplicate by name across retriever instances.
+_LLM_RERANKING_SKIPPED_COUNTER = metric_counter(
+    "khora.vectorcypher.llm_reranking.skipped_total",
+    description=(
+        "Number of times the VectorCypher LLM rerank step was skipped, "
+        "by reason (not_temporal / no_version_metadata / decisive_winner)."
+    ),
+)
 
 
 def _decode_chunker_info(value: Any) -> dict[str, Any]:
@@ -226,11 +240,26 @@ class RetrieverConfig:
     reranking_top_n: int = 50  # Candidates to feed to the cross-encoder
     reranking_blend_weight: float = 0.7  # Rerank vs original score blend
 
-    # LLM reranking (applied after cross-encoder, only for temporal queries)
+    # LLM reranking (applied after cross-encoder, only for temporal queries).
+    #
+    # ``enable_llm_reranking=True`` is also gated by ``llm_reranking_mode``
+    # (see below): in the default ``"auto"`` mode the LLM rerank step is
+    # skipped when no chunk in the top candidates carries
+    # ``metadata["version"]`` — PR #364 showed it regresses MRR on
+    # conversational benchmarks. Set ``llm_reranking_mode="always"`` to
+    # bypass that precondition.
     enable_llm_reranking: bool = False
     llm_reranking_model: str = "gpt-4o-mini"
     llm_reranking_top_n: int = 5
     llm_reranking_confidence_threshold: float = 0.1  # Skip LLM reranking when cross-encoder gap >= this
+    # ``"auto"`` (default) — gate LLM rerank on the version-metadata
+    # precondition. When the gate fires for a namespace, a one-time
+    # WARNING surfaces the skip so users discover why their opt-in did
+    # not invoke the LLM (issue #814).
+    # ``"always"`` — bypass the version-metadata precondition; LLM rerank
+    # runs on every temporal query (subject to the decisive-winner skip,
+    # which is a latency optimization not the bug being addressed).
+    llm_reranking_mode: Literal["auto", "always"] = "auto"
     # "Decisive winner" gate (Sprint 1 — multihop latency regression).
     # Skip LLM rerank when the cross-encoder's #1 result is BOTH high-scoring
     # AND well-separated from #2 — the LLM call adds 200–400 ms and rarely
@@ -292,6 +321,53 @@ def _extract_source_system(item: Any) -> str | None:
         return None
     value = str(value).strip()
     return value or None
+
+
+def _candidates_have_versions(candidates: list[Any]) -> bool:
+    """Return ``True`` if any candidate carries ``metadata["version"]``.
+
+    Used by :meth:`VectorCypherRetriever._evaluate_llm_rerank_gate` to
+    decide whether the version-metadata precondition (PR #364, issue #814)
+    is satisfied. Accepts both candidate shapes that the LLM-rerank gate
+    sees in practice:
+
+    - ``FusedResult`` (complex path) — metadata lives at ``r.item.metadata``.
+    - ``(Chunk, score)`` (simple path) — metadata lives at ``c.metadata``.
+    """
+    for cand in candidates:
+        # Simple-path shape: (Chunk, score)
+        if isinstance(cand, tuple) and len(cand) == 2:
+            chunk = cand[0]
+            meta = getattr(chunk, "metadata", None)
+            if isinstance(meta, dict) and meta.get("version"):
+                return True
+            continue
+        # Complex-path shape: FusedResult (has .item with .metadata)
+        item = getattr(cand, "item", None)
+        meta = getattr(item, "metadata", None) if item is not None else None
+        if isinstance(meta, dict) and meta.get("version"):
+            return True
+    return False
+
+
+def _extract_top_two_scores(candidates: list[Any]) -> tuple[float | None, float | None]:
+    """Return ``(top_score, second_score)`` from candidates, or ``(None, None)``.
+
+    Mirrors ``_candidates_have_versions`` in handling both candidate
+    shapes. When fewer than two candidates are available, returns
+    ``(None, None)`` so callers can short-circuit the decisive-winner
+    check without raising.
+    """
+    if len(candidates) < 2:
+        return None, None
+    first, second = candidates[0], candidates[1]
+    if isinstance(first, tuple) and len(first) == 2 and isinstance(second, tuple) and len(second) == 2:
+        return float(first[1]), float(second[1])
+    top = getattr(first, "rrf_score", None)
+    runner = getattr(second, "rrf_score", None)
+    if top is None or runner is None:
+        return None, None
+    return float(top), float(runner)
 
 
 def _has_target_date(
@@ -407,6 +483,12 @@ class VectorCypherRetriever:
 
         # Cached LLM reranker for temporal queries (lazy-init on first use)
         self._llm_reranker: LLMReranker | None = None
+
+        # Issue #814 — one-time WARNING dedupe for LLM-rerank skip reasons.
+        # Tuples are ``(namespace_id_or_None, skip_reason)``; once a tuple
+        # has been logged we keep silent on subsequent queries for that
+        # namespace so a hot recall path doesn't spam the operator log.
+        self._warned_rerank_skips: set[tuple[UUID | None, str]] = set()
 
     async def retrieve(
         self,
@@ -1338,30 +1420,24 @@ class VectorCypherRetriever:
             with trace_span("khora.vectorcypher.reranking", candidate_count=len(fused_results)):
                 fused_results = await self._apply_reranking(query, fused_results, limit, namespace_id=namespace_id)
 
-        # Step 8d: LLM reranking of top-N for temporal queries (after cross-encoder)
-        # Skip when:
-        #   - Cross-encoder is already confident (large gap between #1 and #2)
-        #   - No version metadata in results (conversational data like LongMemEval/LoCoMo
-        #     doesn't benefit from temporal LLM reranking — it can hurt MRR)
-        if self._config.enable_llm_reranking and temporal_signal and temporal_signal.is_temporal:
-            _skip_llm = False
-            # Check if any results carry version metadata (enterprise temporal signal)
-            _has_versions = any(
-                (r.item.metadata or {}).get("version")
-                if hasattr(r.item, "metadata") and isinstance(r.item.metadata, dict)
-                else False
-                for r in fused_results[:10]
+        # Step 8d: LLM reranking of top-N for temporal queries (after cross-encoder).
+        # Gating centralised in ``_evaluate_llm_rerank_gate`` (issue #814) — covers
+        # the not-temporal, no-version-metadata, and decisive-winner skips and
+        # emits the one-time warning when mode='auto' triggers the version gate.
+        if self._config.enable_llm_reranking:
+            should_run, skip_reason = self._evaluate_llm_rerank_gate(
+                fused_results,
+                temporal_signal,
+                namespace_id=namespace_id,
             )
-            if not _has_versions:
-                _skip_llm = True
-                logger.debug("Skipping LLM reranking: no version metadata in results (conversational data)")
-            elif len(fused_results) >= 2:
-                top_score = fused_results[0].rrf_score
-                gap = top_score - fused_results[1].rrf_score
-                if self._should_skip_llm_rerank(top_score, gap):
-                    _skip_llm = True
-            if not _skip_llm:
-                with trace_span("khora.vectorcypher.llm_reranking", candidate_count=len(fused_results)):
+            if not should_run and skip_reason is not None:
+                _LLM_RERANKING_SKIPPED_COUNTER.add(1, attributes={"reason": skip_reason})
+            if should_run:
+                with trace_span(
+                    "khora.vectorcypher.llm_reranking",
+                    candidate_count=len(fused_results),
+                    mode=self._config.llm_reranking_mode,
+                ):
                     fused_results = await self._apply_llm_reranking(
                         query, fused_results, limit, namespace_id=namespace_id
                     )
@@ -1802,6 +1878,76 @@ class VectorCypherRetriever:
             return True
         return False
 
+    def _evaluate_llm_rerank_gate(
+        self,
+        candidates: list[Any],
+        temporal_signal: TemporalSignal | None,
+        *,
+        namespace_id: UUID | None,
+    ) -> tuple[bool, str | None]:
+        """Centralized gate for the LLM rerank step (issue #814).
+
+        Consolidates the three independent skip reasons that historically
+        lived inline in both the complex ``_vectorcypher_retrieve`` path and
+        the simple ``_simple_retrieve`` path:
+
+        - ``"not_temporal"``: ``enable_llm_reranking=True`` but the query
+          isn't temporal. Documented behavior — never logs a warning.
+        - ``"no_version_metadata"``: ``llm_reranking_mode="auto"`` (the
+          default) and no chunk in the top candidates carries
+          ``metadata["version"]``. Logs a one-time WARNING per
+          ``(namespace_id, reason)`` tuple so users who opted in to LLM
+          rerank discover why it isn't being invoked.
+        - ``"decisive_winner"``: cross-encoder already produced a confident
+          #1 (latency optimization — runs in both modes).
+
+        ``candidates`` may be a list of ``FusedResult`` (complex path) or a
+        list of ``(Chunk, score)`` tuples (simple path); both shapes are
+        handled by ``_extract_candidate_metadata`` / ``_extract_top_scores``.
+
+        Returns ``(should_run, skip_reason)``. ``skip_reason`` is ``None``
+        only when ``should_run`` is ``True``.
+        """
+        if not self._config.enable_llm_reranking:
+            # Caller already gated on this — defensive return so the helper
+            # can be invoked unconditionally without paying the unused-skip
+            # warning cost.
+            return False, "not_temporal"
+
+        if not (temporal_signal and temporal_signal.is_temporal):
+            return False, "not_temporal"
+
+        if not candidates:
+            # Nothing to rerank — treat as a decisive-winner-style skip
+            # (silent, no warning).
+            return False, "decisive_winner"
+
+        # Version-metadata gate is bypassed in "always" mode (issue #814).
+        if self._config.llm_reranking_mode == "auto":
+            has_versions = _candidates_have_versions(candidates[:10])
+            if not has_versions:
+                key = (namespace_id, "no_version_metadata")
+                if key not in self._warned_rerank_skips:
+                    self._warned_rerank_skips.add(key)
+                    logger.warning(
+                        "VectorCypher LLM reranking skipped for this namespace: "
+                        "enable_llm_reranking=True but no chunks in the top "
+                        "candidates carry metadata['version']. Set "
+                        "llm_reranking_mode='always' to force LLM rerank on all "
+                        "temporal queries, or set enable_llm_reranking=False to "
+                        "suppress this warning."
+                    )
+                return False, "no_version_metadata"
+
+        # Decisive-winner gate — applies in both auto and always modes.
+        top_score, second_score = _extract_top_two_scores(candidates)
+        if top_score is not None and second_score is not None:
+            gap = top_score - second_score
+            if self._should_skip_llm_rerank(top_score, gap):
+                return False, "decisive_winner"
+
+        return True, None
+
     async def _apply_llm_reranking(
         self,
         query: str,
@@ -2013,23 +2159,24 @@ class VectorCypherRetriever:
                     fused = await self._apply_reranking(query, fused, limit, namespace_id=namespace_id)
                 chunk_results = [(r.item, r.rrf_score) for r in fused]
 
-            # LLM reranking of top-N for temporal queries (after cross-encoder)
-            # Skip when: no version metadata (conversational data) or cross-encoder confident.
-            if self._config.enable_llm_reranking and temporal_signal and temporal_signal.is_temporal and chunk_results:
-                _skip_llm_simple = False
-                _has_versions_simple = any(
-                    (c.metadata or {}).get("version") for c, _ in chunk_results[:10] if isinstance(c.metadata, dict)
+            # LLM reranking of top-N for temporal queries (after cross-encoder).
+            # Gating centralised in ``_evaluate_llm_rerank_gate`` (issue #814) —
+            # see the parallel comment in ``_vectorcypher_retrieve``.
+            if self._config.enable_llm_reranking and chunk_results:
+                should_run, skip_reason = self._evaluate_llm_rerank_gate(
+                    chunk_results,
+                    temporal_signal,
+                    namespace_id=namespace_id,
                 )
-                if not _has_versions_simple:
-                    _skip_llm_simple = True
-                elif len(chunk_results) >= 2:
-                    _top_score = chunk_results[0][1]
-                    _gap = _top_score - chunk_results[1][1]
-                    if self._should_skip_llm_rerank(_top_score, _gap):
-                        _skip_llm_simple = True
-                if not _skip_llm_simple:
+                if not should_run and skip_reason is not None:
+                    _LLM_RERANKING_SKIPPED_COUNTER.add(1, attributes={"reason": skip_reason})
+                if should_run:
                     fused = [FusedResult(item=c, rrf_score=s, item_id=c.id) for c, s in chunk_results]
-                    with trace_span("khora.vectorcypher.llm_reranking", candidate_count=len(fused)):
+                    with trace_span(
+                        "khora.vectorcypher.llm_reranking",
+                        candidate_count=len(fused),
+                        mode=self._config.llm_reranking_mode,
+                    ):
                         fused = await self._apply_llm_reranking(query, fused, limit, namespace_id=namespace_id)
                     chunk_results = [(r.item, r.rrf_score) for r in fused]
 

--- a/tests/unit/engines/vectorcypher/test_llm_rerank_gate.py
+++ b/tests/unit/engines/vectorcypher/test_llm_rerank_gate.py
@@ -1,0 +1,572 @@
+"""Tests for the LLM-rerank skip gate (issue #814).
+
+The gate centralises three independent skip reasons that used to be
+duplicated inline in the complex (``_vectorcypher_retrieve``) and simple
+(``_simple_retrieve``) paths:
+
+- ``"not_temporal"``  — opt-in but query isn't temporal (silent skip).
+- ``"no_version_metadata"`` — ``mode='auto'`` precondition (PR #364).
+  Emits a one-time per-namespace WARNING so users discover why their
+  opt-in is being silently no-op'd.
+- ``"decisive_winner"`` — latency optimisation; applies in both modes.
+
+Tests live separately from ``test_retriever_coverage.py`` so the gate
+contract is easy to find and the OTel meter fixture stays localised.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from opentelemetry import metrics as _otel_metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+from khora.engines.vectorcypher.fusion import FusedResult
+from khora.engines.vectorcypher.retriever import (
+    RetrieverConfig,
+    VectorCypherRetriever,
+)
+from khora.engines.vectorcypher.router import QueryComplexity, RoutingDecision
+from khora.engines.vectorcypher.temporal_detection import (
+    TemporalCategory,
+    TemporalSignal,
+)
+
+# ---------------------------------------------------------------------------
+# OTel meter fixture — rebinds the cached counter on the retriever module
+# so the new SDK MeterProvider sees the call.
+# ---------------------------------------------------------------------------
+
+
+def _reset_otel_globals() -> None:
+    import opentelemetry.metrics._internal as _m
+    import opentelemetry.trace as _t
+    from opentelemetry.metrics._internal import _ProxyMeterProvider
+    from opentelemetry.trace import ProxyTracerProvider
+
+    _t._TRACER_PROVIDER_SET_ONCE = _t.Once()
+    _t._TRACER_PROVIDER = None
+    _t._PROXY_TRACER_PROVIDER = ProxyTracerProvider()
+
+    _m._METER_PROVIDER_SET_ONCE = _m.Once()
+    _m._METER_PROVIDER = None
+    _m._PROXY_METER_PROVIDER = _ProxyMeterProvider()
+
+
+@pytest.fixture
+def metric_reader(monkeypatch: pytest.MonkeyPatch):
+    """Install an in-memory MeterProvider and rebind the rerank-skip counter."""
+    _reset_otel_globals()
+    reader = InMemoryMetricReader()
+    mp = MeterProvider(metric_readers=[reader])
+    _otel_metrics.set_meter_provider(mp)
+
+    from khora.engines.vectorcypher import retriever as retriever_mod
+    from khora.telemetry import _otel as _otel_module
+    from khora.telemetry.metrics import metric_counter
+
+    _otel_module._METER = _otel_metrics.get_meter("khora", _otel_module._KHORA_VERSION)
+    new_counter = metric_counter(
+        "khora.vectorcypher.llm_reranking.skipped_total",
+        description=(
+            "Number of times the VectorCypher LLM rerank step was skipped, "
+            "by reason (not_temporal / no_version_metadata / decisive_winner)."
+        ),
+    )
+    monkeypatch.setattr(retriever_mod, "_LLM_RERANKING_SKIPPED_COUNTER", new_counter)
+
+    yield reader
+
+    _reset_otel_globals()
+    _otel_module._METER = _otel_metrics.get_meter("khora", _otel_module._KHORA_VERSION)
+
+
+def _skip_points(reader: InMemoryMetricReader, reason: str) -> int:
+    """Return the total count emitted for ``reason``."""
+    data = reader.get_metrics_data()
+    if data is None:
+        return 0
+    total = 0
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name != "khora.vectorcypher.llm_reranking.skipped_total":
+                    continue
+                for point in metric.data.data_points:
+                    if dict(point.attributes).get("reason") == reason:
+                        total += int(point.value)
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Helpers — TemporalSearchResult builder + retriever factory
+# ---------------------------------------------------------------------------
+
+
+_SENTINEL: Any = object()
+
+
+def _make_retriever(
+    *,
+    config: RetrieverConfig | None = None,
+    vector_store: Any | None = None,
+) -> VectorCypherRetriever:
+    if vector_store is None:
+        vector_store = AsyncMock()
+    return VectorCypherRetriever(
+        vector_store=vector_store,
+        neo4j_driver=None,
+        embedder=AsyncMock(),
+        config=config or RetrieverConfig(enable_llm_reranking=True, enable_reranking=False),
+        storage=None,
+    )
+
+
+def _make_temporal_search_result(
+    content: str,
+    *,
+    similarity: float = 0.9,
+    version: int | None = None,
+):
+    """Build a TemporalSearchResult mirroring the production shape."""
+    from khora.engines.skeleton.backends import TemporalChunk, TemporalSearchResult
+
+    metadata: dict[str, Any] = {}
+    if version is not None:
+        metadata["version"] = version
+    tc = TemporalChunk(
+        id=uuid4(),
+        namespace_id=uuid4(),
+        document_id=uuid4(),
+        content=content,
+        embedding=None,
+        occurred_at=datetime.now(UTC),
+        metadata=metadata,
+    )
+    return TemporalSearchResult(chunk=tc, similarity=similarity, combined_score=similarity)
+
+
+def _temporal_signal(category: TemporalCategory = TemporalCategory.RECENCY) -> TemporalSignal:
+    return TemporalSignal(
+        is_temporal=True,
+        category=category,
+        confidence=0.9,
+        source="dictionary",
+    )
+
+
+def _non_temporal_signal() -> TemporalSignal:
+    return TemporalSignal(
+        is_temporal=False,
+        category=TemporalCategory.NONE,
+        confidence=0.0,
+        source="dictionary",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Direct helper-level gate tests — both paths use ``_evaluate_llm_rerank_gate``
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEvaluateGateUnit:
+    """Unit-test the gate helper directly with both candidate shapes."""
+
+    def test_auto_no_versions_skips_with_reason(self) -> None:
+        retriever = _make_retriever(
+            config=RetrieverConfig(enable_llm_reranking=True, llm_reranking_mode="auto"),
+        )
+        # FusedResult (complex-path) shape — no version metadata.
+        c1 = type("X", (), {"metadata": {}})()
+        c2 = type("X", (), {"metadata": {}})()
+        candidates = [
+            FusedResult(item=c1, rrf_score=0.9, item_id=uuid4()),
+            FusedResult(item=c2, rrf_score=0.8, item_id=uuid4()),
+        ]
+        should_run, reason = retriever._evaluate_llm_rerank_gate(candidates, _temporal_signal(), namespace_id=uuid4())
+        assert should_run is False
+        assert reason == "no_version_metadata"
+
+    def test_auto_with_versions_runs(self) -> None:
+        retriever = _make_retriever(
+            config=RetrieverConfig(
+                enable_llm_reranking=True,
+                llm_reranking_mode="auto",
+                # Make the decisive-winner gate not fire.
+                llm_reranking_confidence_threshold=0.99,
+                llm_reranking_min_top_score=0.99,
+                llm_reranking_decisive_gap=0.99,
+            ),
+        )
+        c1 = type("X", (), {"metadata": {"version": 2}})()
+        c2 = type("X", (), {"metadata": {"version": 1}})()
+        candidates = [
+            FusedResult(item=c1, rrf_score=0.5, item_id=uuid4()),
+            FusedResult(item=c2, rrf_score=0.49, item_id=uuid4()),
+        ]
+        should_run, reason = retriever._evaluate_llm_rerank_gate(candidates, _temporal_signal(), namespace_id=uuid4())
+        assert should_run is True
+        assert reason is None
+
+    def test_always_bypasses_version_check(self) -> None:
+        retriever = _make_retriever(
+            config=RetrieverConfig(
+                enable_llm_reranking=True,
+                llm_reranking_mode="always",
+                # Decisive-winner gate cannot fire.
+                llm_reranking_confidence_threshold=0.99,
+                llm_reranking_min_top_score=0.99,
+                llm_reranking_decisive_gap=0.99,
+            ),
+        )
+        # No version metadata — under "auto" this would skip, under "always" it must run.
+        c1 = type("X", (), {"metadata": {}})()
+        c2 = type("X", (), {"metadata": {}})()
+        candidates = [
+            FusedResult(item=c1, rrf_score=0.5, item_id=uuid4()),
+            FusedResult(item=c2, rrf_score=0.49, item_id=uuid4()),
+        ]
+        should_run, reason = retriever._evaluate_llm_rerank_gate(candidates, _temporal_signal(), namespace_id=uuid4())
+        assert should_run is True
+        assert reason is None
+
+    def test_always_still_respects_decisive_winner(self) -> None:
+        retriever = _make_retriever(
+            config=RetrieverConfig(
+                enable_llm_reranking=True,
+                llm_reranking_mode="always",
+                llm_reranking_confidence_threshold=0.1,  # fires when gap >= 0.1
+                llm_reranking_min_top_score=0.7,
+                llm_reranking_decisive_gap=0.1,
+            ),
+        )
+        c1 = type("X", (), {"metadata": {}})()
+        c2 = type("X", (), {"metadata": {}})()
+        candidates = [
+            FusedResult(item=c1, rrf_score=0.9, item_id=uuid4()),
+            FusedResult(item=c2, rrf_score=0.5, item_id=uuid4()),
+        ]
+        should_run, reason = retriever._evaluate_llm_rerank_gate(candidates, _temporal_signal(), namespace_id=uuid4())
+        assert should_run is False
+        assert reason == "decisive_winner"
+
+    def test_non_temporal_returns_not_temporal(self) -> None:
+        retriever = _make_retriever()
+        c1 = type("X", (), {"metadata": {"version": 1}})()
+        candidates = [FusedResult(item=c1, rrf_score=0.9, item_id=uuid4())]
+        should_run, reason = retriever._evaluate_llm_rerank_gate(
+            candidates, _non_temporal_signal(), namespace_id=uuid4()
+        )
+        assert should_run is False
+        assert reason == "not_temporal"
+
+    def test_warning_emitted_once_per_namespace(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Repeated skips for the same namespace produce exactly one WARNING."""
+        retriever = _make_retriever(
+            config=RetrieverConfig(enable_llm_reranking=True, llm_reranking_mode="auto"),
+        )
+        c1 = type("X", (), {"metadata": {}})()
+        candidates = [FusedResult(item=c1, rrf_score=0.9, item_id=uuid4())]
+        ns = uuid4()
+
+        # loguru → stdlib bridge: use propagate-aware capture.
+        from loguru import logger as _loguru
+
+        msgs: list[str] = []
+        handler_id = _loguru.add(lambda m: msgs.append(str(m)), level="WARNING")
+        try:
+            for _ in range(3):
+                retriever._evaluate_llm_rerank_gate(candidates, _temporal_signal(), namespace_id=ns)
+        finally:
+            _loguru.remove(handler_id)
+
+        warnings = [m for m in msgs if "VectorCypher LLM reranking skipped" in m]
+        assert len(warnings) == 1, f"expected exactly one warning, got {len(warnings)}: {warnings}"
+
+    def test_warning_dedup_keyed_per_namespace(self) -> None:
+        """Two distinct namespaces each get their own one-time warning."""
+        retriever = _make_retriever(
+            config=RetrieverConfig(enable_llm_reranking=True, llm_reranking_mode="auto"),
+        )
+        c1 = type("X", (), {"metadata": {}})()
+        candidates = [FusedResult(item=c1, rrf_score=0.9, item_id=uuid4())]
+
+        from loguru import logger as _loguru
+
+        msgs: list[str] = []
+        handler_id = _loguru.add(lambda m: msgs.append(str(m)), level="WARNING")
+        try:
+            retriever._evaluate_llm_rerank_gate(candidates, _temporal_signal(), namespace_id=uuid4())
+            retriever._evaluate_llm_rerank_gate(candidates, _temporal_signal(), namespace_id=uuid4())
+        finally:
+            _loguru.remove(handler_id)
+
+        warnings = [m for m in msgs if "VectorCypher LLM reranking skipped" in m]
+        assert len(warnings) == 2, f"expected one warning per namespace, got {warnings}"
+
+    def test_simple_path_candidate_shape_supported(self) -> None:
+        """(Chunk, score) tuples — the simple-path candidate shape — work too."""
+        from khora.core.models import Chunk
+
+        retriever = _make_retriever(
+            config=RetrieverConfig(
+                enable_llm_reranking=True,
+                llm_reranking_mode="auto",
+                llm_reranking_confidence_threshold=0.99,
+                llm_reranking_min_top_score=0.99,
+                llm_reranking_decisive_gap=0.99,
+            ),
+        )
+        c_with = Chunk(id=uuid4(), namespace_id=uuid4(), document_id=uuid4(), content="a", metadata={"version": 1})
+        c_other = Chunk(id=uuid4(), namespace_id=uuid4(), document_id=uuid4(), content="b", metadata={})
+        # Has versions — should run.
+        should_run, reason = retriever._evaluate_llm_rerank_gate(
+            [(c_with, 0.5), (c_other, 0.49)], _temporal_signal(), namespace_id=uuid4()
+        )
+        assert should_run is True
+        assert reason is None
+
+        # No versions — should skip with no_version_metadata.
+        should_run, reason = retriever._evaluate_llm_rerank_gate(
+            [(c_other, 0.5), (c_other, 0.49)], _temporal_signal(), namespace_id=uuid4()
+        )
+        assert should_run is False
+        assert reason == "no_version_metadata"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end on the simple path: assert reranker invocation + counter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSimplePathRerankGate:
+    @pytest.mark.asyncio
+    async def test_auto_no_versions_skips_and_counts(self, metric_reader: InMemoryMetricReader) -> None:
+        retriever = _make_retriever(
+            config=RetrieverConfig(
+                enable_llm_reranking=True,
+                enable_reranking=False,
+                llm_reranking_mode="auto",
+            ),
+        )
+        r1 = _make_temporal_search_result("c1", similarity=0.9)
+        r2 = _make_temporal_search_result("c2", similarity=0.8)
+        retriever._vector_store.search = AsyncMock(return_value=[r1, r2])
+        retriever._apply_llm_reranking = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+        routing = RoutingDecision(
+            complexity=QueryComplexity.SIMPLE, use_graph=False, graph_depth=0, confidence=0.5, reasoning=""
+        )
+        await retriever._simple_retrieve(
+            query="q",
+            query_embedding=[0.1],
+            namespace_id=uuid4(),
+            temporal_filter=None,
+            limit=10,
+            routing=routing,
+            temporal_signal=_temporal_signal(TemporalCategory.STATE_QUERY),
+        )
+        retriever._apply_llm_reranking.assert_not_called()
+        assert _skip_points(metric_reader, "no_version_metadata") == 1
+
+    @pytest.mark.asyncio
+    async def test_auto_with_versions_invokes_reranker(self, metric_reader: InMemoryMetricReader) -> None:
+        retriever = _make_retriever(
+            config=RetrieverConfig(
+                enable_llm_reranking=True,
+                enable_reranking=False,
+                llm_reranking_mode="auto",
+                # Disable the decisive-winner skip so we can isolate the version gate.
+                llm_reranking_confidence_threshold=0.99,
+                llm_reranking_min_top_score=0.99,
+                llm_reranking_decisive_gap=0.99,
+            ),
+        )
+        r1 = _make_temporal_search_result("c1", similarity=0.9, version=2)
+        r2 = _make_temporal_search_result("c2", similarity=0.89, version=1)
+        retriever._vector_store.search = AsyncMock(return_value=[r1, r2])
+        retriever._apply_llm_reranking = AsyncMock(  # type: ignore[method-assign]
+            side_effect=lambda q, fused, limit, *, namespace_id: fused
+        )
+
+        routing = RoutingDecision(
+            complexity=QueryComplexity.SIMPLE, use_graph=False, graph_depth=0, confidence=0.5, reasoning=""
+        )
+        await retriever._simple_retrieve(
+            query="q",
+            query_embedding=[0.1],
+            namespace_id=uuid4(),
+            temporal_filter=None,
+            limit=10,
+            routing=routing,
+            temporal_signal=_temporal_signal(TemporalCategory.STATE_QUERY),
+        )
+        retriever._apply_llm_reranking.assert_called_once()
+        # No skip counted.
+        assert _skip_points(metric_reader, "no_version_metadata") == 0
+        assert _skip_points(metric_reader, "decisive_winner") == 0
+        assert _skip_points(metric_reader, "not_temporal") == 0
+
+    @pytest.mark.asyncio
+    async def test_always_no_versions_still_invokes(self, metric_reader: InMemoryMetricReader) -> None:
+        retriever = _make_retriever(
+            config=RetrieverConfig(
+                enable_llm_reranking=True,
+                enable_reranking=False,
+                llm_reranking_mode="always",
+                llm_reranking_confidence_threshold=0.99,
+                llm_reranking_min_top_score=0.99,
+                llm_reranking_decisive_gap=0.99,
+            ),
+        )
+        r1 = _make_temporal_search_result("c1", similarity=0.9)
+        r2 = _make_temporal_search_result("c2", similarity=0.89)
+        retriever._vector_store.search = AsyncMock(return_value=[r1, r2])
+        retriever._apply_llm_reranking = AsyncMock(  # type: ignore[method-assign]
+            side_effect=lambda q, fused, limit, *, namespace_id: fused
+        )
+
+        routing = RoutingDecision(
+            complexity=QueryComplexity.SIMPLE, use_graph=False, graph_depth=0, confidence=0.5, reasoning=""
+        )
+        await retriever._simple_retrieve(
+            query="q",
+            query_embedding=[0.1],
+            namespace_id=uuid4(),
+            temporal_filter=None,
+            limit=10,
+            routing=routing,
+            temporal_signal=_temporal_signal(TemporalCategory.STATE_QUERY),
+        )
+        retriever._apply_llm_reranking.assert_called_once()
+        assert _skip_points(metric_reader, "no_version_metadata") == 0
+
+    @pytest.mark.asyncio
+    async def test_always_decisive_winner_skips_with_reason(self, metric_reader: InMemoryMetricReader) -> None:
+        retriever = _make_retriever(
+            config=RetrieverConfig(
+                enable_llm_reranking=True,
+                enable_reranking=False,
+                llm_reranking_mode="always",
+                # Decisive-winner gate: top>=0.7 AND gap>=0.1
+                llm_reranking_confidence_threshold=0.99,
+                llm_reranking_min_top_score=0.7,
+                llm_reranking_decisive_gap=0.1,
+            ),
+        )
+        r1 = _make_temporal_search_result("c1", similarity=0.95)
+        r2 = _make_temporal_search_result("c2", similarity=0.5)
+        retriever._vector_store.search = AsyncMock(return_value=[r1, r2])
+        retriever._apply_llm_reranking = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+        routing = RoutingDecision(
+            complexity=QueryComplexity.SIMPLE, use_graph=False, graph_depth=0, confidence=0.5, reasoning=""
+        )
+        await retriever._simple_retrieve(
+            query="q",
+            query_embedding=[0.1],
+            namespace_id=uuid4(),
+            temporal_filter=None,
+            limit=10,
+            routing=routing,
+            temporal_signal=_temporal_signal(TemporalCategory.STATE_QUERY),
+        )
+        retriever._apply_llm_reranking.assert_not_called()
+        assert _skip_points(metric_reader, "decisive_winner") == 1
+
+    @pytest.mark.asyncio
+    async def test_non_temporal_query_skips_with_reason(self, metric_reader: InMemoryMetricReader) -> None:
+        retriever = _make_retriever(
+            config=RetrieverConfig(
+                enable_llm_reranking=True,
+                enable_reranking=False,
+                llm_reranking_mode="always",
+            ),
+        )
+        r1 = _make_temporal_search_result("c1", similarity=0.9, version=1)
+        r2 = _make_temporal_search_result("c2", similarity=0.8, version=1)
+        retriever._vector_store.search = AsyncMock(return_value=[r1, r2])
+        retriever._apply_llm_reranking = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+        routing = RoutingDecision(
+            complexity=QueryComplexity.SIMPLE, use_graph=False, graph_depth=0, confidence=0.5, reasoning=""
+        )
+        await retriever._simple_retrieve(
+            query="q",
+            query_embedding=[0.1],
+            namespace_id=uuid4(),
+            temporal_filter=None,
+            limit=10,
+            routing=routing,
+            temporal_signal=_non_temporal_signal(),
+        )
+        retriever._apply_llm_reranking.assert_not_called()
+        assert _skip_points(metric_reader, "not_temporal") == 1
+
+
+# ---------------------------------------------------------------------------
+# Complex path: assert the same gate semantics directly. We invoke the
+# helper through synthetic candidates (sidesteps the heavy graph mocking
+# required to drive _vectorcypher_retrieve end-to-end) — gate is shared
+# code, so unit-checking it once on the helper plus an end-to-end pass on
+# the simple path is sufficient parameter coverage.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCounterEmission:
+    """Direct counter-emission check through the gate helper.
+
+    The simple-path end-to-end tests above exercise the live counter via
+    ``_simple_retrieve``. This class adds direct gate-helper coverage so
+    counter regressions on the complex path are caught even if the heavy
+    mock harness around ``_vectorcypher_retrieve`` ever drifts.
+    """
+
+    def _emit(self, retriever: VectorCypherRetriever, candidates: list[Any], signal: TemporalSignal) -> None:
+        """Replicates the call-site contract: emit the counter on skip."""
+        from khora.engines.vectorcypher import retriever as retriever_mod
+
+        should_run, reason = retriever._evaluate_llm_rerank_gate(candidates, signal, namespace_id=uuid4())
+        if not should_run and reason is not None:
+            retriever_mod._LLM_RERANKING_SKIPPED_COUNTER.add(1, attributes={"reason": reason})
+
+    def test_no_version_counter_emits(self, metric_reader: InMemoryMetricReader) -> None:
+        retriever = _make_retriever()
+        c1 = type("X", (), {"metadata": {}})()
+        candidates = [FusedResult(item=c1, rrf_score=0.9, item_id=uuid4())]
+        self._emit(retriever, candidates, _temporal_signal())
+        assert _skip_points(metric_reader, "no_version_metadata") == 1
+
+    def test_not_temporal_counter_emits(self, metric_reader: InMemoryMetricReader) -> None:
+        retriever = _make_retriever()
+        c1 = type("X", (), {"metadata": {"version": 1}})()
+        candidates = [FusedResult(item=c1, rrf_score=0.9, item_id=uuid4())]
+        self._emit(retriever, candidates, _non_temporal_signal())
+        assert _skip_points(metric_reader, "not_temporal") == 1
+
+    def test_decisive_winner_counter_emits(self, metric_reader: InMemoryMetricReader) -> None:
+        retriever = _make_retriever(
+            config=RetrieverConfig(
+                enable_llm_reranking=True,
+                llm_reranking_mode="always",
+                llm_reranking_confidence_threshold=0.05,
+                llm_reranking_min_top_score=0.7,
+                llm_reranking_decisive_gap=0.1,
+            ),
+        )
+        c1 = type("X", (), {"metadata": {}})()
+        c2 = type("X", (), {"metadata": {}})()
+        candidates = [
+            FusedResult(item=c1, rrf_score=0.95, item_id=uuid4()),
+            FusedResult(item=c2, rrf_score=0.5, item_id=uuid4()),
+        ]
+        self._emit(retriever, candidates, _temporal_signal())
+        assert _skip_points(metric_reader, "decisive_winner") == 1


### PR DESCRIPTION
## Summary

- `VectorCypherConfig.enable_llm_reranking=True` was silently a no-op for the standard ingestion path. The LLM rerank step is gated on `chunk.metadata["version"]`, which `Khora.remember` / `remember_batch` never populate — so users who opted in saw no rerank, no cost, and only a DEBUG log message.
- The gate isn't dead code: PR #364 added it to fix a measured MRR regression on conversational benchmarks (LongMemEval / LoCoMo). So this PR keeps the gate but makes the skip discoverable, and adds an explicit opt-out for users who want unconditional rerank on temporal queries.

## What changes

- New field `llm_reranking_mode: Literal["auto", "always"]` (default `"auto"`) on `VectorCypherConfig` / `RetrieverConfig`. `"always"` bypasses the version-metadata precondition; the decisive-winner latency skip still applies in both modes.
- Gate logic centralised in `VectorCypherRetriever._evaluate_llm_rerank_gate`, called from both the complex `_vectorcypher_retrieve` path and the simple `_simple_retrieve` path (replaces two duplicated inline gate blocks that had drifted on telemetry).
- One-time `logger.warning` per `(namespace_id, reason)` when `"auto"` mode triggers `no_version_metadata` — surfaces the silent opt-in without spamming hot recall paths. The message names the override knob (`llm_reranking_mode="always"`) and the off switch (`enable_llm_reranking=False`).
- New metric `khora.vectorcypher.llm_reranking.skipped_total{reason}` with values `not_temporal | no_version_metadata | decisive_winner`. Declared in `docs/telemetry-contract.json` (stability: internal, owner: vectorcypher). No `namespace_id` label — cardinality rule.
- `mode` span attribute added to the existing `khora.vectorcypher.llm_reranking` span.
- `enable_llm_reranking` docstring rewritten to describe the gate explicitly and point at the override.

## Why this shape and not "just remove the gate"

The first-instinct fix is to delete the `_has_versions` precondition entirely. That would re-introduce the measured MRR regression PR #364 fixed, on exactly the conversational data shape that drives the shipped OSS integration adapters. The flag default for `enable_llm_reranking` is `False`, so this PR doesn't change behaviour for anyone who hasn't opted in. For users who *have* opted in, they now see a WARNING explaining what's happening and how to override.

## Test plan

- [x] `make format` — clean.
- [x] `make lint` — `All checks passed!` (ty warnings are pre-existing, unrelated to this PR).
- [x] `uv run pytest tests/unit/ --ignore=tests/unit/integrations/langgraph -q` — 6025 passed, 45 skipped. (langgraph optional-extra collection error is pre-existing.)
- [x] Coverage baseline on `main` is 76.07%; this PR brings it to 76.14% (+0.07pp).
- [x] New file `tests/unit/engines/vectorcypher/test_llm_rerank_gate.py` covers both candidate shapes, WARNING dedupe across namespaces, counter emissions, decisive-winner skip, and the `"always"`-mode bypass.

Fixes #814