### PR TITLE
Report honest filter pushdown status in recall engine_info

### DIFF
--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -642,6 +642,34 @@ class SkeletonConstructionEngine:
                 )
             )
 
+        engine_info: dict[str, Any] = {
+            "engine": "skeleton",
+            "backend": self._backend_type,
+            "hybrid_alpha": hybrid_alpha,
+            "temporal_filter": str(temporal_filter) if temporal_filter else None,
+        }
+        # Report honest filter pushdown. The pgvector compiler runs in
+        # on_unsupported="raise" mode, which is all-or-nothing: an unsupported
+        # leaf raises RecallFilterUnsupportedError before recall returns, so a
+        # recall that returns WITH a filter_ast on pgvector means every leaf was
+        # consumed (consumed_keys == all leaves) = fully pushed down. We derive
+        # the flag from that contract without recompiling. When split-mode
+        # (partial pushdown) lands, read CompiledFilter.consumed_keys and
+        # compare against the AST leaves instead.
+        #
+        # A constraint-free filter (the empty-AND root that ``filter={}`` /
+        # ``RecallFilter()`` normalizes to) carries zero leaves, so "all leaves
+        # consumed" is vacuous - nothing was pushed down. We report False for it,
+        # matching the no-filter case rather than claiming a pushdown that did
+        # not narrow anything. ``filter_ast.children`` is the "has constraints"
+        # check (the root is always an AND ``FilterNode``).
+        #
+        # The carrier is written on every recall (the no-filter case lands here
+        # too, with ``filter_ast is None`` -> False); only the boolean varies.
+        engine_info["filter"] = {
+            "pushed_down": filter_ast is not None and bool(filter_ast.children) and self._backend_type == "pgvector"
+        }
+
         return RecallResult(
             query=query,
             namespace_id=namespace_id,
@@ -649,12 +677,7 @@ class SkeletonConstructionEngine:
             chunks=recall_chunks,
             entities=[],  # Skeleton engine focuses on chunks, not entities
             relationships=[],
-            engine_info={
-                "engine": "skeleton",
-                "backend": self._backend_type,
-                "hybrid_alpha": hybrid_alpha,
-                "temporal_filter": str(temporal_filter) if temporal_filter else None,
-            },
+            engine_info=engine_info,
         )
 
     def _build_temporal_filter_from_dict(self, filters: dict[str, Any]) -> TemporalFilter:

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -2127,16 +2127,20 @@ class Khora:
                 # per-chunk entity linkage, and emit a new RecallResult.
                 result = await self._upgrade_recall_documents(result, namespace_id)
 
-                # Record an honest filter-handling summary on every call. No
-                # engine pushes filters down in this revision, so ``pushed_down``
-                # is always False; ``supported`` is True only for the skeleton
-                # engine (the planned pushdown target). The engine name prefers
-                # whatever the engine already reported.
+                # Record an honest filter-handling summary on every call.
+                # ``pushed_down`` is engine-reported: the skeleton-pgvector path
+                # compiles ``filter_ast`` into SQL and stamps the result on
+                # ``engine_info["filter"]["pushed_down"]``; engines that do not
+                # push filters down leave it absent, so we default to False.
+                # ``supported`` is True only for the skeleton engine (the
+                # pushdown target). The engine name prefers whatever the engine
+                # already reported.
                 _engine_name = (result.engine_info or {}).get("engine", self._engine_name)
+                _pushed_down = (result.engine_info or {}).get("filter", {}).get("pushed_down", False)
                 _filter_info = {
                     "engine": _engine_name,
                     "supported": _engine_name == "skeleton",
-                    "pushed_down": False,
+                    "pushed_down": _pushed_down,
                 }
                 result = replace(result, engine_info={**(result.engine_info or {}), "filter": _filter_info})
 

--- a/tests/recall/test_filter_skeleton_pgvector.py
+++ b/tests/recall/test_filter_skeleton_pgvector.py
@@ -353,22 +353,17 @@ async def test_no_filter_returns_all_chunks(kb: Khora) -> None:
 
 
 async def test_engine_info_reports_skeleton_filter_row(kb: Khora) -> None:
-    """``engine_info['filter']`` carries the skeleton support row, and the
-    filtered row-set is correct.
+    """``engine_info['filter']`` carries the skeleton support row with HONEST
+    ``pushed_down=True``, and the filtered row-set is correct.
 
