### PR TITLE
Fixing docs snippets according to Khora API

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -13,7 +13,7 @@ from khora import (
     RememberResult,
     RecallResult,
     BatchResult,
-    BatchHandle,        # submit_batch() return value - has .wait() and .id
+    BatchHandle,        # submit_batch() return value - has .wait() and .batch_id
     DocumentResult,     # per-document callback payload from submit_batch
     Stats,
     LLMUsage,

--- a/docs/architecture/multi-tenancy.md
+++ b/docs/architecture/multi-tenancy.md
@@ -15,7 +15,9 @@ async with Khora() as kb:
     # Store in a specific namespace (required)
     await kb.remember(
         "Important document content...",
-        namespace=namespace_id
+        namespace=namespace_id,
+        entity_types=["PERSON", "ORG"],
+        relationship_types=["WORKS_AT"],
     )
 
     # Search within that namespace (required)
@@ -97,7 +99,9 @@ async with Khora() as kb:
     # Now store data using the stable namespace_id
     await kb.remember(
         "Important content...",
-        namespace=namespace.namespace_id
+        namespace=namespace.namespace_id,
+        entity_types=["PERSON", "ORG"],
+        relationship_types=["WORKS_AT"],
     )
 ```
 
@@ -171,7 +175,9 @@ async with Khora() as kb:
     for doc in all_your_documents:
         await kb.remember(
             doc.content,
-            namespace=new_version.id
+            namespace=new_version.id,
+            entity_types=["PERSON", "ORG"],
+            relationship_types=["WORKS_AT"],
         )
 
     # 4. Verify everything looks good
@@ -238,7 +244,12 @@ new_messages = await slack_client.get_messages(since=checkpoint)
 
 # Process them...
 for msg in new_messages:
-    await kb.remember(msg.content, namespace=namespace_id)
+    await kb.remember(
+        msg.content,
+        namespace=namespace_id,
+        entity_types=["PERSON", "TOPIC"],
+        relationship_types=["DISCUSSES", "AGREES_WITH"],
+    )
 
 # Update checkpoint
 await kb.storage.set_sync_checkpoint(

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -148,17 +148,25 @@ Your primary interface. Lives at `src/khora/khora.py`.
 from khora import Khora
 
 async with Khora() as kb:
+    ns = await kb.create_namespace()
+
     # Store something
     result = await kb.remember(
         "Einstein developed relativity while working at the patent office.",
-        title="Einstein Biography"
+        namespace=ns.namespace_id,
+        title="Einstein Biography",
+        entity_types=["PERSON", "ORG"],
+        relationship_types=["WORKS_AT"],
     )
 
     # Find it later
-    results = await kb.recall("Who developed the theory of relativity?")
+    results = await kb.recall(
+        "Who developed the theory of relativity?",
+        namespace=ns.namespace_id,
+    )
 
     # Remove if needed
-    await kb.forget(result.document_id)
+    await kb.forget(result.document_id, namespace=ns.namespace_id)
 ```
 
 Khora handles all the complexity of coordinating three databases, running extraction pipelines, and combining search results. You just tell it what to remember and what to recall.

--- a/docs/data-models/documents-chunks.md
+++ b/docs/data-models/documents-chunks.md
@@ -195,11 +195,15 @@ chunk_overlap = 50
 from khora import Khora
 
 async with Khora() as kb:
+    ns = await kb.create_namespace()
     result = await kb.remember(
         "Einstein developed the theory of relativity in 1905.",
+        namespace=ns.namespace_id,
         title="Physics History",
         source="wikipedia",
         metadata={"topic": "physics"},
+        entity_types=["PERSON", "ORG"],
+        relationship_types=["MENTIONS"],
     )
 
     print(f"Document ID: {result.document_id}")
@@ -236,8 +240,11 @@ documents = [
 
 result = await kb.remember_batch(
     documents,
+    namespace=ns.namespace_id,
     skill_name="general_entities",
     max_concurrent=10,
+    entity_types=["PERSON", "ORG"],
+    relationship_types=["MENTIONS"],
 )
 
 print(f"Processed: {result['processed_documents']}")
@@ -248,7 +255,7 @@ print(f"Skipped (duplicates): {result['skipped_documents']}")
 
 ```python
 # Remove document and all associated data
-await kb.forget(document_id)
+await kb.forget(document_id, namespace=ns.namespace_id)
 
 # This removes:
 # - The document

--- a/docs/dream-phase.md
+++ b/docs/dream-phase.md
@@ -26,7 +26,7 @@ The master switch is `KhoraConfig.dream.enabled` (env var `KHORA_DREAM_ENABLED`)
 from khora import Khora, KhoraConfig, DreamConfig
 
 kb = Khora(
-    config=KhoraConfig(
+    KhoraConfig(
         dream=DreamConfig(
             enabled=True,
             report_file_sink_enabled=True,

--- a/docs/engines/chronicle-engine.md
+++ b/docs/engines/chronicle-engine.md
@@ -77,7 +77,7 @@ async def main():
         engine="chronicle",
         run_migrations=True,
     ) as kb:
-        ns = await kb.create_namespace("conversations")
+        ns = await kb.create_namespace()
 
         # Store conversation turns
         await kb.remember(
@@ -85,6 +85,8 @@ async def main():
             "Bob: I agree, monthly is too frequent.",
             namespace=ns.namespace_id,
             metadata={"occurred_at": "2026-03-15T10:00:00Z"},
+            entity_types=["PERSON", "TOPIC"],
+            relationship_types=["DISCUSSES", "AGREES_WITH"],
         )
 
         await kb.remember(
@@ -92,6 +94,8 @@ async def main():
             "The team prefers the faster cadence.",
             namespace=ns.namespace_id,
             metadata={"occurred_at": "2026-03-22T14:00:00Z"},
+            entity_types=["PERSON", "TOPIC"],
+            relationship_types=["DISCUSSES", "AGREES_WITH"],
         )
 
         # Temporal query - Chronicle uses recency to find the latest stance
@@ -109,8 +113,13 @@ asyncio.run(main())
 
 ```python
 async with Khora("memory://", engine="chronicle") as kb:
-    ns = await kb.create_namespace("demo")
-    await kb.remember("...", namespace=ns.namespace_id)
+    ns = await kb.create_namespace()
+    await kb.remember(
+        "...",
+        namespace=ns.namespace_id,
+        entity_types=["PERSON", "TOPIC"],
+        relationship_types=["DISCUSSES", "AGREES_WITH"],
+    )
     result = await kb.recall("...", namespace=ns.namespace_id)
 ```
 

--- a/docs/engines/engine-comparison.md
+++ b/docs/engines/engine-comparison.md
@@ -44,15 +44,25 @@ The embedded path (SQLite + LanceDB) has a documented scale ceiling: **~1M chunk
 ```python
 # VectorCypher: skeleton-selective extraction
 async with Khora(db_url, engine="vectorcypher") as kb:
-    ns = await kb.create_namespace("default")
-    result = await kb.remember(content, namespace=ns.namespace_id)
+    ns = await kb.create_namespace()
+    result = await kb.remember(
+        content,
+        namespace=ns.namespace_id,
+        entity_types=["PERSON", "ORG"],
+        relationship_types=["WORKS_AT"],
+    )
     print(f"Extracted {result.entities_extracted} entities")
 
 # For 100% extraction (legacy GraphRAG behavior):
 async with Khora(db_url, engine="vectorcypher",
                  engine_kwargs={"skeleton_core_ratio": 1.0}) as kb:
-    ns = await kb.create_namespace("default")
-    result = await kb.remember(content, namespace=ns.namespace_id)
+    ns = await kb.create_namespace()
+    result = await kb.remember(
+        content,
+        namespace=ns.namespace_id,
+        entity_types=["PERSON", "ORG"],
+        relationship_types=["WORKS_AT"],
+    )
 ```
 
 **Skeleton Construction:**
@@ -64,8 +74,13 @@ async with Khora(db_url, engine="vectorcypher",
 ```python
 # Skeleton Construction: minimal extraction, skeleton-based
 async with Khora(db_url, engine="skeleton") as kb:
-    ns = await kb.create_namespace("default")
-    result = await kb.remember(content, namespace=ns.namespace_id)
+    ns = await kb.create_namespace()
+    result = await kb.remember(
+        content,
+        namespace=ns.namespace_id,
+        entity_types=["PERSON", "ORG"],
+        relationship_types=["MENTIONS"],
+    )
     # Entities only extracted for "core" chunks (high PageRank)
 ```
 
@@ -94,13 +109,16 @@ await kb.remember(
     content,
     namespace=ns_id,
     metadata={"occurred_at": "2024-01-15T00:00:00Z"},
+    entity_types=["PERSON", "EVENT"],
+    relationship_types=["PARTICIPATES_IN"],
 )
 
 # Query: "What happened in January?"
 results = await kb.recall(
     "January events",
     namespace=ns_id,
-    time_range=("2024-01-01", "2024-01-31"),
+    start_time=datetime(2024, 1, 1),
+    end_time=datetime(2024, 1, 31),
 )
 ```
 
@@ -130,7 +148,8 @@ results = await kb.recall("CEO recent news", namespace=ns_id)  # Hybrid vector +
 results = await kb.recall(
     "deployment errors",
     namespace=ns_id,
-    time_range=("2024-01-01", "2024-01-31"),
+    start_time=datetime(2024, 1, 1),
+    end_time=datetime(2024, 1, 31),
     mode=SearchMode.HYBRID,
 )
 ```
@@ -226,4 +245,3 @@ async def hybrid_query(query: str, ns_id):
 - [Chronicle Engine](chronicle-engine.md) - conversational + temporal.
 - [Temporal Model](temporal-model.md) - bi-temporal design details.
 - [Hybrid Search](hybrid-search.md) - vector + BM25 fusion primitive.
-- [References](../REFERENCES.md) - research papers and inspirations.

--- a/docs/engines/hybrid-search.md
+++ b/docs/engines/hybrid-search.md
@@ -426,12 +426,11 @@ async with Khora(db_url, engine="skeleton") as kb:
         query,
         namespace=ns_id,
         mode=SearchMode.HYBRID,
-        hybrid_alpha=0.7,
-        temporal_filter={
-            "occurred_after": "2024-01-01",
-            "author": "alice@company.com"
-        }
+        start_time=datetime(2024, 1, 1),
     )
+# Note: per-call hybrid alpha / author filters aren't exposed on the
+# public facade. Configure global weighting via environment variables
+# (see below) or `KhoraConfig.query`.
 ```
 
 ### Via Environment

--- a/docs/engines/skeleton-engine.md
+++ b/docs/engines/skeleton-engine.md
@@ -70,7 +70,7 @@ from khora import Khora
 
 # Use Skeleton Construction engine explicitly
 async with Khora("postgresql://...", engine="skeleton") as kb:
-    ns = await kb.create_namespace("q1-review")
+    ns = await kb.create_namespace()
 
     # Store with temporal context
     result = await kb.remember(
@@ -81,20 +81,20 @@ async with Khora("postgresql://...", engine="skeleton") as kb:
             "author": "alice@company.com",
             "channel": "leadership",
             "occurred_at": "2024-01-15T10:00:00Z"
-        }
+        },
+        entity_types=["PERSON", "EVENT"],
+        relationship_types=["PARTICIPATES_IN"],
     )
 
