### PR TITLE
Add denormalized document-grained columns to khora_chunks

### DIFF
--- a/src/khora/db/migrations/versions/041_khora_chunks_denormalized_columns.py
+++ b/src/khora/db/migrations/versions/041_khora_chunks_denormalized_columns.py
@@ -1,0 +1,182 @@
+"""Add denormalized document-grained columns to khora_chunks.
+
+Revision ID: 041_khora_chunks_denormalized_columns
+Revises: 040_chunks_last_accessed_at
+Create Date: 2026-06-05
+
+Schema changes:
+
+* Eight nullable columns on the ``khora_chunks`` temporal-store table,
+  copied down from the parent document so recall filters can be applied
+  directly on the chunk row without a join:
+
+  - ``source_type`` ``VARCHAR`` — document source category (nullable; no
+    default — chunks predating the backfill stay NULL).
+  - ``source_name`` ``VARCHAR`` — human-readable source label.
+  - ``source_url`` ``TEXT`` — origin URL (may be long).
+  - ``source_timestamp`` ``TIMESTAMPTZ`` — the producer's verbatim event
+    time, distinct from ``occurred_at`` (the chunk event-time).
+  - ``external_id`` ``VARCHAR`` — upstream identifier.
+  - ``content_type`` ``VARCHAR`` — MIME / content category.
+  - ``source`` ``VARCHAR`` — raw source identifier.
+  - ``title`` ``TEXT`` — document title (may be long).
+
+  All eight are nullable with NO server_default. This is a pure catalog
+  update: a nullable ``ADD COLUMN`` with no default is an instant catalog
+  change on PG 11+ — no table rewrite — so we deliberately avoid the
+  NOT-NULL-DEFAULT fast-path (and its ``server_version_num`` assert) used
+  by migration 038.
+
+Index note: NO indexes are created here. The indexed subset
+(``source_type``, ``source_name``, ``source_timestamp`` (partial),
+``external_id``, ``content_type``) is created by the runtime
+``PgVectorTemporalStore.connect()`` via ``CREATE INDEX IF NOT EXISTS`` and
+will be added against the populated columns in a later post-backfill step.
+This migration only widens the catalog.
+
+Lock-timeout safety: a Postgres-only ``SET lock_timeout = '5s'`` is issued
+**before any DDL** so the ``ADD COLUMN`` AccessExclusiveLock acquisition is
+bounded. The setting is scoped to the migration's enclosing transaction
+(env.py wraps the whole upgrade in a single transaction; the SET expires at
+COMMIT). On lock-timeout the upgrade logs ``khora.migration.applied`` at
+ERROR with ``lock_timeout_tripped=True`` (detected by the Postgres SQLSTATE
+``55P03`` / ``lock_not_available`` on ``OperationalError.orig.pgcode`` — any
+other ``OperationalError`` class logs ``lock_timeout_tripped=False`` so
+dashboards don't conflate deadlocks / connection drops with the lock-timeout
+signal). Either path re-raises so Alembic rolls back the transaction.
+
+Runtime-def convergence: ``khora_chunks`` is created at runtime by
+``PgVectorTemporalStore.connect()`` (via ``metadata.create_all``) and by
+``SQLiteLanceTemporalStore``'s DDL — it is not part of the Alembic-managed
+schema. On fresh deploys and on the sqlite_lance test fixture the table
+doesn't exist when the chain runs; the new columns then land from the
+updated ``khora_chunks_table`` definition. This migration is required for
+existing deployments where ``khora_chunks`` predates these columns.
+
+Cross-dialect: this migration is Postgres-only and early-returns on other
+dialects (SQLite). The sqlite_lance fixture stack runs the full Alembic
+chain, so the early-return keeps it green; on SQLite the columns come from
+the runtime table definition, not Alembic.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from loguru import logger
+from sqlalchemy.exc import OperationalError
+
+revision: str = "041_khora_chunks_denormalized_columns"
+down_revision: str | Sequence[str] | None = "040_chunks_last_accessed_at"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# PostgreSQL SQLSTATE for "lock_not_available" — what `lock_timeout` raises
+# when an acquisition exceeds the configured timeout.
+_PG_LOCK_NOT_AVAILABLE = "55P03"
+
+
+def _new_columns() -> list[sa.Column]:
+    """Build the eight denormalized columns fresh on each call.
+
+    All nullable with no server_default. Seven are string/text;
+    ``source_timestamp`` is timezone-aware. A ``Column`` object cannot be
+    reused across multiple ``op.add_column`` invocations once bound, so we
+    construct them here rather than at module scope.
+    """
+    return [
+        sa.Column("source_type", sa.String(64), nullable=True),
+        sa.Column("source_name", sa.String(255), nullable=True),
+        sa.Column("source_url", sa.Text(), nullable=True),
+        sa.Column("source_timestamp", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("external_id", sa.String(255), nullable=True),
+        sa.Column("content_type", sa.String(128), nullable=True),
+        sa.Column("source", sa.String(255), nullable=True),
+        sa.Column("title", sa.Text(), nullable=True),
+    ]
+
+
+def _is_postgres() -> bool:
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def _is_lock_timeout(exc: OperationalError) -> bool:
+    """Distinguish a real lock_timeout trip from any other OperationalError.
+
+    OperationalError is a broad SQLAlchemy class — it wraps deadlocks,
+    connection drops, syntax errors, server shutdowns, AND lock_timeout
+    failures. The structured log field ``lock_timeout_tripped`` must
+    only be True for the latter so monitoring dashboards aren't misled.
+    """
+    orig = getattr(exc, "orig", None)
+    if orig is None:
+        return False
+    return getattr(orig, "pgcode", None) == _PG_LOCK_NOT_AVAILABLE
+
+
+def _upgrade_impl() -> None:
+    """Perform the schema change."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("khora_chunks"):
+        # ``khora_chunks`` is created at runtime by the vectorcypher
+        # ``PgVectorTemporalStore.connect()`` (via ``metadata.create_all``)
+        # and by ``SQLiteLanceTemporalStore``'s DDL — it is not part of the
+        # Alembic-managed schema. On fresh deploys and on the sqlite_lance
+        # test fixture the table doesn't exist when the chain runs; in that
+        # case the new columns land when the runtime creates the table from
+        # the updated ``khora_chunks_table`` definition. The migration is
+        # still required for existing production deployments where
+        # ``khora_chunks`` was created before these columns existed.
+        return
+
+    # Bound the ADD COLUMN AccessExclusiveLock acquisition — a stuck
+    # pg_stat_activity entry on khora_chunks cannot stall the deploy past
+    # 5 seconds. Issued before any DDL. Nullable ADD COLUMN with no default
+    # is an instant catalog update (no table rewrite) on PG 11+.
+    op.execute("SET lock_timeout = '5s'")
+
+    for column in _new_columns():
+        op.add_column("khora_chunks", column)
+
+
+def upgrade() -> None:
+    if not _is_postgres():
+        return
+
+    start = time.monotonic()
+    try:
+        _upgrade_impl()
+    except OperationalError as exc:
+        duration_ms = int((time.monotonic() - start) * 1000)
+        logger.bind(
+            migration_id=revision,
+            duration_ms=duration_ms,
+            lock_timeout_tripped=_is_lock_timeout(exc),
+        ).error("khora.migration.applied")
+        # Bare ``raise`` re-raises the active exception with the original
+        # traceback preserved. env.py's wrapping context.begin_transaction()
+        # rolls back all DDL from this revision.
+        raise
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+    logger.bind(
+        migration_id=revision,
+        duration_ms=duration_ms,
+        lock_timeout_tripped=False,
+    ).info("khora.migration.applied")
+
+
+def downgrade() -> None:
+    if not _is_postgres():
+        return
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("khora_chunks"):
+        return
+    for column in reversed(_new_columns()):
+        op.drop_column("khora_chunks", column.name)

