### PR TITLE
Docs cleanup - no versions, remove mention of cli and explorer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ uv run alembic upgrade head                       # Run migrations
 
 **Installing all extras at once doesn't work.** `crewai` and `google-adk` declare mutually-incompatible `opentelemetry-api` ranges (crewai pins `<1.35`, google-adk pins `>=1.36`) and `[tool.uv].conflicts` makes the conflict explicit, so `uv sync --all-extras` is rejected. Pick one combo: `make install` for crewai (matches CI's `test` job), `make install-adk` for google-adk. CI also keeps `UV_NO_SYNC=1` set so subsequent `uv run` calls don't silently re-resolve the venv to the other combo.
 
-CLI tooling (`extract`, `search`) lives in the separate `khora-cli` package (to be released soon). Ontology tooling (construct / validate / preview) lives in `khora-explorer` (to be released soon). khora is a Python library.
+CLI tooling (`extract`, `search`, ontology tools) was removed from the `khora` package. khora is a Python library.
 
 ## Test Commands
 
@@ -40,7 +40,7 @@ Docker Compose is always available. Always run `make test` before opening a PR. 
 - **Engines:** implement `MemoryEngineProtocol` in `engines/protocol.py`. Default engine is `vectorcypher`
 - **Graph backends:** Neo4j, SurrealDB, Memgraph, Neptune, AGE - implement `GraphBackend` in `storage/backends/base.py`
 - **SurrealDB:** unified backend (graph + vector + relational). Modes: `memory://`, `surrealkv://` (embedded), `ws://` (remote). Set `backend: surrealdb` in config
-- **Extraction skills:** YAML-defined in `extraction/skills/builtin/`. Generate with `khora-explorer construct` (separate package)
+- **Extraction skills:** YAML-defined in `extraction/skills/builtin/`.
 - **Config:** env vars with `KHORA_` prefix and single underscore (e.g., `KHORA_QUERY_ENABLE_HYDE=true`, `KHORA_LLM_MODEL=gpt-4o`). The legacy `__` nesting form is kept working silently for backward compatibility; single underscore is the documented form
 
 ### Key Entry Points
@@ -52,7 +52,7 @@ Docker Compose is always available. Always run `make test` before opening a PR. 
 - `storage/backends/surrealdb/` - Unified SurrealDB backend
 - `db/models.py` - SQLAlchemy ORM (UUID columns use `as_uuid=True`)
 - `_accel.py` - Rust/NumPy acceleration (MMR, cosine, pagerank, entity resolution, community detection, temporal)
-- `extraction/binary_readers.py` - PDF/xlsx/docx/parquet readers consumed by khora-cli (stable boundary)
+- `extraction/binary_readers.py` - PDF/xlsx/docx/parquet readers; stable public boundary.
 - `pipelines/flows/ingest.py` - Document ingestion pipeline (3-phase: stage → enrich → expand)
 - `db/migrations/env.py` - Alembic with advisory locking
 - `config/schema.py` - `KhoraConfig` Pydantic settings (storage, LLM, pipeline, query, tenancy)
@@ -215,15 +215,15 @@ These principles are working if: fewer unnecessary changes in diffs, fewer rewri
 
 ### Logging
 - **loguru sinks are sync by default** - `logger.add(...)` has `enqueue=False`. In async code, `logger.*` calls then block the event loop on each format+write. Khora's `setup_logging()` enables `enqueue=True` on all sinks it installs, and registers `atexit.register(logger.complete)` so the queue drains on clean exit.
-- **Library consumers MUST either** (a) call `khora.logging_config.setup_logging()`, OR (b) configure their own loguru sinks with `enqueue=True` explicitly. If a downstream service imports khora without doing either, it inherits loguru's default sync stderr sink and silently pays event-loop-blocking cost on every `logger.*` call inside an `async def`.
-- **Graceful shutdown drains via `logger.complete()`** - setup_logging registers this via atexit. Downstream consumers that configure their own sinks must do the same, otherwise in-flight queue entries are lost on exit.
+- **Downstream code MUST either** (a) call `khora.logging_config.setup_logging()`, OR (b) configure its own loguru sinks with `enqueue=True` explicitly. If a downstream service imports khora without doing either, it inherits loguru's default sync stderr sink and silently pays event-loop-blocking cost on every `logger.*` call inside an `async def`.
+- **Graceful shutdown drains via `logger.complete()`** - setup_logging registers this via atexit. Downstream code that configures its own sinks must do the same, otherwise in-flight queue entries are lost on exit.
 - **Abrupt termination (SIGKILL, crash) drops in-flight log records.** This is inherent to the enqueue model - the queue is drained by a background thread that can't run during a kill.
 - **loguru queue is unbounded in 0.7.3.** Under sustained burst (DEBUG mode + error storm + slow sink), records accumulate faster than the background thread can drain them and eventually OOM the process. Napkin math: ~1 KB/record × ~9k records/s net accumulation → 512 MB pod OOMs in ~60s (INFO) or ~3s (DEBUG with cascading errors). loguru 0.7.3 does not expose a `maxsize` kwarg on `logger.add()`. Mitigation: keep log volume bounded by request rate (avoid unbounded DEBUG in prod); watch for `MemoryError` in low-memory containers. Revisit if loguru exposes `maxsize` upstream.
 - **`enqueue=True` is not a free latency win.** See `scripts/bench_logger_enqueue.py`: on fast buffered sinks, the pickle + IPC overhead dominates a userspace memcpy, so enqueue is ~5× slower per call than sync. On slow sinks with sustained throughput (no idle between bursts), enqueue does not help either - the kernel pipe fills and the producer blocks. Enqueue wins only in the realistic case: slow sink + idle between bursts (a request handler doing async I/O between log calls), where p99 event-loop stalls drop ~25-40% (≈15-18 ms → ≈11 ms, run-dependent) and wall time drops ~23% (2058 ms → 1593 ms) on the handler-shaped scenario. Keep this in mind when evaluating logging overhead on hot paths.
 
 ### Telemetry
 - **Public contract lives at `docs/telemetry-contract.json`** (with sibling explainer `docs/telemetry-contract.md`). When you add a span (`trace_span`), pipeline stage (`pipeline_stage` / `record_pipeline_stage`), metric (`metric_counter` / `metric_histogram` / `metric_gauge_callback`), event-type field, or new public export to `khora.telemetry.__all__`, you MUST update the contract JSON in the same PR. CI fails otherwise via `tests/unit/telemetry/test_contract.py` (10-test drift gate that walks the codebase with ripgrep).
-- **Public vs internal stability tags.** Items tagged `stability: public` in the contract are part of the OSS API surface - renaming or removing them requires a major version bump and prior coordination with published consumer packages (khora-cli, khora-explorer). Items tagged `internal` may be renamed freely as long as the JSON is updated. Top-level engine entry points (`khora.recall`, `khora.remember`, `khora.vectorcypher.retrieve`) and operator-facing metrics (`khora.memory.recall.duration`, `khora.llm.tokens`, etc.) are public. Inner-loop spans (`khora.vectorcypher.coherence_boost`, `khora.vectorcypher.rrf_fusion`, etc.) are internal.
+- **Public vs internal stability tags.** Items tagged `stability: public` in the contract are part of the OSS API surface - renaming or removing them requires a major version bump and prior coordination through the CHANGELOG / release-notes process. Items tagged `internal` may be renamed freely as long as the JSON is updated. Top-level engine entry points (`khora.recall`, `khora.remember`, `khora.vectorcypher.retrieve`) and operator-facing metrics (`khora.memory.recall.duration`, `khora.llm.tokens`, etc.) are public. Inner-loop spans (`khora.vectorcypher.coherence_boost`, `khora.vectorcypher.rrf_fusion`, etc.) are internal.
 - **Cardinality rule - never put `namespace_id` on a metric.** It is a span attribute and a log field only. Phase-0 audit measured 438 distinct namespace IDs over the production retention window in one deployment; Logfire and Prometheus bill per series, so a `namespace_id` label produces an unbounded cost curve. The same rule applies to any other attribute with cardinality ~O(tenants).
 - **Free-text span attributes.** Use `khora.telemetry.bounded_text_hash` (added in #504) for any free-text value (raw user query, document content, chunk text) - it returns a SHA1[:8] hash. Never put raw text on a span attribute: it is both a privacy hazard and a cardinality bomb.
 - **OTel semconv adopted for new attributes.** `gen_ai.*` for LLM (model, prompt tokens, completion tokens), `db.*` for storage backends, `code.*` for stack info. Keeps khora vendor-neutral over the OTel exporter chain.
@@ -234,7 +234,7 @@ These principles are working if: fewer unnecessary changes in diffs, fewer rewri
 - **Telemetry collector is opt-in.** `KHORA_TELEMETRY_DATABASE_URL` enables PostgreSQL-backed event recording; without it, `NoOpCollector` is used (zero cost). Logfire integration is gated by `_HAS_LOGFIRE` - `trace_span()` yields a no-op when the optional `logfire` extra is absent.
 
 ### Downstream
-- The published consumer packages `khora-cli` and `khora-explorer` consume khora's public API. `kb.storage` is a stable public API. The full stability policy is documented in `docs/consumers.md`.
-- **LLMUsage contract:** `LLMUsage` fields are part of the stable public API and are consumed by external cost-tracking integrations - changes require coordination.
-- **ExpertiseConfig contract:** stable API - `ExpertiseConfig`, `EntityTypeConfig`, `RelationshipTypeConfig`, `ConfidenceConfig`, `ExpansionConfig`, `CorrelationRule`, `InferenceRule` changes require coordination with published consumer packages. `__all__` in `src/khora/extraction/skills/base.py` is the machine-readable contract.
-- Any breaking change to the stable public API requires coordinated release with published consumer packages. `__all__` in `src/khora/__init__.py` is the machine-readable contract for the top-level surface.
+- `kb.storage` is a stable public API.
+- **LLMUsage contract:** `LLMUsage` fields are part of the stable public API; breaking changes are recorded in CHANGELOG.md.
+- **ExpertiseConfig contract:** stable API - changes to `ExpertiseConfig`, `EntityTypeConfig`, `RelationshipTypeConfig`, `ConfidenceConfig`, `ExpansionConfig`, `CorrelationRule`, `InferenceRule` are recorded in CHANGELOG.md. `__all__` in `src/khora/extraction/skills/base.py` is the machine-readable contract.
+- Any breaking change to the stable public API is recorded in CHANGELOG.md. `__all__` in `src/khora/__init__.py` is the machine-readable contract for the top-level surface.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,11 @@ optional SQLite + LanceDB embedded path).
 ```bash
 git clone https://github.com/DeytaHQ/khora.git
 cd khora
-uv sync --all-extras
+make install ## installs support for crewai
 ```
