### PR TITLE
Populate denormalized chunk columns from document attrs at ingest

### DIFF
--- a/src/khora/core/models/document.py
+++ b/src/khora/core/models/document.py
@@ -172,6 +172,9 @@ class Chunk:
     # Timestamps
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     source_timestamp: datetime | None = None
+    # Chunk event-time, distinct from source_timestamp (the producer's
+    # verbatim time). NULL when the chunk carries no event-time of its own.
+    occurred_at: datetime | None = None
     # Reinforcement-on-recall (#855). NULL until the chunk is first
     # returned by a recall path that has reinforcement enabled.
     last_accessed_at: datetime | None = None

--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -1896,7 +1896,7 @@ class ChronicleEngine:
                 content=chunk.content,
                 score=score,
                 created_at=chunk.created_at,
-                occurred_at=chunk.source_timestamp,
+                occurred_at=(chunk.occurred_at if chunk.occurred_at is not None else chunk.source_timestamp),
                 chunker_info=chunk.chunker_info or {},
             )
             for (chunk, _), score in zip(chunks_with_scores, normalized_chunk_scores, strict=False)

--- a/src/khora/engines/skeleton/backends/__init__.py
+++ b/src/khora/engines/skeleton/backends/__init__.py
@@ -17,6 +17,7 @@ from khora.core.models.document import Chunk
 
 if TYPE_CHECKING:
     from khora.config import KhoraConfig
+    from khora.core.models.document import Document
 
 
 @dataclass
@@ -53,6 +54,26 @@ class TemporalChunk:
     content_type: str | None = None
     source: str | None = None
     title: str | None = None
+
+
+def document_denorm_fields(document: Document) -> dict[str, Any]:
+    """Return the denormalized document-grained chunk fields from a Document.
+
+    Copies the eight provenance fields off the typed Document so chunk
+    builders can stamp them onto a :class:`TemporalChunk` without repeating
+    the mapping at every write site. ``source_timestamp`` is the producer's
+    verbatim time, kept distinct from the chunk event-time ``occurred_at``.
+    """
+    return {
+        "source_type": document.source_type,
+        "source_name": document.source_name,
+        "source_url": document.source_url,
+        "source_timestamp": document.source_timestamp,
+        "external_id": document.external_id,
+        "content_type": document.content_type,
+        "source": document.source,
+        "title": document.title,
+    }
 
 
 @dataclass
