### PR TITLE
Widen khora_chunks source and external_id columns to documents widths

### DIFF
--- a/src/khora/db/migrations/versions/042_widen_khora_chunks_source_external_id.py
+++ b/src/khora/db/migrations/versions/042_widen_khora_chunks_source_external_id.py
@@ -1,0 +1,204 @@
+"""Widen two denormalized ``khora_chunks`` columns to match their source widths.
+
+Revision ID: 042_widen_khora_chunks_source_external_id
+Revises: 041_khora_chunks_denormalized_columns
+Create Date: 2026-06-05
+
+Schema changes:
+
+* ``khora_chunks.source`` ``VARCHAR(255)`` -> ``TEXT``
+* ``khora_chunks.external_id`` ``VARCHAR(255)`` -> ``VARCHAR(512)``
+
+Both columns were added (empty, no backfill) by the immediately preceding
+migration 041. An upcoming write-path change plus a one-shot backfill will
+copy these two fields down from the parent ``documents`` table, whose source
+columns are wider than the 255-char placeholder 041 used:
+
+  - ``documents.source`` is ``VARCHAR(1024)`` -> chunk side widened to ``TEXT``
+    (``TEXT`` >= 1024, so no value can truncate).
+  - ``documents.external_id`` is ``VARCHAR(512)`` -> chunk side widened to the
+    matching ``VARCHAR(512)``.
+
+Without this widening the backfill ``UPDATE khora_chunks ... FROM documents``
+would raise ``StringDataRightTruncation`` on long values. The columns are
+EMPTY today, so widening a ``varchar`` (and ``varchar`` -> ``text``) is a pure
+catalog change in Postgres -- no table rewrite, instant on any table size,
+zero risk.
+
+Lock-timeout safety: a Postgres-only ``SET lock_timeout = '5s'`` is issued
+**before any DDL** so the ``ALTER COLUMN`` AccessExclusiveLock acquisition is
+bounded, mirroring migration 041. The setting is scoped to the migration's
+enclosing transaction (env.py wraps the whole upgrade in a single
+transaction; the SET expires at COMMIT). On lock-timeout the upgrade logs
+``khora.migration.applied`` at ERROR with ``lock_timeout_tripped=True``
+(detected via the Postgres SQLSTATE ``55P03`` / ``lock_not_available`` on
+``OperationalError.orig.pgcode``); any other ``OperationalError`` logs
+``lock_timeout_tripped=False`` so dashboards don't conflate deadlocks /
+connection drops with the lock-timeout signal. Either path re-raises so
+Alembic rolls back the transaction.
+
+Cross-dialect: this migration is Postgres-only and early-returns on other
+dialects (SQLite). The sqlite_lance fixture stack runs the full Alembic
+chain, so the early-return keeps it green; on SQLite the columns come from
+the runtime ``khora_chunks_table`` definition (which carries the correct
+widened types), not Alembic.
+
+Runtime-def convergence: ``khora_chunks`` is created at runtime by
+``PgVectorTemporalStore.connect()`` (via ``metadata.create_all``) and is not
+part of the Alembic-managed schema, so the migration is guarded by
+``has_table("khora_chunks")`` and exists only for existing deployments where
+the table predates this widening. Fresh deploys pick up the widened types
+straight from the runtime table definition.
+
+Downgrade narrowing-truncation guard: narrowing ``source`` back to
+``VARCHAR(255)`` and ``external_id`` to ``VARCHAR(255)`` would truncate any
+value longer than 255 chars (which only exists after the backfill runs).
+``downgrade`` first probes for such a row and, if one is found, SKIPS the
+narrowing as a no-op and logs a WARNING rather than silently destroying data.
+NULLs are safe -- ``length(NULL)`` is NULL, never > 255.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from loguru import logger
+from sqlalchemy.exc import OperationalError
+
+revision: str = "042_widen_khora_chunks_source_external_id"
+down_revision: str | Sequence[str] | None = "041_khora_chunks_denormalized_columns"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# PostgreSQL SQLSTATE for "lock_not_available" -- what `lock_timeout` raises
+# when an acquisition exceeds the configured timeout.
+_PG_LOCK_NOT_AVAILABLE = "55P03"
+
+
+def _is_postgres() -> bool:
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def _is_lock_timeout(exc: OperationalError) -> bool:
+    """Distinguish a real lock_timeout trip from any other OperationalError.
+
+    OperationalError is a broad SQLAlchemy class -- it wraps deadlocks,
+    connection drops, syntax errors, server shutdowns, AND lock_timeout
+    failures. The structured log field ``lock_timeout_tripped`` must only be
+    True for the latter so monitoring dashboards aren't misled.
+    """
+    orig = getattr(exc, "orig", None)
+    if orig is None:
+        return False
+    return getattr(orig, "pgcode", None) == _PG_LOCK_NOT_AVAILABLE
+
+
+def _upgrade_impl() -> None:
+    """Perform the schema change."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("khora_chunks"):
+        # ``khora_chunks`` is created at runtime by the vectorcypher
+        # ``PgVectorTemporalStore.connect()`` (via ``metadata.create_all``)
+        # and is not part of the Alembic-managed schema. On fresh deploys and
+        # on the sqlite_lance test fixture the table doesn't exist when the
+        # chain runs; in that case the widened types land when the runtime
+        # creates the table from the updated ``khora_chunks_table``
+        # definition. The migration is still required for existing
+        # deployments where ``khora_chunks`` was created with the narrower
+        # placeholder widths from migration 041.
+        return
+
+    # Bound the ALTER COLUMN AccessExclusiveLock acquisition -- a stuck
+    # pg_stat_activity entry on khora_chunks cannot stall the deploy past
+    # 5 seconds. Issued before any DDL. Both columns are empty today, so
+    # widening varchar (and varchar -> text) is an instant catalog change
+    # with no table rewrite.
+    op.execute("SET lock_timeout = '5s'")
+
+    op.alter_column(
+        "khora_chunks",
+        "source",
+        existing_type=sa.String(255),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "khora_chunks",
+        "external_id",
+        existing_type=sa.String(255),
+        type_=sa.String(512),
+        existing_nullable=True,
+    )
+
+
+def upgrade() -> None:
+    if not _is_postgres():
+        return
+
+    start = time.monotonic()
+    try:
+        _upgrade_impl()
+    except OperationalError as exc:
+        duration_ms = int((time.monotonic() - start) * 1000)
+        logger.bind(
+            migration_id=revision,
+            duration_ms=duration_ms,
+            lock_timeout_tripped=_is_lock_timeout(exc),
+        ).error("khora.migration.applied")
+        # Bare ``raise`` re-raises the active exception with the original
+        # traceback preserved. env.py's wrapping context.begin_transaction()
+        # rolls back all DDL from this revision.
+        raise
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+    logger.bind(
+        migration_id=revision,
+        duration_ms=duration_ms,
+        lock_timeout_tripped=False,
+    ).info("khora.migration.applied")
+
+
+def downgrade() -> None:
+    if not _is_postgres():
+        return
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("khora_chunks"):
+        return
+
+    # Narrowing back to VARCHAR(255) would truncate any value longer than 255
+    # chars (which can only exist once the backfill has run). Probe for such a
+    # row first; if one is found, skip the narrowing rather than destroy data.
+    # NULLs are safe -- length(NULL) is NULL, never > 255.
+    has_long_value = (
+        bind.execute(
+            sa.text("SELECT 1 FROM khora_chunks WHERE length(source) > 255 OR length(external_id) > 255 LIMIT 1")
+        ).first()
+        is not None
+    )
+    if has_long_value:
+        logger.bind(migration_id=revision).warning(
+            "khora.migration.downgrade_skipped: khora_chunks has source/external_id "
+            "values longer than 255 chars; skipping narrowing to avoid truncation"
+        )
+        return
+
+    op.alter_column(
+        "khora_chunks",
+        "external_id",
+        existing_type=sa.String(512),
+        type_=sa.String(255),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "khora_chunks",
+        "source",
+        existing_type=sa.Text(),
+        type_=sa.String(255),
+        existing_nullable=True,
+    )

