### PR TITLE
docs: cleanup batch — align public docs with current API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ async def main() -> None:
         await kb.remember(
             "Marie Curie won the Nobel Prize in Physics in 1903.",
             namespace=ns.namespace_id,
+            entity_types=["PERSON", "AWARD"],
+            relationship_types=["WON"],
         )
         result = await kb.recall("What did Curie win?", namespace=ns.namespace_id)
         print(context_text(result))
@@ -106,6 +108,8 @@ async with Khora() as kb:
         [{"content": "doc 1"}, {"content": "doc 2"}],
         on_result=lambda completed, total, result: print(result),
         namespace=ns_id,
+        entity_types=["PERSON", "ORG"],
+        relationship_types=["WORKS_AT"],
     )
     await handle.wait()
 ```
@@ -140,7 +144,7 @@ Khora ships an **offline maintenance pass** ("dream phase") that audits an accum
 ```python
 from khora import Khora, KhoraConfig, DreamConfig
 
-kb = Khora(config=KhoraConfig(dream=DreamConfig(enabled=True)))
+kb = Khora(KhoraConfig(dream=DreamConfig(enabled=True)))
 
 # Dry-run - pure observation/planning, zero writes.
 result = await kb.dream(namespace_id, mode="dry-run")
@@ -149,22 +153,24 @@ for op in result.ops:
     print(op.op_type, op.decision, op.outputs)
 ```
 
-Ten operations ship in v0.15.0 across both engines:
+Operations span both engines and cover audits (Phase 1: read-only,
+report-only), planning (Phase 2: emit `DreamOp` per work item), and
+apply (mutating with snapshot-before-delete and per-op transactions).
+The current `OpKind` surface is enumerated in
+[docs/dream-phase.md](docs/dream-phase.md); examples include
+schema-drift / orphan-PageRank / `source_chunk_ids` audits on the
+vectorcypher side, abstention-threshold + tombstone audits on
+chronicle, and planners for cross-batch entity dedupe, centroid
+recompute, `source_chunk_ids` GC, fact compaction, event clustering,
+community summary, contradiction detection, and schema normalization.
 
-| Phase | Engine | Operation | Surfaces |
-|---|---|---|---|
-| 1 audit | chronicle | abstention-threshold drift | Configured thresholds vs observed p50/p90/p99 |
-| 1 audit | chronicle | tombstone audit | Active / inactive / invalidated fact ratios + age distribution |
-| 1 audit | vectorcypher | schema drift | New / unused / frequency-changed types vs `ExpertiseConfig` |
-| 1 audit | vectorcypher | orphan PageRank | Bottom-5% PR entities flagged as `archive_candidate` |
-| 1 audit | vectorcypher | source_chunk_ids audit | Dead UUID counts + array-length distribution |
-| 2 planner | vectorcypher | cross-batch entity dedupe | Pairs above the per-type cosine threshold, planned merges |
-| 2 planner | vectorcypher | centroid recompute | Per-cluster `centroid` / `re_embed` / `skip_multimodal` decisions |
-| 2 planner | vectorcypher | source_chunk_ids GC | Per-entity rewrites dropping dead chunk UUIDs |
-| 2 planner | chronicle | memory_facts compaction | Tombstoned rows past `retention_days` |
-| 2 planner | chronicle | event clustering | Near-duplicate `chronicle_events` within a sliding window |
-
-Default is `DreamConfig(enabled=False)` - the master switch is opt-in. **Both modes are live in v0.15.0**: `mode="dry-run"` emits the plan only; `mode="apply"` runs the matching apply handler under a per-op transaction with the pre-state snapshotted into `undo.json` before each mutation. Five guardrails protect the apply path (7-day hard retention floor, `KHORA_DREAM_DISABLE_APPLY` kill-switch, chunk_id runtime assertion, snapshot-before-delete, advisory-lock-held-through-apply).
+Default is `DreamConfig(enabled=False)` - the master switch is opt-in.
+**Both modes are live**: `mode="dry-run"` emits the plan only;
+`mode="apply"` runs the matching apply handler under a per-op
+transaction with the pre-state snapshotted into `undo.json` before
+each mutation. Five guardrails protect the apply path (7-day hard
+retention floor, `KHORA_DREAM_DISABLE_APPLY` kill-switch, `chunk_id`
+runtime assertion, snapshot-before-delete, advisory-lock-held-through-apply).
 
 See [docs/dream-phase.md](docs/dream-phase.md) for the full operator guide: research lineage, configuration surface, sink wiring, telemetry contract, storage substrate, and stability tags.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -160,7 +160,9 @@ handle: BatchHandle = await kb.submit_batch(
 )
 ```
 