-    What this pins is the *carrier contract*: ``engine_info['filter']`` is
-    present on a filtered recall and reports ``engine="skeleton"`` /
-    ``supported=True``, alongside a ``pushed_down`` flag. The assertion that
+    What this pins is the *carrier contract* with honest pushdown reporting:
+    ``engine_info['filter']`` is present on a filtered recall and
+    reports ``engine="skeleton"`` / ``supported=True`` / ``pushed_down=True``.
+    The skeleton-pgvector backend compiles the whole filter to a SQL WHERE
+    predicate, so the pushdown is genuine — the facade surfaces the
+    engine-reported flag rather than hardcoding ``False``. The assertion that
     actually matters — that the filter narrows to exactly the in-scope rows — is
     re-checked here too.
-
-    NOTE on ``pushed_down``: this test deliberately does NOT pin the flag's
-    value. Filtering is provably effective end-to-end
-    (test_filter_returns_exactly_in_scope_chunks proves it), but the as-built
-    carrier still reports ``pushed_down=False`` (khora.py:2136-2141); honest
-    per-engine pushdown reporting is a follow-up. Asserting only that the key is
-    present — not its value — means that follow-up can flip it to honest
-    reporting without having to come back and edit this interim test.
     """
     ns = await kb.create_namespace()
     namespace_id: UUID = ns.namespace_id
@@ -382,18 +377,75 @@ async def test_engine_info_reports_skeleton_filter_row(kb: Khora) -> None:
         filter=_RECALL_FILTER,
     )
 
-    # Carrier present with the stable skeleton support row. ``pushed_down`` must
-    # be present (carrier shape) but its value is intentionally not pinned — see
-    # the note above (a follow-up corrects it to honest reporting).
+    # Carrier present with the stable skeleton support row. The full filter is
+    # compiled to a khora_chunks WHERE predicate, so ``pushed_down`` is honestly
+    # True for the skeleton-pgvector path.
     info = (result.engine_info or {}).get("filter")
     assert info is not None, "engine_info['filter'] carrier must be present on a filtered recall"
     assert info["engine"] == "skeleton"
     assert info["supported"] is True
-    assert "pushed_down" in info
+    assert info["pushed_down"] is True
 
     # The assertion that actually matters: the filter narrows to exactly the
     # in-scope rows (same contract as S1, re-pinned alongside the carrier).
     assert {c.id for c in result.chunks} == _ids_for(chunk_ids, _IN_SCOPE)
+
+
+async def test_engine_info_no_filter_reports_pushed_down_false(kb: Khora) -> None:
+    """A no-filter recall reports ``pushed_down=False`` on the live lake.
+
+    Pushdown is reported honestly per call. With no ``filter=`` there
+    is nothing to push down, so the carrier — still present on every recall —
+    reports ``pushed_down=False`` even on the skeleton-pgvector path that DOES
+    push filters down when one is supplied.
+    """
+    ns = await kb.create_namespace()
+    namespace_id: UUID = ns.namespace_id
+    await _seed(kb, namespace_id)
+
+    result = await kb.recall(
+        "alpha bravo charlie",
+        namespace=namespace_id,
+        limit=20,
+        mode=SearchMode.VECTOR,
+    )
+
+    info = (result.engine_info or {}).get("filter")
+    assert info is not None, "engine_info['filter'] carrier must be present even with no filter"
+    assert info["engine"] == "skeleton"
+    assert info["pushed_down"] is False
+
+
+async def test_engine_info_bare_filter_reports_pushed_down_false(kb: Khora) -> None:
+    """A bare ``filter={}`` reports ``pushed_down=False`` on the live lake.
+
+    Edge case: ``{}`` is a non-None match-everything AST (so it reaches
+    the engine), but it carries zero predicates and narrows nothing. The live
+    skeleton-pgvector derivation requires the filter to actually have
+    constraints (``bool(filter_ast.children)``), so a constraint-free filter
+    honestly reports ``pushed_down=False`` — no pushdown bit, nothing to claim.
+    The unfiltered row-set is returned (same as the control), confirming the
+    bare filter does not narrow.
+    """
+    ns = await kb.create_namespace()
+    namespace_id: UUID = ns.namespace_id
+    chunk_ids = await _seed(kb, namespace_id)
+
+    result = await kb.recall(
+        "alpha bravo charlie",
+        namespace=namespace_id,
+        limit=20,
+        mode=SearchMode.VECTOR,
+        filter={},
+    )
+
+    info = (result.engine_info or {}).get("filter")
+    assert info is not None, "engine_info['filter'] carrier must be present on a bare-filter recall"
+    assert info["engine"] == "skeleton"
+    assert info["pushed_down"] is False, "a constraint-free filter narrows nothing → not pushed down"
+
+    # The bare filter matches everything, so the full corpus comes back.
+    assert {c.id for c in result.chunks} == set(chunk_ids.values())
 
 
 async def test_invalid_filter_raises_validation_error(kb: Khora) -> None:

--- a/tests/unit/test_khora.py
+++ b/tests/unit/test_khora.py
@@ -971,9 +971,30 @@ class TestRecallFilterKwarg:
 
         kb._engine.recall.assert_not_awaited()
 
+    @staticmethod
+    def _mock_result_with_engine_info(ns_id: object, engine_info: dict[str, object]) -> RecallResult:
+        """A ``_mock_result`` whose ``engine_info`` is pre-populated by the engine.
+
+        The facade reads the engine-reported ``engine_info["filter"]["pushed_down"]``
+        and surfaces it; this helper lets a facade test stage that engine report.
+        """
+        return RecallResult(
+            query="q",
+            namespace_id=ns_id,  # type: ignore[arg-type]
+            documents=[],
+            chunks=[],
+            entities=[],
+            relationships=[],
+            engine_info=engine_info,  # type: ignore[arg-type]
+        )
+
     @pytest.mark.asyncio
     async def test_engine_info_filter_present_with_filter(self) -> None:
-        """engine_info['filter'] is populated on the result when filter= is passed."""
+        """engine_info['filter'] is populated on the result when filter= is passed.
+
+        The default vectorcypher engine reports no pushdown, so the facade
+        surfaces ``pushed_down=False``.
+        """
         kb = _make_kb(connected=True)
         ns_id = uuid4()
         kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
@@ -985,6 +1006,96 @@ class TestRecallFilterKwarg:
         assert info["engine"] == "vectorcypher"
         assert info["pushed_down"] is False
         assert info["supported"] is False
+
+    @pytest.mark.asyncio
+    async def test_engine_info_surfaces_engine_reported_pushdown(self) -> None:
+        """The facade SURFACES an engine-reported pushdown.
+
+        When the engine already reports
+        ``engine_info["filter"]["pushed_down"] = True`` (the skeleton-pgvector
+        path reports this from its engine-level derivation), the facade must carry
+        that honest value through to the final result rather than hardcoding
+        ``False``.
+        """
+        kb = _make_kb(connected=True)
+        kb._engine_name = "skeleton"
+        ns_id = uuid4()
+        kb._engine.recall = AsyncMock(
+            return_value=self._mock_result_with_engine_info(
+                ns_id,
+                {"engine": "skeleton", "backend": "pgvector", "filter": {"pushed_down": True}},
+            )
+        )
+
+        result = await self._async_recall(kb, "q", namespace=ns_id, filter={"source_name": "linear"})
+
+        info = result.engine_info.get("filter")
+        assert info is not None
+        assert info["engine"] == "skeleton"
+        assert info["supported"] is True
+        assert info["pushed_down"] is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "engine_info",
+        [
+            # No "filter" key at all (e.g. an engine that never writes one).
+            {"engine": "skeleton", "backend": "lance"},
+            # A non-pgvector skeleton backend that accept-and-ignores the AST
+            # writes filter={"pushed_down": False} — the shape the live engine
+            # actually emits when the filter is not pushed into SQL.
+            {"engine": "skeleton", "backend": "lance", "filter": {"pushed_down": False}},
+        ],
+        ids=["filter-key-absent", "filter-pushed-down-false"],
+    )
+    async def test_engine_info_defaults_pushdown_false_when_engine_silent(self, engine_info: dict[str, object]) -> None:
+        """The facade reports ``pushed_down=False`` when the engine does not push down.
+
+        False case: a skeleton recall whose engine_info carries no
+        pushdown signal (a non-pgvector skeleton backend that accept-and-ignores
+        the filter, or any engine that omits the key) surfaces
+        ``pushed_down=False`` — the facade never claims a pushdown the engine did
+        not report.
+        """
+        kb = _make_kb(connected=True)
+        kb._engine_name = "skeleton"
+        ns_id = uuid4()
+        kb._engine.recall = AsyncMock(return_value=self._mock_result_with_engine_info(ns_id, engine_info))
+
+        result = await self._async_recall(kb, "q", namespace=ns_id, filter={"source_name": "linear"})
+
+        info = result.engine_info.get("filter")
+        assert info is not None
+        assert info["engine"] == "skeleton"
+        assert info["pushed_down"] is False
+
+    @pytest.mark.asyncio
+    async def test_bare_empty_filter_reaches_engine_as_non_none_ast(self) -> None:
+        """A bare ``filter={}`` reaches the engine as a non-None empty-AND AST.
+
+        Edge case: ``{}`` is NOT short-circuited to "no filter" at the
+        facade — it lowers to a match-everything ``FilterNode(op=AND, children=())``
+        which the facade still threads to the engine as a non-None ``filter_ast``.
+        The engine reports ``pushed_down=False`` for this empty AST because it
+        carries no constraints/leaves (nothing to push) — consistent with the
+        no-filter case. The plumbing fact pinned here is that ``{}`` is not
+        short-circuited to ``None``; the engine-level empty→False derivation is
+        exercised on the live pg path in
+        ``tests/recall/test_filter_skeleton_pgvector.py``.
+        """
+        from khora.filter import FilterNode
+        from khora.filter.ast import Op
+
+        kb = _make_kb(connected=True)
+        ns_id = uuid4()
+        kb._engine.recall = AsyncMock(return_value=self._mock_result(ns_id))
+
+        await self._async_recall(kb, "q", namespace=ns_id, filter={})
+
+        filter_ast = kb._engine.recall.call_args.kwargs.get("filter_ast")
+        assert isinstance(filter_ast, FilterNode)
+        assert filter_ast.op == Op.AND
+        assert not filter_ast.children  # empty match-everything AND
 
     @pytest.mark.asyncio
     async def test_engine_info_filter_present_without_filter(self) -> None:
@@ -1015,7 +1126,12 @@ class TestRecallFilterKwarg:
 
     @pytest.mark.asyncio
     async def test_engine_info_filter_supported_for_skeleton(self) -> None:
-        """The skeleton engine is the planned pushdown target → supported=True (still not pushed down)."""
+        """The skeleton engine is the pushdown target → supported=True.
+
+        This mock engine reports no pushdown signal, so ``pushed_down`` defaults
+        to ``False`` (the live skeleton-pgvector pushdown is asserted True in
+        ``tests/recall/test_filter_skeleton_pgvector.py``).
+        """
         kb = _make_kb(connected=True)
         kb._engine_name = "skeleton"
         ns_id = uuid4()


### PR DESCRIPTION
## Summary
- `RecallResult.engine_info["filter"]["pushed_down"]` was hardcoded `False` on the live recall path, so a caller reading that contract field saw `False` even when the skeleton-pgvector backend had compiled the recall filter into a SQL `WHERE` predicate and fully pushed it down.
- The skeleton engine now reports `pushed_down` honestly: a constraint-bearing filter on the pgvector backend reports `True`; a no-filter recall, a constraint-free (empty) filter, and the accept-and-ignore non-pgvector backends report `False`. The value is derived from the pgvector compiler's all-or-nothing (`on_unsupported="raise"`) contract — a recall that returns with a compiled filter consumed every leaf — so no recompile happens on the hot path.
- The facade now surfaces the engine-reported value instead of hardcoding `False`, defaulting to `False` when an engine reports nothing, and the stale "no engine pushes filters down in this revision" comment is removed.

## Test plan
- [x] Unit tests pass (`make test-unit`): facade contract tests cover the `True` case, the engine-silent / non-pgvector default-`False` cases, and the bare empty-filter `False` case
- [ ] Integration tests pass: live skeleton-pgvector `True`/`False` pushdown assertions run in CI's Postgres matrix (self-skip locally without Postgres)
- [x] Manual verification: `engine_info["filter"]["pushed_down"]` is `True` for a constraint-bearing skeleton-pgvector filter and `False` for no-filter / empty-filter / non-pgvector backends