--- a/src/khora/engines/skeleton/backends/pgvector.py
+++ b/src/khora/engines/skeleton/backends/pgvector.py
@@ -80,9 +80,9 @@ khora_chunks_table = Table(
     Column("source_name", String(255), nullable=True),
     Column("source_url", Text, nullable=True),
     Column("source_timestamp", DateTime(timezone=True), nullable=True),
-    Column("external_id", String(255), nullable=True),
+    Column("external_id", String(512), nullable=True),
     Column("content_type", String(128), nullable=True),
-    Column("source", String(255), nullable=True),
+    Column("source", Text, nullable=True),
     Column("title", Text, nullable=True),
     # Full-text search
     Column("content_tsv", TSVECTOR, nullable=True),

--- a/tests/integration/db/test_migration_032_dream_runs.py
+++ b/tests/integration/db/test_migration_032_dream_runs.py
@@ -296,7 +296,7 @@ class TestMigration032OnSqlite:
                 async with engine.connect() as conn:
                     # Chain reached head (sanity).
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "041_khora_chunks_denormalized_columns"
+                    assert result.scalar() == "042_widen_khora_chunks_source_external_id"
 
                     # khora_dream_runs exists on SQLite (#896) so dream_history /
                     # dream_status work on the embedded sqlite_lance stack.

--- a/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
+++ b/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
@@ -135,8 +135,8 @@ def pg_url() -> Iterator[str]:
                     await conn.execute(
                         sa.text(
                             "UPDATE khora_alembic_version SET version_num = "
-                            "'040_chunks_last_accessed_at' WHERE version_num = "
-                            "'041_khora_chunks_denormalized_columns'"
+                            "'040_chunks_last_accessed_at' WHERE version_num != "
+                            "'040_chunks_last_accessed_at'"
                         )
                     )
         finally:
@@ -205,16 +205,18 @@ class TestMigration041OnPostgres:
                         assert cols[name][1] == "YES", f"{name} should be nullable"
                         assert cols[name][2] is None, f"{name} should have no default"
 
-                    # Load-bearing types: source_timestamp is timestamptz,
-                    # source_url / title are text, the rest are varchar.
+                    # Load-bearing types after the chain reaches head:
+                    # source_timestamp is timestamptz; source_url / title / source
+                    # are text (migration 042 widens source varchar -> text); the
+                    # rest are varchar.
                     assert cols["source_timestamp"][0] == "timestamp with time zone"
                     assert cols["source_url"][0] == "text"
                     assert cols["title"][0] == "text"
+                    assert cols["source"][0] == "text"
                     assert cols["source_type"][0] == "character varying"
                     assert cols["source_name"][0] == "character varying"
                     assert cols["external_id"][0] == "character varying"
                     assert cols["content_type"][0] == "character varying"
-                    assert cols["source"][0] == "character varying"
             finally:
                 await engine.dispose()
 
@@ -274,7 +276,7 @@ class TestMigration041OnPostgres:
                 async with engine.connect() as conn:
                     # Chain reached head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "041_khora_chunks_denormalized_columns"
+                    assert result.scalar() == "042_widen_khora_chunks_source_external_id"
 
                     # The migration did not create the table.
                     result = await conn.execute(
@@ -296,7 +298,7 @@ class TestMigration041OnPostgres:
 
 class TestMigration041OnSqlite:
     def test_chain_reaches_head_on_sqlite(self, sqlite_url: str) -> None:
-        """Migration 041 is a clean no-op on SQLite; chain reaches head 041."""
+        """Migration 041 is a clean no-op on SQLite; chain reaches head."""
         cfg = _make_config(sqlite_url)
         command.upgrade(cfg, "head")
 
@@ -305,7 +307,7 @@ class TestMigration041OnSqlite:
             try:
                 async with engine.connect() as conn:
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "041_khora_chunks_denormalized_columns"
+                    assert result.scalar() == "042_widen_khora_chunks_source_external_id"
             finally:
                 await engine.dispose()
 

--- a/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
+++ b/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
@@ -1,0 +1,309 @@
+"""Coverage for migration ``042_widen_khora_chunks_source_external_id``.
+
+The migration widens two denormalized columns on the runtime-managed
+``khora_chunks`` table so an upcoming backfill copying values down from the
+parent ``documents`` table cannot truncate:
+
+    source       VARCHAR(255) -> TEXT
+    external_id  VARCHAR(255) -> VARCHAR(512)
+
+``khora_chunks`` is NOT part of the Alembic-managed schema -- it is created at
+runtime by ``PgVectorTemporalStore.connect()``. The migration is therefore
+guarded by ``has_table("khora_chunks")`` and exists only for existing
+deployments where the table predates this widening. These tests cover:
+
+1. Postgres upgrade: seed a legacy ``khora_chunks`` (no denormalized columns),
+   run the chain to head, and assert ``source`` is ``text`` and ``external_id``
+   is ``character varying(512)`` (041 first adds them at 255, 042 widens).
+2. Postgres clean downgrade: with no over-length values, ``downgrade`` back to
+   041 narrows both columns to ``character varying(255)``.
+3. Postgres guarded downgrade: with a ``source`` value longer than 255 chars,
+   ``downgrade`` SKIPS the narrowing (no-op) so the over-length data is not
+   truncated; the columns stay wide.
+4. Postgres missing-table path: on a fresh DB where ``khora_chunks`` does not
+   exist, the migration early-returns (``has_table`` guard) and the chain still
+   reaches head.
+5. SQLite: the migration is Postgres-only and early-returns; the full chain
+   reaches head cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+from collections.abc import Iterator
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+from sqlalchemy.ext.asyncio import create_async_engine
+
+DATABASE_URL = os.environ.get(
+    "KHORA_DATABASE_URL",
+    "postgresql+asyncpg://khora:khora@localhost:5434/khora",
+)
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
+
+
+def _pg_reachable() -> bool:
+    parsed = urlparse(DATABASE_URL.replace("+asyncpg", ""))
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+pytestmark = pytest.mark.integration
+
+
+_MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
+_HEAD = "042_widen_khora_chunks_source_external_id"
+_PREV = "041_khora_chunks_denormalized_columns"
+
+
+def _make_config(url: str) -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", str(_MIGRATIONS_DIR))
+    # Alembic uses configparser.BasicInterpolation; escape any literal '%' in
+    # the URL so it isn't read as a config-interpolation token.
+    cfg.set_main_option("sqlalchemy.url", url.replace("%", "%%"))
+    cfg.attributes["database_url"] = url
+    return cfg
+
+
+# A pre-migration ``khora_chunks`` table: the identity/temporal columns the
+# runtime always created, but WITHOUT the eight denormalized columns. Creating
+# this before upgrade lets migration 041 add ``source`` / ``external_id`` at the
+# narrow 255 width, which 042 then widens.
+_LEGACY_KHORA_CHUNKS_DDL = """
+CREATE TABLE khora_chunks (
+    id UUID PRIMARY KEY,
+    namespace_id UUID NOT NULL,
+    document_id UUID NOT NULL,
+    content TEXT NOT NULL,
+    occurred_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ
+)
+"""
+
+
+async def _seed_legacy_table_at_baseline(url: str) -> None:
+    """Drop ``khora_chunks``, recreate it legacy-shaped, step version to 040."""
+    engine = create_async_engine(url, isolation_level="AUTOCOMMIT")
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(sa.text("DROP TABLE IF EXISTS khora_chunks CASCADE"))
+            await conn.execute(sa.text(_LEGACY_KHORA_CHUNKS_DDL))
+            await conn.execute(sa.text("UPDATE khora_alembic_version SET version_num = '040_chunks_last_accessed_at'"))
+    finally:
+        await engine.dispose()
+
+
+async def _source_external_id_widths(url: str) -> dict[str, tuple[str, int | None]]:
+    """Return {column_name: (data_type, character_maximum_length)} for the two cols."""
+    engine = create_async_engine(url)
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(
+                sa.text(
+                    "SELECT column_name, data_type, character_maximum_length "
+                    "FROM information_schema.columns "
+                    "WHERE table_name = 'khora_chunks' "
+                    "AND column_name IN ('source', 'external_id')"
+                )
+            )
+            return {row[0]: (row[1], row[2]) for row in result}
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+def pg_url() -> Iterator[str]:
+    """Yield the base Postgres URL.
+
+    Resets the Alembic head back to ``040`` and drops ``khora_chunks`` on setup
+    and teardown so the migration-test files can run in arbitrary order against
+    shared PostgreSQL without leaking state. The version-table walk-back is
+    guarded on table existence so the fixture is also safe on a never-migrated
+    DB (the version table is created by the first ``command.upgrade``).
+    """
+    if not _pg_reachable():
+        pytest.skip("PostgreSQL not reachable (run `make dev` first)")
+
+    async def _reset() -> None:
+        admin = create_async_engine(DATABASE_URL, isolation_level="AUTOCOMMIT")
+        try:
+            async with admin.connect() as conn:
+                await conn.execute(sa.text("DROP TABLE IF EXISTS khora_chunks CASCADE"))
+                table_exists = await conn.execute(
+                    sa.text(
+                        "SELECT EXISTS(SELECT 1 FROM information_schema.tables "
+                        "WHERE table_name = 'khora_alembic_version')"
+                    )
+                )
+                if table_exists.scalar():
+                    await conn.execute(
+                        sa.text(
+                            "UPDATE khora_alembic_version SET version_num = "
+                            "'040_chunks_last_accessed_at' WHERE version_num != "
+                            "'040_chunks_last_accessed_at'"
+                        )
+                    )
+        finally:
+            await admin.dispose()
+
+    asyncio.run(_reset())
+    try:
+        yield DATABASE_URL
+    finally:
+        asyncio.run(_reset())
+
+
+@pytest.fixture
+def sqlite_url(tmp_path: Path) -> str:
+    return f"sqlite+aiosqlite:///{tmp_path / 'test.db'}"
+
+
+# ---------------------------------------------------------------------------
+# Postgres
+# ---------------------------------------------------------------------------
+
+
+class TestMigration042OnPostgres:
+    def test_upgrade_widens_source_and_external_id(self, pg_url: str) -> None:
+        """Chain to head: ``source`` becomes TEXT, ``external_id`` becomes VARCHAR(512)."""
+        cfg = _make_config(pg_url)
+        command.upgrade(cfg, "head")  # bring the chain to head first
+
+        asyncio.run(_seed_legacy_table_at_baseline(pg_url))
+
+        # Re-run: 041 adds source/external_id at 255, then 042 widens them.
+        command.upgrade(cfg, "head")
+
+        widths = asyncio.run(_source_external_id_widths(pg_url))
+        # source: varchar -> text (unbounded; no character_maximum_length).
+        assert widths["source"][0] == "text"
+        assert widths["source"][1] is None
+        # external_id: varchar(255) -> varchar(512).
+        assert widths["external_id"][0] == "character varying"
+        assert widths["external_id"][1] == 512
+
+    def test_clean_downgrade_narrows_both_columns(self, pg_url: str) -> None:
+        """With no over-length values, downgrade narrows both back to VARCHAR(255)."""
+        cfg = _make_config(pg_url)
+        command.upgrade(cfg, "head")
+        asyncio.run(_seed_legacy_table_at_baseline(pg_url))
+        command.upgrade(cfg, "head")
+
+        command.downgrade(cfg, _PREV)
+
+        widths = asyncio.run(_source_external_id_widths(pg_url))
+        assert widths["source"][0] == "character varying"
+        assert widths["source"][1] == 255
+        assert widths["external_id"][0] == "character varying"
+        assert widths["external_id"][1] == 255
+
+    def test_guarded_downgrade_skips_when_value_would_truncate(self, pg_url: str) -> None:
+        """An over-length ``source`` value makes downgrade skip the narrowing."""
+        cfg = _make_config(pg_url)
+        command.upgrade(cfg, "head")
+        asyncio.run(_seed_legacy_table_at_baseline(pg_url))
+        command.upgrade(cfg, "head")  # widened: source TEXT, external_id VARCHAR(512)
+
+        async def _insert_long_source() -> None:
+            engine = create_async_engine(pg_url, isolation_level="AUTOCOMMIT")
+            try:
+                async with engine.connect() as conn:
+                    await conn.execute(
+                        sa.text(
+                            "INSERT INTO khora_chunks (id, namespace_id, document_id, content, source) "
+                            "VALUES (gen_random_uuid(), gen_random_uuid(), gen_random_uuid(), 'x', :s)"
+                        ),
+                        {"s": "a" * 300},
+                    )
+            finally:
+                await engine.dispose()
+
+        asyncio.run(_insert_long_source())
+
+        # Downgrade must NOT raise and must NOT truncate -- it skips the narrowing.
+        command.downgrade(cfg, _PREV)
+
+        widths = asyncio.run(_source_external_id_widths(pg_url))
+        # Columns stay wide because narrowing was skipped to avoid truncation.
+        assert widths["source"][0] == "text"
+        assert widths["external_id"][1] == 512
+
+    def test_no_op_when_table_absent(self, pg_url: str) -> None:
+        """Fresh DB with no ``khora_chunks``: chain reaches head, no error."""
+        cfg = _make_config(pg_url)
+        # pg_url fixture already dropped khora_chunks; just upgrade.
+        command.upgrade(cfg, "head")
+
+        async def check() -> None:
+            engine = create_async_engine(pg_url)
+            try:
+                async with engine.connect() as conn:
+                    result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
+                    assert result.scalar() == _HEAD
+
+                    result = await conn.execute(
+                        sa.text(
+                            "SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name = 'khora_chunks')"
+                        )
+                    )
+                    assert result.scalar() is False
+            finally:
+                await engine.dispose()
+
+        asyncio.run(check())
+
+
+# ---------------------------------------------------------------------------
+# SQLite — Postgres-only migration must early-return and stay green
+# ---------------------------------------------------------------------------
+
+
+class TestMigration042OnSqlite:
+    def test_chain_reaches_head_on_sqlite(self, sqlite_url: str) -> None:
+        """Migration 042 is a clean no-op on SQLite; chain reaches head."""
+        cfg = _make_config(sqlite_url)
+        command.upgrade(cfg, "head")
+
+        async def check() -> None:
+            engine = create_async_engine(sqlite_url)
+            try:
+                async with engine.connect() as conn:
+                    result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
+                    assert result.scalar() == _HEAD
+            finally:
+                await engine.dispose()
+
+        asyncio.run(check())
+
+    def test_downgrade_is_clean_on_sqlite(self, sqlite_url: str) -> None:
+        """upgrade head -> downgrade to 041 is a clean no-op on SQLite."""
+        cfg = _make_config(sqlite_url)
+        command.upgrade(cfg, "head")
+        command.downgrade(cfg, _PREV)
+
+        async def check() -> None:
+            engine = create_async_engine(sqlite_url)
+            try:
+                async with engine.connect() as conn:
+                    result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
+                    assert result.scalar() == _PREV
+            finally:
+                await engine.dispose()
+
+        asyncio.run(check())

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -442,14 +442,14 @@ class TestMigrationPackageStructure:
         assert env_path.exists(), f"env.py not found at {env_path}"
 
     @pytest.mark.unit
-    def test_versions_dir_has_42_files(self):
-        """versions/ directory contains 42 migration files."""
+    def test_versions_dir_has_43_files(self):
+        """versions/ directory contains 43 migration files."""
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
         # Filter out __pycache__ and __init__
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
-        assert len(migration_files) == 42, (
-            f"Expected 42 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
+        assert len(migration_files) == 43, (
+            f"Expected 43 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
         )
 
     @pytest.mark.unit

--- a/tests/unit/test_sqlite_migrations.py
+++ b/tests/unit/test_sqlite_migrations.py
@@ -82,7 +82,7 @@ class TestSqliteMigrations:
                     # Version table must point at head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
                     version = result.scalar()
-                    assert version == "041_khora_chunks_denormalized_columns"
+                    assert version == "042_widen_khora_chunks_source_external_id"
             finally:
                 await engine.dispose()
 


### PR DESCRIPTION
## Summary
- The denormalized `source` and `external_id` columns on `khora_chunks` were introduced one `varchar(255)` narrower than their parent `documents` columns (`documents.source` is `varchar(1024)`, `documents.external_id` is `varchar(512)`). An upcoming write-path change and one-shot backfill copy these fields down from `documents`, which would raise `StringDataRightTruncation` on long values.
- Add a Postgres-only catalog migration that widens `khora_chunks.source` → `TEXT` and `khora_chunks.external_id` → `VARCHAR(512)`. Both columns are empty today, so this is a no-rewrite catalog change (instant on any table size). It mirrors the preceding migration's guards: dialect-gated to Postgres, `has_table` guard, `lock_timeout` set before DDL, and structured apply-logging.
- `downgrade` is NULL-safe and guards against narrowing-truncation: it probes for any value longer than 255 chars and skips the narrowing (logging a warning) rather than destroying data.
- Update the runtime `khora_chunks_table` definition so fresh deploys and the embedded SQLite fixture get the correct widths directly.
- Bump the affected migration head-pin and versions-directory file-count test assertions to account for the new revision.

## Test plan
- [x] Unit tests pass (migration bundling/file-count, SQLite migration head-pin, migration drift/contiguity)
- [x] Integration tests pass: new migration test covers upgrade widths (via `information_schema`), a clean downgrade, a guarded downgrade that inserts an over-length value and asserts the narrowing is skipped, the table-absent no-op, and the SQLite early-return
- [x] `make format` clean; `make lint` passes
- [x] Single Alembic head; chain remains linear