### PR TITLE
Thread recall filter_ast from skeleton engine to backend search()

### DIFF
--- a/src/khora/engines/skeleton/backends/__init__.py
+++ b/src/khora/engines/skeleton/backends/__init__.py
@@ -18,6 +18,7 @@ from khora.core.models.document import Chunk
 if TYPE_CHECKING:
     from khora.config import KhoraConfig
     from khora.core.models.document import Document
+    from khora.filter.ast import FilterNode
 
 
 @dataclass
@@ -162,6 +163,7 @@ class TemporalVectorStore(Protocol):
         temporal_filter: TemporalFilter | None = None,
         hybrid_alpha: float | None = None,  # None = vector only, 0-1 = blend
         query_text: str | None = None,  # Required for hybrid search
+        filter_ast: FilterNode | None = None,
     ) -> list[TemporalSearchResult]:
         """Search for similar chunks with temporal filtering.
 
@@ -173,6 +175,9 @@ class TemporalVectorStore(Protocol):
             temporal_filter: Structured temporal and metadata filters
             hybrid_alpha: Blend factor for hybrid search (0=BM25 only, 1=vector only)
             query_text: Original query text for BM25 (required if hybrid_alpha is set)
+            filter_ast: Canonical recall-filter AST. The pgvector backend
+                compiles it to a WHERE predicate; the other backends accept
+                it for protocol parity and ignore it (no compilation yet).
 
         Returns:
             List of matching chunks with similarity scores

--- a/src/khora/engines/skeleton/backends/sqlite_lance.py
+++ b/src/khora/engines/skeleton/backends/sqlite_lance.py
@@ -49,6 +49,7 @@ from khora.storage.backends.sqlite_lance._helpers import (
 from khora.telemetry import trace_span
 
 if TYPE_CHECKING:
+    from khora.filter.ast import FilterNode
     from khora.storage.backends.sqlite_lance.connection import EmbeddedStorageHandle
 
 
@@ -368,7 +369,10 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         temporal_filter: TemporalFilter | None = None,
         hybrid_alpha: float | None = None,
         query_text: str | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> list[TemporalSearchResult]:
+        # ``filter_ast`` is accepted for protocol parity; this backend does not
+        # compile the recall-filter AST yet, so it is ignored.
         with trace_span(
             "khora.temporal_store.search",
             namespace_id=str(namespace_id),

--- a/src/khora/engines/skeleton/backends/surrealdb.py
+++ b/src/khora/engines/skeleton/backends/surrealdb.py
@@ -34,6 +34,7 @@ from khora.telemetry import trace, trace_span
 if TYPE_CHECKING:
     from khora.config import KhoraConfig
     from khora.config.schema import SurrealDBConfig
+    from khora.filter.ast import FilterNode
 
 
 def _ensure_list(value: Any) -> list:
@@ -315,8 +316,13 @@ class SurrealDBTemporalStore(TemporalVectorStore):
         temporal_filter: TemporalFilter | None = None,
         hybrid_alpha: float | None = None,
         query_text: str | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> list[TemporalSearchResult]:
-        """Search temporal chunks with optional hybrid (vector + BM25) ranking."""
+        """Search temporal chunks with optional hybrid (vector + BM25) ranking.
+
+        ``filter_ast`` is accepted for protocol parity; this backend does not
+        compile the recall-filter AST yet, so it is ignored.
+        """
         with trace_span(
             "khora.temporal_store.search",
             namespace_id=str(namespace_id),

--- a/src/khora/engines/skeleton/backends/turbopuffer.py
+++ b/src/khora/engines/skeleton/backends/turbopuffer.py
@@ -55,6 +55,7 @@ from khora.engines.skeleton.backends import (
 
 if TYPE_CHECKING:
     from khora.config import KhoraConfig
+    from khora.filter.ast import FilterNode
 
 
 # Distance metric we always use - matches our pre-normalized embeddings
@@ -326,6 +327,7 @@ class TurbopufferTemporalStore(TemporalVectorStore):
         temporal_filter: TemporalFilter | None = None,
         hybrid_alpha: float | None = None,
         query_text: str | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> list[TemporalSearchResult]:
         """Vector or hybrid (vector + BM25) search.
 
@@ -336,6 +338,9 @@ class TurbopufferTemporalStore(TemporalVectorStore):
             blend is rank-based, not score-weighted. Document this in
             the operator docs so users picking turbopuffer know
             ``hybrid_alpha`` is a no-op on this backend.
