### PR TITLE
Honor Neo4j pool-sampler config on the shared-driver path

### DIFF
--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -507,6 +507,8 @@ class VectorCypherEngine:
                     entity_write_concurrency=getattr(neo4j_cfg, "entity_write_concurrency", 12),
                     relationship_write_concurrency=getattr(neo4j_cfg, "relationship_write_concurrency", 8),
                     query_timeout=neo4j_query_timeout,
+                    pool_sampler_enabled=getattr(neo4j_cfg, "pool_sampler_enabled", False),
+                    pool_sampler_interval_ms=getattr(neo4j_cfg, "pool_sampler_interval_ms", 500),
                 )
 
         await self._storage.connect()
@@ -683,17 +685,20 @@ class VectorCypherEngine:
 
         await shutdown_telemetry()
 
-        if self._neo4j_driver:
-            await self._neo4j_driver.close()
-            self._neo4j_driver = None
+        # Disconnect the storage coordinator (which owns the from_driver-wrapped
+        # Neo4jBackend) BEFORE closing the shared driver, so the backend's
+        # pool sampler task is stopped while the pool is still alive.
+        if self._storage:
+            await self._storage.disconnect()
+            self._storage = None
 
         if self._temporal_store:
             await self._temporal_store.disconnect()
             self._temporal_store = None
 
-        if self._storage:
-            await self._storage.disconnect()
-            self._storage = None
+        if self._neo4j_driver:
+            await self._neo4j_driver.close()
+            self._neo4j_driver = None
 
         self._embedder = None
         self._retriever = None

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -641,20 +641,21 @@ class Neo4jBackend(GraphBackendBase):
         entity_write_concurrency: int = _DEFAULT_ENTITY_WRITE_CONCURRENCY,
         relationship_write_concurrency: int = _DEFAULT_RELATIONSHIP_WRITE_CONCURRENCY,
         query_timeout: float | None = 5.0,