@@ -191,10 +212,9 @@ def temporal_chunk_to_chunk(tc: TemporalChunk) -> Chunk:
     Preserves fields the retriever and rerankers depend on:
     ``chunker_info`` (#800), ``created_at`` (#810), and ``session_id``
     (#620 — stamped into ``TemporalChunk.metadata`` by the engines).
-    Builds ``source_timestamp`` from the distinct producer value
-    (``tc.source_timestamp``), falling back to ``tc.occurred_at`` (the
-    chunk event-time) when the producer value is absent, so temporal-decay
-    boosts use the document time rather than the ingest time.
+    Surfaces ``occurred_at`` (the chunk event-time) and ``source_timestamp``
+    (the producer's verbatim time) as distinct values; the recall projection
+    applies the event-time-then-producer-time fallback downstream.
     """
     md = tc.metadata or {}
     sid_raw = md.get("session_id")
@@ -223,10 +243,10 @@ def temporal_chunk_to_chunk(tc: TemporalChunk) -> Chunk:
         embedding=tc.embedding,
         embedding_model=str(md.get("embedding_model", "") or ""),
         created_at=tc.created_at or datetime.now(UTC),
-        # Prefer the distinct producer value; fall back to the chunk
-        # event-time. The write-path will populate the verbatim producer
-        # value in a follow-up.
-        source_timestamp=tc.source_timestamp if tc.source_timestamp is not None else tc.occurred_at,
+        # Carry the chunk event-time and the producer's verbatim time as
+        # distinct values; the recall projection applies the fallback.
+        occurred_at=tc.occurred_at,
+        source_timestamp=tc.source_timestamp,
         session_id=session_id,
     )
 
@@ -316,5 +336,6 @@ __all__ = [
     "TemporalSearchResult",
     "TemporalVectorStore",
     "create_temporal_store",
+    "document_denorm_fields",
     "temporal_chunk_to_chunk",
 ]

--- a/src/khora/engines/skeleton/backends/pgvector.py
+++ b/src/khora/engines/skeleton/backends/pgvector.py
@@ -267,6 +267,14 @@ class PgVectorTemporalStore(TemporalVectorStore):
                 confidence=chunk.confidence,
                 metadata=chunk.metadata or {},
                 chunker_info=chunk.chunker_info or {},
+                source_type=chunk.source_type,
+                source_name=chunk.source_name,
+                source_url=chunk.source_url,
+                source_timestamp=chunk.source_timestamp,
+                external_id=chunk.external_id,
+                content_type=chunk.content_type,
+                source=chunk.source,
+                title=chunk.title,
             )
             await session.execute(stmt)
             await session.commit()
@@ -299,6 +307,14 @@ class PgVectorTemporalStore(TemporalVectorStore):
                     "confidence": chunk.confidence,
                     "metadata": chunk.metadata or {},
                     "chunker_info": chunk.chunker_info or {},
+                    "source_type": chunk.source_type,
+                    "source_name": chunk.source_name,
+                    "source_url": chunk.source_url,
+                    "source_timestamp": chunk.source_timestamp,
+                    "external_id": chunk.external_id,
+                    "content_type": chunk.content_type,
+                    "source": chunk.source,
+                    "title": chunk.title,
                 }
             )
 
@@ -707,6 +723,14 @@ class PgVectorTemporalStore(TemporalVectorStore):
             confidence=row.confidence or 1.0,
             metadata=row.metadata or {},
             chunker_info=dict(row.chunker_info) if row.chunker_info else {},
+            source_type=row.source_type,
+            source_name=row.source_name,
+            source_url=row.source_url,
+            source_timestamp=row.source_timestamp,
+            external_id=row.external_id,
+            content_type=row.content_type,
+            source=row.source,
+            title=row.title,
         )
 
     async def health_check(self) -> dict[str, Any]:

--- a/src/khora/engines/skeleton/backends/sqlite_lance.py
+++ b/src/khora/engines/skeleton/backends/sqlite_lance.py
@@ -73,7 +73,15 @@ _KHORA_CHUNKS_SCHEMA: tuple[str, ...] = (
         tags TEXT NOT NULL DEFAULT '[]',
         confidence REAL NOT NULL DEFAULT 1.0,
         metadata TEXT NOT NULL DEFAULT '{}',
-        chunker_info TEXT NOT NULL DEFAULT '{}'
+        chunker_info TEXT NOT NULL DEFAULT '{}',
+        source_type TEXT,
+        source_name TEXT,
+        source_url TEXT,
+        source_timestamp TEXT,
+        external_id TEXT,
+        content_type TEXT,
+        source TEXT,
+        title TEXT
     )
     """,
     "CREATE INDEX IF NOT EXISTS ix_khora_chunks_namespace ON khora_chunks(namespace_id)",
@@ -242,6 +250,14 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
                     float(c.confidence) if c.confidence is not None else 1.0,
                     to_json_text(c.metadata or {}),
                     to_json_text(c.chunker_info or {}),
+                    c.source_type,
+                    c.source_name,
+                    c.source_url,
+                    _dt_to_iso(c.source_timestamp),
+                    c.external_id,
+                    c.content_type,
+                    c.source,
+                    c.title,
                 )
             )
             if c.embedding:
@@ -258,8 +274,10 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         await self._sqlite.executemany(
             "INSERT INTO khora_chunks "
             "(id, namespace_id, document_id, content, occurred_at, created_at, "
-            "source_system, author, channel, tags, confidence, metadata, chunker_info) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "source_system, author, channel, tags, confidence, metadata, chunker_info, "
+            "source_type, source_name, source_url, source_timestamp, external_id, "
+            "content_type, source, title) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             sqlite_rows,
         )
         await self._sqlite.commit()
@@ -678,6 +696,14 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
             confidence=row["confidence"] if row["confidence"] is not None else 1.0,
             metadata=meta,
             chunker_info=chunker_info,
+            source_type=row["source_type"],
+            source_name=row["source_name"],
+            source_url=row["source_url"],
+            source_timestamp=_parse_dt(row["source_timestamp"]),
+            external_id=row["external_id"],
+            content_type=row["content_type"],
+            source=row["source"],
+            title=row["title"],
         )
 
     # ------------------------------------------------------------------

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -37,7 +37,13 @@ from khora.query import SearchMode
 from khora.storage import StorageConfig, StorageCoordinator, create_storage_coordinator
 from khora.telemetry import trace, trace_span
 
-from .backends import TemporalChunk, TemporalFilter, TemporalVectorStore, create_temporal_store
+from .backends import (
+    TemporalChunk,
+    TemporalFilter,
+    TemporalVectorStore,
+    create_temporal_store,
+    document_denorm_fields,
+)
 
 if TYPE_CHECKING:
     from khora.extraction.chunkers import ChunkStrategy
@@ -465,6 +471,7 @@ class SkeletonConstructionEngine:
                     "start_char": raw_chunk.start_char if hasattr(raw_chunk, "start_char") else 0,
                     "end_char": raw_chunk.end_char if hasattr(raw_chunk, "end_char") else len(raw_chunk.content),
                 },
+                **document_denorm_fields(document),
             )
             temporal_chunks.append(temporal_chunk)
 
@@ -585,7 +592,8 @@ class SkeletonConstructionEngine:
                     **(result.chunk.metadata or {}),
                 },
                 created_at=result.chunk.created_at or result.chunk.occurred_at or datetime.now(UTC),
-                source_timestamp=result.chunk.occurred_at,
+                occurred_at=result.chunk.occurred_at,
+                source_timestamp=result.chunk.source_timestamp,
             )
             chunks_with_scores.append((chunk, result.combined_score or result.similarity))
 
@@ -601,7 +609,7 @@ class SkeletonConstructionEngine:
                 content=chunk.content,
                 score=score,
                 created_at=chunk.created_at,
