### PR TITLE
Add opt-in Neo4j connection-pool keepalive

### DIFF
--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -925,6 +925,20 @@
       "unit": ""
     },
     {
+      "name": "khora.neo4j.pool.keepalive.pings",
+      "type": "counter",
+      "stability": "internal",
+      "unit": "1",
+      "description": "RETURN 1 keepalive pings attempted on idle pooled connections by the opt-in connection-pool keepalive (KHORA_STORAGE_GRAPH_POOL_KEEPALIVE_ENABLED). Counts every ping attempt, fired only when the keepalive loop observes idle connections. Zero when the keepalive is disabled."
+    },
+    {
+      "name": "khora.neo4j.pool.keepalive.failures",
+      "type": "counter",
+      "stability": "internal",
+      "unit": "1",
+      "description": "Keepalive pings that raised. A non-zero rate is the expected dead-connection self-heal canary (the failed close runs to completion in the background and removes the stale connection from the pool), not an error condition."
+    },
+    {
       "name": "khora.neo4j.relationship.source_id_truncated",
       "type": "counter",
       "stability": "public",

--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -929,14 +929,14 @@
       "type": "counter",
       "stability": "internal",
       "unit": "1",
-      "description": "RETURN 1 keepalive pings attempted on idle pooled connections by the opt-in connection-pool keepalive (KHORA_STORAGE_GRAPH_POOL_KEEPALIVE_ENABLED). Counts every ping attempt, fired only when the keepalive loop observes idle connections. Zero when the keepalive is disabled."
+      "description": "Keepalive RETURN 1 pings attempted on idle pooled connections. Incremented on every ping attempt by the opt-in keepalive loop (KHORA_STORAGE_GRAPH_POOL_KEEPALIVE_ENABLED); the per-cycle ping count tracks the observed idle-connection count, capped at 16. Zero when the keepalive is disabled."
     },
     {
       "name": "khora.neo4j.pool.keepalive.failures",
       "type": "counter",
       "stability": "internal",
       "unit": "1",
-      "description": "Keepalive pings that raised. A non-zero rate is the expected dead-connection self-heal canary (the failed close runs to completion in the background and removes the stale connection from the pool), not an error condition."
+      "description": "Keepalive pings that raised an exception. A non-zero rate is expected and indicates the self-heal canary working: the ping hit a dead connection, whose teardown then runs to completion in the background and removes the stale connection from the pool. Not an error condition."
     },
     {
       "name": "khora.neo4j.relationship.source_id_truncated",

--- a/src/khora/config/schema.py
+++ b/src/khora/config/schema.py
@@ -198,6 +198,8 @@ _ENV_ALIAS_PAIRS: tuple[tuple[str, str], ...] = (
     ("KHORA_STORAGE_GRAPH_RELATIONSHIP_WRITE_CONCURRENCY", "KHORA_STORAGE__GRAPH__RELATIONSHIP_WRITE_CONCURRENCY"),
     ("KHORA_STORAGE_GRAPH_POOL_SAMPLER_ENABLED", "KHORA_STORAGE__GRAPH__POOL_SAMPLER_ENABLED"),
     ("KHORA_STORAGE_GRAPH_POOL_SAMPLER_INTERVAL_MS", "KHORA_STORAGE__GRAPH__POOL_SAMPLER_INTERVAL_MS"),
+    ("KHORA_STORAGE_GRAPH_POOL_KEEPALIVE_ENABLED", "KHORA_STORAGE__GRAPH__POOL_KEEPALIVE_ENABLED"),
+    ("KHORA_STORAGE_GRAPH_POOL_KEEPALIVE_INTERVAL_MS", "KHORA_STORAGE__GRAPH__POOL_KEEPALIVE_INTERVAL_MS"),
     (
         "KHORA_STORAGE_GRAPH_RELATIONSHIP_SOURCE_DOCUMENT_IDS_MAX",
         "KHORA_STORAGE__GRAPH__RELATIONSHIP_SOURCE_DOCUMENT_IDS_MAX",
@@ -402,6 +404,37 @@ class Neo4jConfig(BaseModel):
         validation_alias=_env_aliases(
             "KHORA_STORAGE_GRAPH_POOL_SAMPLER_INTERVAL_MS",
             "KHORA_STORAGE__GRAPH__POOL_SAMPLER_INTERVAL_MS",
+        ),
+    )
+    pool_keepalive_enabled: bool = Field(
+        default=False,
+        description=(
+            "Opt-in Neo4j connection-pool keepalive. When True, Khora starts a "
+            "background task that fires periodic ``RETURN 1`` pings on idle pooled "
+            "connections at ``pool_keepalive_interval_ms`` cadence so they are never "
+            "idle-dropped by an intermediary (load balancer, firewall) before the "
+            "driver's own liveness check would catch a stale connection. Zero-cost "
+            "when False. Set via env: KHORA_STORAGE_GRAPH_POOL_KEEPALIVE_ENABLED=true."
+        ),
+        validation_alias=_env_aliases(
+            "KHORA_STORAGE_GRAPH_POOL_KEEPALIVE_ENABLED",
+            "KHORA_STORAGE__GRAPH__POOL_KEEPALIVE_ENABLED",
+        ),
+    )
+    pool_keepalive_interval_ms: int = Field(
+        default=15000,
+        ge=50,
+        le=60_000,
+        description=(
+            "Interval in milliseconds between Neo4j keepalive pings when "
+            "``pool_keepalive_enabled`` is True. Clamped to [50, 60000]. Default "
+            "15000 is intentionally below the driver's 30s liveness window so idle "
+            "connections are exercised before they go stale. "
+            "Set via env: KHORA_STORAGE_GRAPH_POOL_KEEPALIVE_INTERVAL_MS=15000."
+        ),
+        validation_alias=_env_aliases(
+            "KHORA_STORAGE_GRAPH_POOL_KEEPALIVE_INTERVAL_MS",
+            "KHORA_STORAGE__GRAPH__POOL_KEEPALIVE_INTERVAL_MS",
         ),
     )
     relationship_source_document_ids_max: int = Field(

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -509,6 +509,8 @@ class VectorCypherEngine:
                     query_timeout=neo4j_query_timeout,
                     pool_sampler_enabled=getattr(neo4j_cfg, "pool_sampler_enabled", False),
                     pool_sampler_interval_ms=getattr(neo4j_cfg, "pool_sampler_interval_ms", 500),
+                    pool_keepalive_enabled=getattr(neo4j_cfg, "pool_keepalive_enabled", False),
+                    pool_keepalive_interval_ms=getattr(neo4j_cfg, "pool_keepalive_interval_ms", 15000),
                 )
 
         await self._storage.connect()

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -122,6 +122,22 @@ def _cancel_sampler_task_on_gc(task: asyncio.Task[None]) -> None:
         pass
 
 
+def _cancel_keepalive_task_on_gc(task: asyncio.Task[None]) -> None:
+    """Cancel a keepalive task from a ``weakref.finalize`` callback.
+
+    Never raises: finalizers run at interpreter shutdown too, where logging
+    may no longer be available. If the loop is closed or the task is done,
+    silently no-op. Defense in depth — the primary cleanup path is
+    ``disconnect()``.
+    """
+    if task.done():
+        return
+    try:
+        task.cancel()
+    except Exception:  # pragma: no cover  # noqa: S110 — finalizer must never raise
+        pass
+
+
 class _InstrumentedSession:
     """Proxy around an ``AsyncSession`` that records real pool acquire time.
 
@@ -375,6 +391,8 @@ class Neo4jBackend(GraphBackendBase):
         relationship_write_concurrency: int = _DEFAULT_RELATIONSHIP_WRITE_CONCURRENCY,
         pool_sampler_enabled: bool = False,
         pool_sampler_interval_ms: int = 500,
+        pool_keepalive_enabled: bool = False,
+        pool_keepalive_interval_ms: int = 15000,
         relationship_source_document_ids_max: int = 100,
         relationship_source_chunk_ids_max: int = 250,
         entity_source_document_ids_max: int = 100,
@@ -401,6 +419,15 @@ class Neo4jBackend(GraphBackendBase):
                 ``khora.neo4j.pool.sampled.*`` histograms. Zero cost when False.
             pool_sampler_interval_ms: Sampler interval in milliseconds. Clamped to
                 [50, 60000]. Only relevant when ``pool_sampler_enabled`` is True.
+            pool_keepalive_enabled: When True, start a background task that fires
+                periodic ``RETURN 1`` pings on idle pooled connections every
+                ``pool_keepalive_interval_ms`` milliseconds so they are never
+                idle-dropped before the driver's liveness check would catch a
+                stale connection. Zero cost when False.
+            pool_keepalive_interval_ms: Keepalive ping interval in milliseconds.
+                Clamped to [50, 60000]. Only relevant when
+                ``pool_keepalive_enabled`` is True. Default 15000 is intentionally
+                below the driver's 30s liveness window.
             relationship_source_document_ids_max: Cap on retained
                 ``source_document_ids`` per relationship after MERGE. When the
                 (existing + incoming) union exceeds this cap the most-recent
@@ -451,6 +478,11 @@ class Neo4jBackend(GraphBackendBase):
         self._sampler_task: asyncio.Task[None] | None = None
         self._sampler_warned = False
         self._sampler_finalizer: _weakref.finalize | None = None
+        self._pool_keepalive_enabled = pool_keepalive_enabled
+        self._pool_keepalive_interval_ms = max(50, min(60_000, pool_keepalive_interval_ms))
+        self._keepalive_task: asyncio.Task[None] | None = None
+        self._keepalive_warned = False
+        self._keepalive_finalizer: _weakref.finalize | None = None
         self._relationship_source_document_ids_max = relationship_source_document_ids_max
         self._relationship_source_chunk_ids_max = relationship_source_chunk_ids_max
         self._entity_source_document_ids_max = entity_source_document_ids_max
@@ -507,6 +539,17 @@ class Neo4jBackend(GraphBackendBase):
         self._sampled_utilization_histogram = metric_histogram(
             "khora.neo4j.pool.sampled.utilization",
             description="Neo4j pool utilization (0.0-1.0), high-frequency sample.",
+        )
+        # Keepalive counters (opt-in). ``pings`` counts every RETURN 1 attempt
+        # the keepalive loop fires; ``failures`` counts those that raised. A
+        # non-zero failure rate is the expected self-heal canary, not an error.
+        self._keepalive_pings_counter = metric_counter(
+            "khora.neo4j.pool.keepalive.pings",
+            description="Neo4j keepalive RETURN 1 pings attempted on idle pooled connections.",
+        )
+        self._keepalive_failures_counter = metric_counter(
+            "khora.neo4j.pool.keepalive.failures",
+            description="Neo4j keepalive pings that raised (expected dead-connection self-heal canary).",
         )
         # Provenance-list truncation counter (#737). Incremented whenever a
         # relationship MERGE's (existing + incoming) union exceeds the
@@ -626,6 +669,8 @@ class Neo4jBackend(GraphBackendBase):
             ),
             pool_sampler_enabled=getattr(config, "pool_sampler_enabled", False),
             pool_sampler_interval_ms=getattr(config, "pool_sampler_interval_ms", 500),
+            pool_keepalive_enabled=getattr(config, "pool_keepalive_enabled", False),
+            pool_keepalive_interval_ms=getattr(config, "pool_keepalive_interval_ms", 15000),
             relationship_source_document_ids_max=getattr(config, "relationship_source_document_ids_max", 100),
             relationship_source_chunk_ids_max=getattr(config, "relationship_source_chunk_ids_max", 250),
             entity_source_document_ids_max=getattr(config, "entity_source_document_ids_max", 100),
@@ -643,6 +688,8 @@ class Neo4jBackend(GraphBackendBase):
         query_timeout: float | None = 5.0,
         pool_sampler_enabled: bool = False,
         pool_sampler_interval_ms: int = 500,
+        pool_keepalive_enabled: bool = False,
+        pool_keepalive_interval_ms: int = 15000,
     ) -> Neo4jBackend:
         """Create a Neo4jBackend from an existing AsyncDriver.
 
@@ -657,6 +704,12 @@ class Neo4jBackend(GraphBackendBase):
         driver's real ``_pool.pool_config.max_connection_pool_size`` so it
         matches the sampler's observations.
 
+        The pool keepalive is honored on this path too: pass
+        ``pool_keepalive_enabled=True`` (with an optional
+        ``pool_keepalive_interval_ms``) and ``connect()`` starts the keepalive
+        loop against the shared driver's pool, just as the standard
+        constructor does.
+
         Args:
             driver: An existing Neo4j async driver
             database: Database name
@@ -665,6 +718,8 @@ class Neo4jBackend(GraphBackendBase):
             query_timeout: Per-transaction timeout in seconds for bounded read queries (None disables)
             pool_sampler_enabled: Start the high-frequency pool sampler on connect
             pool_sampler_interval_ms: Sampler cadence in milliseconds when enabled
+            pool_keepalive_enabled: Start the connection-pool keepalive on connect
+            pool_keepalive_interval_ms: Keepalive ping cadence in milliseconds when enabled
 
         Returns:
             Neo4jBackend wrapping the shared driver
@@ -697,6 +752,11 @@ class Neo4jBackend(GraphBackendBase):
         instance._sampler_task = None
         instance._sampler_warned = False
         instance._sampler_finalizer = None
+        instance._pool_keepalive_enabled = pool_keepalive_enabled
+        instance._pool_keepalive_interval_ms = pool_keepalive_interval_ms
+        instance._keepalive_task = None
+        instance._keepalive_warned = False
+        instance._keepalive_finalizer = None
         # Relationship provenance caps (#737) — defaults mirror the public
         # constructor; callers building backends via from_driver typically
         # set these on the instance directly post-construction.
@@ -714,6 +774,7 @@ class Neo4jBackend(GraphBackendBase):
             await self._create_indexes()
             self._register_pool_metrics()
             self._start_pool_sampler()
+            self._start_pool_keepalive()
             return
 
         logger.info("Connecting to Neo4j at {url}...", url=_safe_url_for_log(self._url))
@@ -734,11 +795,13 @@ class Neo4jBackend(GraphBackendBase):
         await self._create_indexes()
         self._register_pool_metrics()
         self._start_pool_sampler()
+        self._start_pool_keepalive()
         logger.info("Connected to Neo4j")
 
     async def disconnect(self) -> None:
         """Close Neo4j connections."""
         await self._stop_pool_sampler()
+        await self._stop_pool_keepalive()
         if self._driver is not None:
             if self._owns_driver:
                 logger.info("Disconnecting from Neo4j...")
@@ -1236,6 +1299,160 @@ class Neo4jBackend(GraphBackendBase):
         except Exception as exc:
             # Sampler is instrumentation-only; never propagate cleanup errors.
             logger.debug(f"Neo4j pool sampler shutdown raised: {exc}")
+
+    # =========================================================================
+    # Connection-pool keepalive
+    # =========================================================================
+
+    def _count_free_connections(self) -> int:
+        """Return the count of idle (free) pooled connections, or 0 on failure.
+
+        Reads ``driver._pool`` under a brief ``pool.lock`` critical section —
+        no ``await`` while the lock is held — mirroring ``_sample_pool_once``'s
+        getattr-guarded read pattern (``idle = max(0, total - active)``).
+        Returns 0 (warning once via ``self._keepalive_warned``) if the driver
+        internals are unavailable or shaped unexpectedly.
+        """
+        driver = self._driver
+        if driver is None:
+            return 0
+        pool = getattr(driver, "_pool", None)
+        if pool is None:
+            return 0
+        try:
+            in_use_fn = getattr(pool, "in_use_connection_count", None)
+            pool_lock = getattr(pool, "lock", None)
+
+            # Short critical section — snapshot the (address, deque) pairs and
+            # per-address in_use counts. No await inside the lock.
+            if pool_lock is not None:
+                with pool_lock:
+                    conns_snapshot: list[tuple[Any, list[Any]]] = [
+                        (addr, list(deq)) for addr, deq in getattr(pool, "connections", {}).items()
+                    ]
+                    in_use_counts: dict[Any, int] | None = None
+                    if in_use_fn is not None:
+                        in_use_counts = {}
+                        for addr, _deq in conns_snapshot:
+                            try:
+                                in_use_counts[addr] = int(in_use_fn(addr))
+                            except Exception:
+                                in_use_counts[addr] = -1  # sentinel → fall back below
+            else:
+                # Best-effort read without a lock (driver shape changed).
+                conns_snapshot = [(addr, list(deq)) for addr, deq in (getattr(pool, "connections", {}) or {}).items()]
+                in_use_counts = None
+                if in_use_fn is not None:
+                    in_use_counts = {}
+                    for addr, _deq in conns_snapshot:
+                        try:
+                            in_use_counts[addr] = int(in_use_fn(addr))
+                        except Exception:
+                            in_use_counts[addr] = -1
+
+            active = 0
+            total = 0
+            for address, deq in conns_snapshot:
+                total += len(deq)
+                if in_use_counts is not None and in_use_counts.get(address, -1) >= 0:
+                    active += in_use_counts[address]
+                else:
+                    active += sum(1 for c in deq if getattr(c, "in_use", False))
+            # Clamp: driver state can be transiently inconsistent during churn.
+            idle = max(0, total - active)
+        except Exception as exc:
+            if not self._keepalive_warned:
+                logger.warning(f"Neo4j pool keepalive read failed; disabling further warnings: {exc}")
+                self._keepalive_warned = True
+            return 0
+        return idle
+
+    async def _run_keepalive(self) -> None:
+        """Fire keepalive pings on idle pooled connections at configured cadence.
+
+        Each cycle reads the free-connection count and fires up to 16 detached
+        (non-awaited) ping tasks, then sleeps. Hard refs to the in-flight pings
+        are held so they are not GC'd mid-flight; a done-callback discards each
+        ref when it finishes. Returns on cancellation.
+        """
+        interval_s = self._pool_keepalive_interval_ms / 1000.0
+        pings: set[asyncio.Task[None]] = set()
+        try:
+            while True:
+                free = self._count_free_connections()
+                n = min(free, 16)
+                for _ in range(n):
+                    ping = asyncio.create_task(self._keepalive_ping_once())
+                    pings.add(ping)
+                    ping.add_done_callback(pings.discard)
+                await asyncio.sleep(interval_s)
+        except asyncio.CancelledError:
+            return
+
+    async def _keepalive_ping_once(self) -> None:
+        """Run a single ``RETURN 1`` on a raw session to exercise one connection.
+
+        Opens a **raw** ``driver.session(...)`` — never ``self._session()`` —
+        so the keepalive does not pollute ``acquire_duration`` /
+        ``session.duration`` / the timeout counter with synthetic traffic.
+
+        Never wrapped in ``asyncio.wait_for``: cancelling mid-teardown would
+        strand a half-closed connection. The whole point is to let a
+        dead-connection close run to completion in the background, which is
+        what self-heals the pool. A failure here is the expected canary, not an
+        error — counted on the failures counter and logged at DEBUG.
+        """
+        driver = self._driver
+        if driver is None:
+            return
+        self._keepalive_pings_counter.add(1)
+        try:
+            session = driver.session(database=self._database)
+            try:
+                await session.execute_read(lambda tx: tx.run("RETURN 1"))
+            finally:
+                await session.close()
+        except Exception as exc:
+            self._keepalive_failures_counter.add(1)
+            logger.debug(f"Neo4j keepalive ping failed (expected self-heal canary): {exc}")
+
+    def _start_pool_keepalive(self) -> None:
+        """Start the background keepalive task if enabled and not already running.
+
+        Idempotent — calling ``connect()`` twice (or ``_start_pool_keepalive``
+        directly) will not spawn a second task.
+        """
+        if not self._pool_keepalive_enabled:
+            return
+        if self._keepalive_task is not None and not self._keepalive_task.done():
+            return
+        task = asyncio.create_task(self._run_keepalive())
+        self._keepalive_task = task
+        # Register a GC-triggered finalizer that cancels the task if the
+        # backend is dropped without an awaited ``disconnect()`` (crash path,
+        # test teardown). ``_cancel_keepalive_task_on_gc`` swallows
+        # loop-closed / no-loop errors — it is defense in depth only.
+        if self._keepalive_finalizer is not None:
+            self._keepalive_finalizer.detach()
+        self._keepalive_finalizer = _weakref.finalize(self, _cancel_keepalive_task_on_gc, task)
+
+    async def _stop_pool_keepalive(self) -> None:
+        """Cancel and await the keepalive task, if any."""
+        task = self._keepalive_task
+        if task is None:
+            return
+        self._keepalive_task = None
+        if self._keepalive_finalizer is not None:
+            self._keepalive_finalizer.detach()
+            self._keepalive_finalizer = None
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            # Keepalive is best-effort; never propagate cleanup errors.
+            logger.debug(f"Neo4j pool keepalive shutdown raised: {exc}")
 
     # =========================================================================
     # Entity operations

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -1362,7 +1362,10 @@ class Neo4jBackend(GraphBackendBase):
             idle = max(0, total - active)
         except Exception as exc:
             if not self._keepalive_warned:
-                logger.warning(f"Neo4j pool keepalive read failed; disabling further warnings: {exc}")
+                logger.warning(
+                    "Neo4j pool keepalive read failed; disabling further warnings: {error}",
+                    error=exc,
+                )
                 self._keepalive_warned = True
             return 0
         return idle
@@ -1380,6 +1383,9 @@ class Neo4jBackend(GraphBackendBase):
         try:
             while True:
                 free = self._count_free_connections()
+                # Cap per-cycle fan-out: warming any idle connection resets the
+                # network idle timer, so a small fixed cap suffices even on a
+                # large idle pool and bounds the concurrent-session burst.
                 n = min(free, 16)
                 for _ in range(n):
                     ping = asyncio.create_task(self._keepalive_ping_once())
@@ -1414,7 +1420,7 @@ class Neo4jBackend(GraphBackendBase):
                 await session.close()
         except Exception as exc:
             self._keepalive_failures_counter.add(1)
-            logger.debug(f"Neo4j keepalive ping failed (expected self-heal canary): {exc}")
+            logger.debug("Neo4j keepalive ping failed (expected self-heal canary): {error}", error=exc)
 
     def _start_pool_keepalive(self) -> None:
         """Start the background keepalive task if enabled and not already running.
@@ -1452,7 +1458,7 @@ class Neo4jBackend(GraphBackendBase):
             pass
         except Exception as exc:
             # Keepalive is best-effort; never propagate cleanup errors.
-            logger.debug(f"Neo4j pool keepalive shutdown raised: {exc}")
+            logger.debug("Neo4j pool keepalive shutdown raised: {error}", error=exc)
 
     # =========================================================================
     # Entity operations

--- a/tests/integration/test_neo4j_pool_keepalive_integration.py
+++ b/tests/integration/test_neo4j_pool_keepalive_integration.py
@@ -1,0 +1,205 @@
+"""Real-Neo4j integration tests for the connection-pool keepalive.
+
+Mirrors the gating of the other real-Neo4j integration modules in this
+repo (``test_neo4j_get_entity_relationships_integration.py``): marked
+``@pytest.mark.integration`` and skipped unless ``NEO4J_INTEGRATION_TEST=1``,
+because Khora's CI does not provision a Neo4j instance. Local developers
+running ``make dev`` can exercise these.
+
+How to run locally:
+
+    make dev  # starts postgres + neo4j via docker compose
+    NEO4J_INTEGRATION_TEST=1 uv run pytest \
+        tests/integration/test_neo4j_pool_keepalive_integration.py -v
+
+Connection parameters (match the ``make dev`` compose stack):
+
+    KHORA_NEO4J_URL       (default: bolt://localhost:7687)
+    KHORA_NEO4J_USERNAME  (default: neo4j)
+    KHORA_NEO4J_PASSWORD  (default: password)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+from khora.storage.backends.neo4j import Neo4jBackend
+
+try:
+    import aiosqlite  # noqa: F401
+    import lancedb  # noqa: F401
+
+    _HAS_EMBEDDED = True
+except ImportError:
+    _HAS_EMBEDDED = False
+
+_NEO4J_GATE = pytest.mark.skipif(
+    not os.environ.get("NEO4J_INTEGRATION_TEST"),
+    reason="set NEO4J_INTEGRATION_TEST=1 to run against real Neo4j (requires make dev)",
+)
+
+
+def _neo4j_params() -> tuple[str, str, str]:
+    url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+    user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+    password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+    return url, user, password
+
+
+def _wire_keepalive_counters(backend: Neo4jBackend) -> dict[str, int]:
+    """Replace the keepalive counters with counting recorders.
+
+    The OTel counters are no-ops without logfire, so we swap in plain
+    recorders to observe ping / failure activity deterministically.
+    """
+    observed = {"pings": 0, "failures": 0}
+
+    class _Recorder:
+        def __init__(self, key: str) -> None:
+            self._key = key
+
+        def add(self, value: int, **_kw: object) -> None:
+            observed[self._key] += value
+
+    backend._keepalive_pings_counter = _Recorder("pings")
+    backend._keepalive_failures_counter = _Recorder("failures")
+    return observed
+
+
+@pytest.mark.integration
+@_NEO4J_GATE
+class TestKeepaliveAgainstRealNeo4j:
+    """Real driver, real pool — the keepalive fires pings and stops cleanly."""
+
+    @pytest.mark.asyncio
+    async def test_keepalive_fires_pings_over_a_couple_intervals(self) -> None:
+        """from_driver path: connect → warm one pooled connection → wait a few
+        intervals → assert pings fired and no failures, then disconnect cleanly.
+        """
+        from neo4j import AsyncGraphDatabase
+
+        url, user, password = _neo4j_params()
+        driver = AsyncGraphDatabase.driver(url, auth=(user, password))
+        backend = Neo4jBackend.from_driver(
+            driver,
+            pool_keepalive_enabled=True,
+            pool_keepalive_interval_ms=50,
+        )
+        observed = _wire_keepalive_counters(backend)
+        try:
+            await backend.connect()
+            assert backend._keepalive_task is not None
+
+            # Warm at least one connection into the pool so the keepalive has
+            # an idle connection to count and ping.
+            async with backend._session() as s:
+                await s.run("RETURN 1")
+
+            # ~6 intervals at 50ms.
+            await asyncio.sleep(0.3)
+        finally:
+            await backend.disconnect()
+            await driver.close()
+
+        assert backend._keepalive_task is None, "disconnect() must stop the keepalive"
+        assert observed["pings"] >= 1, f"expected the keepalive to fire pings, got {observed}"
+        # Against a healthy local Neo4j, pings should not fail.
+        assert observed["failures"] == 0, f"unexpected keepalive ping failures: {observed}"
+
+    @pytest.mark.asyncio
+    async def test_sampler_and_keepalive_coexist(self) -> None:
+        """Sampler + keepalive both enabled run together without interfering."""
+        from neo4j import AsyncGraphDatabase
+
+        url, user, password = _neo4j_params()
+        driver = AsyncGraphDatabase.driver(url, auth=(user, password))
+        backend = Neo4jBackend.from_driver(
+            driver,
+            pool_sampler_enabled=True,
+            pool_sampler_interval_ms=50,
+            pool_keepalive_enabled=True,
+            pool_keepalive_interval_ms=50,
+        )
+        observed = _wire_keepalive_counters(backend)
+        try:
+            await backend.connect()
+            assert backend._sampler_task is not None
+            assert backend._keepalive_task is not None
+            assert backend._sampler_task is not backend._keepalive_task
+
+            async with backend._session() as s:
+                await s.run("RETURN 1")
+
+            await asyncio.sleep(0.3)
+
+            # Both tasks still alive (no deadlock, no crash).
+            assert not backend._sampler_task.done()
+            assert not backend._keepalive_task.done()
+        finally:
+            await backend.disconnect()
+            await driver.close()
+
+        assert backend._sampler_task is None
+        assert backend._keepalive_task is None
+        assert observed["pings"] >= 1, f"keepalive did not fire alongside sampler: {observed}"
+
+    @pytest.mark.asyncio
+    async def test_disconnect_does_not_touch_a_closed_driver(self) -> None:
+        """disconnect() stops the keepalive cleanly even after the driver closed.
+
+        The keepalive owns no driver lifecycle (from_driver => not owns_driver),
+        so stopping it must be a clean task-cancel with no use of the driver.
+        """
+        from neo4j import AsyncGraphDatabase
+
+        url, user, password = _neo4j_params()
+        driver = AsyncGraphDatabase.driver(url, auth=(user, password))
+        backend = Neo4jBackend.from_driver(
+            driver,
+            pool_keepalive_enabled=True,
+            pool_keepalive_interval_ms=50,
+        )
+        await backend.connect()
+        await asyncio.sleep(0.1)
+        # disconnect() cancels+awaits the keepalive task; it does not close the
+        # shared driver (owns_driver=False). Must not raise.
+        await backend.disconnect()
+        assert backend._keepalive_task is None
+        await driver.close()
+
+
+@pytest.mark.embedded
+@pytest.mark.integration
+@pytest.mark.skipif(not _HAS_EMBEDDED, reason="aiosqlite/lancedb not installed (pip install khora[sqlite_lance])")
+class TestKeepaliveUnaffectedBackends:
+    """Graph-less / non-Neo4j stacks never create a keepalive task.
+
+    This needs no real Neo4j — the sqlite_lance coordinator uses no
+    ``Neo4jBackend`` — so it is gated on the embedded extras rather than
+    ``NEO4J_INTEGRATION_TEST``, matching the embedded-stack integration
+    tests' style.
+    """
+
+    @pytest.mark.asyncio
+    async def test_sqlite_lance_stack_has_no_neo4j_keepalive(self, tmp_path: Path) -> None:
+        from tests.integration._sqlite_lance_fixtures import build_sqlite_lance_coordinator
+
+        coord = await build_sqlite_lance_coordinator(tmp_path)
+        try:
+            # No graph backend is a Neo4jBackend on the embedded path; none of
+            # the coordinator's backends carries a running keepalive task.
+            for backend in (
+                getattr(coord, "graph", None),
+                getattr(coord, "vector", None),
+                getattr(coord, "relational", None),
+            ):
+                if backend is None:
+                    continue
+                assert not isinstance(backend, Neo4jBackend), "sqlite_lance stack must not use Neo4jBackend"
+                assert getattr(backend, "_keepalive_task", None) is None
+        finally:
+            await coord.disconnect()

--- a/tests/unit/config/test_env_var_aliases.py
+++ b/tests/unit/config/test_env_var_aliases.py
@@ -182,6 +182,68 @@ def test_neo4j_provenance_max_fields_single_underscore(
 
 
 # ---------------------------------------------------------------------------
+# Neo4j connection-pool keepalive (opt-in)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "env_var",
+    [
+        "KHORA_STORAGE_GRAPH_POOL_KEEPALIVE_ENABLED",
+        "KHORA_STORAGE__GRAPH__POOL_KEEPALIVE_ENABLED",
+    ],
+)
+def test_neo4j_pool_keepalive_enabled_both_forms(monkeypatch: pytest.MonkeyPatch, env_var: str) -> None:
+    """Both alias spellings flip ``Neo4jConfig.pool_keepalive_enabled``."""
+    monkeypatch.setenv("KHORA_STORAGE_GRAPH_BACKEND", "neo4j")
+    monkeypatch.setenv("KHORA_STORAGE_GRAPH_URL", "bolt://localhost:7687")
+    monkeypatch.setenv(env_var, "true")
+
+    config = KhoraConfig()
+    assert isinstance(config.storage.graph, Neo4jConfig)
+    assert config.storage.graph.pool_keepalive_enabled is True
+
+
+@pytest.mark.parametrize(
+    "env_var",
+    [
+        "KHORA_STORAGE_GRAPH_POOL_KEEPALIVE_INTERVAL_MS",
+        "KHORA_STORAGE__GRAPH__POOL_KEEPALIVE_INTERVAL_MS",
+    ],
+)
+def test_neo4j_pool_keepalive_interval_ms_both_forms(monkeypatch: pytest.MonkeyPatch, env_var: str) -> None:
+    """Both alias spellings populate ``Neo4jConfig.pool_keepalive_interval_ms``."""
+    monkeypatch.setenv("KHORA_STORAGE_GRAPH_BACKEND", "neo4j")
+    monkeypatch.setenv("KHORA_STORAGE_GRAPH_URL", "bolt://localhost:7687")
+    monkeypatch.setenv(env_var, "30000")
+
+    config = KhoraConfig()
+    assert isinstance(config.storage.graph, Neo4jConfig)
+    assert config.storage.graph.pool_keepalive_interval_ms == 30000
+
+
+def test_neo4j_pool_keepalive_alias_conflict_raises_when_values_differ(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Conflict detection must fire for the keepalive aliases too.
+
+    The keepalive pair must be registered in the canonical/legacy alias
+    table, so setting both spellings to different values names both env
+    vars in the error.
+    """
+    monkeypatch.setenv("KHORA_STORAGE_GRAPH_BACKEND", "neo4j")
+    monkeypatch.setenv("KHORA_STORAGE_GRAPH_URL", "bolt://localhost:7687")
+    monkeypatch.setenv("KHORA_STORAGE_GRAPH_POOL_KEEPALIVE_INTERVAL_MS", "30000")
+    monkeypatch.setenv("KHORA_STORAGE__GRAPH__POOL_KEEPALIVE_INTERVAL_MS", "45000")
+
+    with pytest.raises(ValueError) as excinfo:
+        KhoraConfig()
+    message = str(excinfo.value)
+    assert "KHORA_STORAGE_GRAPH_POOL_KEEPALIVE_INTERVAL_MS" in message
+    assert "KHORA_STORAGE__GRAPH__POOL_KEEPALIVE_INTERVAL_MS" in message
+
+
+# ---------------------------------------------------------------------------
 # dream.ops nested
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_neo4j_backend.py
+++ b/tests/unit/test_neo4j_backend.py
@@ -112,9 +112,12 @@ class TestNeo4jBackendFromConfig:
         config.entity_write_concurrency = 16
         config.relationship_write_concurrency = 8
         # Additions: prevent MagicMock auto-attrs from leaking into
-        # the ``max(50, min(60_000, ...))`` clamp on pool_sampler_interval_ms.
+        # the ``max(50, min(60_000, ...))`` clamp on pool_sampler_interval_ms
+        # and pool_keepalive_interval_ms.
         config.pool_sampler_enabled = False
         config.pool_sampler_interval_ms = 500
+        config.pool_keepalive_enabled = False
+        config.pool_keepalive_interval_ms = 15000
 
         backend = Neo4jBackend.from_config(config)
         assert backend._query_timeout == 3.5

--- a/tests/unit/test_neo4j_pool_keepalive.py
+++ b/tests/unit/test_neo4j_pool_keepalive.py
@@ -1,0 +1,778 @@
+"""Unit tests for the opt-in Neo4j connection-pool keepalive.
+
+Mirrors ``tests/unit/test_neo4j_pool_metrics_correctness.py``'s
+``TestPoolSampler`` / ``TestConnectStartsSampler`` / ``TestSamplerConfig``
+structure for the keepalive feature: a default-OFF background task that
+fires ``RETURN 1`` pings on idle pooled connections so they are never
+idle-dropped before the driver's liveness check would catch a stale
+connection.
+
+No real Neo4j here — the driver / pool are mocked. The keepalive's
+defining property is **metric isolation**: a ping uses a RAW
+``driver.session(...)`` (never ``Neo4jBackend._session`` /
+``_InstrumentedSession``), so it must never touch ``acquire_duration`` /
+``session.duration`` / the timeout counter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from khora.storage.backends.neo4j import Neo4jBackend, _cancel_keepalive_task_on_gc
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_keepalive_driver(*, idle: int = 1) -> MagicMock:
+    """Shared-driver mock with a pool the keepalive can read deterministically.
+
+    ``idle`` connections are exposed as a single-address deque with
+    ``in_use_connection_count`` reporting zero in-use, so
+    ``_count_free_connections`` returns exactly ``idle``.
+    """
+    driver = MagicMock()
+    pool = MagicMock()
+    pool.connections = {"addr1": deque(MagicMock() for _ in range(idle))}
+    pool.connections_reservations = {"addr1": 0}
+    pool.in_use_connection_count = MagicMock(return_value=0)
+    pool.lock = MagicMock()
+    pool.lock.__enter__ = MagicMock(return_value=pool.lock)
+    pool.lock.__exit__ = MagicMock(return_value=False)
+    pool.pool_config = MagicMock()
+    pool.pool_config.max_connection_pool_size = 10
+    driver._pool = pool
+
+    # Raw-session path the keepalive ping uses: driver.session(...) returns
+    # an AsyncSession with execute_read + close. NOT an async context manager
+    # here — the keepalive opens it directly and closes it in a finally.
+    def _new_session(*_a: Any, **_kw: Any) -> AsyncMock:
+        session = AsyncMock()
+        session.execute_read = AsyncMock(return_value=[1])
+        session.close = AsyncMock(return_value=None)
+        return session
+
+    driver.session.side_effect = _new_session
+    return driver
+
+
+# ===========================================================================
+# Default-OFF: zero cost when the keepalive is not enabled.
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestKeepaliveDefaultOff:
+    @pytest.mark.asyncio
+    async def test_connect_does_not_start_keepalive_when_disabled(self) -> None:
+        """connect() with pool_keepalive_enabled=False must not spawn a task."""
+        driver = _make_keepalive_driver()
+        backend = Neo4jBackend.from_driver(driver)  # default: disabled
+        assert backend._pool_keepalive_enabled is False
+
+        backend._create_indexes = AsyncMock()
+        backend._register_pool_metrics = MagicMock()
+
+        await backend.connect()
+        try:
+            assert backend._keepalive_task is None, "disabled keepalive must not start a task"
+            await asyncio.sleep(0.05)
+            assert driver.session.call_count == 0, "disabled keepalive must fire zero pings"
+        finally:
+            await backend.disconnect()
+
+    def test_start_pool_keepalive_noop_when_disabled(self) -> None:
+        """Calling _start_pool_keepalive directly is inert when disabled."""
+        driver = _make_keepalive_driver()
+        backend = Neo4jBackend.from_driver(driver)
+        backend._start_pool_keepalive()
+        assert backend._keepalive_task is None
+
+
+# ===========================================================================
+# Enabled via __init__ AND via from_driver — connect() starts the task.
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestKeepaliveStarts:
+    @pytest.mark.asyncio
+    async def test_connect_starts_keepalive_via_from_driver(self) -> None:
+        """from_driver honors pool_keepalive_enabled; connect() starts the task."""
+        driver = _make_keepalive_driver()
+        backend = Neo4jBackend.from_driver(
+            driver,
+            pool_keepalive_enabled=True,
+            pool_keepalive_interval_ms=50,
+        )
+        assert backend._pool_keepalive_enabled is True
+        assert backend._pool_keepalive_interval_ms == 50
+
+        backend._create_indexes = AsyncMock()
+        backend._register_pool_metrics = MagicMock()
+
+        await backend.connect()
+        try:
+            assert backend._keepalive_task is not None, "connect() must start the keepalive when enabled"
+        finally:
+            await backend.disconnect()
+        assert backend._keepalive_task is None, "disconnect() must stop the keepalive"
+
+    @pytest.mark.asyncio
+    async def test_init_kwargs_set_instance_flags(self) -> None:
+        """The public constructor honors the keepalive kwargs on the instance."""
+        backend = Neo4jBackend(
+            "bolt://localhost:7687",
+            pool_keepalive_enabled=True,
+            pool_keepalive_interval_ms=200,
+        )
+        assert backend._pool_keepalive_enabled is True
+        assert backend._pool_keepalive_interval_ms == 200
+        # No event loop / task yet — connect() owns task creation.
+        assert backend._keepalive_task is None
+
+    @pytest.mark.asyncio
+    async def test_start_pool_keepalive_spawns_when_enabled(self) -> None:
+        """_start_pool_keepalive creates a task when enabled."""
+        driver = _make_keepalive_driver()
+        backend = Neo4jBackend.from_driver(driver, pool_keepalive_enabled=True, pool_keepalive_interval_ms=50)
+        backend._start_pool_keepalive()
+        try:
+            assert backend._keepalive_task is not None
+            assert not backend._keepalive_task.done()
+        finally:
+            await backend._stop_pool_keepalive()
+
+
+# ===========================================================================
+# Idempotent start.
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestKeepaliveIdempotentStart:
+    @pytest.mark.asyncio
+    async def test_double_start_does_not_leak_a_second_task(self) -> None:
+        """Calling _start_pool_keepalive twice reuses the first task."""
+        driver = _make_keepalive_driver()
+        backend = Neo4jBackend.from_driver(driver, pool_keepalive_enabled=True, pool_keepalive_interval_ms=50)
+
+        backend._start_pool_keepalive()
+        first_task = backend._keepalive_task
+        assert first_task is not None
+
+        backend._start_pool_keepalive()  # second call — must be a no-op
+        assert backend._keepalive_task is first_task, "second _start_pool_keepalive must reuse the first task"
+
+        await backend._stop_pool_keepalive()
+        assert backend._keepalive_task is None
+
+    @pytest.mark.asyncio
+    async def test_double_connect_does_not_spawn_a_second_task(self) -> None:
+        """connect() twice on a shared driver does not spawn a second keepalive."""
+        driver = _make_keepalive_driver()
+        backend = Neo4jBackend.from_driver(driver, pool_keepalive_enabled=True, pool_keepalive_interval_ms=50)
+        backend._create_indexes = AsyncMock()
+        backend._register_pool_metrics = MagicMock()
+
+        await backend.connect()
+        try:
+            first_task = backend._keepalive_task
+            assert first_task is not None
+            await backend.connect()  # second connect — keepalive must be reused
+            assert backend._keepalive_task is first_task
+        finally:
+            await backend.disconnect()
+
+
+# ===========================================================================
+# Clean stop.
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestKeepaliveStop:
+    @pytest.mark.asyncio
+    async def test_stop_cancels_and_clears_task_and_detaches_finalizer(self) -> None:
+        """_stop_pool_keepalive cancels + awaits, nulls the task, detaches finalizer."""
+        driver = _make_keepalive_driver()
+        backend = Neo4jBackend.from_driver(driver, pool_keepalive_enabled=True, pool_keepalive_interval_ms=50)
+        backend._start_pool_keepalive()
+        task = backend._keepalive_task
+        assert task is not None
+        assert backend._keepalive_finalizer is not None
+
+        await backend._stop_pool_keepalive()
+
+        assert backend._keepalive_task is None
+        assert task.done(), "the keepalive task must be done after stop"
+        assert backend._keepalive_finalizer is None, "stop must detach the finalizer"
+
+    @pytest.mark.asyncio
+    async def test_stop_is_safe_when_no_task_running(self) -> None:
+        """_stop_pool_keepalive must not raise when nothing is running."""
+        backend = Neo4jBackend.from_driver(MagicMock())
+        assert backend._keepalive_task is None
+        await backend._stop_pool_keepalive()  # must not raise
+        assert backend._keepalive_task is None
+
+
+# ===========================================================================
+# Metric isolation (critical): a ping uses a RAW driver.session(...) and
+# does NOT go through _session() / _InstrumentedSession.
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestKeepaliveMetricIsolation:
+    @pytest.mark.asyncio
+    async def test_ping_uses_raw_driver_session_not_instrumented_session(self) -> None:
+        """A keepalive ping opens driver.session(...) directly, never _session()."""
+        driver = _make_keepalive_driver()
+        backend = Neo4jBackend.from_driver(driver, pool_keepalive_enabled=True)
+
+        # Spy on the instrumented helper — it must NOT be touched by the ping.
+        session_spy = MagicMock(side_effect=AssertionError("keepalive must not call _session()"))
+        backend._session = session_spy
+
+        await backend._keepalive_ping_once()
+
+        session_spy.assert_not_called()
+        driver.session.assert_called_once()
+        # The ping runs against the configured database via the raw session.
+        _, kwargs = driver.session.call_args
+        assert kwargs.get("database") == backend._database
+
+    @pytest.mark.asyncio
+    async def test_ping_does_not_touch_acquire_or_session_or_timeout_instruments(self) -> None:
+        """The keepalive ping records nothing on the read/write hot-path instruments."""
+        driver = _make_keepalive_driver()
+        backend = Neo4jBackend.from_driver(driver, pool_keepalive_enabled=True)
+
+        # Wire spies onto every hot-path instrument the keepalive must avoid.
+        backend._acquire_duration_histogram = MagicMock()
+        backend._acquisition_histogram = MagicMock()
+        backend._session_duration_histogram = MagicMock()
+        backend._timeout_counter = MagicMock()
+        # And the keepalive's own counters, which it SHOULD touch.
+        backend._keepalive_pings_counter = MagicMock()
+        backend._keepalive_failures_counter = MagicMock()
+
+        await backend._keepalive_ping_once()
+
+        backend._acquire_duration_histogram.record.assert_not_called()
+        backend._acquisition_histogram.record.assert_not_called()
+        backend._session_duration_histogram.record.assert_not_called()
+        backend._timeout_counter.add.assert_not_called()
+        # The ping path increments pings (attempt) and, on success, not failures.
+        backend._keepalive_pings_counter.add.assert_called_once_with(1)
+        backend._keepalive_failures_counter.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ping_uses_execute_read_return_1_and_closes_session(self) -> None:
+        """The ping does a single execute_read(RETURN 1) and closes the session."""
+        opened: list[AsyncMock] = []
+
+        driver = MagicMock()
+        driver._pool = MagicMock()
+
+        def _new_session(*_a: Any, **_kw: Any) -> AsyncMock:
+            session = AsyncMock()
+            session.execute_read = AsyncMock(return_value=[1])
+            session.close = AsyncMock(return_value=None)
+            opened.append(session)
+            return session
+
+        driver.session.side_effect = _new_session
+        backend = Neo4jBackend.from_driver(driver, pool_keepalive_enabled=True)
+
+        await backend._keepalive_ping_once()
+
+        assert len(opened) == 1
+        opened[0].execute_read.assert_awaited_once()
+        opened[0].close.assert_awaited_once()
+
+
+# ===========================================================================
+# Cap: at most min(N, 16) pings per round.
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestKeepaliveCap:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("free", "expected"),
+        [
+            (0, 0),
+            (5, 5),  # N < 16
+            (16, 16),  # N == 16
+            (40, 16),  # N > 16 — capped
+        ],
+    )
+    async def test_one_round_fires_min_n_16_pings(self, free: int, expected: int) -> None:
+        """_run_keepalive fires exactly min(free, 16) pings in a single round."""
+        backend = Neo4jBackend.from_driver(MagicMock(), pool_keepalive_enabled=True)
+        backend._pool_keepalive_interval_ms = 10_000  # long sleep — we cancel after round 1
+        backend._count_free_connections = MagicMock(return_value=free)
+
+        pinged = 0
+
+        async def _fake_ping() -> None:
+            nonlocal pinged
+            pinged += 1
+
+        backend._keepalive_ping_once = _fake_ping
+
+        task = asyncio.create_task(backend._run_keepalive())
+        # Let the first round dispatch its ping tasks, then cancel before the
+        # next interval. A short sleep lets the created ping tasks run.
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert pinged == expected, f"free={free}: expected {expected} pings, fired {pinged}"
+
+
+# ===========================================================================
+# Failure resilience: a raising ping increments failures, logs (not ERROR),
+# and does NOT stall / kill the loop.
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestKeepaliveFailureResilience:
+    @pytest.mark.asyncio
+    async def test_failing_ping_increments_failures_and_logs_debug_not_error(self) -> None:
+        """A ping whose session raises bumps the failures counter and logs at DEBUG."""
+        driver = MagicMock()
+        driver._pool = MagicMock()
+        driver.session.side_effect = RuntimeError("connection reset by peer")
+
+        backend = Neo4jBackend.from_driver(driver, pool_keepalive_enabled=True)
+        backend._keepalive_pings_counter = MagicMock()
+        backend._keepalive_failures_counter = MagicMock()
+
+        with patch("khora.storage.backends.neo4j.logger") as mock_logger:
+            await backend._keepalive_ping_once()  # must not raise
+
+        backend._keepalive_pings_counter.add.assert_called_once_with(1)
+        backend._keepalive_failures_counter.add.assert_called_once_with(1)
+        mock_logger.debug.assert_called_once()
+        mock_logger.error.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_loop_keeps_firing_after_a_ping_raises(self) -> None:
+        """A raising ping in round 1 must not stop round 2 from firing."""
+        backend = Neo4jBackend.from_driver(MagicMock(), pool_keepalive_enabled=True)
+        backend._pool_keepalive_interval_ms = 20
+        backend._count_free_connections = MagicMock(return_value=1)
+
+        rounds = 0
+
+        async def _ping() -> None:
+            nonlocal rounds
+            rounds += 1
+            raise RuntimeError("ping blew up")
+
+        backend._keepalive_ping_once = _ping
+
+        task = asyncio.create_task(backend._run_keepalive())
+        # ~3 intervals at 20ms — expect multiple rounds despite each raising.
+        await asyncio.sleep(0.1)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert rounds >= 2, f"loop stalled after a failing ping; only {rounds} round(s) fired"
+
+
+# ===========================================================================
+# No asyncio.wait_for in the ping path — a slow ping must not be cancelled
+# by the loop (the half-closed connection must be allowed to self-heal).
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestKeepaliveNoWaitFor:
+    @pytest.mark.asyncio
+    async def test_ping_path_does_not_wrap_in_wait_for(self) -> None:
+        """Patch asyncio.wait_for and assert the keepalive never calls it."""
+        driver = _make_keepalive_driver()
+        backend = Neo4jBackend.from_driver(driver, pool_keepalive_enabled=True)
+
+        with patch("khora.storage.backends.neo4j.asyncio.wait_for") as mock_wait_for:
+            await backend._keepalive_ping_once()
+            mock_wait_for.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_slow_ping_runs_to_completion_uncancelled(self) -> None:
+        """A slow ping is awaited to completion — not deadline-cancelled."""
+        completed = asyncio.Event()
+
+        driver = MagicMock()
+        driver._pool = MagicMock()
+
+        def _new_session(*_a: Any, **_kw: Any) -> AsyncMock:
+            session = AsyncMock()
+
+            async def _slow_execute_read(*_a: Any, **_kw: Any) -> list[int]:
+                await asyncio.sleep(0.1)
+                completed.set()
+                return [1]
+
+            session.execute_read = _slow_execute_read
+            session.close = AsyncMock(return_value=None)
+            return session
+
+        driver.session.side_effect = _new_session
+        backend = Neo4jBackend.from_driver(driver, pool_keepalive_enabled=True)
+
+        await backend._keepalive_ping_once()
+        assert completed.is_set(), "slow ping was cut short — it must run to completion"
+
+
+# ===========================================================================
+# Detached-task hygiene: the in-flight ping set holds hard refs so pings are
+# not GC'd mid-flight, and the done-callback drains the set as pings finish.
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestKeepaliveDetachedTaskHygiene:
+    @pytest.mark.asyncio
+    async def test_in_flight_pings_held_then_drained_by_done_callback(self) -> None:
+        """A round holds hard refs to its ping tasks, then the done-callback
+        discards each when it completes — no leak, no GC mid-flight.
+
+        Runs the REAL ``_run_keepalive`` (only the ping body is gated) so the
+        ``pings`` set + ``add_done_callback(pings.discard)`` wiring is exercised.
+        """
+        backend = Neo4jBackend.from_driver(MagicMock(), pool_keepalive_enabled=True)
+        backend._pool_keepalive_interval_ms = 10_000  # one round, then long sleep
+        backend._count_free_connections = MagicMock(return_value=3)
+
+        release = asyncio.Event()
+        started = 0
+
+        async def _gated_ping() -> None:
+            nonlocal started
+            started += 1
+            await release.wait()  # stay in-flight until released
+
+        backend._keepalive_ping_once = _gated_ping
+
+        task = asyncio.create_task(backend._run_keepalive())
+        # Let the round dispatch all 3 ping tasks and block them in-flight.
+        while started < 3:
+            await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        # All 3 pings are alive: the loop must be holding hard refs to them
+        # (otherwise they'd be GC-eligible). Count keepalive ping tasks on the
+        # loop that are not yet done.
+        live_pings = [
+            t
+            for t in asyncio.all_tasks()
+            if t is not task and not t.done() and t.get_coro().__qualname__.endswith("_gated_ping")
+        ]
+        assert len(live_pings) == 3, f"expected 3 in-flight pings held, found {len(live_pings)}"
+
+        # Release them — the done-callback (pings.discard) drains the set.
+        release.set()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        for t in live_pings:
+            await t
+        assert all(t.done() for t in live_pings)
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+# ===========================================================================
+# Shutdown race: stopping the loop while pings are airborne is clean — the
+# loop cancels without an exception escaping and pings are not awaited by it.
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestKeepaliveShutdownRace:
+    @pytest.mark.asyncio
+    async def test_stop_while_pings_in_flight_is_clean(self) -> None:
+        """Fire a full round of pings, then stop the loop mid-flight.
+
+        ``_stop_pool_keepalive`` cancels + awaits the loop without raising,
+        even though detached ping tasks are still airborne (the loop never
+        awaits them, so cancelling the loop cannot surface a ping error).
+        """
+        backend = Neo4jBackend.from_driver(MagicMock(), pool_keepalive_enabled=True)
+        backend._pool_keepalive_interval_ms = 10_000
+        backend._count_free_connections = MagicMock(return_value=16)
+
+        release = asyncio.Event()
+        started = 0
+
+        async def _gated_ping() -> None:
+            nonlocal started
+            started += 1
+            await release.wait()
+
+        backend._keepalive_ping_once = _gated_ping
+
+        backend._start_pool_keepalive()
+        while started < 16:
+            await asyncio.sleep(0)
+
+        # Stop the loop while all 16 pings are airborne — must be clean.
+        await backend._stop_pool_keepalive()
+        assert backend._keepalive_task is None
+
+        # Drain the orphaned ping tasks so the test leaves no pending tasks.
+        release.set()
+        pending = [t for t in asyncio.all_tasks() if not t.done() and t.get_coro().__qualname__.endswith("_gated_ping")]
+        for t in pending:
+            await t
+
+    @pytest.mark.asyncio
+    async def test_disconnect_while_pings_in_flight_does_not_raise(self) -> None:
+        """A real-shaped ping that errors mid-shutdown never escapes disconnect().
+
+        The ping body raises (driver going away), but because pings are
+        fire-and-forget and the failure is caught + logged at DEBUG inside
+        ``_keepalive_ping_once``, ``disconnect()`` completes cleanly.
+        """
+        driver = _make_keepalive_driver(idle=4)
+        backend = Neo4jBackend.from_driver(driver, pool_keepalive_enabled=True, pool_keepalive_interval_ms=20)
+        backend._create_indexes = AsyncMock()
+        backend._register_pool_metrics = MagicMock()
+
+        await backend.connect()
+        await asyncio.sleep(0.03)  # let at least one round dispatch pings
+        # Simulate the driver going away under in-flight pings.
+        driver.session.side_effect = RuntimeError("driver closed")
+        await asyncio.sleep(0.03)
+
+        # disconnect() must stop the keepalive cleanly despite ping errors.
+        await backend.disconnect()
+        assert backend._keepalive_task is None
+
+
+# ===========================================================================
+# _count_free_connections: idle math + getattr fallbacks.
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestCountFreeConnections:
+    def test_idle_math_total_minus_active(self) -> None:
+        """idle = total - active from a well-formed pool."""
+        driver = MagicMock()
+        pool = MagicMock()
+        pool.connections = {"addr1": deque([MagicMock(), MagicMock(), MagicMock()])}
+        pool.in_use_connection_count = MagicMock(return_value=1)
+        pool.lock = MagicMock()
+        pool.lock.__enter__ = MagicMock(return_value=pool.lock)
+        pool.lock.__exit__ = MagicMock(return_value=False)
+        driver._pool = pool
+
+        backend = Neo4jBackend.from_driver(driver)
+        assert backend._count_free_connections() == 2  # 3 total - 1 active
+
+    def test_idle_clamped_when_active_exceeds_total(self) -> None:
+        """Transient inconsistency must not yield a negative free count."""
+        driver = MagicMock()
+        pool = MagicMock()
+        pool.connections = {"addr1": deque([MagicMock()])}  # 1 total
+        pool.in_use_connection_count = MagicMock(return_value=5)  # lies
+        pool.lock = MagicMock()
+        pool.lock.__enter__ = MagicMock(return_value=pool.lock)
+        pool.lock.__exit__ = MagicMock(return_value=False)
+        driver._pool = pool
+
+        backend = Neo4jBackend.from_driver(driver)
+        assert backend._count_free_connections() == 0
+
+    def test_returns_zero_when_driver_detached(self) -> None:
+        backend = Neo4jBackend.from_driver(MagicMock())
+        backend._driver = None
+        assert backend._count_free_connections() == 0
+
+    def test_returns_zero_when_no_pool(self) -> None:
+        driver = MagicMock(spec=[])  # no _pool attribute
+        backend = Neo4jBackend.from_driver(driver)
+        assert backend._count_free_connections() == 0
+
+    def test_unlocked_pool_takes_fallback_path(self) -> None:
+        """A pool with no ``.lock`` reads via the unlocked branch without crashing."""
+
+        class LocklessPool:
+            def __init__(self) -> None:
+                self.connections = {"addr1": deque([MagicMock(), MagicMock()])}
+
+            def in_use_connection_count(self, _addr: Any) -> int:
+                return 1
+
+        driver = MagicMock()
+        driver._pool = LocklessPool()
+        assert not hasattr(driver._pool, "lock"), "test needs a pool without .lock"
+
+        backend = Neo4jBackend.from_driver(driver)
+        assert backend._count_free_connections() == 1  # 2 total - 1 active
+
+    def test_warns_once_and_returns_zero_on_malformed_pool(self) -> None:
+        """A pool whose reads raise warns exactly once and returns 0 thereafter."""
+
+        class BrokenPool:
+            @property
+            def connections(self) -> dict[str, Any]:
+                raise RuntimeError("driver shape drifted mid-read")
+
+        driver = MagicMock()
+        driver._pool = BrokenPool()
+        backend = Neo4jBackend.from_driver(driver)
+
+        with patch("khora.storage.backends.neo4j.logger") as mock_logger:
+            assert backend._count_free_connections() == 0
+            mock_logger.warning.assert_called_once()
+
+        # Subsequent failures are silent — no log-storm on every tick.
+        with patch("khora.storage.backends.neo4j.logger") as mock_logger:
+            assert backend._count_free_connections() == 0
+            mock_logger.warning.assert_not_called()
+
+
+# ===========================================================================
+# GC finalizer cancel helper — mirrors _cancel_sampler_task_on_gc coverage.
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestCancelKeepaliveTaskOnGc:
+    @pytest.mark.asyncio
+    async def test_cancels_a_live_task(self) -> None:
+        async def _runs_forever() -> None:
+            await asyncio.sleep(3600)
+
+        task = asyncio.create_task(_runs_forever())
+        await asyncio.sleep(0)  # let it start
+        _cancel_keepalive_task_on_gc(task)
+        assert task.cancelled() or task.cancelling() > 0
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_noop_on_done_task(self) -> None:
+        async def _instant() -> None:
+            return None
+
+        task = asyncio.create_task(_instant())
+        await task
+        _cancel_keepalive_task_on_gc(task)  # must not raise
+
+
+# ===========================================================================
+# Config: defaults / validation / clamp / env aliases.
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestKeepaliveConfig:
+    def test_init_clamps_interval_low(self) -> None:
+        backend = Neo4jBackend(
+            "bolt://localhost:7687",
+            pool_keepalive_enabled=True,
+            pool_keepalive_interval_ms=1,
+        )
+        assert backend._pool_keepalive_interval_ms == 50
+
+    def test_init_clamps_interval_high(self) -> None:
+        backend = Neo4jBackend(
+            "bolt://localhost:7687",
+            pool_keepalive_enabled=True,
+            pool_keepalive_interval_ms=10**9,
+        )
+        assert backend._pool_keepalive_interval_ms == 60_000
+
+    def test_init_defaults_off_with_15s_interval(self) -> None:
+        backend = Neo4jBackend("bolt://localhost:7687")
+        assert backend._pool_keepalive_enabled is False
+        assert backend._pool_keepalive_interval_ms == 15000
+
+    def test_from_driver_keepalive_defaults_off(self) -> None:
+        backend = Neo4jBackend.from_driver(MagicMock())
+        assert backend._pool_keepalive_enabled is False
+        assert backend._pool_keepalive_interval_ms == 15000
+
+    def test_from_driver_honors_keepalive_kwargs(self) -> None:
+        backend = Neo4jBackend.from_driver(
+            MagicMock(),
+            pool_keepalive_enabled=True,
+            pool_keepalive_interval_ms=250,
+        )
+        assert backend._pool_keepalive_enabled is True
+        assert backend._pool_keepalive_interval_ms == 250
+
+    def test_config_defaults(self) -> None:
+        from khora.config.schema import Neo4jConfig
+
+        cfg = Neo4jConfig(url="bolt://localhost:7687")
+        assert cfg.pool_keepalive_enabled is False
+        assert cfg.pool_keepalive_interval_ms == 15000
+
+    def test_config_rejects_interval_below_range(self) -> None:
+        from pydantic import ValidationError
+
+        from khora.config.schema import Neo4jConfig
+
+        with pytest.raises(ValidationError):
+            Neo4jConfig(url="bolt://localhost:7687", pool_keepalive_interval_ms=49)
+
+    def test_config_rejects_interval_above_range(self) -> None:
+        from pydantic import ValidationError
+
+        from khora.config.schema import Neo4jConfig
+
+        with pytest.raises(ValidationError):
+            Neo4jConfig(url="bolt://localhost:7687", pool_keepalive_interval_ms=60_001)
+
+    def test_config_accepts_in_range(self) -> None:
+        from khora.config.schema import Neo4jConfig
+
+        cfg = Neo4jConfig(url="bolt://localhost:7687", pool_keepalive_enabled=True, pool_keepalive_interval_ms=750)
+        assert cfg.pool_keepalive_enabled is True
+        assert cfg.pool_keepalive_interval_ms == 750
+
+    def test_from_config_reads_keepalive_fields(self) -> None:
+        """from_config must forward the keepalive fields into the backend.
+
+        Mirrors ``TestSamplerConfig.test_from_config_reads_new_fields``. If
+        from_config drops the keepalive kwargs, a config-driven keepalive
+        silently never starts.
+        """
+        from khora.config.schema import Neo4jConfig
+
+        cfg = Neo4jConfig(
+            url="bolt://localhost:7687",
+            pool_keepalive_enabled=True,
+            pool_keepalive_interval_ms=750,
+        )
+        backend = Neo4jBackend.from_config(cfg)
+        assert backend._pool_keepalive_enabled is True
+        assert backend._pool_keepalive_interval_ms == 750


### PR DESCRIPTION
## Summary

Adds an opt-in, **default-off** background *keepalive* to the Neo4j backend that keeps idle pooled connections warm, so they are not silently idle-dropped by an intervening NAT / load balancer. An idle-dropped (half-open) socket otherwise triggers a slow, unbounded stale-connection teardown on the next reuse, which can stall connection acquisition well past the configured timeout. The keepalive removes that idle-drop trigger using only public driver APIs (it is a mitigation, not a hard guarantee against all dead-connection causes).

It mirrors the existing pool-sampler task lifecycle:

- **Config** — `Neo4jConfig.pool_keepalive_enabled` (default `False`) and `pool_keepalive_interval_ms` (default `15000`, validated `[50, 60000]`), each with single- and double-underscore env-var aliases. Default 15s sits below the typical 30s liveness window by design.
- **Backend** — every interval, read the *free (idle)* connection count from the driver pool under a brief lock, then fire `min(free, 16)` **detached, non-awaited** `RETURN 1` pings on a **raw driver session**. The cap bounds fan-out on a large idle pool. Pings deliberately bypass the instrumented session wrapper, so they never pollute the `acquire_duration` / `session.duration` / pool-timeout metrics, and are never wrapped in `asyncio.wait_for` — a ping that hits a dead connection runs its close to completion in the background (self-healing), rather than being cancelled mid-teardown and stranding a half-open socket.
- **Lifecycle** — honored on all three backend construction paths (`__init__`, `from_config`, `from_driver`) and forwarded from the vectorcypher engine; started on `connect()`, stopped on `disconnect()`, with a `weakref.finalize` GC-cancel guard. Idempotent start, clean cancel-and-await stop.
- **Telemetry** — dedicated counters `khora.neo4j.pool.keepalive.pings` / `khora.neo4j.pool.keepalive.failures`, registered in the telemetry contract.
- **Scope** — Neo4j-backend only; the other graph backends and the embedded SQLite/Lance path are unaffected. Closes a config-plumbing parity gap so the feature is reachable whether the backend is built from config or from a shared driver, and via both env-var alias forms.

## Test plan

- [ ] Unit tests pass (keepalive lifecycle, metric isolation via raw session, `min(free, 16)` cap, failure resilience, no `asyncio.wait_for`, idle-count read, config validation + env aliases, all three construction paths)
- [ ] Telemetry-contract drift gate passes (both new counters registered)
- [ ] Integration tests pass (real Neo4j: pings fire and idle stays warm; clean disconnect; sampler + keepalive coexist; non-Neo4j paths unaffected) — gated, runs in CI
- [ ] Manual verification: set `KHORA_STORAGE_GRAPH_POOL_KEEPALIVE_ENABLED=true`, leave the service idle past the network idle window, then issue a read — acquisition completes promptly and idle connection count stays warm across the gap