### PR TITLE
Add case/separator-insensitive matching for source-timestamp metadata keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Khora are documented here.
 
 Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were internal (no git tags).
 
+## [0.18.2] - tolerant source-timestamp key matching
+
+Patch release. Fixes silent source-timestamp loss when connectors emit timestamp keys in non-snake_case styles, and adds a public extractor helper. No breaking changes.
+
+### Fixed
+
+- **Silent `source_timestamp` loss for non-snake_case connector keys**: the ingestion extractor only matched exact snake_case keys (`occurred_at`, `sent_at`, …), so connectors emitting camelCase / kebab-case / SCREAMING_CASE / TitleCase variants (`occurredAt`, `occurred-at`, `OCCURRED_AT`, `OccurredAt`) silently fell back to ingest time, breaking recency scoring. Key matching is now case/separator-insensitive; an exact key still wins over a normalized variant when both are present. `updated_at` is now honored by the extractor (appended last in priority for both event and non-event sources).
+
+### Added
+
+- **Public `khora.pipelines.extract_source_timestamp(metadata)` helper**: the timestamp-extraction logic shared by the ingestion pipeline is now an importable public function (`khora.pipelines.extract_source_timestamp`).
+
 ## [0.18.1] - silent-config and observability fixes
 
 Patch release. Fixes a batch of "accepted but silently ignored / silently dropped" config and observability gaps from Damir Krstanovic's reports. No breaking changes.

--- a/docs/extraction/ingestion-pipeline.md
+++ b/docs/extraction/ingestion-pipeline.md
@@ -567,10 +567,17 @@ This is a one-time migration for existing data.
 ## Canonical metadata fields per source
 
 Connector authors should populate `metadata.custom` with the canonical
-fields below. The ingestion pipeline reads them in
-`_extract_source_timestamp` to build `TemporalChunk.occurred_at`, which
-drives temporal recency scoring + per-source decay. The shape is exported
-as `khora.pipelines.ConnectorMetadata` (a `TypedDict`).
+fields below. The ingestion pipeline reads them via the public
+`khora.pipelines.extract_source_timestamp()` helper to build
+`TemporalChunk.occurred_at`, which drives temporal recency scoring +
+per-source decay. The shape is exported as
+`khora.pipelines.ConnectorMetadata` (a `TypedDict`).
+
+Key matching is **case/separator-insensitive** (since 0.18.2): a connector
+emitting `occurredAt`, `occurred-at`, `OCCURRED_AT`, or `Occurred At` all
+resolve to the canonical `occurred_at` field, though an exact snake_case
+key still wins when both are present. `updated_at` is also honored as a
+lowest-priority fallback.
 
 | Source | Upstream field | Map to `metadata.custom` key | Notes |
 |---|---|---|---|

--- a/src/khora/pipelines/__init__.py
+++ b/src/khora/pipelines/__init__.py
@@ -11,6 +11,7 @@ from .connector_metadata import (
     CANONICAL_TIMESTAMP_FIELDS,
     ConnectorMetadata,
     SourceSystem,
+    extract_source_timestamp,
     validate_connector_metadata,
 )
 from .manager import PipelineManager
@@ -22,6 +23,7 @@ __all__ = [
     "PipelineManager",
     "PipelineRegistry",
     "SourceSystem",
+    "extract_source_timestamp",
     "pipeline",
     "validate_connector_metadata",
 ]

--- a/src/khora/pipelines/connector_metadata.py
+++ b/src/khora/pipelines/connector_metadata.py
@@ -14,6 +14,7 @@ mistakes before chunks reach khora.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from datetime import datetime
 from typing import Any, Literal, NotRequired, TypedDict, get_args
@@ -22,6 +23,8 @@ __all__ = [
     "CANONICAL_TIMESTAMP_FIELDS",
     "ConnectorMetadata",
     "SourceSystem",
+    "coerce_source_timestamp",
+    "extract_source_timestamp",
     "validate_connector_metadata",
 ]
 