-                occurred_at=chunk.source_timestamp,
+                occurred_at=(chunk.occurred_at if chunk.occurred_at is not None else chunk.source_timestamp),
                 chunker_info=chunk.chunker_info or {},
             )
             for (chunk, _), score in zip(chunks_with_scores, normalized_chunk_scores, strict=False)
@@ -1030,6 +1038,7 @@ class SkeletonConstructionEngine:
                         "start_char": (raw_chunk.start_char if hasattr(raw_chunk, "start_char") else 0),
                         "end_char": (raw_chunk.end_char if hasattr(raw_chunk, "end_char") else len(raw_chunk.content)),
                     },
+                    **document_denorm_fields(doc),
                 )
                 temporal_chunks.append(temporal_chunk)
 

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -47,7 +47,12 @@ from khora.core.recall_abstention import compute_abstention_signals
 from khora.engines._forget_cascade import cascade_forget_extraction
 from khora.engines._stats import gather_counts
 from khora.engines._storage_config import build_storage_config
-from khora.engines.skeleton.backends import TemporalChunk, TemporalFilter, create_temporal_store
+from khora.engines.skeleton.backends import (
+    TemporalChunk,
+    TemporalFilter,
+    create_temporal_store,
+    document_denorm_fields,
+)
 from khora.engines.skeleton.skeleton import SkeletonIndexer
 from khora.exceptions import EngineCapabilityError
 from khora.extraction.embedders import LiteLLMEmbedder
@@ -1059,6 +1064,7 @@ class VectorCypherEngine:
                                 else len(raw_chunk.content),
                             },
                             chunker_info=dict(raw_chunk.metadata),
+                            **document_denorm_fields(document),
                         )
                         temporal_chunks.append(temporal_chunk)
 
@@ -1685,6 +1691,7 @@ class VectorCypherEngine:
                         "end_char": c.end_char or len(c.content),
                     },
                     chunker_info=dict(c.chunker_info or {}),
+                    **document_denorm_fields(new_document),
                 )
             )
 
@@ -2067,7 +2074,7 @@ class VectorCypherEngine:
                 content=chunk.content,
                 score=score,
                 created_at=chunk.created_at,
-                occurred_at=chunk.source_timestamp,
+                occurred_at=(chunk.occurred_at if chunk.occurred_at is not None else chunk.source_timestamp),
                 chunker_info=chunk.chunker_info or {},
             )
             for chunk, score in validated_chunks
@@ -2750,6 +2757,7 @@ class VectorCypherEngine:
                             else len(raw_chunk.content),
                         },
                         chunker_info=dict(raw_chunk.metadata),
+                        **document_denorm_fields(doc),
                     )
                     all_temporal_chunks.append(tc)
 

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -986,10 +986,12 @@ class VectorCypherRetriever:
                         content=c_data.get("content", ""),
                         metadata={"occurred_at": c_data.get("occurred_at")},
                         chunker_info=_decode_chunker_info(c_data.get("chunker_info")),
-                        # #859: surface persisted occurred_at to the recall
-                        # projection (engine._build_recall_result reads
-                        # chunk.source_timestamp). Neo4j stores occurred_at
-                        # as an ISO-8601 string; coerce to datetime.
+                        # The graph store carries only the chunk event-time;
+                        # surface it as occurred_at so the recall projection
+                        # uses it. Neo4j stores it as an ISO-8601 string;
+                        # coerce to datetime. source_timestamp mirrors it as
+                        # the projection fallback carrier.
+                        occurred_at=_coerce_occurred_at(c_data.get("occurred_at")),
                         source_timestamp=_coerce_occurred_at(c_data.get("occurred_at")),
                     )
                     chunks.append((chunk, rank_score))
@@ -2292,11 +2294,11 @@ class VectorCypherRetriever:
                     },
                     chunker_info=r.chunk.chunker_info or {},
                     created_at=r.chunk.created_at or r.chunk.occurred_at,
-                    # #859: surface persisted occurred_at to the recall
-                    # projection (engine._build_recall_result reads
-                    # chunk.source_timestamp). TemporalChunk.occurred_at
-                    # is already datetime|None.
-                    source_timestamp=r.chunk.occurred_at,
+                    # Carry the chunk event-time and the producer's verbatim
+                    # time as distinct values; the recall projection applies
+                    # the fallback.
+                    occurred_at=r.chunk.occurred_at,
+                    source_timestamp=r.chunk.source_timestamp,
                 )
                 chunk_results.append((chunk, r.combined_score or r.similarity))
 
@@ -2944,11 +2946,13 @@ class VectorCypherRetriever:
                         **(record.get("metadata") or {}),
                     },
                     chunker_info=_decode_chunker_info(record.get("chunker_info")),
