### PR TITLE
Carry document metadata onto Skeleton chunks and backfill existing chunk metadata

### DIFF
--- a/src/khora/db/migrations/versions/043_khora_chunks_metadata_backfill.py
+++ b/src/khora/db/migrations/versions/043_khora_chunks_metadata_backfill.py
@@ -1,0 +1,213 @@
+"""Backfill khora_chunks.metadata by merging in the parent document's metadata.
+
+Revision ID: 043_khora_chunks_metadata_backfill
+Revises: 042_widen_khora_chunks_source_external_id
+Create Date: 2026-06-05
+
+Data change only — NO schema change. Every existing ``khora_chunks`` row
+gets the parent ``documents.metadata`` JSONB merged into its own
+``metadata``, with the chunk's own keys taking precedence on conflict
+(``d.metadata || c.metadata`` — the right-hand operand wins in Postgres
+JSONB concatenation). New chunks written after this migration already
+carry the merged metadata from the ingest path; this migration only
+catches chunks that predate that behavior.
+
+Merge predicate / idempotency: the UPDATE is guarded by
+``NOT (c.metadata @> d.metadata)`` so a chunk whose metadata already
+contains every parent key/value is skipped. Re-running the migration (or
+re-running within the same transaction) therefore updates zero rows once
+the merge has landed — the operation converges. The ``@>`` containment
+check is conservative: a chunk that overrides a parent key with a
+different value does NOT contain the parent pair, so it is re-visited, but
+the merge is stable (chunk key wins again, producing the identical row),
+so this is correct, just a touch less selective.
+
+Parent filter: only documents with a non-empty ``metadata`` participate
+(``d.metadata IS NOT NULL AND d.metadata <> '{}'::jsonb``). A parent with
+no metadata contributes nothing, so those joins are pruned up front.
+
+Scale (~1M chunk rows): the backfill runs namespace-batched — one UPDATE
+per distinct ``khora_chunks.namespace_id`` — rather than as a single
+table-wide statement. Per-namespace statements take an index scan on the
+``namespace_id`` index instead of a full-table hash join against
+``documents``, keep each statement's working set bounded, and let the
+structured log report progress per namespace. Note the whole Alembic
+chain runs inside ONE transaction (``env.py:do_run_migrations`` wraps
+``context.run_migrations()`` in a single ``context.begin_transaction()``),
+so the row locks taken by each batch are held until the chain commits —
+batching bounds per-statement cost and planning, not lock-hold duration.
+
+Trigger suppression: ``khora_chunks`` carries a ``BEFORE INSERT OR UPDATE``
+trigger (``khora_chunks_content_tsv_update``) that recomputes
+``to_tsvector('english', content)`` on every updated row. This backfill
+touches only ``metadata`` and never ``content``, so re-deriving the
+tsvector for every row would be wasted CPU on a ~1M-row table. The trigger
+is disabled for the duration of the backfill and re-enabled in a
+``finally`` so it is restored on every exit path (success, lock-timeout,
+or any error). ``DISABLE TRIGGER`` / ``ENABLE TRIGGER`` is itself
+transactional, so a rolled-back migration leaves the trigger enabled.
+
+Lock-timeout safety: a Postgres-only ``SET lock_timeout = '5s'`` is issued
+before the trigger toggle so the brief ``ACCESS EXCLUSIVE`` lock that
+``ALTER TABLE ... DISABLE TRIGGER`` acquires, and every row lock the
+UPDATEs take, are bounded. The setting is scoped to the migration's
+enclosing transaction (env.py wraps the whole upgrade in a single
+transaction; the SET expires at COMMIT). On lock-timeout the upgrade logs
+``khora.migration.applied`` at ERROR with ``lock_timeout_tripped=True``
+(detected by the Postgres SQLSTATE ``55P03`` / ``lock_not_available`` on
+``OperationalError.orig.pgcode`` — any other ``OperationalError`` class
+logs ``lock_timeout_tripped=False`` so dashboards don't conflate deadlocks
+/ connection drops with the lock-timeout signal). Either path re-raises so
+Alembic rolls back the transaction.
+
+Runtime-def convergence: ``khora_chunks`` is created at runtime by
+``PgVectorTemporalStore.connect()`` (via ``metadata.create_all``), not by
+the Alembic-managed schema. On fresh deploys and on the sqlite_lance test
+fixture the table doesn't exist when the chain runs; the backfill then has
+nothing to do and the ``has_table`` guard early-returns.
+
+Cross-dialect: this migration is Postgres-only and early-returns on other
+dialects (SQLite). The ``||`` JSONB merge, ``@>`` containment operator,
+and ``DISABLE TRIGGER`` are Postgres-specific; the sqlite_lance fixture
+stack runs the full Alembic chain, so the early-return keeps it green.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from loguru import logger
+from sqlalchemy.exc import OperationalError
+
+revision: str = "043_khora_chunks_metadata_backfill"
+down_revision: str | Sequence[str] | None = "042_widen_khora_chunks_source_external_id"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# PostgreSQL SQLSTATE for "lock_not_available" — what `lock_timeout` raises
+# when an acquisition exceeds the configured timeout.
+_PG_LOCK_NOT_AVAILABLE = "55P03"
+
+# Name of the BEFORE INSERT OR UPDATE trigger on khora_chunks that recomputes
+# content_tsv. Defined at runtime in
+# ``src/khora/engines/skeleton/backends/pgvector.py``.
+_CONTENT_TSV_TRIGGER = "khora_chunks_content_tsv_update"
+
+# Namespace-batched merge: chunk keys win on conflict
+# (``d.metadata || c.metadata`` — right operand wins in JSONB concat). The
+# ``@>`` guard makes the statement a no-op for already-merged rows.
+_MERGE_SQL = sa.text(
+    "UPDATE khora_chunks c "
+    "SET metadata = d.metadata || c.metadata "
+    "FROM documents d "
+    "WHERE c.document_id = d.id "
+    "AND c.namespace_id = :namespace_id "
+    "AND d.metadata IS NOT NULL "
+    "AND d.metadata <> '{}'::jsonb "
+    "AND NOT (c.metadata @> d.metadata)"
+)
+
+
+def _is_postgres() -> bool:
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def _is_lock_timeout(exc: OperationalError) -> bool:
+    """Distinguish a real lock_timeout trip from any other OperationalError.
+
+    OperationalError is a broad SQLAlchemy class — it wraps deadlocks,
+    connection drops, syntax errors, server shutdowns, AND lock_timeout
+    failures. The structured log field ``lock_timeout_tripped`` must
+    only be True for the latter so monitoring dashboards aren't misled.
+    """
+    orig = getattr(exc, "orig", None)
+    if orig is None:
+        return False
+    return getattr(orig, "pgcode", None) == _PG_LOCK_NOT_AVAILABLE
+
+
+def _upgrade_impl() -> tuple[int, int]:
+    """Run the namespace-batched backfill. Returns ``(namespaces, rows)``."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("khora_chunks") or not inspector.has_table("documents"):
+        # ``khora_chunks`` is created at runtime by the vectorcypher
+        # ``PgVectorTemporalStore.connect()`` (via ``metadata.create_all``),
+        # not by the Alembic-managed schema. On fresh deploys and on the
+        # sqlite_lance test fixture one or both tables may not exist when the
+        # chain runs; new chunks already carry merged metadata from the ingest
+        # path, so there is nothing to backfill here.
+        return 0, 0
+
+    # Bound every lock acquisition — the brief ACCESS EXCLUSIVE lock that
+    # ``DISABLE TRIGGER`` takes and the row locks the UPDATEs take — so a stuck
+    # pg_stat_activity entry on khora_chunks cannot stall the deploy past 5s.
+    # Issued before the trigger toggle.
+    op.execute("SET lock_timeout = '5s'")
+
+    # The content_tsv trigger only matters when ``content`` changes; this
+    # backfill touches only ``metadata``, so re-deriving the tsvector for every
+    # updated row is wasted CPU on a ~1M-row table. Disable it for the backfill
+    # and restore it in the ``finally`` on every exit path.
+    op.execute(f"ALTER TABLE khora_chunks DISABLE TRIGGER {_CONTENT_TSV_TRIGGER}")
+    try:
+        namespace_ids = [row[0] for row in bind.execute(sa.text("SELECT DISTINCT namespace_id FROM khora_chunks"))]
+        total_rows = 0
+        for namespace_id in namespace_ids:
+            result = bind.execute(_MERGE_SQL, {"namespace_id": namespace_id})
+            total_rows += int(result.rowcount or 0)
+        return len(namespace_ids), total_rows
+    finally:
+        op.execute(f"ALTER TABLE khora_chunks ENABLE TRIGGER {_CONTENT_TSV_TRIGGER}")
+
+
+def upgrade() -> None:
+    if not _is_postgres():
+        return
+
+    start = time.monotonic()
+    # Initialize log fields up-front so the error path always emits a uniform
+    # event for dashboards / alerts.
+    namespaces_backfilled = 0
+    rows_backfilled = 0
+    try:
+        namespaces_backfilled, rows_backfilled = _upgrade_impl()
+    except OperationalError as exc:
+        duration_ms = int((time.monotonic() - start) * 1000)
+        logger.bind(
+            migration_id=revision,
+            duration_ms=duration_ms,
+            lock_timeout_tripped=_is_lock_timeout(exc),
+            namespaces_backfilled=namespaces_backfilled,
+            rows_backfilled=rows_backfilled,
+        ).error("khora.migration.applied")
+        # Bare ``raise`` re-raises the active exception with the original
+        # traceback preserved. env.py's wrapping context.begin_transaction()
+        # rolls back the UPDATEs from this revision (and the trigger toggle).
+        raise
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+    logger.bind(
+        migration_id=revision,
+        duration_ms=duration_ms,
+        lock_timeout_tripped=False,
+        namespaces_backfilled=namespaces_backfilled,
+        rows_backfilled=rows_backfilled,
+    ).info("khora.migration.applied")
+
+
+def downgrade() -> None:
+    """Irreversible data merge — no-op.
+
+    The upgrade merges parent ``documents.metadata`` into each chunk's
+    ``metadata`` (chunk keys winning). Once merged, the migration cannot
+    distinguish keys that originated on the chunk from keys that were copied
+    down from the parent, so the merge cannot be cleanly un-done. The
+    downgrade is therefore a dialect-gated no-op.
+    """
+    if not _is_postgres():
+        return

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -467,6 +467,7 @@ class SkeletonConstructionEngine:
                 tags=doc_metadata.get("tags", []),
                 confidence=1.0,
                 metadata={
+                    **doc_metadata,
                     "chunk_index": i,
                     "start_char": raw_chunk.start_char if hasattr(raw_chunk, "start_char") else 0,
                     "end_char": raw_chunk.end_char if hasattr(raw_chunk, "end_char") else len(raw_chunk.content),
@@ -1034,6 +1035,7 @@ class SkeletonConstructionEngine:
                     tags=doc_custom.get("tags", []),
                     confidence=1.0,
                     metadata={
+                        **doc_custom,
                         "chunk_index": chunk_idx,
                         "start_char": (raw_chunk.start_char if hasattr(raw_chunk, "start_char") else 0),
                         "end_char": (raw_chunk.end_char if hasattr(raw_chunk, "end_char") else len(raw_chunk.content)),

--- a/tests/integration/db/test_migration_032_dream_runs.py
+++ b/tests/integration/db/test_migration_032_dream_runs.py
@@ -296,7 +296,7 @@ class TestMigration032OnSqlite:
                 async with engine.connect() as conn:
                     # Chain reached head (sanity).
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "042_widen_khora_chunks_source_external_id"
+                    assert result.scalar() == "043_khora_chunks_metadata_backfill"
 
                     # khora_dream_runs exists on SQLite (#896) so dream_history /
                     # dream_status work on the embedded sqlite_lance stack.

--- a/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
+++ b/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
@@ -99,6 +99,7 @@ CREATE TABLE khora_chunks (
     namespace_id UUID NOT NULL,
     document_id UUID NOT NULL,
     content TEXT NOT NULL,
+    metadata JSONB DEFAULT '{}'::jsonb,
     occurred_at TIMESTAMPTZ,
     created_at TIMESTAMPTZ
 )
@@ -276,7 +277,7 @@ class TestMigration041OnPostgres:
                 async with engine.connect() as conn:
                     # Chain reached head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "042_widen_khora_chunks_source_external_id"
+                    assert result.scalar() == "043_khora_chunks_metadata_backfill"
 
                     # The migration did not create the table.
                     result = await conn.execute(
@@ -307,7 +308,7 @@ class TestMigration041OnSqlite:
             try:
                 async with engine.connect() as conn:
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "042_widen_khora_chunks_source_external_id"
+                    assert result.scalar() == "043_khora_chunks_metadata_backfill"
             finally:
                 await engine.dispose()
 

--- a/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
+++ b/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
@@ -67,7 +67,7 @@ pytestmark = pytest.mark.integration
 
 
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
-_HEAD = "042_widen_khora_chunks_source_external_id"
+_HEAD = "043_khora_chunks_metadata_backfill"
 _PREV = "041_khora_chunks_denormalized_columns"
 
 
@@ -92,7 +92,8 @@ CREATE TABLE khora_chunks (
     document_id UUID NOT NULL,
     content TEXT NOT NULL,
     occurred_at TIMESTAMPTZ,
-    created_at TIMESTAMPTZ
+    created_at TIMESTAMPTZ,
+    metadata JSONB DEFAULT '{}'::jsonb
 )
 """
 

--- a/tests/unit/engines/skeleton/test_engine_coverage.py
+++ b/tests/unit/engines/skeleton/test_engine_coverage.py
@@ -160,6 +160,111 @@ class TestProcessDocument:
 
 
 # ---------------------------------------------------------------------------
+# Chunk metadata = document metadata merged with bookkeeping keys
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestChunkMetadataMerge:
+    """Document metadata is spread onto every chunk's ``metadata`` so
+    ``metadata.<path>`` filters can read it back, while the bookkeeping keys
+    (``chunk_index`` / ``start_char`` / ``end_char``) always win on collision."""
+
+    @pytest.mark.asyncio
+    async def test_process_document_merges_doc_metadata(self) -> None:
+        eng = _connected()
+
+        document = MagicMock()
+        document.id = uuid4()
+        document.namespace_id = uuid4()
+        document.content = "lorem ipsum"
+        # Real dict so the {**doc_metadata, ...} spread carries the keys; a
+        # colliding ``chunk_index`` proves the bookkeeping key wins.
+        document.metadata = {"tag": "release", "source_name": "linear", "chunk_index": 999}
+        document.mark_completed = MagicMock()
+
+        raw = SimpleNamespace(content="chunk text", start_char=3, end_char=13)
+        mock_chunker = MagicMock()
+        mock_chunker.chunk.return_value = [raw]
+
+        eng._embedder.embed_batch = AsyncMock(return_value=[[0.1, 0.2]])
+        eng._temporal_store.create_chunks_batch = AsyncMock(return_value=[object()])
+
+        with patch(
+            "khora.extraction.chunkers.create_chunker",
+            return_value=mock_chunker,
+        ):
+            await eng._process_document(
+                document,
+                skill_name="general",
+                occurred_at=datetime(2024, 1, 1, tzinfo=UTC),
+            )
+
+        sent_chunks = eng._temporal_store.create_chunks_batch.call_args[0][0]
+        assert len(sent_chunks) == 1
+        md = sent_chunks[0].metadata
+        # Document keys propagated.
+        assert md["tag"] == "release"
+        assert md["source_name"] == "linear"
+        # Bookkeeping keys present and authoritative — the doc's colliding
+        # chunk_index=999 must NOT survive.
+        assert md["chunk_index"] == 0
+        assert md["start_char"] == 3
+        assert md["end_char"] == 13
+
+    @pytest.mark.asyncio
+    async def test_remember_batch_merges_doc_metadata(self) -> None:
+        eng = _connected()
+        eng._storage.get_documents_by_checksums = AsyncMock(return_value={})
+
+        ns = uuid4()
+
+        def _make_doc(content: str) -> MagicMock:
+            doc = MagicMock()
+            doc.id = uuid4()
+            doc.namespace_id = ns
+            doc.content = content
+            doc.mark_completed = MagicMock()
+            return doc
+
+        eng._storage.create_document = AsyncMock(side_effect=lambda d: _make_doc(d.content))
+        eng._storage.update_document = AsyncMock()
+
+        raw = SimpleNamespace(content="chunk text", start_char=3, end_char=13)
+        mock_chunker = MagicMock()
+        mock_chunker.chunk.return_value = [raw]
+        eng._embedder.embed_batch = AsyncMock(return_value=[[0.1, 0.2]])
+        eng._temporal_store.create_chunks_batch = AsyncMock(return_value=[object()])
+
+        with patch("khora.extraction.chunkers.create_chunker", return_value=mock_chunker):
+            await eng.remember_batch(
+                [
+                    {
+                        "content": "a",
+                        "metadata": {
+                            "tag": "release",
+                            "source_name": "linear",
+                            "chunk_index": 999,
+                        },
+                    }
+                ],
+                ns,
+                entity_types=[],
+                relationship_types=[],
+            )
+
+        sent_chunks = eng._temporal_store.create_chunks_batch.call_args[0][0]
+        assert len(sent_chunks) == 1
+        md = sent_chunks[0].metadata
+        assert md["tag"] == "release"
+        assert md["source_name"] == "linear"
+        # Real chunk_index wins over the colliding doc-metadata value.
+        assert md["chunk_index"] == 0
+        assert md["start_char"] == 3
+        assert md["end_char"] == 13
+
+
+# ---------------------------------------------------------------------------
 # remember_batch() — empty + all-skipped
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -442,14 +442,14 @@ class TestMigrationPackageStructure:
         assert env_path.exists(), f"env.py not found at {env_path}"
 
     @pytest.mark.unit
-    def test_versions_dir_has_43_files(self):
-        """versions/ directory contains 43 migration files."""
+    def test_versions_dir_has_44_files(self):
+        """versions/ directory contains 44 migration files."""
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
         # Filter out __pycache__ and __init__
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
-        assert len(migration_files) == 43, (
-            f"Expected 43 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
+        assert len(migration_files) == 44, (
+            f"Expected 44 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
         )
 
     @pytest.mark.unit

--- a/tests/unit/test_sqlite_migrations.py
+++ b/tests/unit/test_sqlite_migrations.py
@@ -82,7 +82,7 @@ class TestSqliteMigrations:
                     # Version table must point at head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
                     version = result.scalar()
-                    assert version == "042_widen_khora_chunks_source_external_id"
+                    assert version == "043_khora_chunks_metadata_backfill"
             finally:
                 await engine.dispose()
 


### PR DESCRIPTION
## Summary
- Skeleton ingest now spreads the parent document's free-form `metadata` onto each chunk's `metadata` dict, with chunk bookkeeping keys (`chunk_index`/`start_char`/`end_char`) still taking precedence on collision. This mirrors the VectorCypher engine and lets `metadata.<path>` recall filters match on the Skeleton-pgvector backend (previously they matched nothing because Skeleton chunks only carried bookkeeping keys).
- Both ingest paths are patched: single-document (`_process_document`) and batch (`remember_batch`).
- New Postgres-only Alembic migration backfills existing `khora_chunks` rows by merging `documents.metadata` into each chunk's `metadata` (chunk keys win, matching the ingest order). The merge is idempotent via a JSONB containment guard (`NOT (c.metadata @> d.metadata)`), namespace-batched to bound per-statement cost, and disables the `content_tsv` trigger for the duration (the update never touches `content`, so re-deriving the tsvector would be wasted work). Lock-timeout-bounded with structured progress logging, dialect-gated (no-op on SQLite), and a documented irreversible no-op downgrade.
- The migration scopes strictly to the `metadata` JSONB column — no schema/column/index changes.

## Test plan
- [x] Unit tests pass (new `TestChunkMetadataMerge` covers both ingest paths and the bookkeeping-key collision case; migration-chain head pins updated; single Alembic head verified)
- [x] Lint + format clean (`ruff check`, `ruff format --check`)
- [ ] Full integration/e2e suite + Postgres migration run — gated by CI (requires Docker + optional extras not available in the authoring sandbox)