### PR TITLE
Add Neo4j Cypher recall-filter compiler with system-key pushdown

### DIFF
--- a/src/khora/filter/compilers/cypher.py
+++ b/src/khora/filter/compilers/cypher.py
@@ -1,0 +1,281 @@
+"""Neo4j Cypher recall-filter compiler — ``@internal``.
+
+Lowers a canonical :class:`~khora.filter.ast.FilterNode` to a single Cypher
+``WHERE`` fragment against a recall ``Chunk`` node (no relationship traversal —
+the filterable document keys are projected onto the chunk node). The output is a
+:class:`~khora.filter.registry.CompiledFilter` whose ``predicate`` is a Cypher
+boolean *string* the engine splices into its own ``WHERE``, paired with a
+``params`` dict of ``$name`` binds the engine passes through to the driver.
+
+The compiler is the Layer-4 half of the §4/§7 filter contract. It speaks
+the four emission rules:
+
+1. **Never abort.** Cypher comparisons against a property of the wrong type or
+   an absent property evaluate to ``null`` (not an error), so a numeric compare
+   on a string-valued property never blows up — it yields ``null`` (then
+   ``false`` via ``coalesce``) instead of erroring.
+2. **Polarity.** Negations include absent/null rows: a system ``$ne`` is
+   ``(var.key IS NULL OR var.key <> $v)``; a ``$nin`` is ``(var.key IS NULL OR
+   NOT var.key IN $vs)``. Never drop a NULL row on a negation.
+3. **Impossible pairs (narrow).** ONLY an ``$eq`` exact-array (tuple) operand
+   against a scalar node property is compiled as a normal ``=`` against a list
+   bind — a scalar property never equals a list, so Cypher yields ``false``; no
+   special-cased constant is emitted. ``$in`` / ``$nin`` are normal membership.
+4. **Presence/null.** ``$exists`` resolves to ``var.key IS NOT NULL`` /
+   ``var.key IS NULL`` and a ``{k: null}`` match resolves to ``var.key IS NULL``
+   (Neo4j has no stored-null property — an absent property *is* null).
+
+**Totality (the rule that makes negation uniform).** ``NOT`` is compiled as
+``(NOT (<child>))``; Cypher ``NOT null`` is ``null`` (drops the row), which would
+violate Rule 2. So every leaf that *can* produce ``null`` (an absent property in
+an ``$eq`` / range / ``$in`` compare) is wrapped in ``coalesce(<expr>, false)``
+— a total boolean. The positive use is unchanged (``false`` excludes exactly as
+``null`` would), and a wrapping ``NOT`` then flips absent rows to ``true``
+correctly. ``IS NULL`` / ``IS NOT NULL`` are already total.
+
+**Dates compare as ISO strings.** A chunk stores every datetime property as an
+ISO-8601 string (``.isoformat()``), so a :class:`~datetime.datetime` /
+:class:`DateLiteral` operand binds as its ``.isoformat()`` string and compares
+lexicographically — ISO-8601's fixed-width, big-endian layout makes string order
+agree with chronological order for the UTC-normalized values the validator
+produces.
+
+``@internal``. Reachable as ``khora.filter.compilers.cypher.compile_cypher`` for
+khora's own engines; not re-exported from :mod:`khora.__init__`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from khora.filter import (
+    CompileContext,
+    CompiledFilter,
+    RecallFilterUnsupportedError,
+)
+from khora.filter.ast import (
+    DateLiteral,
+    FilterClause,
+    FilterNode,
+    canonical_hash,
+)
+from khora.filter.model import SYSTEM_KEYS, Op
+
+__all__ = ["compile_cypher"]
+
+
+# Cypher comparison operator strings for the range ops, keyed by AST op.
+_RANGE_OP = {
+    Op.GT: ">",
+    Op.GTE: ">=",
+    Op.LT: "<",
+    Op.LTE: "<=",
+}
+
+
+def compile_cypher(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[str]:
+    """Compile a canonical AST to a Cypher ``WHERE`` fragment + bind dict.
+
+    ``ast`` is always a :class:`FilterNode` (the ``parse_to_ast`` root invariant).
+    An empty ``AND`` (the match-everything root of a bare filter) compiles to the
+    literal ``"true"``. Binds are returned out-of-band in ``params`` as a
+    ``{name: value}`` dict; each ``$name`` placeholder in the predicate string has
+    a matching entry. Bind names are generated as ``{param_namespace}_{n}`` so
+    they cannot collide with the engine's own query parameters.
+
+    Property references are derived from ``ctx`` alone: the node variable is
+    ``ctx.table_alias`` if set else ``"c"``, and ``field_mapping`` remaps a logical
+    key to its physical property name (identity when ``None``), so the compiler
+    embeds no engine schema. Honors ``ctx.on_unsupported``: on a clause this
+    backend cannot express, ``"raise"`` raises :class:`RecallFilterUnsupportedError`;
+    ``"split"`` omits it from ``consumed_keys`` and emits a non-constraining
+    ``"true"`` placeholder.
+    """
+    consumed: set[str] = set()
+    builder = _Builder(ctx=ctx, consumed=consumed)
+    predicate = builder.compile_node(ast)
+    return CompiledFilter(
+        predicate=predicate,
+        params=builder.params,
+        consumed_keys=frozenset(consumed),
+        # canonical_hash over the whole AST. In on_unsupported="raise" mode (the
+        # only mode used today) every leaf is consumed, so the whole tree == the
+        # consumed slice. When split-mode is implemented, hash the reconstructed
+        # consumed sub-AST instead, not the whole tree.
+        canonical_hash=canonical_hash(ast),
+    )
+
+
+def _path_str(path: tuple[str, ...]) -> str:
+    """Render an AST path as the dotted key string used for diagnostics/consumed."""
+    return ".".join(path)
+
+
+class _Builder:
+    """Per-compile-pass state: the :class:`CompileContext`, consumed set, binds.
+
+    A compile pass threads the ``ctx`` (the node variable and property names are
+    derived from it), the ``consumed`` accumulator, and the ``params`` bind dict
+    every leaf appends to. Keeping them on a small object avoids passing the
+    triple through every recursion frame. A monotonic counter names each bind
+    ``{param_namespace}_{n}`` so two clauses on the same key never collide.
+    """
+
+    def __init__(self, *, ctx: CompileContext, consumed: set[str]) -> None:
+        self._ctx = ctx
+        self._consumed = consumed
+        self._var = ctx.table_alias or "c"
+        self.params: dict[str, Any] = {}
+        self._counter = 0
+
+    # ----- bind allocation ------------------------------------------------ #
+
+    def _bind(self, value: Any) -> str:
+        """Allocate a fresh ``$name`` placeholder bound to ``value``."""
+        name = f"{self._ctx.param_namespace}_{self._counter}"
+        self._counter += 1
+        self.params[name] = value
+        return f"${name}"
+
+    def _prop(self, key: str) -> str:
+        """Render a node-property reference ``var.key`` for a logical key.
+
+        ``field_mapping`` remaps a logical key to its physical property name
+        (identity when ``None``). ``key`` is always a controlled token (a system
+        key from the closed ``SYSTEM_KEYS`` whitelist) — never free user text, so
+        the property access is not an injection surface. Metadata leaves never
+        reach this method; they are handled separately.
+        """
+        physical = (self._ctx.field_mapping or {}).get(key, key)
+        return f"{self._var}.{physical}"
+
+    # ----- logical node walk ---------------------------------------------- #
+
+    def compile_node(self, node: FilterNode | FilterClause) -> str:
+        """Compile a logical node or leaf to a Cypher boolean string."""
+        if isinstance(node, FilterClause):
+            return self.compile_clause(node)
+        if node.op == Op.AND:
+            if not node.children:
+                # The empty match-everything root — no constraint.
+                return "true"
+            return "(" + " AND ".join(self.compile_node(c) for c in node.children) + ")"
+        if node.op == Op.OR:
+            if not node.children:
+                # The validator forbids an empty $or; guard defensively.
+                return "false"
+            return "(" + " OR ".join(self.compile_node(c) for c in node.children) + ")"
+        # Op.NOT — exactly one child per the AST contract. Leaves are built total
+        # (never null) so this negation flips absent rows correctly.
+        return f"(NOT ({self.compile_node(node.children[0])}))"
+
+    # ----- leaf key-kind split -------------------------------------------- #
+
+    def compile_clause(self, clause: FilterClause) -> str:
+        """Dispatch a leaf on key-kind (system key vs metadata path)."""
+        path = clause.path
+        if len(path) == 1 and path[0] in SYSTEM_KEYS:
+            expr = self._compile_system_clause(clause)
+        elif path and path[0] == "metadata":
+            # Neo4j stores metadata as a serialized JSON string property, not a
+            # nested map, so a metadata sub-path is not pushdownable here. Defer to
+            # the engine's post-filter per ``ctx.on_unsupported``.
+            return self._unsupported(clause, "metadata predicates are not pushed down to Cypher")
+        else:
+            return self._unsupported(clause, "path is neither a system key nor a metadata path")
+        self._consumed.add(_path_str(path))
+        return expr
+
+    # ----- system-key leaves (typed node properties) ---------------------- #
+
+    def _compile_system_clause(self, clause: FilterClause) -> str:
+        key = clause.path[0]
+        prop = self._prop(key)
+        op = clause.op
+        operand = clause.operand
+
+        if op == Op.EXISTS:
+            # A chunk node has no stored null — an absent property IS null. So
+            # $exists is presence: IS NOT NULL (true) / IS NULL (false).
+            return f"({prop} IS NOT NULL)" if operand else f"({prop} IS NULL)"
+
+        if op in (Op.IN, Op.NIN):
+            if not operand:
+                # An empty operand list is a valid filter with a defined row-set
+                # (the validator accepts it). Positive $in over ∅ matches nothing;
+                # $nin over ∅ matches everything. Cypher's IN already yields this
+                # (``x IN []`` is false for every x, including null), but emit the
+                # constant explicitly — it mirrors the Postgres compiler and makes
+                # the contract self-evident without relying on the empty-list rule.
+                return "false" if op == Op.IN else "true"
+            values_bind = self._bind([_system_value(v) for v in operand])
+            if op == Op.IN:
+                # Made total so a wrapping field-level $not includes NULL rows.
+                return f"coalesce({prop} IN {values_bind}, false)"
+            # $nin includes NULL rows (Rule 2 polarity). Already a total boolean.
+            return f"({prop} IS NULL OR NOT {prop} IN {values_bind})"
+
+        # Rule 3 (NARROW): a bare list on a system key lowers to EQ-with-tuple. A
+        # scalar property can never equal a list, so the compare yields false at
+        # query time — no special-cased constant is needed (the list binds like
+        # any other operand). The $ne complement is the polarity mirror and stays
+        # uniform with the scalar $ne form below. $in / $nin are NOT impossible —
+        # they were already handled above as normal membership.
+        if operand is None:
+            # {k: null} → active null-or-missing match. An absent property IS
+            # null on a chunk node. $ne null → IS NOT NULL. Both are total.
+            if op == Op.NE:
+                return f"({prop} IS NOT NULL)"
+            return f"({prop} IS NULL)"
+
+        value_bind = self._bind(_system_value(operand))
+        if op == Op.NE:
+            # Include NULL rows (Rule 2): a row whose property is null satisfies
+            # $ne. Already a total boolean (no coalesce needed).
+            return f"({prop} IS NULL OR {prop} <> {value_bind})"
+        # $eq and the range ops compare directly. Wrap in coalesce(..., false) so
+        # the leaf is a total boolean: a null property yields false (same
+        # exclusion as the bare null comparison on the positive side), and a
+        # wrapping field-level $not then flips a null-property row to true — which
+        # is what $not($eq) / $not($gt) must do (parity with the explicit $ne).
+        symbol = "=" if op == Op.EQ else _RANGE_OP[op]
+        return f"coalesce({prop} {symbol} {value_bind}, false)"
+
+    # ----- unsupported ---------------------------------------------------- #
+
+    def _unsupported(self, clause: FilterClause, reason: str) -> str:
+        """Handle a clause this backend cannot express per ``ctx.on_unsupported``.
+
+        ``"raise"`` raises the public :class:`RecallFilterUnsupportedError`;
+        ``"split"`` leaves the clause out of ``consumed_keys`` (the engine
+        post-filters it) and emits a non-constraining ``"true"`` so it does not
+        narrow the result set.
+        """
+        path = _path_str(clause.path)
+        if self._ctx.on_unsupported == "raise":
+            raise RecallFilterUnsupportedError(path, reason)
+        return "true"
+
+
+# --------------------------------------------------------------------------- #
+# Module-level helpers (no per-pass state).
+# --------------------------------------------------------------------------- #
+
+
+def _system_value(value: Any) -> Any:
+    """Coerce a system-key operand to a driver-bindable value.
+
+    A chunk stores datetime properties as ISO-8601 strings, so a
+    :class:`DateLiteral` / :class:`~datetime.datetime` binds as its
+    ``.isoformat()`` string (lexicographic compare). An exact-array ``tuple`` (a
+    bare-list ``$eq`` operand) binds as a ``list`` — the driver's list value type
+    — with each element coerced the same way. Other scalars pass through.
+    """
+    if isinstance(value, DateLiteral):
+        return value.value.isoformat()
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, tuple):
+        return [_system_value(item) for item in value]
+    return value

--- a/tests/unit/filter/test_compile_cypher.py
+++ b/tests/unit/filter/test_compile_cypher.py
@@ -1,0 +1,480 @@
+"""Unit tests for the Neo4j Cypher recall-filter compiler (Layer 4) — ``@internal``.
+
+``compile_cypher(ast, ctx)`` lowers a canonical :class:`~khora.filter.ast.FilterNode`
+into a Cypher ``WHERE``-fragment *string* (plus a ``params`` bind dict) over a recall
+``Chunk`` node. These tests pin the §4 *Field-match contract* at the Cypher level: each
+test builds an AST (by validating a :class:`~khora.filter.RecallFilter` and lowering it
+with :func:`~khora.filter.ast.parse_to_ast`), compiles it, and asserts on the emitted
+predicate string and bind dict — never re-implementing the compiler, only inspecting
+what it emits.
+
+Unlike the Postgres compiler (which inlines literals into a SQLAlchemy expression), the
+Cypher compiler returns a plain string with ``$name`` placeholders and carries the
+values out-of-band in ``params``. So the assertions match against the string directly
+(no SQLAlchemy ``compile()`` step) and check ``params`` for the bound values.
+
+The contract these tests lock (§4):
+
+* Every operator ``$eq``/``$ne``/``$gt``/``$gte``/``$lt``/``$lte``/``$in``/``$nin``/``$exists``.
+* System key (typed node property) emission; the empty AST → match-everything (``true``).
+* ``$and``/``$or``/``$not`` composition.
+* The four field-match rules, as Cypher expresses them:
+  1. range / ``$eq`` compares are wrapped in ``coalesce(..., false)`` so an absent or
+     wrong-typed property yields ``false`` (never aborts);
+  2. ``$ne``/``$nin`` emit ``IS NULL OR ...`` so a null/absent row is admitted;
+  3. a bare-list (exact-array) operand binds as a list against a scalar property — the
+     compare yields ``false`` at query time, no special-cased constant;
+  4. ``$exists`` / null resolve to ``IS NOT NULL`` / ``IS NULL`` (Neo4j has no stored
+     null — an absent property *is* null).
+* Dates bind as ``.isoformat()`` strings (lexicographic compare).
+* Metadata predicates are NOT pushed down (Neo4j stores metadata as a serialized JSON
+  string property): ``on_unsupported="raise"`` raises; ``"split"`` emits a
+  non-constraining ``true`` and consumes nothing.
+* The :class:`CompiledFilter` envelope: ``params`` binds, ``consumed_keys`` frozenset,
+  ``canonical_hash``.
+* ``field_mapping`` / ``table_alias`` / ``param_namespace`` honored — one compiler, many
+  schemas, no per-engine branching.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from khora.filter import RecallFilter
+from khora.filter.ast import FilterClause, FilterNode, parse_to_ast
+from khora.filter.compilers.cypher import compile_cypher
+from khora.filter.context import CompileContext
+from khora.filter.model import Op
+
+# Hard import (NOT importorskip): the compiler is on the branch, so an import
+# failure here must be a LOUD test error — never a silent module skip that would
+# pass CI green with zero coverage.
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+_CTX = CompileContext(backend_target="Chunk")
+
+
+def _ast(wire: dict) -> FilterNode:
+    """Validate a wire-form filter and lower it to the canonical AST."""
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+def _norm(cypher: str) -> str:
+    """Collapse whitespace and lowercase for resilient substring matching."""
+    return " ".join(cypher.split()).lower()
+
+
+def _cypher_norm(node: FilterNode | FilterClause, ctx: CompileContext = _CTX) -> str:
+    """Compile an AST and return the predicate string, whitespace-collapsed.
+
+    The predicate is already a Cypher boolean string (the bind values live in the
+    sibling ``params`` dict), so there is no compile step — normalize and assert
+    substrings directly.
+    """
+    return _norm(compile_cypher(node, ctx).predicate)
+
+
+# ===========================================================================
+# Empty AST → match-everything.
+# ===========================================================================
+
+
+def test_empty_filter_compiles_to_true() -> None:
+    # A bare RecallFilter() (no predicates) lowers to the empty match-everything
+    # AND. The compiler must emit a tautology so the engine applies no constraint.
+    assert _cypher_norm(_ast({})) == "true"
+
+
+def test_empty_and_node_compiles_to_true() -> None:
+    # Construct the empty AND directly — same match-everything contract.
+    assert _cypher_norm(FilterNode(op=Op.AND, children=())) == "true"
+
+
+def test_empty_filter_binds_nothing() -> None:
+    assert compile_cypher(_ast({}), _CTX).params == {}
+
+
+# ===========================================================================
+# Scalar operators on a SYSTEM (typed node property) key.
+# ===========================================================================
+
+
+def test_system_eq_is_coalesced_property_equals() -> None:
+    compiled = compile_cypher(_ast({"source_name": "linear"}), _CTX)
+    sql = _norm(compiled.predicate)
+    # $eq is a total boolean: coalesce(prop = $bind, false) so an absent property
+    # excludes (and a wrapping $not flips it in). The operand is bound, not inlined.
+    assert "coalesce(c.source_name = $f_0, false)" in sql
+    assert compiled.params == {"f_0": "linear"}
+    # System key is a typed node property, NOT a metadata extraction.
+    assert "metadata" not in sql
+
+
+def test_system_eq_on_string_key_with_ops_form() -> None:
+    compiled = compile_cypher(_ast({"source_type": {"$eq": "slack"}}), _CTX)
+    assert "coalesce(c.source_type = $f_0, false)" in _norm(compiled.predicate)
+    assert compiled.params == {"f_0": "slack"}
+
+
+def test_system_gt_is_property_compare() -> None:
+    # A system DATE key takes a plain ISO-8601 string operand (DateOps parses it to
+    # a datetime); the operand binds as its .isoformat() string.
+    compiled = compile_cypher(_ast({"created_at": {"$gt": "2026-01-01T00:00:00Z"}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "coalesce(c.created_at > $f_0, false)" in sql
+    assert compiled.params["f_0"].startswith("2026-01-01")
+
+
+@pytest.mark.parametrize(
+    ("wire_op", "cypher_op"),
+    [
+        ("$gt", ">"),
+        ("$gte", ">="),
+        ("$lt", "<"),
+        ("$lte", "<="),
+    ],
+)
+def test_system_date_range_operators(wire_op: str, cypher_op: str) -> None:
+    sql = _cypher_norm(_ast({"occurred_at": {wire_op: "2026-03-04T05:06:07Z"}}))
+    assert f"coalesce(c.occurred_at {cypher_op} $f_0, false)" in sql
+
+
+# ===========================================================================
+# Rule 2 — $ne / $nin include NULL / absent.
+# ===========================================================================
+
+
+def test_system_ne_includes_null_rows() -> None:
+    # Rule 2: $ne on a system property must match rows where the property IS NULL
+    # too (an absent property is "not equal"). Emitted as the null-inclusive OR.
+    compiled = compile_cypher(_ast({"source_name": {"$ne": "linear"}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "c.source_name is null or c.source_name <> $f_0" in sql
+    assert compiled.params == {"f_0": "linear"}
+
+
+def test_system_nin_includes_null_rows() -> None:
+    # $nin is the list form of $ne — NULL rows are included via the leading IS NULL.
+    compiled = compile_cypher(_ast({"source_name": {"$nin": ["a", "b"]}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "c.source_name is null or not c.source_name in $f_0" in sql
+    assert compiled.params == {"f_0": ["a", "b"]}
+
+
+# ===========================================================================
+# Rule 3 — bare-list (exact-array) operand vs scalar SYSTEM property.
+# ===========================================================================
+
+
+def test_system_eq_array_operand_binds_as_list() -> None:
+    # A bare list on a scalar system key lowers to $eq EXACT-ARRAY. The compiler
+    # binds the operand as a Cypher list and emits the same coalesced `=` compare;
+    # a scalar property never equals a list, so it yields false at query time —
+    # no special-cased constant, the list binds like any other operand. (The AST
+    # carries a tuple; it is bound as a driver list, not a tuple.)
+    compiled = compile_cypher(_ast({"source_name": ["a", "b"]}), _CTX)
+    assert "coalesce(c.source_name = $f_0, false)" in _norm(compiled.predicate)
+    assert compiled.params == {"f_0": ["a", "b"]}
+
+
+def test_system_in_is_membership_not_exact_array() -> None:
+    # $in on a system key is membership (coalesced IN), NOT exact-array — distinct
+    # from the bare-list $eq case above.
+    compiled = compile_cypher(_ast({"occurred_at": {"$in": ["2026-01-01T00:00:00Z"]}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "coalesce(c.occurred_at in $f_0, false)" in sql
+    assert "<>" not in sql
+
+
+# ===========================================================================
+# $in / $nin on a SYSTEM key → IN / NOT IN membership.
+# ===========================================================================
+
+
+def test_system_in_is_coalesced_in_list() -> None:
+    compiled = compile_cypher(_ast({"source_name": {"$in": ["a", "b", "c"]}}), _CTX)
+    assert "coalesce(c.source_name in $f_0, false)" in _norm(compiled.predicate)
+    assert compiled.params == {"f_0": ["a", "b", "c"]}
+
+
+def test_system_nin_is_not_in_with_null_guard() -> None:
+    compiled = compile_cypher(_ast({"source_type": {"$nin": ["spam", "junk"]}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "not c.source_type in $f_0" in sql
+    assert "c.source_type is null" in sql
+    assert compiled.params == {"f_0": ["spam", "junk"]}
+
+
+def test_system_empty_in_is_constant_false() -> None:
+    # An empty $in operand list is a valid filter (the validator accepts it) with a
+    # defined row-set: a positive membership over ∅ matches nothing. The compiler
+    # emits the constant explicitly (the single-clause filter normalizes to
+    # AND([leaf]), so it renders as the wrapped "(false)") and binds nothing.
+    compiled = compile_cypher(_ast({"source_name": {"$in": []}}), _CTX)
+    assert _norm(compiled.predicate) == "(false)"
+    assert compiled.params == {}
+
+
+def test_system_empty_nin_is_constant_true() -> None:
+    # An empty $nin operand list matches everything (negation over ∅). Emitted as
+    # the constant "true" (wrapped "(true)" for the single-clause filter), binding
+    # nothing — the polarity mirror of the empty-$in case above.
+    compiled = compile_cypher(_ast({"source_name": {"$nin": []}}), _CTX)
+    assert _norm(compiled.predicate) == "(true)"
+    assert compiled.params == {}
+
+
+# ===========================================================================
+# Rule 4 — $exists / null resolve to IS [NOT] NULL.
+# ===========================================================================
+
+
+def test_system_exists_true_is_is_not_null() -> None:
+    # A chunk node has no stored null — an absent property IS null — so $exists is a
+    # presence test (IS NOT NULL), and it binds nothing.
+    compiled = compile_cypher(_ast({"source_name": {"$exists": True}}), _CTX)
+    assert "c.source_name is not null" in _norm(compiled.predicate)
+    assert compiled.params == {}
+
+
+def test_system_exists_false_is_is_null() -> None:
+    compiled = compile_cypher(_ast({"source_name": {"$exists": False}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "c.source_name is null" in sql
+    assert "is not null" not in sql
+    assert compiled.params == {}
+
+
+def test_system_null_operand_is_is_null() -> None:
+    # An explicit null is an active null-or-missing match → IS NULL.
+    compiled = compile_cypher(_ast({"source_name": None}), _CTX)
+    assert "c.source_name is null" in _norm(compiled.predicate)
+    assert compiled.params == {}
+
+
+def test_system_ne_null_is_is_not_null() -> None:
+    # $ne null → present (IS NOT NULL).
+    compiled = compile_cypher(_ast({"source_name": {"$ne": None}}), _CTX)
+    assert "c.source_name is not null" in _norm(compiled.predicate)
+    assert compiled.params == {}
+
+
+# ===========================================================================
+# Dates bind as ISO strings.
+# ===========================================================================
+
+
+def test_system_date_binds_iso_string() -> None:
+    # A system date key takes a plain ISO string (the `$date` typed literal is a
+    # metadata-only form). It compiles to a coalesced `=` compare; the operand
+    # binds as its UTC-normalized .isoformat() string.
+    compiled = compile_cypher(_ast({"source_timestamp": "2026-02-03T00:00:00Z"}), _CTX)
+    assert "coalesce(c.source_timestamp = $f_0, false)" in _norm(compiled.predicate)
+    assert compiled.params["f_0"].startswith("2026-02-03")
+
+
+def test_direct_datetime_clause_binds_iso_string() -> None:
+    # Build a leaf clause directly with a tz-aware datetime operand — the AST is a
+    # valid compiler input independent of the validator path, and the datetime
+    # binds as its .isoformat() string.
+    clause = FilterClause(path=("occurred_at",), op=Op.GTE, operand=datetime(2026, 1, 1, tzinfo=UTC))
+    node = FilterNode(op=Op.AND, children=(clause,))
+    compiled = compile_cypher(node, _CTX)
+    assert "coalesce(c.occurred_at >= $f_0, false)" in _norm(compiled.predicate)
+    assert compiled.params["f_0"] == datetime(2026, 1, 1, tzinfo=UTC).isoformat()
+
+
+# ===========================================================================
+# Logical composition — AND / OR / NOT.
+# ===========================================================================
+
+
+def test_and_node_joins_with_and() -> None:
+    # Two sibling keys compose with " AND ". Child order is normalized (the system
+    # keys lower in a fixed order), not authored order — so do NOT assert order,
+    # only that both leaves and the AND join are present.
+    sql = _cypher_norm(_ast({"source_name": "linear", "source_type": "slack"}))
+    assert " and " in sql
+    assert "c.source_name = $" in sql
+    assert "c.source_type = $" in sql
+
+
+def test_or_node_joins_with_or() -> None:
+    sql = _cypher_norm(_ast({"$or": [{"source_name": "linear"}, {"source_type": "slack"}]}))
+    assert " or " in sql
+    assert "c.source_name = $" in sql
+    assert "c.source_type = $" in sql
+
+
+def test_not_node_negates_with_total_child() -> None:
+    # SEMANTICS over tokens: NOT compiles via `(NOT (<child>))`, and the child
+    # equality is built as a TOTAL boolean (`coalesce(prop = $v, false)`) precisely
+    # so the negation is NULL-INCLUSIVE — `NOT coalesce(NULL = v, false)` =
+    # `NOT false` = TRUE flips a NULL/absent row IN (Rule 2), making $not($eq)
+    # behave like $ne rather than dropping the NULL row. We assert the total-child
+    # SHAPE here (the `coalesce(..., false)` wrap is the load-bearing guarantee).
+    sql = _cypher_norm(_ast({"$not": {"source_name": "linear"}}))
+    assert sql.startswith("(not (")
+    assert "coalesce(c.source_name = $f_0, false)" in sql
+
+
+def test_nested_and_or_structure() -> None:
+    sql = _cypher_norm(
+        _ast(
+            {
+                "source_name": "linear",
+                "$or": [{"source_type": "slack"}, {"content_type": "text/plain"}],
+            }
+        )
+    )
+    assert " and " in sql
+    assert " or " in sql
+
+
+def test_composition_binds_are_distinct_per_clause() -> None:
+    # Each leaf allocates a fresh monotonic bind name, so two clauses on different
+    # keys never collide — three keys → $f_0, $f_1, $f_2.
+    compiled = compile_cypher(
+        _ast(
+            {
+                "source_name": "linear",
+                "$or": [{"source_type": "slack"}, {"content_type": "text/plain"}],
+            }
+        ),
+        _CTX,
+    )
+    assert set(compiled.params) == {"f_0", "f_1", "f_2"}
+    assert set(compiled.params.values()) == {"linear", "slack", "text/plain"}
+
+
+# ===========================================================================
+# Metadata predicates — NOT pushed down (serialized-JSON-string property).
+# ===========================================================================
+
+
+def test_metadata_leaf_raises_in_raise_mode() -> None:
+    # Neo4j stores metadata as a serialized JSON string, not a nested map, so a
+    # metadata sub-path cannot be expressed in Cypher. In the default "raise" mode
+    # the compiler raises the public unsupported error.
+    from khora.filter import RecallFilterUnsupportedError
+
+    with pytest.raises(RecallFilterUnsupportedError):
+        compile_cypher(_ast({"metadata.tier": "gold"}), _CTX)
+
+
+def test_metadata_leaf_splits_to_nonconstraining_true() -> None:
+    # In "split" mode the engine post-filters what the backend cannot express, so
+    # the compiler emits a non-constraining predicate, binds nothing, and leaves
+    # the key OUT of consumed_keys. A lone metadata leaf normalizes to AND([leaf]),
+    # so the single-clause filter renders as the wrapped "(true)".
+    ctx = CompileContext(backend_target="Chunk", on_unsupported="split")
+    compiled = compile_cypher(_ast({"metadata.tier": "gold"}), ctx)
+    assert _norm(compiled.predicate) == "(true)"
+    assert compiled.params == {}
+    assert "metadata.tier" not in compiled.consumed_keys
+
+
+def test_bare_metadata_blob_splits_to_nonconstraining_true() -> None:
+    # The bare metadata blob ($eq whole-document) is equally not pushdownable.
+    ctx = CompileContext(backend_target="Chunk", on_unsupported="split")
+    compiled = compile_cypher(_ast({"metadata": {"a": 1}}), ctx)
+    assert _norm(compiled.predicate) == "(true)"
+    assert compiled.consumed_keys == frozenset()
+
+
+# ===========================================================================
+# on_unsupported policy on a structurally-unknown key (neither system nor metadata).
+# ===========================================================================
+
+
+def _unknown_key_node() -> FilterNode:
+    # A leaf whose path is neither a system key nor a metadata path — the only
+    # clause this backend cannot express (should not occur post-validation).
+    return FilterNode(op=Op.AND, children=(FilterClause(path=("not_a_key",), op=Op.EQ, operand="x"),))
+
+
+def test_unsupported_clause_raises_in_raise_mode() -> None:
+    from khora.filter import RecallFilterUnsupportedError
+
+    ctx = CompileContext(backend_target="Chunk", on_unsupported="raise")
+    with pytest.raises(RecallFilterUnsupportedError):
+        compile_cypher(_unknown_key_node(), ctx)
+
+
+def test_unsupported_clause_splits_to_nonconstraining_true() -> None:
+    ctx = CompileContext(backend_target="Chunk", on_unsupported="split")
+    compiled = compile_cypher(_unknown_key_node(), ctx)
+    assert _norm(compiled.predicate) == "(true)"
+    assert "not_a_key" not in compiled.consumed_keys
+
+
+# ===========================================================================
+# CompiledFilter envelope — consumed_keys / canonical_hash / params.
+# ===========================================================================
+
+
+def test_compiled_filter_carries_canonical_hash() -> None:
+    node = _ast({"source_name": "linear"})
+    compiled = compile_cypher(node, _CTX)
+    from khora.filter.ast import canonical_hash
+
+    assert compiled.canonical_hash == canonical_hash(node)
+
+
+def test_compiled_filter_consumed_keys_is_frozenset() -> None:
+    compiled = compile_cypher(_ast({"source_name": "linear"}), _CTX)
+    assert isinstance(compiled.consumed_keys, frozenset)
+    assert "source_name" in compiled.consumed_keys
+
+
+def test_empty_filter_consumes_nothing() -> None:
+    compiled = compile_cypher(_ast({}), _CTX)
+    assert compiled.consumed_keys == frozenset()
+
+
+# ===========================================================================
+# field_mapping / table_alias / param_namespace — one compiler, many schemas.
+# ===========================================================================
+
+
+def test_field_mapping_remaps_system_property_name() -> None:
+    # CompileContext.field_mapping lets the same compiler serve a different schema
+    # (a property under a different name) without any per-engine `if engine == ...`
+    # branching.
+    ctx = CompileContext(
+        backend_target="Chunk",
+        field_mapping={"source_name": "src"},
+    )
+    assert "coalesce(c.src = $f_0, false)" in _cypher_norm(_ast({"source_name": "linear"}), ctx)
+
+
+def test_table_alias_qualifies_node_variable() -> None:
+    # The node variable defaults to "c"; table_alias overrides it.
+    ctx = CompileContext(backend_target="Chunk", table_alias="n")
+    assert "coalesce(n.source_name = $f_0, false)" in _cypher_norm(_ast({"source_name": "linear"}), ctx)
+
+
+def test_table_alias_and_field_mapping_compose() -> None:
+    ctx = CompileContext(
+        backend_target="Chunk",
+        table_alias="ch",
+        field_mapping={"source_name": "src"},
+    )
+    assert "coalesce(ch.src = $f_0, false)" in _cypher_norm(_ast({"source_name": "x"}), ctx)
+
+
+def test_param_namespace_prefixes_bind_names() -> None:
+    # param_namespace prefixes every bind name so compiled params cannot collide
+    # with the engine's own query parameters.
+    ctx = CompileContext(backend_target="Chunk", param_namespace="p")
+    compiled = compile_cypher(_ast({"source_name": "linear"}), ctx)
+    assert "$p_0" in compiled.predicate
+    assert compiled.params == {"p_0": "linear"}


### PR DESCRIPTION
## Summary
- Add `compile_cypher(ast, ctx)` — the Layer-4 backend compiler that lowers a canonical recall-filter AST to a Cypher `WHERE` fragment against a recall `Chunk` node, mirroring the existing Postgres compiler in structure and contract.
- **System-key pushdown:** the date keys and the eight projected document keys compile to first-class node-property predicates. `datetime` operands bind as ISO-8601 strings to match the chunk node's stored representation, so comparisons are lexicographic (ISO-8601 string order == chronological order for the UTC-normalized values the validator produces).
- **Mongo-faithful negation guard:** `$ne` / `$nin` emit `(prop IS NULL OR prop <> $v)` / `(prop IS NULL OR NOT prop IN $vs)` so a node missing the property is **included** (a naive `<>` evaluates to null and silently excludes it). `$eq` / range / `$in` are built total via `coalesce(..., false)` so a wrapping `NOT` flips absent rows correctly. `$exists` and null matches use `IS [NOT] NULL` (an absent node property is null).
- **Metadata routing:** metadata predicates are not pushed down (the graph backend stores metadata as a serialized JSON string). They honor the `on_unsupported` policy — `raise`, or `split` which emits a non-constraining placeholder and omits the leaf from `consumed_keys` so the engine can over-fetch and post-filter. `consumed_keys` reports exactly the pushed-down system keys.
- Add a focused unit-test module covering every operator, null-guard polarity, totality under negation, ISO-string date binding, exact-array vs membership handling, empty-list guards, `consumed_keys` reporting, context customization (node variable / field mapping / param namespace), and the raise/split unsupported paths.
- Scope is surgical: one new compiler module + its tests. No engine, registry, or protocol wiring (that is handled separately).

## Test plan
- [x] Unit tests pass (`uv run pytest tests/unit/filter/ tests/recall/ -q` → all green; 39 new tests for the compiler)
- [x] Lint/format/typecheck clean (`ruff check`, `ruff format --check`, `ty check`)
- [ ] Integration tests pass (CI, with the full backend environment)
- [x] Manual verification: empirically compiled representative ASTs (every operator, AND/OR/NOT composition, metadata raise/split) and confirmed the emitted Cypher + bind params