--- a/src/khora/engines/skeleton/backends/__init__.py
+++ b/src/khora/engines/skeleton/backends/__init__.py
@@ -42,6 +42,18 @@ class TemporalChunk:
     metadata: dict[str, Any] = field(default_factory=dict)
     chunker_info: dict[str, Any] = field(default_factory=dict)
 
+    # Denormalized document-grained fields (copied from the parent document)
+    # for deterministic recall filters. All nullable. ``source_timestamp`` is
+    # the producer's verbatim event time, distinct from ``occurred_at``.
+    source_type: str | None = None
+    source_name: str | None = None
+    source_url: str | None = None
+    source_timestamp: datetime | None = None
+    external_id: str | None = None
+    content_type: str | None = None
+    source: str | None = None
+    title: str | None = None
+
 
 @dataclass
 class TemporalSearchResult:
@@ -179,7 +191,9 @@ def temporal_chunk_to_chunk(tc: TemporalChunk) -> Chunk:
     Preserves fields the retriever and rerankers depend on:
     ``chunker_info`` (#800), ``created_at`` (#810), and ``session_id``
     (#620 — stamped into ``TemporalChunk.metadata`` by the engines).
-    Maps ``occurred_at`` to ``source_timestamp`` so temporal-decay
+    Builds ``source_timestamp`` from the distinct producer value
+    (``tc.source_timestamp``), falling back to ``tc.occurred_at`` (the
+    chunk event-time) when the producer value is absent, so temporal-decay
     boosts use the document time rather than the ingest time.
     """
     md = tc.metadata or {}
@@ -209,7 +223,10 @@ def temporal_chunk_to_chunk(tc: TemporalChunk) -> Chunk:
         embedding=tc.embedding,
         embedding_model=str(md.get("embedding_model", "") or ""),
         created_at=tc.created_at or datetime.now(UTC),
-        source_timestamp=tc.occurred_at,
+        # Prefer the distinct producer value; fall back to the chunk
+        # event-time. The write-path will populate the verbatim producer
+        # value in a follow-up.
+        source_timestamp=tc.source_timestamp if tc.source_timestamp is not None else tc.occurred_at,
         session_id=session_id,
     )
 

--- a/src/khora/engines/skeleton/backends/pgvector.py
+++ b/src/khora/engines/skeleton/backends/pgvector.py
@@ -74,6 +74,16 @@ khora_chunks_table = Table(
         nullable=False,
         server_default=text("'{}'::jsonb"),
     ),
+    # Denormalized document-grained fields (copied from the parent document)
+    # for deterministic recall filters without a join. All nullable.
+    Column("source_type", String(64), nullable=True),
+    Column("source_name", String(255), nullable=True),
+    Column("source_url", Text, nullable=True),
+    Column("source_timestamp", DateTime(timezone=True), nullable=True),
+    Column("external_id", String(255), nullable=True),
+    Column("content_type", String(128), nullable=True),
+    Column("source", String(255), nullable=True),
+    Column("title", Text, nullable=True),
     # Full-text search
     Column("content_tsv", TSVECTOR, nullable=True),
     # Indexes are defined below
@@ -158,6 +168,42 @@ class PgVectorTemporalStore(TemporalVectorStore):
                 text("""
                 CREATE INDEX IF NOT EXISTS ix_khora_chunks_content_tsv
                 ON khora_chunks USING GIN (content_tsv)
+                """)
+            )
+
+            # Indexes on the denormalized document-grained columns used by
+            # recall filters. Only the filterable subset is indexed;
+            # source_url / source / title are left unindexed. Each statement
+            # runs separately (asyncpg disallows multi-statement execute).
+            await conn.execute(
+                text("""
+                CREATE INDEX IF NOT EXISTS ix_khora_chunks_ns_source_type
+                ON khora_chunks (namespace_id, source_type)
+                """)
+            )
+            await conn.execute(
+                text("""
+                CREATE INDEX IF NOT EXISTS ix_khora_chunks_ns_source_name
+                ON khora_chunks (namespace_id, source_name)
+                """)
+            )
+            await conn.execute(
+                text("""
+                CREATE INDEX IF NOT EXISTS ix_khora_chunks_ns_source_timestamp
+                ON khora_chunks (namespace_id, source_timestamp)
+                WHERE source_timestamp IS NOT NULL
+                """)
+            )
+            await conn.execute(
+                text("""
+                CREATE INDEX IF NOT EXISTS ix_khora_chunks_ns_external_id
+                ON khora_chunks (namespace_id, external_id)
+                """)
+            )
+            await conn.execute(
+                text("""
+                CREATE INDEX IF NOT EXISTS ix_khora_chunks_ns_content_type
+                ON khora_chunks (namespace_id, content_type)
                 """)
             )
 

--- a/tests/integration/db/test_migration_032_dream_runs.py
+++ b/tests/integration/db/test_migration_032_dream_runs.py
@@ -296,7 +296,7 @@ class TestMigration032OnSqlite:
                 async with engine.connect() as conn:
                     # Chain reached head (sanity).
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "040_chunks_last_accessed_at"
+                    assert result.scalar() == "041_khora_chunks_denormalized_columns"
 
                     # khora_dream_runs exists on SQLite (#896) so dream_history /
                     # dream_status work on the embedded sqlite_lance stack.

--- a/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
+++ b/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
@@ -1,0 +1,329 @@
+"""Coverage for migration ``041_khora_chunks_denormalized_columns``.
+
+The migration adds eight nullable, denormalized document-grained columns to
+the runtime-managed ``khora_chunks`` temporal store so recall filters can be
+applied on the chunk row without a join:
+
+    source_type, source_name, source_url, source_timestamp,
+    external_id, content_type, source, title
+
+``khora_chunks`` is NOT part of the Alembic-managed schema — it is created at
+runtime by ``PgVectorTemporalStore.connect()``. The migration is therefore
+guarded by ``has_table("khora_chunks")`` and exists only for existing
+deployments where the table predates these columns. These tests cover both
+shapes:
+
+1. Postgres, existing-table path: we hand-create a ``khora_chunks`` table
+   *without* the eight columns (mirroring a pre-migration deployment), run
+   ``alembic upgrade head``, and assert the eight columns now exist with the
+   promised types and that all are nullable with no default. ``downgrade``
+   back to 040 drops exactly those eight.
+2. Postgres, missing-table path: on a fresh DB where ``khora_chunks`` does not
+   exist, the migration must early-return (``has_table`` guard) and the chain
+   must still reach head without error.
+3. SQLite: the migration is Postgres-only and early-returns; the full chain
+   must reach head ``041`` cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+from collections.abc import Iterator
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+from sqlalchemy.ext.asyncio import create_async_engine
+
+DATABASE_URL = os.environ.get(
+    "KHORA_DATABASE_URL",
+    "postgresql+asyncpg://khora:khora@localhost:5434/khora",
+)
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
+
+
+def _pg_reachable() -> bool:
+    parsed = urlparse(DATABASE_URL.replace("+asyncpg", ""))
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+pytestmark = pytest.mark.integration
+
+
+_MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
+
+# The eight columns this migration adds. ``source_timestamp`` is timezone-aware;
+# the rest are string/text. All nullable, no default.
+_NEW_COLUMNS = {
+    "source_type",
+    "source_name",
+    "source_url",
+    "source_timestamp",
+    "external_id",
+    "content_type",
+    "source",
+    "title",
+}
+
+
+def _make_config(url: str) -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", str(_MIGRATIONS_DIR))
+    # Alembic uses configparser.BasicInterpolation; escape any literal '%' in
+    # the URL so it isn't read as a config-interpolation token.
+    cfg.set_main_option("sqlalchemy.url", url.replace("%", "%%"))
+    cfg.attributes["database_url"] = url
+    return cfg
+
+
+# A pre-migration ``khora_chunks`` table: the identity/temporal columns the
+# runtime always created, but WITHOUT the eight denormalized columns. Creating
+# this before upgrade exercises the migration's existing-deployment path.
+_LEGACY_KHORA_CHUNKS_DDL = """
+CREATE TABLE khora_chunks (
+    id UUID PRIMARY KEY,
+    namespace_id UUID NOT NULL,
+    document_id UUID NOT NULL,
+    content TEXT NOT NULL,
+    occurred_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ
+)
+"""
+
+
+@pytest.fixture
+def pg_url() -> Iterator[str]:
+    """Yield the base Postgres URL.
+
+    Each test resets the Alembic head to 040 and drops ``khora_chunks`` on
+    setup and teardown so the four migration-test files can run in arbitrary
+    order against shared PostgreSQL without leaking state.
+    """
+    if not _pg_reachable():
+        pytest.skip("PostgreSQL not reachable (run `make dev` first)")
+
+    async def _reset() -> None:
+        admin = create_async_engine(DATABASE_URL, isolation_level="AUTOCOMMIT")
+        try:
+            async with admin.connect() as conn:
+                await conn.execute(sa.text("DROP TABLE IF EXISTS khora_chunks CASCADE"))
+                # Walk the version table back to 040 so the next upgrade re-runs
+                # 041 from a known baseline. Guarded on table existence so the
+                # fixture is also safe against a never-migrated DB (the version
+                # table is created by the first `command.upgrade`).
+                table_exists = await conn.execute(
+                    sa.text(
+                        "SELECT EXISTS(SELECT 1 FROM information_schema.tables "
+                        "WHERE table_name = 'khora_alembic_version')"
+                    )
+                )
+                if table_exists.scalar():
+                    await conn.execute(
+                        sa.text(
+                            "UPDATE khora_alembic_version SET version_num = "
+                            "'040_chunks_last_accessed_at' WHERE version_num = "
+                            "'041_khora_chunks_denormalized_columns'"
+                        )
+                    )
+        finally:
+            await admin.dispose()
+
+    asyncio.run(_reset())
+    try:
+        yield DATABASE_URL
+    finally:
+        asyncio.run(_reset())
+
+
+@pytest.fixture
+def sqlite_url(tmp_path: Path) -> str:
+    return f"sqlite+aiosqlite:///{tmp_path / 'test.db'}"
+
+
+# ---------------------------------------------------------------------------
+# Postgres
+# ---------------------------------------------------------------------------
+
+
+class TestMigration041OnPostgres:
+    def test_adds_eight_columns_to_existing_table(self, pg_url: str) -> None:
+        """Existing ``khora_chunks`` (missing the columns) gains all eight."""
+        cfg = _make_config(pg_url)
+        command.upgrade(cfg, "head")  # bring the Alembic chain to head first
+
+        async def _seed_legacy_table() -> None:
+            engine = create_async_engine(pg_url, isolation_level="AUTOCOMMIT")
+            try:
+                async with engine.connect() as conn:
+                    await conn.execute(sa.text("DROP TABLE IF EXISTS khora_chunks CASCADE"))
+                    await conn.execute(sa.text(_LEGACY_KHORA_CHUNKS_DDL))
+                    # Step the version table back so we can re-run 041 against
+                    # the table we just created.
+                    await conn.execute(
+                        sa.text("UPDATE khora_alembic_version SET version_num = '040_chunks_last_accessed_at'")
+                    )
+            finally:
+                await engine.dispose()
+
+        asyncio.run(_seed_legacy_table())
+
+        # Re-run the chain: 041 now sees an existing khora_chunks and adds cols.
+        command.upgrade(cfg, "head")
+
+        async def check_added() -> None:
+            engine = create_async_engine(pg_url)
+            try:
+                async with engine.connect() as conn:
+                    result = await conn.execute(
+                        sa.text(
+                            "SELECT column_name, data_type, is_nullable, column_default "
+                            "FROM information_schema.columns "
+                            "WHERE table_name = 'khora_chunks'"
+                        )
+                    )
+                    cols = {row[0]: (row[1], row[2], row[3]) for row in result}
+
+                    # All eight present.
+                    assert _NEW_COLUMNS <= set(cols.keys()), f"missing: {_NEW_COLUMNS - set(cols.keys())}"
+
+                    # All eight nullable with no server default.
+                    for name in _NEW_COLUMNS:
+                        assert cols[name][1] == "YES", f"{name} should be nullable"
+                        assert cols[name][2] is None, f"{name} should have no default"
+
+                    # Load-bearing types: source_timestamp is timestamptz,
+                    # source_url / title are text, the rest are varchar.
+                    assert cols["source_timestamp"][0] == "timestamp with time zone"
+                    assert cols["source_url"][0] == "text"
+                    assert cols["title"][0] == "text"
+                    assert cols["source_type"][0] == "character varying"
+                    assert cols["source_name"][0] == "character varying"
+                    assert cols["external_id"][0] == "character varying"
+                    assert cols["content_type"][0] == "character varying"
+                    assert cols["source"][0] == "character varying"
+            finally:
+                await engine.dispose()
+
+        asyncio.run(check_added())
+
+    def test_downgrade_drops_the_eight_columns(self, pg_url: str) -> None:
+        """``downgrade`` to 040 removes exactly the eight columns it added."""
+        cfg = _make_config(pg_url)
+        command.upgrade(cfg, "head")
+
+        async def _seed_legacy_table() -> None:
+            engine = create_async_engine(pg_url, isolation_level="AUTOCOMMIT")
+            try:
+                async with engine.connect() as conn:
+                    await conn.execute(sa.text("DROP TABLE IF EXISTS khora_chunks CASCADE"))
+                    await conn.execute(sa.text(_LEGACY_KHORA_CHUNKS_DDL))
+                    await conn.execute(
+                        sa.text("UPDATE khora_alembic_version SET version_num = '040_chunks_last_accessed_at'")
+                    )
+            finally:
+                await engine.dispose()
+
+        asyncio.run(_seed_legacy_table())
+        command.upgrade(cfg, "head")
+        command.downgrade(cfg, "040_chunks_last_accessed_at")
+
+        async def check_dropped() -> None:
+            engine = create_async_engine(pg_url)
+            try:
+                async with engine.connect() as conn:
+                    result = await conn.execute(
+                        sa.text("SELECT column_name FROM information_schema.columns WHERE table_name = 'khora_chunks'")
+                    )
+                    cols = {row[0] for row in result}
+                    # None of the eight remain.
+                    assert _NEW_COLUMNS.isdisjoint(cols), f"still present after downgrade: {_NEW_COLUMNS & cols}"
+                    # The legacy identity columns are untouched.
+                    assert {"id", "namespace_id", "document_id", "content"} <= cols
+            finally:
+                await engine.dispose()
+
+        asyncio.run(check_dropped())
+
+    def test_no_op_when_table_absent(self, pg_url: str) -> None:
+        """Fresh DB with no ``khora_chunks``: chain reaches head, no error.
+
+        The ``has_table`` guard must early-return rather than fail when the
+        runtime-managed table has not been created yet.
+        """
+        cfg = _make_config(pg_url)
+        # pg_url fixture already dropped khora_chunks; just upgrade.
+        command.upgrade(cfg, "head")
+
+        async def check() -> None:
+            engine = create_async_engine(pg_url)
+            try:
+                async with engine.connect() as conn:
+                    # Chain reached head.
+                    result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
+                    assert result.scalar() == "041_khora_chunks_denormalized_columns"
+
+                    # The migration did not create the table.
+                    result = await conn.execute(
+                        sa.text(
+                            "SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name = 'khora_chunks')"
+                        )
+                    )
+                    assert result.scalar() is False
+            finally:
+                await engine.dispose()
+
+        asyncio.run(check())
+
+
+# ---------------------------------------------------------------------------
+# SQLite — Postgres-only migration must early-return and stay green
+# ---------------------------------------------------------------------------
+
+
+class TestMigration041OnSqlite:
+    def test_chain_reaches_head_on_sqlite(self, sqlite_url: str) -> None:
+        """Migration 041 is a clean no-op on SQLite; chain reaches head 041."""
+        cfg = _make_config(sqlite_url)
+        command.upgrade(cfg, "head")
+
+        async def check() -> None:
+            engine = create_async_engine(sqlite_url)
+            try:
+                async with engine.connect() as conn:
+                    result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
+                    assert result.scalar() == "041_khora_chunks_denormalized_columns"
+            finally:
+                await engine.dispose()
+
+        asyncio.run(check())
+
+    def test_downgrade_is_clean_on_sqlite(self, sqlite_url: str) -> None:
+        """upgrade head → downgrade to 040 is a clean no-op on SQLite."""
+        cfg = _make_config(sqlite_url)
+        command.upgrade(cfg, "head")
+        command.downgrade(cfg, "040_chunks_last_accessed_at")
+
+        async def check() -> None:
+            engine = create_async_engine(sqlite_url)
+            try:
+                async with engine.connect() as conn:
+                    result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
+                    assert result.scalar() == "040_chunks_last_accessed_at"
+            finally:
+                await engine.dispose()
+
+        asyncio.run(check())

--- a/tests/unit/engines/skeleton/test_temporal_chunk_adapter.py
+++ b/tests/unit/engines/skeleton/test_temporal_chunk_adapter.py
@@ -59,6 +59,37 @@ def test_maps_occurred_at_to_source_timestamp() -> None:
     assert c.source_timestamp == ts
 
 
+def test_source_timestamp_is_distinct_from_occurred_at() -> None:
+    """The producer ``source_timestamp`` survives as a value of its own.
+
+    Tripwire for date-collapse: when a chunk carries BOTH a chunk event-time
+    (``occurred_at``) and a distinct producer time (``source_timestamp``), the
+    adapter must surface the producer value — not silently collapse it onto
+    ``occurred_at``.
+    """
+    occurred = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
+    produced = datetime(2024, 6, 15, 9, 30, tzinfo=UTC)
+    assert occurred != produced
+
+    c = temporal_chunk_to_chunk(_make_tc(occurred_at=occurred, source_timestamp=produced))
+
+    assert c.source_timestamp == produced
+    assert c.source_timestamp != occurred
+
+
+def test_source_timestamp_falls_back_to_occurred_at_when_absent() -> None:
+    """No producer value → fall back to the chunk event-time."""
+    occurred = datetime(2024, 3, 10, 7, 0, tzinfo=UTC)
+    c = temporal_chunk_to_chunk(_make_tc(occurred_at=occurred, source_timestamp=None))
+    assert c.source_timestamp == occurred
+
+
+def test_source_timestamp_none_when_both_absent() -> None:
+    """Neither producer time nor chunk event-time → ``None``."""
+    c = temporal_chunk_to_chunk(_make_tc(occurred_at=None, source_timestamp=None))
+    assert c.source_timestamp is None
+
+
 def test_pulls_session_id_from_metadata_uuid_str() -> None:
     sid = uuid4()
     c = temporal_chunk_to_chunk(_make_tc(metadata={"session_id": str(sid)}))

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -442,14 +442,14 @@ class TestMigrationPackageStructure:
         assert env_path.exists(), f"env.py not found at {env_path}"
 
     @pytest.mark.unit
-    def test_versions_dir_has_41_files(self):
-        """versions/ directory contains 41 migration files."""
+    def test_versions_dir_has_42_files(self):
+        """versions/ directory contains 42 migration files."""
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
         # Filter out __pycache__ and __init__
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
-        assert len(migration_files) == 41, (
-            f"Expected 41 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
+        assert len(migration_files) == 42, (
+            f"Expected 42 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
         )
 
     @pytest.mark.unit

--- a/tests/unit/test_sqlite_migrations.py
+++ b/tests/unit/test_sqlite_migrations.py
@@ -82,7 +82,7 @@ class TestSqliteMigrations:
                     # Version table must point at head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
                     version = result.scalar()
-                    assert version == "040_chunks_last_accessed_at"
+                    assert version == "041_khora_chunks_denormalized_columns"
             finally:
                 await engine.dispose()
 


### PR DESCRIPTION
## Summary

Adds eight nullable, document-grained columns to the `khora_chunks` temporal-store table so recall filters can push down on a single chunk row without joining back to `documents`. This is a schema/catalog-only change — the write-path population and the post-backfill production indexes land in follow-up changes.

- **New catalog-only Alembic migration.** Adds `source_type`, `source_name`, `source_url`, `source_timestamp`, `external_id`, `content_type`, `source`, `title` — all **nullable with no `server_default`**, so it is an instant catalog update with no table rewrite on PostgreSQL 11+. The migration follows the established catalog-only precedent: Postgres dialect gate, `has_table` guard (the table is runtime-created, so fresh deploys/SQLite fixtures get the columns from the table definition instead), a bounded `lock_timeout`, and a structured applied/lock-timeout log. It creates **no indexes**, and skips cleanly on non-Postgres dialects. `downgrade()` symmetrically drops the eight columns.
- **Runtime table definition + indexes.** The runtime `khora_chunks` table definition gains the eight columns, and `connect()` creates `CREATE INDEX IF NOT EXISTS` for the filterable subset — `(namespace_id, source_type)`, `(namespace_id, source_name)`, a partial `(namespace_id, source_timestamp) WHERE source_timestamp IS NOT NULL`, `(namespace_id, external_id)`, `(namespace_id, content_type)`. `source_url`, `source`, and `title` are intentionally left unindexed.
- **Carrier model.** `TemporalChunk` carries the eight fields. `source_timestamp` (the producer's verbatim event-time) is now **distinct** from `occurred_at` (the chunk event-time) and is no longer aliased to it; it falls back to `occurred_at` only when unset, preserving today's temporal-decay behavior until the write-path populates the distinct value.

## Test plan
- [x] Unit tests for the `TemporalChunk` → `Chunk` carrier: distinct `source_timestamp` vs `occurred_at` survives the round-trip (date-collapse tripwire), fallback to `occurred_at` when unset, and both-unset → `None`.
- [x] Migration tests: upgrade adds the eight columns (nullable, no default), downgrade drops them, no-op when the table is absent, and the chain stays green on SQLite.
- [x] `ruff format` / `ruff check` clean; targeted suite green locally (Postgres-marked migration tests run in CI's integration lane).
- [ ] Full CI suite (unit + integration + e2e) green.