### PR TITLE
Add recall-filter telemetry counters and canonical-hash span attribute

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -176,6 +176,7 @@ Highlights:
 - **Public metrics**: `khora.memory.{recall,ingest}.duration`,
   `khora.llm.tokens`, `khora.llm.cost_usd`,
   `khora.neo4j.pool.{acquire_duration,timeout,connections.*,utilization}`,
+  `khora.recall.filter.{unindexed_metadata,under_filled,graph_channel_empty}`,
   `khora.chronicle.abstention_signal`, `khora.log.queue.depth`.
 - **Khora-contributed resource attribute**:
   `khora.telemetry.contract.version` - bumped alongside contract changes

--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -1455,6 +1455,33 @@
       ],
       "description": "Issue #932. A queued document identity could not be re-loaded at dequeue time because the row was deleted/forgotten between enqueue and dequeue. The pending processor carries lean items (doc_id + namespace_id) and re-loads the full Document in the worker; when the loader returns None the item is skipped per ADR-001 (logged INFO, batch registration decremented so BatchHandle.wait can't hang). NO namespace_id label - cardinality rule.",
       "_comment": "Issue #932. NO namespace_id label - cardinality rule."
+    },
+    {
+      "name": "khora.recall.filter.unindexed_metadata",
+      "type": "counter",
+      "stability": "public",
+      "unit": "1",
+      "owner": "filter",
+      "labels": [
+        {"name": "op", "values": ["$eq", "$ne", "$gt", "$gte", "$lt", "$lte", "$in", "$nin", "$exists"], "_comment": "The metadata leaf's comparison operator (Op enum wire literal). Logical operators ($and/$or/$not) are nodes, not leaves, so they never appear here. Bounded by the closed Op enum."}
+      ],
+      "description": "Metadata leaves in a deterministic recall filter that compile to an unindexed JSONB column access. Incremented once per metadata leaf at compile time (a filter with N metadata predicates emits N times); compile runs once per recall, so the hybrid vector+bm25 path does not double-count. NO namespace_id label - cardinality rule. The metadata key-path is also unbounded and never a label."
+    },
+    {
+      "name": "khora.recall.filter.under_filled",
+      "type": "counter",
+      "stability": "public",
+      "unit": "1",
+      "owner": "filter",
+      "description": "Filtered recalls that returned fewer results than the requested limit (the deterministic recall filter narrowed the candidate set below the requested k). NO namespace_id label - cardinality rule."
+    },
+    {
+      "name": "khora.recall.filter.graph_channel_empty",
+      "type": "counter",
+      "stability": "public",
+      "unit": "1",
+      "owner": "filter",
+      "description": "Filtered recalls whose graph channel returned no candidates because the deterministic recall filter narrowed the graph side to empty. NO namespace_id label - cardinality rule."
     }
   ]
 }

--- a/src/khora/filter/compilers/postgres.py
+++ b/src/khora/filter/compilers/postgres.py
@@ -58,6 +58,7 @@ from khora.filter.ast import (
     canonical_hash,
 )
 from khora.filter.model import SYSTEM_KEYS, Op
+from khora.filter.telemetry import record_unindexed_metadata
 
 __all__ = ["compile_postgres"]
 
@@ -177,6 +178,13 @@ class _Builder:
             expr = self._compile_system_clause(clause)
         elif path and path[0] == "metadata":
             expr = self._compile_metadata_clause(clause)
+            # A metadata leaf compiles to an unindexed JSONB column access.
+            # Emit once per metadata leaf (a filter with N metadata predicates
+            # emits N times) — each leaf is a separate unindexed-column access.
+            # compile_postgres runs once per recall (the compiled predicate is
+            # reused across the vector + bm25 channels), so this does not
+            # double-count on the hybrid path.
+            record_unindexed_metadata(op=clause.op.value)
         else:
             return self._unsupported(clause, "path is neither a system key nor a metadata path")
         self._consumed.add(_path_str(path))