-                    # #859: surface persisted occurred_at to the recall
-                    # projection (engine._build_recall_result reads
-                    # chunk.source_timestamp). record["occurred_at"] is
-                    # an ISO-8601 string from Neo4j or a datetime from
-                    # the SurrealDB fallback above (chunk.source_timestamp).
+                    # The graph store carries only the chunk event-time;
+                    # surface it as occurred_at so the recall projection uses
+                    # it. record["occurred_at"] is an ISO-8601 string from
+                    # Neo4j or a datetime from the SurrealDB fallback above.
+                    # source_timestamp mirrors it as the projection fallback
+                    # carrier.
+                    occurred_at=_coerce_occurred_at(record.get("occurred_at")),
                     source_timestamp=_coerce_occurred_at(record.get("occurred_at")),
                 )
                 results.append((chunk_id, score, chunk))
@@ -3012,6 +3016,8 @@ class VectorCypherRetriever:
                         },
                         chunker_info=r.chunk.chunker_info or {},
                         created_at=r.chunk.created_at or r.chunk.occurred_at,
+                        occurred_at=r.chunk.occurred_at,
+                        source_timestamp=r.chunk.source_timestamp,
                     ),
                 )
                 for r in results
@@ -3106,6 +3112,10 @@ class VectorCypherRetriever:
                             },
                             chunker_info=getattr(chunk, "chunker_info", None) or {},
                             created_at=getattr(chunk, "created_at", None) or getattr(chunk, "occurred_at", None),
+                            # Recency channel reads the main chunks table, which
+                            # carries the producer time but no chunk event-time;
+                            # the projection falls back to source_timestamp.
+                            source_timestamp=getattr(chunk, "source_timestamp", None),
                         ),
                     )
                 )

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -1087,7 +1087,7 @@ async def process_document(
                 if temporal_store is not None:
                     from datetime import UTC, datetime
 
-                    from khora.engines.skeleton.backends import TemporalChunk
+                    from khora.engines.skeleton.backends import TemporalChunk, document_denorm_fields
                     from khora.telemetry import trace_span
                     from khora.telemetry.temporal_metrics import record_ingestion_fallback
 
@@ -1147,6 +1147,7 @@ async def process_document(
                                     "token_count": chunk.token_count,
                                     **(chunk.metadata or {}),
                                 },
+                                **document_denorm_fields(document),
                             )
                             for chunk in chunks
                         ]

--- a/src/khora/storage/backends/sqlite_lance/vector.py
+++ b/src/khora/storage/backends/sqlite_lance/vector.py
@@ -323,7 +323,8 @@ class SQLiteLanceVectorAdapter:
             embedding=None,
             embedding_model=str(md.get("embedding_model", "") or ""),
             created_at=_parse_dt(row["created_at"]) or datetime.now(UTC),
-            source_timestamp=_parse_dt(row["occurred_at"]),
+            occurred_at=_parse_dt(row["occurred_at"]),
+            source_timestamp=_parse_dt(row["source_timestamp"]),
             session_id=session_id,
         )
 