-    # Recall with temporal and structured filters
+    # Recall with temporal filters
     results = await kb.recall(
         "What decisions were made?",
         namespace=ns.namespace_id,
-        temporal_filter={
-            "occurred_after": "2024-01-01",
-            "occurred_before": "2024-03-31",
-            "author": "alice@company.com"
-        },
-        hybrid_alpha=0.7  # 70% vector, 30% BM25
+        start_time=datetime(2024, 1, 1),
+        end_time=datetime(2024, 3, 31),
     )
+    # Note: structured filters (author, channel) and per-call hybrid
+    # alpha aren't exposed on the public facade today.
 ```
 
 **Key Methods:**
@@ -487,19 +487,18 @@ results = await engine.recall(query, namespace_id=ns_id, mode=SearchMode.HYBRID)
 ### Via KhoraConfig
 
 ```python
-from khora.config import KhoraConfig
+from khora.config import KhoraConfig, QueryConfig
 
 config = KhoraConfig(
     database_url="postgresql://localhost/khora",
-    engine=EngineConfig(
-        name="skeleton",
-        backend="pgvector",  # or "weaviate"
-    ),
     query=QueryConfig(
-        hybrid_alpha=0.7,
         recency_decay_days=30,
     ),
 )
+# Engine selection is a Khora() constructor kwarg, not a config field:
+#     kb = Khora(config, engine="skeleton")
+# Per-query hybrid alpha isn't exposed; set it globally via
+# KHORA_QUERY_HYBRID_ALPHA (environment) instead.
 ```
 
 ### Via Environment Variables
@@ -546,4 +545,3 @@ temporal:
 - [Temporal Model](temporal-model.md) - Deep dive into bi-temporal design
 - [Skeleton Indexing](skeleton-indexing.md) - PageRank-based core selection
 - [Hybrid Search](hybrid-search.md) - Vector + BM25 fusion details
-- [References](../REFERENCES.md) - Research papers and inspirations

--- a/docs/engines/skeleton-indexing.md
+++ b/docs/engines/skeleton-indexing.md
@@ -430,6 +430,4 @@ state = {
 
 ## Related Documentation
 
-- [Khora Engine](khora-engine.md) - Overview of the Khora engine
 - [Engine Comparison](engine-comparison.md) - Cost comparison with VectorCypher and Chronicle
-- [References](../REFERENCES.md) - KET-RAG paper citation

--- a/docs/engines/temporal-model.md
+++ b/docs/engines/temporal-model.md
@@ -443,5 +443,4 @@ edges = await storage.get_edges_by_entity(
 ## Related Documentation
 
 - [Skeleton Construction Engine](skeleton-engine.md) - Overview of the Skeleton Construction engine
-- [References](../REFERENCES.md) - Graphiti and TG-RAG paper citations
 - [Query Engine](../query-engine/temporal-queries.md) - Temporal query patterns

--- a/docs/engines/vectorcypher-engine.md
+++ b/docs/engines/vectorcypher-engine.md
@@ -81,20 +81,27 @@ from khora import Khora
 
 # Use VectorCypher engine explicitly
 async with Khora("postgresql://...", engine="vectorcypher") as kb:
+    ns = await kb.create_namespace()
+
     # Store with temporal context
     result = await kb.remember(
         "Meeting notes from Q1 planning with John",
+        namespace=ns.namespace_id,
         title="Q1 Planning",
         metadata={
             "author": "alice@company.com",
             "occurred_at": "2024-01-15T10:00:00Z"
-        }
+        },
+        entity_types=["PERSON", "EVENT"],
+        relationship_types=["PARTICIPATES_IN"],
     )
 
-    # Recall with graph-enhanced retrieval
+    # Recall with graph-enhanced retrieval. Per-call graph depth isn't
+    # exposed on kb.recall(); configure globally via
+    # `KhoraConfig.query.max_graph_depth`.
     results = await kb.recall(
         "What did we discuss with John about planning?",
-        graph_depth=2,  # Expand 2 hops in graph
+        namespace=ns.namespace_id,
     )
 ```
 