--- a/src/khora/filter/telemetry.py
+++ b/src/khora/filter/telemetry.py
@@ -1,0 +1,86 @@
+"""OTel counters for the deterministic recall filter — ``@internal``.
+
+Three service-level counters that surface how the deterministic recall
+filter behaves at compile/recall time. They complement the per-recall
+``filter.*`` span attributes (on ``khora.recall``) with aggregate signals
+SREs can alert on without subscribing to sampled spans.
+
+The instruments use the same lazy-init + :class:`threading.Lock` pattern as
+:mod:`khora.telemetry.aggregate_metrics`: each is created on first use behind
+a double-checked lock so a cold import never builds an instrument, and so the
+no-op meter (no real ``MeterProvider`` installed) stays free to call.
+
+Cardinality discipline (matching the rest of khora's metrics): ``namespace_id``
+is **never** an attribute here — it lives on span attributes only. The single
+bounded label exposed is ``op`` (the metadata leaf's comparison operator, a
+member of the closed :class:`~khora.filter.model.Op` enum).
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from khora.telemetry.metrics import metric_counter
+
+_lock = threading.Lock()
+_unindexed_metadata_counter: Any | None = None
+_under_filled_counter: Any | None = None
+_graph_channel_empty_counter: Any | None = None
+
+
+def _get_unindexed_metadata_counter() -> Any:
+    global _unindexed_metadata_counter
+    if _unindexed_metadata_counter is None:
+        with _lock:
+            if _unindexed_metadata_counter is None:
+                _unindexed_metadata_counter = metric_counter(
+                    "khora.recall.filter.unindexed_metadata",
+                    unit="1",
+                    description=(
+                        "Metadata leaves in a deterministic recall filter that compile to an "
+                        "unindexed JSONB column access. Split by op (the leaf's comparison operator)."
+                    ),
+                )
+    return _unindexed_metadata_counter
+
+
+def _get_under_filled_counter() -> Any:
+    global _under_filled_counter
+    if _under_filled_counter is None:
+        with _lock:
+            if _under_filled_counter is None:
+                _under_filled_counter = metric_counter(
+                    "khora.recall.filter.under_filled",
+                    unit="1",
+                    description=("Filtered recalls that returned fewer results than the requested limit."),
+                )
+    return _under_filled_counter
+
+
+def _get_graph_channel_empty_counter() -> Any:
+    global _graph_channel_empty_counter
+    if _graph_channel_empty_counter is None:
+        with _lock:
+            if _graph_channel_empty_counter is None:
+                _graph_channel_empty_counter = metric_counter(
+                    "khora.recall.filter.graph_channel_empty",
+                    unit="1",
+                    description=(
+                        "Filtered recalls whose graph channel returned no candidates "
+                        "(the filter narrowed the graph side to empty)."
+                    ),
+                )
+    return _graph_channel_empty_counter
+
+
+def record_unindexed_metadata(*, op: str) -> None:
+    """Record one metadata leaf that compiled to an unindexed JSONB access.
+
+    Fired once per metadata leaf, so a filter with N metadata predicates emits
+    N observations (each leaf is a distinct unindexed-column access). ``op`` is
+    the leaf's comparison operator wire literal (an :class:`~khora.filter.model.Op`
+    value, e.g. ``"$eq"``) — the only attribute, and bounded by that closed enum.
+    Never pass ``namespace_id`` or a metadata key-path (both unbounded).
+    """
+    _get_unindexed_metadata_counter().add(1, attributes={"op": op})

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -2019,7 +2019,7 @@ class Khora:
         _t0 = _time.perf_counter()
         _status = "success"
         _recall_id = uuid4()
-        from khora.filter import RecallFilter, parse_to_ast
+        from khora.filter import RecallFilter, canonical_hash, parse_to_ast
 
         try:
             # Resolve the recall filter once, at the facade. Two inputs feed the
@@ -2106,7 +2106,11 @@ class Khora:
                 namespace_id=str(namespace_id),
                 query_hash=bounded_text_hash(query),
                 query_length=len(query),
-            ):
+            ) as _recall_span:
+                # Tag the canonical filter hash only when a filter is present, so
+                # the common no-filter recall does not carry a meaningless attribute.
+                if filter_ast is not None:
+                    _recall_span.set_attribute("filter.canonical_hash", canonical_hash(filter_ast))
                 result = await self._get_engine().recall(
                     query,
                     namespace_id,

--- a/tests/unit/filter/test_filter_telemetry.py
+++ b/tests/unit/filter/test_filter_telemetry.py
@@ -1,0 +1,347 @@
+"""Unit tests for the deterministic recall-filter telemetry — ``@internal``.
+
+Covers the three OTel counters in :mod:`khora.filter.telemetry` and the
+``filter.canonical_hash`` attribute set on the ``khora.recall`` span:
+
+1. All three counters are constructible via their ``_get_*`` helpers (and
+   memoized — a second call returns the same instrument).
+2. ``khora.recall.filter.unindexed_metadata`` fires once per metadata leaf when
+   :func:`compile_postgres` lowers a metadata predicate, and does **not** fire
+   for a system-key-only filter.
+3. The two V1-only counters (``under_filled`` / ``graph_channel_empty``) are
+   pre-declared but have no ``.add()`` call site yet, so they stay quiet on the
+   compile + recall paths exercised here.
+4. ``filter.canonical_hash`` is present on the ``khora.recall`` span exactly when
+   a ``filter=`` is supplied, and absent on an unfiltered recall.
+
+Hermetic — no Docker / DB. The counter tests monkeypatch the module-level
+singletons in ``khora.filter.telemetry`` with recording fakes (mirroring
+``tests/unit/telemetry/test_aggregate_metrics.py``). The span test installs an
+in-memory OTel exporter (mirroring ``tests/unit/telemetry/test_otel.py``) and
+drives the real ``Khora.recall`` facade over a mocked engine (the ``_make_kb``
+shape from ``test_aggregate_metrics.py``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from opentelemetry import trace as _otel_trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from khora.filter import RecallFilter, canonical_hash
+from khora.filter import telemetry as filter_telemetry
+from khora.filter.ast import parse_to_ast
+from khora.filter.compilers.postgres import compile_postgres
+from khora.filter.context import CompileContext
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Recording fakes + helpers.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingCounter:
+    """Captures ``.add(value, attributes=...)`` calls for assertions."""
+
+    def __init__(self) -> None:
+        self.adds: list[tuple[float, dict[str, Any]]] = []
+
+    def add(self, value: float, attributes: Any = None) -> None:
+        self.adds.append((value, dict(attributes or {})))
+
+
+_CTX = CompileContext(backend_target="khora_chunks")
+
+
+def _ast(wire: dict) -> Any:
+    """Validate a wire-form filter and lower it to the canonical AST."""
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+@pytest.fixture
+def recording_counters(monkeypatch: pytest.MonkeyPatch) -> dict[str, _RecordingCounter]:
+    """Replace the three module-level counter singletons with recording fakes.
+
+    The ``_get_*`` helpers return the singleton if already set, so pre-seeding
+    each module global makes ``record_*`` / any ``.add()`` site land on the fake.
+    """
+    counters = {
+        "unindexed_metadata": _RecordingCounter(),
+        "under_filled": _RecordingCounter(),
+        "graph_channel_empty": _RecordingCounter(),
+    }
+    monkeypatch.setattr(filter_telemetry, "_unindexed_metadata_counter", counters["unindexed_metadata"])
+    monkeypatch.setattr(filter_telemetry, "_under_filled_counter", counters["under_filled"])
+    monkeypatch.setattr(filter_telemetry, "_graph_channel_empty_counter", counters["graph_channel_empty"])
+    return counters
+
+
+# ===========================================================================
+# (1) All three counters are constructible via their _get_* helpers.
+# ===========================================================================
+
+
+@pytest.fixture
+def _reset_counter_singletons() -> Any:
+    """Null out the three singletons so the _get_* helpers build fresh ones."""
+    saved = (
+        filter_telemetry._unindexed_metadata_counter,
+        filter_telemetry._under_filled_counter,
+        filter_telemetry._graph_channel_empty_counter,
+    )
+    filter_telemetry._unindexed_metadata_counter = None
+    filter_telemetry._under_filled_counter = None
+    filter_telemetry._graph_channel_empty_counter = None
+    yield
+    (
+        filter_telemetry._unindexed_metadata_counter,
+        filter_telemetry._under_filled_counter,
+        filter_telemetry._graph_channel_empty_counter,
+    ) = saved
+
+
+def test_all_three_counter_helpers_construct(_reset_counter_singletons: Any) -> None:
+    """Each ``_get_*`` helper returns a non-None instrument (no real provider needed)."""
+    assert filter_telemetry._get_unindexed_metadata_counter() is not None
+    assert filter_telemetry._get_under_filled_counter() is not None
+    assert filter_telemetry._get_graph_channel_empty_counter() is not None
+
+
+def test_counter_helpers_are_memoized(_reset_counter_singletons: Any) -> None:
+    """A second call returns the same instrument (lazy double-checked singleton)."""
+    for getter in (
+        filter_telemetry._get_unindexed_metadata_counter,
+        filter_telemetry._get_under_filled_counter,
+        filter_telemetry._get_graph_channel_empty_counter,
+    ):
+        first = getter()
+        assert getter() is first
+
+
+# ===========================================================================
+# (2) unindexed_metadata fires for metadata leaves, not system-key-only.
+# ===========================================================================
+
+
+def test_unindexed_metadata_fires_on_metadata_predicate(
+    recording_counters: dict[str, _RecordingCounter],
+) -> None:
+    """Compiling a single metadata predicate emits exactly one observation."""
+    compile_postgres(_ast({"metadata.tier": "gold"}), _CTX)
+
+    adds = recording_counters["unindexed_metadata"].adds
+    assert len(adds) == 1
+    value, attrs = adds[0]
+    assert value == 1
+    assert attrs == {"op": "$eq"}
+
+
+def test_unindexed_metadata_silent_for_system_key_only(
+    recording_counters: dict[str, _RecordingCounter],
+) -> None:
+    """A system-key-only filter compiles to a typed column — no JSONB access."""
+    compile_postgres(_ast({"source_name": "linear"}), _CTX)
+
+    assert recording_counters["unindexed_metadata"].adds == []
+
+
+def test_unindexed_metadata_fires_once_per_metadata_leaf(
+    recording_counters: dict[str, _RecordingCounter],
+) -> None:
+    """N metadata predicates → N observations; a sibling system key does not add."""
+    wire = {
+        "source_name": "linear",  # system key — no emit
+        "metadata.tier": "gold",  # $eq metadata leaf
+        "metadata.score": {"$gt": 5},  # $gt metadata leaf
+    }
+    compile_postgres(_ast(wire), _CTX)
+
+    adds = recording_counters["unindexed_metadata"].adds
+    assert len(adds) == 2
+    ops = sorted(a[1]["op"] for a in adds)
+    assert ops == ["$eq", "$gt"]
+    assert all(a[0] == 1 for a in adds)
+
+
+def test_unindexed_metadata_op_attribute_tracks_operator(
+    recording_counters: dict[str, _RecordingCounter],
+) -> None:
+    """The ``op`` attribute is the metadata leaf's comparison-operator wire literal."""
+    compile_postgres(_ast({"metadata.tags": {"$in": ["a", "b"]}}), _CTX)
+
+    adds = recording_counters["unindexed_metadata"].adds
+    assert len(adds) == 1
+    assert adds[0][1] == {"op": "$in"}
+
+
+def test_record_unindexed_metadata_helper_adds_one(
+    recording_counters: dict[str, _RecordingCounter],
+) -> None:
+    """The public ``record_unindexed_metadata`` helper adds 1 with the op label."""
+    filter_telemetry.record_unindexed_metadata(op="$lte")
+
+    assert recording_counters["unindexed_metadata"].adds == [(1, {"op": "$lte"})]
+
+
+# ===========================================================================
+# (3) under_filled + graph_channel_empty stay quiet on V1 paths.
+# ===========================================================================
+
+
+def test_v1_counters_quiet_on_metadata_compile(
+    recording_counters: dict[str, _RecordingCounter],
+) -> None:
+    """Compiling a metadata predicate touches only unindexed_metadata."""
+    compile_postgres(_ast({"metadata.tier": "gold"}), _CTX)
+
+    assert recording_counters["under_filled"].adds == []
+    assert recording_counters["graph_channel_empty"].adds == []
+
+
+def test_v1_counters_quiet_on_system_key_compile(
+    recording_counters: dict[str, _RecordingCounter],
+) -> None:
+    """A system-key-only compile emits none of the three counters."""
+    compile_postgres(_ast({"source_name": "linear"}), _CTX)
+
+    assert recording_counters["unindexed_metadata"].adds == []
+    assert recording_counters["under_filled"].adds == []
+    assert recording_counters["graph_channel_empty"].adds == []
+
+
+# ===========================================================================
+# (4) filter.canonical_hash on the khora.recall span.
+# ===========================================================================
+#
+# Drive the real ``Khora.recall`` facade over a mocked engine so the actual
+# ``trace_span("khora.recall")`` block runs, and read the emitted span back from
+# an in-memory exporter. The mock shape mirrors test_aggregate_metrics.py.
+
+
+from khora.khora import Khora, RecallResult  # noqa: E402 - after the OTel imports above
+
+_RESOLVE_ROW_ID = uuid4()
+
+
+def _mock_config() -> MagicMock:
+    cfg = MagicMock()
+    cfg.get_postgresql_url.return_value = "postgresql://test"
+    cfg.get_graph_config.return_value = None
+    cfg.get_vector_config.return_value = None
+    cfg.get_neo4j_url.return_value = None
+    cfg.get_neo4j_user.return_value = None
+    cfg.get_neo4j_password.return_value = None
+    cfg.get_neo4j_database.return_value = None
+    cfg.storage.embedding_dimension = 1536
+    cfg.llm.model = "gpt-4o-mini"
+    cfg.llm.embedding_model = "text-embedding-3-small"
+    cfg.llm.embedding_dimension = 1536
+    cfg.llm.extraction_model = None
+    cfg.llm.timeout = 30
+    cfg.llm.max_retries = 3
+    cfg.telemetry_database_url = None
+    cfg.telemetry_service_name = "khora-test"
+    return cfg
+
+
+def _make_kb(ns_id: Any) -> Khora:
+    with patch("khora.khora.load_config", return_value=_mock_config()):
+        kb = Khora()
+    kb._connected = True
+    engine = MagicMock()
+    engine._storage = MagicMock()
+    engine._storage.resolve_namespace = AsyncMock(return_value=_RESOLVE_ROW_ID)
+    engine.recall = AsyncMock(
+        return_value=RecallResult(
+            query="q",
+            namespace_id=ns_id,
+            documents=[],
+            chunks=[],
+            entities=[],
+            relationships=[],
+        )
+    )
+    kb._engine = engine
+    return kb
+
+
+@pytest.fixture
+def span_exporter(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Install an in-memory OTel exporter and rebind khora's cached tracer.
+
+    Resets the process-wide tracer provider so a real ``TracerProvider`` can be
+    set, then restores the proxy provider on teardown (so the recording span
+    machinery does not leak into later tests).
+    """
+    import opentelemetry.trace as _t
+    from opentelemetry.trace import ProxyTracerProvider
+
+    from khora.telemetry import _otel as _otel_module
+
+    # Fresh provider slot.
+    _t._TRACER_PROVIDER_SET_ONCE = _t.Once()
+    _t._TRACER_PROVIDER = None
+    _t._PROXY_TRACER_PROVIDER = ProxyTracerProvider()
+
+    tp = TracerProvider()
+    exporter = InMemorySpanExporter()
+    tp.add_span_processor(SimpleSpanProcessor(exporter))
+    _otel_trace.set_tracer_provider(tp)
+    monkeypatch.setattr(
+        _otel_module,
+        "_TRACER",
+        _otel_trace.get_tracer("khora", _otel_module._KHORA_VERSION),
+    )
+
+    yield exporter
+
+    exporter.shutdown()
+    # Restore proxy provider + cached tracer so other tests start clean.
+    _t._TRACER_PROVIDER_SET_ONCE = _t.Once()
+    _t._TRACER_PROVIDER = None
+    _t._PROXY_TRACER_PROVIDER = ProxyTracerProvider()
+    monkeypatch.setattr(
+        _otel_module,
+        "_TRACER",
+        _otel_trace.get_tracer("khora", _otel_module._KHORA_VERSION),
+    )
+
+
+def _recall_span(exporter: InMemorySpanExporter) -> Any:
+    spans = [s for s in exporter.get_finished_spans() if s.name == "khora.recall"]
+    assert len(spans) == 1, f"expected exactly one khora.recall span, got {len(spans)}"
+    return spans[0]
+
+
+@pytest.mark.asyncio
+async def test_recall_span_has_canonical_hash_when_filter_given(span_exporter: Any) -> None:
+    """A ``filter=`` recall tags the span with the AST's canonical hash."""
+    ns_id = uuid4()
+    kb = _make_kb(ns_id)
+    wire = {"source_name": "linear"}
+
+    await kb.recall("q", namespace=ns_id, filter=wire)
+
+    span = _recall_span(span_exporter)
+    expected = canonical_hash(parse_to_ast(RecallFilter.model_validate(wire)))
+    assert span.attributes.get("filter.canonical_hash") == expected
+
+
+@pytest.mark.asyncio
+async def test_recall_span_omits_canonical_hash_without_filter(span_exporter: Any) -> None:
+    """An unfiltered recall does not carry the ``filter.canonical_hash`` attribute."""
+    ns_id = uuid4()
+    kb = _make_kb(ns_id)
+
+    await kb.recall("q", namespace=ns_id)
+
+    span = _recall_span(span_exporter)
+    assert "filter.canonical_hash" not in span.attributes


### PR DESCRIPTION
## Summary
- Add three OpenTelemetry counters for the deterministic recall filter, behind a lazy-init + double-checked-lock helper in a new `filter/telemetry.py`:
  - `khora.recall.filter.unindexed_metadata` — incremented once per metadata leaf that compiles to an unindexed JSONB column access (full-scan risk), split only by the bounded operator enum.
  - `khora.recall.filter.under_filled` and `khora.recall.filter.graph_channel_empty` — defined now, left quiet until a later graph-engine change wires them.
- Emit `unindexed_metadata` from the Postgres filter compiler on the metadata-leaf branch only (system-key predicates do not emit). Compilation runs once per recall, so the hybrid vector + keyword path does not double-count.
- Tag the `khora.recall` span with `filter.canonical_hash` (only when a filter is supplied) so traces correlate with the engine's filter cache key.
- Register all three counters in the telemetry contract (drift gate).
- Cardinality discipline: no `namespace_id` and no metadata key-path on any metric label — both stay span attributes only.

## Test plan
- [x] New unit tests pass (`tests/unit/filter/test_filter_telemetry.py`, 11 tests): counter construction, per-metadata-leaf firing, system-key silence, quiet V2 counters, and the span attribute present/absent
- [x] Telemetry contract drift gate green (`tests/unit/telemetry/test_contract.py`, both forward and reverse checks)
- [x] `make format` and `make lint` clean
- [ ] CI: full `make test` suite green