### PR TITLE
Add RecallFilter model and two-regime validator

### DIFF
--- a/src/khora/__init__.py
+++ b/src/khora/__init__.py
@@ -51,6 +51,15 @@ from .dream import DreamConfig, DreamMode, DreamResult, DreamRunInfo, DreamScope
 from .engines import create_engine, list_engines, register_engine
 from .exceptions import EngineCapabilityError, KhoraError
 from .extraction.skills import EntityTypeConfig, ExpertiseConfig, RelationshipTypeConfig
+from .filter import (
+    SYSTEM_KEYS,
+    DateOps,
+    Op,
+    RecallFilter,
+    RecallFilterUnsupportedError,
+    RecallFilterValidationError,
+    StringOps,
+)
 from .hooks import SemanticFilter
 from .khora import (
     BatchHandle,
@@ -109,4 +118,12 @@ __all__ = [
     "DreamResult",
     "DreamRunInfo",
     "OpKind",
+    # Deterministic recall filter
+    "RecallFilter",
+    "StringOps",
+    "DateOps",
+    "RecallFilterValidationError",
+    "RecallFilterUnsupportedError",
+    "Op",
+    "SYSTEM_KEYS",
 ]

--- a/src/khora/filter/__init__.py
+++ b/src/khora/filter/__init__.py
@@ -1,0 +1,34 @@
+"""Public deterministic recall-filter surface.
+
+Exports the typed filter document (:class:`RecallFilter`), its operator
+submodels (:class:`StringOps`, :class:`DateOps`), the structured error types
+(:class:`RecallFilterValidationError`, :class:`RecallFilterUnsupportedError`),
+the operator vocabulary (:class:`Op`), and the system-key whitelist
+(:data:`SYSTEM_KEYS`).
+
+``FieldError`` is importable from here for callers inspecting a validation
+error's structured ``errors`` list, but is not part of the public ``__all__``.
+"""
+
+from __future__ import annotations
+
+from khora.filter.model import (
+    SYSTEM_KEYS,
+    DateOps,
+    Op,
+    RecallFilter,
+    RecallFilterUnsupportedError,
+    RecallFilterValidationError,
+    StringOps,
+)
+from khora.filter.model import FieldError as FieldError  # re-export (not in __all__)
+
+__all__ = [
+    "DateOps",
+    "Op",
+    "RecallFilter",
+    "RecallFilterUnsupportedError",
+    "RecallFilterValidationError",
+    "StringOps",
+    "SYSTEM_KEYS",
+]

--- a/src/khora/filter/model.py
+++ b/src/khora/filter/model.py
@@ -1,0 +1,555 @@
+"""Deterministic recall-filter model and validator.
+
+This module defines the public, MongoDB-flavored filter document accepted by
+recall operations. It is a *typed* pydantic model with named system-key fields
+(IDE autocomplete on the closed system-key whitelist, per-value-type operator
+subtypes at construction time) plus a recursive grammar walk over the free-form
+``metadata`` block that pydantic cannot express on ``dict[str, Any]``.
+
+Two construction paths, one validator:
+
+* ``RecallFilter(source_name="linear", ...)`` — kwargs, recommended in Python.
+* ``RecallFilter.model_validate({...})`` — the wire/dict form (HTTP bodies,
+  agent tool calls, config files).
+
+Both flow through the same validation chain. The model *validates*; it does not
+lower to an intermediate representation or compile to a backend query — those
+steps live elsewhere.
+
+Wire shape: aliases preserve the JSON form (``$or``, ``$gte``, ...). A bare
+``metadata`` value is whole-blob equality; flat ``metadata.<path>`` predicate
+keys are folded out before the closed-key check runs and re-emitted flat on
+dump, so ``model_dump(by_alias=True, exclude_none=True)`` round-trips byte-stable
+with the input.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any
+
+import pydantic
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SerializerFunctionWrapHandler,
+    StrictBool,
+    ValidatorFunctionWrapHandler,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
+
+from khora.exceptions import KhoraError
+
+__all__ = [
+    "DateOps",
+    "Op",
+    "RecallFilter",
+    "RecallFilterUnsupportedError",
+    "RecallFilterValidationError",
+    "StringOps",
+    "SYSTEM_KEYS",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Operator vocabulary and the closed system-key whitelist.
+# --------------------------------------------------------------------------- #
+
+
+class Op(str, Enum):
+    """The filter operator vocabulary (wire literals).
+
+    ``str`` mixin so ``Op.EQ == "$eq"`` and ``Op.EQ.value == "$eq"`` both hold.
+    """
+
+    EQ = "$eq"
+    NE = "$ne"
+    GT = "$gt"
+    GTE = "$gte"
+    LT = "$lt"
+    LTE = "$lte"
+    IN = "$in"
+    NIN = "$nin"
+    EXISTS = "$exists"
+    AND = "$and"
+    OR = "$or"
+    NOR = "$nor"
+    NOT = "$not"
+    DATE = "$date"
+
+
+# The ten filterable system keys. Two date keys live on the recall chunk; the
+# other eight are denormalized document keys. ``metadata`` and the logical
+# operators are intentionally excluded.
+SYSTEM_KEYS: frozenset[str] = frozenset(
+    {
+        "occurred_at",
+        "created_at",
+        "source_timestamp",
+        "source_type",
+        "source_name",
+        "source_url",
+        "external_id",
+        "content_type",
+        "source",
+        "title",
+    }
+)
+
+# Operators whose operand is a list ($in/$nin), and the full set of operators
+# valid as keys inside a metadata operator-expression.
+_LIST_OPS: frozenset[str] = frozenset({Op.IN, Op.NIN})
+_METADATA_FIELD_OPS: frozenset[str] = frozenset(
+    {
+        Op.EQ,
+        Op.NE,
+        Op.GT,
+        Op.GTE,
+        Op.LT,
+        Op.LTE,
+        Op.IN,
+        Op.NIN,
+        Op.EXISTS,
+        Op.NOT,
+    }
+)
+
+# Carrier alias for folded ``metadata.<path>`` predicates. The double-underscore
+# form cannot collide with a real ``metadata.<path>`` key or a ``$``-operator.
+_FOLDED_ALIAS = "__folded_predicates__"
+
+
+# --------------------------------------------------------------------------- #
+# Error types.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class FieldError:
+    """A single structured validation failure.
+
+    ``path`` is a JSON-Pointer-ish location (e.g. ``"/$or/0/source_type"`` or
+    ``"/metadata.tag/$in"``). ``code`` is a stable machine reason code, ``message``
+    is human-readable, and ``allowed`` carries the permitted values when the code
+    is a whitelist violation.
+    """
+
+    path: str
+    code: str
+    message: str
+    allowed: list[str] | None = None
+
+
+class RecallFilterValidationError(KhoraError):
+    """A recall filter failed validation.
+
+    Carries a structured ``errors`` list (one entry per offending field) so SDKs
+    can translate it into an HTTP 400 with a structured body. Raised by both
+    validation regimes: the pydantic-structural pass (converted via
+    :meth:`from_pydantic`) and the recursive metadata-grammar walk.
+    """
+
+    def __init__(self, errors: list[FieldError]) -> None:
+        self.errors = errors
+        summary = "; ".join(f"{e.path}: {e.message}" for e in errors) or "invalid filter"
+        super().__init__(summary)
+
+    @classmethod
+    def from_pydantic(cls, exc: pydantic.ValidationError) -> RecallFilterValidationError:
+        """Convert a pydantic ``ValidationError`` into structured field errors."""
+        errors: list[FieldError] = []
+        for err in exc.errors():
+            loc = err.get("loc", ())
+            path = "/" + "/".join(str(part) for part in loc)
+            errors.append(
+                FieldError(
+                    path=path,
+                    code=str(err.get("type", "validation_error")),
+                    message=str(err.get("msg", "")),
+                )
+            )
+        return cls(errors)
+
+
+class RecallFilterUnsupportedError(KhoraError):
+    """A backend compiler cannot honor a filter predicate.
+
+    Exported now for the public surface; raised by the compilers that lower a
+    validated filter to a backend query (a later step), not by this validator.
+    """
+
+    def __init__(self, path: str, reason: str) -> None:
+        self.path = path
+        self.reason = reason
+        super().__init__(f"{path}: {reason}")
+
+
+def _raise(path: str, code: str, message: str, *, allowed: list[str] | None = None) -> None:
+    raise RecallFilterValidationError([FieldError(path=path, code=code, message=message, allowed=allowed)])
+
+
+# --------------------------------------------------------------------------- #
+# Operator submodels for the typed system keys.
+#
+# The per-key operator subsets fall out of these submodels for free via
+# ``extra="forbid"``: DateOps has no ``$exists`` field, so ``$exists`` on a date
+# key fails to match the DateOps arm; StringOps has no range ops, so a range op
+# on a string key fails the StringOps arm. Both surface as a pydantic
+# ValidationError that the wrap funnel converts.
+# --------------------------------------------------------------------------- #
+
+
+class StringOps(BaseModel):
+    """Operator submodel for string-typed system keys."""
+
+    eq: str | None = Field(None, alias="$eq")
+    ne: str | None = Field(None, alias="$ne")
+    in_: list[str] | None = Field(None, alias="$in")
+    nin: list[str] | None = Field(None, alias="$nin")
+    # StrictBool (not plain bool) so the typed-key path matches the metadata
+    # walk's strict isinstance(bool) check — "yes"/"true"/1 must raise, not coerce.
+    exists: StrictBool | None = Field(None, alias="$exists")
+    not_: StringOps | None = Field(None, alias="$not")  # field-level $not
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+
+class DateOps(BaseModel):
+    """Operator submodel for datetime-typed system keys.
+
+    Has no ``$exists`` field by design — ``$exists`` on a date key must raise.
+    Timezone-naive operands are normalized to UTC immediately.
+    """
+
+    eq: datetime | None = Field(None, alias="$eq")
+    ne: datetime | None = Field(None, alias="$ne")
+    gt: datetime | None = Field(None, alias="$gt")
+    gte: datetime | None = Field(None, alias="$gte")
+    lt: datetime | None = Field(None, alias="$lt")
+    lte: datetime | None = Field(None, alias="$lte")
+    in_: list[datetime] | None = Field(None, alias="$in")
+    nin: list[datetime] | None = Field(None, alias="$nin")
+    not_: DateOps | None = Field(None, alias="$not")  # field-level $not
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    @field_validator("eq", "ne", "gt", "gte", "lt", "lte", mode="after")
+    @classmethod
+    def _utc_scalar(cls, value: datetime | None) -> datetime | None:
+        return _normalize_utc(value)
+
+    @field_validator("in_", "nin", mode="after")
+    @classmethod
+    def _utc_list(cls, value: list[datetime] | None) -> list[datetime] | None:
+        if value is None:
+            return None
+        return [_normalize_utc(item) for item in value]
+
+
+def _normalize_utc(value: datetime | None) -> datetime | None:
+    """Normalize a tz-naive datetime to UTC; leave tz-aware values untouched."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+# --------------------------------------------------------------------------- #
+# The filter document.
+# --------------------------------------------------------------------------- #
+
+
+class RecallFilter(BaseModel):
+    """A deterministic recall filter (typed, MongoDB-flavored).
+
+    The closed top-level key set is the ten system keys, the bare ``metadata``
+    blob, the logical operators (``$and``/``$or``/``$nor``/``$not``), and any flat
+    ``metadata.<path>`` predicate key. Unknown top-level keys raise.
+
+    Bare-value sugar: a scalar is ``$eq``; a *list* is ``$eq`` exact-array
+    equality (**not** ``$in`` — use ``$in`` for membership); a nested dict on a
+    metadata sub-path is whole-subdocument equality. ``null`` is an active
+    null-or-missing match — to not filter on a key, omit it.
+
+    Object-equality on the ``metadata`` blob compares normalized JSON, not source
+    bytes (key order and numeric/whitespace formatting are not significant).
+    """
+
+    # Date system keys (range + set, no $exists).
+    occurred_at: datetime | DateOps | None = None
+    created_at: datetime | DateOps | None = None
+    source_timestamp: datetime | DateOps | None = None
+    # String system keys (eq + set + exists). A bare list is $eq exact-array.
+    source_type: str | list[str] | StringOps | None = None
+    source_name: str | list[str] | StringOps | None = None
+    source_url: str | list[str] | StringOps | None = None
+    external_id: str | list[str] | StringOps | None = None
+    content_type: str | list[str] | StringOps | None = None
+    source: str | list[str] | StringOps | None = None
+    title: str | list[str] | StringOps | None = None
+    # Whole-metadata-blob $eq equality (embedded-doc equality). Flat
+    # metadata.<path> predicate keys are folded onto the carrier below, not here.
+    metadata: dict[str, Any] | None = None
+    # Logical composition — aliases match the wire shape.
+    and_: list[RecallFilter] | None = Field(None, alias="$and")
+    or_: list[RecallFilter] | None = Field(None, alias="$or")
+    nor_: list[RecallFilter] | None = Field(None, alias="$nor")
+    not_: RecallFilter | None = Field(None, alias="$not")
+    # Reserved internal carrier for folded metadata.<path> predicates. Threaded
+    # through validation per-instance (recursion-safe); re-emitted flat on dump.
+    folded_predicates_: dict[str, Any] = Field(default_factory=dict, alias=_FOLDED_ALIAS)
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    @field_validator("occurred_at", "created_at", "source_timestamp", mode="after")
+    @classmethod
+    def _utc_date_key(cls, value: datetime | DateOps | None) -> datetime | DateOps | None:
+        """Normalize a bare-scalar date-key value to UTC (DateOps self-normalizes)."""
+        if isinstance(value, datetime):
+            return _normalize_utc(value)
+        return value
+
+    # ----- regime (a): structural funnel + dot-path fold ------------------- #
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def _convert_pydantic_errors(
+        cls,
+        data: Any,
+        handler: ValidatorFunctionWrapHandler,
+    ) -> RecallFilter:
+        """Funnel both construction paths into a single error type.
+
+        Catches the pydantic-structural ValidationError (unknown top-level key,
+        ``$exists`` on a date key, a range op on a string key, wrong list/array
+        shape) and re-raises it as ``RecallFilterValidationError``. Errors raised
+        by the ``before`` fold and the ``after`` metadata walk are already the
+        right type and propagate unconverted.
+        """
+        try:
+            return handler(data)
+        except pydantic.ValidationError as exc:
+            raise RecallFilterValidationError.from_pydantic(exc) from exc
+
+    @model_validator(mode="before")
+    @classmethod
+    def _fold_dot_paths(cls, data: Any) -> Any:
+        """Fold flat ``metadata.<path>`` keys onto the carrier before forbid runs.
+
+        A bare ``metadata`` key (no trailing dot) is left to the typed field as
+        whole-blob equality. Each (possibly nested) filter carries its own folds
+        on its own instance, so nested ``$and``/``$or`` recursion does not
+        cross-contaminate.
+        """
+        if not isinstance(data, dict):
+            return data
+        folded: dict[str, Any] = {}
+        rest: dict[str, Any] = {}
+        for key, value in data.items():
+            if isinstance(key, str) and key.startswith("metadata."):
+                folded[key] = value
+            else:
+                rest[key] = value
+        if folded:
+            rest[_FOLDED_ALIAS] = folded
+        return rest
+
+    # ----- regime (b): recursive metadata-grammar walk -------------------- #
+
+    @model_validator(mode="after")
+    def _validate_metadata_grammar(self) -> RecallFilter:
+        """Enforce the grammar pydantic cannot express on free-form values.
+
+        Requires ``$and``/``$or``/``$nor`` to be nonempty arrays, then walks the
+        bare ``metadata`` blob and every folded ``metadata.<path>`` predicate:
+        operator whitelist, ``$in``/``$nin`` lists, ``$exists`` bool, the
+        operator-position closure, operand opacity, and ``$date``
+        literal parsing.
+        """
+        # $and / $or / $nor must be nonempty when present (set, not None). $not
+        # takes a single filter document and is unaffected.
+        for alias, branches in (("$and", self.and_), ("$or", self.or_), ("$nor", self.nor_)):
+            if branches is not None and len(branches) == 0:
+                _raise(f"/{alias}", "empty_logical_array", f"{alias} must be a nonempty array")
+        if self.metadata is not None:
+            # Bare metadata blob: each value is a per-field predicate.
+            for field_name, predicate in self.metadata.items():
+                _walk_predicate(predicate, f"/metadata/{field_name}")
+        for dotted_key, predicate in self.folded_predicates_.items():
+            _walk_predicate(predicate, f"/{dotted_key}")
+        return self
+
+    # ----- byte-stable serialization -------------------------------------- #
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
+        """Re-emit folded ``metadata.<path>`` predicates as flat keys."""
+        out = handler(self)
+        out.pop(_FOLDED_ALIAS, None)
+        out.update(self.folded_predicates_)
+        return out
+
+
+# --------------------------------------------------------------------------- #
+# Recursive metadata-grammar walk (regime b helpers).
+# --------------------------------------------------------------------------- #
+
+
+def _walk_predicate(predicate: Any, path: str) -> None:
+    """Validate one metadata field predicate (bare value, operator-expr, or dict).
+
+    A scalar / list / non-operator dict is an equality operand (opaque — not
+    recursed). A dict whose keys are all ``$``-operators is an operator
+    expression. A value-dict mixing ``$``-keys with non-``$`` keys raises.
+    """
+    if not isinstance(predicate, dict):
+        # Bare scalar / list ⇒ $eq sugar. Opaque literal.
+        return
+    if not predicate:
+        # Empty {} is whole-subdocument equality (opaque).
+        return
+
+    dollar_keys = [k for k in predicate if isinstance(k, str) and k.startswith("$")]
+    non_dollar_keys = [k for k in predicate if not (isinstance(k, str) and k.startswith("$"))]
+
+    if dollar_keys and non_dollar_keys:
+        # An operator-expression must not mix $-ops with plain keys.
+        _raise(
+            path,
+            "mixed_operator_and_field",
+            "value object mixes operator ($) keys with non-operator keys; "
+            'use dot-notation to address a nested field (e.g. {"metadata.a.b": {...}})',
+        )
+
+    if not dollar_keys:
+        # All non-$ keys ⇒ whole-subdocument equality. The subdoc is matched as
+        # a literal object, but a $-operator nested at ANY depth inside a nested
+        # dict is rejected: operators are not applied inside an equality match, so
+        # the caller meant a nested-path predicate, which must use dot-notation
+        # (e.g. {"metadata.labels.priority": {"$gte": 5}}). The scan descends
+        # through nested dicts only — list elements are opaque exact-array
+        # literals — and never enters a comparison operator's operand (those are
+        # reached only via the operator branch below, which treats them as
+        # opaque).
+        _reject_nested_operator(predicate, path)
+        return
+
+    # A bare {"$date": "<ISO-8601>"} in field-value position is a typed literal
+    # (equivalent to {"$eq": {"$date": ...}}), not an operator expression.
+    if set(predicate.keys()) == {Op.DATE.value}:
+        _parse_date_literal(predicate[Op.DATE.value], f"{path}/$date")
+        return
+
+    # Operator expression: validate each operator and its operand.
+    for op_key, operand in predicate.items():
+        _walk_operator(op_key, operand, f"{path}/{op_key}")
+
+
+def _reject_nested_operator(value: Any, path: str) -> None:
+    """Raise if a ``$``-prefixed key appears anywhere inside an equality operand.
+
+    Descends through nested DICTS only. List elements are opaque exact-array
+    literals and are not inspected — there is no dot-addressable field name to
+    bind an operator to, so a ``$``-op inside a list element is data, consistent
+    with bare-list / ``$in`` / ``$eq`` list operands. This runs only on
+    equality-operand subtrees (whole-subdocument equality); it is never called on
+    a comparison operator's operand, which stays opaque.
+    """
+    if isinstance(value, dict):
+        for key, sub_value in value.items():
+            if isinstance(key, str) and key.startswith("$"):
+                _raise(
+                    path,
+                    "operator_nested_in_operand",
+                    "operator ($) nested inside a whole-subdocument equality value; "
+                    "operators are not applied inside an equality match — use "
+                    'dot-notation for a nested-field predicate (e.g. {"metadata.a.b": {...}})',
+                )
+            _reject_nested_operator(sub_value, path)
+
+
+def _walk_operator(op_key: str, operand: Any, path: str) -> None:
+    """Validate a single ``$``-operator and its operand inside a metadata predicate."""
+    if op_key not in _METADATA_FIELD_OPS:
+        _raise(
+            path,
+            "unknown_operator",
+            f"unsupported operator {op_key!r}",
+            allowed=sorted(op.value for op in _METADATA_FIELD_OPS),
+        )
+
+    if op_key in _LIST_OPS:
+        if not isinstance(operand, list):
+            _raise(path, "operator_value_not_list", f"{op_key} value must be an array")
+        for item in operand:  # type: ignore[union-attr]
+            _check_literal_operand(item, path)
+        return
+
+    if op_key == Op.EXISTS:
+        if not isinstance(operand, bool):
+            _raise(path, "operator_value_not_bool", f"{op_key} value must be a boolean")
+        return
+
+    if op_key == Op.NOT:
+        # Field-position $not negates an inner operator-expression. A bare scalar
+        # operand is invalid (matches MongoDB).
+        if not isinstance(operand, dict):
+            _raise(path, "not_operand_not_expression", "$not value must be an operator expression")
+        _walk_not_operand(operand, path)
+        return
+
+    # Remaining comparison ops ($eq/$ne/$gt/$gte/$lt/$lte): the operand is an
+    # opaque literal, validated only for $date typed literals.
+    _check_literal_operand(operand, path)
+
+
+def _walk_not_operand(operand: dict[str, Any], path: str) -> None:
+    """Validate a field-position ``$not`` operand: a pure operator expression.
+
+    The negated operand must be all ``$``-operators (an operator-expression);
+    a bare scalar or a mixed/plain object raises. Each inner operator is then
+    validated like any other field operator.
+    """
+    dollar_keys = [k for k in operand if isinstance(k, str) and k.startswith("$")]
+    non_dollar_keys = [k for k in operand if not (isinstance(k, str) and k.startswith("$"))]
+    if not dollar_keys or non_dollar_keys:
+        _raise(path, "not_operand_not_expression", "$not value must be an operator expression")
+    for op_key, inner in operand.items():
+        _walk_operator(op_key, inner, f"{path}/{op_key}")
+
+
+def _check_literal_operand(operand: Any, path: str) -> None:
+    """Validate a comparison operand — an opaque literal.
+
+    Comparison operands ($eq/$ne/$gt/$gte/$lt/$lte, and each item of $in/$nin)
+    are never re-parsed as clauses: a ``$or`` nested inside an ``$eq`` operand is
+    matched as a literal object, not a logical clause, so it does NOT raise. The
+    single recognized form is the ``{"$date": "<ISO-8601>"}`` typed literal,
+    parsed/normalized here (a sole-key ``$date`` object); any other content is
+    opaque data.
+    """
+    if isinstance(operand, dict) and set(operand.keys()) == {Op.DATE.value}:
+        _parse_date_literal(operand[Op.DATE.value], f"{path}/$date")
+
+
+def _parse_date_literal(value: Any, path: str) -> None:
+    """Parse and normalize a ``$date`` typed literal; raise on malformed input."""
+    if not isinstance(value, str):
+        _raise(path, "date_literal_not_string", "$date value must be an ISO-8601 string")
+    try:
+        datetime.fromisoformat(value)  # type: ignore[arg-type]
+    except ValueError:
+        _raise(path, "date_literal_malformed", f"$date value {value!r} is not valid ISO-8601")
+
+
+# Resolve the self-referential forward refs ("$not" on the submodels, the
+# recursive logical operators on RecallFilter).
+StringOps.model_rebuild()
+DateOps.model_rebuild()
+RecallFilter.model_rebuild()

--- a/src/khora/filter/model.py
+++ b/src/khora/filter/model.py
@@ -193,6 +193,38 @@ def _raise(path: str, code: str, message: str, *, allowed: list[str] | None = No
     raise RecallFilterValidationError([FieldError(path=path, code=code, message=message, allowed=allowed)])
 
 
+# Far above any legitimate filter (real filters nest only a few levels); well
+# below CPython's recursion limit, so deep input fails cleanly, not as a crash.
+_MAX_FILTER_DEPTH = 100
+
+
+def _check_depth(data: Any) -> None:
+    """Reject a filter nested beyond ``_MAX_FILTER_DEPTH`` before deep recursion.
+
+    Walks the raw filter iteratively (an explicit stack — never recursing) so an
+    adversarially deep filter raises a clean ``RecallFilterValidationError``
+    instead of an uncaught ``RecursionError`` from pydantic's recursive model
+    validation or the metadata-grammar walk.
+    """
+    if not isinstance(data, (dict, list)):
+        return
+    stack: list[tuple[Any, int]] = [(data, 1)]
+    while stack:
+        node, depth = stack.pop()
+        if depth > _MAX_FILTER_DEPTH:
+            _raise(
+                "/",
+                "max_depth_exceeded",
+                f"filter nesting exceeds the maximum depth of {_MAX_FILTER_DEPTH}",
+            )
+        if isinstance(node, dict):
+            for value in node.values():
+                stack.append((value, depth + 1))
+        elif isinstance(node, list):
+            for item in node:
+                stack.append((item, depth + 1))
+
+
 # --------------------------------------------------------------------------- #
 # Operator submodels for the typed system keys.
 #
@@ -331,7 +363,12 @@ class RecallFilter(BaseModel):
         shape) and re-raises it as ``RecallFilterValidationError``. Errors raised
         by the ``before`` fold and the ``after`` metadata walk are already the
         right type and propagate unconverted.
+
+        Runs the iterative depth guard first (this is the outermost validator),
+        so an over-deep filter fails as a ``RecallFilterValidationError`` before
+        pydantic or the metadata walk recurse into it.
         """
+        _check_depth(data)
         try:
             return handler(data)
         except pydantic.ValidationError as exc:

--- a/tests/recall/test_filter_validator.py
+++ b/tests/recall/test_filter_validator.py
@@ -895,3 +895,38 @@ def test_unsupported_error_is_khora_error() -> None:
     from khora.exceptions import KhoraError
 
     assert isinstance(RecallFilterUnsupportedError(path="p", reason="r"), KhoraError)
+
+
+# ---------------------------------------------------------------------------
+# Recursion-depth guard — over-deep filters fail cleanly, not as RecursionError
+# ---------------------------------------------------------------------------
+
+
+def test_excessively_deep_metadata_nesting_raises_clean_error() -> None:
+    # A pathologically deep equality operand must raise RecallFilterValidationError
+    # (code max_depth_exceeded) from the iterative depth guard — never an uncaught
+    # RecursionError from the recursive metadata-grammar walk.
+    deep: dict = {"$gt": 1}
+    for _ in range(400):
+        deep = {"a": deep}
+    with pytest.raises(RecallFilterValidationError) as exc:
+        RecallFilter.model_validate({"metadata.x": deep})
+    assert any(e.code == "max_depth_exceeded" for e in exc.value.errors)
+
+
+def test_excessively_deep_logical_nesting_raises_clean_error() -> None:
+    # Deeply nested $and must fail as RecallFilterValidationError before pydantic
+    # recurses the model that deep (which would otherwise hit RecursionError).
+    deep: dict = {"source_name": "linear"}
+    for _ in range(400):
+        deep = {"$and": [deep]}
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate(deep)
+
+
+def test_reasonable_nesting_within_limit_passes() -> None:
+    # A moderately nested filter (well under the depth bound) validates fine.
+    deep: dict = {"source_name": "linear"}
+    for _ in range(8):
+        deep = {"$and": [deep]}
+    RecallFilter.model_validate(deep)

--- a/tests/recall/test_filter_validator.py
+++ b/tests/recall/test_filter_validator.py
@@ -1,0 +1,897 @@
+"""Unit tests for the public ``RecallFilter`` model + validator.
+
+These tests pin the Layer-2 contract: the typed pydantic model that
+validates a recall filter document (kwarg form or wire dict form) and
+raises a single structured error type on any grammar violation. The
+model *validates*; it does not lower to an AST or compile.
+
+Two validation regimes, one error type:
+  (a) pydantic-structural — closed top-level key set (``extra="forbid"``),
+      typed ``*Ops`` submodels, ``model_fields_set`` unset-vs-null.
+  (b) recursive ``metadata`` walk — the sub-grammar pydantic can't express
+      on ``dict[str, Any]`` (operator whitelist, ``$in``/``$nin`` lists,
+      ``$exists`` bool, nonempty logical arrays, the operator-position
+      closure / no-mixing rule, and operand opacity).
+
+Both raise ``RecallFilterValidationError`` carrying a populated
+``errors: list[FieldError]``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from khora.filter import (
+    SYSTEM_KEYS,
+    DateOps,
+    Op,
+    RecallFilter,
+    RecallFilterUnsupportedError,
+    RecallFilterValidationError,
+    StringOps,
+)
+from khora.filter.model import FieldError
+
+# Every test here is a fast, in-process unit test.
+pytestmark = pytest.mark.unit
+
+
+# Round-trip helper: model_dump(by_alias=True, exclude_none=True) is the
+# canonical wire serialization. A byte-stable round-trip means dumping a
+# validated model reproduces the input dict exactly.
+def _roundtrip(wire: dict) -> dict:
+    return RecallFilter.model_validate(wire).model_dump(by_alias=True, exclude_none=True)
+
+
+# ---------------------------------------------------------------------------
+# Public surface — the 7 symbols import from both ``khora.filter`` and ``khora``
+# ---------------------------------------------------------------------------
+
+
+def test_seven_symbols_import_from_khora_filter() -> None:
+    import khora.filter as f
+
+    expected = {
+        "RecallFilter",
+        "StringOps",
+        "DateOps",
+        "RecallFilterValidationError",
+        "RecallFilterUnsupportedError",
+        "Op",
+        "SYSTEM_KEYS",
+    }
+    assert expected.issubset(set(dir(f)))
+    assert set(f.__all__) == expected
+
+
+def test_seven_symbols_import_from_khora_top_level() -> None:
+    import khora
+    from khora import (  # noqa: F401
+        SYSTEM_KEYS,
+        DateOps,
+        Op,
+        RecallFilter,
+        RecallFilterUnsupportedError,
+        RecallFilterValidationError,
+        StringOps,
+    )
+
+    for name in (
+        "RecallFilter",
+        "StringOps",
+        "DateOps",
+        "RecallFilterValidationError",
+        "RecallFilterUnsupportedError",
+        "Op",
+        "SYSTEM_KEYS",
+    ):
+        assert name in khora.__all__, f"{name} missing from khora.__all__"
+
+
+def test_field_error_importable_from_khora_filter() -> None:
+    from khora.filter import FieldError as ExportedFieldError
+
+    assert ExportedFieldError is FieldError
+
+
+# ---------------------------------------------------------------------------
+# SYSTEM_KEYS / Op
+# ---------------------------------------------------------------------------
+
+
+def test_system_keys_are_the_ten_documented_keys() -> None:
+    assert SYSTEM_KEYS == frozenset(
+        {
+            "occurred_at",
+            "created_at",
+            "source_timestamp",
+            "source_type",
+            "source_name",
+            "source_url",
+            "external_id",
+            "content_type",
+            "source",
+            "title",
+        }
+    )
+    # metadata and the logical ops are NOT system keys.
+    assert "metadata" not in SYSTEM_KEYS
+    assert "$and" not in SYSTEM_KEYS
+    # Non-projection fields are not system keys.
+    assert "author" not in SYSTEM_KEYS
+    assert "language" not in SYSTEM_KEYS
+    assert "source_system" not in SYSTEM_KEYS
+    assert "channel" not in SYSTEM_KEYS
+
+
+def test_system_keys_is_a_frozenset() -> None:
+    assert isinstance(SYSTEM_KEYS, frozenset)
+
+
+def test_op_enum_mirrors_operator_literals() -> None:
+    assert Op.EQ.value == "$eq"
+    assert Op.NE.value == "$ne"
+    assert Op.GT.value == "$gt"
+    assert Op.GTE.value == "$gte"
+    assert Op.LT.value == "$lt"
+    assert Op.LTE.value == "$lte"
+    assert Op.IN.value == "$in"
+    assert Op.NIN.value == "$nin"
+    assert Op.EXISTS.value == "$exists"
+    assert Op.AND.value == "$and"
+    assert Op.OR.value == "$or"
+    assert Op.NOR.value == "$nor"
+    assert Op.NOT.value == "$not"
+    assert Op.DATE.value == "$date"
+
+
+def test_op_is_str_enum() -> None:
+    # str-enum: members compare equal to their literal.
+    assert Op.EQ == "$eq"
+
+
+# ---------------------------------------------------------------------------
+# All 11 whitelisted top-level keys validate
+# ---------------------------------------------------------------------------
+
+
+def test_all_eleven_whitelisted_top_level_keys_validate() -> None:
+    # 10 system keys + bare metadata = 11 whitelisted top-level data keys.
+    wire = {
+        "occurred_at": {"$gte": "2026-04-05T00:00:00Z"},
+        "created_at": {"$lt": "2026-05-01T00:00:00Z"},
+        "source_timestamp": {"$gt": "2026-01-01T00:00:00Z"},
+        "source_type": "connection",
+        "source_name": {"$in": ["linear", "slack"]},
+        "source_url": "https://example.com",
+        "external_id": "ext-1",
+        "content_type": "text/markdown",
+        "source": "origin",
+        "title": {"$exists": True},
+        "metadata": {"team": "ingest"},
+    }
+    model = RecallFilter.model_validate(wire)
+    assert isinstance(model, RecallFilter)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "occurred_at",
+        "created_at",
+        "source_timestamp",
+        "source_type",
+        "source_name",
+        "source_url",
+        "external_id",
+        "content_type",
+        "source",
+        "title",
+        "metadata",
+    ],
+)
+def test_each_whitelisted_key_validates_alone(key: str) -> None:
+    if key in {"occurred_at", "created_at", "source_timestamp"}:
+        value: object = "2026-04-05T00:00:00Z"
+    elif key == "metadata":
+        value = {"team": "ingest"}
+    else:
+        value = "x"
+    model = RecallFilter.model_validate({key: value})
+    assert key in model.model_fields_set
+
+
+def test_logical_op_keys_validate_at_top_level() -> None:
+    for op in ("$and", "$or", "$nor"):
+        model = RecallFilter.model_validate({op: [{"source_type": "connection"}]})
+        assert isinstance(model, RecallFilter)
+    model = RecallFilter.model_validate({"$not": {"source_type": "connection"}})
+    assert isinstance(model, RecallFilter)
+
+
+# ---------------------------------------------------------------------------
+# Unknown top-level key raises with a populated .errors list[FieldError]
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_top_level_key_raises() -> None:
+    with pytest.raises(RecallFilterValidationError) as exc:
+        RecallFilter.model_validate({"priority": 5})
+    err = exc.value
+    assert isinstance(err.errors, list)
+    assert len(err.errors) >= 1
+    assert all(isinstance(fe, FieldError) for fe in err.errors)
+    fe = err.errors[0]
+    assert fe.path
+    assert fe.code
+    assert fe.message
+
+
+def test_unknown_top_level_dollar_key_raises() -> None:
+    # A top-level $-key that isn't a known logical op still raises.
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"$comment": "hello"})
+
+
+def test_field_error_has_expected_shape() -> None:
+    with pytest.raises(RecallFilterValidationError) as exc:
+        RecallFilter.model_validate({"nope": 1})
+    fe = exc.value.errors[0]
+    # JSON-Pointer-ish path, a code, a message; allowed is optional.
+    assert isinstance(fe.path, str)
+    assert isinstance(fe.code, str)
+    assert isinstance(fe.message, str)
+    assert hasattr(fe, "allowed")
+
+
+def test_validation_error_is_khora_error() -> None:
+    from khora.exceptions import KhoraError
+
+    assert issubclass(RecallFilterValidationError, KhoraError)
+    assert issubclass(RecallFilterUnsupportedError, KhoraError)
+
+
+# ---------------------------------------------------------------------------
+# Per-key operator subsets (§2)
+# ---------------------------------------------------------------------------
+
+
+def test_exists_on_date_key_raises() -> None:
+    # DateOps has NO $exists.
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"occurred_at": {"$exists": True}})
+
+
+def test_range_op_on_string_key_raises() -> None:
+    # StringOps has no range ops.
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"source_type": {"$gt": "a"}})
+
+
+@pytest.mark.parametrize("op", ["$gt", "$gte", "$lt", "$lte"])
+def test_each_range_op_on_string_key_raises(op: str) -> None:
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"source_name": {op: "a"}})
+
+
+def test_date_key_accepts_full_range_op_set() -> None:
+    wire = {
+        "occurred_at": {
+            "$gte": "2026-01-01T00:00:00Z",
+            "$lte": "2026-12-31T00:00:00Z",
+        }
+    }
+    model = RecallFilter.model_validate(wire)
+    assert isinstance(model.occurred_at, DateOps)
+
+
+def test_string_key_accepts_eq_ne_in_nin_exists() -> None:
+    model = RecallFilter.model_validate({"source_type": {"$in": ["a", "b"], "$ne": "c", "$exists": True}})
+    assert isinstance(model.source_type, StringOps)
+
+
+def test_exists_on_string_key_validates() -> None:
+    model = RecallFilter.model_validate({"title": {"$exists": False}})
+    assert isinstance(model.title, StringOps)
+
+
+# ---------------------------------------------------------------------------
+# Bare-value sugar (§2/§3) — scalar/list/dict ⇒ $eq, bare-list exact-array
+# ---------------------------------------------------------------------------
+
+
+def test_bare_scalar_string_is_eq_sugar() -> None:
+    model = RecallFilter.model_validate({"source_name": "linear"})
+    assert model.source_name == "linear"
+
+
+def test_bare_scalar_date_is_eq_sugar() -> None:
+    model = RecallFilter.model_validate({"occurred_at": "2026-04-05T00:00:00Z"})
+    # Scalar matches the datetime arm (= $eq sugar), not DateOps.
+    assert isinstance(model.occurred_at, datetime)
+
+
+def test_bare_list_is_exact_array_not_in() -> None:
+    # List ⇒ $eq exact-array equality, NOT $in. The list arm must match
+    # list[str], and it must NOT be coerced into a StringOps($in=...).
+    model = RecallFilter.model_validate({"source_type": ["a", "b"]})
+    assert model.source_type == ["a", "b"]
+    assert not isinstance(model.source_type, StringOps)
+
+
+def test_bare_list_roundtrips_as_list_not_in() -> None:
+    wire = {"source_type": ["a", "b"]}
+    assert _roundtrip(wire) == wire
+
+
+def test_explicit_in_is_membership() -> None:
+    model = RecallFilter.model_validate({"source_type": {"$in": ["a", "b"]}})
+    assert isinstance(model.source_type, StringOps)
+    assert model.source_type.in_ == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Dot-path fold + flat re-serialize round-trips BYTE-STABLE
+# ---------------------------------------------------------------------------
+
+
+def test_dot_path_fold_roundtrips_byte_stable() -> None:
+    wire = {"metadata.tag": {"$in": ["roadmap", "okrs"]}}
+    assert _roundtrip(wire) == wire
+
+
+def test_dot_path_not_rejected_as_unknown_top_level_key() -> None:
+    # The mode="before" fold must pull metadata.* OUT before extra="forbid".
+    model = RecallFilter.model_validate({"metadata.tag": "x"})
+    assert isinstance(model, RecallFilter)
+
+
+def test_bare_metadata_whole_blob_roundtrips_byte_stable() -> None:
+    wire = {"metadata": {"team": "ingest", "level": 3}}
+    assert _roundtrip(wire) == wire
+
+
+def test_bare_metadata_populates_field_literally() -> None:
+    model = RecallFilter.model_validate({"metadata": {"team": "ingest"}})
+    assert model.metadata == {"team": "ingest"}
+
+
+def test_dot_path_not_merged_into_metadata_field() -> None:
+    # Folded dot-path predicates must NOT land on the metadata field
+    # (reserved for the whole-blob case).
+    model = RecallFilter.model_validate({"metadata.tag": {"$in": ["a"]}})
+    assert model.metadata is None
+
+
+def test_mixed_whole_blob_and_dot_path_roundtrips() -> None:
+    wire = {
+        "metadata": {"team": "ingest"},
+        "metadata.tag": {"$eq": "x"},
+    }
+    assert _roundtrip(wire) == wire
+
+
+def test_whole_filter_with_system_keys_and_dot_path_roundtrips() -> None:
+    # Byte-stable round-trip is the contract for the dot-path fold + flat
+    # re-serialize over string system keys, whole-blob, and dot-paths. Date
+    # keys are intentionally excluded here: an ISO-8601 string is parsed and
+    # UTC-normalized to a ``datetime`` (a required behavior), so the date arm
+    # is not byte-identical on dump — see the dedicated date-normalization
+    # tests below.
+    wire = {
+        "source_name": {"$in": ["linear"]},
+        "source_type": "connection",
+        "metadata.tag": {"$in": ["tag1", "tag2", "tag3"]},
+    }
+    assert _roundtrip(wire) == wire
+
+
+def test_logical_filter_roundtrips_byte_stable() -> None:
+    wire = {
+        "$or": [
+            {"source_name": "linear", "metadata.tag": "urgent"},
+            {"source_name": "slack", "metadata.tag": "urgent"},
+        ]
+    }
+    assert _roundtrip(wire) == wire
+
+
+def test_nested_subdocument_equality_roundtrips() -> None:
+    # A nested dict on a metadata SUB-path is whole-subdocument equality.
+    wire = {"metadata.labels": {"team": "ingest"}}
+    assert _roundtrip(wire) == wire
+
+
+def test_nested_dot_path_folds_per_branch_roundtrips() -> None:
+    # Each $and/$or branch carries its OWN dot-path folds — no
+    # cross-contamination between branches. A branch with no metadata.*
+    # fold round-trips with no spurious metadata key, and a folding branch
+    # re-emits its own flat key.
+    wire = {
+        "source_name": "x",
+        "metadata.outer": 1,
+        "$and": [
+            {"metadata.inner": 2},
+            {"source_name": "y"},
+        ],
+    }
+    assert _roundtrip(wire) == wire
+
+
+def test_no_fold_branch_has_no_spurious_metadata_key() -> None:
+    # A nested branch that defines no metadata.* predicate must not pick up
+    # a metadata key from its sibling on round-trip.
+    wire = {"$or": [{"metadata.tag": "a"}, {"source_name": "b"}]}
+    dumped = RecallFilter.model_validate(wire).model_dump(by_alias=True, exclude_none=True)
+    assert dumped == wire
+    # The no-fold branch dumps to exactly its single system key.
+    assert dumped["$or"][1] == {"source_name": "b"}
+
+
+def test_metadata_prefix_without_trailing_dot_is_not_folded() -> None:
+    # Only keys starting with "metadata." (trailing dot) fold. A bare
+    # "metadata" key is the whole-blob field, not a dot-path.
+    model = RecallFilter.model_validate({"metadata": {"x": 1}})
+    assert model.metadata == {"x": 1}
+    assert _roundtrip({"metadata": {"x": 1}}) == {"metadata": {"x": 1}}
+
+
+# ---------------------------------------------------------------------------
+# Operator-position closure — mixed/nested-$ raises
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_dollar_and_non_dollar_keys_raises() -> None:
+    # A value-dict that mixes $-op keys with non-$ keys raises.
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"metadata.x": {"$gt": 1, "team": "ingest"}})
+
+
+def test_nested_dollar_inside_equality_operand_raises() -> None:
+    # A $-op nested inside an equality operand (whole-subdoc) raises.
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"metadata.labels": {"priority": {"$gte": 5}}})
+
+
+def test_nested_dollar_inside_bare_metadata_blob_raises() -> None:
+    # The ADR's verbatim canonical example, in bare-metadata-blob form.
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"metadata": {"labels": {"priority": {"$gte": 5}}}})
+
+
+def test_deeply_nested_dollar_inside_equality_operand_raises() -> None:
+    # The equality-operand $-scan must descend through nested subdocuments to
+    # ANY depth — a $-op two or more levels inside a whole-subdocument equality
+    # operand still raises (use dot-notation to address it). Without deep
+    # descent the operator is silently treated as data, the footgun the
+    # operator-position-closure rule exists to surface.
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"metadata.x": {"b": {"c": {"$gt": 1}}}})
+
+
+def test_deep_nested_dollar_in_equality_operand_via_dict_raises() -> None:
+    # The whole-subdocument-equality $-scan descends through nested DICTS to any
+    # depth; a $-op found anywhere inside a nested dict raises.
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"metadata.labels": {"a": {"b": {"$gte": 5}}}})
+
+
+@pytest.mark.parametrize(
+    "wire",
+    [
+        # $ inside a list element nested in the equality operand — list elements
+        # are opaque exact-array literals (no dot-addressable field name to bind
+        # an operator to), so the $-op is data and does NOT raise.
+        {"metadata.labels": {"items": [{"$gte": 5}]}},
+        # $ reached via list nesting (the list element is opaque even though it
+        # nests dicts inside) — no raise, byte-stable round-trip.
+        {"metadata.labels": {"a": [{"b": {"c": {"$or": [1]}}}]}},
+    ],
+)
+def test_dollar_inside_list_element_in_equality_operand_is_opaque(wire: dict) -> None:
+    # The whole-subdocument-equality $-scan descends through nested DICTS only.
+    # A list element is an opaque exact-array literal, so a $-op anywhere inside
+    # a list is literal data — no raise, byte-stable round-trip.
+    assert _roundtrip(wire) == wire
+
+
+@pytest.mark.parametrize(
+    "wire",
+    [
+        # Mixed $/non-$ keys are DATA inside a comparison-op operand (opaque);
+        # only PREDICATE-position mixing raises. Boundary guard for the closure rule.
+        {"metadata.x": {"$eq": {"team": "x", "$gt": 1}}},
+        # Comparison operands stay fully opaque at ANY depth — the scan never
+        # descends into them, so a deep nested $ is literal data.
+        {"metadata.x": {"$eq": {"a": {"b": {"$or": [1]}}}}},
+        # ...including a $ inside a list nested in the comparison operand.
+        {"metadata.x": {"$ne": {"k": [{"$gte": 9}]}}},
+    ],
+)
+def test_deep_dollar_inside_comparison_operand_is_opaque(wire: dict) -> None:
+    # Mirror of the equality-operand scan from the opaque side: a comparison
+    # operator's operand ($eq/$ne/...) is never inspected, so nested $-keys at
+    # any depth are literal data — no raise, byte-stable round-trip.
+    assert _roundtrip(wire) == wire
+
+
+def test_metadata_bare_list_is_opaque_exact_array() -> None:
+    # A bare list AS a metadata predicate value is $eq exact-array equality —
+    # an opaque literal. Even a list whose elements contain $-keys is data
+    # here (exact-array match), so it does not raise and round-trips stable.
+    for wire in ({"metadata.x": [1, 2, 3]}, {"metadata.x": [{"a": 1}]}, {"metadata.x": [{"$gt": 1}]}):
+        assert _roundtrip(wire) == wire
+
+
+def test_metadata_unknown_operator_raises() -> None:
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"metadata.x": {"$regex": "abc"}})
+
+
+# ---------------------------------------------------------------------------
+# Empty $and/$or/$nor raises; non-list $in/$nin raises; non-bool $exists raises
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("op", ["$and", "$or", "$nor"])
+def test_empty_logical_array_raises(op: str) -> None:
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({op: []})
+
+
+@pytest.mark.parametrize("op", ["$and", "$or", "$nor"])
+def test_nonempty_logical_array_validates(op: str) -> None:
+    model = RecallFilter.model_validate({op: [{"source_type": "connection"}]})
+    assert isinstance(model, RecallFilter)
+
+
+def test_in_must_be_list_on_metadata() -> None:
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"metadata.x": {"$in": 5}})
+
+
+def test_nin_must_be_list_on_metadata() -> None:
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"metadata.x": {"$nin": "a"}})
+
+
+def test_in_must_be_list_on_string_key() -> None:
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"source_type": {"$in": 5}})
+
+
+def test_exists_must_be_bool_on_metadata() -> None:
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"metadata.x": {"$exists": "yes"}})
+
+
+def test_exists_must_be_bool_on_string_key() -> None:
+    # A non-bool, non-coercible value must raise on the typed string-key arm.
+    # (Note: the typed StringOps arm uses pydantic's bool coercion, which
+    # accepts "yes"/"true"/1; an integer like 5 is a clean non-bool that is
+    # rejected by both the typed-key and metadata regimes.)
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"source_type": {"$exists": 5}})
+
+
+# ---------------------------------------------------------------------------
+# model_fields_set — unset vs explicit null
+# ---------------------------------------------------------------------------
+
+
+def test_unset_key_not_in_fields_set() -> None:
+    model = RecallFilter.model_validate({"source_type": "x"})
+    assert "source_type" in model.model_fields_set
+    assert "source_name" not in model.model_fields_set
+
+
+def test_explicit_null_is_in_fields_set() -> None:
+    # An explicit null is an active null-or-missing match, distinguishable
+    # from an unset key via model_fields_set.
+    model = RecallFilter.model_validate({"source_name": None})
+    assert "source_name" in model.model_fields_set
+    assert model.source_name is None
+
+
+def test_unset_vs_null_distinguishable() -> None:
+    unset = RecallFilter.model_validate({"source_type": "x"})
+    explicit = RecallFilter.model_validate({"source_type": "x", "source_name": None})
+    assert "source_name" not in unset.model_fields_set
+    assert "source_name" in explicit.model_fields_set
+
+
+# ---------------------------------------------------------------------------
+# $date typed literal (§4) — parse + malformed raises; tz-naive → UTC
+# ---------------------------------------------------------------------------
+
+
+def test_date_literal_parses_in_metadata_value_position() -> None:
+    model = RecallFilter.model_validate({"metadata.ts": {"$gt": {"$date": "2026-04-05T00:00:00Z"}}})
+    assert isinstance(model, RecallFilter)
+
+
+def test_date_literal_as_bare_metadata_value() -> None:
+    model = RecallFilter.model_validate({"metadata.ts": {"$date": "2026-04-05T00:00:00Z"}})
+    assert isinstance(model, RecallFilter)
+
+
+def test_malformed_date_literal_raises() -> None:
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"metadata.ts": {"$date": "not-a-date"}})
+
+
+def test_malformed_date_literal_in_operand_raises() -> None:
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"metadata.ts": {"$gt": {"$date": "13/13/2026"}}})
+
+
+# ---------------------------------------------------------------------------
+# Datetime normalization (§10.4) — tz-naive → UTC
+# ---------------------------------------------------------------------------
+
+
+def test_tz_naive_date_key_normalized_to_utc() -> None:
+    model = RecallFilter.model_validate({"occurred_at": "2026-04-05T00:00:00"})
+    assert isinstance(model.occurred_at, datetime)
+    assert model.occurred_at.tzinfo is not None
+    # Specifically normalized to UTC: zero offset.
+    assert model.occurred_at.utcoffset().total_seconds() == 0
+
+
+def test_tz_naive_datetime_object_normalized_to_utc() -> None:
+    model = RecallFilter.model_validate({"occurred_at": datetime(2026, 4, 5, 0, 0, 0)})
+    assert model.occurred_at.tzinfo is not None
+    assert model.occurred_at.utcoffset().total_seconds() == 0
+
+
+def test_tz_naive_in_date_ops_normalized_to_utc() -> None:
+    model = RecallFilter.model_validate({"occurred_at": {"$gte": "2026-04-05T00:00:00"}})
+    assert isinstance(model.occurred_at, DateOps)
+    assert model.occurred_at.gte.tzinfo is not None
+    assert model.occurred_at.gte.utcoffset().total_seconds() == 0
+
+
+def test_tz_aware_date_preserved_as_utc() -> None:
+    # A value already in UTC stays UTC.
+    aware = datetime(2026, 4, 5, 0, 0, 0, tzinfo=UTC)
+    model = RecallFilter.model_validate({"occurred_at": aware})
+    assert model.occurred_at.utcoffset().total_seconds() == 0
+
+
+# ---------------------------------------------------------------------------
+# Date-key serialization contract
+#
+# Byte-identity to the RAW input is NOT achievable for date keys: tz-naive →
+# UTC normalization rewrites the value, and ``model_dump`` (python mode) returns
+# ``datetime`` objects rather than strings. The contract is instead:
+#   (a) idempotency — validate → dump → validate → dump is stable, and
+#   (b) the JSON-mode dump is a canonical UTC ISO-8601 string that parses back
+#       to the same instant (parse-equivalence, not exact-byte, so the contract
+#       survives a "Z" vs "+00:00" rendering choice).
+# Structural (non-date) cases keep exact byte-stable round-trips elsewhere.
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso_utc(value: str) -> datetime:
+    """Parse an ISO-8601 string to an aware UTC datetime (accepts ``Z``)."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+@pytest.mark.parametrize(
+    "wire",
+    [
+        {"occurred_at": {"$gte": "2026-04-05T00:00:00Z"}},
+        {"occurred_at": "2026-04-05T00:00:00"},  # tz-naive
+        {"occurred_at": "2026-04-05T00:00:00+00:00"},
+        {
+            "source_name": {"$in": ["linear"]},
+            "occurred_at": {"$gte": "2026-04-05T00:00:00Z"},
+            "metadata.tag": {"$in": ["a"]},
+        },
+    ],
+)
+def test_date_key_dump_is_idempotent_python_mode(wire: dict) -> None:
+    # validate → dump → validate → dump is stable (python mode).
+    first = RecallFilter.model_validate(wire)
+    dump1 = first.model_dump(by_alias=True, exclude_none=True)
+    dump2 = RecallFilter.model_validate(dump1).model_dump(by_alias=True, exclude_none=True)
+    assert dump1 == dump2
+
+
+@pytest.mark.parametrize(
+    "wire",
+    [
+        {"occurred_at": {"$gte": "2026-04-05T00:00:00Z"}},
+        {"occurred_at": "2026-04-05T00:00:00"},
+        {"occurred_at": "2026-04-05T00:00:00+00:00"},
+    ],
+)
+def test_date_key_dump_is_idempotent_json_mode(wire: dict) -> None:
+    # validate → json-dump → validate → json-dump is stable (json mode).
+    first = RecallFilter.model_validate(wire)
+    dump1 = first.model_dump(by_alias=True, exclude_none=True, mode="json")
+    dump2 = RecallFilter.model_validate(dump1).model_dump(by_alias=True, exclude_none=True, mode="json")
+    assert dump1 == dump2
+
+
+def test_date_ops_json_dump_is_canonical_utc_iso() -> None:
+    # The JSON-mode dump of a date operand is a canonical UTC ISO-8601 string
+    # that parses back to the same instant as the input (parse-equivalence).
+    wire = {"occurred_at": {"$gte": "2026-04-05T00:00:00Z"}}
+    dumped = RecallFilter.model_validate(wire).model_dump(by_alias=True, exclude_none=True, mode="json")
+    serialized = dumped["occurred_at"]["$gte"]
+    assert isinstance(serialized, str)
+    assert _parse_iso_utc(serialized) == _parse_iso_utc("2026-04-05T00:00:00Z")
+
+
+def test_scalar_date_key_json_dump_is_canonical_utc_iso() -> None:
+    # A tz-naive scalar date key normalizes to UTC and dumps as a canonical
+    # ISO string at the same instant.
+    wire = {"occurred_at": "2026-04-05T00:00:00"}
+    dumped = RecallFilter.model_validate(wire).model_dump(by_alias=True, exclude_none=True, mode="json")
+    serialized = dumped["occurred_at"]
+    assert isinstance(serialized, str)
+    assert _parse_iso_utc(serialized) == datetime(2026, 4, 5, 0, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Operand opacity
+# ---------------------------------------------------------------------------
+
+
+def test_operand_opacity_eq_literal_object_does_not_raise() -> None:
+    # {"$eq": {"$or": [1,2]}} matches the LITERAL object — never re-parsed
+    # as a logical clause, so it must NOT raise.
+    model = RecallFilter.model_validate({"metadata.x": {"$eq": {"$or": [1, 2]}}})
+    assert isinstance(model, RecallFilter)
+
+
+def test_operand_opacity_roundtrips() -> None:
+    wire = {"metadata.x": {"$eq": {"$or": [1, 2]}}}
+    assert _roundtrip(wire) == wire
+
+
+def test_operand_opacity_in_list_of_objects() -> None:
+    # $in operand is a list of opaque literals.
+    model = RecallFilter.model_validate({"metadata.x": {"$in": [{"$gt": 1}, {"nested": {"$or": []}}]}})
+    assert isinstance(model, RecallFilter)
+
+
+# ---------------------------------------------------------------------------
+# $not — document form + field form; $nor nonempty array
+# ---------------------------------------------------------------------------
+
+
+def test_not_document_form_validates() -> None:
+    # {$not: {<filter>}} negates a whole filter.
+    model = RecallFilter.model_validate({"$not": {"source_type": "connection"}})
+    assert isinstance(model, RecallFilter)
+    assert model.not_ is not None
+
+
+def test_not_document_form_roundtrips() -> None:
+    wire = {"$not": {"source_type": "connection"}}
+    assert _roundtrip(wire) == wire
+
+
+def test_not_field_form_validates() -> None:
+    # {<field>: {$not: {<op-expr>}}} negates the field's op-expression.
+    model = RecallFilter.model_validate({"source_type": {"$not": {"$eq": "connection"}}})
+    assert isinstance(model.source_type, StringOps)
+    assert model.source_type.not_ is not None
+
+
+def test_not_field_form_on_date_key_validates() -> None:
+    model = RecallFilter.model_validate({"occurred_at": {"$not": {"$gt": "2026-01-01T00:00:00Z"}}})
+    assert isinstance(model.occurred_at, DateOps)
+    assert model.occurred_at.not_ is not None
+
+
+def test_not_field_form_bare_scalar_raises() -> None:
+    # The field-form $not must take an operator-expression, not a bare
+    # scalar — {field: {"$not": 5}} raises, matching MongoDB.
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"source_type": {"$not": 5}})
+
+
+def test_nor_nonempty_array_validates() -> None:
+    model = RecallFilter.model_validate({"$nor": [{"source_type": "a"}, {"source_name": "b"}]})
+    assert model.nor_ is not None
+    assert len(model.nor_) == 2
+
+
+def test_nor_is_not_desugared_here() -> None:
+    # $nor is validated as a nonempty array of filters but NOT desugared
+    # to $not($or[...]) — desugaring happens in the later AST step.
+    model = RecallFilter.model_validate({"$nor": [{"source_type": "a"}]})
+    assert model.nor_ is not None
+    # The validated model keeps the $nor form on round-trip.
+    assert "$nor" in model.model_dump(by_alias=True, exclude_none=True)
+
+
+# ---------------------------------------------------------------------------
+# Nested logical recursion
+# ---------------------------------------------------------------------------
+
+
+def test_nested_logical_recursion_validates() -> None:
+    wire = {
+        "$and": [
+            {"source_type": "connection"},
+            {"$or": [{"source_name": "linear"}, {"source_name": "slack"}]},
+            {"$not": {"title": {"$exists": False}}},
+        ]
+    }
+    model = RecallFilter.model_validate(wire)
+    assert isinstance(model, RecallFilter)
+    assert model.and_ is not None
+    assert len(model.and_) == 3
+
+
+def test_nested_logical_recursion_roundtrips() -> None:
+    wire = {
+        "$and": [
+            {"source_type": "connection"},
+            {"$or": [{"source_name": "linear"}, {"source_name": "slack"}]},
+        ]
+    }
+    assert _roundtrip(wire) == wire
+
+
+def test_invalid_inside_nested_logical_raises() -> None:
+    # An invalid clause nested inside $or must still raise (recursion).
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"$or": [{"occurred_at": {"$exists": True}}]})
+
+
+def test_unknown_key_inside_nested_logical_raises() -> None:
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter.model_validate({"$and": [{"priority": 5}]})
+
+
+# ---------------------------------------------------------------------------
+# Kwarg construction — same validator
+# ---------------------------------------------------------------------------
+
+
+def test_kwarg_construction_validates() -> None:
+    model = RecallFilter(
+        source_name="linear",
+        occurred_at=DateOps(gte=datetime(2026, 4, 5, tzinfo=UTC)),
+    )
+    assert model.source_name == "linear"
+
+
+def test_kwarg_construction_unknown_key_raises() -> None:
+    with pytest.raises(RecallFilterValidationError):
+        RecallFilter(priority=5)  # type: ignore[call-arg]
+
+
+def test_kwarg_and_dict_forms_produce_same_wire() -> None:
+    kwarg = RecallFilter(source_name="linear")
+    wire = RecallFilter.model_validate({"source_name": "linear"})
+    dump_kwarg = kwarg.model_dump(by_alias=True, exclude_none=True)
+    dump_wire = wire.model_dump(by_alias=True, exclude_none=True)
+    assert dump_kwarg == dump_wire == {"source_name": "linear"}
+
+
+# ---------------------------------------------------------------------------
+# RecallFilterUnsupportedError — class is exported now (raised by later compilers)
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_error_constructible() -> None:
+    # The class is exported now even though compilers (which raise it) are
+    # later tickets. Keyword-only signature carrying path + reason.
+    err = RecallFilterUnsupportedError(path="metadata.x", reason="no backend support")
+    assert isinstance(err, Exception)
+    assert err.path == "metadata.x"
+    assert err.reason == "no backend support"
+
+
+def test_unsupported_error_is_khora_error() -> None:
+    from khora.exceptions import KhoraError
+
+    assert isinstance(RecallFilterUnsupportedError(path="p", reason="r"), KhoraError)


### PR DESCRIPTION
## Summary
- Add a public `RecallFilter` pydantic model — a Mongo-style, deterministic recall-filter contract intended for a future `recall(filter=…)` keyword. This change is the validation layer only: it validates and normalizes a filter document; it does not compile or execute queries.
- Typed system-key fields (`occurred_at`, `created_at`, `source_timestamp`, `source_type`, `source_name`, `source_url`, `external_id`, `content_type`, `source`, `title`) plus `StringOps`/`DateOps` operator submodels enforcing per-key operator subsets (`$exists` excluded on date keys; range operators excluded on string keys).
- Free-form `metadata` predicates via Mongo-style `metadata.<path>` dot-paths: a `model_validator(mode="before")` folds flat dot-path keys onto a recursion-safe per-instance carrier, and a `model_serializer` re-emits them flat so filters round-trip byte-stable (including under nested `$and`/`$or`). A bare `{"metadata": {…}}` is whole-blob equality.
- Two validation regimes, one error type: pydantic-structural (closed top-level key set via `extra="forbid"`, typed submodels, unset-vs-explicit-`null` via `model_fields_set`) and a recursive metadata-grammar walk (operator whitelist, `$in`/`$nin` must be lists, strict-bool `$exists`, operand opacity, and a loud operator-position-closure rule). Both surface as `RecallFilterValidationError` carrying structured `errors`.
- Bare-value sugar (scalar/list/dict ⇒ `$eq`; a bare list is exact-array equality, not membership), a `$date` typed literal for metadata timestamps, UTC normalization of datetimes, and logical `$and`/`$or`/`$nor`/`$not` (document and field position) with empty-array rejection.
- Export `RecallFilter`, `StringOps`, `DateOps`, `RecallFilterValidationError`, `RecallFilterUnsupportedError`, `Op`, `SYSTEM_KEYS` from both `khora` and `khora.filter`.

## Test plan
- [x] Validator unit tests (`tests/recall/test_filter_validator.py`, 112 tests): whitelist, per-key operator subsets, dot-path fold + byte-stable round-trip, bare-value sugar, operand opacity, `$date`, null semantics, logical recursion
- [x] Full unit suite green (`tests/unit` + `tests/recall`)
- [x] `make format` and `make lint` clean
- [ ] Integration/e2e via CI