--- a/tests/integration/matrix/test_chunk_denormalization_contract.py
+++ b/tests/integration/matrix/test_chunk_denormalization_contract.py
@@ -1,0 +1,386 @@
+"""End-to-end contract for chunk-level denormalized document fields.
+
+This suite pins three guarantees that the chunk-denormalization work must
+hold across the engines that read the temporal-store chunk table
+(``khora_chunks``): VectorCypher (the default engine) and Skeleton.
+
+1. ``occurred_at`` and ``source_timestamp`` stay DISTINCT end-to-end.
+   When a document carries a producer-level ``source_timestamp`` (T_doc)
+   and a chunk-level ``occurred_at`` (T_chunk) that differ, recall must
+   surface the chunk's ``occurred_at`` — never collapse it onto the
+   document's ``source_timestamp``. The collapse is the regression this
+   guards: once the write-path populates the denormalized
+   ``source_timestamp`` column, a read path that prefers it over
+   ``occurred_at`` would silently rewrite every chunk's event time to the
+   document time. This is checked under both VECTOR and KEYWORD recall so
+   the contract holds across retrieval channels.
+
+2. The denormalized document-grained fields are written to the chunk row
+   from the parent ``Document``'s attributes at ingest, so recall filters
+   can hit the chunk row without a document join.
+
+3. With no chunk-level ``occurred_at``, the chunk's event time falls back
+   to the document ``source_timestamp`` and recall surfaces that value —
+   the existing single-timestamp behavior is preserved.
+
+Scope: sqlite_lance only — lightweight, no Docker / Postgres / Neo4j
+required. The embedded ``khora_chunks`` table is created at runtime from
+the same column definition the migration adds on Postgres, so the
+write/read round-trip exercised here matches the production schema.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+try:
+    import aiosqlite  # noqa: F401
+    import lancedb  # noqa: F401
+
+    _HAS_EMBEDDED = True
+except ImportError:
+    _HAS_EMBEDDED = False
+
+from khora.config import KhoraConfig
+from khora.config.schema import SQLiteLanceConfig
+from khora.extraction.extractors.base import ExtractedEntity, ExtractionResult
+from khora.extraction.skills import ExpertiseConfig
+from khora.khora import Khora
+from khora.query import SearchMode
+
+EMBED_DIM = 32
+
+# The denormalized document-grained columns the chunk row carries.
+# ``content_type`` is not settable through the public ``remember`` kwarg
+# surface, so the round-trip test sets it on the ``Document`` directly via
+# metadata pass-through where the engine reads it; the write-path test
+# below asserts the API-settable subset end-to-end and ``content_type``
+# through the document attribute.
+_DENORMALIZED_FIELDS = (
+    "source_type",
+    "source_name",
+    "source_url",
+    "source_timestamp",
+    "external_id",
+    "content_type",
+    "source",
+    "title",
+)
+
+pytestmark = [
+    pytest.mark.embedded,
+    pytest.mark.integration,
+    pytest.mark.skipif(not _HAS_EMBEDDED, reason="aiosqlite/lancedb not installed"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Deterministic embedder + extractor stubs (no OPENAI_API_KEY required)
+# ---------------------------------------------------------------------------
+
+
+def _embed_for(text_in: str) -> list[float]:
+    """SHA-256 -> 32-dim unit vector. Same text yields the same vector."""
+    seed = hashlib.sha256(text_in.encode("utf-8")).digest()
+    raw = [(seed[i % len(seed)] - 128) / 128.0 for i in range(EMBED_DIM)]
+    norm = sum(x * x for x in raw) ** 0.5 or 1.0
+    return [x / norm for x in raw]
+
+
+async def _stub_embed_batch(self: Any, texts: list[str]) -> list[list[float]]:
+    return [_embed_for(t) for t in texts]
+
+
+async def _stub_embed(self: Any, text_in: str) -> list[float]:
+    return _embed_for(text_in)
+
+
+async def _stub_extract_multi(self: Any, texts: list[str], **_kwargs: Any) -> list[ExtractionResult]:
+    out: list[ExtractionResult] = []
+    for t in texts:
+        if "Marie Curie" in t:
+            out.append(
+                ExtractionResult(
+                    entities=[ExtractedEntity(name="Marie Curie", entity_type="PERSON", confidence=0.99)],
+                )
+            )
+        else:
+            out.append(ExtractionResult())
+    return out
+
+
+@pytest.fixture(autouse=True)
+def _patch_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "khora.extraction.embedders.litellm.LiteLLMEmbedder.embed_batch",
+        _stub_embed_batch,
+    )
+    monkeypatch.setattr(
+        "khora.extraction.embedders.litellm.LiteLLMEmbedder.embed",
+        _stub_embed,
+    )
+    monkeypatch.setattr(
+        "khora.extraction.extractors.llm.LLMEntityExtractor.extract_multi",
+        _stub_extract_multi,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-engine Khora fixture (sqlite_lance)
+# ---------------------------------------------------------------------------
+
+
+async def _build_kb(tmp_path: Path, engine: str) -> Khora:
+    config = KhoraConfig()
+    config.storage.backend = "sqlite_lance"
+    config.storage.sqlite_lance = SQLiteLanceConfig(
+        db_path=str(tmp_path / "khora.db"),
+        lance_path=str(tmp_path / "khora.lance"),
+        embedding_dimension=EMBED_DIM,
+    )
+    config.llm.embedding_dimension = EMBED_DIM
+    config.storage.embedding_dimension = EMBED_DIM
+    config.neo4j_url = None
+    config.pipelines.chunk_size = 1024
+    if engine == "vectorcypher":
+        config.pipelines.extract_entities = True
+        config.pipelines.selective_extraction = False
+
+    kb = Khora(config, engine=engine, run_migrations=True)
+    await kb.connect()
+    return kb
+
+
+@pytest.fixture
+async def kb(tmp_path: Path, request: pytest.FixtureRequest) -> AsyncIterator[Khora]:
+    """Per-test Khora bound to a sqlite_lance stack on the requested engine."""
+    engine: str = request.param
+    instance = await _build_kb(tmp_path, engine)
+    try:
+        yield instance
+    finally:
+        try:
+            await instance.disconnect()
+        except Exception:
+            pass
+
+
+def _types_for(engine: str) -> tuple[list[str], list[str]]:
+    """Skeleton refuses non-empty entity/relationship types (no extraction)."""
+    if engine == "skeleton":
+        return [], []
+    return ["PERSON", "CONCEPT"], ["RELATES_TO"]
+
+
+def _as_utc(dt: datetime | None) -> datetime | None:
+    """Treat naive datetimes as UTC — the sqlite round-trip drops tzinfo."""
+    if dt is None:
+        return None
+    return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt
+
+
+def _khora_chunks_rows(db_path: str) -> tuple[list[str], list[sqlite3.Row]]:
+    """Read the raw ``khora_chunks`` table from the embedded SQLite file."""
+    con = sqlite3.connect(db_path)
+    con.row_factory = sqlite3.Row
+    try:
+        cols = [r["name"] for r in con.execute("PRAGMA table_info(khora_chunks)").fetchall()]
+        rows = con.execute("SELECT * FROM khora_chunks").fetchall()
+        return cols, rows
+    finally:
+        con.close()
+
+
+_CONTENT = "Marie Curie won the Nobel Prize in Physics in 1903 for her work on radioactivity."
+
+
+# ---------------------------------------------------------------------------
+# 1. Tripwire: occurred_at and source_timestamp stay distinct end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kb",
+    ["vectorcypher", "skeleton"],
+    indirect=True,
+    ids=["vectorcypher", "skeleton"],
+)
+@pytest.mark.parametrize("mode", [SearchMode.VECTOR, SearchMode.KEYWORD], ids=["vector", "keyword"])
+async def test_recall_occurred_at_does_not_collapse_onto_source_timestamp(kb: Khora, mode: SearchMode) -> None:
+    """A chunk's ``occurred_at`` survives even when it differs from the
+    document ``source_timestamp``.
+
+    The document is ingested with a producer ``source_timestamp`` 100 days
+    old and a chunk-level ``occurred_at`` 10 days old (supplied via
+    ``metadata['occurred_at']``). Recall must return the chunk's
+    ``occurred_at`` (10 days), not the document's ``source_timestamp``
+    (100 days). The VECTOR / KEYWORD parametrization runs the assertion
+    over both the vector dispatch and the full-text / BM25 dispatch so the
+    contract holds regardless of which retrieval channel surfaces a chunk.
+    """
+    ns = await kb.create_namespace()
+    namespace_id: UUID = ns.namespace_id
+
+    t_doc = datetime.now(UTC) - timedelta(days=100)  # document source_timestamp
+    t_chunk = datetime.now(UTC) - timedelta(days=10)  # chunk occurred_at (distinct)
+    assert t_doc != t_chunk
+
+    engine_name: str = kb._engine_name  # type: ignore[attr-defined]
+    entity_types, relationship_types = _types_for(engine_name)
+
+    await kb.remember(
+        content=_CONTENT,
+        namespace=namespace_id,
+        title="curie",
+        source_timestamp=t_doc,
+        metadata={"occurred_at": t_chunk.isoformat()},
+        entity_types=entity_types,
+        relationship_types=relationship_types,
+        expertise=ExpertiseConfig(name=f"denorm-{engine_name}"),
+    )
+
+    result = await kb.recall(
+        "Marie Curie Nobel Prize",
+        namespace=namespace_id,
+        limit=5,
+        mode=mode,
+    )
+
+    assert result.chunks, f"expected at least one chunk back (engine={engine_name}, mode={mode})"
+    occurred_at = _as_utc(result.chunks[0].occurred_at)
+    assert occurred_at is not None, f"chunk.occurred_at is None (engine={engine_name}, mode={mode})"
+
+    # The contract: occurred_at reflects the chunk event time (T_chunk),
+    # NOT the document source_timestamp (T_doc).
+    assert abs((occurred_at - t_chunk).total_seconds()) < 120, (
+        f"RecallChunk.occurred_at={occurred_at!r} should reflect the chunk's "
+        f"occurred_at={t_chunk!r}, not document source_timestamp={t_doc!r} "
+        f"(engine={engine_name}, mode={mode})"
+    )
+    assert abs((occurred_at - t_doc).total_seconds()) > 120, (
+        f"RecallChunk.occurred_at={occurred_at!r} collapsed onto the document "
+        f"source_timestamp={t_doc!r} (engine={engine_name}, mode={mode})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Denormalized fields are written to the chunk row from Document attrs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kb",
+    ["vectorcypher", "skeleton"],
+    indirect=True,
+    ids=["vectorcypher", "skeleton"],
+)
+async def test_denormalized_fields_written_from_document(kb: Khora) -> None:
+    """The chunk row carries the parent document's denormalized fields.
+
+    Ingest a document with the API-settable provenance fields populated,
+    then read the raw ``khora_chunks`` row and assert each denormalized
+    column equals the document attribute it was copied from.
+    """
+    ns = await kb.create_namespace()
+    namespace_id: UUID = ns.namespace_id
+
+    t_doc = datetime.now(UTC) - timedelta(days=42)
+    engine_name: str = kb._engine_name  # type: ignore[attr-defined]
+    entity_types, relationship_types = _types_for(engine_name)
+
+    await kb.remember(
+        content=_CONTENT,
+        namespace=namespace_id,
+        title="Curie Biography",
+        source="library://curie",
+        source_type="article",
+        source_name="wikipedia",
+        source_url="https://en.wikipedia.org/wiki/Marie_Curie",
+        source_timestamp=t_doc,
+        external_id="ext-curie-001",
+        entity_types=entity_types,
+        relationship_types=relationship_types,
+        expertise=ExpertiseConfig(name=f"denorm-{engine_name}"),
+    )
+
+    db_path = str(kb._config.storage.sqlite_lance.db_path)  # type: ignore[attr-defined]
+    cols, rows = _khora_chunks_rows(db_path)
+
+    missing_cols = [f for f in _DENORMALIZED_FIELDS if f not in cols]
+    assert not missing_cols, f"khora_chunks is missing denormalized columns: {missing_cols}"
+    assert rows, "expected at least one khora_chunks row"
+    row = rows[0]
+
+    assert row["source_type"] == "article"
+    assert row["source_name"] == "wikipedia"
+    assert row["source_url"] == "https://en.wikipedia.org/wiki/Marie_Curie"
+    assert row["external_id"] == "ext-curie-001"
+    assert row["source"] == "library://curie"
+    assert row["title"] == "Curie Biography"
+
+    stored_ts = row["source_timestamp"]
+    assert stored_ts is not None, "denormalized source_timestamp not written"
+    parsed = _as_utc(datetime.fromisoformat(str(stored_ts)))
+    assert parsed is not None
+    assert abs((parsed - t_doc).total_seconds()) < 120, (
+        f"denormalized source_timestamp={parsed!r} does not match document source_timestamp={t_doc!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Fallback: no chunk occurred_at -> occurred_at derives from source_timestamp
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kb",
+    ["vectorcypher", "skeleton"],
+    indirect=True,
+    ids=["vectorcypher", "skeleton"],
+)
+async def test_recall_occurred_at_falls_back_to_source_timestamp(kb: Khora) -> None:
+    """With no chunk-level ``occurred_at``, recall surfaces the document
+    ``source_timestamp`` as the chunk event time.
+
+    This preserves the single-timestamp behavior: callers who supply only
+    ``source_timestamp`` still get it back as ``RecallChunk.occurred_at``.
+    """
+    ns = await kb.create_namespace()
+    namespace_id: UUID = ns.namespace_id
+
+    t_doc = datetime.now(UTC) - timedelta(days=30)
+    engine_name: str = kb._engine_name  # type: ignore[attr-defined]
+    entity_types, relationship_types = _types_for(engine_name)
+
+    await kb.remember(
+        content=_CONTENT,
+        namespace=namespace_id,
+        title="curie",
+        source_timestamp=t_doc,
+        # No metadata["occurred_at"] — chunk event time must fall back.
+        entity_types=entity_types,
+        relationship_types=relationship_types,
+        expertise=ExpertiseConfig(name=f"denorm-{engine_name}"),
+    )
+
+    result = await kb.recall(
+        "Marie Curie Nobel Prize",
+        namespace=namespace_id,
+        limit=5,
+    )
+
+    assert result.chunks, f"expected at least one chunk back (engine={engine_name})"
+    occurred_at = _as_utc(result.chunks[0].occurred_at)
+    assert occurred_at is not None, f"chunk.occurred_at is None (engine={engine_name})"
+    assert abs((occurred_at - t_doc).total_seconds()) < 120, (
+        f"RecallChunk.occurred_at={occurred_at!r} did not fall back to the "
+        f"document source_timestamp={t_doc!r} (engine={engine_name})"
+    )

--- a/tests/unit/engines/skeleton/backends/test_pgvector_coverage.py
+++ b/tests/unit/engines/skeleton/backends/test_pgvector_coverage.py
@@ -76,6 +76,14 @@ def _row(**kwargs) -> SimpleNamespace:
         confidence=0.9,
         metadata={"chunk_index": 0},
         chunker_info={},
+        source_type="email",
+        source_name="inbox",
+        source_url="https://example.test/msg/1",
+        source_timestamp=datetime(2024, 1, 3, tzinfo=UTC),
+        external_id="ext-1",
+        content_type="text/plain",
+        source="mailbox",
+        title="Subject line",
     )
     base.update(kwargs)
     return SimpleNamespace(**base)

--- a/tests/unit/engines/skeleton/test_temporal_chunk_adapter.py
+++ b/tests/unit/engines/skeleton/test_temporal_chunk_adapter.py
@@ -9,8 +9,9 @@ adaptation:
 * ``created_at`` (GH #810) — drives temporal-decay reranking
 * ``session_id`` (GH #620) — pulled from ``TemporalChunk.metadata``
 
-``occurred_at`` maps to ``Chunk.source_timestamp`` so temporal boosts
-key on event time rather than ingest time.
+``occurred_at`` (chunk event-time) and ``source_timestamp`` (producer
+verbatim time) are surfaced as distinct fields; the recall projection
+applies the event-time-then-producer-time fallback downstream.
 """
 
 from __future__ import annotations