@@ -454,8 +461,14 @@ async with Khora(
         retriever_min_entity_similarity=0.25,
     )},
 ) as kb:
-    result = await kb.remember("content")
-    results = await kb.recall("query")
+    ns = await kb.create_namespace()
+    result = await kb.remember(
+        "content",
+        namespace=ns.namespace_id,
+        entity_types=["PERSON", "ORG"],
+        relationship_types=["WORKS_AT"],
+    )
+    results = await kb.recall("query", namespace=ns.namespace_id)
 ```
 
 The `engine_kwargs` dict is forwarded directly to the `VectorCypherEngine` constructor, which accepts `vectorcypher_config` as a keyword argument.
@@ -643,4 +656,3 @@ uv run alembic upgrade head
 - [Temporal Model](temporal-model.md) - Bi-temporal design deep dive
 - [Hybrid Search](hybrid-search.md) - Vector + BM25 fusion details
 - [Temporal Queries](../query-engine/temporal-queries.md) - Temporal detection, recency bias, and temporal filters
-- [References](../REFERENCES.md) - Research papers and inspirations (HippoRAG 2, Graph RAG 2026)

--- a/docs/extraction/chunkers.md
+++ b/docs/extraction/chunkers.md
@@ -275,14 +275,36 @@ More overlap = more redundancy = better boundary handling, but larger storage.
 
 ```python
 # Use semantic chunking (default)
