### PR TITLE
fix: surface clear error when running python -m khora (issue #835)

### DIFF
--- a/src/khora/__main__.py
+++ b/src/khora/__main__.py
@@ -1,6 +1,7 @@
-"""Allow running as python -m khora."""
+"""Allow running as python -m khora.
 
-from .cli import main
+Khora is a library. The CLI tooling lives in the separate khora-cli package.
+"""
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit("Khora is a library and does not provide a CLI. Use khora-cli instead.")


### PR DESCRIPTION
## Summary

`python -m khora` currently crashes with `ModuleNotFoundError: No module named 'khora.cli'` because `src/khora/__main__.py` imports from `.cli` which was removed and moved to the separate `khora-cli` package.

This fix replaces the broken import with a clear error message that tells users Khora is a library and they should use `khora-cli` instead.

## Fix

Replace `from .cli import main` + `main()` call with a `SystemExit` that surfaces a clear message:

```
Khora is a library and does not provide a CLI. Use khora-cli instead.
```

## Testing

`python -m khora` now shows a helpful error instead of a cryptic `ModuleNotFoundError`.

Fixes #835