### PR TITLE
fix(vectorcypher): guard reranker lazy init with asyncio.Lock (#985)

### DIFF
--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -521,11 +521,18 @@ class VectorCypherRetriever:
         # Lazy entity expansion cache: chunk_id -> expansion_score (0 = no match)
         self._expansion_cache: dict[UUID, float] = {}
 
-        # Cached cross-encoder reranker (lazy-init on first use, reused across queries)
+        # Cached cross-encoder reranker (lazy-init on first use, reused across queries).
+        # An ``asyncio.Lock`` makes the check-then-set explicit even though today's
+        # ``CrossEncoderReranker()`` constructor is synchronous: it survives a future
+        # refactor that adds an ``await`` between the check and the assignment, and
+        # documents at the call site that this state is shared across concurrent
+        # recall tasks (see issue #985).
         self._reranker: CrossEncoderReranker | None = None
+        self._reranker_lock = asyncio.Lock()
 
-        # Cached LLM reranker for temporal queries (lazy-init on first use)
+        # Cached LLM reranker for temporal queries (lazy-init on first use, same guard).
         self._llm_reranker: LLMReranker | None = None
+        self._llm_reranker_lock = asyncio.Lock()
 
         # Issue #814 — one-time WARNING dedupe for LLM-rerank skip reasons.
         # Tuples are ``(namespace_id_or_None, skip_reason)``; once a tuple
@@ -1963,8 +1970,9 @@ class VectorCypherRetriever:
         )
 
         try:
-            if self._reranker is None:
-                self._reranker = CrossEncoderReranker(model_name=self._config.reranking_model)
+            async with self._reranker_lock:
+                if self._reranker is None:
+                    self._reranker = CrossEncoderReranker(model_name=self._config.reranking_model)
             results = await self._reranker.rerank(
                 query, candidates, top_k=top_n, blend_weight=self._config.reranking_blend_weight
             )
@@ -2159,8 +2167,9 @@ class VectorCypherRetriever:
         )
 
         try:
-            if self._llm_reranker is None:
-                self._llm_reranker = LLMReranker(model=self._config.llm_reranking_model)
+            async with self._llm_reranker_lock:
+                if self._llm_reranker is None:
+                    self._llm_reranker = LLMReranker(model=self._config.llm_reranking_model)
             results = await self._llm_reranker.rerank(query, candidates, top_k=top_n, blend_weight=0.7)
 
             reranked: list[FusedResult] = []

--- a/tests/unit/engines/test_vectorcypher_retriever.py
+++ b/tests/unit/engines/test_vectorcypher_retriever.py
@@ -283,10 +283,7 @@ class TestRerankerLazyInitRace:
         ns = uuid4()
         with patch("khora.query.reranking.CrossEncoderReranker", _FakeReranker):
             await _asyncio.gather(
-                *[
-                    retriever._apply_reranking("q", list(fused_results), limit=1, namespace_id=ns)
-                    for _ in range(5)
-                ]
+                *[retriever._apply_reranking("q", list(fused_results), limit=1, namespace_id=ns) for _ in range(5)]
             )
 
         assert call_count == 1, f"expected one CrossEncoderReranker construction, got {call_count}"
@@ -313,10 +310,7 @@ class TestRerankerLazyInitRace:
         ns = uuid4()
         with patch("khora.query.reranking.LLMReranker", _FakeLLMReranker):
             await _asyncio.gather(
-                *[
-                    retriever._apply_llm_reranking("q", list(fused_results), limit=1, namespace_id=ns)
-                    for _ in range(5)
-                ]
+                *[retriever._apply_llm_reranking("q", list(fused_results), limit=1, namespace_id=ns) for _ in range(5)]
             )
 
         assert call_count == 1, f"expected one LLMReranker construction, got {call_count}"

--- a/tests/unit/engines/test_vectorcypher_retriever.py
+++ b/tests/unit/engines/test_vectorcypher_retriever.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -218,6 +218,109 @@ class TestRetrieverInit:
 
         assert retriever._dual_nodes is not None
         assert retriever._dual_nodes._pool_backend is raw_graph
