### PR TITLE
fix(reranking): pin CrossEncoderReranker to CPU on macOS arm64 (#985)

### DIFF
--- a/src/khora/query/reranking.py
+++ b/src/khora/query/reranking.py
@@ -8,6 +8,7 @@ Provides neural re-ranking of search results using:
 from __future__ import annotations
 
 import asyncio
+import platform
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -22,6 +23,16 @@ if TYPE_CHECKING:
     from khora.storage.coordinator import StorageCoordinator
 
 T = TypeVar("T")
+
+
+def _is_darwin_arm64() -> bool:
+    """True on Apple Silicon Macs.
+
+    Used to pin the cross-encoder reranker to CPU because torch-MPS is
+    not thread-safe under concurrent ``.predict()`` calls dispatched
+    through ``asyncio.to_thread`` (see issue #985).
+    """
+    return platform.system() == "Darwin" and platform.machine() == "arm64"
 
 
 @dataclass
@@ -173,7 +184,14 @@ class CrossEncoderReranker(Reranker):
 
         Args:
             model_name: Cross-encoder model name from sentence-transformers
-            device: Device to use (cuda, cpu, or None for auto)
+            device: Device to use (cuda, cpu, or None for auto). When ``None``
+                on macOS arm64, the device is pinned to ``cpu``: sentence-
+                transformers would otherwise default to the MPS backend, and
+                torch-MPS is not thread-safe under concurrent ``.predict()``
+                calls dispatched through ``asyncio.to_thread`` (see issue
+                #985). The CPU path is ~2-3x slower per rerank batch but
+                stable. Pass ``device="mps"`` explicitly to opt back in if
+                your call pattern is known-serialized.
             batch_size: Batch size for scoring
             include_date_prefix: When True, prepend ``[YYYY-MM-DD] `` to each
                 candidate's content using the source timestamp from
@@ -184,6 +202,13 @@ class CrossEncoderReranker(Reranker):
                 forward pass. Default OFF; flip after a positive A/B on
                 the corporate-shape benchmark. Issue #594 (Phase D5).
         """
+        if device is None and _is_darwin_arm64():
+            device = "cpu"
+            logger.debug(
+                "CrossEncoderReranker pinned to device='cpu' on macOS arm64 "
+                "(torch-MPS is not thread-safe under concurrent .predict() — issue #985). "
+                "Pass device='mps' explicitly to override."
+            )
         self._model_name = model_name
         self._device = device
         self._batch_size = batch_size

--- a/tests/unit/test_query_reranking.py
+++ b/tests/unit/test_query_reranking.py
@@ -128,6 +128,58 @@ class TestCrossEncoderReranker:
         assert results[0].final_score == 0.9
 
 
+class TestCrossEncoderDeviceSelection:
+    """Tests for the device-selection policy (issue #985).
+
+    The cross-encoder's ``__init__`` resolves ``device=None`` to a concrete
+    string only on macOS arm64, where it pins to ``"cpu"`` to dodge the
+    torch-MPS thread-unsafety that segfaulted under concurrent
+    ``asyncio.to_thread(model.predict, ...)`` calls. On every other
+    platform — Linux, Intel Mac, Windows — the code path is dead and
+    ``device`` stays ``None`` (= sentence-transformers' auto-select).
+    """
+
+    def test_default_pinned_to_cpu_on_darwin_arm64(self) -> None:
+        """On Apple Silicon, ``device=None`` resolves to ``'cpu'``."""
+        with patch("khora.query.reranking.platform") as fake_platform:
+            fake_platform.system.return_value = "Darwin"
+            fake_platform.machine.return_value = "arm64"
+            r = CrossEncoderReranker()
+        assert r._device == "cpu"
+
+    def test_default_unchanged_on_linux_x86_64(self) -> None:
+        """On Linux, ``device=None`` stays None (sentence-transformers auto-selects)."""
+        with patch("khora.query.reranking.platform") as fake_platform:
+            fake_platform.system.return_value = "Linux"
+            fake_platform.machine.return_value = "x86_64"
+            r = CrossEncoderReranker()
+        assert r._device is None
+
+    def test_default_unchanged_on_linux_arm64(self) -> None:
+        """On Linux arm64 (e.g. Graviton), ``device=None`` stays None — only Darwin+arm64 hits the pin."""
+        with patch("khora.query.reranking.platform") as fake_platform:
+            fake_platform.system.return_value = "Linux"
+            fake_platform.machine.return_value = "aarch64"
+            r = CrossEncoderReranker()
+        assert r._device is None
+
+    def test_default_unchanged_on_intel_mac(self) -> None:
+        """On Intel Macs, ``device=None`` stays None — MPS isn't in the picture."""
+        with patch("khora.query.reranking.platform") as fake_platform:
+            fake_platform.system.return_value = "Darwin"
+            fake_platform.machine.return_value = "x86_64"
+            r = CrossEncoderReranker()
+        assert r._device is None
+
+    def test_explicit_device_overrides_darwin_arm64_pin(self) -> None:
+        """Passing ``device='mps'`` explicitly opts back in even on Apple Silicon."""
+        with patch("khora.query.reranking.platform") as fake_platform:
+            fake_platform.system.return_value = "Darwin"
+            fake_platform.machine.return_value = "arm64"
+            r = CrossEncoderReranker(device="mps")
+        assert r._device == "mps"
+
+
 class TestLLMReranker:
     """Tests for LLMReranker."""
 


### PR DESCRIPTION
## Summary
On Apple Silicon, default ``CrossEncoderReranker(device=None)`` to ``device='cpu'`` instead of letting sentence-transformers auto-select MPS. On every other platform — Linux, Intel Mac, Windows — the path is dead and behavior is unchanged.

## Why
Sentence-transformers' ``CrossEncoder`` picks the MPS backend on macOS arm64 when ``device`` is not set. The khora-graphrag-benchmark harness drives 5 concurrent ``asyncio.to_thread(model.predict, …)`` calls from a shared retriever instance, and torch-MPS is not thread-safe under that pattern — concurrent ``.predict()`` on a shared model segfaulted the process on Apple Silicon. Full details + crash log in #985.

The companion PR #988 adds an ``asyncio.Lock`` around the lazy init of ``self._reranker`` / ``self._llm_reranker``. That makes the lazy-init invariant explicit, but the lock alone doesn't fix the segfault — the real hazard is concurrent ``.predict()`` on a shared MPS-backed model, not the construction. Pinning to CPU on Apple Silicon is the actual fix.

Callers who know their access pattern is serialized can opt back in by passing ``device='mps'`` explicitly.

## Latency / metric impact
- **macOS arm64**: cross-encoder rerank goes from MPS (~50 ms per batch) to CPU (~120–150 ms). On a full GraphRAG-Bench run that's ~+2.5 min wall-clock (~+0.8% of total). Quality metrics (accuracy, r_score, ar_metric, faithfulness, …) are unchanged within fp32-level numerical noise — ordering of the top reranked candidates is bit-identical in practice.
- **Linux + Intel Mac + Windows**: zero change. The new code path doesn't fire (``_is_darwin_arm64()`` returns False).
- **Memory / cost**: unchanged.

## Test plan
- [x] New ``TestCrossEncoderDeviceSelection`` class in ``tests/unit/test_query_reranking.py``, 5 cases:
  - Darwin + arm64 + ``device=None`` → ``device='cpu'``.
  - Linux x86_64 → unchanged (``None``).
  - Linux aarch64 (Graviton) → unchanged.
  - Darwin x86_64 (Intel Mac) → unchanged.
  - Darwin arm64 + explicit ``device='mps'`` → respected.
- [x] Full ``test_query_reranking.py`` suite still green (32/32).

## Related
- Issue #985
- Companion: PR #988 (asyncio.Lock around reranker lazy init).