+
+Alternatitively you can run `make install-adk` if you want to play around with google-adk.
+Currently, due to third party dependencies, it is not possible to install google-adk and crewai support together.
 
 You need Python 3.13 and [`uv`](https://github.com/astral-sh/uv). For
 integration tests against Postgres/Neo4j you also need Docker.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Khora is a knowledge memory library. This directory contains everything beyond t
 - [API reference](api-reference.md) - public `Khora` methods and result types.
 - [Observability](observability.md) - OTel spans/metrics, `[otel]` and `[logfire]` paths, `configure_telemetry()`.
 - [Migrations](migrations.md) - Alembic workflow for library users (PostgreSQL backends only).
-- [Consumers](consumers.md) - how downstream packages (e.g. khora-cli, khora-explorer) use khora.
+- [Consumers](consumers.md) - how downstream packages consume khora's public API.
 
 ## Architecture
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -178,7 +178,7 @@ result: RecallResult = await kb.recall(
 ```
 
 - `mode` - one of `SearchMode.VECTOR`, `GRAPH`, `HYBRID`, or `ALL`.
-- `start_time` / `end_time` - explicit temporal filter; bypasses NLP temporal detection. Both-naive or both-aware datetimes are required. Honored on all three engines (chronicle, vectorcypher, graphrag) as of v0.17.0 - vectorcypher and graphrag previously dropped the explicit bound silently.
+- `start_time` / `end_time` - explicit temporal filter; bypasses NLP temporal detection. Both-naive or both-aware datetimes are required. Honored on all three engines (chronicle, vectorcypher, skeleton).
 - To skip LLM-side work (reranking, HyDE expansion), set the config flags `enable_llm_reranking=False` and `enable_hyde="never"` on `KhoraConfig.query` (env: `KHORA_QUERY_ENABLE_LLM_RERANKING`, `KHORA_QUERY_ENABLE_HYDE`).
 
 ### `context_text`
@@ -236,7 +236,7 @@ entity = await kb.get_entity(entity_id, namespace=ns.namespace_id)
 # Entity | None  - returns None for cross-namespace lookups.
 
 document = await kb.get_document(document_id, namespace=ns.namespace_id)
-# Document | None - namespace kwarg required since v0.16.0.
+# Document | None - namespace kwarg required.
 ```
 
 `namespace` is **required** (accepts `str | UUID`, mirrors `list_entities` / `find_related_entities`). The facade fetches the row and verifies its `namespace_id` matches - cross-namespace ids resolve to `None` rather than the foreign entity. Calling without `namespace=` raises `TypeError`.
@@ -252,9 +252,9 @@ This shape applies to the whole `kb.storage` getter surface - namespace is the t
 | `kb.storage.get_chunks_batch(chunk_ids, *, namespace_id)` | `namespace_id: UUID` - cross-namespace ids silently dropped from the returned dict |
 | `kb.storage.get_chunks_by_document(document_id, *, namespace_id)` | `namespace_id: UUID` - returns `[]` if the document doesn't belong to the namespace |
 
-**v0.16.0 expanded the contract to every backend method** (PRs #761 / #765 / #766 / #769). Every read, exists-check, and mutation on `RelationalBackend` / `VectorBackend` / `GraphBackend` / `EventStore` now requires `*, namespace_id: UUID` (kwarg-only) and filters at the SQL / Cypher / SurrealQL layer - not post-fetch. Cross-namespace reads return `None` / `{}` / `[]`; cross-namespace writes silently no-op (raising would expose row existence). The full list of tightened methods is in [migrations.md](migrations.md#v0160--api-migration-namespace-kwarg-required-everywhere).
+**The contract applies to every backend method** (PRs #761 / #765 / #766 / #769). Every read, exists-check, and mutation on `RelationalBackend` / `VectorBackend` / `GraphBackend` / `EventStore` requires `*, namespace_id: UUID` (kwarg-only) and filters at the SQL / Cypher / SurrealQL layer - not post-fetch. Cross-namespace reads return `None` / `{}` / `[]`; cross-namespace writes silently no-op (raising would expose row existence). The full list of tightened methods is in [migrations.md](migrations.md#v0160--api-migration-namespace-kwarg-required-everywhere).
 
-> **Deprecation (v0.16.0 → v0.17).** `StorageCoordinator.{relational,vector,graph,event_store}` are now `NamespaceRequiredProxy` wrappers. Accessing them emits one `DeprecationWarning` per role per process; calling a method without `namespace_id=` raises `TypeError`. Public attributes are removed in v0.17 - call coordinator-level methods (`kb.storage.<method>`) instead.
+> **Deprecation.** `StorageCoordinator.{relational,vector,graph,event_store}` are `NamespaceRequiredProxy` wrappers. Accessing them emits one `DeprecationWarning` per role per process; calling a method without `namespace_id=` raises `TypeError`. Call coordinator-level methods (`kb.storage.<method>`) instead.
 
 ### `stats`
 
@@ -342,7 +342,7 @@ JSON-serializable response projection. Lives at `khora.core.models.recall.Recall
 | `source_name` | `str \| None` | SaaS-tool / connector identifier. |
 | `source_url` | `str \| None` | Addressable doc URL. |
 | `content_type` | `str \| None` | MIME / content type. |
-| `source_timestamp` | `datetime \| None` | Source-system timestamp (e.g., message sent-at), distinct from ingest `created_at`. ISO-8601 strings are accepted on input and coerced via `coerce_source_timestamp` (v0.17.0+). |
+| `source_timestamp` | `datetime \| None` | Source-system timestamp (e.g., message sent-at), distinct from ingest `created_at`. ISO-8601 strings are accepted on input and coerced via `coerce_source_timestamp`. |
 | `metadata` | `dict[str, Any]` | Free-form user metadata. |
 
 #### `RecallChunk`
@@ -426,7 +426,7 @@ A custom engine **must** implement the full `MemoryEngineProtocol` from `src/kho
 
 ## Expertise
 
-`ExpertiseConfig` is a stable sibling API maintained in coordination with khora-explorer.
+`ExpertiseConfig` is a stable public API.
 
 ```python
 from khora import ExpertiseConfig, EntityTypeConfig, RelationshipTypeConfig
@@ -457,7 +457,7 @@ from khora import SemanticFilter, EventType
 
 Subscribe to extraction and recall events. The full Phase 2 surface (EventBridge-style `match` DSL, `CHUNK_ENTITIES_RESOLVED` for co-occurrence filtering, Level 2 LLM evaluator with cache + per-subscription budget) is documented in [hooks/semantic-hooks.md](hooks/semantic-hooks.md).
 
-## Advanced (opt-in, v0.12.0)
+## Advanced (opt-in)
 
 These surfaces are documented for completeness but are **default-OFF** behind config flags pending A/B validation.
 
@@ -484,6 +484,6 @@ except KhoraError as exc:
 
 ## Stability guarantee
 
-Symbols imported from the top-level `khora` namespace and `khora.extraction.skills` are stable. Additive changes land in minor releases; breaking changes require a major version bump and coordinated release with khora-cli and khora-explorer.
+Symbols imported from the top-level `khora` namespace and `khora.extraction.skills` are stable. Additive changes land in minor releases; breaking changes require a major version bump.
 
 Private imports (`khora.engines.vectorcypher`, `khora.query.engine`, `khora.pipelines.flows`, etc.) are **not** stable and can change between minor versions.

--- a/docs/architecture/multi-tenancy.md
+++ b/docs/architecture/multi-tenancy.md
@@ -39,14 +39,14 @@ ORDER BY similarity DESC;
 
 You can't accidentally see another namespace's data.
 
-## Protocol-level isolation contract (v0.16.0)
+## Protocol-level isolation contract
 
 Namespace scoping is part of the storage Protocol contract itself. Every read, exists-check, AND mutation method on every backend (`RelationalBackend`, `VectorBackend`, `GraphBackend`, `EventStore`) declares `*, namespace_id: UUID` as a required keyword-only parameter and filters at the **query layer** (SQL `WHERE`, Cypher `MATCH (... {namespace_id: $ns})`, SurrealQL filter) - the namespace check happens in the database, never as a Python comparison after the row has already been fetched.
 
 Looking up a row whose id belongs to a different namespace returns `None` / `False` / an empty list / dict straight from the query. The caller's `namespace_id` is the authority; the row's stored `namespace_id` only matters as the value the filter matches against.
 
 ```python
-# Pattern (v0.16.0+):
+# Pattern:
 doc = await coordinator.get_document(document_id, namespace_id=caller_ns)
 # `doc` is None if the id does not exist OR belongs to a different namespace.
 
@@ -83,7 +83,7 @@ A new backend method without `namespace_id=` fails CI at test collection - the r
 2. Refuses the namespace-scoped read methods unless `namespace_id=` is passed (raises `TypeError`).
 3. Does not forward access to underscore-prefixed attributes - backend internals such as `_engine`, `_handle`, `_conn`, `_session_factory` are reachable only via the private `coord._{role}` accessors used by coordinator internals.
 
-The public attributes are scheduled for removal in v0.17 - call the coordinator's facade methods (`coordinator.get_document(...)`, `coordinator.get_entity(...)`, `coordinator.get_neighborhood(...)`) instead.
+The public attributes are deprecated - call the coordinator's facade methods (`coordinator.get_document(...)`, `coordinator.get_entity(...)`, `coordinator.get_neighborhood(...)`) instead.
 
 ## Creating Namespaces
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -298,7 +298,7 @@ class GraphBackendProtocol(Protocol):
     ) -> dict[str, Any]: ...
 ```
 
-Since v0.16.0, every read / exists / mutation method on a storage backend takes `*, namespace_id: UUID` as a required keyword-only parameter and filters at the SQL / Cypher / SurrealQL layer. See [Multi-Tenancy](multi-tenancy.md) for the structural invariant and [Storage Backends](storage-backends.md) for the full surface.
+Every read / exists / mutation method on a storage backend takes `*, namespace_id: UUID` as a required keyword-only parameter and filters at the SQL / Cypher / SurrealQL layer. See [Multi-Tenancy](multi-tenancy.md) for the structural invariant and [Storage Backends](storage-backends.md) for the full surface.
 
 ## What's Next?
 

--- a/docs/architecture/performance-optimization.md
+++ b/docs/architecture/performance-optimization.md
@@ -205,7 +205,7 @@ Database connection pools are sized to match concurrent operation patterns:
 | PostgreSQL max overflow | 30 |
 | Neo4j max connection pool | 50 |
 
-As of v0.3.0, `StorageFactory` caches engines by normalized URL. When PostgreSQL, pgvector, and the event store share the same database URL (the common case), they reuse a single connection pool instead of creating three independent ones. This reduces total database connections to one-third of the previous default without any configuration changes.
+`StorageFactory` caches engines by normalized URL. When PostgreSQL, pgvector, and the event store share the same database URL (the common case), they reuse a single connection pool instead of creating three independent ones. This keeps total database connections to one-third of what three independent pools would use.
 
 ## Search Pipeline Timing
 
@@ -364,7 +364,7 @@ The PostgreSQL entity upsert changed from N individual INSERT statements in a si
 
 ### `remember_batch` Through `ingest_documents`
 
-`Khora.remember_batch()` now delegates to `ingest_documents` instead of calling `remember()` N times. This enables the shared `EntityIndex` for cross-document entity deduplication, smart mode resolution, and parallel document processing - all of which were previously only available through the direct pipeline API.
+`Khora.remember_batch()` delegates to `ingest_documents` rather than calling `remember()` N times. This enables the shared `EntityIndex` for cross-document entity deduplication, smart mode resolution, and parallel document processing.
 
 ### Impact
 
@@ -377,9 +377,9 @@ The PostgreSQL entity upsert changed from N individual INSERT statements in a si
 
 After optimizing database patterns and pipeline parallelism, the remaining bottlenecks were CPU-bound: cosine similarity, Levenshtein distance, PageRank, keyword extraction, and entity resolution. These operations are now accelerated via an optional Rust extension (`khora-accel`) that provides native implementations with automatic fallback to NumPy or pure Python. See [Rust Acceleration](rust-acceleration.md) for full details.
 
-### Concurrency Headroom (v0.2.1)
+### Concurrency Headroom
 
-With Rust handling CPU-intensive work, Python's event loop has more headroom for I/O concurrency. The default concurrency limits were doubled:
+With Rust handling CPU-intensive work, Python's event loop has more headroom for I/O concurrency. The default concurrency limits are:
 
 | Setting | Before | After | Where |
 |---------|--------|-------|-------|
@@ -388,9 +388,9 @@ With Rust handling CPU-intensive work, Python's event loop has more headroom for
 | `max_concurrent_documents` | 5 | 10 | `ingest_documents` |
 | `max_concurrent_extractions` | 10 | 20 | `ingest_documents` |
 
-These higher limits are safe because Rust acceleration reduces per-operation CPU time, leaving the GIL free for asyncio tasks.
+These limits are safe because Rust acceleration reduces per-operation CPU time, leaving the GIL free for asyncio tasks.
 
-## Phase 8: VectorCypher Query Optimizations (v0.3.5)
+## Phase 8: VectorCypher Query Optimizations
 
 ### Coherence Scoring
 
@@ -406,7 +406,7 @@ config = RetrieverConfig(
 
 `bigram_coherence_score()` checks function-word transitions (articles → content words, prepositions → noun phrases). The score is blended into the RRF score via `apply_coherence_boost()`. This adds negligible latency (pure Python string analysis, no LLM calls) while improving confounder rejection when LLM reranking is disabled (`KHORA_QUERY_ENABLE_LLM_RERANKING=false`).
 
-## Phase 9: Neo4j Write Contention Elimination (v0.3.9)
+## Phase 9: Neo4j Write Contention Elimination
 
 ### The Problem
 
@@ -459,19 +459,13 @@ This is a classic deadlock prevention technique: when all transactions acquire r
 
 ### Relative Recency Scoring
 
-Recency decay previously used `datetime.now()` (wall-clock time) as the reference point. This had two problems:
+Recency decay uses `max(occurred_at)` from the result set as the reference timestamp rather than `datetime.now()` (wall-clock time). A wall-clock reference has two problems:
 
-1. **Non-deterministic** - the same query run seconds apart could produce different scores
-2. **Clock-dependent** - scoring behaved differently across timezones or clock-skewed environments
-
-The recency calculation now uses `max(occurred_at)` from the result set as the reference timestamp:
+1. **Non-deterministic** - the same query run seconds apart can produce different scores
+2. **Clock-dependent** - scoring behaves differently across timezones or clock-skewed environments
 
 ```python
-# Before: wall-clock reference
-now = datetime.now(tz=UTC)
-age_days = (now - doc.occurred_at).total_seconds() / 86400
-
-# After: result-relative reference
+# Result-relative reference:
 max_occurred = max(doc.occurred_at for doc in results)
 age_days = (max_occurred - doc.occurred_at).total_seconds() / 86400
 ```

--- a/docs/architecture/rust-acceleration.md
+++ b/docs/architecture/rust-acceleration.md
@@ -233,7 +233,7 @@ Weighted PageRank for skeleton indexing (where ~10% of chunks are identified as 
 - `khora._accel.pagerank` - called by the skeleton engine's `_calculate_pagerank` (uniform init, document-time)
 - `khora._accel.build_chunk_edges` - called by the skeleton engine's `_build_chunk_edges`
 
-The `personalization` parameter (added in v0.12.0, Issue #597) is the enabler for the HippoRAG-2 query-time graph scoring tracked in Issue #542 - seeding PPR from query entities can produce sharper passage scores than BFS + RRF on dense graphs. The actual VectorCypher swap from BFS+RRF → PPR remains gated on the graph-density audit (`scripts/audit_graph_density.py`, Issue #598) and is not enabled by default; until the audit confirms the lift, callers passing `personalization=None` (every existing call site) get identical behaviour to pre-v0.12.0.
+The `personalization` parameter (Issue #597) is the enabler for the HippoRAG-2 query-time graph scoring tracked in Issue #542 - seeding PPR from query entities can produce sharper passage scores than BFS + RRF on dense graphs. The actual VectorCypher swap from BFS+RRF → PPR remains gated on the graph-density audit (`scripts/audit_graph_density.py`, Issue #598) and is not enabled by default; passing `personalization=None` runs uniform PageRank.
 
 ---
 

--- a/docs/architecture/storage-backends.md
+++ b/docs/architecture/storage-backends.md
@@ -341,7 +341,7 @@ neighborhood = await coordinator.get_neighborhood(
 await coordinator.disconnect()
 ```
 
-### Namespace-scoped reads and writes (v0.16.0)
+### Namespace-scoped reads and writes
 
 Every read, exists-check, and mutation method on each storage backend Protocol takes `*, namespace_id: UUID` as a required keyword-only parameter and filters at the SQL / Cypher / SurrealQL layer. The namespace is **never** post-checked against a returned row - when an id belongs to a different namespace, the backend returns `None` / an empty result / `False` straight from the query. The full surface tightened in PRs #761, #765, #766, #769:
 
@@ -354,7 +354,7 @@ The coordinator's public `coordinator.{relational,vector,graph,event_store}` att
 2. Refuses to dispatch any of the namespace-scoped read methods listed above unless the caller passes `namespace_id=…` (raises `TypeError`).
 3. Does not forward access to underscore-prefixed attributes - backend internals such as `_engine`, `_handle`, `_conn`, `_session_factory` are only reachable via the private `coord._{role}` accessors used by coordinator internals.
 
-The public `coordinator.{relational,vector,graph,event_store}` attributes are scheduled for removal in v0.17. Internal coordinator code uses `self._{role}` directly.
+The public `coordinator.{relational,vector,graph,event_store}` attributes are deprecated; call the coordinator's facade methods instead. Internal coordinator code uses `self._{role}` directly.
 
 A structural signature gate (`tests/security/test_cross_namespace_idor_signatures.py`) walks every concrete backend at collection time and asserts that every `get_*` / `entity_exists` / `find_paths` / `get_neighborhood*` / `delete_*` / `update_entity*` / `supersede_*` method with a required id-typed parameter declares `*, namespace_id: UUID` kwarg-only. A new method that violates this contract fails CI at collection time. See `docs/architecture/multi-tenancy.md` for the structural invariant rationale.
 
@@ -576,7 +576,7 @@ The doubled `GRAPH` in `KHORA_STORAGE_GRAPH_GRAPH_NAME` is not a typo — the fi
 
 **When to use:** When you want graph queries without adding another database to your stack. AGE runs inside PostgreSQL, so there is no extra infrastructure to manage.
 
-**UUID interpolation hardening (v0.16.0).** AGE's `cypher()` SQL function rejects `$param` placeholders, so UUIDs are interpolated directly into the Cypher source. `AgeBackend._uuid_lit(value)` routes every UUID interpolation site (in `storage/backends/age.py`) through `UUID(...)` validation before string conversion. This is type-safe today - every caller passes `uuid.UUID` - and injection-resistant against future duck-typed callers that might pass a `str`. Invalid UUIDs fail fast at the boundary with a `ValueError`, never reaching the graph store.
+**UUID interpolation hardening.** AGE's `cypher()` SQL function rejects `$param` placeholders, so UUIDs are interpolated directly into the Cypher source. `AgeBackend._uuid_lit(value)` routes every UUID interpolation site (in `storage/backends/age.py`) through `UUID(...)` validation before string conversion. This is type-safe today - every caller passes `uuid.UUID` - and injection-resistant against future duck-typed callers that might pass a `str`. Invalid UUIDs fail fast at the boundary with a `ValueError`, never reaching the graph store.
 
 ## SurrealDB: The Unified Backend
 
@@ -626,9 +626,9 @@ src/khora/storage/backends/surrealdb/
 └── _helpers.py       # Shared utilities (UUID conversion, _rid binding, etc.)
 ```
 
-### `RELATES_TO` schema (v0.16.0)
+### `RELATES_TO` schema
 
-The `relates_to` RELATION table now carries a Khora-owned identity column:
+The `relates_to` RELATION table carries a Khora-owned identity column:
 
 ```surql
 DEFINE TABLE IF NOT EXISTS relates_to TYPE RELATION SCHEMAFULL;
@@ -637,22 +637,22 @@ DEFINE FIELD IF NOT EXISTS rel_id ON relates_to TYPE string;
 DEFINE INDEX IF NOT EXISTS idx_relates_to_rel_id ON relates_to FIELDS rel_id UNIQUE;
 ```
 
-`rel_id` stores the Khora `Relationship.id` UUID. Until v0.16.0 the graph adapter relied on SurrealDB's auto-generated record id, but `SCHEMAFULL` plus the parameterized-id bug below meant some `RELATE` writes silently dropped their endpoints and Khora's `Relationship.id` was not round-tripped at all. The `UNIQUE` index on `rel_id` lets `get_relationship(...)` look up edges by the Khora id without colliding with adjacent rows.
+`rel_id` stores the Khora `Relationship.id` UUID. The `UNIQUE` index on `rel_id` lets `get_relationship(...)` look up edges by the Khora id without colliding with adjacent rows.
 
-### `table:⟨$var⟩` interpolation bug fix (v0.16.0, PR #770)
+### `table:⟨$var⟩` interpolation (PR #770)
 
-SurrealDB does not substitute parameters inside the RecordID-literal shorthand `table:⟨$var⟩` - the `$var` reaches the engine as a literal string. 19 sites across `storage/backends/surrealdb/{graph,vector}.py` were silently broken before v0.16.0: `graph.get_relationship`, `vector.get_chunk`, and `vector.get_chunks_by_document` always returned `None` / empty, and every relationship row stored by `RELATE` had corrupted `in` / `out` endpoints with a `rel_id` of `None` (the `SCHEMAFULL` table dropped the writes without raising). The fix is two-fold:
+SurrealDB does not substitute parameters inside the RecordID-literal shorthand `table:⟨$var⟩` - the `$var` reaches the engine as a literal string. Khora avoids this in two ways:
 
 - Bind via the `_rid()` parameter helper (in `surrealdb/_helpers.py`), which constructs a real `RecordID` object Surreal honours as a parameter.
 - Use `(type::thing($var))` in `FOR` loops where a parameter-substituted record-id is needed inside SurrealQL.
 
-Combined with the new `rel_id` field + `UNIQUE` index, the graph adapter now writes and reads relationships correctly under embedded, memory, and remote modes.
+Combined with the `rel_id` field + `UNIQUE` index, the graph adapter writes and reads relationships correctly under embedded, memory, and remote modes.
 
 ### SurrealDB transactions and batching
 
 SurrealDB supports SurrealQL-level transactions (`BEGIN` / `COMMIT` / `CANCEL`) on the WebSocket connection. The Python client surfaces these as ordinary queries in remote mode. Embedded (`surrealkv://`) and memory (`memory://`) modes raise `UnsupportedFeatureError` on `BEGIN`, so khora preserves the per-statement-atomicity contract there and exposes a batched alternative.
 
-`SurrealDBConnection` (v0.12.0) ships three primitives:
+`SurrealDBConnection` ships three primitives:
 
 | Method / property | Remote (`ws://`) | Embedded / memory |
 |---|---|---|
@@ -689,7 +689,7 @@ The coordinator's `StorageCoordinator.transaction()` remains session-shaped (SQL
 | **SurrealDB** | WebSocket/HTTP | Unified single-server setup |
 | **LanceDB** | Embedded (file-backed) | Chronicle engine, zero-infrastructure deployments |
 
-### `sqlite_lance` defense-in-depth (v0.16.0, PR #769)
+### `sqlite_lance` defense-in-depth (PR #769)
 
 The `sqlite_lance` adapter pairs SQLite (chunk metadata, source of truth) with LanceDB (vector index). After the LanceDB nearest-neighbour query returns a list of chunk ids, the SQLite re-fetch step now adds `AND namespace_id = ?` to the row lookup rather than trusting LanceDB's filter alone. If LanceDB's where-clause ever regresses, the SQLite filter still keeps cross-namespace rows out of the result.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,7 +55,7 @@ Programmatic values take priority over environment variables.
 | `sqlite` | SQLite embedded relational + vector | `aiosqlite>=0.20.0` |
 | `lancedb` | LanceDB embedded vector store | `lancedb>=0.17.0`, `pyarrow` |
 | `sqlite-lance` | **[experimental]** Unified SQLite + LanceDB embedded backend. Recommended embedded stack; covers VectorCypher / Skeleton / Chronicle | `lancedb>=0.17.0`, `aiosqlite>=0.20.0`, `pyarrow` |
-| `binary-readers` | PDF / docx / xlsx readers (used by khora-cli and downstream ingestors) | `pymupdf`, `openpyxl`, `python-docx` |
+| `binary-readers` | PDF / docx / xlsx readers (used by downstream ingestors) | `pymupdf`, `openpyxl`, `python-docx` |
 | `parquet` | Parquet readers | `pyarrow>=18.0.0` |
 | `nlp` | spaCy-based sentence splitting | `spacy>=3.8` |
 | `otel` | OpenTelemetry SDK + OTLP/HTTP exporter (vendor-neutral) | `opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-http` |
@@ -200,7 +200,7 @@ The SurrealDB backend is feature-complete (relational + vector + graph + KV in a
 
 Connection schemes: `memory://` (in-process), `surrealkv://...` (embedded file), `ws://...` (remote). Note: `Khora("memory://")` does **not** route to SurrealDB today - the positional argument is treated as the PostgreSQL `database_url`. Set `KHORA_STORAGE_BACKEND=surrealdb` and the relevant `KHORA_STORAGE_SURREALDB_*` settings explicitly.
 
-Remote (`ws://`) mode supports atomic multi-statement transactions via `conn.transaction()` since v0.12.0. Embedded (`surrealkv://`) and memory (`memory://`) modes are per-statement atomic only - `transaction()` is a no-op there, and multi-statement atomicity is approximated by `execute_batch()` (joins statements with `;`). See [architecture/storage-backends.md](architecture/storage-backends.md#surrealdb) for the capability matrix.
+Remote (`ws://`) mode supports atomic multi-statement transactions via `conn.transaction()`. Embedded (`surrealkv://`) and memory (`memory://`) modes are per-statement atomic only - `transaction()` is a no-op there, and multi-statement atomicity is approximated by `execute_batch()` (joins statements with `;`). See [architecture/storage-backends.md](architecture/storage-backends.md#surrealdb) for the capability matrix.
 
 ## LLM
 
@@ -255,7 +255,7 @@ Prefix: `KHORA_QUERY_`. See [query-engine/retrieval-tuning.md](query-engine/retr
 | `KHORA_QUERY_RECENCY_WEIGHT` | `0.2` | How strong the recency bias is. |
 | `KHORA_QUERY_ENABLE_HYDE` | `auto` | HyDE query expansion: `auto` / `always` / `never` (legacy booleans normalize to `always` / `never`). RECENCY / STATE_QUERY / CHANGE queries automatically get a time-anchored prompt - see [temporal-queries.md](query-engine/temporal-queries.md#temporal-anchored-hyde). |
 | `KHORA_QUERY_HYDE_NUM_HYPOTHETICALS` | `1` | Number of hypothetical documents to generate (1–5). |
-| `KHORA_QUERY_ENABLE_HYDE_CYPHER` | `false` | **v0.12.0, opt-in.** Run LLM-picked parameterized Cypher templates as an extra retrieval channel for structured RECENCY queries. See [retrieval-tuning.md](query-engine/retrieval-tuning.md). |
+| `KHORA_QUERY_ENABLE_HYDE_CYPHER` | `false` | **Opt-in.** Run LLM-picked parameterized Cypher templates as an extra retrieval channel for structured RECENCY queries. See [retrieval-tuning.md](query-engine/retrieval-tuning.md). |
 | `KHORA_QUERY_HYDE_CYPHER_LIMIT` | `20` | Max entities returned per HyDE-Cypher template execution. |
 | `KHORA_QUERY_ENABLE_RERANKING` | `true` | Cross-encoder reranking of top candidates. |
 | `KHORA_QUERY_TEMPORAL_SQL_PUSHDOWN` | `true` | Push relative-date filters into SQL WHERE clauses. |

--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -1,71 +1,16 @@
-# Downstream Consumers
+# Public API
 
-Khora is a library. Its stable public API is consumed by several first-party packages. This page is the quick map for anyone asking "where did `khora extract` go?" or "how do I plug khora into my service?"
+Khora is a library. Its stable public API is consumed by services and notebooks. This page documents the public surface that downstream code may rely on.
 
-## Sibling packages
+## No in-library CLI
 
-### khora-cli
+The CLI commands (`khora extract`, `khora search`, `khora ontology …`) were removed from the `khora` package so the library has no CLI dependencies. The `khora` top-level imports (`Khora`, `KhoraConfig`, `SearchMode`, `ExpertiseConfig`, etc.) are unchanged — call them directly from your service or notebook. See [migrations.md](migrations.md#v080---cli-extraction) for the removal notice.
 
-khora-cli (to be released soon) - extract and search CLI.
-
-```bash
-uv pip install khora-cli
-uv run khora-cli extract report.pdf
-uv run khora-cli search "Who worked on the API design?" -n <namespace-id>
-```
-
-Prior to khora v0.8.0, these commands shipped as `uv run khora extract` / `uv run khora search`. The package was split out so that the library has no CLI dependencies (no `click`, no `rich`, no PDF/Excel readers by default). If you need the binary readers without the CLI, install `pip install khora[binary-readers]` and import `from khora.extraction.binary_readers import extract_if_needed`.
-
-khora-cli imports a narrow slice of khora's public API:
+The one piece of CLI-flavoured functionality available inside the library is binary-document text extraction. Install with `pip install khora[binary-readers]` and import directly:
 
 ```python
-from khora import (
-    Khora, KhoraConfig, SearchMode, LLMUsage,
-    RememberResult, RecallResult, BatchResult,
-)
 from khora.extraction.binary_readers import extract_if_needed
-from khora.logging_config import setup_logging
 ```
-
-### khora-explorer
-
-khora-explorer (to be released soon) - ontology construction, validation, and preview.
-
-```bash
-uv pip install khora-explorer
-uv run khora-explorer construct --source <path-or-glob>
-uv run khora-explorer validate my_ontology.yaml
-uv run khora-explorer preview my_ontology.yaml
-```
-
-Prior to v0.7.52 these lived under `uv run khora ontology …` and the underlying `khora.discovery` package. They were extracted because ontology construction needs a heavier dependency set (PDF/HTML scraping, Firecrawl fallback, multi-provider LLM routing) than this library should carry.
-
-khora-explorer imports:
-
-```python
-from khora.extraction.skills.base import (
-    ExpertiseConfig, EntityTypeConfig, RelationshipTypeConfig,
-    ConfidenceConfig, ExpansionConfig, CorrelationRule, InferenceRule,
-)
-from khora.config.schema import KhoraConfig
-```
-
-## Migration from pre-v0.8 khora
-
-If your project installed `khora` before v0.8.0 and used the CLI:
-
-| Before (khora ≤ 0.7.51) | After (khora ≥ 0.8.0) |
-|---|---|
-| `uv run khora extract file.pdf` | `uv pip install khora-cli && uv run khora-cli extract file.pdf` |
-| `uv run khora search "query" -n ns` | `uv run khora-cli search "query" -n ns` |
-| `uv run khora ontology construct --source …` | `uv pip install khora-explorer && uv run khora-explorer construct --source …` |
-| `uv run khora ontology validate file.yaml` | `uv run khora-explorer validate file.yaml` |
-| `uv run khora ontology preview file.yaml` | `uv run khora-explorer preview file.yaml` |
-| `from khora.discovery.extraction import extract_if_needed` | `from khora.extraction.binary_readers import extract_if_needed` |
-| `from khora.discovery import …` | Install `khora-explorer`. Module has moved. |
-| `from khora.cli import …` | Install `khora-cli`. Module has moved. |
-
-The `khora` top-level imports (`Khora`, `KhoraConfig`, `SearchMode`, `ExpertiseConfig`, etc.) are unchanged and continue to work.
 
 ## Stability contract
 
@@ -101,10 +46,8 @@ Canonical machine-readable contract: `__all__` in `src/khora/extraction/skills/b
 ### Versioning policy
 
 - **Additive changes** are permitted in minor and patch releases: new optional dataclass fields with defaults, new optional keyword arguments to existing methods, new helper modules. Adding a field must preserve existing `from_dict` / `to_dict` round-trips for older payloads.
-- **Breaking changes** require a major version bump: renaming or removing a field/method, changing a type, changing a default in a way that alters observable behaviour, removing a class. Breaking changes coordinate with the published consumer packages (khora-cli, khora-explorer).
-- **Security exception.** Breaking changes that close a confidentiality or integrity vulnerability may land in a patch release without a major bump. The patch CHANGELOG entry calls out the affected signatures under `### Changed (breaking)` and the corresponding security finding under `### Security`. Coordinated consumer-package updates still apply; the carve-out only covers the timing of the bump, not the disclosure. Examples:
-  - **v0.15.1** promoted `kb.get_entity` and the `kb.storage` getters (`get_entity` / `get_relationship` / `get_episode` / `get_chunk` / `get_chunks_batch` / `get_chunks_by_document`) to require a `namespace` / `namespace_id` keyword argument.
-  - **v0.16.0** (PRs #761 / #765 / #766 / #769) closed out the rest of the cross-namespace IDOR family. Every read, exists-check, and mutation on every storage backend (`RelationalBackend`, `VectorBackend`, `GraphBackend`, `EventStore`) now requires `*, namespace_id: UUID` (kwarg-only) and filters at the SQL / Cypher / SurrealQL layer rather than post-fetch. `Khora.get_document(doc_id, *, namespace=…)` requires the namespace kwarg. `StorageCoordinator.{relational,vector,graph,event_store}` is wrapped in a `NamespaceRequiredProxy` that emits one `DeprecationWarning` per role per process on first access; the public attributes are kept as a deprecation surface and will be removed in v0.17 - internal canonical references are `self._{relational,vector,graph,event_store}`. A signature-level regression gate (`tests/security/test_cross_namespace_idor_signatures.py`) blocks future drift at test-collection time.
+- **Breaking changes** require a major version bump: renaming or removing a field/method, changing a type, changing a default in a way that alters observable behaviour, removing a class. Breaking changes are recorded in CHANGELOG.md.
+- **Security exception.** Breaking changes that close a confidentiality or integrity vulnerability may land in a patch release without a major bump. The patch CHANGELOG entry calls out the affected signatures under `### Changed (breaking)` and the corresponding security finding under `### Security`. The cross-namespace IDOR close-out (`namespace_id` required on every storage read/write) was landed under this exception - see [migrations.md](migrations.md) and [CHANGELOG.md](../CHANGELOG.md).
 - `from_dict` for extraction-skill dataclasses preserves backward compatibility with historical YAML/JSON payloads for at least one major version after schema evolution.
 
 ### What's NOT pinned
@@ -112,7 +55,7 @@ Canonical machine-readable contract: `__all__` in `src/khora/extraction/skills/b
 - Anything not listed in either `__all__`.
 - Internal models exported from `khora.core.models` - `Document`, `Chunk`, `Entity`, `Episode`, `Relationship`, `MemoryEvent`. Their shapes are dictated by storage schemas and may evolve; consumers that persist these objects should copy them into their own types.
 - The `khora.chat` module aside from `ChatResponse`. The rest (`ChatEngine`, `ChatMessage`, `ConversationHistory`, `HistoryManager`, `PersonaConfig`, `load_persona_config`, `PromptGenerator`) is evolving; breaking changes are announced in CHANGELOG `### Deprecated` one minor release before removal.
-- The `khora.storage.StorageCoordinator` surface exposed via the `Khora.storage` property. The property exists; its API is not pinned. **Note (v0.16.0):** `StorageCoordinator.{relational,vector,graph,event_store}` are now `NamespaceRequiredProxy` wrappers - they emit a `DeprecationWarning` on first access per role per process and refuse dispatch on read methods missing `namespace_id=`. The public attributes are removed in v0.17. Downstream code that needs the unwrapped backends should call coordinator-level methods (all of which take `namespace_id=` as a kwarg-only argument) instead.
+- The `khora.storage.StorageCoordinator` surface exposed via the `Khora.storage` property. The property exists; its API is not pinned. `StorageCoordinator.{relational,vector,graph,event_store}` are `NamespaceRequiredProxy` wrappers - they emit a `DeprecationWarning` on first access per role per process and refuse dispatch on read methods missing `namespace_id=`. Downstream code that needs the unwrapped backends should call coordinator-level methods (all of which take `namespace_id=` as a kwarg-only argument) instead.
 - Anything whose name starts with an underscore.
 
 For full method signatures and dataclass field lists, read the symbols directly (`help(Khora)`, the source on GitHub, or your IDE's type-stub navigation).
@@ -121,10 +64,10 @@ For full method signatures and dataclass field lists, read the symbols directly 
 
 For a new downstream consumer:
 
-1. `pip install khora[<backend-of-choice>]` - pick the backend matrix that matches your infra (`postgres`-default for PG, `surrealdb` for zero-infra, `all-backends` if unsure).
+1. `pip install khora[<backend-of-choice>]` - pick the backend matrix that matches your infra (`postgres`-default for PG, `surrealdb` for zero-infra, `all-backends` if unsure). For binary-document ingestion, add `khora[binary-readers]`.
 2. Either call `khora.logging_config.setup_logging()` once per process, or configure your own loguru sinks with `enqueue=True`. The default loguru sink blocks the event loop in async code - see [configuration.md](configuration.md#logging).
 3. Run migrations (for PostgreSQL) - pass `run_migrations=True` to `Khora` or invoke `alembic upgrade head` out-of-band. See [migrations.md](migrations.md).
 4. Import only from the symbols listed in [api-reference.md](api-reference.md) unless you are willing to follow khora's internal churn.
-5. Pin Khora by major version. Minor-version upgrades are safe; majors may require coordinated releases.
+5. Pin Khora by major version. Minor-version upgrades are safe; majors may include breaking API changes documented in CHANGELOG.md.
 6. **Reading credentials back out of `KhoraConfig`?** Credential fields are `pydantic.SecretStr` - call `.get_secret_value()` for the cleartext. `str(cfg.storage.postgresql_url)` returns `'**********'` by design. See [configuration.md](configuration.md#secretstr-typed-credential-fields).
 7. **Need spans/metrics?** Install `khora[otel]` and call `khora.telemetry.configure_telemetry()` at process startup, or rely on env-based auto-bootstrap. See [observability.md](observability.md) for the precedence rules and vendor recipes.

--- a/docs/data-models/documents-chunks.md
+++ b/docs/data-models/documents-chunks.md
@@ -211,7 +211,7 @@ async with Khora() as kb:
 
 ```python
 # Get document by ID. `namespace_id` is required and kwarg-only -
-# returns None if the document is not in this namespace (v0.16.0).
+# returns None if the document is not in this namespace.
 doc = await kb.storage.get_document(document_id, namespace_id=namespace_id)
 print(f"Status: {doc.status}")
 print(f"Chunk count: {doc.chunk_count}")

--- a/docs/data-models/knowledge-graph.md
+++ b/docs/data-models/knowledge-graph.md
@@ -375,7 +375,7 @@ for entity, score in related:
 
 ```python
 # Get entity neighborhood (graph context). namespace_id is required and
-# kwarg-only (v0.16.0) - the traversal does not cross into other namespaces.
+# kwarg-only - the traversal does not cross into other namespaces.
 neighborhood = await kb.storage.get_neighborhood(
     entity_id,
     namespace_id=namespace_id,

--- a/docs/data-models/overview.md
+++ b/docs/data-models/overview.md
@@ -299,7 +299,7 @@ await storage.create_document(doc)
 
 ```python
 # Get a document. `namespace_id` is required and kwarg-only - the lookup
-# returns None if the id belongs to a different namespace (v0.16.0).
+# returns None if the id belongs to a different namespace.
 doc = await storage.get_document(doc_id, namespace_id=namespace_id)
 
 # Find entities by type (list-style scan; namespace_id is positional).

--- a/docs/dream-phase.md
+++ b/docs/dream-phase.md
@@ -4,7 +4,7 @@
 
 The naming follows the complementary learning systems framework from neuroscience: ingestion is the fast, episodic path (`Khora.remember`), dream phase is the slow, reorganizing path. Same store, different access regime, different objective function. See [Research & Prior Art](#research--prior-art) for the lineage.
 
-> **v0.15.0 status - read this once before scheduling anything in prod.**
+> **Status - read this once before scheduling anything in prod.**
 > Ten ops are live: five Phase-1 audits (read-only, no side effects) and five Phase-2 planners (planning + apply). Apply mode mutates your graph through bi-temporal soft-delete and one hard-delete path (`fact_compaction` on already-tombstoned rows past retention). Five guardrails protect the apply path: hard 7-day retention floor, `KHORA_DREAM_DISABLE_APPLY` env-var kill-switch, advisory-lock-held-through-apply, `chunk_id` runtime assertion, snapshot-before-mutate undo records. Default config is `enabled=False`; nothing happens until you opt in.
 
 ## When to use it
@@ -104,7 +104,7 @@ Joins entities × chunks (Postgres `unnest`; SQLite Python-side) and reports tot
 
 ### Planner operations (Phase 2)
 
-Each op emits one `DreamOp` per work item with `decision` describing what it would do. **Both modes are live in v0.15**: `mode="dry-run"` emits the plan only; `mode="apply"` runs the matching `apply_<op>` handler under per-op transactions, with the pre-state snapshotted into `undo.json` before each mutation. The plan is checkpointed to `khora_dream_runs` so a crashed run can resume via `resume_from=<run_id>`.
+Each op emits one `DreamOp` per work item with `decision` describing what it would do. **Both modes are live**: `mode="dry-run"` emits the plan only; `mode="apply"` runs the matching `apply_<op>` handler under per-op transactions, with the pre-state snapshotted into `undo.json` before each mutation. The plan is checkpointed to `khora_dream_runs` so a crashed run can resume via `resume_from=<run_id>`.
 
 #### VectorCypher: cross-batch entity dedupe
 
@@ -154,7 +154,7 @@ Writes per-run artifacts under `{base_dir}/{namespace_id}/{date}/{run_id}.*`:
 | `summary.md` | Human-readable executive summary + sampled high-impact ops |
 | `events.jsonl` | One `DreamOp` per line, machine-readable, schema-versioned (`dream-report/1`) |
 | `manifest.json` | Run metadata + checksum |
-| `undo.json` | Empty in v0.15 (audit + planner ops have no undo state); populated when apply lands |
+| `undo.json` | Pre-state snapshots per mutating op (apply mode); empty for audit-only / dry-run reports |
 
 Schema version is asserted on read. `redact_text` (`"none" | "summary" | "all"`, default `"summary"`) governs raw-text exposure across all three sinks. Retention via `DreamConfig.retention_days` (default 30) and `retention_runs_per_namespace` (default 50) - rotation is a sweep, not real-time.
 
@@ -167,7 +167,7 @@ Bridges into the existing `HookDispatcher` via six `EventType.DREAM_*` values: `
 Emits spans and metrics declared in [`telemetry-contract.json`](telemetry-contract.json). The drift gate at `tests/unit/telemetry/test_contract.py` enforces that any new span / metric introduced by the orchestrator or an op is registered.
 
 **Public top-level spans** (operator-facing, stable):
-- `khora.dream.run`, `khora.dream.phase`, `khora.dream.llm_call` (reserved for v0.16+), `khora.dream.undo` (reserved for v0.16+)
+- `khora.dream.run`, `khora.dream.phase`, `khora.dream.llm_call` (reserved), `khora.dream.undo` (reserved)
 
 **Internal per-op spans** (names may evolve; don't pin dashboards):
 - `khora.dream.chronicle.{abstention_drift,tombstone_audit,fact_compaction,event_clustering}`
@@ -178,15 +178,15 @@ Emits spans and metrics declared in [`telemetry-contract.json`](telemetry-contra
 - `khora.dream.run.duration {trigger, outcome}` (histogram, seconds)
 - `khora.dream.phase.duration {phase, outcome}` (histogram)
 - `khora.dream.ops_total {phase, op_type, decision}`
-- `khora.dream.llm.tokens {direction, model}` (reserved for v0.16+)
-- `khora.dream.undo_invocations_total {op_type, outcome}` (reserved for v0.16+)
+- `khora.dream.llm.tokens {direction, model}` (reserved)
+- `khora.dream.undo_invocations_total {op_type, outcome}` (reserved)
 - `khora.dream.report.write_failures_total {reason}` (internal)
 
 All free-text attributes (rationale strings, entity names) go through `khora.telemetry.bounded_text_hash` before becoming span attributes. Raw text is never exposed as a label - privacy and cardinality both.
 
 ## API reference
 
-Every public symbol exported from `khora.dream.*` plus the top-level entry point. The dataclasses returned from `Khora.dream()` are **public** (subject to coordinated release with `khora-cli` / `khora-explorer`); the planner functions and orchestrator internals are **internal** (names may evolve through v0.16).
+Every public symbol exported from `khora.dream.*` plus the top-level entry point. The dataclasses returned from `Khora.dream()` are **public**; the planner functions and orchestrator internals are **internal** (names may evolve).
 
 ### Top-level entry points
 
@@ -224,7 +224,7 @@ Functional equivalents live at `khora.dream.api.{dream, dream_status, dream_hist
 | `report_{file,event,collector}_sink_enabled` | `False` | Sink toggles |
 | `redact_text` | `"summary"` | `"none" \| "summary" \| "all"` |
 | `abstention_drift_min_samples` / `_sample_cap` | `1000` / `1024` | Floor before recommending; ring-buffer cap per namespace |
-| `fact_compaction_retention_days` | `365` | Age threshold for tombstone hard-delete (apply v0.16) |
+| `fact_compaction_retention_days` | `365` | Age threshold for tombstone hard-delete |
 | `cooccurrence_edge_weight` | `0.2` | `ASSOCIATED_WITH` down-weight in orphan PageRank |
 | `orphan_pr_percentile_threshold` | `5.0` | Bottom-percentile cut-off |
 | `source_chunk_ids_gc_min_dead` | `1` | Min dead-UUID count to plan GC for an entity |
@@ -247,11 +247,11 @@ Functional equivalents live at `khora.dream.api.{dream, dream_status, dream_hist
 | `CHRONICLE_ABSTENTION_DRIFT_REPORT` | `chronicle_abstention_drift_report` | 1 (audit) | pass-through |
 | `CHRONICLE_TOMBSTONE_AUDIT` | `chronicle_tombstone_audit` | 1 (audit) | pass-through |
 | `VECTORCYPHER_DEDUPE_ENTITIES` | `vectorcypher_dedupe_entities` | 2 (planner) | `apply_vectorcypher_dedupe_entities` - bi-temporal soft-delete + relationship rewrite. Postgres-only. |
-| `VECTORCYPHER_CENTROID_RECOMPUTE` | `vectorcypher_centroid_recompute` | 2 (planner) | `apply_vectorcypher_centroid_recompute` - overwrites canonical entity embedding. Postgres-only in v0.15; SQLite-LanceDB path lands v0.16. |
+| `VECTORCYPHER_CENTROID_RECOMPUTE` | `vectorcypher_centroid_recompute` | 2 (planner) | `apply_vectorcypher_centroid_recompute` - overwrites canonical entity embedding. Postgres-only. |
 | `VECTORCYPHER_SOURCE_CHUNK_IDS_GC` | `vectorcypher_source_chunk_ids_gc` | 2 (planner) | `apply_vectorcypher_source_chunk_ids_gc` - array filter. Dialect-aware. Idempotent. |
 | `CHRONICLE_FACT_COMPACTION` | `chronicle_fact_compaction` | 2 (planner) | `apply_chronicle_fact_compaction` - **only hard-delete op**. Snapshots full rows into undo.json before DELETE. 7-day retention floor. |
 | `CHRONICLE_EVENT_CLUSTERING` | `chronicle_event_clustering` | 2 (planner) | `apply_chronicle_event_clustering` - bi-temporal soft-merge via `merged_into_event_id` (migration 034). |
-| `VECTORCYPHER_NORMALIZE_SCHEMA` | `vectorcypher_normalize_schema` | 5.4 (planner + apply) | `apply_vectorcypher_normalize_schema` - operator-supplied `old_type -> new_type` mapping; rewrites `entity_type` / `relationship_type` and emits one `ENTITY_UPDATED` / `RELATIONSHIP_UPDATED` event per row. Refuses to run on empty mapping. **Coordinated-release impact:** type names are part of the consumer contract (`khora-cli`, `khora-explorer`). |
+| `VECTORCYPHER_NORMALIZE_SCHEMA` | `vectorcypher_normalize_schema` | 5.4 (planner + apply) | `apply_vectorcypher_normalize_schema` - operator-supplied `old_type -> new_type` mapping; rewrites `entity_type` / `relationship_type` and emits one `ENTITY_UPDATED` / `RELATIONSHIP_UPDATED` event per row. Refuses to run on empty mapping. **Consumer-contract impact:** type names are part of the public stability contract - see [consumers.md](consumers.md). |
 
 ### Plan / scope / result dataclasses
 
@@ -372,9 +372,9 @@ Adds three NULLable columns to both `relationships` and `memory_facts`:
 | `invalidated_at` | When the system marked this row superseded |
 | `invalidated_by` | UUID of the dream op (or future apply-mode operation) that invalidated it |
 
-Plus Postgres-only partial composite indexes `ix_relationships_live` and `ix_memory_facts_live` over `WHERE invalidated_at IS NULL`. Existing query paths filtering on the legacy `memory_facts.is_active` flag keep working unchanged; the two coexist until a future major version.
+Plus Postgres-only partial composite indexes `ix_relationships_live` and `ix_memory_facts_live` over `WHERE invalidated_at IS NULL`. Query paths filtering on the `memory_facts.is_active` flag and the new `invalidated_at`-based filter coexist - the flag is deprecated but kept working for backwards compatibility.
 
-These columns are unused by Phase 1 audit and Phase 2 planner ops. They're already in place because apply mode (v0.16) needs them, and migrations land best ahead of the code that depends on them.
+These columns are unused by Phase 1 audit and Phase 2 planner ops. They're in place because future apply paths need them, and migrations land best ahead of the code that depends on them.
 
 ## Concurrency
 
@@ -431,18 +431,18 @@ The cleanest framing: dream phase is to memory what OLAP is to OLTP. Same store,
 
 ### Honest limits
 
-Dream phase does not solve memory drift. It provides the substrate to detect drift (audit mode, since v0.14), plan corrective ops (planner mode, since v0.15), and execute them with bi-temporal soft-delete + per-op undo snapshots (apply mode, since v0.15). What it does **not** do:
+Dream phase does not solve memory drift. It provides the substrate to detect drift (audit mode), plan corrective ops (planner mode), and execute them with bi-temporal soft-delete + per-op undo snapshots (apply mode). What it does **not** do:
 
 - Decide *when* to run. That's operator policy - cron / Temporal / k8s CronJob.
 - Validate that a planned op makes business sense. The planner uses heuristics (cosine, Levenshtein, age thresholds); operators are expected to dry-run several times and review the file-sink reports before flipping to apply.
-- Reverse an applied op automatically. Undo records are persisted to `undo.json` (schema `dream-undo/1`) but there is no `kb.undo(run_id)` API. Restoring from the snapshot is a hand-rolled operation in v0.15; an automated undo player lands in v0.16.
+- Reverse an applied op automatically. Undo records are persisted to `undo.json` (schema `dream-undo/1`) but there is no `kb.undo(run_id)` API. Restoring from the snapshot is a hand-rolled operation; an automated undo player is planned.
 - Replace good ingest-time decisions. If dedupe finds 10,000 candidate merges in a fresh namespace, the bug is upstream - in the extraction pipeline, the embedding model choice, or the per-type thresholds - not in dream phase.
 
 ## Stability
 
 | Symbol | Tag | Notes |
 |---|---|---|
-| `Khora.dream()`, `dream_status()`, `dream_history()` | **public** | Coordinated release with `khora-cli` / `khora-explorer` |
+| `Khora.dream()`, `dream_status()`, `dream_history()` | **public** | - |
 | `DreamConfig`, `DreamResult`, `DreamRunInfo`, `DreamMode`, `DreamScope`, `OpKind` | **public** | Re-exported from top-level `khora` |
 | Dream-specific exceptions (`DreamDisabledError`, `DreamApplyDisabled`, `DreamForbiddenOpError`, `DreamRunStuckError`, `DreamLockUnavailable`) | **public** | Pattern-match from job runners |
 | `UndoRecord` | **public** | Returned by apply handlers; persisted into `undo.json` |
@@ -452,13 +452,13 @@ Dream phase does not solve memory drift. It provides the substrate to detect dri
 | Per-op OTel spans | **internal** | Names may evolve |
 | Planner functions (`plan_*`) and the orchestrator | **internal** | Call via `Khora.dream()` unless writing tests |
 
-## What's NOT in v0.15.0 - planned for v0.16+
+## Not yet implemented
 
 Tracked under the umbrella [#649](https://github.com/DeytaHQ/khora/issues/649).
 
 - **Phase 5 - advanced operations** (#670, #671, #672, #673). Community detection + LLM-generated summaries (GraphRAG-style; the first dream-phase ops to actually call an LLM, gated by the existing `llm_max_tokens_per_run` budget), edge pruning by weight × recency, contradiction detection across `memory_facts`, schema-drift normalization with an operator-supplied mapping.
-- **`apply_vectorcypher_centroid_recompute` on SQLite-LanceDB.** The handler is Postgres-only in v0.15 because the embedded vector backend's `update_entity_embedding` commits out-of-band, violating the caller-owned-transaction contract. SQLite path needs a session-aware vector-backend write API first.
-- **`apply_vectorcypher_dedupe_entities` Neo4j re-target.** v0.15 ships the Postgres `relationships` rewrite. The Neo4j edge re-target + archived-node path needs a different transactional shape (no shared session with PG) and is deferred.
+- **`apply_vectorcypher_centroid_recompute` on SQLite-LanceDB.** The handler is Postgres-only because the embedded vector backend's `update_entity_embedding` commits out-of-band, violating the caller-owned-transaction contract. The SQLite path needs a session-aware vector-backend write API first.
+- **`apply_vectorcypher_dedupe_entities` Neo4j re-target.** The Postgres `relationships` rewrite ships today. The Neo4j edge re-target + archived-node path needs a different transactional shape (no shared session with PG) and is deferred.
 - **Auto-chaining of dedupe → centroid_recompute.** Today `centroid_recompute` in the default plan dispatch receives `merge_clusters=[]` and emits no DreamOps. Real centroid plans require direct invocation with clusters from a prior dedupe run, or manual operator stitching via `resume_from`.
 - **Planner `mode="apply"` cleanup.** Two of the Phase 2 planners (`plan_vectorcypher_dedupe_entities`, `plan_vectorcypher_source_chunk_ids_gc`, `plan_vectorcypher_centroid_recompute`) still accept a `mode="apply"` kwarg that raises `NotImplementedError`. The orchestrator never sets this kwarg - the dedicated `apply_<op>` functions are the real apply entry point. The raise path is dead code reachable only from direct callers; removing the kwarg is a follow-up cleanup.
 

--- a/docs/engines/chronicle-engine.md
+++ b/docs/engines/chronicle-engine.md
@@ -116,17 +116,16 @@ async with Khora("memory://", engine="chronicle") as kb:
 
 ### Recall response shape
 
-Since v0.16.0 (#761), `result.documents` is always populated for every
-document referenced by a chunk in the result - Chronicle relies on the
-namespace-scoped coordinator facade to batch-fetch documents, never on
-the legacy public sub-backend attrs. The `RecallResult.context_text`
-attribute is gone; render a context string with the public
+`result.documents` is always populated for every
+document referenced by a chunk in the result (#761) - Chronicle relies on the
+namespace-scoped coordinator facade to batch-fetch documents. Render a
+context string with the public
 `khora.context_text(result, max_chunks=…)` helper if you need one.
 
 Chronicle's namespace scoping is enforced at the SQL/SurrealQL layer:
 every read filters by `namespace_id` directly rather than post-fetching
 and comparing in Python (which would leak existence as a timing oracle).
-See the v0.16.0 IDOR close-out (#769) for the full Protocol-level
+See the IDOR close-out (#769) for the full Protocol-level
 contract on every storage backend.
 
 ## Comparison with Other Engines

--- a/docs/engines/engine-comparison.md
+++ b/docs/engines/engine-comparison.md
@@ -2,9 +2,7 @@
 
 Khora supports three pluggable engines with different strengths. This guide helps you choose the right engine for your use case.
 
-> **Note (0.10.1):** The `graphrag` engine was removed in v0.10.1. Use `vectorcypher` (default) for hybrid graph+vector recall; set `engine_kwargs={"skeleton_core_ratio": 1.0}` for the legacy GraphRAG behavior of extracting entities from 100% of chunks instead of the default selective 70%.
-
-## Production-readiness by stack (v0.9.0)
+## Production-readiness by stack
 
 Production-readiness is **per (engine × stack)**, not per engine. The same engine can be production-ready on one storage stack and experimental on another.
 
@@ -14,7 +12,7 @@ Production-readiness is **per (engine × stack)**, not per engine. The same engi
 | Chronicle     | n/a (graph not required)       | **Production-ready**             | Experimental                | Experimental               |
 | Skeleton      | n/a (graph not required)       | Available                        | Experimental     | Experimental               |
 
-- **Production-ready** - qualified for production deployment in v0.9.0; covered by integration and e2e tests; documented gotchas have known mitigations.
+- **Production-ready** - qualified for production deployment; covered by integration and e2e tests; documented gotchas have known mitigations.
 - **Available** - supported, exercised in tests, but not stamped production-ready. Equivalent retrieval semantics; less load-tested.
 - **Experimental** - feature-complete enough for demos, evaluation, and tests on small corpora. Not a deployment story. See the [embedded backend caveats](../configuration.md#embedded-backends-experimental) for the full list of gaps.
 
@@ -184,33 +182,14 @@ For 1000 documents averaging 5KB each:
 - **Temporal queries**: "What did Alice say last week about the budget?"
 - **No graph DB**: Runs on PostgreSQL + pgvector only.
 
-## Migration
+## Switching engines
 
-### Replacing GraphRAG (removed in 0.10.1)
-
-```python
-# Before (graphrag - no longer available)
-async with Khora(db_url, engine="graphrag") as kb:
-    await kb.remember(content, namespace=ns_id)
-
-# After - drop-in: vectorcypher with full extraction
-async with Khora(db_url, engine="vectorcypher",
-                 engine_kwargs={"skeleton_core_ratio": 1.0}) as kb:
-    await kb.remember(content, namespace=ns_id)
-
-# Or accept default selective extraction (recommended - 30% cheaper):
-async with Khora(db_url, engine="vectorcypher") as kb:
-    await kb.remember(content, namespace=ns_id)
-```
-
-Existing graphrag-ingested data remains queryable via `vectorcypher` against the same database - the table shapes are identical.
-
-### Between VectorCypher and Skeleton Construction
-
-VectorCypher and Skeleton store data differently (Skeleton has no graph backend), so switching is a re-ingest, not a query-side switch. Pick based on your workload:
+Switching between VectorCypher and Skeleton Construction is a re-ingest, not a query-side switch - they store data differently (Skeleton has no graph backend). Pick based on your workload:
 
 - Cost-sensitive + PG-only → Skeleton
 - Multi-hop entity queries + graph DB available → VectorCypher
+
+For migration from the retired `graphrag` engine to `vectorcypher`, see [migrations.md](../migrations.md#replacing-the-removed-graphrag-engine).
 
 ## Hybrid Approach
 

--- a/docs/engines/hybrid-search.md
+++ b/docs/engines/hybrid-search.md
@@ -299,7 +299,7 @@ async def search(
     return results
 ```
 
-> Since v0.16.0 (#769) `namespace_id` is a required kwarg on every storage read/write and is filtered at the SQL/SurrealQL layer. The `sqlite_lance` backend's `search_similar` additionally re-filters by `namespace_id` on the SQLite re-fetch step as defense-in-depth.
+> `namespace_id` is a required kwarg on every storage read/write and is filtered at the SQL/SurrealQL layer (#769). The `sqlite_lance` backend's `search_similar` additionally re-filters by `namespace_id` on the SQLite re-fetch step as defense-in-depth.
 
 ### Weaviate Backend
 

--- a/docs/engines/skeleton-engine.md
+++ b/docs/engines/skeleton-engine.md
@@ -45,7 +45,7 @@ Choose VectorCypher instead when:
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
-> **Note (v0.2.3):** `TemporalEdge Storage` and `TimeHierarchy Builder` shown above exist as code modules but are not yet wired into the engine's ingest/recall pipeline. Temporal filtering via `occurred_at` on chunks works through the pgvector backend directly.
+> **Note:** `TemporalEdge Storage` and `TimeHierarchy Builder` shown above exist as code modules but are not yet wired into the engine's ingest/recall pipeline. Temporal filtering via `occurred_at` on chunks works through the pgvector backend directly.
 
 ### Core Design Principles
 
@@ -151,7 +151,7 @@ edge2 = await storage.create_edge(
 )
 ```
 
-<!-- TODO(docs-v0.16.0): TemporalEdgeStorage was never wired into the skeleton engine's ingest/recall path (see v0.2.3 note above). Verify the create_edge/get_valid_at signatures shown here against current code if this module is ever revived. -->
+<!-- TODO(docs): TemporalEdgeStorage is not wired into the skeleton engine's ingest/recall path (see status note above). Verify the create_edge/get_valid_at signatures shown here against current code if this module is ever revived. -->
 
 
 ### TimeHierarchyBuilder (`src/khora/engines/skeleton/time_hierarchy.py`)
@@ -289,7 +289,7 @@ engine = SkeletonConstructionEngine(
 )
 ```
 
-**Auth and Weaviate Cloud** (added in v0.16.3 / issue #783). The
+**Auth and Weaviate Cloud** (issue #783). The
 backend accepts a `WeaviateBackendConfig` in place of the URL string
 for cloud, authenticated, or custom-port deployments:
 
@@ -327,7 +327,7 @@ so the Skeleton event loop does not block on Weaviate I/O.
 - Multi-tenant isolation (namespace = tenant)
 - Horizontal scaling
 - Built-in BM25 + vector fusion
-- API-key auth + Weaviate Cloud (added v0.16.3)
+- API-key auth + Weaviate Cloud
 
 **Tests.** Unit tests exercise the async client via mocks. Integration
 tests against a real cluster live in

--- a/docs/engines/temporal-model.md
+++ b/docs/engines/temporal-model.md
@@ -1,8 +1,8 @@
 # Temporal Model
 
-> **Status (v0.3.9):** The bi-temporal edge storage (`TemporalEdgeStorage`) and time hierarchy (`TimeHierarchyBuilder`) described here exist as code but are **never called** by any engine's ingest or recall paths. The `occurred_at` column on chunks is populated and filterable via the pgvector backend, but the full bi-temporal edge model is not yet active.
+> **Status:** The bi-temporal edge storage (`TemporalEdgeStorage`) and time hierarchy (`TimeHierarchyBuilder`) described here exist as code but are **never called** by any engine's ingest or recall paths. The `occurred_at` column on chunks is populated and filterable via the pgvector backend, but the full bi-temporal edge model is not yet active.
 >
-> **VectorCypher temporal detection (v0.3.9):** The VectorCypher engine now classifies queries into 7 temporal categories via `TemporalDetector` (see [temporal-queries.md](../query-engine/temporal-queries.md)) and applies category-specific retrieval parameters (recency boost, sorting, decay override). The `occurred_at` column on chunks is also used for temporal sorting during Neo4j graph traversal (`ORDER BY c.occurred_at DESC`) when the temporal signal indicates it.
+> **VectorCypher temporal detection:** The VectorCypher engine classifies queries into 7 temporal categories via `TemporalDetector` (see [temporal-queries.md](../query-engine/temporal-queries.md)) and applies category-specific retrieval parameters (recency boost, sorting, decay override). The `occurred_at` column on chunks is also used for temporal sorting during Neo4j graph traversal (`ORDER BY c.occurred_at DESC`) when the temporal signal indicates it.
 
 The Skeleton Construction engine implements a bi-temporal model inspired by [Graphiti](https://github.com/getzep/graphiti), with a hierarchical time graph inspired by [TG-RAG](https://arxiv.org/abs/2410.15149). This document explains the theory and implementation.
 

--- a/docs/engines/vectorcypher-engine.md
+++ b/docs/engines/vectorcypher-engine.md
@@ -22,7 +22,7 @@ Choose Skeleton Construction instead when:
 - **No Neo4j available**: VectorCypher requires Neo4j
 - **Simple infrastructure preferred**: Skeleton works with PostgreSQL only
 
-For graphrag-equivalent comprehensive extraction (100% of chunks), pass `engine_kwargs={"skeleton_core_ratio": 1.0}` - VectorCypher's KET-RAG selectivity defaults to the top 70% of chunks but accepts a 1.0 override that matches the legacy GraphRAG engine's extraction quality at the same LLM cost.
+For comprehensive extraction over 100% of chunks, pass `engine_kwargs={"skeleton_core_ratio": 1.0}` - VectorCypher's KET-RAG selectivity defaults to the top 70% of chunks but accepts a 1.0 override that extracts from every chunk.
 
 ## Architecture Overview
 
@@ -115,9 +115,8 @@ async with Khora("postgresql://...", engine="vectorcypher") as kb:
 - **`chunks`** - Matching text passages as `RecallChunk` entries (`chunk.content`)
 - **`entities`** - Entities mentioned in matching chunks
 - **`relationships`** - Connections between entities in the result set
-- **`documents`** - Full `DocumentProjection` rows for every document referenced by a chunk, entity, or relationship (always populated as of v0.16.0; see [Source Document Population](#source-document-population))
+- **`documents`** - Full `DocumentProjection` rows for every document referenced by a chunk, entity, or relationship (always populated; see [Source Document Population](#source-document-population))
 
-The legacy `RecallResult.context_text` attribute was removed in v0.15.3.
 Callers that need a flat context string for an LLM render one with the
 public `khora.context_text(result, max_chunks=...)` helper:
 
@@ -130,7 +129,7 @@ prompt_context = context_text(result, max_chunks=5)
 
 ### Source Document Population
 
-`recall()` always returns a `RecallResult` whose `documents` list holds full `DocumentProjection` rows for every document referenced by a chunk, entity, or relationship in the result - this is a producer-enforced invariant (see #761 / v0.16.0). Khora batch-fetches `DocumentSource` metadata after the engine returns (chunked at 1,000 IDs) and replaces the engine's lightweight stubs in place. The engine itself uses the namespace-scoped coordinator facade for that lookup, so cross-namespace ids never leak through.
+`recall()` always returns a `RecallResult` whose `documents` list holds full `DocumentProjection` rows for every document referenced by a chunk, entity, or relationship in the result - this is a producer-enforced invariant (see #761). Khora batch-fetches `DocumentSource` metadata after the engine returns (chunked at 1,000 IDs) and replaces the engine's lightweight stubs in place. The engine itself uses the namespace-scoped coordinator facade for that lookup, so cross-namespace ids never leak through.
 
 ```python
 result = await kb.recall("query", namespace=ns_id)
@@ -139,7 +138,7 @@ for chunk in result.chunks:
     print(docs_by_id[chunk.document_id].title)
 ```
 
-Entity-read methods (`get_entity()`, `list_entities()`, `find_related_entities()`, `search_entities()`) still accept `include_sources: bool = False` to opt-in to per-entity `source_documents` population. All four require `namespace_id=` (kwarg-only) on every call - the v0.16.0 IDOR close-out (#769) enforces this at the Protocol level on every storage backend.
+Entity-read methods (`get_entity()`, `list_entities()`, `find_related_entities()`, `search_entities()`) accept `include_sources: bool = False` to opt-in to per-entity `source_documents` population. All four require `namespace_id=` (kwarg-only) on every call - the IDOR close-out (#769) enforces this at the Protocol level on every storage backend.
 
 ### VectorCypherRetriever (`src/khora/engines/vectorcypher/retriever.py`)
 
@@ -390,7 +389,7 @@ The detector classifies the query, and the resulting `TemporalSignal.category` m
 
 ### Simple Path Recency
 
-The SIMPLE retrieval path (vector-only, no graph traversal) now also applies recency boosting when the temporal category calls for it. Previously, `_simple_retrieve()` returned raw pgvector scores with no recency adjustment. Now it wraps results in `FusedResult` objects, calls `_calculate_recency_scores()`, and applies `apply_recency_boost()` when the effective recency weight is greater than zero.
+The SIMPLE retrieval path (vector-only, no graph traversal) applies recency boosting when the temporal category calls for it. `_simple_retrieve()` wraps results in `FusedResult` objects, calls `_calculate_recency_scores()`, and applies `apply_recency_boost()` when the effective recency weight is greater than zero.
 
 ### Relative Recency Reference
 
@@ -602,7 +601,7 @@ This prevents two failure modes: (1) candidate explosion when many entities each
 
 The fusion function `weighted_rrf_normalized` normalizes vector and graph scores to [0, 1] via min-max normalization before computing Reciprocal Rank Fusion. This matters when the two sources produce scores on very different scales - for example, cosine similarity scores in [0.3, 0.9] vs graph proximity scores in [0.01, 0.5]. Without normalization, the source with larger absolute scores dominates the fusion.
 
-Both the SIMPLE and COMPLEX retrieval paths normalize final scores to [0,1] using min-max normalization. Previously, only the COMPLEX path applied normalization; SIMPLE path scores could exceed 1.0 when vector and graph contributions were summed.
+Both the SIMPLE and COMPLEX retrieval paths normalize final scores to [0,1] using min-max normalization.
 
 ```
 RRF score = vector_weight / (k + vector_rank) + graph_weight / (k + graph_rank)

--- a/docs/extraction/chunkers.md
+++ b/docs/extraction/chunkers.md
@@ -349,7 +349,7 @@ def filter_empty_chunks(self, chunks: list[Chunk]) -> list[Chunk]:
     return [c for c in chunks if len(c.content.strip()) >= MIN_CHUNK_CHARS]
 ```
 
-This filtering happens at chunk creation time rather than query time, so empty chunks never enter the vector index. Previously, ~17% of retrieval queries encountered sub-10-character chunks that had to be filtered during search.
+This filtering happens at chunk creation time rather than query time, so empty chunks never enter the vector index. Without this, sub-10-character chunks would otherwise be filtered during search (impacting ~17% of retrieval queries in early benchmarks).
 
 ## Performance Tips
 

--- a/docs/extraction/expertise-system.md
+++ b/docs/extraction/expertise-system.md
@@ -205,7 +205,7 @@ class ConfidenceConfig:
     min_inferred: float = 0.3      # Minimum inferred relationship confidence
 ```
 
-> **Note (v0.3.5):** The `min_relationship` default of 0.5 shown above is the dataclass fallback. The builtin `general.yaml` skill overrides this to `min_relationship: 0.25` for denser relationship extraction. If you are using the `general_entities` skill (the default), the effective threshold is 0.25.
+> **Note:** The `min_relationship` default of 0.5 shown above is the dataclass fallback. The builtin `general.yaml` skill overrides this to `min_relationship: 0.25` for denser relationship extraction. If you are using the `general_entities` skill (the default), the effective threshold is 0.25.
 
 ## ExpansionConfig
 
@@ -424,7 +424,7 @@ skill = ExtractionSkill.business_intel()
 skill = ExtractionSkill.research_papers()
 # Types: PERSON, ORGANIZATION, CONCEPT, TECHNOLOGY, EVENT
 
-# Slack messages (v0.3.1)
+# Slack messages
 skill = ExtractionSkill.slack()
 # Types: PERSON, CHANNEL, TEAM, TOPIC, PROJECT, DECISION
 # Extracts DM recipients, conversation threads, and team dynamics

--- a/docs/extraction/ingestion-pipeline.md
+++ b/docs/extraction/ingestion-pipeline.md
@@ -86,7 +86,7 @@ for field in timestamp_fields:
 
 This matters for temporal queries - "what was discussed last week?" should find content from last week, not content that was ingested last week about events from six months ago.
 
-As of v0.17.0, ISO-8601 strings (trailing `Z`, explicit offset, or date-only `YYYY-MM-DD`) can be handed directly to `remember(..., source_timestamp=...)` / `remember_batch` / `submit_batch` - Khora coerces them via the internal `coerce_source_timestamp` helper, so connectors no longer need to parse upstream.
+ISO-8601 strings (trailing `Z`, explicit offset, or date-only `YYYY-MM-DD`) can be handed directly to `remember(..., source_timestamp=...)` / `remember_batch` / `submit_batch` - Khora coerces them via the internal `coerce_source_timestamp` helper, so connectors don't need to parse upstream.
 
 ### Document Creation
 
@@ -236,7 +236,7 @@ await storage.create_relationships_batch(relationships, batch_size=50)
 # Uses UNWIND + CREATE in Neo4j - one transaction instead of N individual writes
 ```
 
-> Since v0.16.0 (#769) every storage read/write requires `namespace_id` as a kwarg-only argument (or as the leading positional on the small set of methods like `get_document_by_checksum` / `list_entities` / `list_relationships` where it has always been positional). The `StorageCoordinator.{relational,vector,graph,event_store}` attrs are wrapped in `NamespaceRequiredProxy` and emit a `DeprecationWarning` once per role per process; they refuse read calls without `namespace_id=`. Internal canonical refs are `self._{relational,vector,graph,event_store}`. The public attrs disappear in v0.17 - engines that talk to them go through the namespace-scoped coordinator facade instead.
+> Every storage read/write requires `namespace_id` as a kwarg-only argument (or as the leading positional on the small set of methods like `get_document_by_checksum` / `list_entities` / `list_relationships` where it has always been positional) (#769). The `StorageCoordinator.{relational,vector,graph,event_store}` attrs are wrapped in `NamespaceRequiredProxy` and emit a `DeprecationWarning` once per role per process; they refuse read calls without `namespace_id=`. Internal canonical refs are `self._{relational,vector,graph,event_store}`. Engines go through the namespace-scoped coordinator facade instead.
 
 ### Entity ID Remapping
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -4,7 +4,7 @@ Khora ships its own Alembic migrations bundled inside the package at `src/khora/
 
 ## Who runs migrations?
 
-Library consumers (e.g. khora-cli and custom services) need Khora's schema to exist before calling `Khora()`. Two options:
+Library consumers need Khora's schema to exist before calling `Khora()`. Two options:
 
 ### 1. Let Khora run them for you
 
@@ -73,6 +73,14 @@ Current dialect-gated migrations:
 - **`029_chunks_created_at_brin` (v0.12.0)** - BRIN index on `chunks.created_at` (`pages_per_range = 32`), built with `CREATE INDEX CONCURRENTLY` inside an Alembic autocommit block so online traffic is not blocked. BRIN indexes are tiny (KB-sized) and well-suited to time-correlated columns like `created_at`; they don't compete with HNSW vector indexes or the existing B-trees on chunks. The index helps long-range archive / export queries (months of data) that today sequential-scan the table. No effect on point queries or HNSW similarity search. SQLite-backed embedded stacks skip this migration entirely - see Issue #593 for the rationale.
 - **`030_session_id_columns`** - adds a nullable `session_id UUID` column to `documents`, `chunks`, `memory_events`, `chronicle_events`, and `memory_facts`. Runs on both PostgreSQL and SQLite (the column itself is portable). Existing rows naturally carry `NULL`; adapters that don't track sessions can keep ignoring the field. Companion to migration 031.
 - **`031_session_id_indexes`** - Postgres-only. Adds two partial B-tree indexes on `(namespace_id, session_id) WHERE session_id IS NOT NULL` for `chunks` and `documents`, and a BRIN index on `chunks (session_id, created_at)` (`pages_per_range = 32`). All created with `CREATE INDEX CONCURRENTLY` inside an autocommit block. The partial indexes cover session-scoped recall (`WHERE namespace_id = ? AND session_id = ?`); the BRIN accelerates time-bounded session replay and `gc.expire_sessions(before=…)`. SQLite-backed embedded stacks skip silently - point lookups on `chunks` are fine at SQLite scale and `CREATE INDEX CONCURRENTLY` is Postgres-specific. See Issue #620.
+- **`032_dream_runs`** - Postgres-only via the same dialect gate as migration 029. Adds `khora_dream_runs`, a per-namespace checkpoint table so the dream-phase orchestrator can resume a crashed apply pass against the last committed op-seq rather than restarting from scratch. The embedded `sqlite_lance` stack mirrors checkpoint state to a `dream_runs.jsonl` file sink instead. See Issue #651 (dream Phase 0.2).
+- **`033_bitemporal_columns`** - Adds nullable `valid_to`, `invalidated_at`, `invalidated_by` to `relationships` and `memory_facts`. The column adds run on both dialects (columns are portable); the partial indexes `ix_relationships_live` and `ix_memory_facts_live` (`WHERE invalidated_at IS NULL`) are Postgres-only via `CREATE INDEX CONCURRENTLY` inside an autocommit block. Existing rows backfill to all-NULL (= "still valid"). See Issue #653 (dream Phase 0.3).
+- **`034_chronicle_events_bitemporal`** - Adds `invalidated_at`, `invalidated_by`, and `merged_into_event_id` (self-FK with `ON DELETE SET NULL`, created via `use_alter=True` mirroring migration 004) to `chronicle_events`. The partial composite index `ix_chronicle_events_live` on `(namespace_id, occurred_at) WHERE invalidated_at IS NULL` is Postgres-only. See Issue #669 (dream Phase 4 event clustering).
+- **`035_dream_communities`** - Postgres-only via the dialect gate. Adds `khora_dream_communities` for community-summary persistence with bi-temporal validity; the apply path writes grounded LLM summaries (uncited claims dropped before INSERT). The `sqlite_lance` stack mirrors community state to the JSONL undo sink instead. See Issue #670 (dream Phase 5.1).
+- **`036_dream_conflicts`** - Postgres-only via the dialect gate. Adds `dream_conflicts` for the vectorcypher contradiction-detection op's report-only findings (the op never mutates `relationships` — Phase 5.4 / Issue #673 will own that). See Issue #672 (dream Phase 5.3).
+- **`037_recall_response_format`** - Cross-dialect. Adds `documents.source_name VARCHAR(64)` (backfilled from `nango://<provider>/...` patterns in `source`), `documents.source_url VARCHAR(2048)`, and `chunks.chunker_info JSONB NOT NULL DEFAULT '{}'::jsonb`. Also flips six `documents` columns (`source`, `content_type`, `title`, `author`, `language`, `checksum`) to nullable-with-no-default; legacy `create_tables()`-created rows that were `NOT NULL DEFAULT ''` need their `NOT NULL` dropped before the empty-string normalisation runs (see PR #819).
+- **`038_khora_chunks_chunker_info`** - Mirrors 037's `chunker_info` onto the vectorcypher temporal-store table `khora_chunks`. Postgres-specific: asserts `server_version_num >= 110000` so the fast `ADD COLUMN NOT NULL DEFAULT` path is available (avoids a multi-hour table rewrite on PG < 11), and issues `SET lock_timeout = '5s'` before DDL so the `AccessExclusiveLock` acquisition is bounded; on lock-timeout, logs `khora.migration.applied` with `lock_timeout_tripped=True` and SQLSTATE `55P03` for dashboard correlation.
+- **`039_khora_chunks_content_tsv_gin`** - Postgres-only. Adds a GIN index on `khora_chunks.content_tsv` (BM25 / `ts_rank` queries against vectorcypher's temporal-store chunks) via `CREATE INDEX CONCURRENTLY ... IF NOT EXISTS` in an autocommit block. Converges cleanly with the runtime `CREATE INDEX IF NOT EXISTS` in `PgVectorTemporalStore.connect()` — whichever runs first wins. SQLite uses an FTS5 virtual table instead.
 
 ## SurrealDB
 
@@ -112,4 +120,39 @@ ent = await kb.storage.get_entity(entity_id, namespace_id=ns_id)  # via coordina
 await kb.storage.delete_document(doc_id, namespace_id=ns_id)      # coordinator method
 ```
 
-Code paths that already routed through the `Khora` facade and the documented public surface (`khora-cli`, `khora-explorer`) are unaffected - none touch `kb.storage.{relational,vector,graph,event_store}` directly. Code paths that reach into `kb.storage.<role>` will see the `DeprecationWarning` in v0.16.x and the `AttributeError` in v0.17.
+Code paths that already routed through the `Khora` facade are unaffected - none touch `kb.storage.{relational,vector,graph,event_store}` directly. Code paths that reach into `kb.storage.<role>` will see the `DeprecationWarning` in v0.16.x and the `AttributeError` in v0.17.
+
+## Replacing the removed GraphRAG engine
+
+The `graphrag` engine is no longer available. Replace it with `vectorcypher`:
+
+```python
+# Old (graphrag - no longer available)
+async with Khora(db_url, engine="graphrag") as kb:
+    await kb.remember(content, namespace=ns_id)
+
+# Drop-in replacement: vectorcypher with full extraction
+async with Khora(db_url, engine="vectorcypher",
+                 engine_kwargs={"skeleton_core_ratio": 1.0}) as kb:
+    await kb.remember(content, namespace=ns_id)
+
+# Or accept default selective extraction (recommended - 30% cheaper):
+async with Khora(db_url, engine="vectorcypher") as kb:
+    await kb.remember(content, namespace=ns_id)
+```
+
+Existing graphrag-ingested data remains queryable via `vectorcypher` against the same database - the table shapes are identical.
+
+## v0.8.0 - CLI extraction
+
+The CLI commands (`khora extract`, `khora search`, `khora ontology …`) were removed from the `khora` package so the library has no CLI dependencies (no `click`, no `rich`, no PDF / Excel readers by default). The `khora` top-level imports (`Khora`, `KhoraConfig`, `SearchMode`, `ExpertiseConfig`, etc.) are unchanged — call them directly from your service or notebook.
+
+Companion CLI packages (`khora-cli`, `khora-explorer`) are planned for a later release and are not available today. Until they ship, there is no in-library CLI replacement.
+
+The one piece of CLI functionality available inside the library today is binary-document text extraction. Install with `pip install khora[binary-readers]` and use it directly:
+
+```python
+from khora.extraction.binary_readers import extract_if_needed
+```
+
+Old `from khora.discovery …` and `from khora.cli …` imports have no in-library replacement — call the public `khora` API instead.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -271,8 +271,7 @@ otherwise vanilla OTel takes over.
 
 The one-line rename: `install_neo4j_logfire_handler` is now
 `install_neo4j_log_bridge` (it still picks the logfire handler when
-logfire is installed). The old name is kept as a deprecated alias for
-khora 0.10.x and will be removed in 0.12.
+logfire is installed). The old name is kept as a deprecated alias.
 
 ## Troubleshooting
 

--- a/docs/query-engine/fusion.md
+++ b/docs/query-engine/fusion.md
@@ -276,7 +276,7 @@ RRF has several nice properties:
 
 Research has shown RRF performs comparably to learned fusion methods while being much simpler to implement and understand.
 
-## Coherence Scoring (v0.3.5)
+## Coherence Scoring
 
 After RRF fusion, the VectorCypher retriever applies a lightweight coherence signal to penalize word-shuffled confounders - documents that share the same vocabulary as a relevant chunk but in a nonsensical order. This avoids the cost of an LLM reranking call for obvious confounders.
 

--- a/docs/query-engine/overview.md
+++ b/docs/query-engine/overview.md
@@ -218,7 +218,7 @@ config = QueryConfig(enable_reranking=True)
 
 This uses a cross-encoder model that looks at query-document pairs together, catching nuances that initial retrieval might miss.
 
-**Optional date-prefix experiment (v0.12.0, opt-in).** `CrossEncoderReranker(include_date_prefix=True)` (or the `include_date_prefix=True` kwarg on `create_reranker`) prepends `[YYYY-MM-DD] ` to each candidate's content before scoring. Off-the-shelf cross-encoders tokenize ISO dates fine, so this gives them an explicit recency signal at negligible token cost. Date source priority: `metadata.custom.occurred_at` → `metadata.custom.sent_at` → `metadata.created_at`. Default **OFF** pending an A/B run on the corporate-shape benchmark (Issue #594, Phase D5).
+**Optional date-prefix experiment (opt-in).** `CrossEncoderReranker(include_date_prefix=True)` (or the `include_date_prefix=True` kwarg on `create_reranker`) prepends `[YYYY-MM-DD] ` to each candidate's content before scoring. Off-the-shelf cross-encoders tokenize ISO dates fine, so this gives them an explicit recency signal at negligible token cost. Date source priority: `metadata.custom.occurred_at` → `metadata.custom.sent_at` → `metadata.created_at`. Default **OFF** pending an A/B run on the corporate-shape benchmark (Issue #594, Phase D5).
 
 ## Step 7: Result Limiting
 
@@ -238,7 +238,7 @@ QueryResult(
 
 > **Two retrieval surfaces, two result shapes.** Khora exposes two independent retrieval paths and they intentionally use different result types:
 >
-> - **`Khora.recall()`** - the top-level public API. Returns a typed `RecallResult` from `khora.core.models.recall` (re-exported as `from khora import RecallResult`) with `chunks: list[RecallChunk]`, `entities: list[RecallEntity]`, `relationships: list[RecallRelationship]`, and a producer-enforced `documents: list[DocumentProjection]` invariant - every chunk's `document_id` and every entity / relationship `source_document_ids` entry is guaranteed to appear in `documents[]`. Use `khora.context_text(result)` to render a formatted context string. The old `RecallResult.context_text` attribute was removed in v0.15.3.
+> - **`Khora.recall()`** - the top-level public API. Returns a typed `RecallResult` from `khora.core.models.recall` (re-exported as `from khora import RecallResult`) with `chunks: list[RecallChunk]`, `entities: list[RecallEntity]`, `relationships: list[RecallRelationship]`, and a producer-enforced `documents: list[DocumentProjection]` invariant - every chunk's `document_id` and every entity / relationship `source_document_ids` entry is guaranteed to appear in `documents[]`. Use `khora.context_text(result)` to render a formatted context string.
 >
 > - **`HybridQueryEngine.query()`** (this doc) - the in-package retrieval surface used by `khora.query.agentic.AgenticSearchAgent`. Returns the tuple-shaped `QueryResult` shown above. Carries richer per-method telemetry (`search_contributions`, `graph_info`, `temporal_info`) that doesn't fit the recall projection. Not consumed by `Khora.recall()` or by any of the typed engines (vectorcypher / chronicle / skeleton).
 >

--- a/docs/query-engine/retrieval-tuning.md
+++ b/docs/query-engine/retrieval-tuning.md
@@ -168,9 +168,9 @@ KHORA_QUERY_ENTITY_LINKING_FUZZY_THRESHOLD=0.6
 KHORA_QUERY_ENTITY_LINKING_EMBEDDING_THRESHOLD=0.4
 ```
 
-### Adaptive Top-K with "Very Focused" Tier (v0.3.1)
+### Adaptive Top-K with "Very Focused" Tier
 
-The query engine uses the `complexity_score` from query understanding to determine how many chunks to retrieve. In v0.3.1, a new "very_focused" tier was added for simple factual queries:
+The query engine uses the `complexity_score` from query understanding to determine how many chunks to retrieve. A "very_focused" tier handles simple factual queries:
 
 | Tier | Complexity | Chunk Limit | Use Case |
 |------|-----------|-------------|----------|
@@ -181,20 +181,20 @@ The query engine uses the `complexity_score` from query understanding to determi
 
 The very_focused tier reduces noise for straightforward questions where a single chunk is likely sufficient. The complexity score is computed during query understanding based on entity count, relationship complexity, and temporal references.
 
-### MMR Diversity Selection (v0.3.1)
+### MMR Diversity Selection
 
-The diversity stage (Stage 5 of the query pipeline) uses Maximal Marginal Relevance to select a diverse set of results from the candidate pool. In v0.3.1:
+The diversity stage (Stage 5 of the query pipeline) uses Maximal Marginal Relevance to select a diverse set of results from the candidate pool:
 
-1. **Enabled by default**: `enable_diversity` now defaults to `True` in both `QueryConfig` and `QuerySettings`. Previously, `QuerySettings` defaulted to `False`, which meant the diversity stage was never activated via environment config.
+1. **Enabled by default**: `enable_diversity` defaults to `True` in both `QueryConfig` and `QuerySettings`.
 
 2. **Rust acceleration**: MMR selection uses a 3-tier fallback (Rust → NumPy → pure Python). The Rust implementation in `khora-accel` uses SIMD-friendly dot product with GIL release, providing ~5x speedup over pure Python for typical result set sizes.
 
-3. **Pre-normalized embeddings**: Embeddings are now L2-normalized at ingest time, allowing MMR to use dot product instead of cosine similarity (~3x speedup since normalization is amortized).
+3. **Pre-normalized embeddings**: Embeddings are L2-normalized at ingest time, allowing MMR to use dot product instead of cosine similarity (~3x speedup since normalization is amortized).
 
 Configuration:
 ```python
 config = QueryConfig(
-    enable_diversity=True,    # default: True (changed in v0.3.1)
+    enable_diversity=True,    # default: True
     diversity_lambda=0.7,     # balance: 1.0 = pure relevance, 0.0 = pure diversity
 )
 ```
@@ -205,7 +205,7 @@ KHORA_QUERY_ENABLE_DIVERSITY=true   # default
 KHORA_QUERY_DIVERSITY_LAMBDA=0.7
 ```
 
-### Coherence Scoring (v0.3.5)
+### Coherence Scoring
 
 The VectorCypher retriever applies a lightweight text coherence signal after RRF fusion to penalize word-shuffled confounders. This is particularly effective when LLM reranking is disabled (`KHORA_QUERY_ENABLE_LLM_RERANKING=false`), where confounders would otherwise rank alongside genuine results.
 
@@ -240,7 +240,7 @@ These changes should eliminate the zero-result problem and significantly improve
 - Latency: some improvement from reranking skip, but the main latency contributors (query understanding, reranking) are unchanged
 
 Further improvements to consider:
-- **HyDE (Hypothetical Document Embeddings)**: Generates a hypothetical document for the query to improve embedding similarity for descriptive queries. Mode is controlled by `KHORA_QUERY_ENABLE_HYDE` taking `auto` (default), `always`, or `never` (booleans `True`/`False` are still accepted and normalize to `always`/`never`). In `auto` mode HyDE fires when the query understanding layer flags the query as complex or temporal. Since v0.12.0, RECENCY / STATE_QUERY / CHANGE queries get a time-anchored hypothetical that injects today's ISO date - see [Temporal queries](temporal-queries.md#temporal-anchored-hyde).
-- **HyDE-Cypher (v0.12.0, opt-in)**: For *structured* RECENCY queries (e.g. "latest action items", "who works for Acme", "Phoenix and security recently"), khora can ask an LLM to pick a parameterized Cypher template and execute it against the graph backend as an additional retrieval channel. Three templates ship: `recent_by_type`, `entity_relationships`, `cooccurrence`. Slot values are validated against `ExpertiseConfig` whitelists and bound via Neo4j parameters - slot strings never reach the Cypher source. Enable via `KHORA_QUERY_ENABLE_HYDE_CYPHER=true`; cap result-set size with `KHORA_QUERY_HYDE_CYPHER_LIMIT` (default 20). **Default OFF - flip after an A/B run on a hand-curated structured-query set.**
-- **Cross-encoder date-prefix experiment (v0.12.0, opt-in)**: `CrossEncoderReranker(include_date_prefix=True)` prepends `[YYYY-MM-DD] ` to each candidate's content before scoring. Off-the-shelf rerankers tokenize ISO dates fine and the extra ~12 tokens per candidate are negligible vs. the model's forward pass. Source-priority: `metadata.custom.occurred_at` → `metadata.custom.sent_at` → `metadata.created_at`. **Default OFF - A/B required before flipping.**
+- **HyDE (Hypothetical Document Embeddings)**: Generates a hypothetical document for the query to improve embedding similarity for descriptive queries. Mode is controlled by `KHORA_QUERY_ENABLE_HYDE` taking `auto` (default), `always`, or `never` (booleans `True`/`False` are still accepted and normalize to `always`/`never`). In `auto` mode HyDE fires when the query understanding layer flags the query as complex or temporal. RECENCY / STATE_QUERY / CHANGE queries get a time-anchored hypothetical that injects today's ISO date - see [Temporal queries](temporal-queries.md#temporal-anchored-hyde).
+- **HyDE-Cypher (opt-in)**: For *structured* RECENCY queries (e.g. "latest action items", "who works for Acme", "Phoenix and security recently"), khora can ask an LLM to pick a parameterized Cypher template and execute it against the graph backend as an additional retrieval channel. Three templates ship: `recent_by_type`, `entity_relationships`, `cooccurrence`. Slot values are validated against `ExpertiseConfig` whitelists and bound via Neo4j parameters - slot strings never reach the Cypher source. Enable via `KHORA_QUERY_ENABLE_HYDE_CYPHER=true`; cap result-set size with `KHORA_QUERY_HYDE_CYPHER_LIMIT` (default 20). **Default OFF - flip after an A/B run on a hand-curated structured-query set.**
+- **Cross-encoder date-prefix experiment (opt-in)**: `CrossEncoderReranker(include_date_prefix=True)` prepends `[YYYY-MM-DD] ` to each candidate's content before scoring. Off-the-shelf rerankers tokenize ISO dates fine and the extra ~12 tokens per candidate are negligible vs. the model's forward pass. Source-priority: `metadata.custom.occurred_at` → `metadata.custom.sent_at` → `metadata.created_at`. **Default OFF - A/B required before flipping.**
 - **SearchMode.ALL as default**: Now that keyword search runs in HYBRID, the distinction between HYBRID and ALL is smaller - HYBRID is effectively ALL.

--- a/docs/query-engine/search-modes.md
+++ b/docs/query-engine/search-modes.md
@@ -134,7 +134,7 @@ Default weights:
 - Graph: 30% (relationships add important context)
 - Keyword: 20% (catches exact terms, proper nouns, dates)
 
-> **Note**: HYBRID previously only ran vector + graph. Keyword search was added to HYBRID after [benchmark analysis](retrieval-tuning.md) showed that the missing keyword fallback caused 25% of descriptive queries to return zero results. You can disable it with `enable_keyword_search=False` if you want the old behavior.
+> **Note**: HYBRID includes keyword search alongside vector + graph. [Benchmark analysis](retrieval-tuning.md) showed that without the keyword fallback, 25% of descriptive queries returned zero results. You can disable keyword search with `enable_keyword_search=False`.
 
 ## All Sources
 

--- a/docs/query-engine/temporal-queries.md
+++ b/docs/query-engine/temporal-queries.md
@@ -105,7 +105,7 @@ final_score = base_score * boost
 
 Recency is computed **relative to the result set**, not wall-clock time. The reference point is `max(occurred_at)` across all results in the current query, with a fallback to `datetime.now(UTC)` when no timestamps exist.
 
-**Why this matters:** If your data is from 2024 but you run queries in 2026, wall-clock-based recency would give every result a near-zero score (all ~2 years old). Relative recency ensures meaningful score discrimination within any time range. For live data where `max(occurred_at) ≈ now`, the behavior is equivalent to the old wall-clock approach.
+**Why this matters:** If your data is from 2024 but you run queries in 2026, wall-clock-based recency would give every result a near-zero score (all ~2 years old). Relative recency ensures meaningful score discrimination within any time range. For live data where `max(occurred_at) ≈ now`, the behavior is equivalent to a wall-clock reference.
 
 ### Category-Specific Behavior
 
@@ -130,7 +130,7 @@ When HyDE is enabled (`enable_hyde` set to `auto` or `always`) and the query's `
 | `RECENCY`, `STATE_QUERY`, `CHANGE` | Time-anchored: injects today's ISO date, asks for specific dates / weekdays / relative markers |
 | `NONE`, `EXPLICIT`, `ORDINAL`, `AGGREGATE` | Generic: time-blind, factual passage |
 
-Cost: zero additional LLM calls - only the system prompt changes. Category detection is sub-millisecond (Rust Aho-Corasick), so the auto-detection path adds no measurable overhead. Available since v0.12.0 (Issue #592, Phase D1).
+Cost: zero additional LLM calls - only the system prompt changes. Category detection is sub-millisecond (Rust Aho-Corasick), so the auto-detection path adds no measurable overhead. (Issue #592, Phase D1)
 
 ### Manual Recency Bias
 
@@ -232,7 +232,7 @@ filter = TemporalFilter(
 
 ### Automatic Date Extraction
 
-When the dictionary detector classifies a query as `EXPLICIT`, it also attempts to extract dates from the query text and build a `TemporalFilter` automatically. Callers can also pass `temporal_filter=...` to `recall()` directly: as of v0.17.0, vectorcypher and graphrag synthesize an `EXPLICIT`-category signal with `confidence=1.0` and `source="api"` so version-aware scoring and the sparse-results fallback fire the same way auto-detected bounds would (previously the explicit kwarg was silently dropped on these two engines).
+When the dictionary detector classifies a query as `EXPLICIT`, it also attempts to extract dates from the query text and build a `TemporalFilter` automatically. Callers can also pass `temporal_filter=...` to `recall()` directly: vectorcypher and graphrag synthesize an `EXPLICIT`-category signal with `confidence=1.0` and `source="api"` so version-aware scoring and the sparse-results fallback fire the same way auto-detected bounds would.
 
 ```python
 # Query: "What happened before April 2024?"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,8 +11,8 @@ These improvements are focused on making Khora faster and more reliable for prod
 | Item | Why It Matters |
 |------|----------------|
 | **HNSW Index Support** | Done. Migration 005 rebuilds the vector index as HNSW with `ef_construction=128`. See [Performance Optimization](architecture/performance-optimization.md). |
-| **Coherence Scoring** | Done (v0.3.5). Bigram coherence scoring for confounder rejection in VectorCypher's RRF fusion (`coherence_weight=0.1`). |
-| **Streaming Pipeline** | Done (v0.3.2). `streaming_pipeline=True` default in `VectorCypherConfig`. |
+| **Coherence Scoring** | Done. Bigram coherence scoring for confounder rejection in VectorCypher's RRF fusion (`coherence_weight=0.1`). |
+| **Streaming Pipeline** | Done. `streaming_pipeline=True` default in `VectorCypherConfig`. |
 | **Incremental Index Updates** | Currently, adding new vectors requires rebuilding indexes. Incremental updates would make real-time ingestion practical. |
 
 ### Ingestion Performance
@@ -141,7 +141,7 @@ Longer-term ideas we're exploring. Less certain timelines.
 
 | Area | What We're Exploring |
 |------|----------------------|
-| **HyDE (Hypothetical Document Embedding)** | Done. Implemented in v0.3.1, disabled by default (`enable_hyde=False`). Generate a hypothetical answer, embed that, search for similar real content. Improves recall for question-style queries. |
+| **HyDE (Hypothetical Document Embedding)** | Done. Disabled by default (`enable_hyde=False`). Generate a hypothetical answer, embed that, search for similar real content. Improves recall for question-style queries. |
 | **Self-Query** | Let the LLM write its own filters based on the query. "Find documents about AI from last month" → automatic date filter. |
 | **Contextual Compression** | Before returning chunks, compress them to just the relevant parts. Reduces noise in results. |
 

--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -716,7 +716,7 @@
       "name": "khora.dream.vectorcypher.normalize_schema",
       "stability": "internal",
       "owner": "dream",
-      "_comment": "Inner span for the vectorcypher schema-drift normalization op (OpKind.VECTORCYPHER_NORMALIZE_SCHEMA, #673, Phase 5.4 of #649). Operator-driven rename of entity_type / relationship_type values per DreamConfig.normalize_schema_mapping; never auto-derives. Attributes: namespace_id (span attr only, never a metric label per cardinality rule), mapping_size (int, number of old_type -> new_type rules), entity_rename_count (int), relationship_rename_count (int). Apply path emits one MemoryEvent (ENTITY_UPDATED / RELATIONSHIP_UPDATED) per renamed row via coordinator.dispatch_hook. Type renames touch the consumer contract (khora-cli, khora-explorer) — coordinated release required."
+      "_comment": "Inner span for the vectorcypher schema-drift normalization op (OpKind.VECTORCYPHER_NORMALIZE_SCHEMA, #673, Phase 5.4 of #649). Operator-driven rename of entity_type / relationship_type values per DreamConfig.normalize_schema_mapping; never auto-derives. Attributes: namespace_id (span attr only, never a metric label per cardinality rule), mapping_size (int, number of old_type -> new_type rules), entity_rename_count (int), relationship_rename_count (int). Apply path emits one MemoryEvent (ENTITY_UPDATED / RELATIONSHIP_UPDATED) per renamed row via coordinator.dispatch_hook. Type renames touch the consumer contract."
     },
     {
       "name": "khora.dream.undo.write",

--- a/docs/telemetry-contract.md
+++ b/docs/telemetry-contract.md
@@ -31,7 +31,7 @@ telemetry public surface. It is enforced by
 
 - **public** - appears in dashboards, alerts, or downstream code that we
   don't control. Cannot break without a coordinated major version bump
-  across downstream consumers (e.g. khora-cli, khora-explorer).
+  across downstream consumers.
 - **internal** - emitted today, but the names are not part of the public
   contract. Rename freely; just keep this file in sync with the codebase.
 


### PR DESCRIPTION
- Removed mention of version from current documentation, as users should view the current documentation as-is on this version, apart from CHANGELOG.md that contains all changes that happen from version to version
- Removed mention of khora-cli and khora-explorer
- Cleaned up also CLAUDE.md of khora-cli and khora-explorer 