-await kb.remember(content, chunk_strategy="semantic")
+await kb.remember(
+    content,
+    namespace=ns.namespace_id,
+    chunk_strategy="semantic",
+    entity_types=["PERSON", "ORG"],
+    relationship_types=["MENTIONS"],
+)
 
 # Use recursive for structured docs
-await kb.remember(content, chunk_strategy="recursive", chunk_size=1024)
+await kb.remember(
+    content,
+    namespace=ns.namespace_id,
+    chunk_strategy="recursive",
+    entity_types=["PERSON", "ORG"],
+    relationship_types=["MENTIONS"],
+)
 
 # Use fixed for speed
-await kb.remember(content, chunk_strategy="fixed", chunk_size=512)
+await kb.remember(
+    content,
+    namespace=ns.namespace_id,
+    chunk_strategy="fixed",
+    entity_types=["PERSON", "ORG"],
+    relationship_types=["MENTIONS"],
+)
 ```
+
+`chunk_size` isn't a per-call kwarg on `kb.remember()`; configure it
+globally via `KhoraConfig.chunker.chunk_size` (or env var
+`KHORA_CHUNKER_CHUNK_SIZE`) at construction time.
 
 ### Direct Usage
 

--- a/docs/extraction/embedders.md
+++ b/docs/extraction/embedders.md
@@ -166,14 +166,18 @@ No API key needed - just run Ollama locally.
 
 ```python
 # Uses configured default embedding model
-await kb.remember("Your content...")
-
-# Override for specific content
 await kb.remember(
     "Your content...",
-    embedding_model="text-embedding-3-large"
+    namespace=ns.namespace_id,
+    entity_types=["PERSON", "ORG"],
+    relationship_types=["MENTIONS"],
 )
 ```
+
+`embedding_model` isn't a per-call kwarg on `kb.remember()`. Configure the
+embedding model globally via `KhoraConfig.embedding.model` (or env var
+`KHORA_EMBEDDING_MODEL`, or pass `embedding_model="text-embedding-3-large"`
+to the `Khora(...)` constructor).
 
 ### In Pipelines
 

--- a/docs/extraction/expertise-system.md
+++ b/docs/extraction/expertise-system.md
@@ -439,7 +439,10 @@ The Slack skill (`extraction/skills/builtin/slack.yaml`) is designed for ingesti
 ```python
 result = await kb.remember(
     content,
+    namespace=ns.namespace_id,
     expertise="saas_expert",  # Name or path
+    entity_types=["PERSON", "ORG"],
+    relationship_types=["WORKS_AT"],
 )
 ```
 

--- a/docs/extraction/extractors.md
+++ b/docs/extraction/extractors.md
@@ -372,10 +372,16 @@ for attempt in range(self._max_retries):
 ```python
 result = await kb.remember(
     content,
-    extraction_model="gpt-4o-mini",
+    namespace=ns.namespace_id,
     skill_name="general_entities",
+    entity_types=["PERSON", "ORG"],
+    relationship_types=["WORKS_AT"],
 )
 ```
+
+`extraction_model` isn't a per-call kwarg on `kb.remember()`. Set the
+extraction model globally via `KhoraConfig.llm.model` (or env var
+`KHORA_LLM_MODEL`) at construction time.
 
 ### In Pipeline Tasks
 

--- a/docs/extraction/ingestion-pipeline.md
+++ b/docs/extraction/ingestion-pipeline.md
@@ -398,13 +398,16 @@ staging_semaphore = asyncio.Semaphore(20)
 | Entity writes | `_EntityKeyGate` (key-aware) | 12 concurrent, serializes overlapping keys | MERGE transactions on the same `(namespace_id, name, entity_type)` would cause Neo4j lock contention and ~1 s retry backoff |
 | Relationship writes | `asyncio.Semaphore` | 8 concurrent | CREATE transactions don't contend - each is a new edge |
 
-These are configurable:
+These are configurable on `remember_batch` via `max_concurrent`, and at
+the engine level via `KhoraConfig` / engine kwargs:
 
 ```python
 result = await kb.remember_batch(
     documents,
-    max_concurrent_documents=10,
-    max_concurrent_extractions=20
+    namespace=ns.namespace_id,
+    max_concurrent=10,
+    entity_types=["PERSON", "ORG"],
+    relationship_types=["WORKS_AT"],
 )
 ```
 
@@ -428,7 +431,12 @@ for doc, result in zip(docs, results):
 Check for failures in the result:
 
 ```python
