### PR TITLE
Add Postgres recall-filter compiler for the pgvector backend

### DIFF
--- a/src/khora/db/migrations/versions/045_khora_try_timestamptz.py
+++ b/src/khora/db/migrations/versions/045_khora_try_timestamptz.py
@@ -1,0 +1,66 @@
+"""Add khora_try_timestamptz() — a safe text→timestamptz cast for $date filters.
+
+Revision ID: 045_khora_try_timestamptz
+Revises: 044_khora_chunks_backfill_denormalized
+Create Date: 2026-06-05
+
+Part of the deterministic recall-filter contract (§4/§7). The Postgres recall-filter compiler needs to
+compare metadata strings against a timestamp for the ``$date`` operator. A bare
+``txt::timestamptz`` cast aborts the whole statement the moment it meets a
+non-parseable string, which is fatal when a JSONB metadata value is malformed or
+of an unexpected shape. This function wraps the cast in an exception handler so a
+bad value yields ``NULL`` (and therefore a non-matching row) instead of erroring
+out the query.
+
+It is ``IMMUTABLE`` (a pure cast of its input — the same text always maps to the
+same timestamptz, given a fixed session ``TimeZone``, which the connection pins
+to UTC) and ``PARALLEL SAFE`` (no side effects, no shared state). ``IMMUTABLE``
+also leaves the door open to backing a functional index on the cast later.
+
+Postgres-only: the function is plpgsql. The sqlite_lance test fixtures run the
+full Alembic chain against SQLite, so we skip silently on non-Postgres dialects
+rather than emit SQL SQLite cannot parse — following migrations 029 and 044.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "045_khora_try_timestamptz"
+down_revision: str | Sequence[str] | None = "044_khora_chunks_backfill_denormalized"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_CREATE_FUNCTION_SQL = """
+CREATE OR REPLACE FUNCTION khora_try_timestamptz(txt text)
+RETURNS timestamptz
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+BEGIN
+    RETURN txt::timestamptz;
+EXCEPTION WHEN others THEN
+    RETURN NULL;
+END;
+$$;
+"""
+
+_DROP_FUNCTION_SQL = "DROP FUNCTION IF EXISTS khora_try_timestamptz(text);"
+
+
+def _is_postgres() -> bool:
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def upgrade() -> None:
+    if not _is_postgres():
+        return
+    op.execute(_CREATE_FUNCTION_SQL)
+
+
+def downgrade() -> None:
+    if not _is_postgres():
+        return
+    op.execute(_DROP_FUNCTION_SQL)

--- a/src/khora/engines/skeleton/backends/pgvector.py
+++ b/src/khora/engines/skeleton/backends/pgvector.py
@@ -42,10 +42,12 @@ from khora.engines.skeleton.backends import (
     TemporalVectorStore,
     temporal_chunk_to_chunk,
 )
+from khora.filter.model import Op
 from khora.telemetry import trace_span
 
 if TYPE_CHECKING:
     from khora.config import KhoraConfig
+    from khora.filter.ast import FilterNode
 
 # Table definition for khora_chunks (separate from existing chunks table)
 metadata = MetaData()
@@ -88,6 +90,16 @@ khora_chunks_table = Table(
     Column("content_tsv", TSVECTOR, nullable=True),
     # Indexes are defined below
 )
+
+
+# Legacy ``TemporalFilter.additional`` range-op names → the canonical filter Op,
+# so the deterministic-filter compiler can build a type-gated metadata compare.
+_LEGACY_RANGE_OPS: dict[str, Op] = {
+    "gt": Op.GT,
+    "gte": Op.GTE,
+    "lt": Op.LT,
+    "lte": Op.LTE,
+}
 
 
 class PgVectorTemporalStore(TemporalVectorStore):
@@ -139,7 +151,18 @@ class PgVectorTemporalStore(TemporalVectorStore):
                 database_url,
                 pool_size=pool_size,
                 max_overflow=max_overflow,
-                connect_args={"server_settings": {"hnsw.ef_search": str(self._hnsw_ef_search)}},
+                # Pin the session TimeZone to UTC so a zoneless metadata date
+                # string read by ``khora_try_timestamptz`` (the $date recall
+                # filter) is interpreted as UTC, matching the UTC-normalized
+                # comparison value the compiler binds. (Only the engine the store
+                # creates itself; an injected shared engine keeps its own pool
+                # default.)
+                connect_args={
+                    "server_settings": {
+                        "hnsw.ef_search": str(self._hnsw_ef_search),
+                        "TimeZone": "UTC",
+                    }
+                },
             )
 
         # Create tables if they don't exist
@@ -373,6 +396,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
         temporal_filter: TemporalFilter | None = None,
         hybrid_alpha: float | None = None,
         query_text: str | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> list[TemporalSearchResult]:
         """Search for similar chunks with temporal filtering.
 
@@ -383,6 +407,11 @@ class PgVectorTemporalStore(TemporalVectorStore):
 
         QUALITY FIX: When vector search returns insufficient results, automatically
         falls back to keyword search to improve recall on non-core chunks.
