### PR TITLE
docs: drop removed KHORA_AUTH_ENABLED from configuration reference

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,7 +80,6 @@ go.
 | `KHORA_LLM_EXTRACTION_MODEL` | str | - | Override extraction model (shortcut for `llm.extraction_model`). |
 | `KHORA_DEBUG` | bool | `false` | Enable debug-level logging. |
 | `KHORA_ENVIRONMENT` | str | `development` | `development`, `staging`, or `production`. |
-| `KHORA_AUTH_ENABLED` | bool | `true` | Disable for local experimentation. |
 | `KHORA_APP_NAME` | str | `khora` | Used in logs and telemetry. |
 
 ## Storage


### PR DESCRIPTION
`auth_enabled` was a dead config field that enforced nothing and was removed from `KhoraConfig` in v0.18.0 (#908, via #941) — with `extra='forbid'`, passing it now raises a Pydantic `ValidationError`. The Core settings table in `docs/configuration.md` still listed `KHORA_AUTH_ENABLED`; this drops the stale row.

Docs-only. Out of scope (flagging for follow-up): `compose.full.yaml` and `config/khora.example.yaml` still reference `auth_enabled`.