### PR TITLE
Add filter= kwarg to recall() with canonical filter AST engine carrier

### DIFF
--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -66,6 +66,7 @@ from khora.telemetry.metrics import metric_counter, metric_histogram
 if TYPE_CHECKING:
     from khora.extraction.chunkers import ChunkStrategy
     from khora.extraction.skills import ExpertiseConfig
+    from khora.filter import FilterNode
 
 ChronicleStorageBackend = Literal["pgvector", "lancedb"]
 
@@ -1462,6 +1463,7 @@ class ChronicleEngine:
         min_similarity: float = 0.0,
         temporal_filter: Any | None = None,
         recency_bias: float | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> RecallResult:
         """Recall memories using 4-channel parallel retrieval with RRF fusion.
 
@@ -1482,6 +1484,8 @@ class ChronicleEngine:
             min_similarity: Minimum similarity threshold
             temporal_filter: Reserved for Phase 2 temporal filtering
             recency_bias: Override temporal decay weight (0.0-1.0)
+            filter_ast: Canonical recall-filter AST. Accepted for protocol
+                parity; Chronicle does not push filters down yet (ignored).
 
         Returns:
             RecallResult with fused and decay-scored chunks

--- a/src/khora/engines/protocol.py
+++ b/src/khora/engines/protocol.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from khora.core.models import Document, Entity, MemoryNamespace
     from khora.extraction.chunkers import ChunkStrategy
     from khora.extraction.skills import ExpertiseConfig
+    from khora.filter import FilterNode
     from khora.khora import BatchResult, RecallResult, RememberResult, Stats
     from khora.query import SearchMode
 
@@ -114,6 +115,7 @@ class MemoryEngineProtocol(Protocol):
         # Temporal parameters (optional — engines may ignore these)
         temporal_filter: Any | None = None,
         recency_bias: float | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> RecallResult:
         """Recall memories relevant to a query.
 
@@ -128,6 +130,8 @@ class MemoryEngineProtocol(Protocol):
                 Engines that do not support temporal filtering may ignore this.
             recency_bias: Optional recency bias weight (0.0–1.0).
                 Engines that do not support recency biasing may ignore this.