-Deferred sibling of `remember_batch()`: persists every document as `PENDING` and returns a `BatchHandle` immediately; processing continues in the background and fires `on_result` per document as it completes. Accepts the same provenance kwargs and per-doc dict shape as `remember_batch()` - per-doc dict values override the top-level kwargs. See [`BatchHandle`](#batchhandle) below for the wait/identity surface.
+Deferred sibling of `remember_batch()`: persists every document as `PENDING` and returns a `BatchHandle` immediately; the pending processor picks each document up and fires `on_result` as it completes. Accepts the same provenance kwargs and per-doc dict shape as `remember_batch()` - per-doc dict values override the top-level kwargs. See [`BatchHandle`](#batchhandle) below for the wait/identity surface.
+
+> **The pending processor is opt-in and must be running.** `submit_batch()` raises if `kb.start_pending_processor()` has not been called first (after `connect()`). The check is enforced after the documents are staged as `PENDING`, so a failure leaves rows in the queue. Call `start_pending_processor()` on every write-path service.
 
 `max_concurrent` caps concurrency for this batch's documents specifically; the global processor pool size still applies as a ceiling. The pool is sized via `KhoraConfig.pipelines.pending_processor_max_concurrent` (env: `KHORA_PIPELINES_PENDING_PROCESSOR_MAX_CONCURRENT`); effective per-batch concurrency is `min(pool_size, max_concurrent)`. Two batches submitted concurrently are rate-limited independently - their `max_concurrent` values do not stack.
 
@@ -292,7 +294,7 @@ All result types are frozen slotted dataclasses.
 
 ### `BatchHandle`
 
-Returned by `kb.submit_batch(...)` (the async-staging path that returns immediately and processes via a background worker). Use `await handle.wait()` to block until all documents finish. `submit_batch` also accepts an optional `session_id: UUID | None = None` kwarg that is stamped onto every staged document (per-document `metadata["session_id"]` wins if both are set) - see #620 and the [`session_id` column](migrations.md) for retention/forget semantics.
+Returned by `kb.submit_batch(...)` (the async-staging path that returns immediately and is processed by the pending-processor task — which must already be running via `kb.start_pending_processor()`; `submit_batch` raises otherwise). Use `await handle.wait()` to block until all documents finish. `submit_batch` also accepts an optional `session_id: UUID | None = None` kwarg that is stamped onto every staged document (per-document `metadata["session_id"]` wins if both are set) - see #620 and the [`session_id` column](migrations.md) for retention/forget semantics.
 
 | Field / method | Type | Description |
 |---|---|---|

--- a/docs/architecture/event-sourcing.md
+++ b/docs/architecture/event-sourcing.md
@@ -120,9 +120,10 @@ event = await storage.append_event(
 
 # Batch (more efficient for pipelines)
 events = await storage.append_events_batch([
-    MemoryEvent.chunk_created(...),
+    MemoryEvent.document_created(...),
     MemoryEvent.chunk_embedded(...),
-    MemoryEvent.entity_created(...)
+    MemoryEvent.entity_created(...),
+    MemoryEvent.relationship_created(...)
 ])
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,25 +43,27 @@ Programmatic values take priority over environment variables.
 | Extra | Purpose | Pulls in |
 |---|---|---|
 | *(default)* | Core: PostgreSQL + pgvector + Neo4j driver + litellm | - |
-| `surrealdb` | **[experimental]** Unified SurrealDB backend (embedded or remote). SDK on alpha track; KNN unreliable in embedded mode | `surrealdb>=2.0.0a1` |
-| `embedded` | Alias for `surrealdb` (zero-infrastructure path) - **experimental** | `surrealdb>=2.0.0a1` |
-| `memgraph` | Memgraph via Bolt | `neo4j>=6.1.0` |
-| `neptune` | AWS Neptune via Bolt | `neo4j>=6.1.0` |
-| `neptune-iam` | Neptune with IAM SigV4 | `neo4j>=6.1.0`, `boto3` |
-| `age` | PostgreSQL AGE graph backend | `asyncpg` |
-| `weaviate` | Weaviate vector store | `weaviate-client>=4.20.1` |
+| `surrealdb` | **[experimental]** Unified SurrealDB backend (embedded or remote). KNN unreliable in embedded mode | `surrealdb>=2.0.0,<3.0` |
+| `embedded` | Alias for `surrealdb` (zero-infrastructure path) - **experimental** | `surrealdb>=2.0.0,<3.0` |
+| `memgraph` | Memgraph via Bolt | `neo4j>=6.2.0` |
+| `neptune` | AWS Neptune via Bolt | `neo4j>=6.2.0` |
+| `neptune-iam` | Neptune with IAM SigV4 | `neo4j>=6.2.0`, `boto3>=1.35.0` |
+| `age` | PostgreSQL AGE graph backend | `asyncpg>=0.31.0` |
+| `weaviate` | Weaviate vector store | `weaviate-client>=4.21.0` |
 | `turbopuffer` | **[experimental]** Serverless vector + BM25 store for the Skeleton engine. See [engines/skeleton-engine.md](engines/skeleton-engine.md#turbopuffer-serverless--large-scale) | `turbopuffer>=2.1.0,<3.0` |
-| `sqlite` | SQLite embedded relational + vector | `aiosqlite>=0.20.0` |
-| `lancedb` | LanceDB embedded vector store | `lancedb>=0.17.0`, `pyarrow` |
-| `sqlite-lance` | **[experimental]** Unified SQLite + LanceDB embedded backend. Recommended embedded stack; covers VectorCypher / Skeleton / Chronicle | `lancedb>=0.17.0`, `aiosqlite>=0.20.0`, `pyarrow` |
-| `binary-readers` | PDF / docx / xlsx readers (used by downstream ingestors) | `pymupdf`, `openpyxl`, `python-docx` |
-| `parquet` | Parquet readers | `pyarrow>=18.0.0` |
-| `nlp` | spaCy-based sentence splitting | `spacy>=3.8` |
-| `otel` | OpenTelemetry SDK + OTLP/HTTP exporter (vendor-neutral) | `opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-http` |
-| `otel-grpc` | `khora[otel]` + OTLP/gRPC transport | adds `opentelemetry-exporter-otlp-proto-grpc` |
-| `logfire` | Logfire - managed OTel backend with auto-bootstrap | `logfire>=4.0` |
-| `rust` | Rust acceleration (`khora-accel`) | `khora-accel>=0.1.0` |
-| `all-backends` | Everything graph-and-vector (no observability/nlp/rust) | - |
+| `sqlite` | SQLite embedded relational + vector | `aiosqlite>=0.21.0` |
+| `lancedb` | LanceDB embedded vector store | `lancedb>=0.30.0`, `pyarrow>=24.0.0` |
+| `sqlite-lance` | **[experimental]** Unified SQLite + LanceDB embedded backend. Recommended embedded stack; covers VectorCypher / Skeleton / Chronicle | `lancedb>=0.30.0`, `aiosqlite>=0.21.0`, `pyarrow>=24.0.0` |
+| `reranking` | Neural reranking via cross-encoders | `sentence-transformers>=5.4.1` |
+| `binary-readers` | PDF / docx / xlsx readers (used by downstream ingestors) | `pymupdf>=1.27.2`, `openpyxl>=3.1.0`, `python-docx>=1.2.0` |
+| `parquet` | Parquet readers | `pyarrow>=24.0.0` |
+| `accel` | Accelerated CPU ops (string-matching fuzz, used by dream-phase centroid recompute) | `rapidfuzz>=3.0.0` |
+| `nlp` | spaCy-based sentence splitting | `spacy>=3.8.0` |
+| `otel` | OpenTelemetry SDK + OTLP/HTTP exporter (vendor-neutral) | `opentelemetry-sdk>=1.34.1`, `opentelemetry-exporter-otlp-proto-http>=1.34.1` |
+| `otel-grpc` | `khora[otel]` + OTLP/gRPC transport | adds `opentelemetry-exporter-otlp-proto-grpc>=1.34.1` |
+| `logfire` | Logfire - managed OTel backend with auto-bootstrap | `logfire>=4.6.0` |
+| `rust` | Rust acceleration (`khora-accel`); pin tracks khora's own version in lockstep | `khora-accel` (exact lockstep pin) |
+| `all-backends` | All graph + vector backends (no observability / nlp / rust / accel) | postgres + neo4j + weaviate + surrealdb + sqlite + lancedb pins |
 
 Combine extras as needed: `pip install 'khora[surrealdb,otel]'`. See
 [observability.md](observability.md) for the full env-var contract,

--- a/docs/data-models/events.md
+++ b/docs/data-models/events.md
@@ -105,9 +105,11 @@ class EventType(str, Enum):
 
 ## Factory Methods
 
-`MemoryEvent` provides factory methods for common event types:
-
-### Document Events
+`MemoryEvent` provides four factory classmethods that wrap the common
+event shapes for the four most-frequent resource types. Each takes
+`(namespace_id, <resource>_id, data, **kwargs)`; the `**kwargs`
+forward to the dataclass constructor (`actor_id`, `actor_type`,
+`correlation_id`, `causation_id`, …).
 
 ```python
 # Document created
@@ -123,26 +125,6 @@ event = MemoryEvent.document_created(
     actor_type="user",
 )
 
-# Document processed
-event = MemoryEvent.document_processed(
-    namespace_id=ns_id,
-    document_id=doc.id,
-    data={
-        "chunk_count": 5,
-        "entity_count": 12,
-    },
-)
-
-# Document deleted
-event = MemoryEvent.document_deleted(
-    namespace_id=ns_id,
-    document_id=doc.id,
-)
-```
-
-### Entity Events
-
-```python
 # Entity created
 event = MemoryEvent.entity_created(
     namespace_id=ns_id,
@@ -151,39 +133,6 @@ event = MemoryEvent.entity_created(
         "name": entity.name,
         "type": entity.entity_type.value,
         "confidence": entity.confidence,
-    },
-)
-
-# Entity merged
-event = MemoryEvent.entity_merged(
-    namespace_id=ns_id,
-    entity_id=merged_into.id,
-    data={
-        "merged_entity_id": str(merged_from.id),
-        "merged_entity_name": merged_from.name,
-    },
-)
-
-# Entity updated
-event = MemoryEvent.entity_updated(
-    namespace_id=ns_id,
-    entity_id=entity.id,
-    data={"confidence": 0.95},
-    previous_data={"confidence": 0.85},
-)
-```
-
-### Chunk Events
-
-```python
-# Chunk created
-event = MemoryEvent.chunk_created(
-    namespace_id=ns_id,
-    chunk_id=chunk.id,
-    data={
-        "document_id": str(chunk.document_id),
-        "index": chunk.index,
-        "token_count": chunk.token_count,
     },
 )
 
@@ -196,31 +145,36 @@ event = MemoryEvent.chunk_embedded(
         "dimension": 1536,
     },
 )
+
+# Relationship created
+event = MemoryEvent.relationship_created(
+    namespace_id=ns_id,
+    relationship_id=rel.id,
+    data={
+        "source_id": str(rel.source_entity_id),
+        "target_id": str(rel.target_entity_id),
+        "type": rel.relationship_type,
+    },
+)
 ```
 
-### Sync Events
+For event types without a factory (document updates, entity merges,
+sync events, deletes, anything custom), construct `MemoryEvent`
+directly with `event_type=EventType.<KIND>`:
 
 ```python
-# Sync started
-event = MemoryEvent.sync_started(
-    namespace_id=ns_id,
-    sync_id=sync_id,
-    data={
-        "source": "slack",
-        "channel": "general",
-    },
-)
+from khora.core.models.event import MemoryEvent, EventType
 
-# Sync completed
-event = MemoryEvent.sync_completed(
+event = MemoryEvent(
+    event_type=EventType.DOCUMENT_DELETED,
     namespace_id=ns_id,
-    sync_id=sync_id,
-    data={
-        "documents_processed": 25,
-        "entities_extracted": 150,
-    },
+    resource_id=doc.id,
+    resource_type="document",
+    data={"reason": "manual_purge"},
 )
 ```
+
+See [Event Types](#event-types) above for the full enum.
 
 ## Correlation IDs
 
@@ -238,15 +192,15 @@ events = [
         ...,
         correlation_id=correlation_id,
     ),
-    MemoryEvent.chunk_created(
-        ...,
-        correlation_id=correlation_id,
-    ),
     MemoryEvent.chunk_embedded(
         ...,
         correlation_id=correlation_id,
     ),
     MemoryEvent.entity_created(
+        ...,
+        correlation_id=correlation_id,
+    ),
+    MemoryEvent.relationship_created(
         ...,
         correlation_id=correlation_id,
     ),

--- a/docs/engines/hybrid-search.md
+++ b/docs/engines/hybrid-search.md
@@ -458,7 +458,7 @@ query:
   keyword_weight: 0.3
   min_chunk_similarity: 0.0
   min_entity_similarity: 0.0
-  recency_decay_days: 30
+  recency_decay_days: 7
 ```
 
 ## Related Documentation

--- a/docs/engines/skeleton-engine.md
+++ b/docs/engines/skeleton-engine.md
@@ -492,7 +492,7 @@ from khora.config import KhoraConfig, QueryConfig
 config = KhoraConfig(
     database_url="postgresql://localhost/khora",
     query=QueryConfig(
-        recency_decay_days=30,
+        recency_decay_days=7,
     ),
 )
 # Engine selection is a Khora() constructor kwarg, not a config field:
@@ -518,7 +518,7 @@ to `kb.recall(...)` and has no env-var equivalent.
 ```yaml
 # config/skeleton/khora.yaml
 query:
-  recency_decay_days: 30
+  recency_decay_days: 7
 
 temporal:
   default_lookback_days: 90

--- a/docs/extraction/ingestion-pipeline.md
+++ b/docs/extraction/ingestion-pipeline.md
@@ -438,9 +438,9 @@ result = await kb.remember_batch(
     relationship_types=["WORKS_AT"],
 )
 
-print(f"Processed: {result['processed_documents']}")
-print(f"Skipped (duplicates): {result['skipped_documents']}")
-print(f"Failed: {result['failed_documents']}")
+print(f"Processed: {result.processed}")
+print(f"Skipped (duplicates): {result.skipped}")
+print(f"Failed: {result.failed}")
 ```
 
 ## Usage Examples
@@ -488,7 +488,6 @@ result = await kb.remember(
     content,
     namespace=ns.namespace_id,
     chunk_strategy="recursive",
-    expertise="technical_docs",
     entity_types=["PERSON", "ORG"],
     relationship_types=["WORKS_AT"],
 )
@@ -496,8 +495,14 @@ result = await kb.remember(
 
 `chunk_size`, `embedding_model`, and `extraction_model` aren't per-call
 kwargs on `kb.remember()`. Configure them at construction time via
-`KhoraConfig.chunker.chunk_size`, `KhoraConfig.embedding.model`, and
-`KhoraConfig.llm.model` (or the corresponding `KHORA_*` env vars).
+`KhoraConfig.pipelines.chunk_size`, `KhoraConfig.llm.embedding_model`,
+and `KhoraConfig.llm.model` (or the corresponding env vars
+`KHORA_PIPELINES_CHUNK_SIZE`, `KHORA_LLM_EMBEDDING_MODEL`,
+`KHORA_LLM_MODEL`). The `expertise` kwarg on `kb.remember` accepts an
+`ExpertiseConfig` instance, not a string — for ad-hoc per-call
+expertise without setting up the config object, use the lower-level
+`ingest_documents()` direct path shown below, which accepts the
+string form.
 
 ### Direct Pipeline Call
 


### PR DESCRIPTION
## Summary

A batch of pure-docs cleanups against the current API surface. Eight
files touched (+93/-123). No code changes.

## What changed

- **README**: quickstart `remember()` / `submit_batch()` examples now
  pass the required `entity_types` / `relationship_types` ontology
  kwargs; dream-phase example drops the unsupported `config=` keyword
  (constructor takes `KhoraConfig` positionally); the "ten operations
  ship in v0.15.0" table is replaced by a paragraph pointing at
  `docs/dream-phase.md` (the current `OpKind` surface has 19 values
  and the version-stamped count rots on every release).
- **`docs/api-reference.md`**: `submit_batch()` and `BatchHandle`
  sections now state explicitly that the pending processor must be
  running (`kb.start_pending_processor()`) before `submit_batch()`
  succeeds. The README already carries this warning; the API ref was
  silent.
- **`docs/configuration.md`**: install-extras table refreshed against
  `pyproject.toml`. Stale pins corrected (surrealdb, neo4j, weaviate,
  aiosqlite, lancedb, pyarrow, logfire). Missing `accel` and
  `reranking` rows added.
- **`docs/extraction/ingestion-pipeline.md`**: `BatchResult` is a
  frozen dataclass — examples now use attribute access
  (`.processed` / `.skipped` / `.failed`) instead of dict keys. The
  `kb.remember(..., expertise="technical_docs")` example dropped the
  string `expertise` (the facade requires `ExpertiseConfig`; the
  string form is only valid on the lower-level `ingest_documents()`
  pipeline call already shown right below). The "configure globally"
  pointer now names the real config paths
  (`KhoraConfig.pipelines.chunk_size`,
  `KhoraConfig.llm.embedding_model`, `KhoraConfig.llm.model`).
- **`docs/data-models/events.md` + `docs/architecture/event-sourcing.md`**:
  the Factory Methods section had seven phantom classmethods
  (`document_processed`, `document_deleted`, `entity_merged`,
  `entity_updated`, `chunk_created`, `sync_started`, `sync_completed`)
  alongside four real ones. Rewrote the section to only show the
  four that exist (`document_created`, `entity_created`,
  `chunk_embedded`, `relationship_created`) and added an explainer
  for using `MemoryEvent(event_type=EventType.X, ...)` directly for
  other event kinds. Same fix in the event-sourcing batch example.
- **`docs/engines/{hybrid-search,skeleton-engine}.md`**:
  `recency_decay_days` documented default updated from `30` to `7` to
  match the live `QuerySettings` default (changed during the BEAM
  retuning).

## Test plan

- [ ] Re-read each edited section against the linked source files
      (paths above) and confirm names + defaults still match.
- [ ] Run `uv run python -c "from khora.config.schema import KhoraConfig; KhoraConfig()"` — current dependency pins shouldn't change the import path.
- [ ] Spot-check the README quickstart: paste into a fresh script + run; it should not raise `TypeError` on `remember()` or `submit_batch()` for missing `entity_types`/`relationship_types`.