+
+        ``filter_ast`` is accepted for protocol parity; this backend does not
+        compile the recall-filter AST yet, so it is ignored.
         """
         ns = self._namespace(namespace_id)
         tp_filter = _build_turbopuffer_filter(temporal_filter)

--- a/src/khora/engines/skeleton/backends/weaviate.py
+++ b/src/khora/engines/skeleton/backends/weaviate.py
@@ -52,6 +52,7 @@ from khora.storage._log_safe import _safe_url_for_log
 
 if TYPE_CHECKING:
     from khora.config import KhoraConfig
+    from khora.filter.ast import FilterNode
 
 # Collection name for temporal chunks
 COLLECTION_NAME = "KhoraChunk"
@@ -389,6 +390,7 @@ class WeaviateTemporalStore(TemporalVectorStore):
         temporal_filter: TemporalFilter | None = None,
         hybrid_alpha: float | None = None,
         query_text: str | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> list[TemporalSearchResult]:
         """Search for similar chunks with temporal filtering.
 
@@ -396,6 +398,9 @@ class WeaviateTemporalStore(TemporalVectorStore):
         - alpha=1: Pure vector search
         - alpha=0: Pure BM25 search
         - 0 < alpha < 1: Blend of both
+
+        ``filter_ast`` is accepted for protocol parity; this backend does not
+        compile the recall-filter AST yet, so it is ignored.
         """
         from weaviate.classes.query import HybridFusion, MetadataQuery
 

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -517,8 +517,9 @@ class SkeletonConstructionEngine:
             temporal_reference: Reference point for relative time (e.g., message timestamp)
             hybrid_alpha: Blend factor for hybrid search (0=BM25, 1=vector)
             filters: Additional structured filters (converted to TemporalFilter)
-            filter_ast: Canonical recall-filter AST. Accepted for protocol
-                parity; skeleton does not push it down yet (ignored).
+            filter_ast: Canonical recall-filter AST. Threaded through to the
+                temporal store's ``search``; the pgvector backend compiles it
+                to a WHERE predicate, the other backends accept-and-ignore it.
             recency_bias: Accepted only as ``None`` for protocol parity.
                 Skeleton does not implement temporal decay on the recall
                 path; passing a non-None value silently no-ops in pre-fix
@@ -583,6 +584,7 @@ class SkeletonConstructionEngine:
             temporal_filter=temporal_filter,
             hybrid_alpha=hybrid_alpha,
             query_text=query,
+            filter_ast=filter_ast,
         )
 
         chunks_with_scores: list[tuple[Chunk, float]] = []

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -2027,12 +2027,14 @@ class Khora:
             # deprecated ``start_time``/``end_time`` bounds. They are mutually
             # exclusive. ``temporal_filter`` is still built from the deprecated
             # bounds so the engines' existing temporal behavior (recency
-            # weighting, version filter) is unchanged. No engine threads
-            # ``filter_ast`` to its backend on the recall path yet (the pgvector
-            # backend can compile it, but the skeleton engine does not pass it
-            # through), so the two cannot currently double-filter; the folded
-            # bounds below still mirror ``temporal_filter``'s boundary semantics
-            # so they stay consistent if/when an engine AND-s both.
+            # weighting, version filter) is unchanged. The skeleton engine now
+            # threads ``filter_ast`` through to its temporal store, where the
+            # pgvector backend compiles it to a WHERE predicate (the other
+            # backends accept-and-ignore it). When the deprecated bounds are
+            # used, both ``temporal_filter`` and the folded AST are AND-ed on
+            # the pgvector path, so the folded bounds below mirror
+            # ``temporal_filter``'s boundary semantics exactly to stay
+            # consistent and avoid dropping boundary rows.
             temporal_filter: Any = None
             filter_ast: Any = None
             if filter is not None and (start_time is not None or end_time is not None):

--- a/tests/unit/engines/test_skeleton_filter_ast.py
+++ b/tests/unit/engines/test_skeleton_filter_ast.py
@@ -1,0 +1,182 @@
+"""Regression tests: Skeleton recall must push ``filter_ast`` to the store.
+
+The Skeleton engine's ``recall`` accepted a ``filter_ast`` (the canonical
+recall-filter AST) for protocol parity but historically dropped it on the
+floor — it never forwarded the node to ``temporal_store.search(...)``. This
+file guards two distinct regressions:
+
+1. **Engine drop (the primary regression).** ``recall(..., filter_ast=node)``
+   MUST forward ``filter_ast=node`` in the kwargs of the ``temporal_store.search``
+   call. ``test_recall_forwards_filter_ast_to_store`` drives ``recall`` against
+   an ``AsyncMock`` store and asserts the spy received the exact node. If the
+   engine ever again drops ``filter_ast=filter_ast`` from the call, this fails.
+
+2. **Backend signature drift (the turbopuffer regression).** Every concrete
+   backend ``search()`` must accept a ``filter_ast`` parameter, otherwise the
+   engine's forwarded kwarg raises ``TypeError`` at runtime on that backend.
+   ``test_all_backend_search_methods_accept_filter_ast`` walks the protocol +
+   all five concrete stores via ``inspect.signature``. PgVector already had the
+   param (#1008); the other four were added when the engine was wired.
+
+Both tests are NO-Postgres: they use shallow ``AsyncMock`` stubs (mirroring
+``test_skeleton_kwarg_drift`` / ``test_skeleton_search_mode``) and module-level
+``inspect`` reads. The Postgres-dependent end-to-end filter test lives on a
+separate ticket.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from khora.engines.skeleton.engine import SkeletonConstructionEngine
+from khora.filter import FilterClause, FilterNode, FilterOp
+from khora.query import SearchMode
+
+
+def _build_engine_with_stubs() -> tuple[SkeletonConstructionEngine, AsyncMock]:
+    """Construct an engine with embedder + temporal store stubs.
+
+    Mirrors ``test_skeleton_search_mode._build_engine_with_stubs``: the
+    engine's ``__init__`` does no network I/O until ``connect()``, so we
+    bypass ``connect()`` via ``__new__`` and inject the two collaborators
+    ``recall()`` actually touches (``_embedder`` and ``_temporal_store``).
+    """
+    cfg = MagicMock()
+    cfg.storage.backend = "pgvector"
+
+    engine = SkeletonConstructionEngine.__new__(SkeletonConstructionEngine)
+    engine._config = cfg
+    engine._backend_type = "pgvector"
+    engine._weaviate_url = None
+    engine._storage_config = MagicMock()
+    engine._storage = None
+    engine._connected = True
+
+    embedder = AsyncMock()
+    embedder.embed = AsyncMock(return_value=[0.1, 0.2, 0.3])
+    engine._embedder = embedder
+
+    temporal_store = AsyncMock()
+    temporal_store.search = AsyncMock(return_value=[])
+    engine._temporal_store = temporal_store
+
+    return engine, temporal_store
+
+
+def _sample_filter_ast() -> FilterNode:
+    """A small, real ``FilterNode`` — ``AND([author $eq "alice"])``.
+
+    Built directly (no ``RecallFilter`` round-trip) so the test depends only
+    on the AST layer, not the wire-model validator. The exact shape is
+    irrelevant to the assertion — what matters is that this *specific object*
+    is the one handed back to the store.
+    """
+    return FilterNode(
+        op=FilterOp.AND,
+        children=(FilterClause(path=("author",), op=FilterOp.EQ, operand="alice"),),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression 1: the engine must forward filter_ast to temporal_store.search.
+# ---------------------------------------------------------------------------
+
+
+async def test_recall_forwards_filter_ast_to_store() -> None:
+    """``recall(..., filter_ast=node)`` forwards ``filter_ast=node`` to search.
+
+    This is the core regression guard. If a future edit drops
+    ``filter_ast=filter_ast`` from the ``temporal_store.search(...)`` call in
+    ``engine.recall`` (reverting to the "ignored for protocol parity"
+    behavior), the kwarg vanishes from ``await_args.kwargs`` and this fails.
+    """
+    engine, temporal_store = _build_engine_with_stubs()
+    namespace_id = uuid4()
+    node = _sample_filter_ast()
+
+    await engine.recall("alpha", namespace_id, mode=SearchMode.VECTOR, filter_ast=node)
+
+    temporal_store.search.assert_awaited_once()
+    kwargs = temporal_store.search.await_args.kwargs
+    assert "filter_ast" in kwargs, (
+        "engine.recall must forward filter_ast as a kwarg to temporal_store.search; "
+        "it was dropped (the pre-wiring 'ignored for protocol parity' regression)"
+    )
+    # Identity, not just equality: the exact node passed in must reach the store.
+    assert kwargs["filter_ast"] is node
+
+
+async def test_recall_filter_ast_none_forwards_none() -> None:
+    """The default ``filter_ast=None`` still reaches the store as ``None``.
+
+    Forwarding must be unconditional — the engine should pass ``filter_ast``
+    through on every call, not only when it is non-None. A ``None`` here means
+    "no filter", and the store's compiler treats it as no constraint.
+    """
+    engine, temporal_store = _build_engine_with_stubs()
+    namespace_id = uuid4()
+
+    await engine.recall("alpha", namespace_id, mode=SearchMode.VECTOR)
+
+    temporal_store.search.assert_awaited_once()
+    kwargs = temporal_store.search.await_args.kwargs
+    assert "filter_ast" in kwargs
+    assert kwargs["filter_ast"] is None
+
+
+# ---------------------------------------------------------------------------
+# Regression 2: every backend search() must accept the filter_ast parameter.
+# ---------------------------------------------------------------------------
+
+
+def _all_search_owners() -> list[tuple[str, object]]:
+    """The protocol + the five concrete temporal stores, by class.
+
+    Importing the concrete stores is cheap — each defers its framework SDK
+    (weaviate / turbopuffer / surreal client) to a lazy in-method import, so
+    the class object is reachable without the optional extra installed.
+    """
+    from khora.engines.skeleton.backends import TemporalVectorStore
+    from khora.engines.skeleton.backends.pgvector import PgVectorTemporalStore
+    from khora.engines.skeleton.backends.sqlite_lance import SQLiteLanceTemporalStore
+    from khora.engines.skeleton.backends.surrealdb import SurrealDBTemporalStore
+    from khora.engines.skeleton.backends.turbopuffer import TurbopufferTemporalStore
+    from khora.engines.skeleton.backends.weaviate import WeaviateTemporalStore
+
+    return [
+        ("TemporalVectorStore", TemporalVectorStore),
+        ("PgVectorTemporalStore", PgVectorTemporalStore),
+        ("WeaviateTemporalStore", WeaviateTemporalStore),
+        ("TurbopufferTemporalStore", TurbopufferTemporalStore),
+        ("SurrealDBTemporalStore", SurrealDBTemporalStore),
+        ("SQLiteLanceTemporalStore", SQLiteLanceTemporalStore),
+    ]
+
+
+@pytest.mark.parametrize("name,store_cls", _all_search_owners())
+def test_all_backend_search_methods_accept_filter_ast(name: str, store_cls: object) -> None:
+    """Every backend ``search()`` exposes a ``filter_ast`` keyword parameter.
+
+    Guards the turbopuffer-style regression: the engine forwards
+    ``filter_ast=...`` to whichever backend is configured, so a backend whose
+    ``search`` lacks the parameter raises ``TypeError`` at recall time. The
+    ``inspect.signature`` walk catches the drift statically across all five
+    backends + the protocol they implement.
+    """
+    sig = inspect.signature(store_cls.search)  # type: ignore[attr-defined]
+    assert "filter_ast" in sig.parameters, (
+        f"{name}.search() is missing the 'filter_ast' parameter; the engine "
+        f"forwards filter_ast= to it and would raise TypeError at recall time"
+    )
+    # It must be keyword-acceptable (keyword-only or positional-or-keyword),
+    # because the engine forwards it by keyword. A VAR_KEYWORD (**kwargs) sink
+    # would technically swallow it but is not the contract here.
+    param = sig.parameters["filter_ast"]
+    assert param.kind in (
+        inspect.Parameter.KEYWORD_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    ), f"{name}.search() 'filter_ast' must be passable by keyword, got kind={param.kind}"


### PR DESCRIPTION
## Summary
- The skeleton engine's `recall()` accepted a canonical recall-filter AST (`filter_ast`) but dropped it before calling the temporal store, so a live `recall(filter=...)` validated and built the AST yet returned **unfiltered** results — the filter evaporated at the engine boundary.
- Forward `filter_ast` from `recall()` into `temporal_store.search()`, and declare the kwarg on the `TemporalVectorStore` protocol plus all five backends so the polymorphic call stays type-safe and no backend breaks.
- The pgvector backend already compiles the AST into a SQL `WHERE` predicate — it is now actually reached on the live recall path. The other four backends (`sqlite_lance`, `surrealdb`, `weaviate`, `turbopuffer`) accept the kwarg for protocol parity and ignore it for now (per-backend pushdown is a later slice).
- Correct a stale facade comment that claimed the skeleton engine does not thread the filter through.
- Add a fast, no-Postgres regression test that fails if the engine drops the kwarg or any backend signature loses it.

## Test plan
- [x] `make format` clean; `make lint` (ruff + ty) exits 0
- [x] New unit test `tests/unit/engines/test_skeleton_filter_ast.py` passes — engine-forwarding identity check + all-five-backend signature guard
- [x] `tests/unit/engines/` suite green locally (1240 passed, 6 skipped)
- [ ] Full Postgres integration suite (`make test-integration`) — **gated by CI** (requires Docker; not runnable in the local sandbox). Pre-existing unit failures in the local sandbox are limited to suites needing uninstalled optional extras (`langgraph`, `lancedb`) and are identical on the base branch.
- [ ] Manual verification: a live `recall(filter=...)` on the skeleton+pgvector path returns only matching chunks (the full end-to-end assertion lives in the integration-test slice)

## Follow-up (out of scope here)
- The recall facade still reports `engine_info["filter"]["pushed_down"] = False` unconditionally. Now that the skeleton+pgvector path pushes the filter into SQL, that summary is inaccurate for that path. Making the per-engine pushdown matrix honest (and asserting it) is owned by the integration-test slice and intentionally left untouched here to keep this change surgical.