+
+        ``filter_ast`` is the deterministic recall-filter AST. When
+        provided it is compiled to a single-table ``khora_chunks`` WHERE predicate
+        and AND-ed alongside the legacy ``temporal_filter`` conditions. The two
+        coexist during the ``TemporalFilter`` deprecation window.
         """
         with trace_span(
             "khora.temporal_store.search",
@@ -398,6 +427,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
                 temporal_filter=temporal_filter,
                 hybrid_alpha=hybrid_alpha,
                 query_text=query_text,
+                filter_ast=filter_ast,
             )
             _search_span.set_attribute("result_count", len(results))
             return results
@@ -412,6 +442,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
         temporal_filter: TemporalFilter | None = None,
         hybrid_alpha: float | None = None,
         query_text: str | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> list[TemporalSearchResult]:
         async with self._get_session() as session:
             # Build base conditions
@@ -420,6 +451,20 @@ class PgVectorTemporalStore(TemporalVectorStore):
             # Add temporal filters
             if temporal_filter:
                 conditions.extend(self._build_filter_conditions(temporal_filter))
+
+            # Deterministic recall-filter AST: compile to a single
+            # khora_chunks WHERE predicate and AND it into the conditions. The
+            # compiler aliases nothing here (the store queries the base table),
+            # so ``table_alias`` stays None.
+            if filter_ast is not None:
+                from khora.filter import CompileContext
+                from khora.filter.compilers.postgres import compile_postgres
+
+                compiled = compile_postgres(
+                    filter_ast,
+                    CompileContext(backend_target="khora_chunks", on_unsupported="raise"),
+                )
+                conditions.append(compiled.predicate)
 
             # Vector search
             vector_results = await self._vector_search(
@@ -685,26 +730,41 @@ class PgVectorTemporalStore(TemporalVectorStore):
             # so we cast the literal to ``varchar[]`` explicitly to match.
             conditions.append(khora_chunks_table.c.tags.contains(cast(f.tags, ARRAY(String))))
 
-        # Handle additional filters
+        # Handle additional metadata filters. Range comparisons go through the
+        # deterministic-filter compiler's type-gated JSONB path rather than the
+        # old ``.astext`` lexicographic compare, which mis-ordered numbers (the
+        # "10" < "2" bug). Equality keeps the text-equality semantics callers
+        # already depend on.
         for key, value in f.additional.items():
             if isinstance(value, dict):
-                # Operator-style filter
                 for op, val in value.items():
                     if op == "eq":
                         conditions.append(khora_chunks_table.c.metadata[key].astext == str(val))
-                    elif op == "gte":
-                        conditions.append(khora_chunks_table.c.metadata[key].astext >= str(val))
-                    elif op == "lte":
-                        conditions.append(khora_chunks_table.c.metadata[key].astext <= str(val))
-                    elif op == "gt":
-                        conditions.append(khora_chunks_table.c.metadata[key].astext > str(val))
-                    elif op == "lt":
-                        conditions.append(khora_chunks_table.c.metadata[key].astext < str(val))
+                    elif op in _LEGACY_RANGE_OPS:
+                        conditions.append(self._legacy_metadata_range(key, op, val))
             else:
                 # Simple equality
                 conditions.append(khora_chunks_table.c.metadata[key].astext == str(value))
 
         return conditions
+
+    @staticmethod
+    def _legacy_metadata_range(key: str, op: str, val: Any):
+        """Type-gated metadata range compare for the legacy ``additional`` dict.
+
+        Reuses the deterministic-filter Postgres compiler so a numeric metadata
+        value orders numerically (not lexicographically). ``key`` is a top-level
+        metadata key, ``op`` one of ``gt``/``gte``/``lt``/``lte`` and ``val`` the
+        comparison operand (numeric values compare numerically; strings fall back
+        to a gated lexicographic compare).
+        """
+        from khora.filter.ast import FilterClause
+        from khora.filter.compilers.postgres import _Builder
+        from khora.filter.context import CompileContext
+
+        builder = _Builder(ctx=CompileContext(backend_target="khora_chunks"), consumed=set())
+        clause = FilterClause(path=("metadata", key), op=_LEGACY_RANGE_OPS[op], operand=val)
+        return builder.compile_clause(clause)
 
     def _row_to_chunk(self, row) -> TemporalChunk:
         """Convert a database row to a TemporalChunk."""
@@ -747,3 +807,14 @@ class PgVectorTemporalStore(TemporalVectorStore):
 
 
 __all__ = ["PgVectorTemporalStore"]
+
+
+# Register the deterministic recall-filter compiler for this engine/target at
+# import time (idempotent — same function object). ``pgvector.py`` is imported
+# lazily by ``create_temporal_store("pgvector", ...)``, so registration happens
+# exactly when the pgvector backend is first constructed — no eager cost, and no
+# registration when the backend is unused.
+from khora.filter import CompilerRegistry  # noqa: E402
+from khora.filter.compilers.postgres import compile_postgres  # noqa: E402
+
+CompilerRegistry.register("skeleton.pgvector", "khora_chunks", compile_postgres)

--- a/src/khora/filter/compilers/__init__.py
+++ b/src/khora/filter/compilers/__init__.py
@@ -1,0 +1,17 @@
+"""Backend filter compilers (Layer 4 implementations) — ``@internal``.
+
+Each module here lowers a canonical :class:`~khora.filter.ast.FilterNode` to one
+backend's query fragment. A compiler is a stateless
+``Callable[[FilterNode, CompileContext], CompiledFilter]`` registered against an
+``(engine_id, storage_target)`` key on the
+:class:`~khora.filter.registry.CompilerRegistry` at engine import time.
+
+``@internal``. Re-exported under :mod:`khora.filter.compilers` only — not from
+:mod:`khora.__init__`.
+"""
+
+from __future__ import annotations
+
+from khora.filter.compilers.postgres import compile_postgres
+
+__all__ = ["compile_postgres"]

--- a/src/khora/filter/compilers/postgres.py
+++ b/src/khora/filter/compilers/postgres.py
@@ -1,0 +1,462 @@
+"""PostgreSQL recall-filter compiler — ``@internal``.
+
+Lowers a canonical :class:`~khora.filter.ast.FilterNode` to a single-table
+SQLAlchemy ``WHERE`` predicate against ``khora_chunks`` (no documents join — the
+filterable document columns are denormalized onto the chunk row). The output is a
+:class:`~khora.filter.registry.CompiledFilter` whose ``predicate`` is a SQLAlchemy
+``ColumnElement[bool]`` the engine ``AND``-s into its own conditions list.
+
+The compiler is the Layer-4 half of the §4/§7 filter contract. It speaks
+the four emission rules:
+
+1. **Never abort.** A metadata range op type-gates its cast through
+   ``jsonb_typeof`` so a string/bool value never blows up a numeric compare — the
+   gate yields ``NULL`` (then ``FALSE`` via ``coalesce``) instead of erroring.
+2. **Polarity.** Negations include absent/null/wrong-type rows: metadata ``$ne``
+   matches a row missing the key; a system ``$ne`` is ``col IS NULL OR col <> v``.
+   Never drop a NULL row on a negation.
+3. **Impossible pairs (narrow).** ONLY an ``$eq`` exact-array (tuple) operand
+   against a scalar system column emits ``sqlalchemy.false()`` (unsatisfiable —
+   a scalar column never equals an array). ``$in`` / ``$nin`` are normal
+   membership, not impossible.
+4. **Presence/null.** ``$exists`` and a ``{k: null}`` match resolve to JSONB
+   presence (``?`` / ``#>``) on metadata and to a constant / ``IS NULL`` on a
+   system column.
+
+**Totality (the rule that makes negation uniform).** ``NOT`` is compiled as
+``sqlalchemy.not_(child)``; SQL ``NOT NULL`` is ``NULL`` (drops the row), which
+would violate Rule 2. So every metadata leaf that *can* produce ``NULL`` (the
+scalar-range gate, the ``$date`` gate, an exact-array equality whose path is
+absent) is wrapped in ``coalesce(<expr>, false())`` — a total boolean. The
+positive use is unchanged (``FALSE`` excludes exactly as ``NULL`` would), and a
+wrapping ``NOT`` then flips absent rows to ``TRUE`` correctly. Containment /
+presence (``@>`` / ``?``) are already total.
+
+``@internal``. Reachable as ``khora.filter.compilers.postgres.compile_postgres``
+for khora's own engines; not re-exported from :mod:`khora.__init__`.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy import ColumnElement
+from sqlalchemy.dialects.postgresql import JSONB
+
+from khora.filter import (
+    CompileContext,
+    CompiledFilter,
+    RecallFilterUnsupportedError,
+)
+from khora.filter.ast import (
+    DateLiteral,
+    FilterClause,
+    FilterNode,
+    canonical_hash,
+)
+from khora.filter.model import SYSTEM_KEYS, Op
+
+__all__ = ["compile_postgres"]
+
+
+def _col(ctx: CompileContext, logical_name: str) -> ColumnElement[Any]:
+    """Resolve a logical key to a SQLAlchemy column reference from ``ctx`` alone.
+
+    The compiler never imports the engine's ``Table`` — it receives schema *shape*
+    through ``ctx`` and emits a raw column token, so one ``compile_postgres`` can
+    serve any single-table schema (e.g. the legacy ``chunks``/``documents`` tables)
+    just by varying ``field_mapping`` / ``table_alias``.
+
+    ``field_mapping`` remaps a logical key to its physical column name (identity
+    when ``None``); the qualifier is ``table_alias`` if set else ``backend_target``.
+    ``logical_name`` is always a controlled token (a system key from the closed
+    ``SYSTEM_KEYS`` whitelist, or the literal ``"metadata"``) — never free user
+    text, so the f-string column token is not an injection surface. (User-supplied
+    metadata path segments only ever reach the bound ``#>`` path literal, never
+    this column token.)
+    """
+    physical = (ctx.field_mapping or {}).get(logical_name, logical_name)
+    qualifier = ctx.table_alias or ctx.backend_target
+    return sa.literal_column(f"{qualifier}.{physical}")
+
+
+# Python operator callables for the range ops, keyed by AST op.
+_RANGE_FN = {
+    Op.GT: lambda a, b: a > b,
+    Op.GTE: lambda a, b: a >= b,
+    Op.LT: lambda a, b: a < b,
+    Op.LTE: lambda a, b: a <= b,
+}
+
+
+def compile_postgres(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[ColumnElement[bool]]:
+    """Compile a canonical AST to a ``khora_chunks`` SQLAlchemy ``WHERE`` predicate.
+
+    ``ast`` is always a :class:`FilterNode` (the ``parse_to_ast`` root invariant).
+    An empty ``AND`` (the match-everything root of a bare filter) compiles to
+    ``sqlalchemy.true()``. Binds are carried inline inside the expression
+    (asyncpg renders them as ``$N`` at execute time), so ``params`` is always
+    empty — the field exists for backends that bind out-of-band.
+
+    Column references are derived from ``ctx`` alone (``backend_target`` /
+    ``table_alias`` qualify, ``field_mapping`` remaps) via :func:`_col`, so the
+    compiler embeds no engine schema. Honors ``ctx.on_unsupported``: on a clause
+    this backend cannot express (should not happen post-validation), ``"raise"``
+    raises :class:`RecallFilterUnsupportedError`; ``"split"`` omits it from
+    ``consumed_keys`` and emits a non-constraining placeholder.
+    """
+    consumed: set[str] = set()
+    builder = _Builder(ctx=ctx, consumed=consumed)
+    predicate = builder.compile_node(ast)
+    return CompiledFilter(
+        predicate=predicate,
+        params={},
+        consumed_keys=frozenset(consumed),
+        # canonical_hash over the whole AST. In on_unsupported="raise" mode (the
+        # only mode used today) every leaf is consumed, so the whole tree == the
+        # consumed slice. When split-mode is implemented, hash the reconstructed
+        # consumed sub-AST instead, not the whole tree.
+        canonical_hash=canonical_hash(ast),
+    )
+
+
+def _path_str(path: tuple[str, ...]) -> str:
+    """Render an AST path as the dotted key string used for diagnostics/consumed."""
+    return ".".join(path)
+
+
+class _Builder:
+    """Per-compile-pass state: the :class:`CompileContext` and consumed set.
+
+    A compile pass threads two things every helper needs — the ``ctx`` (column
+    refs are derived from it via :func:`_col`) and the ``consumed`` accumulator.
+    Keeping them on a small object avoids passing the pair through every recursion
+    frame.
+    """
+
+    def __init__(self, *, ctx: CompileContext, consumed: set[str]) -> None:
+        self._ctx = ctx
+        self._consumed = consumed
+        # The metadata column is nullable. Coalesce a NULL blob to an empty JSONB
+        # object once here so every downstream operator (`?`, `@>`, `#>`, `=`) is
+        # total against a NULL row: `'{}' ? k` / `'{}' @> x` return FALSE (not
+        # NULL) and `'{}' #> path` returns NULL for a missing path — exactly the
+        # absent-key semantics. Without this, `NOT (metadata ? k)` on a NULL blob
+        # would be `NOT NULL = NULL` and wrongly drop the row from a negation.
+        self._md = sa.func.coalesce(_col(ctx, "metadata"), sa.cast(sa.literal("{}"), JSONB))
+
+    # ----- logical node walk ---------------------------------------------- #
+
+    def compile_node(self, node: FilterNode | FilterClause) -> ColumnElement[bool]:
+        """Compile a logical node or leaf to a boolean expression."""
+        if isinstance(node, FilterClause):
+            return self.compile_clause(node)
+        if node.op == Op.AND:
+            if not node.children:
+                # The empty match-everything root — no constraint.
+                return sa.true()
+            return sa.and_(*(self.compile_node(c) for c in node.children))
+        if node.op == Op.OR:
+            if not node.children:
+                # The validator forbids an empty $or; guard defensively.
+                return sa.false()
+            return sa.or_(*(self.compile_node(c) for c in node.children))
+        # Op.NOT — exactly one child per the AST contract. Leaves are built total
+        # (never NULL) so this negation flips absent rows correctly.
+        return sa.not_(self.compile_node(node.children[0]))
+
+    # ----- leaf key-kind split -------------------------------------------- #
+
+    def compile_clause(self, clause: FilterClause) -> ColumnElement[bool]:
+        """Dispatch a leaf on key-kind (system key vs metadata path)."""
+        path = clause.path
+        if len(path) == 1 and path[0] in SYSTEM_KEYS:
+            expr = self._compile_system_clause(clause)
+        elif path and path[0] == "metadata":
+            expr = self._compile_metadata_clause(clause)
+        else:
+            return self._unsupported(clause, "path is neither a system key nor a metadata path")
+        self._consumed.add(_path_str(path))
+        return expr
+
+    # ----- system-key leaves (typed columns) ------------------------------ #
+
+    def _system_column(self, key: str) -> ColumnElement[Any]:
+        """Resolve a system key to its column ref from ``ctx`` (via :func:`_col`)."""
+        return _col(self._ctx, key)
+
+    def _compile_system_clause(self, clause: FilterClause) -> ColumnElement[bool]:
+        key = clause.path[0]
+        col = self._system_column(key)
+        op = clause.op
+        operand = clause.operand
+
+        if op == Op.EXISTS:
+            # A system column is always present in the row — $exists is constant.
+            return sa.true() if operand else sa.false()
+
+        if op in (Op.IN, Op.NIN):
+            values = [sa.literal(_system_value(v)) for v in operand]
+            if op == Op.IN:
+                # Made total so a wrapping field-level $not includes NULL rows.
+                return sa.func.coalesce(col.in_(values), sa.false())
+            # $nin includes NULL rows (Rule 2 polarity). Already a total boolean.
+            return sa.or_(col.is_(None), col.notin_(values))
+
+        # Rule 3 (NARROW): the ONLY system-key clause that short-circuits to a
+        # constant is an $eq EXACT-ARRAY (tuple) operand against a scalar column —
+        # a bare list on a system key lowers to EQ-with-tuple, and a scalar column
+        # can never equal an array, so it is unsatisfiable → sa.false(). The $ne
+        # complement is unreachable (StringOps.ne is str-only, so the validator
+        # never produces a tuple here); it is the polarity-mirror of the $eq case
+        # → sa.true(). $in / $nin are NOT impossible — they were already handled
+        # above as normal membership.
+        if op == Op.EQ and isinstance(operand, tuple):
+            return sa.false()
+        if op == Op.NE and isinstance(operand, tuple):
+            return sa.true()
+
+        if operand is None:
+            # {k: null} → active null-or-missing match. For a system column,
+            # "missing" is NULL. $ne null → IS NOT NULL. Both are total booleans.
+            if op == Op.NE:
+                return col.isnot(None)
+            return col.is_(None)
+
+        value = sa.literal(_system_value(operand))
+        if op == Op.NE:
+            # Include NULL rows (Rule 2): a row whose column is NULL satisfies $ne.
+            # Already a total boolean (no coalesce needed).
+            return sa.or_(col.is_(None), col != value)
+        # $eq and the range ops compare directly. Wrap in coalesce(..., false())
+        # so the leaf is a total boolean: a NULL column yields FALSE (same
+        # exclusion as the bare NULL comparison on the positive side), and a
+        # wrapping field-level $not then flips a NULL-column row to TRUE — which
+        # is what $not($eq) / $not($gt) must do (parity with the explicit $ne).
+        positive = (col == value) if op == Op.EQ else _RANGE_FN[op](col, value)
+        return sa.func.coalesce(positive, sa.false())
+
+    # ----- metadata leaves (JSONB) ---------------------------------------- #
+
+    def _compile_metadata_clause(self, clause: FilterClause) -> ColumnElement[bool]:
+        path = clause.path
+        op = clause.op
+        operand = clause.operand
+
+        # Bare-blob metadata $eq (whole-document equality). JSONB `=` is
+        # structural-normalized in PG (key order / whitespace insensitive). The
+        # NULL-coalesced ``self._md`` keeps this total: a NULL blob compares as
+        # the empty object, so a wrapping $not includes it.
+        if len(path) == 1:
+            if op != Op.EQ:
+                return self._unsupported(clause, "only $eq is defined on the bare metadata blob")
+            return self._md == _jsonb_literal(operand)
+
+        segs = path[1:]  # drop the leading "metadata" root
+
+        if op == Op.EXISTS:
+            present = self._md_exists(segs)
+            return present if operand else sa.not_(present)
+
+        if op in (Op.IN, Op.NIN):
+            chain = sa.or_(*(self._md_containment(segs, v) for v in operand))
+            return chain if op == Op.IN else sa.not_(chain)
+
+        if op == Op.EQ:
+            if operand is None:
+                # Active null-or-missing match: an explicit JSON null value OR an
+                # absent key. `@>` containment of `null` would only catch the
+                # former, so emit the explicit OR (Rule 4).
+                return self._md_null(segs)
+            return self._md_eq(segs, operand)
+        if op == Op.NE:
+            if operand is None:
+                # $ne null → present AND not a JSON null value.
+                return sa.not_(self._md_null(segs))
+            # Negate the positive equality form. Each positive form is a total
+            # boolean (containment, or coalesced exact-array), so NOT flips
+            # absent rows to TRUE (Rule 2).
+            return sa.not_(self._md_eq(segs, operand))
+
+        # Range ops ($gt/$gte/$lt/$lte) — type-gated cast, made total.
+        return self._md_range(segs, op, operand)
+
+    def _md_eq(self, segs: tuple[str, ...], operand: Any) -> ColumnElement[bool]:
+        """Positive metadata equality — always a total boolean.
+
+        A ``$date`` literal compares through the guarded timestamptz gate; a tuple
+        is an exact-array equality on the extracted node; any other scalar is
+        array-aware ``@>`` containment.
+        """
+        if isinstance(operand, DateLiteral):
+            return self._md_date_compare(segs, Op.EQ, operand)
+        if isinstance(operand, tuple):
+            # Exact-array equality (bare list → $eq exact-array). `#>` is NULL when
+            # the path is absent, so coalesce the comparison to FALSE for totality.
+            node = self._md_json(segs)
+            return sa.func.coalesce(node == _jsonb_literal(list(operand)), sa.false())
+        return self._md_containment(segs, operand)
+
+    def _md_range(self, segs: tuple[str, ...], op: Op, operand: Any) -> ColumnElement[bool]:
+        """A metadata range op — jsonb_typeof-gated cast, coalesced to total."""
+        if isinstance(operand, DateLiteral):
+            return self._md_date_compare(segs, op, operand)
+        json_type, sa_type = _operand_json_type(operand)
+        node = self._md_json(segs)
+        if sa_type is None:
+            # String range: lexicographic compare on the text extraction, gated.
+            gated = sa.case((sa.func.jsonb_typeof(node) == json_type, self._md_text(segs)), else_=sa.null())
+        else:
+            gated = sa.case(
+                (sa.func.jsonb_typeof(node) == json_type, sa.cast(self._md_text(segs), sa_type)),
+                else_=sa.null(),
+            )
+        return sa.func.coalesce(_RANGE_FN[op](gated, sa.literal(operand)), sa.false())
+
+    def _md_date_compare(self, segs: tuple[str, ...], op: Op, operand: DateLiteral) -> ColumnElement[bool]:
+        """Guarded ``$date`` compare via ``khora_try_timestamptz`` — total.
+
+        The compare relies on the session ``TimeZone='UTC'`` (set in the backend's
+        ``create_async_engine`` ``server_settings``): a zoneless stored date string
+        is cast to ``timestamptz`` under that session zone, matching the
+        UTC-normalized ``DateLiteral.value`` operand. Deliberately NO per-expression
+        ``AT TIME ZONE 'UTC'`` — the session-TZ contract is the documented
+        mechanism (§7). **Caveat:** when ``StorageCoordinator`` injects a
+        *shared* engine, the backend does not control its session TZ, so a zoneless
+        ``$date`` metadata string is interpreted in the pool's default zone. Known,
+        documented limitation — not defended against in SQL.
+        """
+        text = self._md_text(segs)
+        gate = sa.case(
+            (
+                sa.and_(
+                    sa.func.jsonb_typeof(self._md_json(segs)) == "string",
+                    text.op("~")(sa.literal(r"^\d{4}-\d\d-\d\d")),
+                ),
+                sa.func.khora_try_timestamptz(text),
+            ),
+            else_=sa.null(),
+        )
+        cmp = sa.cast(sa.literal(operand.value), sa.DateTime(timezone=True))
+        return sa.func.coalesce(_RANGE_FN[op](gate, cmp) if op in _RANGE_FN else gate == cmp, sa.false())
+
+    def _md_containment(self, segs: tuple[str, ...], value: Any) -> ColumnElement[bool]:
+        """Array-aware ``@>`` containment rooted at the metadata column.
+
+        For a single-segment path ``("tags",)`` this is ``metadata @> '{"tags":
+        v}'`` — which matches both a scalar field equal to ``v`` and an array
+        field containing ``v``. For a nested path the one-key doc is wrapped at
+        each segment (``{"a": {"tags": v}}``). ``@>`` returns a total boolean
+        (``FALSE`` on absent/mismatch, never ``NULL``), so it is negation-safe.
+        """
+        doc: Any = _date_to_jsonable(value)
+        for seg in reversed(segs):
+            doc = {seg: doc}
+        return self._md.op("@>")(_jsonb_literal(doc))
+
+    def _md_exists(self, segs: tuple[str, ...]) -> ColumnElement[bool]:
+        """Presence test for a metadata path — total boolean.
+
+        Single segment uses the GIN-friendly ``?`` key-existence operator. A
+        nested path uses ``#>``-is-not-null: ``#>`` returns SQL NULL only when the
+        path is missing (an explicit JSON ``null`` value yields ``'null'::jsonb``),
+        so ``IS NOT NULL`` is TRUE iff the path resolves — matching Mongo
+        ``$exists``.
+        """
+        if len(segs) == 1:
+            return self._md.op("?")(sa.literal(segs[0]))
+        return self._md_json(segs).isnot(None)
+
+    def _md_null(self, segs: tuple[str, ...]) -> ColumnElement[bool]:
+        """Active null-or-missing match — total boolean.
+
+        ``(metadata #> '{path}') = 'null'::jsonb OR NOT <present>``: the value is
+        an explicit JSON ``null`` OR the key is absent. Both count as "null" for
+        the ``{k: null}`` filter, matching Mongo semantics.
+        """
+        is_json_null = self._md_json(segs) == _jsonb_literal(None)
+        return sa.or_(is_json_null, sa.not_(self._md_exists(segs)))
+
+    # ----- JSONB extraction primitives ------------------------------------ #
+
+    def _md_json(self, segs: tuple[str, ...]) -> ColumnElement[Any]:
+        """``metadata #> '{a,b}'`` — extract the JSONB node at ``segs``."""
+        return self._md.op("#>")(_jpath(segs))
+
+    def _md_text(self, segs: tuple[str, ...]) -> ColumnElement[Any]:
+        """``metadata #>> '{a,b}'`` — extract the text at ``segs``."""
+        return self._md.op("#>>")(_jpath(segs))
+
+    # ----- unsupported ---------------------------------------------------- #
+
+    def _unsupported(self, clause: FilterClause, reason: str) -> ColumnElement[bool]:
+        """Handle a clause this backend cannot express per ``ctx.on_unsupported``.
+
+        ``"raise"`` raises the public :class:`RecallFilterUnsupportedError`;
+        ``"split"`` leaves the clause out of ``consumed_keys`` (the engine
+        post-filters it) and emits a non-constraining ``sqlalchemy.true()`` so it
+        does not narrow the result set.
+        """
+        path = _path_str(clause.path)
+        if self._ctx.on_unsupported == "raise":
+            raise RecallFilterUnsupportedError(path, reason)
+        return sa.true()
+
+
+# --------------------------------------------------------------------------- #
+# Module-level helpers (no per-pass state).
+# --------------------------------------------------------------------------- #
+
+
+def _jpath(segments: tuple[str, ...]) -> ColumnElement[Any]:
+    """Build the Postgres ``text[]`` path literal ``'{a,b}'`` for ``#>`` / ``#>>``.
+
+    Each segment is double-quoted (and its backslashes / quotes escaped) so a
+    segment containing ``,`` ``{`` ``}`` or whitespace survives the array-literal
+    parse.
+    """
+    inner = ",".join('"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"' for s in segments)
+    return sa.literal("{" + inner + "}")
+
+
+def _jsonb_literal(value: Any) -> ColumnElement[Any]:
+    """A ``CAST('<json>' AS JSONB)`` literal for a Python value (sorted keys)."""
+    return sa.cast(sa.literal(json.dumps(value, sort_keys=True)), JSONB)
+
+
+def _operand_json_type(operand: Any) -> tuple[str, Any]:
+    """Map a range operand's Python type to its ``jsonb_typeof`` gate + cast type.
+
+    ``int``/``float`` → ``("number", Numeric)``; ``bool`` → ``("boolean",
+    Boolean)``; everything else → ``("string", None)`` (lexicographic text
+    compare, no cast). ``bool`` is checked before ``int`` (``bool`` is an
+    ``int`` subclass).
+    """
+    if isinstance(operand, bool):
+        return "boolean", sa.Boolean()
+    if isinstance(operand, (int, float)):
+        return "number", sa.Numeric()
+    return "string", None
+
+
+def _system_value(value: Any) -> Any:
+    """Unwrap a :class:`DateLiteral` to its datetime; pass other values through."""
+    if isinstance(value, DateLiteral):
+        return value.value
+    return value
+
+
+def _date_to_jsonable(value: Any) -> Any:
+    """Coerce a containment operand to a JSON-serializable scalar.
+
+    A :class:`DateLiteral` / :class:`~datetime.datetime` is rendered as its
+    ISO-8601 string so the ``@>`` doc is valid JSON; other scalars pass through.
+    """
+    if isinstance(value, DateLiteral):
+        return value.value.isoformat()
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value

--- a/src/khora/filter/compilers/postgres.py
+++ b/src/khora/filter/compilers/postgres.py
@@ -262,6 +262,14 @@ class _Builder:
             return present if operand else sa.not_(present)
 
         if op in (Op.IN, Op.NIN):
+            if not operand:
+                # An empty operand list is a valid filter with a defined row-set
+                # (the validator accepts it). Positive $in over ∅ matches nothing;
+                # $nin over ∅ matches everything. Guard before building the OR
+                # chain: sa.or_() with no clauses vanishes from the enclosing AND
+                # (so $in would wrongly match all), and sa.not_() of that empty
+                # chain is invalid SQL (so $nin would error at execute time).
+                return sa.false() if op == Op.IN else sa.true()
             chain = sa.or_(*(self._md_containment(segs, v) for v in operand))
             return chain if op == Op.IN else sa.not_(chain)
 

--- a/tests/integration/db/test_migration_032_dream_runs.py
+++ b/tests/integration/db/test_migration_032_dream_runs.py
@@ -296,7 +296,7 @@ class TestMigration032OnSqlite:
                 async with engine.connect() as conn:
                     # Chain reached head (sanity).
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "044_khora_chunks_backfill_denormalized"
+                    assert result.scalar() == "045_khora_try_timestamptz"
 
                     # khora_dream_runs exists on SQLite (#896) so dream_history /
                     # dream_status work on the embedded sqlite_lance stack.

--- a/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
+++ b/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
@@ -277,7 +277,7 @@ class TestMigration041OnPostgres:
                 async with engine.connect() as conn:
                     # Chain reached head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "044_khora_chunks_backfill_denormalized"
+                    assert result.scalar() == "045_khora_try_timestamptz"
 
                     # The migration did not create the table.
                     result = await conn.execute(
@@ -308,7 +308,7 @@ class TestMigration041OnSqlite:
             try:
                 async with engine.connect() as conn:
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "044_khora_chunks_backfill_denormalized"
+                    assert result.scalar() == "045_khora_try_timestamptz"
             finally:
                 await engine.dispose()
 

--- a/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
+++ b/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
@@ -67,7 +67,7 @@ pytestmark = pytest.mark.integration
 
 
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
-_HEAD = "044_khora_chunks_backfill_denormalized"
+_HEAD = "045_khora_try_timestamptz"
 _PREV = "041_khora_chunks_denormalized_columns"
 
 

--- a/tests/integration/db/test_migration_044_chunks_backfill.py
+++ b/tests/integration/db/test_migration_044_chunks_backfill.py
@@ -90,7 +90,7 @@ pytestmark = pytest.mark.integration
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
 
 _PREV_REVISION = "043_khora_chunks_metadata_backfill"
-_HEAD_REVISION = "044_khora_chunks_backfill_denormalized"
+_HEAD_REVISION = "045_khora_try_timestamptz"
 
 _TSV_TRIGGER = "khora_chunks_content_tsv_update"
 
@@ -189,8 +189,8 @@ def pg_url() -> Iterator[str]:
                 )
                 if table_exists.scalar():
                     await conn.execute(
-                        sa.text("UPDATE khora_alembic_version SET version_num = :prev WHERE version_num = :head"),
-                        {"prev": _PREV_REVISION, "head": _HEAD_REVISION},
+                        sa.text("UPDATE khora_alembic_version SET version_num = :prev WHERE version_num != :prev"),
+                        {"prev": _PREV_REVISION},
                     )
         finally:
             await admin.dispose()
@@ -731,7 +731,7 @@ class TestMigration044OnPostgres:
 
     def test_no_op_when_table_absent(self, pg_url: str) -> None:
         """Fresh DB with no ``khora_chunks``: the ``has_table`` guard
-        early-returns, the chain reaches head 044, and the migration does not
+        early-returns, the chain reaches head, and the migration does not
         create the runtime table."""
         cfg = _make_config(pg_url)
         # pg_url fixture already dropped khora_chunks; just upgrade.
@@ -763,7 +763,7 @@ class TestMigration044OnPostgres:
 
 class TestMigration044OnSqlite:
     def test_chain_reaches_head_on_sqlite(self, sqlite_url: str) -> None:
-        """Migration 044 is a clean no-op on SQLite; chain reaches head 044."""
+        """Migration 044 is a clean no-op on SQLite; chain reaches head."""
         cfg = _make_config(sqlite_url)
         command.upgrade(cfg, "head")
 

--- a/tests/integration/test_compile_postgres_rowset.py
+++ b/tests/integration/test_compile_postgres_rowset.py
@@ -1,0 +1,410 @@
+"""Postgres-backed row-set test for the recall-filter compiler (§4).
+
+Where ``tests/unit/filter/test_compile_postgres.py`` asserts the *shape* of the emitted SQL, this
+file asserts its *behavior* against a real PostgreSQL ``khora_chunks`` table seeded
+with ADVERSARIAL rows. For each representative filter we compile the AST to a
+SQLAlchemy predicate, run ``SELECT id FROM khora_chunks WHERE ns = :ns AND
+<predicate>``, and assert the EXACT set of returned chunk ids. The hand-authored
+expected set is the oracle — there is exactly one Postgres compiler, so the
+behavior is fully determined and a divergence is a real bug.
+
+Adversarial seed (one namespace, one row per "id" label below). Every row carries
+a ``score`` and a ``tier`` metadata field plus a ``sent_at`` string, chosen to break
+naive ``->>`` text comparisons:
+
+* ``num10``   — metadata.score = 10  (number)
+* ``num2``    — metadata.score = 2   (number; "10" < "2" as TEXT, 2 < 10 as number)
+* ``numstr``  — metadata.score = "10" (numeric-looking STRING — must NOT count as a number)
+* ``strabc``  — metadata.score = "abc" (non-numeric string)
+* ``arr``     — metadata.score = [1, 2] (ARRAY value)
+* ``missing`` — metadata has no ``score`` key at all
+* ``sysnull`` — system column ``source_name`` IS NULL
+* ``baddate`` — metadata.sent_at = "not-a-date" (malformed; khora_try_timestamptz → NULL)
+
+Docker Compose (this repo's ``compose.yaml``, Postgres on port 5434) provides the
+database; the module skips cleanly when Postgres is unreachable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import AsyncIterator
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncConnection, create_async_engine
+
+from khora.filter import RecallFilter
+from khora.filter.ast import parse_to_ast
+from khora.filter.compilers.postgres import compile_postgres
+from khora.filter.context import CompileContext
+
+# Hard import (NOT importorskip): the compiler is on the branch, so an import
+# failure must be a LOUD test error — never a silent module skip. (This module
+# still skips when Postgres is unreachable, via the pytestmark skipif below.)
+
+
+# This repo's compose puts Postgres on 5434 (see compose.yaml). Honor an explicit
+# override, else default to the compose port — never another project's container.
+_DEFAULT_URL = "postgresql+asyncpg://khora:khora@localhost:5434/khora"
+
+
+def _database_url() -> str:
+    url = os.environ.get("KHORA_DATABASE_URL", _DEFAULT_URL)
+    if url.startswith("postgresql://"):
+        url = url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    elif url.startswith("postgres://"):
+        url = url.replace("postgres://", "postgresql+asyncpg://", 1)
+    return url
+
+
+def _pg_reachable() -> bool:
+    import socket
+    from urllib.parse import urlparse
+
+    parsed = urlparse(_database_url().replace("+asyncpg", ""))
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not _pg_reachable(), reason="PostgreSQL not reachable (run `make dev`)"),
+]
+
+
+# The compiler qualifies columns with ``ctx.backend_target`` (``_col`` derives
+# ``<backend_target>.<col>`` from ctx alone), so a predicate built with
+# ``backend_target="khora_chunks"`` references ``khora_chunks.<col>``. To run that
+# predicate against real data WITHOUT touching any production ``khora_chunks``, we
+# create a session-local ``TEMPORARY TABLE khora_chunks`` on a single dedicated
+# connection: a temp table shadows any permanent same-named table for this session
+# only (``pg_temp`` is first on the search_path), is invisible to every other
+# session, and is dropped automatically when the connection closes. That satisfies
+# the test-isolation rule (never reuse / clobber another project's or the real
+# khora_chunks) while letting FROM and the compiled predicate agree on the name.
+_TEST_TABLE = "khora_chunks"
+
+_CREATE_TABLE = f"""
+CREATE TEMPORARY TABLE {_TEST_TABLE} (
+    id UUID PRIMARY KEY,
+    namespace_id UUID NOT NULL,
+    content TEXT NOT NULL DEFAULT '',
+    occurred_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ,
+    source_timestamp TIMESTAMPTZ,
+    source_type VARCHAR(64),
+    source_name VARCHAR(255),
+    source_url TEXT,
+    external_id VARCHAR(512),
+    content_type VARCHAR(128),
+    source TEXT,
+    title TEXT,
+    metadata JSONB NOT NULL DEFAULT '{{}}'::jsonb
+)
+"""
+
+# khora_try_timestamptz (migration 045) — the safe text→timestamptz cast the
+# $date metadata path depends on. Created in pg_temp so it is session-local and
+# never collides with (or shadows-then-orphans) a real installed function; the
+# compiler calls it unqualified, which resolves via pg_temp first on search_path.
+# Self-sufficient even on a DB that has not run the Alembic chain.
+_CREATE_TRY_TS = """
+CREATE FUNCTION pg_temp.khora_try_timestamptz(txt text)
+RETURNS timestamptz
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+BEGIN
+    RETURN txt::timestamptz;
+EXCEPTION WHEN others THEN
+    RETURN NULL;
+END;
+$$;
+"""
+
+
+# Row label → (system-column overrides, metadata dict). namespace_id is filled in
+# at seed time. Unspecified system columns default to a benign non-null value so a
+# row only differs on the dimension under test.
+_ROWS: dict[str, dict] = {
+    "num10": {"metadata": {"score": 10, "tier": "gold", "sent_at": "2026-01-10T00:00:00Z"}},
+    "num2": {"metadata": {"score": 2, "tier": "silver", "sent_at": "2026-01-02T00:00:00Z"}},
+    "numstr": {"metadata": {"score": "10", "tier": "bronze"}},
+    "strabc": {"metadata": {"score": "abc", "tier": "gold"}},
+    "arr": {"metadata": {"score": [1, 2], "tier": ["gold", "silver"]}},
+    "missing": {"metadata": {"tier": "gold"}},
+    "sysnull": {"system": {"source_name": None}, "metadata": {"score": 5, "tier": "gold"}},
+    "baddate": {"metadata": {"score": 7, "tier": "silver", "sent_at": "not-a-date"}},
+}
+
+_ALL_IDS = set(_ROWS)
+
+
+@pytest.fixture
+async def seeded() -> AsyncIterator[tuple[AsyncConnection, UUID, dict[str, UUID]]]:
+    """Create the session-local temp table + function, seed the adversarial rows.
+
+    Everything happens on ONE connection because the ``khora_chunks`` temp table
+    and the ``pg_temp`` cast function are connection-scoped; the same connection
+    then runs the compiled predicates. The temp objects vanish when the
+    connection closes, so there is no cross-test or cross-project leakage.
+    """
+    eng = create_async_engine(_database_url())
+    ns = uuid4()
+    ids: dict[str, UUID] = {label: uuid4() for label in _ROWS}
+    try:
+        async with eng.connect() as conn:
+            await conn.execute(sa.text(_CREATE_TABLE))
+            await conn.execute(sa.text(_CREATE_TRY_TS))
+            for label, spec in _ROWS.items():
+                system = spec.get("system", {})
+                await conn.execute(
+                    sa.text(
+                        # _TEST_TABLE is a hardcoded module constant, not user input.
+                        f"INSERT INTO {_TEST_TABLE} "  # noqa: S608
+                        "(id, namespace_id, source_name, source_type, occurred_at, metadata) "
+                        "VALUES (:id, :ns, :source_name, :source_type, :occurred_at, "
+                        "CAST(:metadata AS jsonb))"
+                    ),
+                    {
+                        "id": ids[label],
+                        "ns": ns,
+                        "source_name": system.get("source_name", "linear"),
+                        "source_type": system.get("source_type", "slack"),
+                        "occurred_at": system.get("occurred_at", "2026-01-05T00:00:00Z"),
+                        "metadata": json.dumps(spec["metadata"]),
+                    },
+                )
+            await conn.commit()
+            yield conn, ns, ids
+    finally:
+        await eng.dispose()
+
+
+async def _matching_labels(
+    seeded: tuple[AsyncConnection, UUID, dict[str, UUID]],
+    wire: dict,
+) -> set[str]:
+    """Compile ``wire`` and return the set of ROW LABELS whose rows match.
+
+    Runs the compiled predicate against the seeded temp ``khora_chunks`` on the
+    same connection. FROM is a lightweight ``sa.table("khora_chunks", ...)`` whose
+    name matches the qualifier the compiler emits (``ctx.backend_target``), so the
+    statement's table and the predicate's ``khora_chunks.<col>`` references agree.
+    """
+    conn, ns, ids = seeded
+    id_to_label = {v: k for k, v in ids.items()}
+
+    ast = parse_to_ast(RecallFilter.model_validate(wire))
+    ctx = CompileContext(backend_target=_TEST_TABLE)
+    predicate = compile_postgres(ast, ctx).predicate
+
+    table = sa.table(_TEST_TABLE, sa.column("id"), sa.column("namespace_id"))
+    stmt = sa.select(table.c.id).where(sa.and_(table.c.namespace_id == ns, predicate))
+    result = await conn.execute(stmt)
+    return {id_to_label[r[0]] for r in result.fetchall()}
+
+
+# ===========================================================================
+# Numeric range — excludes array, "abc", numeric STRING; orders numerically.
+# ===========================================================================
+
+
+async def test_numeric_gte_excludes_non_numbers_and_orders_numerically(seeded) -> None:
+    # metadata.score >= 5 must include the numbers 10, 7, 5 — and EXCLUDE the
+    # numeric-looking string "10" (it is text, not a number), the non-numeric
+    # "abc", the array [1,2], and the row with no score key. Crucially num2
+    # (score=2) is excluded: numeric ordering, not "10" < "2" text ordering.
+    labels = await _matching_labels(seeded, {"metadata.score": {"$gte": 5}})
+    assert labels == {"num10", "sysnull", "baddate"}
+
+
+async def test_numeric_lt_orders_numerically_not_lexically(seeded) -> None:
+    # metadata.score < 5 → only num2 (=2). If the compiler compared as TEXT,
+    # "10" < "5" would be true and numstr would wrongly appear; the jsonb_typeof
+    # gate + numeric cast keeps it out, and "10"-the-string is excluded anyway.
+    labels = await _matching_labels(seeded, {"metadata.score": {"$lt": 5}})
+    assert labels == {"num2"}
+
+
+async def test_numeric_range_band(seeded) -> None:
+    # 3 <= score <= 9 → only the numbers 5 (sysnull) and 7 (baddate).
+    labels = await _matching_labels(seeded, {"metadata.score": {"$gte": 3, "$lte": 9}})
+    assert labels == {"sysnull", "baddate"}
+
+
+# ===========================================================================
+# $ne / $nin include the missing/NULL rows (Rule 2).
+# ===========================================================================
+
+
+async def test_metadata_ne_includes_missing_key(seeded) -> None:
+    # tier != "gold" compiles to NOT(metadata @> {"tier":"gold"}). Containment is
+    # array-aware, so the array-tier row ("arr": ["gold","silver"]) DOES contain
+    # "gold" → it is excluded by the $ne, exactly like the scalar-gold rows.
+    # The $ne includes rows whose tier is a *different* scalar; there is no
+    # missing-tier row here (every row has a tier), but the polarity is still
+    # exercised — a hypothetical missing-tier row would be admitted because
+    # containment is FALSE (not NULL) for an absent key, and NOT(FALSE) = TRUE.
+    labels = await _matching_labels(seeded, {"metadata.tier": {"$ne": "gold"}})
+    # @>{"tier":"gold"} is TRUE for num10/strabc/missing/sysnull (scalar gold) and
+    # arr (array contains gold). NOT(...) keeps the rest:
+    assert labels == {"num2", "numstr", "baddate"}
+
+
+async def test_metadata_ne_admits_absent_key(seeded) -> None:
+    # Direct Rule-2 proof: $ne on a key NO row carries ("nope" is absent
+    # everywhere) must match EVERY row — NOT(metadata @> {"nope": "x"}) is
+    # NOT(FALSE) = TRUE for an absent key, never NULL-dropped.
+    labels = await _matching_labels(seeded, {"metadata.nope": {"$ne": "x"}})
+    assert labels == _ALL_IDS
+
+
+async def test_system_ne_includes_null_column(seeded) -> None:
+    # source_name != "linear" must INCLUDE the row whose source_name IS NULL
+    # (a missing value is "not equal"). All non-sysnull rows have "linear", so
+    # only sysnull qualifies.
+    labels = await _matching_labels(seeded, {"source_name": {"$ne": "linear"}})
+    assert labels == {"sysnull"}
+
+
+async def test_not_eq_admits_null_row_like_ne(seeded) -> None:
+    # SEMANTICS over tokens (architect note): $not($eq x) is NULL-INCLUSIVE — it
+    # must admit a row whose column IS NULL, exactly like $ne. The child equality
+    # is total (`coalesce(col = x, false)`), so NOT(false) = TRUE flips the NULL
+    # row IN. Proven by the row-set, not the rendered operator: $not($eq "linear")
+    # returns the SAME set as {"$ne": "linear"} — only the NULL-valued row.
+    not_eq = await _matching_labels(seeded, {"$not": {"source_name": "linear"}})
+    ne = await _matching_labels(seeded, {"source_name": {"$ne": "linear"}})
+    assert not_eq == {"sysnull"}
+    assert not_eq == ne  # $not($eq) ≡ $ne at the row-set level (NULL-inclusion)
+
+
+# ===========================================================================
+# $in — array-contains membership.
+# ===========================================================================
+
+
+async def test_metadata_in_matches_scalar_and_array_membership(seeded) -> None:
+    # tier $in ["silver"] → every row whose tier is the scalar "silver" (num2,
+    # baddate) AND the array-tier row (arr contains "silver"). Containment
+    # membership spans both the scalar and array shapes.
+    labels = await _matching_labels(seeded, {"metadata.tier": {"$in": ["silver"]}})
+    assert labels == {"num2", "baddate", "arr"}
+
+
+async def test_metadata_in_multiple_values(seeded) -> None:
+    labels = await _matching_labels(seeded, {"metadata.tier": {"$in": ["silver", "bronze"]}})
+    # silver: num2, baddate, arr (contains silver). bronze: numstr.
+    assert labels == {"num2", "baddate", "numstr", "arr"}
+
+
+# ===========================================================================
+# $date — excludes malformed via khora_try_timestamptz.
+# ===========================================================================
+
+
+async def test_metadata_date_range_excludes_malformed(seeded) -> None:
+    # sent_at >= 2026-01-05 → num10 (2026-01-10). num2 (2026-01-02) is before.
+    # baddate ("not-a-date") must be EXCLUDED — khora_try_timestamptz returns
+    # NULL so the comparison is NULL (non-match) rather than erroring the query.
+    # numstr/strabc/arr/missing/sysnull have no sent_at at all → excluded.
+    labels = await _matching_labels(seeded, {"metadata.sent_at": {"$gte": {"$date": "2026-01-05T00:00:00Z"}}})
+    assert labels == {"num10"}
+
+
+async def test_metadata_date_eq_excludes_malformed(seeded) -> None:
+    labels = await _matching_labels(seeded, {"metadata.sent_at": {"$date": "2026-01-02T00:00:00Z"}})
+    assert labels == {"num2"}
+
+
+# ===========================================================================
+# $exists — key presence, true/false (Rule 4).
+# ===========================================================================
+
+
+async def test_metadata_exists_true(seeded) -> None:
+    # score key present → all rows EXCEPT "missing".
+    labels = await _matching_labels(seeded, {"metadata.score": {"$exists": True}})
+    assert labels == _ALL_IDS - {"missing"}
+
+
+async def test_metadata_exists_false(seeded) -> None:
+    # score key absent → only "missing".
+    labels = await _matching_labels(seeded, {"metadata.score": {"$exists": False}})
+    assert labels == {"missing"}
+
+
+async def test_metadata_exists_true_includes_null_valued_array_and_string(seeded) -> None:
+    # $exists is KEY-PRESENCE (Rule 4): a present-but-array ("arr") and a
+    # present-but-string ("strabc"/"numstr") value all count as existing — a ->>
+    # value extraction would have mishandled the array/typed values.
+    labels = await _matching_labels(seeded, {"metadata.score": {"$exists": True}})
+    assert {"arr", "strabc", "numstr"} <= labels
+
+
+# ===========================================================================
+# Array containment scalar $eq spans scalar + array fields.
+# ===========================================================================
+
+
+async def test_metadata_scalar_eq_matches_array_membership(seeded) -> None:
+    # tier == "gold" via @> containment matches the scalar-gold rows AND the
+    # array-tier row that contains "gold".
+    labels = await _matching_labels(seeded, {"metadata.tier": "gold"})
+    # scalar gold: num10, strabc, missing, sysnull. array containing gold: arr.
+    assert labels == {"num10", "strabc", "missing", "sysnull", "arr"}
+
+
+# ===========================================================================
+# Empty filter — match everything.
+# ===========================================================================
+
+
+async def test_empty_filter_matches_all_rows(seeded) -> None:
+    labels = await _matching_labels(seeded, {})
+    assert labels == _ALL_IDS
+
+
+# ===========================================================================
+# System $exists is a CONSTANT (a denormalized column is structurally always
+# present), and NULL-ness on a system column is reached via {key: null}.
+# ===========================================================================
+
+
+async def test_system_exists_true_matches_all_rows(seeded) -> None:
+    # $exists:true on a system column is a tautology — the column is always
+    # present on the row, including the NULL-valued one (postgres.py:182-184).
+    labels = await _matching_labels(seeded, {"source_name": {"$exists": True}})
+    assert labels == _ALL_IDS
+
+
+async def test_system_exists_false_matches_nothing(seeded) -> None:
+    # ...and $exists:false matches NOTHING, even the NULL-valued row — a present
+    # column is never "absent". This is the deliberate divergence from metadata
+    # $exists; NULL-ness is asserted via {source_name: null} below.
+    labels = await _matching_labels(seeded, {"source_name": {"$exists": False}})
+    assert labels == set()
+
+
+async def test_system_null_operand_finds_null_column(seeded) -> None:
+    # {"source_name": null} is the active null-or-missing match → IS NULL. THIS is
+    # how a NULL system column is found (not $exists:false). Only sysnull matches.
+    labels = await _matching_labels(seeded, {"source_name": None})
+    assert labels == {"sysnull"}
+
+
+async def test_system_eq_excludes_null_column(seeded) -> None:
+    # A positive scalar $eq on a system column excludes the NULL-valued row
+    # (NULL = 'linear' is NULL, not TRUE) — the complement of the $ne polarity.
+    labels = await _matching_labels(seeded, {"source_name": "linear"})
+    assert labels == _ALL_IDS - {"sysnull"}

--- a/tests/integration/test_compile_postgres_rowset.py
+++ b/tests/integration/test_compile_postgres_rowset.py
@@ -308,6 +308,25 @@ async def test_metadata_in_multiple_values(seeded) -> None:
     assert labels == {"num2", "baddate", "numstr", "arr"}
 
 
+async def test_metadata_empty_in_matches_nothing(seeded) -> None:
+    # An empty $in operand is a valid filter (the validator accepts it): positive
+    # membership over ∅ matches NO row. Regression guard for the bug where the
+    # empty sa.or_() vanished from the AND and the filter matched every row.
+    # ``score`` is absent on `missing`, so this also exercises the absent-key row.
+    labels = await _matching_labels(seeded, {"metadata.score": {"$in": []}})
+    assert labels == set()
+
+
+async def test_metadata_empty_nin_matches_everything(seeded) -> None:
+    # An empty $nin operand matches EVERY row (negation over ∅) — including the
+    # `missing` row whose `score` key is absent and the `sysnull` row whose system
+    # column is NULL. This MUST execute against Postgres: the original bug emitted
+    # NOT(<empty or>), invalid SQL that errored at execute time; a render-only
+    # assertion would not catch it.
+    labels = await _matching_labels(seeded, {"metadata.score": {"$nin": []}})
+    assert labels == _ALL_IDS
+
+
 # ===========================================================================
 # $date — excludes malformed via khora_try_timestamptz.
 # ===========================================================================

--- a/tests/unit/engines/skeleton/backends/test_pgvector_coverage.py
+++ b/tests/unit/engines/skeleton/backends/test_pgvector_coverage.py
@@ -538,4 +538,5 @@ class TestSearchTelemetryWrapper:
             temporal_filter=None,
             hybrid_alpha=0.5,
             query_text="x",
+            filter_ast=None,
         )

--- a/tests/unit/filter/test_compile_postgres.py
+++ b/tests/unit/filter/test_compile_postgres.py
@@ -294,6 +294,23 @@ def test_metadata_in_is_or_of_containments_or_overlap() -> None:
     assert "@>" in sql or "?|" in sql
 
 
+def test_metadata_empty_in_is_constant_false() -> None:
+    # An empty $in operand list is a valid filter (the validator accepts it) with
+    # a defined row-set: a positive membership over ∅ matches nothing. It must
+    # render as a constant FALSE — never a vanishing sa.or_() that the enclosing
+    # AND would drop (which would wrongly match every row).
+    sql = _sql_norm(_ast({"metadata.tier": {"$in": []}}))
+    assert sql == "false"
+
+
+def test_metadata_empty_nin_is_constant_true() -> None:
+    # An empty $nin operand list matches everything (negation over ∅). It must
+    # render as a constant TRUE — never sa.not_() of an empty OR chain, which is
+    # invalid SQL that would error at execute time.
+    sql = _sql_norm(_ast({"metadata.tier": {"$nin": []}}))
+    assert sql == "true"
+
+
 def test_metadata_array_operand_eq_is_exact_jsonb_match() -> None:
     # A bare list on a metadata path is $eq EXACT-ARRAY: the field must equal the
     # whole JSON array, emitted as #> = <jsonb array> (NOT containment, NOT $in).

--- a/tests/unit/filter/test_compile_postgres.py
+++ b/tests/unit/filter/test_compile_postgres.py
@@ -1,0 +1,551 @@
+"""Unit tests for the Postgres recall-filter compiler (Layer 4) — ``@internal``.
+
+``compile_postgres(ast, ctx)`` lowers a canonical :class:`~khora.filter.ast.FilterNode`
+into a SQLAlchemy boolean predicate over the ``khora_chunks`` temporal store. These
+tests pin the §4 *Field-match contract* at the SQL level: each test builds an
+AST (by validating a :class:`~khora.filter.RecallFilter` and lowering it with
+:func:`~khora.filter.ast.parse_to_ast`), compiles it, and asserts on the rendered SQL
+(``literal_binds`` so the structure is visible inline) — never re-implementing the
+compiler, only inspecting what it emits.
+
+The contract these tests lock (§4):
+
+* Every operator ``$eq``/``$ne``/``$gt``/``$gte``/``$lt``/``$lte``/``$in``/``$nin``/``$exists``.
+* System key (typed column) vs metadata (JSONB) emission paths, incl. nested paths.
+* ``$and``/``$or``/``$not`` composition; the empty AST → match-everything (``true``).
+* ``$date``: a system date key compiles to a direct column compare; a metadata
+  ``$date`` literal goes through the guarded ``khora_try_timestamptz`` cast.
+* The four field-match rules:
+  1. metadata numeric range emits a ``jsonb_typeof`` gate (no bare cast);
+  2. ``$ne``/``$nin`` emit ``col IS NULL OR ...`` for system cols and include-absent
+     for metadata;
+  3. a list operand against a scalar system column → constant ``false``;
+  4. ``$exists`` / null use ``?`` / ``#>``-vs-``null``, not ``->>`` value extraction.
+* Array containment: scalar ``$eq`` on metadata → ``@>``; ``$in`` → OR of
+  containments / ``?|``; array operand ``$eq`` → exact ``#>`` = jsonb.
+
+If the compiler module is not yet on the branch (implementation lands separately),
+the whole module skips cleanly so the suite stays green.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql.elements import ColumnElement
+
+from khora.filter import RecallFilter
+from khora.filter.ast import FilterClause, FilterNode, parse_to_ast
+from khora.filter.compilers.postgres import compile_postgres
+from khora.filter.context import CompileContext
+from khora.filter.model import Op
+
+# Hard import (NOT importorskip): the compiler is on the branch, so an import
+# failure here must be a LOUD test error — never a silent module skip that would
+# pass CI green with zero coverage.
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+_CTX = CompileContext(backend_target="khora_chunks")
+
+
+def _ast(wire: dict) -> FilterNode:
+    """Validate a wire-form filter and lower it to the canonical AST."""
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+def _sql(node: FilterNode | FilterClause, ctx: CompileContext = _CTX) -> str:
+    """Compile an AST and render the predicate as inline-literal Postgres SQL.
+
+    The predicate is a SQLAlchemy ``ColumnElement[bool]``; rendering with
+    ``literal_binds`` makes the emitted structure (operators, JSONB paths, casts,
+    null-guards) visible as a single string the tests can assert substrings on.
+    """
+    compiled = compile_postgres(node, ctx)
+    predicate = compiled.predicate
+    assert isinstance(predicate, ColumnElement), f"predicate is not a SQLAlchemy ColumnElement: {type(predicate)!r}"
+    return str(
+        predicate.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+def _norm(sql: str) -> str:
+    """Collapse whitespace and lowercase for resilient substring matching."""
+    return " ".join(sql.split()).lower()
+
+
+def _sql_norm(node: FilterNode | FilterClause, ctx: CompileContext = _CTX) -> str:
+    return _norm(_sql(node, ctx))
+
+
+# ===========================================================================
+# Empty AST → match-everything.
+# ===========================================================================
+
+
+def test_empty_filter_compiles_to_true() -> None:
+    # A bare RecallFilter() (no predicates) lowers to the empty match-everything
+    # AND. The compiler must emit a tautology so the engine applies no constraint.
+    sql = _sql_norm(_ast({}))
+    assert sql == "true"
+
+
+def test_empty_and_node_compiles_to_true() -> None:
+    # Construct the empty AND directly — same match-everything contract.
+    sql = _sql_norm(FilterNode(op=Op.AND, children=()))
+    assert sql == "true"
+
+
+# ===========================================================================
+# Scalar operators on a SYSTEM (typed-column) key.
+# ===========================================================================
+
+
+def test_system_eq_is_column_equals() -> None:
+    sql = _sql_norm(_ast({"source_name": "linear"}))
+    assert "source_name" in sql
+    assert "= 'linear'" in sql
+    # System key is a typed column, NOT a JSONB extraction.
+    assert "->>" not in sql
+    assert "#>>" not in sql
+
+
+def test_system_gt_is_column_compare() -> None:
+    # A system DATE key takes a plain ISO-8601 string operand (DateOps parses it
+    # to a datetime) — the `{"$date": ...}` typed literal is a METADATA-only form.
+    sql = _sql_norm(_ast({"created_at": {"$gt": "2026-01-01T00:00:00Z"}}))
+    assert "created_at >" in sql
+    # Direct column compare on a TIMESTAMPTZ column — no try-cast wrapper.
+    assert "khora_try_timestamptz" not in sql
+
+
+@pytest.mark.parametrize(
+    ("wire_op", "sql_op"),
+    [
+        ("$gt", ">"),
+        ("$gte", ">="),
+        ("$lt", "<"),
+        ("$lte", "<="),
+    ],
+)
+def test_system_date_range_operators(wire_op: str, sql_op: str) -> None:
+    sql = _sql_norm(_ast({"occurred_at": {wire_op: "2026-03-04T05:06:07Z"}}))
+    assert f"occurred_at {sql_op}" in sql
+
+
+def test_system_eq_on_string_key_with_ops_form() -> None:
+    sql = _sql_norm(_ast({"source_type": {"$eq": "slack"}}))
+    assert "source_type" in sql
+    assert "= 'slack'" in sql
+
+
+# ===========================================================================
+# Rule 2 — $ne / $nin include NULL / absent.
+# ===========================================================================
+
+
+def test_system_ne_includes_null_rows() -> None:
+    # Rule 2: $ne on a system column must match rows where the column IS NULL
+    # too (a missing value is "not equal"). Emitted as `col IS NULL OR col != x`.
+    sql = _sql_norm(_ast({"source_name": {"$ne": "linear"}}))
+    assert "source_name is null" in sql
+    assert "!=" in sql or "<>" in sql
+    assert " or " in sql
+
+
+def test_system_nin_includes_null_rows() -> None:
+    # $nin is the list form of $ne — NULL rows are included.
+    sql = _sql_norm(_ast({"source_name": {"$nin": ["a", "b"]}}))
+    assert "source_name is null" in sql
+    assert "not in" in sql
+    assert " or " in sql
+
+
+def test_metadata_ne_includes_absent_key() -> None:
+    # Rule 2 for metadata: $ne must also match rows where the key is ABSENT.
+    # The compiler negates the total `@>` containment form — `NOT (... @> ...)`
+    # is TRUE for an absent key (containment is FALSE there, never NULL), so the
+    # absent row is admitted.
+    sql = _sql_norm(_ast({"metadata.tier": {"$ne": "gold"}}))
+    assert "not (" in sql
+    assert "@>" in sql
+
+
+# ===========================================================================
+# Rule 3 — list operand vs scalar SYSTEM column → constant false.
+# ===========================================================================
+
+
+def test_system_eq_array_operand_is_constant_false() -> None:
+    # A bare-list on a scalar system column lowers to $eq EXACT-ARRAY. A scalar
+    # TIMESTAMPTZ/VARCHAR column can never equal an array → the compiler folds it
+    # to a constant false (no row can match) rather than emitting invalid SQL.
+    sql = _sql_norm(_ast({"source_name": ["a", "b"]}))
+    assert sql == "false"
+
+
+def test_system_date_in_is_membership_list_not_false() -> None:
+    sql = _sql_norm(_ast({"occurred_at": {"$in": ["2026-01-01T00:00:00Z"]}}))
+    # $in on a system DATE column is membership, NOT exact-array, so this is a
+    # real IN list — distinct from the exact-array false case above.
+    assert sql != "false"
+    assert " in " in sql
+
+
+# ===========================================================================
+# $in / $nin on a SYSTEM column → IN / NOT IN list.
+# ===========================================================================
+
+
+def test_system_in_is_in_list() -> None:
+    sql = _sql_norm(_ast({"source_name": {"$in": ["a", "b", "c"]}}))
+    assert "source_name in (" in sql
+    assert "'a'" in sql and "'b'" in sql and "'c'" in sql
+
+
+def test_system_nin_is_not_in_list_with_null_guard() -> None:
+    sql = _sql_norm(_ast({"source_type": {"$nin": ["spam", "junk"]}}))
+    assert "not in" in sql
+    assert "source_type is null" in sql
+
+
+# ===========================================================================
+# $exists on a SYSTEM column → constant (the column is structurally always
+# present on the denormalized chunk row, so presence is not value-dependent).
+# ===========================================================================
+
+
+def test_system_exists_true_is_constant_true() -> None:
+    # A system column always exists on the row — $exists:true is a tautology,
+    # NOT a value-dependent IS NOT NULL check (postgres.py:182-184, deliberate).
+    sql = _sql_norm(_ast({"source_name": {"$exists": True}}))
+    assert sql == "true"
+
+
+def test_system_exists_false_is_constant_false() -> None:
+    # ...and $exists:false matches nothing — a present column is never "absent".
+    # NULL-ness on a system column is reached via {"key": null} ($eq null), not
+    # via $exists:false.
+    sql = _sql_norm(_ast({"source_name": {"$exists": False}}))
+    assert sql == "false"
+
+
+# ===========================================================================
+# Null operand ($eq None) — active null-or-missing match.
+# ===========================================================================
+
+
+def test_system_null_operand_is_is_null() -> None:
+    # An explicit null is an active null-or-missing match → IS NULL.
+    sql = _sql_norm(_ast({"source_name": None}))
+    assert "source_name is null" in sql
+
+
+# ===========================================================================
+# Metadata (JSONB) paths.
+# ===========================================================================
+
+
+def test_metadata_eq_scalar_uses_containment() -> None:
+    # Array-containment rule: a scalar $eq on a metadata field is emitted as a
+    # JSONB containment (@>) so it matches both a scalar value AND membership in
+    # an array-valued field — never a brittle ->> text compare.
+    sql = _sql_norm(_ast({"metadata.tier": "gold"}))
+    assert "@>" in sql
+
+
+def test_metadata_nested_path_extraction() -> None:
+    # A nested metadata path addresses through the JSONB document with #> / #>>.
+    sql = _sql_norm(_ast({"metadata.labels.tier": {"$gte": 5}}))
+    assert "#>" in sql  # covers both #> and #>>
+    # The path segments below the metadata root appear in the extraction.
+    assert "labels" in sql and "tier" in sql
+
+
+def test_metadata_numeric_range_has_jsonb_typeof_gate() -> None:
+    # Rule 1: a metadata numeric range must gate on jsonb_typeof(...) = 'number'
+    # BEFORE casting, so a string / array / object value is excluded instead of
+    # erroring the statement on a bad cast.
+    sql = _sql_norm(_ast({"metadata.score": {"$gte": 10}}))
+    assert "jsonb_typeof" in sql
+    assert "'number'" in sql
+
+
+@pytest.mark.parametrize("wire_op", ["$gt", "$gte", "$lt", "$lte"])
+def test_metadata_all_ranges_gate_on_typeof(wire_op: str) -> None:
+    sql = _sql_norm(_ast({"metadata.score": {wire_op: 5}}))
+    assert "jsonb_typeof" in sql
+
+
+def test_metadata_in_is_or_of_containments_or_overlap() -> None:
+    # $in on a metadata field is membership across scalar and array fields:
+    # either an OR of @> containments or the ?| overlap operator.
+    sql = _sql_norm(_ast({"metadata.tier": {"$in": ["gold", "silver"]}}))
+    assert "@>" in sql or "?|" in sql
+
+
+def test_metadata_array_operand_eq_is_exact_jsonb_match() -> None:
+    # A bare list on a metadata path is $eq EXACT-ARRAY: the field must equal the
+    # whole JSON array, emitted as #> = <jsonb array> (NOT containment, NOT $in).
+    sql = _sql_norm(_ast({"metadata.tags": ["x", "y"]}))
+    assert "#>" in sql
+    # Exact array equality renders the array as a jsonb literal on the RHS.
+    assert "jsonb" in sql or "::json" in sql or "[" in sql
+
+
+# ===========================================================================
+# Rule 4 — $exists / null on metadata use key-presence, not value extraction.
+# ===========================================================================
+
+
+def test_metadata_exists_true_uses_has_key_operator() -> None:
+    # Rule 4: $exists on metadata is a KEY-PRESENCE test (?), never a ->> value
+    # extraction (which would be NULL for a present-but-null value).
+    sql = _sql_norm(_ast({"metadata.tier": {"$exists": True}}))
+    assert "?" in sql
+    assert "->>" not in sql
+
+
+def test_metadata_exists_false_negates_has_key() -> None:
+    sql = _sql_norm(_ast({"metadata.tier": {"$exists": False}}))
+    assert "?" in sql
+    assert ("not" in sql) or ("is null" in sql)
+
+
+def test_metadata_null_operand_uses_jsonb_null_not_text_extraction() -> None:
+    # Rule 4: an active null match on metadata compares the JSONB value to
+    # 'null'::jsonb via #> (json-null), NOT ->> (which conflates absent + null).
+    sql = _sql_norm(_ast({"metadata.tier": None}))
+    assert "#>" in sql
+    assert "null" in sql
+    assert "->>" not in sql
+
+
+# ===========================================================================
+# $date typed literal — system vs metadata path.
+# ===========================================================================
+
+
+def test_system_date_is_direct_column_compare() -> None:
+    # A system date key takes a plain ISO string (the `$date` typed literal is a
+    # metadata-only form). It compiles to a direct TIMESTAMPTZ column equality —
+    # no guarded khora_try_timestamptz cast.
+    sql = _sql_norm(_ast({"source_timestamp": "2026-02-03T00:00:00Z"}))
+    assert "source_timestamp =" in sql
+    assert "khora_try_timestamptz" not in sql
+
+
+def test_metadata_date_literal_uses_guarded_cast() -> None:
+    # A $date on a metadata path must go through khora_try_timestamptz so a
+    # malformed stored string yields NULL (non-match) instead of erroring.
+    sql = _sql_norm(_ast({"metadata.sent_at": {"$date": "2026-02-03T00:00:00Z"}}))
+    assert "khora_try_timestamptz" in sql
+
+
+def test_metadata_date_range_uses_guarded_cast() -> None:
+    sql = _sql_norm(_ast({"metadata.sent_at": {"$gte": {"$date": "2026-01-01T00:00:00Z"}}}))
+    assert "khora_try_timestamptz" in sql
+
+
+# ===========================================================================
+# Logical composition — AND / OR / NOT.
+# ===========================================================================
+
+
+def test_and_node_joins_with_and() -> None:
+    sql = _sql_norm(_ast({"source_name": "linear", "source_type": "slack"}))
+    assert " and " in sql
+    assert "source_name" in sql and "source_type" in sql
+
+
+def test_or_node_joins_with_or() -> None:
+    sql = _sql_norm(_ast({"$or": [{"source_name": "linear"}, {"source_type": "slack"}]}))
+    assert " or " in sql
+    assert "source_name" in sql and "source_type" in sql
+
+
+def test_not_node_negates_with_null_inclusive_total_child() -> None:
+    # SEMANTICS over tokens: NOT compiles via sa.not_(child), and the child
+    # equality is built as a TOTAL boolean (`coalesce(col = v, false)`) precisely
+    # so the negation is NULL-INCLUSIVE — `NOT coalesce(NULL = v, false)` =
+    # `NOT false` = TRUE flips a NULL/absent row IN (Rule 2), making $not($eq)
+    # behave like $ne rather than dropping the NULL row. We assert the total-child
+    # SHAPE here (the `coalesce(..., false)` wrap is the load-bearing guarantee);
+    # the actual NULL-inclusion ROW-SET behavior is proven against real Postgres
+    # in test_compile_postgres_rowset.py::test_not_eq_admits_null_row_like_ne.
+    sql = _sql_norm(_ast({"$not": {"source_name": "linear"}}))
+    assert sql.startswith("not ")
+    # The total-child guard (coalesce → false) is what makes the negation
+    # NULL-inclusive — assert it is present, not merely the != token.
+    assert "coalesce(" in sql
+    assert "false" in sql
+    assert "source_name" in sql and "= 'linear'" in sql
+
+
+def test_nested_and_or_structure() -> None:
+    sql = _sql_norm(
+        _ast(
+            {
+                "source_name": "linear",
+                "$or": [{"source_type": "slack"}, {"content_type": "text/plain"}],
+            }
+        )
+    )
+    assert " and " in sql
+    assert " or " in sql
+
+
+# ===========================================================================
+# CompiledFilter envelope — consumed_keys / canonical_hash / params.
+# ===========================================================================
+
+
+def test_compiled_filter_carries_canonical_hash() -> None:
+    node = _ast({"source_name": "linear"})
+    compiled = compile_postgres(node, _CTX)
+    from khora.filter.ast import canonical_hash
+
+    assert compiled.canonical_hash == canonical_hash(node)
+
+
+def test_compiled_filter_consumed_keys_is_frozenset() -> None:
+    compiled = compile_postgres(_ast({"source_name": "linear"}), _CTX)
+    assert isinstance(compiled.consumed_keys, frozenset)
+
+
+def test_empty_filter_consumes_nothing() -> None:
+    compiled = compile_postgres(_ast({}), _CTX)
+    assert compiled.consumed_keys == frozenset()
+
+
+# ===========================================================================
+# field_mapping — one compiler, different schemas, no engine branching.
+# ===========================================================================
+
+
+def test_field_mapping_remaps_system_column_name() -> None:
+    # CompileContext.field_mapping lets the same compiler serve a different schema
+    # (a column under a different name) without any per-engine `if engine == ...`
+    # branching. The mapped name must resolve to a real column on the resolved
+    # table — here we remap source_name → the existing `source` column.
+    ctx = CompileContext(
+        backend_target="khora_chunks",
+        field_mapping={"source_name": "source"},
+    )
+    sql = _sql_norm(_ast({"source_name": "linear"}), ctx)
+    assert "source = 'linear'" in sql
+
+
+# ===========================================================================
+# Datetime construction directly on the AST (no wire round-trip).
+# ===========================================================================
+
+
+def test_direct_datetime_clause_compiles() -> None:
+    # Build a leaf clause directly with a tz-aware datetime operand — the AST is a
+    # valid compiler input independent of the validator path.
+    clause = FilterClause(
+        path=("occurred_at",),
+        op=Op.GTE,
+        operand=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    node = FilterNode(op=Op.AND, children=(clause,))
+    sql = _sql_norm(node)
+    assert "occurred_at >=" in sql
+
+
+# ===========================================================================
+# Bare metadata blob — whole-document $eq equality.
+# ===========================================================================
+
+
+def test_bare_metadata_blob_eq_is_jsonb_document_equality() -> None:
+    # A bare ``metadata`` dict is whole-document JSONB equality (PG `=` is
+    # structural-normalized: key order / whitespace insensitive). Not a per-field
+    # containment — the entire blob must equal the operand object.
+    sql = _sql_norm(_ast({"metadata": {"a": 1, "b": 2}}))
+    assert "metadata" in sql
+    assert "=" in sql
+    assert "jsonb" in sql
+    # Whole-blob equality, NOT array containment / extraction.
+    assert "@>" not in sql
+    assert "#>" not in sql
+
+
+# ===========================================================================
+# $ne null on a metadata path — present AND not a JSON null value.
+# ===========================================================================
+
+
+def test_metadata_ne_null_is_present_and_not_json_null() -> None:
+    # {"metadata.k": {"$ne": null}} → NOT(active-null-or-missing): the key is
+    # present AND its value is not an explicit JSON null. Emitted as the negation
+    # of the null-or-missing form.
+    sql = _sql_norm(_ast({"metadata.tier": {"$ne": None}}))
+    assert sql.startswith("not (")
+    assert "null" in sql
+    assert "?" in sql  # the presence half of the negated null-or-missing form
+
+
+# ===========================================================================
+# $in with $date elements — containment doc carries the ISO string.
+# ===========================================================================
+
+
+def test_metadata_in_with_date_literals_uses_iso_containment() -> None:
+    # A $date element of a metadata $in becomes an ISO-8601 string inside the @>
+    # containment doc (a datetime is not directly JSON-serializable).
+    sql = _sql_norm(_ast({"metadata.day": {"$in": [{"$date": "2026-01-01T00:00:00Z"}]}}))
+    assert "@>" in sql
+    assert "2026-01-01" in sql
+
+
+# ===========================================================================
+# on_unsupported policy — "raise" vs "split".
+# ===========================================================================
+
+
+def _unknown_key_node() -> FilterNode:
+    # A leaf whose path is neither a system key nor a metadata path — the only
+    # clause this backend cannot express (should not occur post-validation).
+    return FilterNode(op=Op.AND, children=(FilterClause(path=("not_a_key",), op=Op.EQ, operand="x"),))
+
+
+def test_unsupported_clause_raises_in_raise_mode() -> None:
+    from khora.filter import RecallFilterUnsupportedError
+
+    ctx = CompileContext(backend_target="khora_chunks", on_unsupported="raise")
+    with pytest.raises(RecallFilterUnsupportedError):
+        compile_postgres(_unknown_key_node(), ctx)
+
+
+def test_unsupported_clause_splits_to_nonconstraining_true() -> None:
+    # In "split" mode the engine post-filters what the backend cannot express, so
+    # the compiler emits a non-constraining predicate and leaves the key OUT of
+    # consumed_keys (it does not narrow the result set).
+    ctx = CompileContext(backend_target="khora_chunks", on_unsupported="split")
+    compiled = compile_postgres(_unknown_key_node(), ctx)
+    sql = _norm(str(compiled.predicate.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})))
+    assert sql == "true"
+    assert "not_a_key" not in compiled.consumed_keys
+
+
+# ===========================================================================
+# table_alias — columns render under the alias.
+# ===========================================================================
+
+
+def test_table_alias_qualifies_columns() -> None:
+    ctx = CompileContext(backend_target="khora_chunks", table_alias="kc")
+    sql = _sql_norm(_ast({"source_name": "linear"}), ctx)
+    assert "kc.source_name" in sql

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -442,14 +442,14 @@ class TestMigrationPackageStructure:
         assert env_path.exists(), f"env.py not found at {env_path}"
 
     @pytest.mark.unit
-    def test_versions_dir_has_45_files(self):
-        """versions/ directory contains 45 migration files."""
+    def test_versions_dir_has_46_files(self):
+        """versions/ directory contains 46 migration files."""
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
         # Filter out __pycache__ and __init__
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
-        assert len(migration_files) == 45, (
-            f"Expected 45 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
+        assert len(migration_files) == 46, (
+            f"Expected 46 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
         )
 
     @pytest.mark.unit

--- a/tests/unit/test_sqlite_migrations.py
+++ b/tests/unit/test_sqlite_migrations.py
@@ -82,7 +82,7 @@ class TestSqliteMigrations:
                     # Version table must point at head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
                     version = result.scalar()
-                    assert version == "044_khora_chunks_backfill_denormalized"
+                    assert version == "045_khora_try_timestamptz"
             finally:
                 await engine.dispose()
 


### PR DESCRIPTION
## Summary

Adds the PostgreSQL backend compiler that lowers the canonical recall-filter
AST into a single-table `khora_chunks` `WHERE` predicate (no `documents` join —
the filterable document columns are denormalized onto the chunk row). The
compiler implements a deterministic field-match contract so the same filter
returns the same row set regardless of stored value shape:

- **Never abort.** Metadata scalar casts are type-gated through `jsonb_typeof`,
  so an array or non-numeric string value can never abort a numeric/date
  comparison on the rest of the scan.
- **Negation polarity.** `$ne`/`$nin` include missing/NULL rows — system columns
  via `col IS NULL OR …`, metadata via a coalesced-totality wrapper — matching
  MongoDB semantics (a negation includes documents lacking the field).
- **Impossible operand/column pairs short-circuit.** An exact-array operand
  against a scalar system column compiles to a constant `false` predicate
  instead of an invalid `varchar = text[]` comparison.
- **Presence/null use JSONB primitives.** `$exists` and null-or-missing use
  `?` / `#> = 'null'::jsonb`, never value extraction.

Metadata equality/set operators use array-aware JSONB containment (`@>` / `?|`);
range operators use the type-gated scalar cast. The `$date` typed literal
parses-or-excludes through a new `khora_try_timestamptz()` SQL helper
(`IMMUTABLE PARALLEL SAFE`, installed by a Postgres-only migration) behind a
cheap regex pre-gate, under a `TimeZone='UTC'` connection.

The compiler is wired into the pgvector backend through an additive `filter_ast`
seam and registered in the internal compiler registry; the previous lexicographic
metadata range comparison (which mis-ordered numeric strings like `"10" < "2"`)
is replaced by the type-gated path. The legacy temporal-filter path is preserved
during its deprecation window.

## Test plan

- [x] Unit tests pass — SQL-emission assertions for every operator and contract rule
- [x] `make lint` / `make format` clean
- [ ] Postgres-backed row-set tests over adversarial rows (array, non-numeric
      string, numeric-string ordering, missing key, NULL column, malformed date)
      — run against a live PostgreSQL