### PR TITLE
Add internal filter AST and compiler-dispatch infrastructure

### DIFF
--- a/src/khora/filter/__init__.py
+++ b/src/khora/filter/__init__.py
@@ -12,6 +12,37 @@ error's structured ``errors`` list, but is not part of the public ``__all__``.
 
 from __future__ import annotations
 
+# Internal compilation seam (the AST + compiler layers). These are reachable as
+# ``khora.filter.X`` for khora's own engines/compilers, but are deliberately NOT
+# in ``__all__`` and NOT re-exported from ``khora.__init__`` — promoting them to
+# a public plugin seam is deferred to a future improvement.
+from khora.filter.ast import (  # noqa: F401
+    DateLiteral as DateLiteral,
+)
+from khora.filter.ast import (
+    FilterClause as FilterClause,
+)
+from khora.filter.ast import (
+    FilterNode as FilterNode,
+)
+from khora.filter.ast import (
+    FilterOp as FilterOp,
+)
+from khora.filter.ast import (
+    canonical_hash as canonical_hash,
+)
+from khora.filter.ast import (
+    parse_to_ast as parse_to_ast,
+)
+from khora.filter.context import (  # noqa: F401
+    CompileContext as CompileContext,
+)
+from khora.filter.context import (
+    CompileError as CompileError,
+)
+from khora.filter.context import (
+    SchemaCapabilities as SchemaCapabilities,
+)
 from khora.filter.model import (
     SYSTEM_KEYS,
     DateOps,
@@ -22,6 +53,15 @@ from khora.filter.model import (
     StringOps,
 )
 from khora.filter.model import FieldError as FieldError  # re-export (not in __all__)
+from khora.filter.registry import (  # noqa: F401
+    CompiledFilter as CompiledFilter,
+)
+from khora.filter.registry import (
+    CompilerFn as CompilerFn,
+)
+from khora.filter.registry import (
+    CompilerRegistry as CompilerRegistry,
+)
 
 __all__ = [
     "DateOps",

--- a/src/khora/filter/ast.py
+++ b/src/khora/filter/ast.py
@@ -1,0 +1,630 @@
+"""Canonical filter AST (Layer 3) — ``@internal``.
+
+The AST is the desugared, normalized intermediate form that backend compilers
+(Layer 4) consume. It sits between the public :class:`~khora.filter.RecallFilter`
+pydantic model (Layer 2, the validated wire contract) and the per-backend
+compilers (Layer 4). :func:`parse_to_ast` lowers a *validated* ``RecallFilter``
+into this form; :func:`canonical_hash` derives a stable cache key from it.
+
+``@internal``. Nothing here is exported from :mod:`khora.__init__`. The AST is
+``__all__``'d under :mod:`khora.filter` only and is free to evolve in minor
+releases (a new node kind for ``$regex`` later does not break the public
+surface). Backend compilers reach it through the (internal) ``CompileContext``;
+callers never see it.
+
+Two lowering invariants the rest of the subsystem depends on — **compilers
+never see dot-strings or sugar**:
+
+* **Paths are always segment tuples, never dot-strings.** A system key lowers to
+  a single-segment path (``("source_name",)``); a folded ``metadata.<path>``
+  predicate splits on ``.`` into a multi-segment path (``("metadata", "a", "b")``).
+* **All bare-value / logical sugar is desugared.** A bare scalar becomes an
+  ``$eq`` clause; a bare list becomes an ``$eq`` *exact-array* clause (NOT ``$in``
+  — membership is the explicit ``$in`` form); ``$nor`` becomes ``$not($or(...))``;
+  implicit sibling AND (several keys on one filter document) becomes an explicit
+  AND node.
+
+Comparison operands stay **opaque** — they are carried verbatim, never recursed
+into as nested clauses (a ``$or`` nested inside an ``$eq`` operand is matched as
+a literal object, mirroring ``model._check_literal_operand``). The one
+recognized typed literal is ``{"$date": "<ISO-8601>"}``, which lowers to a
+:class:`DateLiteral` operand at the leaf.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from khora.filter.model import (
+    DateOps,
+    Op,
+    RecallFilter,
+    StringOps,
+)
+
+__all__ = [
+    "DateLiteral",
+    "FilterClause",
+    "FilterNode",
+    "FilterOp",
+    "canonical_hash",
+    "parse_to_ast",
+]
+
+
+# ``FilterOp`` is the AST's operator vocabulary. It is the same closed set the
+# wire model speaks, so it is a direct alias of ``model.Op`` rather than a
+# parallel enum that could drift out of sync.
+FilterOp = Op
+
+
+# The logical operators that compose child nodes (as opposed to leaf
+# comparison operators). ``$nor`` is desugared away in the lowering step, so it
+# never reaches the AST as a node kind.
+_LOGICAL_OPS: frozenset[FilterOp] = frozenset({Op.AND, Op.OR, Op.NOT})
+
+# The comparison operators whose operand is an ordered list whose element order
+# is semantically significant (so ``canonical_hash`` must preserve it).
+_LIST_OPS: frozenset[FilterOp] = frozenset({Op.IN, Op.NIN})
+
+
+# --------------------------------------------------------------------------- #
+# Leaf operand: the typed ``$date`` literal.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class DateLiteral:
+    """A normalized ``{"$date": "<ISO-8601>"}`` typed-literal operand.
+
+    ``@internal``. A ``$date`` literal appearing in operand position on a
+    metadata predicate is lowered to this carrier so compilers receive an
+    unambiguous datetime instead of re-parsing a string. The validator already
+    proved the string is ISO-8601 and normalized it to UTC (``model._parse_date_literal``
+    / ``DateOps._utc_*``); this just carries the resulting ``datetime``.
+
+    ``value`` is a tz-aware UTC :class:`~datetime.datetime`.
+    """
+
+    value: datetime
+
+
+# --------------------------------------------------------------------------- #
+# Leaf predicate.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class FilterClause:
+    """A single leaf predicate: ``path <op> operand``.
+
+    ``@internal``. ``path`` is the segment tuple addressing the field — a
+    single-segment tuple for a system key (``("source_name",)``) or a
+    multi-segment tuple for a metadata sub-path (``("metadata", "labels", "tier")``).
+    Never a dot-string.
+
+    ``op`` is the comparison operator (never a logical operator — those are
+    :class:`FilterNode` kinds). ``operand`` is the opaque comparison value:
+
+    * a scalar / :class:`~datetime.datetime` / :class:`DateLiteral` for the
+      scalar comparison ops (``$eq``/``$ne``/``$gt``/``$gte``/``$lt``/``$lte``),
+    * an ordered ``tuple`` for ``$in``/``$nin`` (element order significant),
+    * a ``tuple`` for an ``$eq`` *exact-array* operand (a bare list desugars to
+      ``$eq`` exact-array — NOT ``$in``; element order significant),
+    * a ``bool`` for ``$exists``,
+    * ``None`` for an active null-or-missing match (``$eq None``).
+
+    Operands are carried verbatim and never recursed into as clauses.
+    """
+
+    path: tuple[str, ...]
+    op: FilterOp
+    operand: Any = None
+
+
+# --------------------------------------------------------------------------- #
+# Logical composition node.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class FilterNode:
+    """A logical-composition node: ``AND`` / ``OR`` / ``NOT`` over children.
+
+    ``@internal``. The :func:`parse_to_ast` normalization pass guarantees the root
+    is **always** a ``FilterNode`` (never a bare :class:`FilterClause`): a
+    single-predicate filter is ``AND([clause])``, an implicit-AND or multi-predicate
+    filter is an ``AND`` of its predicates, a bare ``$or`` / ``$not`` filter has
+    that logical node as root, and an empty filter is the empty match-everything
+    ``AND``. Same-operator nesting is flattened (no normalized ``AND`` directly
+    contains an ``AND`` child, nor ``OR`` an ``OR``), and a single-child
+    ``AND``/``OR`` whose child is a *logical* node is collapsed away — but a
+    single *leaf* child is kept as ``AND([leaf])`` so the node never degenerates
+    to a bare clause.
+
+    ``op`` is one of ``Op.AND`` / ``Op.OR`` / ``Op.NOT``. ``children`` is the
+    ordered tuple of operands — each a :class:`FilterClause` or a nested
+    :class:`FilterNode`. ``Op.NOT`` carries exactly one child; a normalized
+    ``AND`` / ``OR`` carries zero (the empty match-everything ``AND``), one (only
+    when that child is a single leaf clause, i.e. ``AND([leaf])``), or
+    two-or-more children.
+
+    Child order is preserved as authored. ``canonical_hash`` is what imposes the
+    order-insensitivity of the commutative ``AND`` / ``OR`` operators — the node
+    itself keeps authored order so a round-trip / debug dump is faithful.
+    """
+
+    op: FilterOp
+    children: tuple[FilterNode | FilterClause, ...] = field(default_factory=tuple)
+
+
+# --------------------------------------------------------------------------- #
+# Lowering: RecallFilter -> FilterNode.
+# --------------------------------------------------------------------------- #
+
+
+def parse_to_ast(filter_: RecallFilter) -> FilterNode:
+    """Lower a *validated* :class:`RecallFilter` into the canonical AST.
+
+    ``@internal``. The input must already have passed
+    :meth:`RecallFilter.model_validate` (or kwarg construction) — this function
+    does not re-validate; it desugars and normalizes:
+
+    * system-key fields → single-segment :class:`FilterClause` leaves,
+    * folded ``metadata.<path>`` predicates → multi-segment leaves,
+    * the bare ``metadata`` blob → whole-blob ``$eq`` leaf,
+    * bare scalar → ``$eq``; bare list → ``$eq`` exact-array (NOT ``$in``),
+    * ``$nor`` → ``$not($or(...))``,
+    * field-level and document-level ``$not`` → ``NOT`` nodes,
+    * several sibling predicates on one document → an explicit ``AND`` node.
+
+    A final :func:`_normalize` pass canonicalizes the logical structure so that
+    semantically-equal filters share a structure (and therefore a
+    :func:`canonical_hash`):
+
+    * **Same-operator nesting is flattened** — an ``AND`` directly containing an
+      ``AND`` (or ``OR``-of-``OR``) splices the grandchildren up (associativity).
+      Flattening never crosses a ``NOT`` boundary and never merges ``AND`` into
+      ``OR``.
+    * **A single-child ``AND``/``OR`` whose child is a *logical* node collapses to
+      that child** — a lone ``$and``/``$or`` wrapper around another logical node
+      disappears. A single-child node whose child is a *leaf clause* is rewritten
+      to ``AND([leaf])`` (the op is normalized to ``AND``) — it is **not**
+      collapsed to a bare clause, so the root is always a logical node.
+
+    **The root is always a** :class:`FilterNode` — never a bare
+    :class:`FilterClause`. This is the engine boundary contract: a compiler is a
+    ``Callable[[FilterNode, CompileContext], CompiledFilter]``, so a bare-clause
+    root would not be a valid compiler input. A single-predicate filter therefore
+    normalizes to ``AND([clause])``.
+
+    Result shape after normalization:
+
+    * a single-predicate filter (``{a}``) → ``AND([a])``;
+    * an implicit-AND filter (``{a, b}``) and the explicit ``{$and:[{a},{b}]}``
+      both → ``AND([a, b])`` — identical structure, identical hash;
+    * a bare ``$or`` / ``$not`` filter has that logical node as the root (no
+      spurious ``AND`` wrap);
+    * a bare ``RecallFilter()`` (no predicates) is the empty ``AND`` —
+      match-everything; compilers treat it as "no constraint".
+    """
+    children = _lower_filter(filter_)
+    # Always wrap the document's siblings in an AND, then normalize. ``_normalize``
+    # collapses the redundant wrapper when the sole child is itself a logical node
+    # (e.g. a bare ``$or``/``$not`` document), but keeps an ``AND([clause])`` when
+    # the sole child is a leaf — so normalizing a FilterNode always yields a
+    # FilterNode (never a bare clause). The isinstance assert both documents and
+    # type-narrows that root invariant.
+    root = _normalize(FilterNode(op=Op.AND, children=tuple(children)))
+    assert isinstance(root, FilterNode)  # noqa: S101 - root-shape invariant (see _normalize rule 2)
+    return root
+
+
+def _lower_filter(filter_: RecallFilter) -> list[FilterNode | FilterClause]:
+    """Lower one filter document into its list of sibling AST operands.
+
+    Each system-key field, folded metadata predicate, bare-metadata blob, and
+    logical operator on this document contributes one sibling. Sibling
+    predicates are implicitly AND-ed (the caller wraps them in an ``AND`` node).
+    """
+    out: list[FilterNode | FilterClause] = []
+    set_fields = filter_.model_fields_set
+
+    # --- system keys -------------------------------------------------------- #
+    # ``model_fields_set`` distinguishes an explicit ``null`` (active
+    # null-or-missing match) from an unset field (no filter). Only
+    # fields the caller actually provided contribute a clause.
+    for key in _SYSTEM_KEY_FIELDS:
+        if key not in set_fields:
+            continue
+        value = getattr(filter_, key)
+        out.extend(_lower_system_key((key,), value))
+
+    # --- bare metadata blob ------------------------------------------------- #
+    # A bare ``metadata`` dict is whole-blob ``$eq`` equality (Mongo embedded-doc
+    # equality). Folded ``metadata.<path>`` predicates live on a separate carrier
+    # and are handled below, so this is only the bare-blob form.
+    if "metadata" in set_fields and filter_.metadata is not None:
+        out.append(FilterClause(path=("metadata",), op=Op.EQ, operand=filter_.metadata))
+
+    # --- folded metadata.<path> predicates ---------------------------------- #
+    for dotted_key, predicate in filter_.folded_predicates_.items():
+        # ``metadata.a.b`` -> ("metadata", "a", "b"). The leading "metadata."
+        # prefix is part of the key; split it whole so the path keeps the
+        # ``metadata`` root segment.
+        path = tuple(dotted_key.split("."))
+        out.extend(_lower_metadata_predicate(path, predicate))
+
+    # --- logical operators -------------------------------------------------- #
+    if filter_.and_ is not None:
+        out.append(FilterNode(op=Op.AND, children=_lower_branches(filter_.and_)))
+    if filter_.or_ is not None:
+        out.append(FilterNode(op=Op.OR, children=_lower_branches(filter_.or_)))
+    if filter_.nor_ is not None:
+        # ``$nor`` desugars to ``$not($or(...))`` — no distinct AST node.
+        or_node = FilterNode(op=Op.OR, children=_lower_branches(filter_.nor_))
+        out.append(FilterNode(op=Op.NOT, children=(or_node,)))
+    if filter_.not_ is not None:
+        # Document-form ``$not``: negate the whole inner filter.
+        out.append(FilterNode(op=Op.NOT, children=(parse_to_ast(filter_.not_),)))
+
+    return out
+
+
+def _lower_branches(branches: list[RecallFilter]) -> tuple[FilterNode | FilterClause, ...]:
+    """Lower each branch of a logical array to a child AST node."""
+    return tuple(parse_to_ast(branch) for branch in branches)
+
+
+# --------------------------------------------------------------------------- #
+# Logical-structure normalization (canonical form for stable hashing).
+# --------------------------------------------------------------------------- #
+
+
+def _normalize(node: FilterNode | FilterClause) -> FilterNode | FilterClause:
+    """Canonicalize logical structure so semantically-equal filters match.
+
+    Recurses bottom-up. A leaf :class:`FilterClause` is returned unchanged. A
+    ``NOT`` normalizes its single operand and re-wraps it (``NOT`` is an opaque
+    boundary — its operand is never spliced/collapsed into a parent). An
+    ``AND`` / ``OR`` node ``N`` is rewritten by:
+
+    1. **Flatten same-operator children.** An ``AND`` child of an ``AND`` (or
+       ``OR`` of ``OR``) is spliced in place of itself, lifting its grandchildren
+       up one level (associativity). Per-operator only — an ``OR`` child of an
+       ``AND`` is left intact, and a ``NOT`` is never spliced across.
+    2. **Single-child handling.** After flattening, if ``N`` has exactly one
+       child:
+
+       * child is a **logical node** (``AND``/``OR``/``NOT``) → **collapse**:
+         replace ``N`` with that child (the wrapper is redundant);
+       * child is a **leaf clause** → rewrite to ``AND([leaf])`` (the op is
+         normalized to ``AND``); **do not** collapse to a bare clause.
+
+       An *empty* ``AND``/``OR`` is preserved (the empty ``AND`` is the
+       match-everything root).
+
+    Rule (2) keeps the AST root a :class:`FilterNode` — a single-predicate filter
+    becomes ``AND([clause])``, never a bare clause — which is the engine-boundary
+    contract (a compiler takes a ``FilterNode``). The rewrites still converge the
+    locked equivalences: ``{a, b}`` and ``{$and:[{a},{b}]}`` → ``AND([a, b])``;
+    ``{$and:[{a}]}`` → ``AND([AND([a])])`` → flatten → ``AND([a])``;
+    ``{$or:[{a}]}`` → ``OR([AND([a])])`` → collapse single logical child →
+    ``AND([a])``.
+    """
+    if isinstance(node, FilterClause):
+        return node
+
+    # Normalize children first (bottom-up), so a child AND/OR is already
+    # flattened/collapsed before we decide whether to splice it.
+    norm_children = [_normalize(child) for child in node.children]
+
+    if node.op == Op.NOT:
+        # NOT is an opaque boundary — normalize its operand but never splice
+        # across it. A NOT always has exactly one child (may be a clause).
+        return FilterNode(op=Op.NOT, children=tuple(norm_children))
+
+    # AND / OR: flatten same-operator children (associativity), never merging a
+    # different operator or crossing a NOT.
+    flattened: list[FilterNode | FilterClause] = []
+    for child in norm_children:
+        if isinstance(child, FilterNode) and child.op == node.op:
+            flattened.extend(child.children)
+        else:
+            flattened.append(child)
+
+    if len(flattened) == 1:
+        only = flattened[0]
+        if isinstance(only, FilterNode):
+            # Single logical child -> collapse the redundant wrapper.
+            return only
+        # Single leaf child -> normalize the op to AND and keep AND([leaf]) so
+        # the result is a FilterNode, never a bare clause.
+        return FilterNode(op=Op.AND, children=(only,))
+    return FilterNode(op=node.op, children=tuple(flattened))
+
+
+# --------------------------------------------------------------------------- #
+# System-key lowering.
+# --------------------------------------------------------------------------- #
+
+
+def _lower_system_key(
+    path: tuple[str, ...],
+    value: datetime | DateOps | StringOps | str | list[Any] | None,
+) -> list[FilterNode | FilterClause]:
+    """Lower one system-key field value to its AST leaves.
+
+    Bare scalar -> ``$eq``; bare list -> ``$eq`` *exact-array* (NOT ``$in``);
+    an ``*Ops`` submodel -> one clause per set operator (a field-level ``$not``
+    becomes a ``NOT`` node wrapping its inner operator-expression).
+    """
+    if value is None:
+        # Explicit null -> active null-or-missing $eq match.
+        return [FilterClause(path=path, op=Op.EQ, operand=None)]
+    if isinstance(value, (DateOps, StringOps)):
+        return _lower_ops_submodel(path, value)
+    if isinstance(value, list):
+        # Bare list ⇒ $eq EXACT-ARRAY equality. This is NOT $in: a bare list is
+        # the uniform "bare value ⇒ $eq" sugar. Membership ("one of") is never
+        # synthesized from a bare list — it is the explicit StringOps(in_=[...])
+        # form.
+        return [FilterClause(path=path, op=Op.EQ, operand=tuple(value))]
+    # Bare scalar (str / datetime) ⇒ $eq sugar.
+    return [FilterClause(path=path, op=Op.EQ, operand=value)]
+
+
+def _lower_ops_submodel(
+    path: tuple[str, ...],
+    ops: DateOps | StringOps,
+) -> list[FilterNode | FilterClause]:
+    """Lower a ``StringOps`` / ``DateOps`` submodel to per-operator leaves.
+
+    Each set operator field becomes one clause. A field-level ``$not`` negates
+    the inner operator-expression: it lowers to a ``NOT`` node wrapping the AST
+    of the inner ``*Ops``. ``$in``/``$nin`` operands become order-significant
+    tuples.
+    """
+    out: list[FilterNode | FilterClause] = []
+    set_fields = ops.model_fields_set
+    for attr, op in _OPS_FIELD_TO_OP:
+        if attr not in set_fields:
+            continue
+        operand = getattr(ops, attr)
+        if op == Op.NOT:
+            # Field-level $not: negate the inner operator-expression. ``operand``
+            # is itself an ``*Ops`` submodel.
+            inner = _lower_ops_submodel(path, operand)
+            out.append(FilterNode(op=Op.NOT, children=tuple(inner)))
+            continue
+        if op in _LIST_OPS:
+            out.append(FilterClause(path=path, op=op, operand=tuple(operand)))
+            continue
+        out.append(FilterClause(path=path, op=op, operand=operand))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Metadata-predicate lowering (free-form, validator-checked grammar).
+# --------------------------------------------------------------------------- #
+
+
+def _lower_metadata_predicate(
+    path: tuple[str, ...],
+    predicate: Any,
+) -> list[FilterNode | FilterClause]:
+    """Lower one (already-validated) metadata-field predicate to AST leaves.
+
+    Mirrors the validator's ``_walk_predicate`` shape (the predicate is known
+    well-formed here):
+
+    * a non-dict (scalar / list) -> ``$eq`` sugar (a list is an exact-array
+      operand, NOT ``$in``),
+    * an empty / all-non-``$`` dict -> whole-subdocument ``$eq`` equality,
+    * a sole-key ``{"$date": ...}`` -> ``$eq`` :class:`DateLiteral`,
+    * an operator-expression -> one clause per operator (field ``$not`` -> NOT).
+    """
+    if not isinstance(predicate, dict):
+        if isinstance(predicate, list):
+            # Bare list ⇒ $eq exact-array (NOT $in), same uniform rule as above.
+            return [FilterClause(path=path, op=Op.EQ, operand=tuple(predicate))]
+        return [FilterClause(path=path, op=Op.EQ, operand=predicate)]
+
+    if not predicate:
+        # Empty {} ⇒ whole-subdocument equality (opaque operand).
+        return [FilterClause(path=path, op=Op.EQ, operand={})]
+
+    dollar_keys = [k for k in predicate if isinstance(k, str) and k.startswith("$")]
+    if not dollar_keys:
+        # All non-$ keys ⇒ whole-subdocument equality. Opaque operand, not
+        # recursed (the validator already rejected nested operators here).
+        return [FilterClause(path=path, op=Op.EQ, operand=predicate)]
+
+    # A sole-key {"$date": ...} in value position is a typed literal == $eq.
+    if set(predicate.keys()) == {Op.DATE.value}:
+        return [FilterClause(path=path, op=Op.EQ, operand=_make_date_literal(predicate[Op.DATE.value]))]
+
+    # Operator expression: one leaf per operator.
+    out: list[FilterNode | FilterClause] = []
+    for op_key, operand in predicate.items():
+        op = Op(op_key)
+        if op == Op.NOT:
+            # Field-position $not negates an inner operator-expression (a dict).
+            inner = _lower_metadata_operator_expr(path, operand)
+            out.append(FilterNode(op=Op.NOT, children=tuple(inner)))
+            continue
+        if op in _LIST_OPS:
+            out.append(FilterClause(path=path, op=op, operand=_lower_operand_list(operand)))
+            continue
+        if op == Op.EXISTS:
+            out.append(FilterClause(path=path, op=op, operand=operand))
+            continue
+        # Scalar comparison ($eq/$ne/$gt/$gte/$lt/$lte): opaque operand, with the
+        # one recognized {"$date": ...} typed-literal lowered to a DateLiteral.
+        out.append(FilterClause(path=path, op=op, operand=_lower_scalar_operand(operand)))
+    return out
+
+
+def _lower_metadata_operator_expr(
+    path: tuple[str, ...],
+    expr: dict[str, Any],
+) -> list[FilterNode | FilterClause]:
+    """Lower the inner operator-expression of a field-position ``$not``.
+
+    The operand is a pure operator-expression (validator-guaranteed all-``$``).
+    Each inner operator becomes a clause; the caller wraps the list in a ``NOT``
+    node. A nested ``$not`` recurses into another ``NOT`` node — the validator
+    permits ``$not`` inside a negated operator-expression (``_walk_not_operand``
+    re-validates each inner op, including ``$not``), so the lowering must handle
+    it rather than emit a malformed ``FilterClause(op=NOT, operand=<raw dict>)``.
+    """
+    out: list[FilterNode | FilterClause] = []
+    for op_key, operand in expr.items():
+        op = Op(op_key)
+        if op == Op.NOT:
+            inner = _lower_metadata_operator_expr(path, operand)
+            out.append(FilterNode(op=Op.NOT, children=tuple(inner)))
+        elif op in _LIST_OPS:
+            out.append(FilterClause(path=path, op=op, operand=_lower_operand_list(operand)))
+        elif op == Op.EXISTS:
+            out.append(FilterClause(path=path, op=op, operand=operand))
+        else:
+            out.append(FilterClause(path=path, op=op, operand=_lower_scalar_operand(operand)))
+    return out
+
+
+def _lower_operand_list(operand: list[Any]) -> tuple[Any, ...]:
+    """Lower an ``$in``/``$nin`` operand list (each item may be a ``$date``)."""
+    return tuple(_lower_scalar_operand(item) for item in operand)
+
+
+def _lower_scalar_operand(operand: Any) -> Any:
+    """Lower an opaque comparison operand, recognizing the ``$date`` literal.
+
+    A sole-key ``{"$date": "<ISO-8601>"}`` becomes a :class:`DateLiteral`; any
+    other value is carried verbatim (opaque — never recursed into as a clause).
+    """
+    if isinstance(operand, dict) and set(operand.keys()) == {Op.DATE.value}:
+        return _make_date_literal(operand[Op.DATE.value])
+    return operand
+
+
+def _make_date_literal(raw: Any) -> DateLiteral:
+    """Build a normalized :class:`DateLiteral` from a validated ``$date`` value.
+
+    The validator already proved ``raw`` parses as ISO-8601; normalize to UTC
+    the same way ``DateOps`` does so the AST carries a uniform tz-aware value.
+    """
+    parsed = datetime.fromisoformat(raw)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    else:
+        parsed = parsed.astimezone(UTC)
+    return DateLiteral(value=parsed)
+
+
+# Ordered (field-name, Op) pairs for the ``*Ops`` submodels. Order is fixed so
+# lowering is deterministic; ``canonical_hash`` re-sorts commutative siblings,
+# but a stable emit order keeps debug dumps readable.
+_OPS_FIELD_TO_OP: tuple[tuple[str, FilterOp], ...] = (
+    ("eq", Op.EQ),
+    ("ne", Op.NE),
+    ("gt", Op.GT),
+    ("gte", Op.GTE),
+    ("lt", Op.LT),
+    ("lte", Op.LTE),
+    ("in_", Op.IN),
+    ("nin", Op.NIN),
+    ("exists", Op.EXISTS),
+    ("not_", Op.NOT),
+)
+
+# The system-key field names on ``RecallFilter`` in a fixed order (the ten
+# system keys). ``metadata`` and the logical operators are handled separately.
+_SYSTEM_KEY_FIELDS: tuple[str, ...] = (
+    "occurred_at",
+    "created_at",
+    "source_timestamp",
+    "source_type",
+    "source_name",
+    "source_url",
+    "external_id",
+    "content_type",
+    "source",
+    "title",
+)
+
+
+# --------------------------------------------------------------------------- #
+# Canonical hashing.
+# --------------------------------------------------------------------------- #
+
+
+def canonical_hash(node: FilterNode | FilterClause) -> str:
+    """Return a stable SHA-256 hex digest of an AST.
+
+    ``@internal``. The hash is the cache-key source (the engine assembles the
+    full recall cache key from it). Stability rules:
+
+    * **Commutative** ``$and`` / ``$or`` siblings are sorted, so reordering
+      sibling predicates does not change the hash (``{a AND b}`` == ``{b AND a}``).
+    * **Order is preserved** for a ``$not`` operand, for ``$in``/``$nin`` lists,
+      and for ``$eq`` exact-array operands — those are order-significant.
+    * **Dict operands** (whole-subdocument / whole-blob equality) have their keys
+      sorted so semantically equal objects hash equally.
+    * Two ASTs that differ only in **semantics** (different op, path, or operand)
+      hash differently.
+
+    Implementation: build a canonical, JSON-serializable representation, then
+    SHA-256 over a compact, sorted-where-safe JSON encoding.
+    """
+    canonical = _canonicalize(node)
+    encoded = json.dumps(canonical, separators=(",", ":"), ensure_ascii=False, sort_keys=False)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _canonicalize(node: FilterNode | FilterClause) -> Any:
+    """Build the stable, JSON-serializable representation of an AST subtree."""
+    if isinstance(node, FilterClause):
+        return {
+            "k": "clause",
+            "path": list(node.path),
+            "op": node.op.value,
+            "operand": _canonicalize_operand(node.operand),
+        }
+    # FilterNode (logical).
+    children = [_canonicalize(child) for child in node.children]
+    if node.op in (Op.AND, Op.OR):
+        # Commutative: sort siblings by their stable serialization so order is
+        # irrelevant. The serialization is deterministic, so sorting on it is a
+        # total, stable order.
+        children = sorted(children, key=lambda c: json.dumps(c, separators=(",", ":"), sort_keys=False))
+    # NOT preserves its single operand's position (no sort).
+    return {"k": "node", "op": node.op.value, "children": children}
+
+
+def _canonicalize_operand(operand: Any) -> Any:
+    """Canonicalize a leaf operand into JSON-serializable form.
+
+    Tuples (``$in``/``$nin`` lists, ``$eq`` exact-arrays) keep their order. Dict
+    operands (subdocument / blob equality) sort their keys recursively so
+    key-order is not significant. :class:`DateLiteral` and :class:`~datetime.datetime`
+    are tagged + ISO-encoded so they never collide with a plain string.
+    """
+    if isinstance(operand, DateLiteral):
+        return {"$date": operand.value.isoformat()}
+    if isinstance(operand, datetime):
+        return {"$dt": operand.isoformat()}
+    if isinstance(operand, tuple):
+        # Order-significant — preserve it.
+        return [_canonicalize_operand(item) for item in operand]
+    if isinstance(operand, list):
+        return [_canonicalize_operand(item) for item in operand]
+    if isinstance(operand, dict):
+        # Order-insensitive object equality — sort keys recursively.
+        return {k: _canonicalize_operand(operand[k]) for k in sorted(operand, key=str)}
+    return operand

--- a/src/khora/filter/ast.py
+++ b/src/khora/filter/ast.py
@@ -302,8 +302,11 @@ def _normalize(node: FilterNode | FilterClause) -> FilterNode | FilterClause:
 
        * child is a **logical node** (``AND``/``OR``/``NOT``) → **collapse**:
          replace ``N`` with that child (the wrapper is redundant);
-       * child is a **leaf clause** → rewrite to ``AND([leaf])`` (the op is
-         normalized to ``AND``); **do not** collapse to a bare clause.
+       * child is a **leaf clause** → rewrite to ``AND([leaf])``. The operator
+         is normalized to ``AND`` **even when ``N`` was an ``OR``** — a lone
+         ``OR`` and a lone ``AND`` around a single clause are semantically
+         identical, so the original ``OR`` is intentionally dropped. **Do not**
+         collapse to a bare clause.
 
        An *empty* ``AND``/``OR`` is preserved (the empty ``AND`` is the
        match-everything root).
@@ -580,7 +583,14 @@ def canonical_hash(node: FilterNode | FilterClause) -> str:
       hash differently.
 
     Implementation: build a canonical, JSON-serializable representation, then
-    SHA-256 over a compact, sorted-where-safe JSON encoding.
+    SHA-256 over its compact JSON encoding. All ordering normalization happens
+    while building that representation, in two distinct places — commutative
+    ``$and`` / ``$or`` children are sorted by their own canonical serialization
+    in :func:`_canonicalize`, and dict-operand keys are sorted recursively in
+    :func:`_canonicalize_operand`. The final :func:`json.dumps` deliberately
+    uses ``sort_keys=False``: the representation's field order is already fixed
+    and the meaningful sorting is baked into the structure, so re-sorting the
+    encoding keys would be redundant (and must not be relied on for stability).
     """
     canonical = _canonicalize(node)
     encoded = json.dumps(canonical, separators=(",", ":"), ensure_ascii=False, sort_keys=False)

--- a/src/khora/filter/context.py
+++ b/src/khora/filter/context.py
@@ -1,0 +1,128 @@
+"""Compile context + compiler error types (Layer 4 seam) — ``@internal``.
+
+A :class:`CompileContext` is the engine-supplied, per-compile-pass context that
+a backend compiler reads to know *where* and *how* to emit a predicate — the
+table/alias to attach a WHERE to, the bind-param prefix, an optional system-key
+→ column-name mapping, the backend's native capabilities, and the
+unsupported-node policy. It is the **first** of the two internal seams (the
+other is the :class:`~khora.filter.registry.CompilerRegistry`): a single
+``compile_postgres`` serves multiple engines/schemas just by varying the context
+— **no** ``if engine == "..."`` ever appears in a compiler.
+
+``@internal``. ``CompileContext`` / ``SchemaCapabilities`` are ``__all__``'d under
+:mod:`khora.filter` only; promoting them to a public plugin seam for third-party
+compiler authors is deferred to a future improvement.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import ClassVar, Literal
+
+from khora.exceptions import KhoraError
+
+# Re-export (do NOT redefine) — a compiler that cannot honor a predicate raises
+# the *public* error so callers catch the same type regardless of backend.
+from khora.filter.model import RecallFilterUnsupportedError
+
+__all__ = [
+    "CompileContext",
+    "CompileError",
+    "RecallFilterUnsupportedError",
+    "SchemaCapabilities",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Compiler error base.
+# --------------------------------------------------------------------------- #
+
+
+class CompileError(KhoraError):
+    """Base for errors raised inside the compile step.
+
+    ``@internal``. Distinct from :class:`RecallFilterUnsupportedError` (a
+    *contract* outcome — the backend simply cannot express a predicate, which an
+    engine may legitimately handle by splitting or post-filtering). A
+    ``CompileError`` signals an internal compiler fault (a malformed AST, an
+    unreachable branch) — a bug, not a capability gap.
+    """
+
+
+# --------------------------------------------------------------------------- #
+# Backend capability flags.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaCapabilities:
+    """What a backend can do natively, for compiler feature-gating.
+
+    ``@internal``. A compiler reads these to choose an emission strategy (e.g.
+    nested JSONB path-query vs. flat ``#>>`` extraction) or to decide a predicate
+    is unsupported on this backend. Flags are coarse, capability-shaped booleans
+    — not a fine-grained SQL feature matrix.
+
+    * ``jsonb_path_query`` — backend can evaluate a nested JSON path natively
+      (Postgres ``jsonb_path_query`` / ``#>>``, SurrealQL dot-descent), vs. only
+      top-level key access.
+    * ``full_text`` — backend has a native full-text predicate.
+    * ``native_map_metadata`` — backend stores metadata as a real nested map/object
+      (SurrealDB) rather than a serialized JSON string (Neo4j), so a metadata
+      predicate can push down instead of falling to a post-filter.
+
+    ``DEFAULTS`` is the conservative all-``False`` instance — a backend with no
+    declared capabilities. Engines pass a richer instance for backends that have
+    more; ``CompileContext`` defaults to ``DEFAULTS`` so callers need not
+    construct one.
+    """
+
+    jsonb_path_query: bool = False
+    full_text: bool = False
+    native_map_metadata: bool = False
+
+    # Populated after the class is defined (cannot reference the class in its own
+    # body). ClassVar is excluded from ``__slots__``.
+    DEFAULTS: ClassVar[SchemaCapabilities]
+
+
+SchemaCapabilities.DEFAULTS = SchemaCapabilities()
+
+
+# --------------------------------------------------------------------------- #
+# Compile context.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class CompileContext:
+    """Engine-supplied context for a single compile pass.
+
+    ``@internal``. A compiler is a stateless function of ``(ast, ctx)``; this is
+    the ``ctx``. Frozen + slotted: it is created once per recall and read by the
+    compiler, never mutated.
+
+    * ``backend_target`` — the concrete target the predicate attaches to
+      (``"khora_chunks"``, ``"documents"``, ``"Chunk"``, ``"events"``, ...).
+    * ``table_alias`` — SQL: the alias of the table the WHERE attaches to
+      (``None`` when the target is unaliased or the backend is not SQL).
+    * ``param_namespace`` — bind-param prefix so compiled params cannot collide
+      with the engine's own query parameters.
+    * ``field_mapping`` — optional system-key → backend column/property name map.
+      Lets one compiler serve a different schema (e.g. the legacy
+      ``chunks``/``documents`` tables) without per-engine branching. ``None`` =
+      identity mapping (system key name == column name).
+    * ``schema_capabilities`` — what the backend can do natively
+      (:class:`SchemaCapabilities`).
+    * ``on_unsupported`` — ``"raise"`` stops on the first node the backend cannot
+      express; ``"split"`` compiles what it can and returns the handled leaves via
+      ``CompiledFilter.consumed_keys`` for the engine to post-filter the rest.
+    """
+
+    backend_target: str
+    table_alias: str | None = None
+    param_namespace: str = "f"
+    field_mapping: Mapping[str, str] | None = None
+    schema_capabilities: SchemaCapabilities = field(default=SchemaCapabilities.DEFAULTS)
+    on_unsupported: Literal["raise", "split"] = "raise"

--- a/src/khora/filter/registry.py
+++ b/src/khora/filter/registry.py
@@ -1,0 +1,163 @@
+"""Compiler dispatch registry (Layer 4 seam) — ``@internal``.
+
+The :class:`CompilerRegistry` maps ``(engine_id, storage_target)`` to the
+stateless compiler function that lowers a :class:`~khora.filter.ast.FilterNode`
+to that backend's query fragment. It is the **second** internal seam: adding a
+backend or an alternative compiler does not require touching engine code, and
+adding an engine does not require touching compiler code — within khora's own
+codebase.
+
+``@internal``. The registry is ``__all__``'d under :mod:`khora.filter` only —
+**not** :mod:`khora.__init__`. Exposing ``register()`` as a public extension
+point for third-party engine/backend authors is deferred to a future improvement
+(no current caller authors compilers; khora's five built-in compilers are the
+only consumers).
+
+The registry is **empty at import** — khora's engines register their compilers
+at engine import time, not here. This module imports no compiler.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar
+
+from khora.exceptions import KhoraError
+from khora.filter.ast import FilterNode
+from khora.filter.context import CompileContext
+
+__all__ = [
+    "CompiledFilter",
+    "CompilerFn",
+    "CompilerRegistry",
+    "UnknownCompilerError",
+]
+
+
+T = TypeVar("T")
+
+
+# --------------------------------------------------------------------------- #
+# Compiler output.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledFilter(Generic[T]):
+    """A backend compiler's output.
+
+    ``@internal``. ``T`` varies by backend (a SQLAlchemy expression, a Cypher
+    fragment, a LanceDB filter string, a ``callable(record) -> bool``, ...).
+
+    * ``predicate`` — the compiled backend predicate (typed ``T``).
+    * ``params`` — bind parameters for backends that bind (Postgres, Cypher);
+      empty for backends that inline literals.
+    * ``consumed_keys`` — the AST leaves this compiler handled, for partial
+      pushdown: when ``CompileContext.on_unsupported == "split"`` the engine
+      post-filters whatever is *not* in this set.
+    * ``canonical_hash`` — the stable hash of the consumed slice, the engine's
+      cache-key source.
+    """
+
+    predicate: T
+    params: dict[str, Any]
+    consumed_keys: frozenset[str]
+    canonical_hash: str
+
+
+# A compiler is a stateless function of ``(ast, ctx)``.
+CompilerFn = Callable[[FilterNode, CompileContext], CompiledFilter[Any]]
+
+
+# --------------------------------------------------------------------------- #
+# Errors.
+# --------------------------------------------------------------------------- #
+
+
+class UnknownCompilerError(KhoraError):
+    """No compiler is registered for the requested ``(engine_id, storage_target)``.
+
+    ``@internal``. A :class:`KhoraError` subclass so callers can catch it
+    narrowly or via the base.
+    """
+
+    def __init__(self, engine_id: str, storage_target: str) -> None:
+        self.engine_id = engine_id
+        self.storage_target = storage_target
+        super().__init__(f"no compiler registered for ({engine_id!r}, {storage_target!r})")
+
+
+class CompilerConflictError(KhoraError):
+    """A different compiler is already registered for the same key.
+
+    ``@internal``. Re-registering the *same* function for a key is idempotent and
+    allowed; registering a *different* function for an occupied key is a
+    programming error and raises this.
+    """
+
+    def __init__(self, engine_id: str, storage_target: str) -> None:
+        self.engine_id = engine_id
+        self.storage_target = storage_target
+        super().__init__(
+            f"a different compiler is already registered for ({engine_id!r}, {storage_target!r}); "
+            "re-registering with a different function is not allowed"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# The registry.
+# --------------------------------------------------------------------------- #
+
+
+class CompilerRegistry:
+    """Thread-safe process-wide compiler registry.
+
+    ``@internal``. State and operations are class-level (a single process-wide
+    registry — the canonical usage is ``CompilerRegistry.register(...)`` /
+    ``CompilerRegistry.get(...)``), guarded by a class lock so concurrent
+    engine-import-time registration is safe.
+    """
+
+    _lock: threading.Lock = threading.Lock()
+    _registry: dict[tuple[str, str], CompilerFn] = {}
+
+    def __init__(self) -> None:  # pragma: no cover - guard against instantiation
+        raise TypeError("CompilerRegistry is a process-wide singleton; use its classmethods directly")
+
+    @classmethod
+    def register(cls, engine_id: str, storage_target: str, compiler: CompilerFn) -> None:
+        """Register ``compiler`` for ``(engine_id, storage_target)``.
+
+        Idempotent: re-registering the *same* function object for an already-bound
+        key is a no-op. Registering a *different* function for an occupied key
+        raises :class:`CompilerConflictError` — a registration is never silently
+        overwritten.
+        """
+        key = (engine_id, storage_target)
+        with cls._lock:
+            existing = cls._registry.get(key)
+            if existing is not None and existing is not compiler:
+                raise CompilerConflictError(engine_id, storage_target)
+            cls._registry[key] = compiler
+
+    @classmethod
+    def get(cls, engine_id: str, storage_target: str) -> CompilerFn:
+        """Return the compiler for ``(engine_id, storage_target)``.
+
+        Raises :class:`UnknownCompilerError` (a :class:`KhoraError` subclass) if
+        no compiler is registered for the key.
+        """
+        key = (engine_id, storage_target)
+        with cls._lock:
+            compiler = cls._registry.get(key)
+        if compiler is None:
+            raise UnknownCompilerError(engine_id, storage_target)
+        return compiler
+
+    @classmethod
+    def _clear(cls) -> None:
+        """Drop every registration. Test-only escape hatch (not public API)."""
+        with cls._lock:
+            cls._registry.clear()

--- a/tests/recall/test_compile_context.py
+++ b/tests/recall/test_compile_context.py
@@ -1,0 +1,263 @@
+"""Unit tests for ``CompileContext`` / ``SchemaCapabilities`` (Layer 4 seam).
+
+Pins: the field set + defaults, frozen/slotted shape, the ``DEFAULTS``
+capability instance, ``CompileError`` is a ``KhoraError``, the re-exported
+``RecallFilterUnsupportedError`` is the model's (not a redefinition), and the
+internal-only rule that these are absent from ``khora.__all__``.
+
+A first cut — QA expands coverage after this.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from khora.exceptions import KhoraError
+from khora.filter.context import (
+    CompileContext,
+    CompileError,
+    RecallFilterUnsupportedError,
+    SchemaCapabilities,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# CompileContext field set + defaults.
+# ---------------------------------------------------------------------------
+
+
+def test_context_required_field_only_backend_target() -> None:
+    ctx = CompileContext(backend_target="khora_chunks")
+    assert ctx.backend_target == "khora_chunks"
+
+
+def test_context_defaults() -> None:
+    ctx = CompileContext(backend_target="documents")
+    assert ctx.table_alias is None
+    assert ctx.param_namespace == "f"
+    assert ctx.field_mapping is None
+    assert ctx.schema_capabilities is SchemaCapabilities.DEFAULTS
+    assert ctx.on_unsupported == "raise"
+
+
+def test_context_field_names_match_spec() -> None:
+    names = {f.name for f in dataclasses.fields(CompileContext)}
+    assert names == {
+        "backend_target",
+        "table_alias",
+        "param_namespace",
+        "field_mapping",
+        "schema_capabilities",
+        "on_unsupported",
+    }
+
+
+def test_context_accepts_overrides() -> None:
+    caps = SchemaCapabilities(jsonb_path_query=True, full_text=True, native_map_metadata=True)
+    ctx = CompileContext(
+        backend_target="Chunk",
+        table_alias="c",
+        param_namespace="g",
+        field_mapping={"source_name": "src_name"},
+        schema_capabilities=caps,
+        on_unsupported="split",
+    )
+    assert ctx.table_alias == "c"
+    assert ctx.param_namespace == "g"
+    assert ctx.field_mapping == {"source_name": "src_name"}
+    assert ctx.schema_capabilities is caps
+    assert ctx.on_unsupported == "split"
+
+
+def test_context_on_unsupported_accepts_raise_and_split() -> None:
+    # AC4: on_unsupported is the two-value policy literal — both arms construct.
+    assert CompileContext(backend_target="t", on_unsupported="raise").on_unsupported == "raise"
+    assert CompileContext(backend_target="t", on_unsupported="split").on_unsupported == "split"
+
+
+def test_context_field_mapping_carries_system_key_to_column_map() -> None:
+    # AC4: field_mapping lets one compiler serve a different schema. It is
+    # carried verbatim (a Mapping), defaulting to None (identity mapping).
+    mapping = {"source_name": "src_name", "title": "doc_title"}
+    ctx = CompileContext(backend_target="chunks", field_mapping=mapping)
+    assert ctx.field_mapping == mapping
+    assert CompileContext(backend_target="chunks").field_mapping is None
+
+
+def test_context_field_mapping_accepts_any_mapping_not_just_dict() -> None:
+    # The field is typed Mapping[str, str] | None — an immutable MappingProxyType
+    # (a natural choice for a read-only schema map) is carried verbatim.
+    from types import MappingProxyType
+
+    mp = MappingProxyType({"source_name": "src_name"})
+    ctx = CompileContext(backend_target="chunks", field_mapping=mp)
+    assert ctx.field_mapping is mp
+    assert ctx.field_mapping["source_name"] == "src_name"
+
+
+def test_context_supports_dataclasses_replace_for_derived_variants() -> None:
+    # The context is frozen, but an engine can derive a variant via
+    # dataclasses.replace (e.g. flip on_unsupported for a split pass) without
+    # mutating the original.
+    base = CompileContext(backend_target="khora_chunks", param_namespace="f")
+    split = dataclasses.replace(base, on_unsupported="split")
+    assert split.on_unsupported == "split"
+    assert split.backend_target == "khora_chunks"
+    assert split.param_namespace == "f"
+    # Original is untouched.
+    assert base.on_unsupported == "raise"
+
+
+def test_context_with_dict_field_mapping_is_not_hashable() -> None:
+    # CompileContext is frozen but carries a mutable dict field_mapping, so a
+    # context built with a dict mapping is not hashable (dict is unhashable). This
+    # documents that a CompileContext must not be used as a dict/set key — the
+    # cache key is the canonical_hash of the AST, not the context.
+    ctx = CompileContext(backend_target="khora_chunks", field_mapping={"a": "b"})
+    with pytest.raises(TypeError):
+        hash(ctx)
+
+
+def test_context_is_frozen() -> None:
+    ctx = CompileContext(backend_target="khora_chunks")
+    with pytest.raises((AttributeError, TypeError)):
+        ctx.backend_target = "documents"  # type: ignore[misc]
+
+
+def test_context_is_slotted() -> None:
+    ctx = CompileContext(backend_target="khora_chunks")
+    assert not hasattr(ctx, "__dict__")
+
+
+# ---------------------------------------------------------------------------
+# SchemaCapabilities — 3 flags + DEFAULTS.
+# ---------------------------------------------------------------------------
+
+
+def test_schema_capabilities_flag_defaults_are_false() -> None:
+    caps = SchemaCapabilities()
+    assert caps.jsonb_path_query is False
+    assert caps.full_text is False
+    assert caps.native_map_metadata is False
+
+
+def test_schema_capabilities_defaults_instance_is_all_false() -> None:
+    assert isinstance(SchemaCapabilities.DEFAULTS, SchemaCapabilities)
+    assert SchemaCapabilities.DEFAULTS == SchemaCapabilities()
+
+
+def test_schema_capabilities_field_names() -> None:
+    names = {f.name for f in dataclasses.fields(SchemaCapabilities)}
+    assert names == {"jsonb_path_query", "full_text", "native_map_metadata"}
+
+
+def test_schema_capabilities_is_frozen() -> None:
+    caps = SchemaCapabilities()
+    with pytest.raises((AttributeError, TypeError)):
+        caps.full_text = True  # type: ignore[misc]
+
+
+def test_schema_capabilities_is_slotted() -> None:
+    assert not hasattr(SchemaCapabilities(), "__dict__")
+
+
+def test_context_default_schema_capabilities_is_the_shared_defaults_instance() -> None:
+    # AC4: the default is SchemaCapabilities.DEFAULTS — the same shared instance,
+    # not a freshly-constructed equal one (callers need not construct one).
+    a = CompileContext(backend_target="a")
+    b = CompileContext(backend_target="b")
+    assert a.schema_capabilities is SchemaCapabilities.DEFAULTS
+    assert b.schema_capabilities is SchemaCapabilities.DEFAULTS
+    assert a.schema_capabilities is b.schema_capabilities
+
+
+def test_schema_capabilities_value_equality_and_hashing() -> None:
+    # Frozen dataclass: equal-by-value instances compare equal AND hash equal, so
+    # a richer-capability instance can be used as a dict/set key by an engine.
+    assert SchemaCapabilities(jsonb_path_query=True) == SchemaCapabilities(jsonb_path_query=True)
+    assert hash(SchemaCapabilities(jsonb_path_query=True)) == hash(SchemaCapabilities(jsonb_path_query=True))
+    assert SchemaCapabilities(full_text=True) != SchemaCapabilities()
+    # DEFAULTS equals a freshly-constructed all-False instance but the canonical
+    # default is the shared singleton (asserted elsewhere).
+    assert SchemaCapabilities.DEFAULTS == SchemaCapabilities()
+
+
+def test_schema_capabilities_partial_flags() -> None:
+    # A realistic backend declares a subset of capabilities (e.g. a JSONB-capable
+    # store without native full-text); the other flags stay at their False default.
+    caps = SchemaCapabilities(jsonb_path_query=True)
+    assert caps.jsonb_path_query is True
+    assert caps.full_text is False
+    assert caps.native_map_metadata is False
+
+
+# ---------------------------------------------------------------------------
+# Error types.
+# ---------------------------------------------------------------------------
+
+
+def test_compile_error_is_khora_error() -> None:
+    assert issubclass(CompileError, KhoraError)
+
+
+def test_unsupported_error_is_the_models_not_a_redefinition() -> None:
+    # context.py RE-EXPORTS the model's error; it must be the same class object,
+    # so callers catch one type regardless of import path.
+    from khora.filter.model import RecallFilterUnsupportedError as ModelErr
+
+    assert RecallFilterUnsupportedError is ModelErr
+
+
+def test_unsupported_error_is_distinct_from_compile_error() -> None:
+    # A capability gap (RecallFilterUnsupportedError) is not an internal compiler
+    # fault (CompileError); they are distinct types.
+    assert RecallFilterUnsupportedError is not CompileError
+    assert not issubclass(RecallFilterUnsupportedError, CompileError)
+
+
+def test_compile_error_carries_message_and_catches_as_khora_error() -> None:
+    # CompileError is a plain KhoraError subclass carrying a human message; it
+    # must be catchable via the KhoraError base (callers may catch broadly).
+    with pytest.raises(KhoraError) as exc_info:
+        raise CompileError("unreachable AST branch")
+    assert "unreachable AST branch" in str(exc_info.value)
+
+
+def test_unsupported_error_carries_path_and_reason() -> None:
+    # RecallFilterUnsupportedError carries structured path + reason (the backend
+    # could not express the predicate at that path), surfaced in its message.
+    err = RecallFilterUnsupportedError("/metadata.k/$regex", "backend lacks regex predicate")
+    assert err.path == "/metadata.k/$regex"
+    assert err.reason == "backend lacks regex predicate"
+    assert "/metadata.k/$regex" in str(err)
+    assert "backend lacks regex predicate" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# Internal-only — absent from khora.__all__.
+# ---------------------------------------------------------------------------
+
+
+def test_context_absent_from_khora_top_level_all() -> None:
+    import khora
+
+    for name in ("CompileContext", "SchemaCapabilities", "CompileError"):
+        assert name not in khora.__all__
+
+
+def test_context_reachable_from_khora_filter() -> None:
+    import khora.filter as f
+
+    assert f.CompileContext is CompileContext
+    assert f.SchemaCapabilities is SchemaCapabilities
+
+
+def test_context_names_not_in_khora_filter_public_all() -> None:
+    import khora.filter as f
+
+    for name in ("CompileContext", "SchemaCapabilities", "CompileError"):
+        assert name not in f.__all__

--- a/tests/recall/test_compiler_registry.py
+++ b/tests/recall/test_compiler_registry.py
@@ -1,0 +1,333 @@
+"""Unit tests for the internal compiler registry (Layer 4 seam).
+
+Pins: register/get round-trips on ``(engine_id, storage_target)``, a clear
+``KhoraError`` subclass on a miss, idempotent same-fn re-register, a raise on a
+conflicting fn, thread-safe concurrent registration, and ``CompiledFilter``
+typing/defaults — plus the internal-only rule that the registry is absent from
+``khora.__all__``.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from khora.exceptions import KhoraError
+from khora.filter.ast import FilterNode
+from khora.filter.context import CompileContext
+from khora.filter.model import Op
+from khora.filter.registry import (
+    CompiledFilter,
+    CompilerConflictError,
+    CompilerRegistry,
+    UnknownCompilerError,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> None:
+    """Each test starts and ends with an empty registry (process-wide state).
+
+    The registry is process-wide class state; this fixture prevents tests from
+    leaking registrations into one another. Tests additionally use unique
+    engine_id / storage_target keys so a concurrent or mis-ordered run cannot
+    cross-contaminate.
+    """
+    CompilerRegistry._clear()
+    yield
+    CompilerRegistry._clear()
+
+
+def _fake_compiler(ast: FilterNode, ctx: CompileContext) -> CompiledFilter:
+    return CompiledFilter(predicate="WHERE 1=1", params={}, consumed_keys=frozenset(), canonical_hash="abc")
+
+
+def _other_compiler(ast: FilterNode, ctx: CompileContext) -> CompiledFilter:
+    return CompiledFilter(predicate="WHERE 2=2", params={}, consumed_keys=frozenset(), canonical_hash="def")
+
+
+# ---------------------------------------------------------------------------
+# register / get round-trip.
+# ---------------------------------------------------------------------------
+
+
+def test_register_then_get_returns_same_fn() -> None:
+    CompilerRegistry.register("vectorcypher", "khora_chunks", _fake_compiler)
+    assert CompilerRegistry.get("vectorcypher", "khora_chunks") is _fake_compiler
+
+
+def test_registry_keyed_by_engine_and_storage_target() -> None:
+    CompilerRegistry.register("vectorcypher", "khora_chunks", _fake_compiler)
+    CompilerRegistry.register("vectorcypher", "neo4j_chunk", _other_compiler)
+    assert CompilerRegistry.get("vectorcypher", "khora_chunks") is _fake_compiler
+    assert CompilerRegistry.get("vectorcypher", "neo4j_chunk") is _other_compiler
+
+
+def test_registry_empty_at_import() -> None:
+    # After _clear (autouse fixture), nothing is registered — the registry ships
+    # empty; engines register at import time, not the registry module.
+    with pytest.raises(UnknownCompilerError):
+        CompilerRegistry.get("vectorcypher", "khora_chunks")
+
+
+def test_registry_is_a_non_instantiable_singleton() -> None:
+    # The registry is process-wide class state used via classmethods; constructing
+    # an instance is a misuse and raises TypeError.
+    with pytest.raises(TypeError):
+        CompilerRegistry()
+
+
+def test_registered_compiler_round_trips_and_is_callable() -> None:
+    # The CompilerFn contract is usable end-to-end: a registered compiler is
+    # fetched and invoked as Callable[[FilterNode, CompileContext], CompiledFilter].
+    CompilerRegistry.register("vectorcypher", "khora_chunks", _fake_compiler)
+    compiler = CompilerRegistry.get("vectorcypher", "khora_chunks")
+    result = compiler(FilterNode(op=Op.AND), CompileContext(backend_target="khora_chunks"))
+    assert isinstance(result, CompiledFilter)
+    assert result.predicate == "WHERE 1=1"
+
+
+# ---------------------------------------------------------------------------
+# Miss raises a clear KhoraError subclass.
+# ---------------------------------------------------------------------------
+
+
+def test_get_missing_raises_unknown_compiler_error() -> None:
+    with pytest.raises(UnknownCompilerError):
+        CompilerRegistry.get("nope", "nope")
+
+
+def test_unknown_compiler_error_is_khora_error() -> None:
+    assert issubclass(UnknownCompilerError, KhoraError)
+    with pytest.raises(KhoraError):
+        CompilerRegistry.get("nope", "nope")
+
+
+def test_unknown_compiler_error_carries_key() -> None:
+    try:
+        CompilerRegistry.get("eng", "store")
+    except UnknownCompilerError as exc:
+        assert exc.engine_id == "eng"
+        assert exc.storage_target == "store"
+    else:  # pragma: no cover
+        pytest.fail("expected UnknownCompilerError")
+
+
+# ---------------------------------------------------------------------------
+# Idempotent same-fn re-register; conflicting fn raises.
+# ---------------------------------------------------------------------------
+
+
+def test_reregister_same_fn_is_idempotent() -> None:
+    CompilerRegistry.register("vectorcypher", "khora_chunks", _fake_compiler)
+    CompilerRegistry.register("vectorcypher", "khora_chunks", _fake_compiler)  # no raise
+    assert CompilerRegistry.get("vectorcypher", "khora_chunks") is _fake_compiler
+
+
+def test_reregister_different_fn_raises() -> None:
+    CompilerRegistry.register("vectorcypher", "khora_chunks", _fake_compiler)
+    with pytest.raises(CompilerConflictError):
+        CompilerRegistry.register("vectorcypher", "khora_chunks", _other_compiler)
+    # The original registration is preserved (never silently overwritten).
+    assert CompilerRegistry.get("vectorcypher", "khora_chunks") is _fake_compiler
+
+
+def test_conflict_error_is_khora_error() -> None:
+    assert issubclass(CompilerConflictError, KhoraError)
+
+
+def test_conflict_error_carries_key() -> None:
+    CompilerRegistry.register("eng", "store", _fake_compiler)
+    try:
+        CompilerRegistry.register("eng", "store", _other_compiler)
+    except CompilerConflictError as exc:
+        assert exc.engine_id == "eng"
+        assert exc.storage_target == "store"
+    else:  # pragma: no cover
+        pytest.fail("expected CompilerConflictError")
+
+
+# ---------------------------------------------------------------------------
+# Thread-safe concurrent registration (class-level state, class lock).
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_register_same_fn_is_safe() -> None:
+    # Many threads racing to register the SAME function on the SAME key must all
+    # succeed (idempotent) with no lost update / spurious conflict.
+    errors: list[BaseException] = []
+    barrier = threading.Barrier(16)
+
+    def worker() -> None:
+        try:
+            barrier.wait()
+            CompilerRegistry.register("vc", "same_target", _fake_compiler)
+        except BaseException as exc:  # noqa: BLE001 - record for the assertion
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(16)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    assert CompilerRegistry.get("vc", "same_target") is _fake_compiler
+
+
+def test_concurrent_register_distinct_keys_all_land() -> None:
+    # Each thread registers on a distinct key; the lock must serialize the dict
+    # mutations so every registration survives (no dropped writes under races).
+    barrier = threading.Barrier(20)
+
+    def worker(i: int) -> None:
+        barrier.wait()
+        CompilerRegistry.register("vc", f"target_{i}", _fake_compiler)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    for i in range(20):
+        assert CompilerRegistry.get("vc", f"target_{i}") is _fake_compiler
+
+
+def test_concurrent_conflicting_register_keeps_one_winner() -> None:
+    # Threads race to register DIFFERENT functions on the SAME key. The lock must
+    # serialize so exactly one fn wins and every loser sees a CompilerConflictError
+    # (never a corrupted/partial registration). The final state is one of the two.
+    conflicts: list[CompilerConflictError] = []
+    barrier = threading.Barrier(16)
+    compilers = (_fake_compiler, _other_compiler)
+
+    def worker(i: int) -> None:
+        barrier.wait()
+        try:
+            CompilerRegistry.register("vc", "contested", compilers[i % 2])
+        except CompilerConflictError as exc:
+            conflicts.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(16)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    winner = CompilerRegistry.get("vc", "contested")
+    assert winner in compilers
+    # Everyone who tried to register the OTHER function lost with a clean conflict.
+    assert all(isinstance(c, CompilerConflictError) for c in conflicts)
+
+
+# ---------------------------------------------------------------------------
+# CompiledFilter typing + defaults.
+# ---------------------------------------------------------------------------
+
+
+def test_compiled_filter_fields() -> None:
+    cf = CompiledFilter(
+        predicate="WHERE x = :f_0",
+        params={"f_0": 1},
+        consumed_keys=frozenset({"source_name"}),
+        canonical_hash="deadbeef",
+    )
+    assert cf.predicate == "WHERE x = :f_0"
+    assert cf.params == {"f_0": 1}
+    assert cf.consumed_keys == frozenset({"source_name"})
+    assert cf.canonical_hash == "deadbeef"
+
+
+def test_compiled_filter_is_frozen() -> None:
+    cf = CompiledFilter(predicate=1, params={}, consumed_keys=frozenset(), canonical_hash="h")
+    with pytest.raises((AttributeError, TypeError)):
+        cf.predicate = 2  # type: ignore[misc]
+
+
+def test_compiled_filter_predicate_type_is_generic() -> None:
+    # T varies by backend: a SQLAlchemy expr, a Cypher fragment, a callable, ...
+    # The dataclass carries whatever predicate type the backend emits verbatim.
+    def _callable_predicate(record: object) -> bool:  # pragma: no cover - never called
+        return True
+
+    cf = CompiledFilter(
+        predicate=_callable_predicate,
+        params={},
+        consumed_keys=frozenset({"source_name", "title"}),
+        canonical_hash="h",
+    )
+    assert cf.predicate is _callable_predicate
+    assert cf.consumed_keys == frozenset({"source_name", "title"})
+
+
+def test_compiled_filter_consumed_keys_is_frozenset() -> None:
+    cf = CompiledFilter(
+        predicate="p",
+        params={"f_0": 1},
+        consumed_keys=frozenset({"a"}),
+        canonical_hash="h",
+    )
+    assert isinstance(cf.consumed_keys, frozenset)
+
+
+# ---------------------------------------------------------------------------
+# Internal-only — registry is NOT exported from khora.__all__.
+# ---------------------------------------------------------------------------
+
+
+# The full set of internal Layer 3/4 seam names that AC2 requires to be absent
+# from the top-level ``khora.__all__`` while remaining reachable via
+# ``khora.filter`` (and its submodules).
+_INTERNAL_SEAM_NAMES = (
+    "CompilerRegistry",
+    "CompileContext",
+    "SchemaCapabilities",
+    "FilterNode",
+    "parse_to_ast",
+    "CompiledFilter",
+    "CompilerFn",
+)
+
+
+def test_ac2_internal_seam_absent_from_khora_top_level_all() -> None:
+    import khora
+
+    for name in _INTERNAL_SEAM_NAMES:
+        assert name not in khora.__all__, f"{name} leaked into khora.__all__"
+
+
+def test_ac2_internal_seam_not_in_khora_filter_public_all() -> None:
+    # khora.filter.__all__ is the PUBLIC surface; the internal names are reachable
+    # as attributes but not part of __all__.
+    import khora.filter as f
+
+    for name in _INTERNAL_SEAM_NAMES:
+        assert name not in f.__all__, f"{name} leaked into khora.filter.__all__"
+
+
+def test_ac2_registry_importable_from_khora_filter() -> None:
+    # `from khora.filter import CompilerRegistry` must work even though it's not
+    # in __all__.
+    from khora.filter import CompiledFilter as PkgCompiledFilter
+    from khora.filter import CompilerRegistry as PkgRegistry
+
+    assert PkgRegistry is CompilerRegistry
+    assert PkgCompiledFilter is CompiledFilter
+
+
+def test_ac2_registry_importable_via_submodule() -> None:
+    # ...and via the concrete submodule path.
+    from khora.filter.registry import CompilerRegistry as ModRegistry
+
+    assert ModRegistry is CompilerRegistry
+
+
+def test_registry_reachable_from_khora_filter() -> None:
+    import khora.filter as f
+
+    assert f.CompilerRegistry is CompilerRegistry
+    assert f.CompiledFilter is CompiledFilter

--- a/tests/recall/test_filter_ast.py
+++ b/tests/recall/test_filter_ast.py
@@ -1,0 +1,798 @@
+"""Unit tests for the canonical filter AST (Layer 3) — ``@internal``.
+
+Pins the two lowering invariants the rest of the subsystem depends on:
+compilers never see dot-strings or bare-value/logical sugar. ``parse_to_ast``
+takes a *validated* ``RecallFilter`` and emits a ``FilterNode`` whose paths are
+segment tuples and whose sugar is fully desugared. ``canonical_hash`` derives a
+stable cache key with documented order semantics.
+
+A first cut — QA expands coverage after this.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from khora.filter import RecallFilter
+from khora.filter.ast import (
+    DateLiteral,
+    FilterClause,
+    FilterNode,
+    FilterOp,
+    canonical_hash,
+    parse_to_ast,
+)
+from khora.filter.model import Op
+
+pytestmark = pytest.mark.unit
+
+
+def _ast(wire: dict) -> FilterNode | FilterClause:
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+def _clauses(node: FilterNode | FilterClause) -> list[FilterClause]:
+    """Flatten the immediate clause children of an AST root (non-recursive).
+
+    ``parse_to_ast`` normalizes a single bare predicate down to a lone
+    :class:`FilterClause` (the single-child ``AND`` wrapper collapses), so the
+    root may itself be a clause. Treat that as a one-clause list.
+    """
+    if isinstance(node, FilterClause):
+        return [node]
+    return [c for c in node.children if isinstance(c, FilterClause)]
+
+
+# ---------------------------------------------------------------------------
+# FilterOp is the model's Op (single source of truth, no parallel enum).
+# ---------------------------------------------------------------------------
+
+
+def test_filterop_is_model_op() -> None:
+    assert FilterOp is Op
+    assert FilterOp.EQ == "$eq"
+
+
+# ---------------------------------------------------------------------------
+# Paths are always segment tuples — never dot-strings.
+# ---------------------------------------------------------------------------
+
+
+def test_system_key_lowers_to_single_segment_path() -> None:
+    ast = _ast({"source_name": "linear"})
+    (clause,) = _clauses(ast)
+    assert clause.path == ("source_name",)
+    assert clause.op == Op.EQ
+    assert clause.operand == "linear"
+
+
+def test_metadata_dot_path_lowers_to_multi_segment_path() -> None:
+    ast = _ast({"metadata.labels.tier": {"$gte": 5}})
+    (clause,) = _clauses(ast)
+    # ("metadata", "labels", "tier") — the leading "metadata" root is kept.
+    assert clause.path == ("metadata", "labels", "tier")
+    assert clause.op == Op.GTE
+    assert clause.operand == 5
+
+
+def test_no_path_anywhere_is_a_dot_string() -> None:
+    ast = _ast(
+        {
+            "source_name": "linear",
+            "metadata.a.b": "x",
+            "$or": [{"metadata.c": 1}, {"title": "t"}],
+        }
+    )
+    for clause in _walk_clauses(ast):
+        assert isinstance(clause.path, tuple)
+        assert all("." not in segment for segment in clause.path)
+
+
+def test_bare_metadata_blob_is_single_metadata_segment() -> None:
+    ast = _ast({"metadata": {"x": 1, "y": 2}})
+    (clause,) = _clauses(ast)
+    assert clause.path == ("metadata",)
+    assert clause.op == Op.EQ
+    assert clause.operand == {"x": 1, "y": 2}
+
+
+# ---------------------------------------------------------------------------
+# AC1 — a filter mixing metadata dot-paths + bare sugar + $nor lowers to an AST
+# with SEGMENT-LIST paths, explicit $eq/$or/$not, NO surviving NOR node, and NO
+# dot-string anywhere. Asserted by walking the whole tree.
+# ---------------------------------------------------------------------------
+
+
+def test_ac1_mixed_filter_lowers_to_fully_desugared_segment_path_ast() -> None:
+    ast = _ast(
+        {
+            # bare-scalar sugar -> $eq, single-segment path
+            "source_name": "linear",
+            # metadata dot-path -> multi-segment path, explicit operator
+            "metadata.labels.tier": {"$gte": 5},
+            # $nor -> $not($or(...)); NO NOR node may survive
+            "$nor": [{"title": "draft"}, {"source_type": "spam"}],
+        }
+    )
+
+    # Several siblings on one document -> explicit AND root.
+    assert isinstance(ast, FilterNode)
+    assert ast.op == Op.AND
+
+    nodes = _walk_nodes(ast)
+    clauses = _walk_clauses(ast)
+
+    # No NOR node survives; every logical node is AND / OR / NOT only.
+    assert all(n.op != Op.NOR for n in nodes)
+    assert {n.op for n in nodes} <= {Op.AND, Op.OR, Op.NOT}
+    # The $nor lowered to a NOT wrapping an OR (both present in the tree).
+    assert any(n.op == Op.NOT for n in nodes)
+    assert any(n.op == Op.OR for n in nodes)
+
+    # Every path is a SEGMENT tuple — no dot-strings, no "." inside any segment.
+    for clause in clauses:
+        assert isinstance(clause.path, tuple)
+        assert all(isinstance(seg, str) and "." not in seg for seg in clause.path)
+    # The metadata predicate produced its multi-segment path.
+    assert ("metadata", "labels", "tier") in {c.path for c in clauses}
+    # The bare scalar produced an EXPLICIT $eq clause (sugar fully desugared).
+    assert any(c.path == ("source_name",) and c.op == Op.EQ for c in clauses)
+    # Every leaf op is a concrete comparison op (never a logical op on a leaf).
+    assert all(c.op in {Op.EQ, Op.NE, Op.GT, Op.GTE, Op.LT, Op.LTE, Op.IN, Op.NIN, Op.EXISTS} for c in clauses)
+
+
+# ---------------------------------------------------------------------------
+# Sugar is fully desugared — no bare value / logical sugar reaches the AST.
+# ---------------------------------------------------------------------------
+
+
+def test_bare_scalar_lowers_to_eq() -> None:
+    (clause,) = _clauses(_ast({"title": "Q2 plan"}))
+    assert clause.op == Op.EQ
+    assert clause.operand == "Q2 plan"
+
+
+def test_bare_list_is_eq_exact_array_not_in() -> None:
+    # A bare list is $eq EXACT-ARRAY equality, NOT $in. The operand is an
+    # order-preserving tuple, and the op is $eq (membership is the explicit $in).
+    (clause,) = _clauses(_ast({"source_type": ["a", "b"]}))
+    assert clause.op == Op.EQ
+    assert clause.operand == ("a", "b")
+    assert clause.op != Op.IN
+
+
+def test_bare_metadata_list_is_eq_exact_array_not_in() -> None:
+    # Same uniform bare-list rule on a folded metadata sub-path: $eq exact-array,
+    # NOT $in. The operand is an order-preserving tuple.
+    (clause,) = _clauses(_ast({"metadata.tags": ["x", "y", "z"]}))
+    assert clause.path == ("metadata", "tags")
+    assert clause.op == Op.EQ
+    assert clause.operand == ("x", "y", "z")
+    assert isinstance(clause.operand, tuple)
+
+
+def test_explicit_in_stays_in_with_ordered_tuple() -> None:
+    (clause,) = _clauses(_ast({"source_name": {"$in": ["a", "b"]}}))
+    assert clause.op == Op.IN
+    assert clause.operand == ("a", "b")
+
+
+def test_metadata_explicit_in_stays_in_with_ordered_tuple() -> None:
+    (clause,) = _clauses(_ast({"metadata.k": {"$in": ["a", "b", "c"]}}))
+    assert clause.op == Op.IN
+    assert clause.operand == ("a", "b", "c")
+    assert isinstance(clause.operand, tuple)
+
+
+def test_metadata_nin_lowers_to_ordered_tuple() -> None:
+    (clause,) = _clauses(_ast({"metadata.k": {"$nin": [1, 2]}}))
+    assert clause.op == Op.NIN
+    assert clause.operand == (1, 2)
+    assert isinstance(clause.operand, tuple)
+
+
+def test_metadata_exists_operand_is_bool() -> None:
+    (clause,) = _clauses(_ast({"metadata.k": {"$exists": True}}))
+    assert clause.op == Op.EXISTS
+    assert clause.operand is True
+
+
+def test_nor_desugars_to_not_or() -> None:
+    ast = _ast({"$nor": [{"source_name": "x"}, {"title": "y"}]})
+    assert ast.op == Op.NOT
+    (inner,) = ast.children
+    assert isinstance(inner, FilterNode)
+    assert inner.op == Op.OR
+    assert len(inner.children) == 2
+
+
+def test_no_nor_node_ever_survives_into_ast() -> None:
+    # $nor desugars to $not($or(...)) at build time — no NOR node may reach the
+    # compilers. The AST's only logical node ops are AND / OR / NOT (scope-creep
+    # guard: a future refactor must never emit a NOR node).
+    ast = _ast(
+        {
+            "$nor": [{"source_name": "a"}, {"title": "b"}],
+            "$and": [{"$nor": [{"source": "c"}]}],
+        }
+    )
+    for node in _walk_nodes(ast):
+        assert node.op != Op.NOR
+        assert node.op in {Op.AND, Op.OR, Op.NOT}
+
+
+def test_not_of_not_is_preserved_not_collapsed() -> None:
+    # A doubly-nested $not must stay two NOT nodes — never collapsed to identity
+    # (no missing/extra negation).
+    ast = _ast({"$not": {"$not": {"source_name": "x"}}})
+    assert ast.op == Op.NOT
+    (inner,) = ast.children
+    assert isinstance(inner, FilterNode)
+    assert inner.op == Op.NOT
+
+
+def test_document_level_not_is_a_not_node() -> None:
+    # Document-form $not negates the lowered inner filter. The inner single-key
+    # filter normalizes to AND([clause]) (the root is always a FilterNode — a
+    # single leaf is wrapped, never collapsed to a bare clause), so the NOT wraps
+    # that AND node.
+    ast = _ast({"$not": {"source_name": "x"}})
+    assert isinstance(ast, FilterNode)
+    assert ast.op == Op.NOT
+    (inner,) = ast.children
+    assert isinstance(inner, FilterNode)
+    assert inner.op == Op.AND
+    (clause,) = inner.children
+    assert isinstance(clause, FilterClause)
+    assert clause.path == ("source_name",)
+    assert clause.op == Op.EQ
+    assert clause.operand == "x"
+
+
+def test_document_level_not_over_multikey_inner_wraps_and_node() -> None:
+    # When the inner filter has several siblings it stays an AND node, so the NOT
+    # wraps a FilterNode (the collapse only applies to a single child).
+    ast = _ast({"$not": {"source_name": "x", "source_type": "y"}})
+    assert isinstance(ast, FilterNode)
+    assert ast.op == Op.NOT
+    (inner,) = ast.children
+    assert isinstance(inner, FilterNode)
+    assert inner.op == Op.AND
+    assert {c.path for c in _clauses(inner)} == {("source_name",), ("source_type",)}
+
+
+def test_field_level_not_is_a_not_node() -> None:
+    ast = _ast({"source_name": {"$not": {"$eq": "x"}}})
+    assert ast.op == Op.NOT
+    (clause,) = ast.children
+    assert isinstance(clause, FilterClause)
+    assert clause.path == ("source_name",)
+    assert clause.op == Op.EQ
+
+
+def test_metadata_field_level_not_is_a_not_node() -> None:
+    ast = _ast({"metadata.k": {"$not": {"$gte": 5}}})
+    assert ast.op == Op.NOT
+    (clause,) = ast.children
+    assert isinstance(clause, FilterClause)
+    assert clause.op == Op.GTE
+    assert clause.operand == 5
+
+
+def test_field_level_not_and_document_level_not_both_produce_not_nodes() -> None:
+    # A document-level $not whose inner filter carries a field-level $not yields
+    # two NOT nodes (one per negation): document NOT wrapping the lowered inner
+    # filter, which itself contains the field-level NOT.
+    ast = _ast({"$not": {"source_name": {"$not": {"$eq": "x"}}}})
+    assert ast.op == Op.NOT
+    not_nodes = [n for n in _walk_nodes(ast) if n.op == Op.NOT]
+    assert len(not_nodes) == 2
+    # The single leaf survives with its concrete op.
+    (clause,) = _walk_clauses(ast)
+    assert clause.path == ("source_name",)
+    assert clause.op == Op.EQ
+    assert clause.operand == "x"
+
+
+def test_nested_metadata_not_lowers_to_nested_not_nodes_no_clause_carries_not() -> None:
+    # Regression: a $not nested inside a field-position $not on a metadata
+    # path must lower to NESTED NOT *FilterNodes*, never to a malformed
+    # FilterClause(op=NOT, operand=<raw dict>). Guard the invariant directly: no
+    # FilterClause anywhere in the tree carries a logical op, and the two
+    # negations produced exactly two NOT nodes.
+    ast = _ast({"metadata.k": {"$not": {"$not": {"$gte": 5}}}})
+    not_nodes = [n for n in _walk_nodes(ast) if n.op == Op.NOT]
+    assert len(not_nodes) == 2
+    # Every leaf is a real comparison clause — NONE carries a logical op.
+    leaves = _walk_clauses(ast)
+    assert leaves, "expected at least one leaf clause"
+    assert all(c.op not in {Op.NOT, Op.AND, Op.OR, Op.NOR} for c in leaves)
+    # The surviving comparison is the inner $gte, carried verbatim.
+    (leaf,) = leaves
+    assert leaf.path == ("metadata", "k")
+    assert leaf.op == Op.GTE
+    assert leaf.operand == 5
+
+
+def test_no_filterclause_anywhere_carries_a_logical_op() -> None:
+    # Broader scope-creep guard across a filter that exercises every $not form
+    # plus $nor: logical operators live ONLY on FilterNodes, never on a leaf.
+    ast = _ast(
+        {
+            "source_name": {"$not": {"$eq": "a"}},
+            "metadata.k": {"$not": {"$in": [1, 2]}},
+            "$nor": [{"title": "t"}, {"source_type": "x"}],
+            "$not": {"content_type": "c"},
+        }
+    )
+    for clause in _walk_clauses(ast):
+        assert clause.op not in {Op.NOT, Op.AND, Op.OR, Op.NOR}
+    for node in _walk_nodes(ast):
+        assert node.op in {Op.AND, Op.OR, Op.NOT}
+
+
+def test_implicit_sibling_and_becomes_explicit_and_node() -> None:
+    # Two sibling system keys on one document = implicit AND -> explicit AND.
+    ast = _ast({"source_name": "linear", "source_type": "issue"})
+    assert ast.op == Op.AND
+    paths = {c.path for c in _clauses(ast)}
+    assert paths == {("source_name",), ("source_type",)}
+
+
+def test_single_predicate_filter_wraps_in_and_node_root() -> None:
+    # The root is ALWAYS a FilterNode (the engine boundary contract: a compiler
+    # is Callable[[FilterNode, CompileContext], ...]). A single bare predicate
+    # normalizes to AND([clause]) — wrapped, never collapsed to a bare clause.
+    ast = _ast({"source_name": "linear"})
+    assert isinstance(ast, FilterNode)
+    assert ast.op == Op.AND
+    (clause,) = ast.children
+    assert isinstance(clause, FilterClause)
+    assert clause.path == ("source_name",)
+    assert clause.op == Op.EQ
+    assert clause.operand == "linear"
+
+
+def test_single_element_and_or_and_bare_converge_on_same_and_root() -> None:
+    # {a}, {$and:[{a}]}, and {$or:[{a}]} all normalize to AND([a]) — identical
+    # structure, identical hash. A single-element $and/$or wrapping a leaf is
+    # rewritten to AND([leaf]) (op normalized to AND), not collapsed to a clause.
+    bare = _ast({"source_name": "linear"})
+    single_and = _ast({"$and": [{"source_name": "linear"}]})
+    single_or = _ast({"$or": [{"source_name": "linear"}]})
+    for ast in (bare, single_and, single_or):
+        assert isinstance(ast, FilterNode)
+        assert ast.op == Op.AND
+        (clause,) = ast.children
+        assert isinstance(clause, FilterClause)
+        assert clause.path == ("source_name",)
+    assert canonical_hash(bare) == canonical_hash(single_and) == canonical_hash(single_or)
+
+
+def test_empty_filter_lowers_to_empty_and_match_everything() -> None:
+    # A bare RecallFilter() (no predicates) lowers to an empty AND node — a
+    # match-everything root. Compilers treat an empty AND as "no constraint".
+    ast = parse_to_ast(RecallFilter())
+    assert ast.op == Op.AND
+    assert ast.children == ()
+
+
+def test_lone_logical_node_is_not_double_wrapped() -> None:
+    # A document carrying a single logical operator returns that node directly,
+    # not wrapped in a redundant single-child AND.
+    ast = _ast({"$or": [{"source_name": "a"}, {"source_type": "b"}]})
+    assert ast.op == Op.OR
+    assert len(ast.children) == 2
+
+
+# ---------------------------------------------------------------------------
+# Normalization: same-operator flattening (associativity) + structural
+# convergence of equivalent shapes.
+# ---------------------------------------------------------------------------
+
+
+def test_nested_same_operator_and_is_flattened() -> None:
+    # AND-of-AND splices grandchildren up one level (associativity). The result
+    # is a single flat AND with all three leaves.
+    ast = _ast({"$and": [{"$and": [{"source_name": "a"}, {"source_type": "b"}]}, {"title": "t"}]})
+    assert isinstance(ast, FilterNode)
+    assert ast.op == Op.AND
+    # No AND child remains nested under the AND root (fully flattened).
+    assert all(not (isinstance(c, FilterNode) and c.op == Op.AND) for c in ast.children)
+    assert {c.path for c in _clauses(ast)} == {("source_name",), ("source_type",), ("title",)}
+
+
+def test_nested_same_operator_or_is_flattened() -> None:
+    # OR-of-OR splices the inner OR up one level (associativity). Each branch
+    # leaf is wrapped as AND([leaf]) (single-child leaf wrap), so the flattened
+    # OR root has three AND([leaf]) children and NO nested OR remains.
+    ast = _ast({"$or": [{"$or": [{"source_name": "a"}, {"source_type": "b"}]}, {"title": "t"}]})
+    assert isinstance(ast, FilterNode)
+    assert ast.op == Op.OR
+    # No OR child remains nested under the OR root (fully flattened).
+    assert all(not (isinstance(c, FilterNode) and c.op == Op.OR) for c in ast.children)
+    assert len(ast.children) == 3
+    # All three leaves are present across the (AND-wrapped) branches.
+    assert {c.path for c in _walk_clauses(ast)} == {("source_name",), ("source_type",), ("title",)}
+
+
+def test_or_child_of_and_is_not_flattened() -> None:
+    # Flattening is per-operator: an OR nested in an AND is left intact (never
+    # merged across operators).
+    ast = _ast({"source_name": "a", "$or": [{"source_type": "b"}, {"title": "t"}]})
+    assert isinstance(ast, FilterNode)
+    assert ast.op == Op.AND
+    or_children = [c for c in ast.children if isinstance(c, FilterNode) and c.op == Op.OR]
+    assert len(or_children) == 1
+
+
+def test_implicit_and_and_explicit_and_converge_on_same_structure() -> None:
+    # {a, b} (implicit AND) and {$and:[{a},{b}]} (explicit) normalize to the same
+    # AND([a, b]) — identical structure, identical hash.
+    implicit = canonical_hash(_ast({"source_name": "a", "source_type": "b"}))
+    explicit = canonical_hash(_ast({"$and": [{"source_name": "a"}, {"source_type": "b"}]}))
+    assert implicit == explicit
+
+
+def test_not_is_an_opaque_flattening_boundary() -> None:
+    # An AND inside a NOT is never spliced into an outer AND — NOT is opaque to
+    # flattening. The inner AND survives as a node under the NOT.
+    ast = _ast({"source_name": "a", "$not": {"source_type": "b", "title": "t"}})
+    assert isinstance(ast, FilterNode)
+    assert ast.op == Op.AND
+    not_nodes = [c for c in ast.children if isinstance(c, FilterNode) and c.op == Op.NOT]
+    assert len(not_nodes) == 1
+    (inner,) = not_nodes[0].children
+    assert isinstance(inner, FilterNode)
+    assert inner.op == Op.AND
+
+
+# ---------------------------------------------------------------------------
+# Operands are opaque; $date literals lower to DateLiteral.
+# ---------------------------------------------------------------------------
+
+
+def test_date_literal_operand_lowers_to_dateliteral() -> None:
+    (clause,) = _clauses(_ast({"metadata.when": {"$gte": {"$date": "2026-01-01T00:00:00Z"}}}))
+    assert isinstance(clause.operand, DateLiteral)
+    assert clause.operand.value == datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def test_bare_date_literal_in_value_position_lowers_to_eq_dateliteral() -> None:
+    (clause,) = _clauses(_ast({"metadata.when": {"$date": "2026-01-01"}}))
+    assert clause.op == Op.EQ
+    assert isinstance(clause.operand, DateLiteral)
+    assert clause.operand.value == datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def test_comparison_dict_operand_is_opaque_not_recursed() -> None:
+    # A dict nested inside an $eq operand is matched as a literal object, NOT
+    # recursed into clauses (mirrors model._check_literal_operand).
+    operand = {"$or": [{"a": 1}]}
+    (clause,) = _clauses(_ast({"metadata.k": {"$eq": operand}}))
+    assert clause.op == Op.EQ
+    assert clause.operand == operand
+    assert isinstance(clause.operand, dict)
+
+
+def test_logical_op_nested_in_eq_operand_stays_literal_data() -> None:
+    # {"$eq": {"$or": [1, 2]}} — the $or is DATA inside an opaque equality
+    # operand, NOT a logical node. The AST carries it verbatim as a dict, with
+    # exactly one leaf clause and no OR node synthesized anywhere.
+    ast = _ast({"metadata.k": {"$eq": {"$or": [1, 2]}}})
+    (clause,) = _walk_clauses(ast)
+    assert clause.op == Op.EQ
+    assert clause.operand == {"$or": [1, 2]}
+    assert isinstance(clause.operand, dict)
+    assert all(n.op != Op.OR for n in _walk_nodes(ast))
+
+
+def test_date_literal_is_an_operand_not_a_clause() -> None:
+    # {"$date": ...} is a typed-literal OPERAND, not a logical/comparison clause:
+    # the leaf op is $eq and the operand carries the DateLiteral. The $date key
+    # never becomes its own node or op.
+    (clause,) = _clauses(_ast({"metadata.when": {"$date": "2026-01-01"}}))
+    assert isinstance(clause, FilterClause)
+    assert clause.op == Op.EQ
+    assert clause.op != Op.DATE
+    assert isinstance(clause.operand, DateLiteral)
+
+
+def test_mixed_key_date_dict_operand_stays_opaque() -> None:
+    # {"$date": ..., "other": ...} is NOT a sole-key $date literal, so it stays
+    # an opaque dict — never lowered to a DateLiteral.
+    operand = {"$date": "2026-01-01", "other": "field"}
+    (clause,) = _clauses(_ast({"metadata.nested": {"$eq": operand}}))
+    assert clause.op == Op.EQ
+    assert clause.operand == operand
+    assert isinstance(clause.operand, dict)
+    assert not isinstance(clause.operand, DateLiteral)
+
+
+def test_in_list_lowers_date_elements_keeps_others_opaque() -> None:
+    # Per-element: a sole-key $date item -> DateLiteral; a non-$date dict item
+    # ($or here) stays opaque; a scalar stays verbatim. Order preserved.
+    (clause,) = _clauses(_ast({"metadata.tags": {"$in": [{"$date": "2026-01-01"}, "plain", {"$or": [1]}]}}))
+    assert clause.op == Op.IN
+    a, b, c = clause.operand
+    assert isinstance(a, DateLiteral)
+    assert b == "plain"
+    assert c == {"$or": [1]}
+
+
+def test_whole_subdocument_equality_operand_is_opaque() -> None:
+    (clause,) = _clauses(_ast({"metadata.obj": {"a": 1, "b": 2}}))
+    assert clause.op == Op.EQ
+    assert clause.operand == {"a": 1, "b": 2}
+
+
+def test_empty_subdocument_lowers_to_eq_empty_dict() -> None:
+    (clause,) = _clauses(_ast({"metadata.obj": {}}))
+    assert clause.op == Op.EQ
+    assert clause.operand == {}
+
+
+def test_bare_blob_and_metadata_subpath_lower_distinctly() -> None:
+    # The bare ``metadata`` blob is a single ("metadata",) whole-blob $eq; a
+    # ``metadata.obj`` sub-path whole-subdoc equality is a ("metadata", "obj")
+    # leaf. The two forms lower to DIFFERENT paths even with the same operand.
+    (blob_clause,) = _clauses(_ast({"metadata": {"a": 1}}))
+    (sub_clause,) = _clauses(_ast({"metadata.obj": {"a": 1}}))
+    assert blob_clause.path == ("metadata",)
+    assert sub_clause.path == ("metadata", "obj")
+    assert blob_clause.op == Op.EQ == sub_clause.op
+    # Same operand DATA, distinct paths -> distinct hashes.
+    assert canonical_hash(_ast({"metadata": {"a": 1}})) != canonical_hash(_ast({"metadata.obj": {"a": 1}}))
+
+
+# ---------------------------------------------------------------------------
+# Explicit null is an active match (not dropped).
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_null_lowers_to_eq_none() -> None:
+    (clause,) = _clauses(_ast({"source_name": None}))
+    assert clause.op == Op.EQ
+    assert clause.operand is None
+
+
+def test_unset_key_does_not_appear() -> None:
+    ast = _ast({"source_type": "x"})
+    paths = {c.path for c in _clauses(ast)}
+    assert ("source_name",) not in paths
+    assert paths == {("source_type",)}
+
+
+# ---------------------------------------------------------------------------
+# Date keys normalize to UTC at lowering (parity with DateOps).
+# ---------------------------------------------------------------------------
+
+
+def test_bare_date_scalar_normalized_to_utc() -> None:
+    (clause,) = _clauses(_ast({"occurred_at": "2026-04-05T00:00:00"}))
+    assert isinstance(clause.operand, datetime)
+    assert clause.operand.tzinfo is not None
+    assert clause.operand == datetime(2026, 4, 5, tzinfo=UTC)
+
+
+def test_offset_aware_date_scalar_normalized_to_utc() -> None:
+    # A non-UTC offset is converted to UTC at lowering, matching DateOps.
+    (clause,) = _clauses(_ast({"occurred_at": "2026-04-05T02:00:00+02:00"}))
+    assert isinstance(clause.operand, datetime)
+    assert clause.operand == datetime(2026, 4, 5, 0, 0, 0, tzinfo=UTC)
+
+
+def test_date_ops_range_lowers_per_operator() -> None:
+    ast = _ast({"occurred_at": {"$gte": "2026-01-01T00:00:00Z", "$lt": "2026-02-01T00:00:00Z"}})
+    by_op = {c.op: c for c in _clauses(ast)}
+    assert set(by_op) == {Op.GTE, Op.LT}
+    assert by_op[Op.GTE].operand == datetime(2026, 1, 1, tzinfo=UTC)
+    assert by_op[Op.LT].operand == datetime(2026, 2, 1, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# canonical_hash — stable hex digest with documented order semantics.
+# ---------------------------------------------------------------------------
+
+
+def test_hash_is_stable_hex_string() -> None:
+    h = canonical_hash(_ast({"source_name": "linear"}))
+    assert isinstance(h, str)
+    assert len(h) == 64  # SHA-256 hex
+    int(h, 16)  # parses as hex
+
+
+def test_hash_deterministic_across_calls() -> None:
+    ast = _ast({"source_name": "linear", "occurred_at": {"$gte": "2026-04-05T00:00:00Z"}})
+    assert canonical_hash(ast) == canonical_hash(ast)
+
+
+def test_hash_commutative_and_is_order_insensitive() -> None:
+    a = canonical_hash(_ast({"$and": [{"source_name": "a"}, {"source_type": "b"}]}))
+    b = canonical_hash(_ast({"$and": [{"source_type": "b"}, {"source_name": "a"}]}))
+    assert a == b
+
+
+def test_hash_commutative_or_is_order_insensitive() -> None:
+    a = canonical_hash(_ast({"$or": [{"source_name": "a"}, {"source_type": "b"}]}))
+    b = canonical_hash(_ast({"$or": [{"source_type": "b"}, {"source_name": "a"}]}))
+    assert a == b
+
+
+def test_hash_in_list_is_order_sensitive() -> None:
+    a = canonical_hash(_ast({"source_name": {"$in": ["a", "b"]}}))
+    b = canonical_hash(_ast({"source_name": {"$in": ["b", "a"]}}))
+    assert a != b
+
+
+def test_hash_exact_array_operand_is_order_sensitive() -> None:
+    a = canonical_hash(_ast({"source_type": ["a", "b"]}))
+    b = canonical_hash(_ast({"source_type": ["b", "a"]}))
+    assert a != b
+
+
+def test_hash_dict_operand_key_order_insensitive() -> None:
+    a = canonical_hash(_ast({"metadata.o": {"a": 1, "b": 2}}))
+    b = canonical_hash(_ast({"metadata.o": {"b": 2, "a": 1}}))
+    assert a == b
+
+
+def test_hash_differs_on_operand_semantics() -> None:
+    a = canonical_hash(_ast({"source_name": "a"}))
+    b = canonical_hash(_ast({"source_name": "b"}))
+    assert a != b
+
+
+def test_hash_differs_on_operator_semantics() -> None:
+    a = canonical_hash(_ast({"source_name": {"$eq": "a"}}))
+    b = canonical_hash(_ast({"source_name": {"$ne": "a"}}))
+    assert a != b
+
+
+def test_hash_differs_on_path_semantics() -> None:
+    a = canonical_hash(_ast({"metadata.a": 1}))
+    b = canonical_hash(_ast({"metadata.b": 1}))
+    assert a != b
+
+
+def test_hash_distinguishes_in_from_exact_array() -> None:
+    # $in ["a","b"] and a bare list ["a","b"] ($eq exact-array) are different
+    # semantics and must hash differently.
+    in_hash = canonical_hash(_ast({"source_name": {"$in": ["a", "b"]}}))
+    eq_hash = canonical_hash(_ast({"source_type": ["a", "b"]}))
+    # different paths AND different ops — definitely distinct.
+    assert in_hash != eq_hash
+
+
+# --- AC3: identical for sibling-order-only differences (both directions) --- #
+
+
+def test_hash_nested_commutative_sibling_order_insensitive() -> None:
+    # Order-insensitivity must hold at depth, not only at the root.
+    a = canonical_hash(_ast({"$or": [{"$and": [{"source_name": "a"}, {"title": "t"}]}, {"source_type": "b"}]}))
+    b = canonical_hash(_ast({"$or": [{"source_type": "b"}, {"$and": [{"title": "t"}, {"source_name": "a"}]}]}))
+    assert a == b
+
+
+def test_hash_implicit_sibling_and_order_insensitive() -> None:
+    # Implicit sibling AND (multiple keys on one document) is also commutative —
+    # the dict key order on the wire must not affect the hash.
+    a = canonical_hash(_ast({"source_name": "a", "source_type": "b"}))
+    b = canonical_hash(_ast({"source_type": "b", "source_name": "a"}))
+    assert a == b
+
+
+# --- AC3: different for semantically-different filters --------------------- #
+
+
+def test_hash_differs_and_vs_or() -> None:
+    # Same children, different logical operator -> different semantics.
+    a = canonical_hash(_ast({"$and": [{"source_name": "a"}, {"source_type": "b"}]}))
+    b = canonical_hash(_ast({"$or": [{"source_name": "a"}, {"source_type": "b"}]}))
+    assert a != b
+
+
+def test_hash_distinguishes_eq_list_operand_from_in_same_path() -> None:
+    # A bare list on a key is $eq EXACT-ARRAY; $in is membership. SAME path, SAME
+    # list contents/order — they must STILL hash differently (different op).
+    eq_hash = canonical_hash(_ast({"source_name": ["a", "b"]}))
+    in_hash = canonical_hash(_ast({"source_name": {"$in": ["a", "b"]}}))
+    assert eq_hash != in_hash
+
+
+# --- AC3: order preservation for non-commutative shapes ------------------- #
+
+
+def test_hash_nin_list_is_order_sensitive() -> None:
+    a = canonical_hash(_ast({"metadata.k": {"$nin": [1, 2]}}))
+    b = canonical_hash(_ast({"metadata.k": {"$nin": [2, 1]}}))
+    assert a != b
+
+
+def test_hash_not_operand_order_is_preserved() -> None:
+    # $not is non-commutative: not(or(a,b)) ($nor) must not collapse to or(a,b) —
+    # they hash differently, so the NOT operand is not re-sorted away.
+    nor_hash = canonical_hash(_ast({"$nor": [{"source_name": "a"}, {"source_type": "b"}]}))
+    or_hash = canonical_hash(_ast({"$or": [{"source_name": "a"}, {"source_type": "b"}]}))
+    assert nor_hash != or_hash
+
+
+def test_hash_double_not_differs_from_single_not() -> None:
+    # NOT(NOT(x)) is structurally distinct from NOT(x) — negation depth is part of
+    # the hashed structure (not collapsed).
+    once = canonical_hash(_ast({"$not": {"source_name": "x"}}))
+    twice = canonical_hash(_ast({"$not": {"$not": {"source_name": "x"}}}))
+    assert once != twice
+
+
+def test_hash_nested_dict_operand_key_order_insensitive() -> None:
+    # Key-order insensitivity is recursive through nested equality operands.
+    a = canonical_hash(_ast({"metadata.o": {"a": {"x": 1, "y": 2}, "b": 3}}))
+    b = canonical_hash(_ast({"metadata.o": {"b": 3, "a": {"y": 2, "x": 1}}}))
+    assert a == b
+
+
+def test_hash_distinguishes_date_literal_from_plain_string() -> None:
+    # A DateLiteral operand must not collide with a plain ISO string operand.
+    dt_hash = canonical_hash(_ast({"metadata.when": {"$eq": {"$date": "2026-01-01T00:00:00+00:00"}}}))
+    str_hash = canonical_hash(_ast({"metadata.when": {"$eq": "2026-01-01T00:00:00+00:00"}}))
+    assert dt_hash != str_hash
+
+
+def test_hash_accepts_filterclause_root() -> None:
+    # canonical_hash takes a FilterNode | FilterClause; a bare clause hashes too.
+    h = canonical_hash(FilterClause(path=("source_name",), op=Op.EQ, operand="x"))
+    assert isinstance(h, str)
+    assert len(h) == 64
+
+
+# ---------------------------------------------------------------------------
+# Frozen / slotted dataclasses.
+# ---------------------------------------------------------------------------
+
+
+def test_nodes_are_frozen() -> None:
+    clause = FilterClause(path=("x",), op=Op.EQ, operand=1)
+    node = FilterNode(op=Op.AND, children=(clause,))
+    with pytest.raises((AttributeError, TypeError)):
+        clause.op = Op.NE  # type: ignore[misc]
+    with pytest.raises((AttributeError, TypeError)):
+        node.op = Op.OR  # type: ignore[misc]
+
+
+def test_dateliteral_is_frozen() -> None:
+    lit = DateLiteral(value=datetime(2026, 1, 1, tzinfo=UTC))
+    with pytest.raises((AttributeError, TypeError)):
+        lit.value = datetime(2027, 1, 1, tzinfo=UTC)  # type: ignore[misc]
+
+
+def test_filterclause_default_operand_is_none() -> None:
+    clause = FilterClause(path=("x",), op=Op.EXISTS)
+    assert clause.operand is None
+
+
+def test_filternode_default_children_is_empty_tuple() -> None:
+    node = FilterNode(op=Op.AND)
+    assert node.children == ()
+
+
+def _walk_clauses(node: FilterNode | FilterClause) -> list[FilterClause]:
+    """Recursively collect every leaf clause in an AST."""
+    if isinstance(node, FilterClause):
+        return [node]
+    out: list[FilterClause] = []
+    for child in node.children:
+        out.extend(_walk_clauses(child))
+    return out
+
+
+def _walk_nodes(node: FilterNode | FilterClause) -> list[FilterNode]:
+    """Recursively collect every logical (FilterNode) node in an AST."""
+    if isinstance(node, FilterClause):
+        return []
+    out: list[FilterNode] = [node]
+    for child in node.children:
+        out.extend(_walk_nodes(child))
+    return out


### PR DESCRIPTION
## Summary

Adds the internal compilation layers that backend query compilers will plug into. Nothing here is part of the public package surface — it all lives under `khora.filter` and is intentionally excluded from the top-level `__all__`.

- **`khora/filter/ast.py`** — `parse_to_ast` lowers an already-validated `RecallFilter` into a canonical, backend-agnostic `FilterNode` AST:
  - dot-path metadata keys resolve to path-segment tuples (never dot-strings);
  - all sugar is desugared (bare value → `$eq`, bare list → exact-array `$eq`, `$nor` → `$not($or)`, implicit sibling-key AND made an explicit `$and`);
  - logical nesting is normalized (same-operator flatten + single-child collapse) so two ways of writing the same filter produce one tree;
  - comparison operands stay opaque (a dict operand is data, never re-parsed as a clause).
  - `canonical_hash` derives an order-stable cache key — commutative `$and`/`$or` are order-insensitive, while list / exact-array / `$not` operands preserve order.
- **`khora/filter/context.py`** — `CompileContext` (engine-supplied per-compile-pass context: backend target, table alias, bind-param namespace, optional system-key→column mapping, backend capabilities, unsupported-node policy), `SchemaCapabilities` flags, and a `CompileError` hierarchy.
- **`khora/filter/registry.py`** — `CompilerRegistry`, a thread-safe, process-wide compiler dispatch keyed by `(engine_id, storage_target)` and empty at import, plus the `CompiledFilter` / `CompilerFn` protocol types.

No backend compilers, no engine wiring, and no schema changes are included — those are separate, follow-on changes. The validation model is untouched.

## Test plan
- [x] Unit tests pass — `tests/recall/test_filter_ast.py`, `test_compiler_registry.py`, `test_compile_context.py` (lowering invariants, hash stability, context defaults, registry round-trip + thread-safety, internal-only contract)
- [x] `make format` clean; `make lint` (ruff + ty) clean
- [x] Full `make test` green, total coverage 82.23%
- [ ] CI green