### PR TITLE
docs: remove unimplemented row-level-security claim from TenancyMode.SHARED

### DIFF
--- a/src/khora/core/models/tenancy.py
+++ b/src/khora/core/models/tenancy.py
@@ -16,7 +16,7 @@ from uuid import UUID, uuid4
 class TenancyMode(str, Enum):
     """Tenancy isolation mode."""
 
-    SHARED = "shared"  # Shared database with namespace_id filtering + row-level security
+    SHARED = "shared"  # Shared database with query-layer namespace_id filtering
     ISOLATED = "isolated"  # Separate database instances per tenant
 
 


### PR DESCRIPTION
## What

The `TenancyMode.SHARED` comment claimed `namespace_id filtering + row-level security`, but no RLS policy is implemented anywhere in the schema or migrations. Reword it to describe the mechanism that actually runs: query-layer `namespace_id` filtering.

```diff
-    SHARED = "shared"  # Shared database with namespace_id filtering + row-level security
+    SHARED = "shared"  # Shared database with query-layer namespace_id filtering
```

## Why

Isolation in shared mode is enforced solely by query-layer `WHERE namespace_id = …` filtering (per `docs/architecture/multi-tenancy.md`, which already notes `TenancyMode` is not wired at runtime). The 'row-level security' wording over-promised a Postgres RLS control that does not exist, which is misleading for anyone evaluating tenant isolation.

## Scope

Comment-only; no behavior change.