### PR TITLE
docs+deps: repoint khora[embedded] from SurrealDB to SQLite+LanceDB

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,7 +44,7 @@ Programmatic values take priority over environment variables.
 |---|---|---|
 | *(default)* | Core: PostgreSQL + pgvector + Neo4j driver + litellm | - |
 | `surrealdb` | **[experimental]** Unified SurrealDB backend (embedded or remote). KNN unreliable in embedded mode | `surrealdb>=2.0.0,<3.0` |
-| `embedded` | Alias for `surrealdb` (zero-infrastructure path) - **experimental** | `surrealdb>=2.0.0,<3.0` |
+| `embedded` | Alias for `sqlite-lance` - the zero-infrastructure embedded stack. **[experimental]** | `lancedb>=0.30.0`, `aiosqlite>=0.21.0`, `pyarrow>=24.0.0` |
 | `memgraph` | Memgraph via Bolt | `neo4j>=6.2.0` |
 | `neptune` | AWS Neptune via Bolt | `neo4j>=6.2.0` |
 | `neptune-iam` | Neptune with IAM SigV4 | `neo4j>=6.2.0`, `boto3>=1.35.0` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,8 @@ rust = [
 ]
 # SurrealDB unified backend (graph + vector + relational in one DB)
 surrealdb = ["surrealdb>=2.0.0,<3.0"]
-embedded = ["surrealdb>=2.0.0,<3.0"]
+# Zero-infrastructure embedded stack — alias for `sqlite-lance` (SQLite + LanceDB).
+embedded = ["khora[sqlite-lance]"]
 # SQLite embedded backend (zero-infrastructure relational + vector)
 sqlite = ["aiosqlite>=0.21.0"]
 # LanceDB embedded vector store (Chronicle engine, zero-infrastructure)

--- a/uv.lock
+++ b/uv.lock
@@ -2390,7 +2390,11 @@ dev = [
     { name = "ty" },
 ]
 embedded = [
-    { name = "surrealdb" },
+    { name = "aiosqlite", version = "0.21.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-5-khora-crewai'" },
+    { name = "aiosqlite", version = "0.22.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-5-khora-google-adk' or extra != 'extra-5-khora-crewai'" },
+    { name = "lancedb", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-5-khora-crewai'" },
+    { name = "lancedb", version = "0.30.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-5-khora-google-adk' or extra != 'extra-5-khora-crewai'" },
+    { name = "pyarrow" },
 ]
 google-adk = [
     { name = "google-adk" },
@@ -2505,6 +2509,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", marker = "extra == 'all-backends'", specifier = ">=0.21.0" },
+    { name = "aiosqlite", marker = "extra == 'embedded'", specifier = ">=0.21.0" },
     { name = "aiosqlite", marker = "extra == 'sqlite'", specifier = ">=0.21.0" },
     { name = "aiosqlite", marker = "extra == 'sqlite-lance'", specifier = ">=0.21.0" },
     { name = "alembic", specifier = ">=1.18.4" },
@@ -2522,6 +2527,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "khora-accel", marker = "extra == 'rust'", editable = "rust/khora-accel" },
     { name = "lancedb", marker = "extra == 'all-backends'", specifier = ">=0.30.0" },
+    { name = "lancedb", marker = "extra == 'embedded'", specifier = ">=0.30.0" },
     { name = "lancedb", marker = "extra == 'lancedb'", specifier = ">=0.30.0" },
     { name = "lancedb", marker = "extra == 'sqlite-lance'", specifier = ">=0.30.0" },
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.0,<2.0" },
@@ -2549,6 +2555,7 @@ requires-dist = [
     { name = "pgvector", marker = "extra == 'postgres'", specifier = ">=0.4.2" },
     { name = "prek", marker = "extra == 'dev'", specifier = ">=0.3.13" },
     { name = "pyarrow", marker = "extra == 'all-backends'", specifier = ">=24.0.0" },
+    { name = "pyarrow", marker = "extra == 'embedded'", specifier = ">=24.0.0" },
     { name = "pyarrow", marker = "extra == 'lancedb'", specifier = ">=24.0.0" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=24.0.0" },
     { name = "pyarrow", marker = "extra == 'sqlite-lance'", specifier = ">=24.0.0" },
@@ -2568,7 +2575,6 @@ requires-dist = [
     { name = "spacy", marker = "extra == 'nlp'", specifier = ">=3.8.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.49" },
     { name = "surrealdb", marker = "extra == 'all-backends'", specifier = ">=2.0.0,<3.0" },
-    { name = "surrealdb", marker = "extra == 'embedded'", specifier = ">=2.0.0,<3.0" },
     { name = "surrealdb", marker = "extra == 'surrealdb'", specifier = ">=2.0.0,<3.0" },
     { name = "tenacity", specifier = ">=9.1.4" },
     { name = "tiktoken", specifier = ">=0.12.0" },


### PR DESCRIPTION
## Summary

- `khora[embedded]` previously aliased `khora[surrealdb]` (`surrealdb>=2.0.0,<3.0`), but the zero-infrastructure embedded stack actually documented, migration-gated, and tested in this repo is **SQLite + LanceDB** (the `sqlite-lance` extra).
- Repoint the `embedded` extra so `pip install khora[embedded]` pulls `aiosqlite`, `lancedb`, `pyarrow` — matching the embedded path covered by VectorCypher / Skeleton / Chronicle.
- The `surrealdb` extra is unchanged; users who actually wanted SurrealDB should use `khora[surrealdb]` directly.

## Why

The mismatch was reader-confusing in two ways:
1. `docs/configuration.md` called `embedded` an alias for `surrealdb`, but the same file (and `engines/engine-comparison.md`, the `sqlite_lance` Alembic dialect gates, the `tests/integration/test_sqlite_lance_lifecycle.py` skipif messages, etc.) consistently treat *SQLite + LanceDB* as **the** embedded backend.
2. Anyone following the install-extras table from the top of `configuration.md` and picking `embedded` (because it sounds like the obvious zero-infrastructure choice) got the experimental SurrealDB SDK rather than the recommended embedded stack.

## Changes

- `pyproject.toml`: `embedded = ["khora[sqlite-lance]"]` — same self-reference style already used by `otel-grpc = ["khora[otel]", ...]`. Stays in sync if the `sqlite-lance` pin list ever changes.
- `docs/configuration.md`: install-extras table row updated to reflect the new alias target + pulled deps.

## Breaking change

Installers pinning `khora[embedded]` and expecting the SurrealDB SDK will no longer receive it. Migration: switch the pin to `khora[surrealdb]`. Suggest landing under a minor (0.19) rather than a 0.18.x patch.

## Test plan

- [x] `uv pip install -e ".[embedded]" --dry-run -v` resolves `aiosqlite>=0.21.0`, `lancedb>=0.30.0`, `pyarrow>=24.0.0` and does **not** select `surrealdb`
- [x] `khora[surrealdb]` still resolves `surrealdb>=2.0.0,<3.0` (unchanged)
- [x] `khora[all-backends]` unchanged (inlines every pin explicitly)
- [ ] CHANGELOG.md entry — left out of this PR pending the version-bump decision (0.19 minor vs patch)