+        pool_sampler_enabled: bool = False,
+        pool_sampler_interval_ms: int = 500,
     ) -> Neo4jBackend:
         """Create a Neo4jBackend from an existing AsyncDriver.
 
         The backend will NOT close the driver on disconnect, since
         it does not own it.
 
-        **Sampler note**: the high-frequency pool sampler is *not* started
-        by this constructor, even if the caller mutates
-        ``instance._pool_sampler_enabled`` afterwards. ``from_driver()`` is
-        typically used by shared-driver integrations (tests, fixtures,
-        connection-multiplexing setups) where the owner of the driver is
-        responsible for metric lifecycle. If you need the sampler on a
-        shared-driver backend, use the standard ``Neo4jBackend(...)``
-        constructor with a dedicated driver instead.
+        The high-frequency pool sampler is honored on this path: pass
+        ``pool_sampler_enabled=True`` (with an optional
+        ``pool_sampler_interval_ms``) and ``connect()`` starts the sampler
+        against the shared driver's pool, just as the standard constructor
+        does. The gauge/utilization denominator is read from the shared
+        driver's real ``_pool.pool_config.max_connection_pool_size`` so it
+        matches the sampler's observations.
 
         Args:
             driver: An existing Neo4j async driver
@@ -662,6 +663,8 @@ class Neo4jBackend(GraphBackendBase):
             entity_write_concurrency: Max concurrent entity write transactions
             relationship_write_concurrency: Max concurrent relationship write transactions
             query_timeout: Per-transaction timeout in seconds for bounded read queries (None disables)
+            pool_sampler_enabled: Start the high-frequency pool sampler on connect
+            pool_sampler_interval_ms: Sampler cadence in milliseconds when enabled
 
         Returns:
             Neo4jBackend wrapping the shared driver
@@ -671,7 +674,14 @@ class Neo4jBackend(GraphBackendBase):
         instance._user = ""
         instance._password = ""
         instance._database = database
-        instance._max_connection_pool_size = 0
+        # Read the shared driver's real pool ceiling so the utilization gauge
+        # denominator matches the sampler's observations. Internals are
+        # getattr-guarded (verified stable neo4j 5.x–6.2); falls back to the
+        # neo4j driver default (100), matching the gauge's own fallback at
+        # ``_register_pool_metrics`` so both denominators agree in every branch.
+        _pool = getattr(driver, "_pool", None)
+        _pool_config = getattr(_pool, "pool_config", None)
+        instance._max_connection_pool_size = getattr(_pool_config, "max_connection_pool_size", 0) or 100
         instance._connection_acquisition_timeout = 60.0
         instance._retry_delay_jitter_factor = 0.5
         instance._max_connection_lifetime = 900
@@ -682,8 +692,8 @@ class Neo4jBackend(GraphBackendBase):
         instance._owns_driver = False
         instance._entity_key_gate = _EntityKeyGate(max_concurrent=entity_write_concurrency)
         instance._relationship_write_sem = asyncio.Semaphore(relationship_write_concurrency)
-        instance._pool_sampler_enabled = False
-        instance._pool_sampler_interval_ms = 500
+        instance._pool_sampler_enabled = pool_sampler_enabled
+        instance._pool_sampler_interval_ms = pool_sampler_interval_ms
         instance._sampler_task = None
         instance._sampler_warned = False
         instance._sampler_finalizer = None

--- a/tests/unit/engines/vectorcypher/test_engine_coverage.py
+++ b/tests/unit/engines/vectorcypher/test_engine_coverage.py
@@ -849,6 +849,11 @@ class TestDisconnectOrdering:
         with patch("khora.telemetry.shutdown_telemetry", new_callable=AsyncMock):
             await engine.disconnect()
 
+        # Both must actually be awaited (not merely called) — guards against a
+        # called-but-not-awaited regression that mock_calls alone would miss.
+        order.storage_disconnect.assert_awaited_once()
+        order.driver_close.assert_awaited_once()
+
         names = [c[0] for c in order.mock_calls]
         assert "storage_disconnect" in names
         assert "driver_close" in names

--- a/tests/unit/engines/vectorcypher/test_engine_coverage.py
+++ b/tests/unit/engines/vectorcypher/test_engine_coverage.py
@@ -821,6 +821,58 @@ class TestDisconnectReentrancy:
             assert engine._connected is False
 
 
+@pytest.mark.unit
+class TestDisconnectOrdering:
+    """disconnect() must stop the backend's pool task before closing the shared driver.
+
+    The Neo4jBackend wrapped via ``from_driver`` runs a pool sampler against the
+    shared driver's pool. Closing the driver first would tear the pool out from
+    under a still-running sampler tick. ``disconnect()`` therefore calls
+    ``self._storage.disconnect()`` (which stops the sampler) BEFORE
+    ``self._neo4j_driver.close()``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_storage_disconnect_runs_before_driver_close(self) -> None:
+        from unittest.mock import patch
+
+        engine = _make_connected_engine()
+
+        # Attach both call sites to one parent spy so mock_calls records their
+        # relative order across the two distinct objects.
+        order = MagicMock()
+        order.storage_disconnect = AsyncMock()
+        order.driver_close = AsyncMock()
+        engine._storage.disconnect = order.storage_disconnect
+        engine._neo4j_driver.close = order.driver_close
+
+        with patch("khora.telemetry.shutdown_telemetry", new_callable=AsyncMock):
+            await engine.disconnect()
+
+        names = [c[0] for c in order.mock_calls]
+        assert "storage_disconnect" in names
+        assert "driver_close" in names
+        assert names.index("storage_disconnect") < names.index("driver_close"), (
+            f"storage.disconnect() must run before driver.close(); saw order {names}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_both_storage_and_driver_are_torn_down(self) -> None:
+        from unittest.mock import patch
+
+        engine = _make_connected_engine()
+        storage = engine._storage
+        driver = engine._neo4j_driver
+
+        with patch("khora.telemetry.shutdown_telemetry", new_callable=AsyncMock):
+            await engine.disconnect()
+
+        storage.disconnect.assert_awaited_once()
+        driver.close.assert_awaited_once()
+        assert engine._storage is None
+        assert engine._neo4j_driver is None
+
+
 # ---------------------------------------------------------------------------
 # Recall — entity/relationship section formatting + hybrid_alpha override
 # ---------------------------------------------------------------------------

--- a/tests/unit/storage/backends/test_neo4j_coverage.py
+++ b/tests/unit/storage/backends/test_neo4j_coverage.py
@@ -467,7 +467,7 @@ class TestFromDriver:
 
     def test_sampler_explicitly_disabled_on_from_driver(self) -> None:
         b = Neo4jBackend.from_driver(MagicMock())
-        # from_driver hard-disables the sampler regardless of init args.
+        # from_driver leaves the sampler off by default (no pool_sampler_enabled arg here).
         assert b._pool_sampler_enabled is False
         assert b._sampler_task is None
 

--- a/tests/unit/test_neo4j_pool_metrics.py
+++ b/tests/unit/test_neo4j_pool_metrics.py
@@ -490,6 +490,10 @@ class TestGaugeCallbackObservations:
         driver._pool.connections_reservations = {}
 
         backend = Neo4jBackend.from_driver(driver)
+        # Pin the denominator to a real int so the utilization gauge yields a
+        # numeric 0.0 here (a bare MagicMock pool_config would otherwise seed
+        # _max_connection_pool_size with a MagicMock).
+        backend._max_connection_pool_size = 100
         callbacks = _capture_gauge_callbacks(driver, backend)
 
         obs = _invoke_gauge(callbacks["khora.neo4j.pool.connections.active"])
@@ -505,7 +509,7 @@ class TestGaugeCallbackObservations:
         assert obs[0].value == 0.0
 
     def test_utilization_zero_max_pool_size_falls_back(self) -> None:
-        """Utilization falls back to max_size=100 when _max_connection_pool_size is 0."""
+        """Utilization gauge falls back to max_size=100 when _max_connection_pool_size is 0."""
         driver = MagicMock()
         driver._pool = MagicMock()
         driver._pool.connections = {
@@ -514,8 +518,10 @@ class TestGaugeCallbackObservations:
         driver._pool.connections_reservations = {}
 
         backend = Neo4jBackend.from_driver(driver)
-        # from_driver sets _max_connection_pool_size=0; `or 100` fallback applies
-        assert backend._max_connection_pool_size == 0
+        # Force the falsy denominator so the gauge's own `or 100` fallback applies.
+        # (from_driver now seeds the denominator from the driver's pool_config; a
+        # zero/unreadable ceiling still degrades to the 100 default here.)
+        backend._max_connection_pool_size = 0
         callbacks = _capture_gauge_callbacks(driver, backend)
 
         obs = _invoke_gauge(callbacks["khora.neo4j.pool.utilization"])

--- a/tests/unit/test_neo4j_pool_metrics_correctness.py
+++ b/tests/unit/test_neo4j_pool_metrics_correctness.py
@@ -892,13 +892,15 @@ class TestConnectStartsSampler:
         await backend.connect()
         try:
             assert backend._sampler_task is not None, "connect() must start the sampler when enabled"
-            await asyncio.sleep(0.2)  # ~20 ticks at 10ms
+            await asyncio.sleep(0.4)  # ~40 ticks at 10ms; threshold below leaves ~2.7x margin
         finally:
             await backend.disconnect()
 
         assert backend._sampler_task is None, "disconnect() must stop the sampler"
+        # >= 15 catches a sampler that stalls after a few ticks while staying well
+        # clear of the ~40 expected emits, so event-loop jitter under load won't flake.
         for key, count in observed.items():
-            assert count >= 5, f"{key}: expected the sampler to emit, got {count}"
+            assert count >= 15, f"{key}: expected the sampler to emit repeatedly, got {count}"
 
     @pytest.mark.asyncio
     async def test_connect_does_not_start_sampler_when_disabled(self) -> None:

--- a/tests/unit/test_neo4j_pool_metrics_correctness.py
+++ b/tests/unit/test_neo4j_pool_metrics_correctness.py
@@ -837,6 +837,89 @@ class TestPoolSampler:
 
 
 # ---------------------------------------------------------------------------
+# connect() on the shared-driver path starts/skips the sampler per the
+# from_driver kwarg, and emits the khora.neo4j.pool.sampled.* histograms.
+# ---------------------------------------------------------------------------
+
+
+def _make_sampler_driver() -> MagicMock:
+    """Shared-driver mock with a pool the sampler can read deterministically."""
+    driver = MagicMock()
+    pool = MagicMock()
+    pool.connections = {"addr1": deque([MagicMock()])}
+    pool.connections_reservations = {"addr1": 0}
+    pool.in_use_connection_count = MagicMock(return_value=1)
+    pool.lock = MagicMock()
+    pool.lock.__enter__ = MagicMock(return_value=pool.lock)
+    pool.lock.__exit__ = MagicMock(return_value=False)
+    pool.pool_config = MagicMock()
+    pool.pool_config.max_connection_pool_size = 10
+    driver._pool = pool
+    return driver
+
+
+def _wire_sampled_recorders(backend: Neo4jBackend) -> dict[str, int]:
+    """Replace the 5 sampled histograms with counting recorders."""
+    observed: dict[str, int] = {k: 0 for k in ("active", "idle", "total", "creating", "utilization")}
+    for key in observed:
+        attr = f"_sampled_{key}_histogram"
+        setattr(backend, attr, MagicMock())
+
+        def make_recorder(k: str):
+            def record(_v: float, attributes: Any = None, **_kw: Any) -> None:
+                observed[k] += 1
+
+            return record
+
+        getattr(backend, attr).record = make_recorder(key)
+    return observed
+
+
+@pytest.mark.unit
+class TestConnectStartsSampler:
+    """connect() on the shared-driver path honors the from_driver sampler kwarg."""
+
+    @pytest.mark.asyncio
+    async def test_connect_starts_sampler_and_emits_when_enabled(self) -> None:
+        driver = _make_sampler_driver()
+        backend = Neo4jBackend.from_driver(driver, pool_sampler_enabled=True, pool_sampler_interval_ms=10)
+
+        # Isolate the sampler: stub out the other connect() side effects.
+        backend._create_indexes = AsyncMock()
+        backend._register_pool_metrics = MagicMock()
+        observed = _wire_sampled_recorders(backend)
+
+        await backend.connect()
+        try:
+            assert backend._sampler_task is not None, "connect() must start the sampler when enabled"
+            await asyncio.sleep(0.2)  # ~20 ticks at 10ms
+        finally:
+            await backend.disconnect()
+
+        assert backend._sampler_task is None, "disconnect() must stop the sampler"
+        for key, count in observed.items():
+            assert count >= 5, f"{key}: expected the sampler to emit, got {count}"
+
+    @pytest.mark.asyncio
+    async def test_connect_does_not_start_sampler_when_disabled(self) -> None:
+        driver = _make_sampler_driver()
+        backend = Neo4jBackend.from_driver(driver)  # default: pool_sampler_enabled=False
+
+        backend._create_indexes = AsyncMock()
+        backend._register_pool_metrics = MagicMock()
+        observed = _wire_sampled_recorders(backend)
+
+        await backend.connect()
+        try:
+            assert backend._sampler_task is None, "default connect() must NOT start the sampler"
+            await asyncio.sleep(0.05)
+        finally:
+            await backend.disconnect()
+
+        assert all(count == 0 for count in observed.values()), f"disabled sampler must emit nothing; got {observed}"
+
+
+# ---------------------------------------------------------------------------
 # Config: pool_sampler_enabled / pool_sampler_interval_ms plumbing
 # ---------------------------------------------------------------------------
 
@@ -877,6 +960,64 @@ class TestSamplerConfig:
         backend = Neo4jBackend.from_config(cfg)
         assert backend._pool_sampler_enabled is True
         assert backend._pool_sampler_interval_ms == 750
+
+    def test_from_driver_honors_sampler_kwargs(self) -> None:
+        """from_driver wires its sampler kwargs into the instance fields
+        (was previously hardcoded to False / 500)."""
+        driver = MagicMock()
+        backend = Neo4jBackend.from_driver(
+            driver,
+            pool_sampler_enabled=True,
+            pool_sampler_interval_ms=250,
+        )
+        assert backend._pool_sampler_enabled is True
+        assert backend._pool_sampler_interval_ms == 250
+
+    def test_from_driver_sampler_defaults_off(self) -> None:
+        """from_driver leaves the sampler off by default."""
+        backend = Neo4jBackend.from_driver(MagicMock())
+        assert backend._pool_sampler_enabled is False
+        assert backend._pool_sampler_interval_ms == 500
+
+
+# ---------------------------------------------------------------------------
+# from_driver: gauge/utilization denominator seeded from the shared driver's
+# real pool ceiling (so the gauge denominator equals the sampler's).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFromDriverMaxPoolSize:
+    def test_seeds_max_pool_size_from_driver_pool_config(self) -> None:
+        """from_driver reads ``_pool.pool_config.max_connection_pool_size`` so the
+        gauge denominator matches the sampler's observed ceiling (not the 100
+        fallback)."""
+        driver = MagicMock()
+        pool = MagicMock()
+        pool.pool_config = MagicMock()
+        pool.pool_config.max_connection_pool_size = 37  # != 100 default
+        driver._pool = pool
+
+        backend = Neo4jBackend.from_driver(driver)
+        assert backend._max_connection_pool_size == 37
+
+    def test_falls_back_to_100_when_pool_config_missing(self) -> None:
+        """A driver whose pool exposes no readable ceiling degrades to the
+        neo4j default (100), matching the gauge's own ``or 100`` fallback."""
+        driver = MagicMock(spec=[])  # no _pool attribute at all
+        backend = Neo4jBackend.from_driver(driver)
+        assert backend._max_connection_pool_size == 100
+
+    def test_falls_back_to_100_when_ceiling_is_zero(self) -> None:
+        """A zero ceiling is falsy → degrades to 100 (never a 0 denominator)."""
+        driver = MagicMock()
+        pool = MagicMock()
+        pool.pool_config = MagicMock()
+        pool.pool_config.max_connection_pool_size = 0
+        driver._pool = pool
+
+        backend = Neo4jBackend.from_driver(driver)
+        assert backend._max_connection_pool_size == 100
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `Neo4jBackend.from_driver` now accepts `pool_sampler_enabled` / `pool_sampler_interval_ms` and seeds the instance fields from them, instead of hardcoding the high-frequency pool sampler off. `connect()` already starts the sampler on the shared-driver path, so enabling it via config now works end to end. The docstring no longer claims the sampler is unavailable on this path.
- `from_driver` seeds `_max_connection_pool_size` from the driver's real `pool.pool_config.max_connection_pool_size` (getattr-guarded, falling back to the driver default of 100), so the utilization **gauge** denominator matches the **sampler**'s. Previously the gauge fell back to 100 while the sampler read the real pool size, so the two utilization figures disagreed.
- `VectorCypherEngine.connect()` forwards the sampler config from `get_graph_config()` into `from_driver(...)`, the same way it already forwards write-concurrency and query-timeout settings.
- `VectorCypherEngine.disconnect()` now disconnects storage (which stops the backend's pool sampler task) **before** closing the shared driver, so in-flight sampler reads never run against a closed driver.
- No new background task and no new config field; SurrealDB / sqlite_lance paths are untouched.

## Test plan
- [x] Unit tests pass (`tests/unit/` green locally; added coverage for sampler-via-`from_driver`, `disconnect()` ordering, and the gauge denominator)
- [ ] Integration tests pass (CI — requires Neo4j + Postgres via Docker)
- [x] `ruff format` / `ruff check` / `ty check src/` clean