-result = await kb.remember_batch(documents)
+result = await kb.remember_batch(
+    documents,
+    namespace=ns.namespace_id,
+    entity_types=["PERSON", "ORG"],
+    relationship_types=["WORKS_AT"],
+)
 
 print(f"Processed: {result['processed_documents']}")
 print(f"Skipped (duplicates): {result['skipped_documents']}")
@@ -442,8 +450,11 @@ print(f"Failed: {result['failed_documents']}")
 ```python
 result = await kb.remember(
     "Your content here...",
+    namespace=ns.namespace_id,
     title="Document Title",
-    source="manual"
+    source="manual",
+    entity_types=["PERSON", "ORG"],
+    relationship_types=["WORKS_AT"],
 )
 
 print(f"Document: {result.document_id}")
@@ -461,7 +472,10 @@ documents = [
 
 result = await kb.remember_batch(
     documents,
+    namespace=ns.namespace_id,
     max_concurrent=10,
+    entity_types=["PERSON", "ORG"],
+    relationship_types=["WORKS_AT"],
 )
 ```
 
@@ -472,13 +486,18 @@ result = await kb.remember_batch(
 ```python
 result = await kb.remember(
     content,
+    namespace=ns.namespace_id,
     chunk_strategy="recursive",
-    chunk_size=1024,
-    embedding_model="text-embedding-3-large",
-    extraction_model="claude-sonnet-4-20250514",
-    expertise="technical_docs"
+    expertise="technical_docs",
+    entity_types=["PERSON", "ORG"],
+    relationship_types=["WORKS_AT"],
 )
 ```
+
+`chunk_size`, `embedding_model`, and `extraction_model` aren't per-call
+kwargs on `kb.remember()`. Configure them at construction time via
+`KhoraConfig.chunker.chunk_size`, `KhoraConfig.embedding.model`, and
+`KhoraConfig.llm.model` (or the corresponding `KHORA_*` env vars).
 
 ### Direct Pipeline Call
 

--- a/docs/extraction/overview.md
+++ b/docs/extraction/overview.md
@@ -210,10 +210,12 @@ Here's the complete flow for `remember()`:
 
 ```python
 result = await kb.remember(
-    content="Einstein published his theory of general relativity in 1915...",
+    "Einstein published his theory of general relativity in 1915...",
+    namespace=ns.namespace_id,
     title="Physics History",
     chunk_strategy="semantic",
-    enable_expansion=True
+    entity_types=["PERSON", "ORG"],
+    relationship_types=["WORKS_AT"],
 )
 
 # Result
@@ -224,6 +226,9 @@ RememberResult(
     relationships_extracted=4
 )
 ```
+
+(Semantic expansion is currently controlled globally via
+`KhoraConfig.extraction.enable_semantic_expansion`, not per-call.)
 
 Behind the scenes:
 1. **Staging**: Checksum computed, no duplicate found, document created
@@ -253,13 +258,18 @@ extraction_model = "gpt-4o-mini"
 ```python
 await kb.remember(
     content,
+    namespace=ns.namespace_id,
     chunk_strategy="recursive",
-    chunk_size=1024,
-    embedding_model="text-embedding-3-large",
-    extraction_model="claude-sonnet-4-20250514",
-    expertise="technical_docs"  # Domain-specific extraction
+    expertise="technical_docs",  # Domain-specific extraction
+    entity_types=["PERSON", "ORG"],
+    relationship_types=["WORKS_AT"],
 )
 ```
+
+`chunk_size`, `embedding_model`, and `extraction_model` aren't per-call
+kwargs. Set them via `KhoraConfig.chunker.chunk_size`,
+`KhoraConfig.embedding.model`, and `KhoraConfig.llm.model` (or the
+matching `KHORA_*` env vars) at construction time.
 
 ### Batch Processing
 
@@ -268,11 +278,15 @@ For large ingestions:
 ```python
 results = await kb.remember_batch(
     documents,
-    max_concurrent_documents=10,     # Process 10 docs at once
-    max_concurrent_extractions=20,   # Max 20 LLM calls in flight
-    enable_expansion=True
+    namespace=ns.namespace_id,
+    max_concurrent=10,               # Process 10 docs at once
+    entity_types=["PERSON", "ORG"],
+    relationship_types=["WORKS_AT"],
 )
 ```
+
+(Extraction concurrency and semantic expansion are configured globally
+via `KhoraConfig.extraction.*`, not per call.)
 
 ## Error Handling
 

--- a/docs/hooks/semantic-hooks.md
+++ b/docs/hooks/semantic-hooks.md
@@ -24,10 +24,12 @@ async with Khora() as kb:
     kb.subscribe("entity.created", on_entity, filter=filter)
 
     # Ingestion triggers callbacks
-    ns = await kb.create_namespace("default")
+    ns = await kb.create_namespace()
     await kb.remember(
         "Acme Corp announced a partnership with Globex.",
         namespace=ns.namespace_id,
+        entity_types=["ORGANIZATION"],
+        relationship_types=["PARTNERSHIP_WITH"],
     )
 ```
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -109,10 +109,10 @@ Every read, exists-check, and mutation on every storage backend (`RelationalBack
 If your code calls these methods directly:
 
 ```python
-# Before (v0.15.x)
-doc = await kb.get_document(doc_id)
-ent = await kb.storage.graph.get_entity(entity_id)
-await kb.storage.relational.delete_document(doc_id)
+# Before (v0.15.x) - implicit namespace was allowed
+# doc = await kb.get_document(doc_id)
+# ent = await kb.storage.graph.get_entity(entity_id)
+# await kb.storage.relational.delete_document(doc_id)
 
 # After (v0.16.0+)
 doc = await kb.get_document(doc_id, namespace=ns_id)
@@ -128,17 +128,27 @@ The `graphrag` engine is no longer available. Replace it with `vectorcypher`:
 
 ```python
 # Old (graphrag - no longer available)
-async with Khora(db_url, engine="graphrag") as kb:
-    await kb.remember(content, namespace=ns_id)
+# async with Khora(db_url, engine="graphrag") as kb:
+#     await kb.remember(content, namespace=ns_id, ...)
 
 # Drop-in replacement: vectorcypher with full extraction
 async with Khora(db_url, engine="vectorcypher",
                  engine_kwargs={"skeleton_core_ratio": 1.0}) as kb:
-    await kb.remember(content, namespace=ns_id)
+    await kb.remember(
+        content,
+        namespace=ns_id,
+        entity_types=["PERSON"],
+        relationship_types=["KNOWS"],
+    )
 
 # Or accept default selective extraction (recommended - 30% cheaper):
 async with Khora(db_url, engine="vectorcypher") as kb:
-    await kb.remember(content, namespace=ns_id)
+    await kb.remember(
+        content,
+        namespace=ns_id,
+        entity_types=["PERSON"],
+        relationship_types=["KNOWS"],
+    )
 ```
 
 Existing graphrag-ingested data remains queryable via `vectorcypher` against the same database - the table shapes are identical.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -39,7 +39,12 @@ async def main():
     configure_telemetry()        # picks up OTEL_* env vars
     async with Khora() as kb:
         ns = await kb.create_namespace()      # keyword-only kwargs
-        await kb.remember("Marie Curie won the Nobel Prize.", namespace=ns.namespace_id)
+        await kb.remember(
+            "Marie Curie won the Nobel Prize.",
+            namespace=ns.namespace_id,
+            entity_types=["PERSON", "ORG"],
+            relationship_types=["WORKS_AT"],
+        )
 
 asyncio.run(main())
 ```

--- a/docs/query-engine/agentic-search.md
+++ b/docs/query-engine/agentic-search.md
@@ -120,29 +120,19 @@ print(f"Summary: {result.summary}")
 
 ### Via Khora
 
+Per-query agentic search isn't currently exposed on the public facade -
+use the `AgenticSearchAgent` shown above for now. Temporal narrowing on
+the standard `kb.recall()` facade is handled via the `start_time` /
+`end_time` kwargs (no `temporal_filter` / `recency_bias` configuration
+is exposed today):
+
 ```python
+from datetime import datetime, timedelta, timezone
+
 result = await kb.recall(
     "product strategy",
     namespace=ns_id,
-    config=QueryConfig(
-        enable_agentic=True,
-        max_agentic_steps=3
-    )
-)
-```
-
-### With Other Options
-
-```python
-result = await agent.search(
-    query,
-    namespace_id,
-    config=QueryConfig(
-        mode=SearchMode.HYBRID,
-        temporal_filter=TemporalFilter.last_days(30),
-        recency_bias=0.2
-    ),
-    max_steps=3
+    start_time=datetime.now(timezone.utc) - timedelta(days=30),
 )
 ```
 

--- a/docs/query-engine/fusion.md
+++ b/docs/query-engine/fusion.md
@@ -188,16 +188,9 @@ source_priority = {
 
 To use these recommendations:
 
-```python
-from khora.query import HybridQueryEngine, QueryConfig
-
-# The engine can apply recommendations automatically
-result = await engine.query(
-    "Who manages engineering?",
-    namespace_id=namespace_id,
-    config=QueryConfig(use_adaptive_weights=True),
-)
-```
+Adaptive fusion (auto-tuned weights from query characteristics) isn't
+exposed as a per-call `QueryConfig` flag today; it's handled internally
+by the VectorCypher engine when temporal/complexity signals fire.
 
 ## Rust-Accelerated RRF
 
@@ -310,22 +303,17 @@ config = RetrieverConfig(
 
 ```python
 from khora import Khora, SearchMode
-from khora.query import QueryConfig
 
 async with Khora() as kb:
-    ns = await kb.create_namespace("default")
-    # Search with custom fusion settings
+    ns = await kb.create_namespace()
+    # kb.recall() exposes mode, limit and similarity threshold. Fusion
+    # weights (vector / graph / keyword / rrf_k) aren't per-call kwargs -
+    # set them globally via KhoraConfig.query or KHORA_QUERY_* env vars.
     results = await kb.recall(
         "Einstein's contributions to physics",
         namespace=ns.namespace_id,
         mode=SearchMode.ALL,
-        config=QueryConfig(
-            vector_weight=0.5,
-            graph_weight=0.3,
-            keyword_weight=0.2,
-            rrf_k=60,
-            limit=10
-        )
+        limit=10,
     )
 
     for chunk in results.chunks:

--- a/docs/query-engine/overview.md
+++ b/docs/query-engine/overview.md
@@ -191,12 +191,10 @@ TemporalFilter.last_days(7)
 TemporalFilter.after("2023-06-01")
 ```
 
-Recency bias can also be applied - recent content scores higher:
-
-```python
-# Exponential decay: score *= e^(-decay * days_old)
-config = QueryConfig(recency_bias=0.3)
-```
+Recency bias can also be applied - recent content scores higher.
+Recency weighting is configured globally via `QueryConfig.apply_recency_bias`
+and `QueryConfig.recency_weight`; the legacy `recency_bias=` knob isn't
+exposed on the current public surface.
 
 ## Step 5b: MMR Diversity Selection (Optional)
 
@@ -253,7 +251,7 @@ QueryResult(
 from khora import Khora, SearchMode
 
 async with Khora() as kb:
-    ns = await kb.create_namespace("default")
+    ns = await kb.create_namespace()
     results = await kb.recall(
         "machine learning applications",
         namespace=ns.namespace_id,
@@ -268,40 +266,29 @@ async with Khora() as kb:
 ### With Full Configuration
 
 ```python
-from khora.query import QueryConfig
-from khora.query.temporal import TemporalFilter
+from datetime import datetime, timedelta, timezone
 
 results = await kb.recall(
     "product updates",
     namespace=ns_id,
-    config=QueryConfig(
-        mode=SearchMode.HYBRID,
-        limit=20,
-        min_similarity=0.1,
-        vector_weight=0.6,
-        graph_weight=0.2,
-        keyword_weight=0.2,
-        temporal_filter=TemporalFilter.last_days(30),
-        recency_bias=0.2,
-        enable_reranking=True
-    )
+    mode=SearchMode.HYBRID,
+    limit=20,
+    min_similarity=0.1,
+    start_time=datetime.now(timezone.utc) - timedelta(days=30),
 )
 ```
+
+`kb.recall()` accepts `mode`, `limit`, `min_similarity`, `start_time`,
+and `end_time` directly. Fusion weights, reranking, and recency knobs
+are global - configure them via `KhoraConfig.query` (`QueryConfig`) at
+construction time or via `KHORA_QUERY_*` environment variables; there
+is no `config=` kwarg on `kb.recall()`.
 
 ### Agentic Search
 
-For complex questions, enable multi-step exploration:
-
-```python
-results = await kb.recall(
-    "What's our competitive strategy?",
-    namespace=ns_id,
-    config=QueryConfig(enable_agentic=True)
-)
-
-# The engine may execute follow-up queries automatically
-print(results.trace)  # See the full exploration path
-```
+Per-query agentic search isn't exposed on `kb.recall()`. Use
+`khora.query.agentic.AgenticSearchAgent` directly (see
+[agentic-search.md](agentic-search.md)).
 
 ## Search Mode Quick Reference
 

--- a/docs/query-engine/query-understanding.md
+++ b/docs/query-engine/query-understanding.md
@@ -263,7 +263,7 @@ result = await engine.query(
     "Einstein collaborators at Princeton",
     namespace_id=namespace_id,
     config=QueryConfig(
-        enable_understanding=True,  # Default
+        enable_query_understanding=True,  # Default
     ),
 )
 
@@ -311,7 +311,7 @@ result = await engine.query(
     "simple search",
     namespace_id=namespace_id,
     config=QueryConfig(
-        enable_understanding=False,
+        enable_query_understanding=False,
     ),
 )
 ```

--- a/docs/query-engine/search-modes.md
+++ b/docs/query-engine/search-modes.md
@@ -63,11 +63,9 @@ results = await kb.recall(
     "Machine Learning Team projects and members",
     namespace=ns_id,
     mode=SearchMode.GRAPH,
-    config=QueryConfig(
-        graph_depth=2,  # Go 2 hops out
-        graph_relationship_types=["WORKS_ON", "MEMBER_OF", "MANAGES"]
-    )
 )
+# Note: per-call graph depth isn't exposed; configure max_graph_depth
+# globally via KhoraConfig.query at construction time.
 ```
 
 **The magic**: If Alice works at Acme and Bob also works at Acme, graph search can infer they're colleagues - even if no document explicitly says so.
@@ -209,40 +207,26 @@ QueryConfig(
 Limit results to a time window:
 
 ```python
+from datetime import datetime, timedelta, timezone
+
 results = await kb.recall(
     "product decisions",
     namespace=ns_id,
     mode=SearchMode.HYBRID,
-    temporal_filter=TemporalFilter.last_days(30),
+    start_time=datetime.now(timezone.utc) - timedelta(days=30),
 )
 ```
 
 ### With Graph Constraints
 
-Control how deep and what relationships to explore:
+Graph depth is configured globally (`KhoraConfig.query.max_graph_depth`)
+rather than per-call - there's no `config=` kwarg on `kb.recall()`:
 
 ```python
 results = await kb.recall(
     "engineering org structure",
     namespace=ns_id,
     mode=SearchMode.GRAPH,
-    config=QueryConfig(
-        graph_depth=3,
-        graph_relationship_types=["REPORTS_TO", "MANAGES", "MEMBER_OF"]
-    )
-)
-```
-
-### With Agentic Exploration
-
-Let the query engine follow up on initial results:
-
-```python
-results = await kb.recall(
-    "competitive landscape",
-    namespace=ns_id,
-    mode=SearchMode.HYBRID,
-    config=QueryConfig(enable_agentic=True)
 )
 ```
 

--- a/docs/query-engine/temporal-queries.md
+++ b/docs/query-engine/temporal-queries.md
@@ -80,11 +80,14 @@ The engine's `recall()` method runs detection automatically when no explicit `Te
 results = await kb.recall("What instrument does Alice currently play?", namespace=ns_id)
 # → STATE_QUERY: recency_weight=0.5, temporal_sort=True
 
-# Explicit override - skips automatic detection
+# Explicit override - skips automatic detection.
+# `kb.recall()` accepts `start_time` / `end_time` directly:
+from datetime import datetime, timedelta, timezone
+
 results = await kb.recall(
     "product updates",
     namespace=ns_id,
-    temporal_filter=TemporalFilter.last_days(7),
+    start_time=datetime.now(timezone.utc) - timedelta(days=7),
 )
 ```
 
@@ -134,19 +137,13 @@ Cost: zero additional LLM calls - only the system prompt changes. Category detec
 
 ### Manual Recency Bias
 
-You can also set recency bias explicitly via the API:
+Per-call `recency_bias=` isn't exposed on `kb.recall()`. Configure
+recency weighting globally via `QueryConfig.apply_recency_bias` and
+`QueryConfig.recency_weight` (passed through `KhoraConfig.query` at
+construction time) or via `KHORA_QUERY_*` env vars:
 
-```python
-# All content, but prefer recent
-results = await kb.recall(
-    "team updates",
-    namespace=ns_id,
-    recency_bias=0.3,  # Boost recent content
-)
-```
-
-| Value | Effect |
-|-------|--------|
+| `recency_weight` | Effect |
+|------------------|--------|
 | `0.0` | No recency preference |
 | `0.1` | Subtle - barely noticeable |
 | `0.3` | Moderate - recent content noticeably higher |
@@ -294,12 +291,15 @@ results = await kb.recall("Did Alice switch teams?", namespace=ns_id)
 ### Explicit Temporal Filter
 
 ```python
-# Override automatic detection with a specific time range
+from datetime import datetime, timedelta, timezone
+
+# Override automatic detection with a specific time range. Per-call
+# recency_bias isn't exposed on the facade; set recency weighting
+# globally via KhoraConfig.query.
 results = await kb.recall(
     "incident reports",
     namespace=ns_id,
-    temporal_filter=TemporalFilter.last_hours(6),
-    recency_bias=0.5,
+    start_time=datetime.now(timezone.utc) - timedelta(hours=6),
 )
 ```
 
@@ -309,10 +309,8 @@ results = await kb.recall(
 results = await kb.recall(
     "quarterly planning",
     namespace=ns_id,
-    temporal_filter=TemporalFilter.between(
-        datetime(2024, 10, 1),
-        datetime(2024, 12, 31)
-    )
+    start_time=datetime(2024, 10, 1),
+    end_time=datetime(2024, 12, 31),
 )
 ```
 
@@ -322,38 +320,40 @@ results = await kb.recall(
 results = await kb.recall(
     "team structure",
     namespace=ns_id,
-    temporal_filter=TemporalFilter(
-        operator=TemporalOperator.DURING,
-        start=datetime(2022, 1, 1),
-        end=datetime(2022, 12, 31)
-    )
+    start_time=datetime(2022, 1, 1),
+    end_time=datetime(2022, 12, 31),
 )
 ```
 
 ### Full Config Example
 
 ```python
-from khora.query import QueryConfig
-from khora.query.temporal import TemporalFilter
+from datetime import datetime, timedelta, timezone
 
 results = await kb.recall(
     "product decisions",
     namespace=ns_id,
-    config=QueryConfig(
-        mode=SearchMode.HYBRID,
-        temporal_filter=TemporalFilter.last_days(30),
-        recency_bias=0.3,
-        limit=20
-    )
+    mode=SearchMode.HYBRID,
+    start_time=datetime.now(timezone.utc) - timedelta(days=30),
+    limit=20,
 )
 ```
+
+`kb.recall()` accepts `mode`, `limit`, `min_similarity`, `start_time`,
+and `end_time` directly. Fusion weights and recency knobs are global;
+configure them via `KhoraConfig.query` at construction time.
 
 ## Result Metadata
 
 Query results include information about temporal filtering:
 
 ```python
-result = await kb.recall(query, namespace=ns_id, temporal_filter=filter)
+result = await kb.recall(
+    query,
+    namespace=ns_id,
+    start_time=start,
+    end_time=end,
+)
 
 if result.temporal_info:
     print(f"Filter applied: {result.temporal_info.filter_applied}")


### PR DESCRIPTION
Fixes bad kwarges flagged by docs audit

Covers:

  - Khora.remember / remember_batch / submit_batch — add required entity_types/relationship_types/namespace to 44 sites
  - Khora.recall — strip 16 phantom kwargs (config, temporal_filter, recency_bias, hybrid_alpha, time_range, graph_depth); use the supported start_time/end_time/min_similarity/limit where applicable
  - QueryConfig — remove 22 phantom fields; consolidate examples to the real surface
  - Khora.remember/remember_batch — remove 12 phantom config-style kwargs (chunk_size, embedding_model, extraction_model, etc.) and re-point examples at KhoraConfig.chunker/llm/embedding
  - Khora() constructor — drop the unsupported config= kwarg in dream-phase.md
  - KhoraConfig — drop unsupported engine= field in skeleton-engine.md