@@ -53,19 +54,23 @@ def test_preserves_created_at() -> None:
     assert c.created_at == ts
 
 
-def test_maps_occurred_at_to_source_timestamp() -> None:
+def test_surfaces_occurred_at_distinctly() -> None:
+    """The chunk event-time is surfaced on its own field, not collapsed."""
     ts = datetime(2024, 11, 20, 8, 0, tzinfo=UTC)
     c = temporal_chunk_to_chunk(_make_tc(occurred_at=ts))
-    assert c.source_timestamp == ts
+    assert c.occurred_at == ts
+    # No producer value supplied → source_timestamp stays unset; the
+    # event-time-then-producer-time fallback lives in the recall projection.
+    assert c.source_timestamp is None
 
 
 def test_source_timestamp_is_distinct_from_occurred_at() -> None:
-    """The producer ``source_timestamp`` survives as a value of its own.
+    """The producer ``source_timestamp`` and chunk ``occurred_at`` both survive.
 
     Tripwire for date-collapse: when a chunk carries BOTH a chunk event-time
     (``occurred_at``) and a distinct producer time (``source_timestamp``), the
-    adapter must surface the producer value — not silently collapse it onto
-    ``occurred_at``.
+    adapter must surface each as its own value — never collapse one onto the
+    other.
     """
     occurred = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
     produced = datetime(2024, 6, 15, 9, 30, tzinfo=UTC)
@@ -73,15 +78,22 @@ def test_source_timestamp_is_distinct_from_occurred_at() -> None:
 
     c = temporal_chunk_to_chunk(_make_tc(occurred_at=occurred, source_timestamp=produced))
 
+    assert c.occurred_at == occurred
     assert c.source_timestamp == produced
-    assert c.source_timestamp != occurred
+    assert c.source_timestamp != c.occurred_at
 
 
-def test_source_timestamp_falls_back_to_occurred_at_when_absent() -> None:
-    """No producer value → fall back to the chunk event-time."""
+def test_source_timestamp_not_derived_from_occurred_at() -> None:
+    """No producer value → source_timestamp stays None (no adapter fallback).
+
+    The event-time-then-producer-time fallback now lives in the recall
+    projection, so the adapter must not silently derive source_timestamp
+    from the chunk event-time.
+    """
     occurred = datetime(2024, 3, 10, 7, 0, tzinfo=UTC)
     c = temporal_chunk_to_chunk(_make_tc(occurred_at=occurred, source_timestamp=None))
-    assert c.source_timestamp == occurred
+    assert c.occurred_at == occurred
+    assert c.source_timestamp is None
 
 
 def test_source_timestamp_none_when_both_absent() -> None:

--- a/tests/unit/engines/vectorcypher/test_source_timestamp_recall_859.py
+++ b/tests/unit/engines/vectorcypher/test_source_timestamp_recall_859.py
@@ -67,7 +67,8 @@ class TestSimpleRetrieveSourceTimestamp:
 
     async def test_chunk_carries_source_timestamp_from_temporal_chunk(self) -> None:
         """The vector store returns ``TemporalChunk.occurred_at``; it must
