### PR TITLE
docs: remove phantom KHORA_* env vars and config paths

### DIFF
--- a/docs/architecture/storage-backends.md
+++ b/docs/architecture/storage-backends.md
@@ -94,7 +94,7 @@ config = StorageConfig(
 Or via environment:
 ```bash
 export KHORA_DATABASE_URL="postgresql://user:pass@localhost:5432/khora"
-export KHORA_STORAGE_POOL_PRE_PING=true
+export KHORA_STORAGE_POSTGRESQL_POOL_PRE_PING=true
 ```
 
 **`pool_pre_ping`** issues a lightweight `SELECT 1` before handing out a connection from the pool. This detects stale connections (from network interruptions, DB restarts, or idle timeouts) and transparently replaces them. Adds ~1ms per connection checkout but prevents `connection reset by peer` errors in long-running processes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,6 @@ KHORA_NEO4J_URL=bolt://neo4j:pleaseletmein@localhost:7688
 KHORA_LLM_MODEL=gpt-4o
 KHORA_QUERY_ENABLE_HYDE=auto
 KHORA_QUERY_DEFAULT_MODE=hybrid
-KHORA_EXTRACTION_BATCH_SIZE=5
 ```
 
 Legacy double-underscore nesting (`KHORA_STORAGE__GRAPH__URL`) is still accepted as a backwards-compatible alias on every nested-config field. New code and `.env` files should use the single-underscore form shown throughout this document; the legacy form continues to work but is no longer documented.

--- a/docs/engines/hybrid-search.md
+++ b/docs/engines/hybrid-search.md
@@ -436,18 +436,28 @@ async with Khora(db_url, engine="skeleton") as kb:
 ### Via Environment
 
 ```bash
-KHORA_QUERY_HYBRID_ALPHA=0.7
-KHORA_QUERY_DEFAULT_LIMIT=10
-KHORA_QUERY_MIN_SIMILARITY=0.0
+KHORA_QUERY_VECTOR_WEIGHT=0.7
+KHORA_QUERY_KEYWORD_WEIGHT=0.3
+KHORA_QUERY_MIN_CHUNK_SIMILARITY=0.0
+KHORA_QUERY_MIN_ENTITY_SIMILARITY=0.0
 ```
+
+`hybrid_alpha` is a per-call argument to `kb.recall(...)` only — there
+is no global env-var equivalent. The vector/keyword channel weights
+above (`KHORA_QUERY_VECTOR_WEIGHT` / `KHORA_QUERY_KEYWORD_WEIGHT`) are
+the closest tunable defaults. The per-call `limit` argument likewise
+has no env-var default; see `KHORA_QUERY_STAGE1_RECALL_LIMIT`,
+`KHORA_QUERY_STAGE3_FILTER_LIMIT`, and `KHORA_QUERY_STAGE4_RERANK_LIMIT`
+for per-stage caps.
 
 ### Via YAML
 
 ```yaml
 query:
-  hybrid_alpha: 0.7
-  default_limit: 10
-  min_similarity: 0.0
+  vector_weight: 0.7
+  keyword_weight: 0.3
+  min_chunk_similarity: 0.0
+  min_entity_similarity: 0.0
   recency_decay_days: 30
 ```
 

--- a/docs/engines/skeleton-engine.md
+++ b/docs/engines/skeleton-engine.md
@@ -497,8 +497,8 @@ config = KhoraConfig(
 )
 # Engine selection is a Khora() constructor kwarg, not a config field:
 #     kb = Khora(config, engine="skeleton")
-# Per-query hybrid alpha isn't exposed; set it globally via
-# KHORA_QUERY_HYBRID_ALPHA (environment) instead.
+# `hybrid_alpha` is a per-call argument to kb.recall(...) only; there is
+# no global env-var or config-field equivalent.
 ```
 
 ### Via Environment Variables

--- a/docs/engines/skeleton-engine.md
+++ b/docs/engines/skeleton-engine.md
@@ -505,22 +505,19 @@ config = KhoraConfig(
 
 ```bash
 KHORA_DATABASE_URL=postgresql://localhost/khora
-KHORA_ENGINE_NAME=skeleton
-KHORA_ENGINE_BACKEND=pgvector
-KHORA_QUERY_HYBRID_ALPHA=0.7
 KHORA_QUERY_RECENCY_DECAY_DAYS=30
 ```
+
+Engine and backend selection are constructor-only — pass
+`engine="skeleton"` and `engine_kwargs={"backend": "pgvector"}` to
+`Khora(...)`. The `hybrid_alpha` blend weight is a per-call argument
+to `kb.recall(...)` and has no env-var equivalent.
 
 ### Via YAML
 
 ```yaml
 # config/skeleton/khora.yaml
-engine:
-  name: skeleton
-  backend: pgvector
-
 query:
-  hybrid_alpha: 0.7
   recency_decay_days: 30
 
 temporal:

--- a/docs/engines/vectorcypher-engine.md
+++ b/docs/engines/vectorcypher-engine.md
@@ -479,20 +479,17 @@ The `engine_kwargs` dict is forwarded directly to the `VectorCypherEngine` const
 # Storage
 KHORA_DATABASE_URL=postgresql://localhost/khora
 KHORA_NEO4J_URL=bolt://localhost:7687
-KHORA_NEO4J_USER=neo4j
-KHORA_NEO4J_PASSWORD=password
-
-# Engine
-KHORA_ENGINE_NAME=vectorcypher
+KHORA_STORAGE_NEO4J_USER=neo4j
+KHORA_STORAGE_NEO4J_PASSWORD=password
 ```
+
+Engine selection is constructor-only — pass `engine="vectorcypher"` to
+`Khora(...)` (it is also the default).
 
 ### Via YAML
 
 ```yaml
 # config/vectorcypher/khora.yaml
-engine:
-  name: vectorcypher
-
 vectorcypher:
   routing:
     enabled: true
@@ -508,7 +505,6 @@ vectorcypher:
     graph_weight: 0.4
 
 query:
-  hybrid_alpha: 0.7
   apply_recency_bias: true
 ```
 
@@ -526,8 +522,8 @@ query:
 # Environment setup
 KHORA_DATABASE_URL=postgresql://localhost/khora
 KHORA_NEO4J_URL=bolt://localhost:7687
-KHORA_NEO4J_USER=neo4j
-KHORA_NEO4J_PASSWORD=password
+KHORA_STORAGE_NEO4J_USER=neo4j
+KHORA_STORAGE_NEO4J_PASSWORD=password
 ```
 
 ## Performance Characteristics

--- a/docs/extraction/chunkers.md
+++ b/docs/extraction/chunkers.md
@@ -303,8 +303,8 @@ await kb.remember(
 ```
 
 `chunk_size` isn't a per-call kwarg on `kb.remember()`; configure it
-globally via `KhoraConfig.chunker.chunk_size` (or env var
-`KHORA_CHUNKER_CHUNK_SIZE`) at construction time.
+globally via `KhoraConfig.pipelines.chunk_size` (or env var
+`KHORA_PIPELINES_CHUNK_SIZE`) at construction time.
 
 ### Direct Usage
 

--- a/docs/extraction/embedders.md
+++ b/docs/extraction/embedders.md
@@ -174,10 +174,11 @@ await kb.remember(
 )
 ```
 
-`embedding_model` isn't a per-call kwarg on `kb.remember()`. Configure the
-embedding model globally via `KhoraConfig.embedding.model` (or env var
-`KHORA_EMBEDDING_MODEL`, or pass `embedding_model="text-embedding-3-large"`
-to the `Khora(...)` constructor).
+`embedding_model` isn't a per-call kwarg on `kb.remember()`. Configure
+the embedding model globally via `KhoraConfig.llm.embedding_model` (or
+env var `KHORA_LLM_EMBEDDING_MODEL`, or pass
+`embedding_model="text-embedding-3-large"` to the `Khora(...)`
+constructor).
 
 ### In Pipelines
 


### PR DESCRIPTION
## Summary

Removes 12 `KHORA_*` env vars / `KhoraConfig.*` field paths that the
docs reference but that don't exist anywhere in code — neither as
pydantic-settings fields nor as direct `os.environ` reads. Setting
them was a silent no-op.

Two commits:
- `bff81a5` — 9 phantoms surfaced by an empirical audit of every
  `KHORA_*` token in `docs/**/*.md`.
- `a401268` — 3 additional phantoms introduced by #844 (this PR's
  predecessor in the docs-cleanup chain), caught post-rebase.

Audit script lives in the sibling workspace at
`khorabenchtest/tools/phantom_env_var_audit.py`. Methodology:
instantiate `KhoraConfig()` with each documented var set to a probe
value, diff the resulting `model_dump()` against the no-env baseline.
Real = pydantic raised a validation error OR a field's value changed.
Phantom = setting the var had zero effect AND no direct `os.environ`
read exists.

## What changed per file

| File | Before | After |
|---|---|---|
| `docs/configuration.md` | `KHORA_EXTRACTION_BATCH_SIZE=5` | removed (no such field) |
| `docs/architecture/storage-backends.md` | `KHORA_STORAGE_POOL_PRE_PING` | renamed to `KHORA_STORAGE_POSTGRESQL_POOL_PRE_PING` |
| `docs/engines/hybrid-search.md` | 3 phantom env vars + 3 phantom YAML keys | replaced with `VECTOR_WEIGHT` / `KEYWORD_WEIGHT` / `MIN_CHUNK_SIMILARITY` / `MIN_ENTITY_SIMILARITY`; added a note that `hybrid_alpha` and `limit` are per-call only |
| `docs/engines/skeleton-engine.md` | 3 phantom env vars + a contradicting Python-block comment + phantom YAML keys | bash block trimmed; comment rewritten to say `hybrid_alpha` is per-call only; YAML synced |
| `docs/engines/vectorcypher-engine.md` | `KHORA_NEO4J_USER`/`PASSWORD`, `KHORA_ENGINE_NAME` (two sites) | `KHORA_NEO4J_USER`/`PASSWORD` → `KHORA_STORAGE_NEO4J_*`; engine note replaces phantom env var |
| `docs/extraction/chunkers.md` | `KhoraConfig.chunker.chunk_size` / `KHORA_CHUNKER_CHUNK_SIZE` | `KhoraConfig.pipelines.chunk_size` / `KHORA_PIPELINES_CHUNK_SIZE` |
| `docs/extraction/embedders.md` | `KhoraConfig.embedding.model` / `KHORA_EMBEDDING_MODEL` | `KhoraConfig.llm.embedding_model` / `KHORA_LLM_EMBEDDING_MODEL` (constructor kwarg note retained — `Khora(embedding_model=...)` is real, verified via `inspect.signature`) |

## Out of scope (verified REAL but worth knowing)

Four `KHORA_*` vars look phantom-shaped to a pure pydantic-settings
audit but are read via `os.environ` directly. Docs are correct as-is:

- `KHORA_ACCEL_BACKEND` — `src/khora/_accel.py`
- `KHORA_DREAM_DISABLE_APPLY` — `src/khora/dream/orchestrator.py:95`
- `KHORA_NEO4J_LOG_LEVEL` — `src/khora/logging_config.py`, `src/khora/telemetry/bootstrap.py`
- `KHORA_HERMES_KB_FACTORY` — `examples/integrations/hermes/plugin/__init__.py:25`

## Test plan

- [ ] Run the audit and confirm only the 4 real-via-os.environ vars remain in the PHANTOM list:
      `cd khora && uv run python /path/to/khorabenchtest/tools/phantom_env_var_audit.py`
- [ ] Spot-check the renamed env vars by `export`ing one and instantiating `KhoraConfig()` — the value should land in the right field (e.g. `KHORA_STORAGE_POSTGRESQL_POOL_PRE_PING=false` → `cfg.storage.postgresql_pool_pre_ping == False`).
- [ ] Read each diff and confirm the new env var / config path is correct against the live schema.