+
+
+@pytest.mark.unit
+class TestRerankerLazyInitRace:
+    """Tests for the reranker lazy-init guard (issue #985).
+
+    Background. Both ``_apply_reranking`` and ``_apply_llm_reranking`` lazily
+    construct their reranker on first use. The construction itself is a cheap
+    synchronous call (the expensive sentence-transformers model load is
+    deferred to ``_get_model()`` inside ``rerank()``), so today the event-loop
+    serialization is enough to prevent multiple constructions — but only
+    incidentally. Any future change that adds an ``await`` between the check
+    and the assignment would re-open a race that, on macOS arm64, drove
+    concurrent CrossEncoder loads into MPS and segfaulted the process.
+
+    The ``asyncio.Lock`` makes the guarantee explicit and refactor-stable.
+    These tests pin the expected behavior so a future regression is caught
+    early, even on Linux where the original symptom never reproduced.
+    """
+
+    @pytest.fixture
+    def retriever(self) -> VectorCypherRetriever:
+        return VectorCypherRetriever(
+            vector_store=AsyncMock(),
+            neo4j_driver=AsyncMock(),
+            embedder=AsyncMock(),
+            config=RetrieverConfig(),
+        )
+
+    @pytest.fixture
+    def fused_results(self) -> list[FusedResult]:
+        """A single non-empty fused result so ``_apply_*reranking`` doesn't early-return."""
+        chunk = Chunk(id=uuid4(), namespace_id=uuid4(), document_id=uuid4(), content="hello")
+        return [FusedResult(item_id=chunk.id, item=chunk, rrf_score=0.9)]
+
+    async def test_init_creates_reranker_locks(self, retriever: VectorCypherRetriever) -> None:
+        """The retriever exposes asyncio.Lock instances for both rerankers."""
+        import asyncio as _asyncio
+
+        assert isinstance(retriever._reranker_lock, _asyncio.Lock)
+        assert isinstance(retriever._llm_reranker_lock, _asyncio.Lock)
+        assert retriever._reranker is None
+        assert retriever._llm_reranker is None
+
+    async def test_concurrent_apply_reranking_constructs_cross_encoder_once(
+        self,
+        retriever: VectorCypherRetriever,
+        fused_results: list[FusedResult],
+    ) -> None:
+        """5 concurrent first-touch calls construct exactly one CrossEncoderReranker."""
+        import asyncio as _asyncio
+
+        call_count = 0
+
+        class _FakeReranker:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                nonlocal call_count
+                call_count += 1
+
+            async def rerank(self, *args: object, **kwargs: object) -> list[object]:
+                return []
+
+        ns = uuid4()
+        with patch("khora.query.reranking.CrossEncoderReranker", _FakeReranker):
+            await _asyncio.gather(
+                *[
+                    retriever._apply_reranking("q", list(fused_results), limit=1, namespace_id=ns)
+                    for _ in range(5)
+                ]
+            )
+
+        assert call_count == 1, f"expected one CrossEncoderReranker construction, got {call_count}"
+        assert retriever._reranker is not None
+
+    async def test_concurrent_apply_llm_reranking_constructs_llm_reranker_once(
+        self,
+        retriever: VectorCypherRetriever,
+        fused_results: list[FusedResult],
+    ) -> None:
+        """Same guarantee for the LLM-reranker path (temporal queries)."""
+        import asyncio as _asyncio
+
+        call_count = 0
+
+        class _FakeLLMReranker:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                nonlocal call_count
+                call_count += 1
+
+            async def rerank(self, *args: object, **kwargs: object) -> list[object]:
+                return []
+
+        ns = uuid4()
+        with patch("khora.query.reranking.LLMReranker", _FakeLLMReranker):
+            await _asyncio.gather(
+                *[
+                    retriever._apply_llm_reranking("q", list(fused_results), limit=1, namespace_id=ns)
+                    for _ in range(5)
+                ]
+            )
+
+        assert call_count == 1, f"expected one LLMReranker construction, got {call_count}"
+        assert retriever._llm_reranker is not None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
Add an ``asyncio.Lock`` around the lazy init of both rerankers in ``VectorCypherRetriever``:

- ``khora/engines/vectorcypher/retriever.py:1966-1968`` — ``self._reranker`` (cross-encoder)
- ``khora/engines/vectorcypher/retriever.py:2162-2164`` — ``self._llm_reranker`` (temporal LLM reranker)

## Why
Both methods used an unguarded ``if self._reranker is None: self._reranker = …`` pattern. Today the constructors are synchronous and the event loop alone keeps the check-then-set safe, but only incidentally — any future change that adds an ``await`` between the ``is None`` check and the assignment would re-open a race where concurrent recall tasks could each kick off a parallel ``CrossEncoderReranker`` (or ``LLMReranker``) construction.

This was first surfaced by #985, where the downstream symptom (concurrent ``CrossEncoder`` loads driving 5 worker threads into torch-MPS from cold) segfaulted on macOS arm64. The actual segfault fix is to pin the cross-encoder device to CPU on darwin+arm64; that lands separately. This change makes the lazy-init invariant explicit and refactor-stable on every platform.

## Latency / metric impact
- **Linux + Intel Mac**: zero. The lock is uncontended after first call (a few µs); construction is synchronous so the event loop already serializes it.
- **macOS arm64**: zero (the constructor itself isn't the segfault — see the device-pin PR for that).
- **Quality metrics**: bit-identical. No change to scoring logic.

## Test plan
- [x] New ``TestRerankerLazyInitRace`` class in ``tests/unit/engines/test_vectorcypher_retriever.py`` covers:
  - retriever exposes ``asyncio.Lock`` on both rerankers after init.
  - 5 concurrent ``_apply_reranking`` calls construct exactly one ``CrossEncoderReranker``.
  - 5 concurrent ``_apply_llm_reranking`` calls construct exactly one ``LLMReranker``.
- [x] Full ``test_vectorcypher_retriever.py`` suite still green (47/47).

## Related
- Issue #985
- Companion PR: pin ``device='cpu'`` on darwin+arm64 (separate, fixes the actual segfault).