-        round-trip onto the constructed ``Chunk.source_timestamp``."""
+        round-trip onto the constructed ``Chunk.occurred_at`` (the chunk
+        event-time), distinct from the producer ``source_timestamp``."""
         retriever = VectorCypherRetriever.__new__(VectorCypherRetriever)
         retriever._config = RetrieverConfig(enable_reranking=False, enable_bm25_channel=False)
         retriever._dual_nodes = None
@@ -115,8 +116,11 @@ class TestSimpleRetrieveSourceTimestamp:
 
         assert len(vc_result.chunks) == 1
         chunk, _score = vc_result.chunks[0]
-        # Before the fix this was None - the bug Damir reported.
-        assert chunk.source_timestamp == T_SOURCE
+        # The persisted chunk event-time round-trips onto Chunk.occurred_at.
+        # No producer value was supplied, so source_timestamp stays None;
+        # the recall projection applies the event-time-then-producer fallback.
+        assert chunk.occurred_at == T_SOURCE
+        assert chunk.source_timestamp is None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_pgvector_row_to_chunk.py
+++ b/tests/unit/test_pgvector_row_to_chunk.py
@@ -34,6 +34,14 @@ def _make_row(embedding=None, tags=None):
         confidence=0.95,
         metadata={"key": "value"},
         chunker_info={},