@@ -38,8 +41,11 @@ SourceSystem = Literal[
 ]
 
 # Timestamp field names recognized by the ingestion extractor, in priority
-# order. Kept in sync with ``_extract_source_timestamp`` in
-# ``khora.pipelines.flows.ingest``. Public so connector CIs can iterate.
+# order. ``extract_source_timestamp`` matches these against metadata keys
+# case/separator-insensitively, so connectors emitting ``occurredAt`` /
+# ``occurred-at`` / ``OCCURRED_AT`` / ``OccurredAt`` resolve to the same
+# canonical field; ``CANONICAL_TIMESTAMP_FIELDS`` remains the documented
+# canonical set. Public so connector CIs can iterate.
 CANONICAL_TIMESTAMP_FIELDS: tuple[str, ...] = (
     "sent_at",
     "occurred_at",
@@ -87,20 +93,110 @@ class ConnectorMetadata(TypedDict, total=False):
     tags: list[str]
 
 
-def _parse_iso_or_none(value: str) -> datetime | None:
-    """Return parsed datetime if value is ISO-8601, else None.
+def coerce_source_timestamp(value: datetime | str | None) -> datetime | None:
+    """Coerce a source-timestamp value to a ``datetime``.
 
-    Mirrors the parsing logic used by ``_extract_source_timestamp`` so the
-    validator catches exactly what the pipeline will reject.
+    Returns an existing ``datetime`` unchanged, parses ISO-8601 strings
+    (trailing ``Z``, explicit offset, or date-only ``YYYY-MM-DD``), and
+    returns ``None`` for ``None`` / empty / unparseable input *without*
+    raising. The public ``source_timestamp`` kwarg is typed ``datetime``,
+    but upstream connectors and adapters routinely hand us ISO strings;
+    coercing here keeps a stray string from crashing ingestion.
+
+    Accepted string forms (for adapter authors):
+
+    - ``"2026-01-15T10:30:00Z"``      — UTC, trailing ``Z``
+    - ``"2026-01-15T10:30:00+00:00"`` — explicit offset
+    - ``"2026-01-15"``                — date-only (parsed at midnight UTC)
     """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value:
+        return None
     try:
         if "T" in value:
+            # ISO format with or without timezone.
             if value.endswith("Z"):
                 return datetime.fromisoformat(value.replace("Z", "+00:00"))
             return datetime.fromisoformat(value)
+        # Date-only format.
         return datetime.fromisoformat(value + "T00:00:00+00:00")
     except (ValueError, TypeError):
         return None
+
+
+def _normalize_ts_key(key: str) -> str:
+    return re.sub(r"[\s_\-]+", "", key.lower())
+
+
+def extract_source_timestamp(metadata: Mapping[str, Any]) -> datetime | None:
+    """Extract the original timestamp from source metadata.
+
+    Looks for common timestamp fields and parses them. The priority list
+    is implementation-detail; the public contract is
+    ``khora.pipelines.ConnectorMetadata``.
+
+    For event-shaped sources (calendar/meeting/event) ``occurred_at`` is
+    preferred over ``sent_at`` since the event time, not the dispatch
+    time, is the meaningful temporal anchor.
+
+    Key matching is case/separator-insensitive: a connector emitting
+    ``occurredAt`` / ``occurred-at`` / ``OCCURRED_AT`` resolves to the
+    canonical ``occurred_at`` field. An exact key match always wins over a
+    normalized variant when both are present.
+    """
+    source_type = metadata.get("source_type")
+    if source_type in {"calendar", "meeting", "event"}:
+        timestamp_fields = [
+            "occurred_at",
+            "started_at",
+            "sent_at",
+            "created_at",
+            "timestamp",
+            "date",
+            "updated_at",
+        ]
+    else:
+        timestamp_fields = [
+            "sent_at",
+            "created_at",
+            "timestamp",
+            "date",
+            "occurred_at",
+            "started_at",
+            "updated_at",
+        ]
+
+    # Normalized view of metadata, first occurrence wins on collision.
+    normalized_map: dict[str, Any] = {}
+    for key, value in metadata.items():
+        norm = _normalize_ts_key(key)
+        if norm not in normalized_map:
+            normalized_map[norm] = value
+
+    for field in timestamp_fields:
+        # Exact key match wins over a normalized variant.
+        if field in metadata and metadata[field]:
+            value = metadata[field]
+        else:
+            value = normalized_map.get(_normalize_ts_key(field))
+            if not value:
+                continue
+        parsed = coerce_source_timestamp(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+# Timestamp fields the extractor probes, in canonical-set order plus the two
+# extra implementation-detail keys (``timestamp`` / ``date``) the extractor
+# recognizes. Used by the validator to mirror extractor presence detection.
+_EXTRACTOR_TIMESTAMP_FIELDS: tuple[str, ...] = CANONICAL_TIMESTAMP_FIELDS + ("timestamp", "date")
 
 
 def validate_connector_metadata(
@@ -135,12 +231,31 @@ def validate_connector_metadata(
     """
     warnings: list[str] = []
 
-    # Track which timestamp fields are present with a non-empty string value.
+    # Honor ConnectorMetadata.source_type when not passed explicitly, so
+    # connector CI can hand the whole metadata dict in. Explicit param wins.
+    if source_type is None:
+        raw_source_type = metadata.get("source_type")
+        source_type = raw_source_type if isinstance(raw_source_type, str) else None
+
+    # Normalized view of metadata keys so case/separator-insensitive variants
+    # (camelCase/kebab/SCREAMING/TitleCase) count as present, mirroring the
+    # extractor. First occurrence wins on collision.
+    normalized_map: dict[str, Any] = {}
+    for key, value in metadata.items():
+        norm = _normalize_ts_key(key)
+        if norm not in normalized_map:
+            normalized_map[norm] = value
+
+    # Track which timestamp fields resolve to a non-empty, parseable value.
     present_timestamps: list[str] = []
-    for field_name in CANONICAL_TIMESTAMP_FIELDS:
-        if field_name not in metadata:
+    for field_name in _EXTRACTOR_TIMESTAMP_FIELDS:
+        # Exact key match wins over a normalized variant.
+        if field_name in metadata:
+            value = metadata[field_name]
+        elif _normalize_ts_key(field_name) in normalized_map:
+            value = normalized_map[_normalize_ts_key(field_name)]
+        else:
             continue
-        value = metadata[field_name]
         if isinstance(value, str) and value == "":
             warnings.append(
                 f"metadata field {field_name!r} is an empty string; "
@@ -148,7 +263,7 @@ def validate_connector_metadata(
             )
             continue
         if isinstance(value, str):
-            if _parse_iso_or_none(value) is None:
+            if coerce_source_timestamp(value) is None:
                 warnings.append(
                     f"metadata field {field_name!r} value {value!r} does not parse as "
                     "ISO-8601 — chunk will fall back to ingest time"

--- a/src/khora/pipelines/connector_metadata.py
+++ b/src/khora/pipelines/connector_metadata.py
@@ -67,7 +67,7 @@ class ConnectorMetadata(TypedDict, total=False):
     per-source mapping.
     """
 
-    # Timestamp fields, in priority order matching _extract_source_timestamp.
+    # Timestamp fields, in priority order. See extract_source_timestamp() for matching.
     # For meetings/calendar, set occurred_at; for messages/email/Slack, sent_at.
     sent_at: str  # ISO-8601 UTC, e.g. "2026-05-13T14:00:00Z"
     occurred_at: str  # ISO-8601 UTC; for calendar events use start time

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -20,7 +20,13 @@ from khora._accel import normalize_entity_names_batch
 from khora.core.models.event import EventType, MemoryEvent
 from khora.telemetry.metrics import metric_counter
 
+from ..connector_metadata import coerce_source_timestamp, extract_source_timestamp
 from ..registry import pipeline
+
+# Back-compat alias: existing tests and ``khora.py`` import these names from
+# ``khora.pipelines.flows.ingest``. The implementations now live in
+# ``khora.pipelines.connector_metadata`` (one-way ingest -> connector_metadata).
+_extract_source_timestamp = extract_source_timestamp
 
 # ADR-001 (issue #907): the ingest pipeline drops relationships when their
 # source / target entity cannot be remapped to a canonical id. Previously
@@ -532,84 +538,6 @@ async def stream_extract_and_embed_entities(
 def compute_checksum(content: str) -> str:
     """Compute SHA-256 checksum of content."""
     return hashlib.sha256(content.encode("utf-8")).hexdigest()
-
-
-def coerce_source_timestamp(value: datetime | str | None) -> datetime | None:
-    """Coerce a source-timestamp value to a ``datetime``.
-
-    Returns an existing ``datetime`` unchanged, parses ISO-8601 strings
-    (trailing ``Z``, explicit offset, or date-only ``YYYY-MM-DD``), and
-    returns ``None`` for ``None`` / empty / unparseable input *without*
-    raising. The public ``source_timestamp`` kwarg is typed ``datetime``,
-    but upstream connectors and adapters routinely hand us ISO strings;
-    coercing here keeps a stray string from crashing ingestion.
-
-    Accepted string forms (for adapter authors):
-
-    - ``"2026-01-15T10:30:00Z"``      — UTC, trailing ``Z``
-    - ``"2026-01-15T10:30:00+00:00"`` — explicit offset
-    - ``"2026-01-15"``                — date-only (parsed at midnight UTC)
-    """
-    from datetime import datetime
-
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value
-    if not isinstance(value, str):
-        return None
-    value = value.strip()
-    if not value:
-        return None
-    try:
-        if "T" in value:
-            # ISO format with or without timezone.
-            if value.endswith("Z"):
-                return datetime.fromisoformat(value.replace("Z", "+00:00"))
-            return datetime.fromisoformat(value)
-        # Date-only format.
-        return datetime.fromisoformat(value + "T00:00:00+00:00")
-    except (ValueError, TypeError):
-        return None
-
-
-def _extract_source_timestamp(metadata: dict[str, Any]) -> datetime | None:
-    """Extract the original timestamp from source metadata.
-
-    Looks for common timestamp fields and parses them. The priority list
-    is implementation-detail; the public contract is
-    ``khora.pipelines.ConnectorMetadata``.
-
-    For event-shaped sources (calendar/meeting/event) ``occurred_at`` is
-    preferred over ``sent_at`` since the event time, not the dispatch
-    time, is the meaningful temporal anchor.
-    """
-    source_type = metadata.get("source_type")
-    if source_type in {"calendar", "meeting", "event"}:
-        timestamp_fields = [
-            "occurred_at",
-            "started_at",
-            "sent_at",
-            "created_at",
-            "timestamp",
-            "date",
-        ]
-    else:
-        timestamp_fields = [
-            "sent_at",
-            "created_at",
-            "timestamp",
-            "date",
-            "occurred_at",
-            "started_at",
-        ]
-
-    for field in timestamp_fields:
-        if field in metadata and metadata[field]:
-            parsed = coerce_source_timestamp(metadata[field])
-            if parsed is not None:
-                return parsed
-    return None
 
 
 def _coerce_session_id(value: Any) -> UUID | None:

--- a/tests/unit/pipelines/test_connector_metadata.py
+++ b/tests/unit/pipelines/test_connector_metadata.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+import pytest
+
 from khora.pipelines import (
     CANONICAL_TIMESTAMP_FIELDS,
     ConnectorMetadata,
     SourceSystem,
+    extract_source_timestamp,
     validate_connector_metadata,
 )
 from khora.pipelines.flows.ingest import _extract_source_timestamp
+
+# Reuse the spelling matrix from the source-timestamp suite so the validator and
+# the extractor are exercised against the same case/separator-insensitive keys.
+from tests.unit.test_source_timestamp import CANONICAL, EXPECTED, ISO, VARIANTS, spelling
 
 
 def test_connector_metadata_typeddict_import_and_instance() -> None:
@@ -124,3 +131,25 @@ def test_extractor_default_priority_unchanged_for_non_event_sources() -> None:
     assert ts is not None
     # sent_at still wins for non-event sources.
     assert ts.isoformat() == "2026-05-13T14:00:00+00:00"
+
+
+@pytest.mark.parametrize("field", CANONICAL)
+@pytest.mark.parametrize("variant", VARIANTS)
+def test_validator_accepts_any_spelling(field: str, variant: str) -> None:
+    # A timestamp present under any spelling counts as present, so the validator
+    # must NOT emit the "fall back to ingest time" no-timestamp warning. The
+    # validator now honors source_type from the metadata dict.
+    warnings = validate_connector_metadata({spelling(field, variant): ISO, "source_type": "slack"})
+    assert not any("has no sent_at" in w for w in warnings)
+
+
+def test_validator_warns_when_truly_absent() -> None:
+    warnings = validate_connector_metadata({"source_type": "slack"})
+    assert any("has no sent_at" in w for w in warnings)
+
+
+def test_public_helper_matches_internal_path() -> None:
+    # The public re-export and the internal alias resolve to the same behavior.
+    from khora.pipelines.flows.ingest import extract_source_timestamp as internal
+
+    assert extract_source_timestamp({"sentAt": ISO}) == internal({"sentAt": ISO}) == EXPECTED

--- a/tests/unit/test_source_timestamp.py
+++ b/tests/unit/test_source_timestamp.py
@@ -6,7 +6,31 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import pytest
+
 from khora.core.models.document import Chunk, Document
+from khora.pipelines import extract_source_timestamp
+
+# Shared spelling generator + matrix. The connector-metadata test imports
+# CANONICAL / VARIANTS / ISO / spelling from this module so both suites exercise
+# the same case/separator-insensitive key resolution against the public helper.
+CANONICAL = ["sent_at", "occurred_at", "created_at", "updated_at", "started_at", "timestamp", "date"]
+VARIANTS = ["snake", "camel", "pascal", "kebab", "screaming", "title_space", "flat"]
+ISO = "2026-01-10T14:00:00Z"
+EXPECTED = datetime(2026, 1, 10, 14, 0, tzinfo=UTC)
+
+
+def spelling(snake: str, variant: str) -> str:
+    parts = snake.split("_")
+    return {
+        "snake": snake,
+        "camel": parts[0] + "".join(w.capitalize() for w in parts[1:]),
+        "pascal": "".join(w.capitalize() for w in parts),
+        "kebab": "-".join(parts),
+        "screaming": snake.upper(),
+        "title_space": " ".join(w.capitalize() for w in parts),
+        "flat": "".join(parts),
+    }[variant]
 
 
 class TestDocumentSourceTimestamp:
@@ -208,3 +232,42 @@ class TestSourceTimestampInTemporalFiltering:
         assert len(result) == 1
         # Score should be modified by recency
         assert result[0][1] != 0.9 or True  # May be close to 0.9 depending on age
+
+
+class TestExtractSourceTimestampSpellingMatrix:
+    """Case/separator-insensitive key resolution for the public extractor."""
+
+    @pytest.mark.parametrize("field", CANONICAL)
+    @pytest.mark.parametrize("variant", VARIANTS)
+    def test_variant_resolves_to_canonical_field(self, field: str, variant: str) -> None:
+        # Single-word fields (timestamp/date) collapse several variants to the
+        # same string — harmless, the extractor still resolves them.
+        assert extract_source_timestamp({spelling(field, variant): ISO}) == EXPECTED
+
+    def test_exact_wins_over_variant(self) -> None:
+        # An exact canonical key must beat a normalized variant of the same field.
+        result = extract_source_timestamp({"occurred_at": ISO, "occurredAt": "2030-01-01T00:00:00Z"})
+        assert result == EXPECTED
+
+    def test_priority_preserved_non_event(self) -> None:
+        # No source_type → default priority: sent_at outranks occurred_at, even
+        # when both are supplied as camelCase variants.
+        sent_iso = "2026-01-10T14:00:00Z"
+        occurred_iso = "2026-02-20T09:00:00Z"
+        result = extract_source_timestamp({"sentAt": sent_iso, "occurredAt": occurred_iso})
+        assert result == EXPECTED  # sent_at's ISO won
+
+    @pytest.mark.parametrize("source_type", ["calendar", "meeting", "event"])
+    def test_priority_preserved_event(self, source_type: str) -> None:
+        # Event-shaped sources prefer occurred_at over sent_at, variants and all.
+        sent_iso = "2026-01-10T14:00:00Z"
+        occurred_iso = "2026-02-20T09:00:00Z"
+        result = extract_source_timestamp({"sentAt": sent_iso, "occurredAt": occurred_iso, "source_type": source_type})
+        assert result == datetime(2026, 2, 20, 9, 0, tzinfo=UTC)  # occurred_at won
+
+    def test_unknown_key_ignored(self) -> None:
+        assert extract_source_timestamp({"randomFieldName": ISO}) is None
+
+    def test_empty_or_unparseable_variant(self) -> None:
+        assert extract_source_timestamp({"occurredAt": ""}) is None
+        assert extract_source_timestamp({"occurredAt": "not-a-date"}) is None


### PR DESCRIPTION
## Summary

When a document is ingested without an explicit top-level `source_timestamp`, the event time is derived from `metadata` by matching a set of canonical timestamp fields. Previously this used **exact snake_case** key matching, so connectors emitting `occurredAt` (camelCase), `occurred-at` (kebab), `OCCURRED_AT` (SCREAMING_SNAKE), or `Occurred At` (Title Case) were silently not matched — every chunk fell back to ingest time, corrupting recency/decay scoring with no error. The advisory `validate_connector_metadata()` had the inverse blind spot (false "no timestamp" warnings on variant keys).

This change:

- **Tolerant key matching** — canonical timestamp fields are now matched case/separator-insensitively (a single `_normalize_ts_key` lowercases and strips `_ - ` and whitespace). An **exact** snake_case key still wins over a normalized variant when both are present; otherwise first-occurrence-in-metadata wins (deterministic).
- **`updated_at` now honored** by the extractor (appended at lowest priority for both event and non-event sources), bringing it in sync with the documented canonical field set.
- **New public `extract_source_timestamp(metadata)` helper**, re-exported from `khora.pipelines`, as the single shared implementation. The pipeline's internal extractor now delegates to it (no duplicated field knowledge for downstream consumers).
- **Validator mirrors the same normalization**, so its advisory no-timestamp warning no longer false-fires on variant keys, and it honors `source_type` supplied in the metadata mapping (still overridable by the explicit parameter). Empty-string / non-ISO / `source_system` / `tags` checks are unchanged.
- **No import cycle** — `coerce_source_timestamp` moves into the stdlib-only `connector_metadata` module (the dependency leaf); `ingest` imports and re-exports it, so existing `from ...flows.ingest import coerce_source_timestamp` / `_extract_source_timestamp` call sites keep working.
- **Tests** — parameterized matrices (every canonical field × every case/separator variant) added to the two existing test files; no parallel test files.

## Test plan

- [x] Unit tests pass (full `tests/unit` suite green when run sequentially; new parameterized matrices for the extractor and validator)
- [x] `ruff check`, `ruff format --check`, and type-check on changed files clean
- [ ] Integration tests + coverage gate (run in CI on the Docker-equipped runner)
- [x] Manual verification: `occurredAt` / `occurred-at` / `OCCURRED_AT` / `Occurred At` resolve to the canonical field; exact key wins over a variant; `updated_at` honored; validator no longer false-warns on variant-only metadata but still warns when genuinely absent