### PR TITLE
release: v0.16.5 - ingest source_timestamp coercion + log redaction + engine_info.mode string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to Khora are documented here.
 
 Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were internal (no git tags).
 
-## [Unreleased]
+## [0.16.5] - ingest source_timestamp coercion + ingestion log redaction + engine_info.mode string
+
+Patch release on top of v0.16.4. Three correctness/safety fixes — string `source_timestamp` values from upstream connectors are now coerced to `datetime` before reaching `Document(...)` (a stray ISO-8601 string could previously be persisted as-is or crash ingestion); document-persist failure logs and the `DocumentResult.error` returned to callers no longer leak raw SQL statements and their bind-parameter content (i.e. document body + metadata) via a bounded exception summary; and the vectorcypher `engine_info.mode` is now emitted as the lowercase mode string (`hybrid`) instead of the `SearchMode` enum integer, matching the documented recall `mode` vocabulary.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ nlp = ["spacy>=3.8.0"]
 # LOCKSTEP: this pin must match rust/khora-accel/Cargo.toml's version exactly.
 # Bump both in the same PR. See CLAUDE.md → Version Bumps.
 rust = [
-    "khora-accel==0.16.4",
+    "khora-accel==0.16.5",
 ]
 # SurrealDB unified backend (graph + vector + relational in one DB)
 surrealdb = ["surrealdb>=2.0.0,<3.0"]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "khora-accel"
-version = "0.16.4"
+version = "0.16.5"
 dependencies = [
  "aho-corasick",
  "criterion",

--- a/rust/khora-accel/Cargo.toml
+++ b/rust/khora-accel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khora-accel"
-version = "0.16.4"
+version = "0.16.5"
 edition = "2024"
 rust-version = "1.85"
 description = "Rust-accelerated operations for Khora"


### PR DESCRIPTION
Patch release on top of v0.16.4. Lockstep version bump (`rust/khora-accel/Cargo.toml` + `pyproject.toml` rust-extra pin + `rust/Cargo.lock` + CHANGELOG). **No Rust source changes since v0.16.4** — the two PRs since the last tag are Python-only fixes already merged to `main`.

## Included since v0.16.4

### Fixed
- **ingest: coerce string `source_timestamp` to `datetime`** before it reaches `Document(...)` — connectors passing ISO-8601 strings could previously be persisted as-is or crash ingestion (#823).
- **document ingestion: stop leaking raw DB content in failure logs** — `DBAPIError` reprs embed the failed SQL statement and bind parameters (full document body + metadata). Persist-failure logs and `DocumentResult.error` now use a bounded exception summary that strips the `[SQL: ...]` / `[parameters: ...]` tail (#823).
- **vectorcypher: emit `engine_info.mode` as the lowercase mode string** (e.g. `hybrid`) instead of the `SearchMode` enum integer, matching the documented recall `mode` vocabulary (#822).

## Release checklist
- [x] `rust/khora-accel/Cargo.toml` → `0.16.5`
- [x] `pyproject.toml` rust-extra pin → `khora-accel==0.16.5`
- [x] `rust/Cargo.lock` → khora-accel `0.16.5`
- [x] `CHANGELOG.md` → `## [0.16.5]` entry
- [ ] CI green, then merge and tag `v0.16.5`