+        source_type="email",
+        source_name="inbox",
+        source_url="https://example.test/msg/1",
+        source_timestamp=datetime(2024, 6, 16, tzinfo=UTC),
+        external_id="ext-1",
+        content_type="text/plain",
+        source="mailbox",
+        title="Subject line",
     )
 
 


### PR DESCRIPTION
## Summary
- Copy the eight document-grained provenance fields (`source_type`, `source_name`, `source_url`, `source_timestamp`, `external_id`, `content_type`, `source`, `title`) from the typed `Document` onto every persisted chunk at ingest, via a shared `document_denorm_fields()` helper used by the VectorCypher and Skeleton write paths and the ingest pipeline.
- Persist and read these columns on the `pgvector` and `sqlite_lance` temporal backends (the schema columns already landed previously).
- Add `occurred_at` to the public `Chunk` DTO and stop coalescing it with `source_timestamp` in the temporal-chunk adapter, so the producer's verbatim time (`source_timestamp`) and the chunk event-time (`occurred_at`) are carried distinctly end-to-end.
- Build `RecallChunk.occurred_at` from the chunk's own `occurred_at`, falling back to `source_timestamp` only when no chunk-level event-time exists.
- Out of scope (deferred to follow-ups): Neo4j chunk-node properties and the SurrealDB / Weaviate temporal backends; their absence is intentional and the `None`-fallback keeps them functionally safe.

## Test plan
- [x] `ruff check` + `ruff format --check` + `ty check src/` clean
- [x] New contract test asserts `source_timestamp` and `occurred_at` survive ingest→recall as **distinct** values (parametrized over VectorCypher + Skeleton, vector + keyword modes); it fails on the pre-change behavior
- [x] Per-backend write/read-back coverage for the eight columns (pgvector + sqlite_lance)
- [x] Targeted + engine unit tests pass locally (adapter, recall projection, pgvector row mapping)
- [ ] Full PostgreSQL / Neo4j integration matrix — exercised in CI