+            filter_ast: Optional canonical recall-filter AST. Engines that do
+                not filter may ignore it.
 
         Returns:
             RecallResult with matched memories

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -48,6 +48,7 @@ from .backends import (
 if TYPE_CHECKING:
     from khora.extraction.chunkers import ChunkStrategy
     from khora.extraction.skills import ExpertiseConfig
+    from khora.filter import FilterNode
 
 
 class SkeletonConstructionEngine:
@@ -502,6 +503,7 @@ class SkeletonConstructionEngine:
         hybrid_alpha: float | None = None,
         filters: dict[str, Any] | None = None,
         recency_bias: float | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> RecallResult:
         """Recall memories relevant to a query.
 
@@ -515,6 +517,8 @@ class SkeletonConstructionEngine:
             temporal_reference: Reference point for relative time (e.g., message timestamp)
             hybrid_alpha: Blend factor for hybrid search (0=BM25, 1=vector)
             filters: Additional structured filters (converted to TemporalFilter)
+            filter_ast: Canonical recall-filter AST. Accepted for protocol
+                parity; skeleton does not push it down yet (ignored).
             recency_bias: Accepted only as ``None`` for protocol parity.
                 Skeleton does not implement temporal decay on the recall
                 path; passing a non-None value silently no-ops in pre-fix

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
 
     from khora.extraction.chunkers import ChunkStrategy
     from khora.extraction.skills import ExpertiseConfig
+    from khora.filter import FilterNode
     from khora.khora import _GlobalChunkSemaphore
     from khora.storage import StorageCoordinator
 
@@ -1950,6 +1951,7 @@ class VectorCypherEngine:
         temporal_filter: TemporalFilter | None = None,
         graph_depth: int | None = None,
         hybrid_alpha: float | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> RecallResult:
         """Recall memories relevant to a query using VectorCypher.
 
@@ -1967,6 +1969,8 @@ class VectorCypherEngine:
             temporal_filter: Temporal constraints
             graph_depth: Override graph traversal depth
             hybrid_alpha: Blend factor (0=graph, 1=vector)
+            filter_ast: Canonical recall-filter AST. Accepted for protocol
+                parity; VectorCypher does not push filters down yet (ignored).
 
         Returns:
             RecallResult with chunks, entities, and context

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -2051,30 +2051,35 @@ class Khora:
                 # Normalize tz: naive → UTC, aware → UTC.
                 norm_start = _normalize_recall_bound(start_time)
                 norm_end = _normalize_recall_bound(end_time)
-                # Inverted range folds to an empty filter (no temporal predicate
-                # and no engine window) rather than raising.
-                inverted = norm_start is not None and norm_end is not None and norm_start > norm_end
-                if not inverted:
-                    from khora.engines.skeleton.backends import TemporalFilter as SkeletonTemporalFilter
+                from khora.engines.skeleton.backends import TemporalFilter as SkeletonTemporalFilter
 
-                    temporal_filter = SkeletonTemporalFilter(
-                        occurred_after=norm_start,
-                        occurred_before=norm_end,
-                    )
-                    # Mirror the legacy ``TemporalFilter`` boundary semantics
-                    # exactly so the folded AST and the window agree when both
-                    # are AND-ed: lower bound inclusive (``occurred_at >=``),
-                    # upper bound EXCLUSIVE (``occurred_at <``) — see
-                    # ``pgvector._build_filter_conditions``. Using ``$lte`` here
-                    # would drop boundary rows once an engine applies both.
-                    ops: dict[str, Any] = {}
-                    if norm_start is not None:
-                        ops["$gte"] = norm_start
-                    if norm_end is not None:
-                        ops["$lt"] = norm_end
-                    # Route the folded bounds through the same single validation
-                    # path as the public filter= kwarg.
-                    filter_ast = parse_to_ast(RecallFilter.model_validate({"occurred_at": ops}))
+                temporal_filter = SkeletonTemporalFilter(
+                    occurred_after=norm_start,
+                    occurred_before=norm_end,
+                )
+                # Mirror the legacy ``TemporalFilter`` boundary semantics
+                # exactly so the folded AST and the window agree when both
+                # are AND-ed: lower bound inclusive (``occurred_at >=``),
+                # upper bound EXCLUSIVE (``occurred_at <``) — see
+                # ``pgvector._build_filter_conditions``. Using ``$lte`` here
+                # would drop boundary rows once an engine applies both.
+                #
+                # An inverted range (start > end) flows through this same fold
+                # rather than being special-cased: it yields
+                # ``{occurred_at: {$gte: t1, $lt: t2}}``, which is
+                # empty-MATCHING (no row satisfies ``>= t1 AND < t2`` when
+                # t1 > t2), so the recall returns nothing — parity with the
+                # equivalent ``filter=`` predicate rather than an unfiltered
+                # recall. The legacy window is empty-matching for an inverted
+                # pair too, so the two stay consistent.
+                ops: dict[str, Any] = {}
+                if norm_start is not None:
+                    ops["$gte"] = norm_start
+                if norm_end is not None:
+                    ops["$lt"] = norm_end
+                # Route the folded bounds through the same single validation
+                # path as the public filter= kwarg.
+                filter_ast = parse_to_ast(RecallFilter.model_validate({"occurred_at": ops}))
             namespace_id = await self._resolve_namespace(namespace)
 
             # Emit RECALL_REQUESTED before any embedding/retrieval work.

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import os
+import warnings
 from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field, replace
@@ -73,6 +74,15 @@ def _coerce_session_id_from_dict(metadata: dict[str, Any] | None) -> UUID | None
         return UUID(str(value))
     except (ValueError, TypeError, AttributeError):
         return None
+
+
+def _normalize_recall_bound(value: datetime | None) -> datetime | None:
+    """Normalize a deprecated recall bound to UTC (naive → UTC, aware → UTC)."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
 
 
 def _safe_exc_summary(exc: BaseException, *, max_len: int = 200) -> str:
@@ -177,6 +187,7 @@ if TYPE_CHECKING:
     from khora.engines.protocol import MemoryEngineProtocol
     from khora.extraction.chunkers import ChunkStrategy
     from khora.extraction.skills import ExpertiseConfig
+    from khora.filter import RecallFilter
     from khora.storage import StorageConfig, StorageCoordinator
 
 
@@ -1955,6 +1966,7 @@ class Khora:
         min_similarity: float = 0.0,
         start_time: datetime | None = None,
         end_time: datetime | None = None,
+        filter: RecallFilter | dict[str, Any] | None = None,
     ) -> RecallResult:
         """Recall memories relevant to a query.
 
@@ -1970,11 +1982,16 @@ class Khora:
             limit: Maximum results to return
             mode: Search mode (VECTOR, GRAPH, HYBRID, ALL)
             min_similarity: Minimum similarity threshold
-            start_time: Optional lower bound (inclusive) for memory time.
-                Timezone-aware datetimes are recommended; naive datetimes are
-                assumed UTC. When provided, bypasses NLP temporal detection.
-            end_time: Optional upper bound (inclusive) for memory time.
-                Same timezone semantics as start_time.
+            start_time: Deprecated. Optional lower bound (inclusive) for memory
+                time. Timezone-aware datetimes are recommended; naive datetimes
+                are assumed UTC. Prefer ``filter={"occurred_at": {"$gte": ...}}``.
+            end_time: Deprecated. Optional upper bound (EXCLUSIVE — matches the
+                legacy temporal window) for memory time. Same timezone semantics
+                as start_time. Prefer ``filter={"occurred_at": {"$lt": ...}}``.
+            filter: Optional deterministic recall filter — a
+                :class:`~khora.filter.RecallFilter` instance or its dict/wire
+                form (validated here). Cannot be combined with the deprecated
+                ``start_time``/``end_time`` bounds.
 
         Returns:
             RecallResult with matched memories.  When using the VectorCypher
@@ -1983,8 +2000,8 @@ class Khora:
             relationships as a formatted LLM context string.
 
         Raises:
-            ValueError: If both ``start_time`` and ``end_time`` are provided
-                and ``start_time > end_time``.
+            ValueError: If ``filter`` is combined with ``start_time``/``end_time``.
+            RecallFilterValidationError: If ``filter`` fails validation.
         """
         import time as _time
 
@@ -2002,22 +2019,62 @@ class Khora:
         _t0 = _time.perf_counter()
         _status = "success"
         _recall_id = uuid4()
-        try:
-            if start_time is not None or end_time is not None:
-                if start_time is not None and end_time is not None:
-                    try:
-                        if start_time > end_time:
-                            raise ValueError("start_time must be <= end_time")
-                    except TypeError as e:
-                        raise ValueError("start_time and end_time must both be timezone-aware or both naive") from e
-                from khora.engines.skeleton.backends import TemporalFilter as SkeletonTemporalFilter
+        from khora.filter import RecallFilter, parse_to_ast
 
-                temporal_filter: Any = SkeletonTemporalFilter(
-                    occurred_after=start_time,
-                    occurred_before=end_time,
+        try:
+            # Resolve the recall filter once, at the facade. Two inputs feed the
+            # single canonical AST: the public ``filter=`` kwarg and the
+            # deprecated ``start_time``/``end_time`` bounds. They are mutually
+            # exclusive. ``temporal_filter`` is still built from the deprecated
+            # bounds so the engines' existing temporal behavior (recency
+            # weighting, version filter) is unchanged. No engine threads
+            # ``filter_ast`` to its backend on the recall path yet (the pgvector
+            # backend can compile it, but the skeleton engine does not pass it
+            # through), so the two cannot currently double-filter; the folded
+            # bounds below still mirror ``temporal_filter``'s boundary semantics
+            # so they stay consistent if/when an engine AND-s both.
+            temporal_filter: Any = None
+            filter_ast: Any = None
+            if filter is not None and (start_time is not None or end_time is not None):
+                raise ValueError("Pass either filter= or the deprecated start_time/end_time, not both")
+            if filter is not None:
+                # Validate once: dict → model_validate, instance → use as-is.
+                # RecallFilterValidationError propagates unwrapped.
+                recall_filter = filter if isinstance(filter, RecallFilter) else RecallFilter.model_validate(filter)
+                filter_ast = parse_to_ast(recall_filter)
+            elif start_time is not None or end_time is not None:
+                warnings.warn(
+                    "start_time/end_time are deprecated; use filter={'occurred_at': {...}}",
+                    DeprecationWarning,
+                    stacklevel=2,
                 )
-            else:
-                temporal_filter = None
+                # Normalize tz: naive → UTC, aware → UTC.
+                norm_start = _normalize_recall_bound(start_time)
+                norm_end = _normalize_recall_bound(end_time)
+                # Inverted range folds to an empty filter (no temporal predicate
+                # and no engine window) rather than raising.
+                inverted = norm_start is not None and norm_end is not None and norm_start > norm_end
+                if not inverted:
+                    from khora.engines.skeleton.backends import TemporalFilter as SkeletonTemporalFilter
+
+                    temporal_filter = SkeletonTemporalFilter(
+                        occurred_after=norm_start,
+                        occurred_before=norm_end,
+                    )
+                    # Mirror the legacy ``TemporalFilter`` boundary semantics
+                    # exactly so the folded AST and the window agree when both
+                    # are AND-ed: lower bound inclusive (``occurred_at >=``),
+                    # upper bound EXCLUSIVE (``occurred_at <``) — see
+                    # ``pgvector._build_filter_conditions``. Using ``$lte`` here
+                    # would drop boundary rows once an engine applies both.
+                    ops: dict[str, Any] = {}
+                    if norm_start is not None:
+                        ops["$gte"] = norm_start
+                    if norm_end is not None:
+                        ops["$lt"] = norm_end
+                    # Route the folded bounds through the same single validation
+                    # path as the public filter= kwarg.
+                    filter_ast = parse_to_ast(RecallFilter.model_validate({"occurred_at": ops}))
             namespace_id = await self._resolve_namespace(namespace)
 
             # Emit RECALL_REQUESTED before any embedding/retrieval work.
@@ -2052,11 +2109,25 @@ class Khora:
                     mode=mode,
                     min_similarity=min_similarity,
                     temporal_filter=temporal_filter,
+                    filter_ast=filter_ast,
                 )
                 # Engines return DocumentProjection stubs (id + bare
                 # essentials). Batch-fetch full source metadata, derive
                 # per-chunk entity linkage, and emit a new RecallResult.
                 result = await self._upgrade_recall_documents(result, namespace_id)
+
+                # Record an honest filter-handling summary on every call. No
+                # engine pushes filters down in this revision, so ``pushed_down``
+                # is always False; ``supported`` is True only for the skeleton
+                # engine (the planned pushdown target). The engine name prefers
+                # whatever the engine already reported.
+                _engine_name = (result.engine_info or {}).get("engine", self._engine_name)
+                _filter_info = {
+                    "engine": _engine_name,
+                    "supported": _engine_name == "skeleton",
+                    "pushed_down": False,
+                }
+                result = replace(result, engine_info={**(result.engine_info or {}), "filter": _filter_info})
 
                 # Emit RECALL_RESULTS_READY after engine returns, before packaging.
                 try:

--- a/tests/unit/test_khora.py
+++ b/tests/unit/test_khora.py
@@ -629,7 +629,12 @@ class TestRecall:
 
 
 class TestRecallTemporalBounds:
-    """Tests for start_time/end_time parameters on recall()."""
+    """Tests for the deprecated start_time/end_time bounds on recall().
+
+    The deprecated bounds now fold to a canonical filter AST (passed to the
+    engine as ``filter_ast``) while still building the legacy ``temporal_filter``
+    window for the engines that already consume it.
+    """
 
     # Shared helper: make a minimal RecallResult mock return value
     @staticmethod
@@ -643,10 +648,30 @@ class TestRecallTemporalBounds:
             relationships=[],
         )
 
+    @staticmethod
+    def _occurred_at_clauses(filter_ast: object) -> list[object]:
+        """Collect every ``occurred_at`` leaf clause from a folded filter AST."""
+        from khora.filter import FilterClause, FilterNode
+
+        if filter_ast is None:
+            return []
+        out: list[object] = []
+        stack: list[object] = [filter_ast]
+        while stack:
+            node = stack.pop()
+            if isinstance(node, FilterClause):
+                if node.path == ("occurred_at",):
+                    out.append(node)
+            elif isinstance(node, FilterNode):
+                stack.extend(node.children)
+        return out
+
     @pytest.mark.asyncio
-    async def test_start_time_only_constructs_filter(self) -> None:
-        """start_time only → SkeletonTemporalFilter with occurred_after set, occurred_before None."""
+    async def test_start_time_only_folds_to_gte(self) -> None:
+        """start_time only → temporal_filter window + a single $gte occurred_at clause."""
         from datetime import UTC, datetime
+
+        from khora.filter import Op
 
         kb = _make_kb(connected=True)
         ns_id = uuid4()
@@ -654,11 +679,8 @@ class TestRecallTemporalBounds:
 
         kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
 
-        with (
-            patch("khora.telemetry.context.ensure_trace_id"),
-            patch("khora.telemetry.context.clear_trace_id"),
-        ):
-            await kb.recall("q", namespace=ns_id, start_time=start)
+        with pytest.warns(DeprecationWarning):
+            await self._async_recall(kb, "q", namespace=ns_id, start_time=start)
 
         call_kwargs = kb._engine.recall.call_args
         temporal_filter = call_kwargs.kwargs.get("temporal_filter")
@@ -666,10 +688,21 @@ class TestRecallTemporalBounds:
         assert temporal_filter.occurred_after == start
         assert temporal_filter.occurred_before is None
 
+        clauses = self._occurred_at_clauses(call_kwargs.kwargs.get("filter_ast"))
+        assert [c.op for c in clauses] == [Op.GTE]  # type: ignore[attr-defined]
+        assert clauses[0].operand == start  # type: ignore[attr-defined]
+
     @pytest.mark.asyncio
-    async def test_end_time_only_constructs_filter(self) -> None:
-        """end_time only → SkeletonTemporalFilter with occurred_before set, occurred_after None."""
+    async def test_end_time_only_folds_to_lt(self) -> None:
+        """end_time only → temporal_filter window + a single $lt occurred_at clause.
+
+        The upper bound is EXCLUSIVE to mirror the legacy ``TemporalFilter``
+        window (``occurred_at < occurred_before``), so the folded AST and the
+        window agree at the boundary.
+        """
         from datetime import UTC, datetime
+
+        from khora.filter import Op
 
         kb = _make_kb(connected=True)
         ns_id = uuid4()
@@ -677,11 +710,8 @@ class TestRecallTemporalBounds:
 
         kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
 
-        with (
-            patch("khora.telemetry.context.ensure_trace_id"),
-            patch("khora.telemetry.context.clear_trace_id"),
-        ):
-            await kb.recall("q", namespace=ns_id, end_time=end)
+        with pytest.warns(DeprecationWarning):
+            await self._async_recall(kb, "q", namespace=ns_id, end_time=end)
 
         call_kwargs = kb._engine.recall.call_args
         temporal_filter = call_kwargs.kwargs.get("temporal_filter")
@@ -689,10 +719,16 @@ class TestRecallTemporalBounds:
         assert temporal_filter.occurred_before == end
         assert temporal_filter.occurred_after is None
 
+        clauses = self._occurred_at_clauses(call_kwargs.kwargs.get("filter_ast"))
+        assert [c.op for c in clauses] == [Op.LT]  # type: ignore[attr-defined]
+        assert clauses[0].operand == end  # type: ignore[attr-defined]
+
     @pytest.mark.asyncio
-    async def test_both_bounds_valid(self) -> None:
-        """Both bounds provided (start < end) → filter constructed correctly."""
+    async def test_both_bounds_fold_to_gte_and_lt(self) -> None:
+        """Both bounds (start < end) → $gte (inclusive) and $lt (exclusive) clauses."""
         from datetime import UTC, datetime
+
+        from khora.filter import Op
 
         kb = _make_kb(connected=True)
         ns_id = uuid4()
@@ -701,11 +737,8 @@ class TestRecallTemporalBounds:
 
         kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
 
-        with (
-            patch("khora.telemetry.context.ensure_trace_id"),
-            patch("khora.telemetry.context.clear_trace_id"),
-        ):
-            await kb.recall("q", namespace=ns_id, start_time=start, end_time=end)
+        with pytest.warns(DeprecationWarning):
+            await self._async_recall(kb, "q", namespace=ns_id, start_time=start, end_time=end)
 
         call_kwargs = kb._engine.recall.call_args
         temporal_filter = call_kwargs.kwargs.get("temporal_filter")
@@ -713,27 +746,45 @@ class TestRecallTemporalBounds:
         assert temporal_filter.occurred_after == start
         assert temporal_filter.occurred_before == end
 
+        clauses = self._occurred_at_clauses(call_kwargs.kwargs.get("filter_ast"))
+        ops = {c.op for c in clauses}  # type: ignore[attr-defined]
+        assert ops == {Op.GTE, Op.LT}
+
     @pytest.mark.asyncio
-    async def test_no_bounds_passes_none_filter(self) -> None:
-        """Neither bound → temporal_filter=None passed to engine."""
+    async def test_equal_bounds_fold_to_gte_and_lt(self) -> None:
+        """start == end → both $gte and $lt clauses (equal is not inverted).
+
+        Equal bounds yield a degenerate empty range (``occurred_at >= bound AND
+        occurred_at < bound``) — but that is exactly what the legacy
+        ``TemporalFilter`` window also yields, so the folded AST stays consistent
+        with the window rather than disagreeing at the boundary.
+        """
+        from datetime import UTC, datetime
+
+        from khora.filter import Op
+
         kb = _make_kb(connected=True)
         ns_id = uuid4()
+        bound = datetime(2024, 6, 1, tzinfo=UTC)
 
         kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
 
-        with (
-            patch("khora.telemetry.context.ensure_trace_id"),
-            patch("khora.telemetry.context.clear_trace_id"),
-        ):
-            await kb.recall("q", namespace=ns_id)
+        with pytest.warns(DeprecationWarning):
+            await self._async_recall(kb, "q", namespace=ns_id, start_time=bound, end_time=bound)
 
         call_kwargs = kb._engine.recall.call_args
         temporal_filter = call_kwargs.kwargs.get("temporal_filter")
-        assert temporal_filter is None
+        assert temporal_filter is not None
+        assert temporal_filter.occurred_after == bound
+        assert temporal_filter.occurred_before == bound
+
+        clauses = self._occurred_at_clauses(call_kwargs.kwargs.get("filter_ast"))
+        ops = {c.op for c in clauses}  # type: ignore[attr-defined]
+        assert ops == {Op.GTE, Op.LT}
 
     @pytest.mark.asyncio
-    async def test_start_after_end_raises_valueerror(self) -> None:
-        """start_time > end_time → ValueError before engine is called."""
+    async def test_inverted_range_folds_to_empty(self) -> None:
+        """start > end → empty filter: no occurred_at clause, no window, no error."""
         from datetime import UTC, datetime
 
         kb = _make_kb(connected=True)
@@ -741,25 +792,216 @@ class TestRecallTemporalBounds:
         start = datetime(2024, 12, 31, tzinfo=UTC)
         end = datetime(2024, 1, 1, tzinfo=UTC)
 
-        with pytest.raises(ValueError, match="start_time must be <= end_time"):
-            await kb.recall("q", namespace=ns_id, start_time=start, end_time=end)
+        kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
 
-        kb._engine.recall.assert_not_awaited()
+        with pytest.warns(DeprecationWarning):
+            await self._async_recall(kb, "q", namespace=ns_id, start_time=start, end_time=end)
+
+        call_kwargs = kb._engine.recall.call_args
+        assert call_kwargs.kwargs.get("temporal_filter") is None
+        assert call_kwargs.kwargs.get("filter_ast") is None
 
     @pytest.mark.asyncio
-    async def test_mixed_timezone_raises_valueerror(self) -> None:
-        """naive start_time with aware end_time → ValueError."""
+    async def test_mixed_timezone_normalizes_to_utc(self) -> None:
+        """naive start_time with aware end_time → UTC-normalized, no error."""
         from datetime import UTC, datetime
 
         kb = _make_kb(connected=True)
         ns_id = uuid4()
-        start = datetime(2024, 1, 1)  # naive
+        start = datetime(2024, 1, 1)  # naive → assumed UTC
         end = datetime(2024, 12, 31, tzinfo=UTC)  # aware
 
-        with pytest.raises(ValueError, match="timezone-aware or both naive"):
-            await kb.recall("q", namespace=ns_id, start_time=start, end_time=end)
+        kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
+
+        with pytest.warns(DeprecationWarning):
+            await self._async_recall(kb, "q", namespace=ns_id, start_time=start, end_time=end)
+
+        call_kwargs = kb._engine.recall.call_args
+        temporal_filter = call_kwargs.kwargs.get("temporal_filter")
+        assert temporal_filter is not None
+        assert temporal_filter.occurred_after == start.replace(tzinfo=UTC)
+        assert temporal_filter.occurred_before == end
+
+    @pytest.mark.asyncio
+    async def test_no_bounds_passes_none_filter(self) -> None:
+        """Neither bound → temporal_filter=None and filter_ast=None passed to engine."""
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+
+        kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
+
+        await self._async_recall(kb, "q", namespace=ns_id)
+
+        call_kwargs = kb._engine.recall.call_args
+        assert call_kwargs.kwargs.get("temporal_filter") is None
+        assert call_kwargs.kwargs.get("filter_ast") is None
+
+    @pytest.mark.asyncio
+    async def test_deprecation_warning_fires_once(self) -> None:
+        """The deprecated bounds emit exactly one DeprecationWarning per call."""
+        from datetime import UTC, datetime
+
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+        start = datetime(2024, 1, 1, tzinfo=UTC)
+
+        kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            await self._async_recall(kb, "q", namespace=ns_id, start_time=start)
+
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(deprecations) == 1
+
+    async def _async_recall(self, kb: Khora, *args: object, **kwargs: object) -> RecallResult:
+        with (
+            patch("khora.telemetry.context.ensure_trace_id"),
+            patch("khora.telemetry.context.clear_trace_id"),
+        ):
+            return await kb.recall(*args, **kwargs)  # type: ignore[arg-type]
+
+
+class TestRecallFilterKwarg:
+    """Tests for the public ``filter=`` kwarg on recall()."""
+
+    @staticmethod
+    def _mock_result(ns_id: object) -> RecallResult:
+        return RecallResult(
+            query="q",
+            namespace_id=ns_id,  # type: ignore[arg-type]
+            documents=[],
+            chunks=[],
+            entities=[],
+            relationships=[],
+        )
+
+    async def _async_recall(self, kb: Khora, *args: object, **kwargs: object) -> RecallResult:
+        with (
+            patch("khora.telemetry.context.ensure_trace_id"),
+            patch("khora.telemetry.context.clear_trace_id"),
+        ):
+            return await kb.recall(*args, **kwargs)  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_dict_filter_lowers_to_ast(self) -> None:
+        """A dict filter is validated and lowered to a FilterNode reaching the engine."""
+        from khora.filter import FilterNode
+
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+        kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
+
+        await self._async_recall(kb, "q", namespace=ns_id, filter={"source_name": "linear"})
+
+        filter_ast = kb._engine.recall.call_args.kwargs.get("filter_ast")
+        assert isinstance(filter_ast, FilterNode)
+
+    @pytest.mark.asyncio
+    async def test_instance_filter_lowers_to_ast(self) -> None:
+        """A RecallFilter instance is lowered to a FilterNode reaching the engine."""
+        from khora.filter import FilterNode, RecallFilter
+
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+        kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
+
+        await self._async_recall(kb, "q", namespace=ns_id, filter=RecallFilter(source_name="linear"))
+
+        filter_ast = kb._engine.recall.call_args.kwargs.get("filter_ast")
+        assert isinstance(filter_ast, FilterNode)
+
+    @pytest.mark.asyncio
+    async def test_invalid_filter_dict_raises_validation_error(self) -> None:
+        """An invalid filter dict raises RecallFilterValidationError before the engine call."""
+        from khora.filter import RecallFilterValidationError
+
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+        kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
+
+        with pytest.raises(RecallFilterValidationError):
+            await self._async_recall(kb, "q", namespace=ns_id, filter={"not_a_real_key": "x"})
 
         kb._engine.recall.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_filter_and_temporal_bounds_conflict_raises(self) -> None:
+        """Passing both filter= and the deprecated bounds raises ValueError."""
+        from datetime import UTC, datetime
+
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+        kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
+
+        with pytest.raises(ValueError, match="filter= or the deprecated start_time/end_time"):
+            await self._async_recall(
+                kb,
+                "q",
+                namespace=ns_id,
+                filter={"source_name": "linear"},
+                start_time=datetime(2024, 1, 1, tzinfo=UTC),
+            )
+
+        kb._engine.recall.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_engine_info_filter_present_with_filter(self) -> None:
+        """engine_info['filter'] is populated on the result when filter= is passed."""
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+        kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
+
+        result = await self._async_recall(kb, "q", namespace=ns_id, filter={"source_name": "linear"})
+
+        info = result.engine_info.get("filter")
+        assert info is not None
+        assert info["engine"] == "vectorcypher"
+        assert info["pushed_down"] is False
+        assert info["supported"] is False
+
+    @pytest.mark.asyncio
+    async def test_engine_info_filter_present_without_filter(self) -> None:
+        """engine_info['filter'] is populated on every call, even with no filter."""
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+        kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
+
+        result = await self._async_recall(kb, "q", namespace=ns_id)
+
+        info = result.engine_info.get("filter")
+        assert info is not None
+        assert info["pushed_down"] is False
+
+    @pytest.mark.asyncio
+    async def test_no_filter_no_bounds_passes_none_ast_and_records_info(self) -> None:
+        """filter=None with no bounds → filter_ast=None to engine, engine_info still populated."""
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+        kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
+
+        result = await self._async_recall(kb, "q", namespace=ns_id, filter=None)
+
+        assert kb._engine.recall.call_args.kwargs.get("filter_ast") is None
+        info = result.engine_info.get("filter")
+        assert info is not None
+        assert info["pushed_down"] is False
+
+    @pytest.mark.asyncio
+    async def test_engine_info_filter_supported_for_skeleton(self) -> None:
+        """The skeleton engine is the planned pushdown target → supported=True (still not pushed down)."""
+        kb = _make_kb(connected=True)
+        kb._engine_name = "skeleton"
+        ns_id = uuid4()
+        kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
+
+        result = await self._async_recall(kb, "q", namespace=ns_id, filter={"source_name": "linear"})
+
+        info = result.engine_info.get("filter")
+        assert info is not None
+        assert info["engine"] == "skeleton"
+        assert info["supported"] is True
+        assert info["pushed_down"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_khora.py
+++ b/tests/unit/test_khora.py
@@ -783,14 +783,27 @@ class TestRecallTemporalBounds:
         assert ops == {Op.GTE, Op.LT}
 
     @pytest.mark.asyncio
-    async def test_inverted_range_folds_to_empty(self) -> None:
-        """start > end → empty filter: no occurred_at clause, no window, no error."""
+    async def test_inverted_range_folds_to_empty_matching_filter(self) -> None:
+        """start > end → a real, empty-MATCHING filter (not an unfiltered recall).
+
+        An inverted range flows through the same fold as any other bounds rather
+        than being special-cased away. It yields ``occurred_at >= t1 AND
+        occurred_at < t2`` with t1 > t2 — a predicate nothing can satisfy — so
+        the recall returns zero rows, giving parity with the equivalent
+        ``filter={'occurred_at': {...}}``. The legacy window is built from the
+        same (inverted, empty-matching) bounds, so the two stay consistent.
+
+        This is a unit assertion on the synthesized ``filter_ast`` shape; the
+        zero-row recall behavior follows from the empty-matching predicate.
+        """
         from datetime import UTC, datetime
+
+        from khora.filter import Op
 
         kb = _make_kb(connected=True)
         ns_id = uuid4()
-        start = datetime(2024, 12, 31, tzinfo=UTC)
-        end = datetime(2024, 1, 1, tzinfo=UTC)
+        start = datetime(2024, 12, 31, tzinfo=UTC)  # t1
+        end = datetime(2024, 1, 1, tzinfo=UTC)  # t2 (t1 > t2 → inverted)
 
         kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
 
@@ -798,8 +811,21 @@ class TestRecallTemporalBounds:
             await self._async_recall(kb, "q", namespace=ns_id, start_time=start, end_time=end)
 
         call_kwargs = kb._engine.recall.call_args
-        assert call_kwargs.kwargs.get("temporal_filter") is None
-        assert call_kwargs.kwargs.get("filter_ast") is None
+
+        # The folded AST is a real empty-matching predicate, NOT None.
+        clauses = self._occurred_at_clauses(call_kwargs.kwargs.get("filter_ast"))
+        by_op = {c.op: c.operand for c in clauses}  # type: ignore[attr-defined]
+        assert set(by_op) == {Op.GTE, Op.LT}
+        assert by_op[Op.GTE] == start  # lower bound t1
+        assert by_op[Op.LT] == end  # upper bound t2 (< t1 → no row matches)
+
+        # The legacy window is built from the same inverted bounds (also
+        # empty-matching), so it agrees with the folded AST instead of being
+        # nulled out.
+        temporal_filter = call_kwargs.kwargs.get("temporal_filter")
+        assert temporal_filter is not None
+        assert temporal_filter.occurred_after == start
+        assert temporal_filter.occurred_before == end
 
     @pytest.mark.asyncio
     async def test_mixed_timezone_normalizes_to_utc(self) -> None:


### PR DESCRIPTION
## Summary
- Add a public `filter=` keyword to `recall()` that validates **once** at the facade and lowers a `RecallFilter` (or `dict`) to the canonical filter AST (`parse_to_ast`). Validation failures propagate as the existing structured filter-validation error.
- Carry the canonical `FilterNode` across the engine boundary as an **additive** `filter_ast` parameter on `MemoryEngineProtocol.recall()` and all engine implementations (vectorcypher, chronicle, skeleton). Engines accept-and-ignore it for now — no SQL pushdown is wired in this change (same pattern as the existing `temporal_filter` carrier).
- Surface a per-engine pushdown summary in `RecallResult.engine_info["filter"]` (`{engine, supported, pushed_down}`) on **every** call.
- Replace the legacy temporal block with a **deprecation shim** for `start_time`/`end_time`:
  - Emits a `DeprecationWarning` (once) and folds the bounds into an `occurred_at` filter through the same single validation path.
  - `start_time` → `$gte` (inclusive), `end_time` → `$lt` (exclusive) to match the existing temporal-window semantics (`occurred_at >= start AND occurred_at < end`).
  - Only non-`None` bounds are emitted (no `null` operand stubs).
  - Inverted ranges (`start > end`) fold to an **empty** filter (no error); naive/aware datetimes normalize to UTC.
  - Passing both `filter=` and `start_time`/`end_time` raises `ValueError`.

## Test plan
- [x] Unit tests pass — `tests/unit/test_khora.py` + `tests/recall`: **424 passed**. Rewrote the temporal-bounds tests and added filter-kwarg coverage (validate-once, `FilterNode` reaches the engine, invalid filter raises, `engine_info["filter"]` populated with/without a filter, deprecation/inverted-range/mixed-tz behavior, equal-bounds edge case).
- [x] `ruff format` + `ruff check` clean.
- [ ] Full integration/e2e suite + coverage gate (CI).
- [ ] Manual verification: N/A — library change, covered by unit tests.