### PR TITLE
Project denormalized document keys onto Neo4j chunk nodes

### DIFF
--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -1046,6 +1046,18 @@
       "description": "Issue #904 (ADR-001). VectorCypher relationship-fetch silent fallback - incremented when the parallel rels_task raises and the retrieve path continues without relationships. The same event is also appended to RecallResult.engine_info['degradations']. Asymmetric prior art: _cypher_expand failure already sets engine_info['graph_fallback'] / 'graph_error'; this counter closes the rel-fetch gap. NO namespace_id label - cardinality rule. See docs/architecture/failure-observability-contract.md."
     },
     {
+      "name": "khora.vectorcypher.chunk_mirror.degraded_total",
+      "type": "counter",
+      "stability": "public",
+      "unit": "1",
+      "owner": "vectorcypher",
+      "labels": [
+        {"name": "channel", "values": ["graph"], "_comment": "Which mirror channel degraded; graph = Neo4j Chunk-node mirror."},
+        {"name": "reason", "values": ["neo4j_write_failed"], "_comment": "Low-cardinality enum; extend when adding new chunk-mirror fallback paths."}
+      ],
+      "description": "ADR-001. VectorCypher Neo4j chunk-mirror silent fallback - incremented when the create-path Chunk-node write to Neo4j raises and ingest continues with chunks persisted only in pgvector. The same event is also appended to RememberResult.metadata['degradations']. NO namespace_id label - cardinality rule. See docs/architecture/failure-observability-contract.md."
+    },
+    {
       "name": "khora.forget.cascade.degraded_total",
       "type": "counter",
       "stability": "public",

--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -1055,7 +1055,7 @@
         {"name": "channel", "values": ["graph"], "_comment": "Which mirror channel degraded; graph = Neo4j Chunk-node mirror."},
         {"name": "reason", "values": ["neo4j_write_failed"], "_comment": "Low-cardinality enum; extend when adding new chunk-mirror fallback paths."}
       ],
-      "description": "ADR-001. VectorCypher Neo4j chunk-mirror silent fallback - incremented when the create-path Chunk-node write to Neo4j raises and ingest continues with chunks persisted only in pgvector. The same event is also appended to RememberResult.metadata['degradations']. NO namespace_id label - cardinality rule. See docs/architecture/failure-observability-contract.md."
+      "description": "ADR-001. VectorCypher Neo4j chunk-mirror silent fallback - incremented when a Chunk-node mirror write to Neo4j raises (create, replace, or batch ingest path) and ingest continues with chunks persisted only in pgvector. The same event is also appended to RememberResult.metadata['degradations'] where a diagnostics sink exists. NO namespace_id label - cardinality rule. See docs/architecture/failure-observability-contract.md."
     },
     {
       "name": "khora.forget.cascade.degraded_total",

--- a/src/khora/engines/vectorcypher/dual_nodes.py
+++ b/src/khora/engines/vectorcypher/dual_nodes.py
@@ -148,6 +148,12 @@ class DualNodeManager:
             "CREATE INDEX chunk_source_system IF NOT EXISTS FOR (c:Chunk) ON (c.source_system)",
             "CREATE INDEX chunk_author IF NOT EXISTS FOR (c:Chunk) ON (c.author)",
             "CREATE INDEX chunk_channel IF NOT EXISTS FOR (c:Chunk) ON (c.channel)",
+            # Denormalized document-grained filter indexes for recall pushdown
+            "CREATE INDEX chunk_source_type IF NOT EXISTS FOR (c:Chunk) ON (c.source_type)",
+            "CREATE INDEX chunk_source_name IF NOT EXISTS FOR (c:Chunk) ON (c.source_name)",
+            "CREATE INDEX chunk_source_timestamp IF NOT EXISTS FOR (c:Chunk) ON (c.source_timestamp)",
+            "CREATE INDEX chunk_external_id IF NOT EXISTS FOR (c:Chunk) ON (c.external_id)",
+            "CREATE INDEX chunk_content_type IF NOT EXISTS FOR (c:Chunk) ON (c.content_type)",
             # TimeNode indexes for time hierarchy traversal
             "CREATE INDEX timenode_id IF NOT EXISTS FOR (t:TimeNode) ON (t.id)",
             "CREATE INDEX timenode_namespace IF NOT EXISTS FOR (t:TimeNode) ON (t.namespace_id)",
@@ -184,7 +190,15 @@ class DualNodeManager:
             channel: $channel,
             confidence: $confidence,
             metadata: $metadata,
-            chunker_info: $chunker_info
+            chunker_info: $chunker_info,
+            source_type: $source_type,
+            source_name: $source_name,
+            source_url: $source_url,
+            source_timestamp: $source_timestamp,
+            external_id: $external_id,
+            content_type: $content_type,
+            source: $source,
+            title: $title
         })
         RETURN c.id AS id
         """
@@ -202,6 +216,14 @@ class DualNodeManager:
             confidence=chunk.confidence,
             metadata=serialize_dict(chunk.metadata or {}),
             chunker_info=json.dumps(chunk.chunker_info or {}),
+            source_type=chunk.source_type,
+            source_name=chunk.source_name,
+            source_url=chunk.source_url,
+            source_timestamp=chunk.source_timestamp.isoformat() if chunk.source_timestamp else None,
+            external_id=chunk.external_id,
+            content_type=chunk.content_type,
+            source=chunk.source,
+            title=chunk.title,
         )
 
         async with self._session() as session:
@@ -254,6 +276,14 @@ class DualNodeManager:
                     "confidence": chunk.confidence,
                     "metadata": serialize_dict(chunk.metadata or {}),
                     "chunker_info": json.dumps(chunk.chunker_info or {}),
+                    "source_type": chunk.source_type,
+                    "source_name": chunk.source_name,
+                    "source_url": chunk.source_url,
+                    "source_timestamp": chunk.source_timestamp.isoformat() if chunk.source_timestamp else None,
+                    "external_id": chunk.external_id,
+                    "content_type": chunk.content_type,
+                    "source": chunk.source,
+                    "title": chunk.title,
                 }
             )
 
@@ -271,7 +301,15 @@ class DualNodeManager:
             channel: chunk.channel,
             confidence: chunk.confidence,
             metadata: chunk.metadata,
-            chunker_info: chunk.chunker_info
+            chunker_info: chunk.chunker_info,
+            source_type: chunk.source_type,
+            source_name: chunk.source_name,
+            source_url: chunk.source_url,
+            source_timestamp: chunk.source_timestamp,
+            external_id: chunk.external_id,
+            content_type: chunk.content_type,
+            source: chunk.source,
+            title: chunk.title
         })
         """
 

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -97,14 +97,57 @@ _CHUNK_MIRROR_DEGRADED_COUNTER = metric_counter(
     "khora.vectorcypher.chunk_mirror.degraded_total",
     unit="1",
     description=(
-        "VectorCypher Neo4j chunk-mirror silent fallback. Incremented when the "
-        "create-path Chunk-node write to Neo4j raises and ingest continues with "
-        "chunks persisted only in pgvector. The same event is also appended to "
-        "RememberResult.metadata['degradations']. Labels: channel (graph), "
-        "reason (neo4j_write_failed). NO namespace_id label - cardinality rule. "
+        "VectorCypher Neo4j chunk-mirror silent fallback. Incremented when a "
+        "Chunk-node mirror write to Neo4j raises (create, replace, or batch "
+        "ingest path) and ingest continues with chunks persisted only in "
+        "pgvector. The same event is also appended to "
+        "RememberResult.metadata['degradations'] where a diagnostics sink "
+        "exists. Labels: channel (graph), reason (neo4j_write_failed). NO "
+        "namespace_id label - cardinality rule. "
         "See docs/architecture/failure-observability-contract.md."
     ),
 )
+
+
+async def _mirror_chunks_or_degrade(
+    dual_nodes: DualNodeManager | None,
+    chunks: list[TemporalChunk],
+    namespace_id: UUID,
+    out_diagnostics: dict[str, Any] | None = None,
+) -> None:
+    """Mirror chunks to Neo4j, degrading instead of raising on failure (ADR-001).
+
+    Every VectorCypher "pgvector first, then mirror to Neo4j" create path routes
+    its ``:Chunk`` write through this helper so the fallback behavior and the
+    observability signal are uniform across the create, replace, and batch
+    ingest paths. The chunks are already durable in pgvector by the time this
+    runs, so a Neo4j mirror failure must not abort ingest: it is logged at
+    WARNING, the ``khora.vectorcypher.chunk_mirror.degraded_total`` counter is
+    incremented with ``{channel, reason}`` (no ``namespace_id`` - cardinality
+    rule), and - when an ``out_diagnostics`` dict is supplied - a ``Degradation``
+    is appended to ``out_diagnostics['degradations']`` so it surfaces on
+    ``RememberResult.metadata``. No-ops when ``dual_nodes`` is ``None`` (e.g. the
+    SurrealDB unified backend keeps chunks in its temporal store).
+    """
+    if dual_nodes is None:
+        return
+    try:
+        await dual_nodes.create_chunk_nodes_batch(chunks, namespace_id)
+    except Exception as exc:
+        logger.warning(
+            "Neo4j chunk-mirror write failed, continuing with chunks in pgvector only",
+            exc_info=True,
+        )
+        _CHUNK_MIRROR_DEGRADED_COUNTER.add(1, attributes={"channel": "graph", "reason": "neo4j_write_failed"})
+        if out_diagnostics is not None:
+            out_diagnostics.setdefault("degradations", []).append(
+                Degradation(
+                    component="vectorcypher.chunk_mirror",
+                    reason="neo4j_write_failed",
+                    detail=str(exc)[:200] or None,
+                    exception=type(exc).__name__,
+                )
+            )
 
 
 def _ensure_tags(value: Any) -> list[str]:
@@ -1137,30 +1180,11 @@ class VectorCypherEngine:
                     for i, stored in enumerate(stored_chunks):
                         temporal_chunks[i].id = stored.id
 
-                    # Create Chunk nodes in Neo4j (skipped for SurrealDB — chunks in temporal store).
-                    # The chunks are already durably stored in pgvector above, so a Neo4j
-                    # mirror failure must not abort ingest (ADR-001): record a Degradation,
-                    # increment the counter, and continue without the graph-side mirror.
-                    if dual_nodes is not None:
-                        try:
-                            await dual_nodes.create_chunk_nodes_batch(temporal_chunks, document.namespace_id)
-                        except Exception as exc:
-                            logger.warning(
-                                "Neo4j chunk-mirror write failed, continuing with chunks in pgvector only",
-                                exc_info=True,
-                            )
-                            _CHUNK_MIRROR_DEGRADED_COUNTER.add(
-                                1, attributes={"channel": "graph", "reason": "neo4j_write_failed"}
-                            )
-                            if out_diagnostics is not None:
-                                out_diagnostics.setdefault("degradations", []).append(
-                                    Degradation(
-                                        component="vectorcypher.chunk_mirror",
-                                        reason="neo4j_write_failed",
-                                        detail=str(exc)[:200] or None,
-                                        exception=type(exc).__name__,
-                                    )
-                                )
+                    # Mirror the chunks to Neo4j (skipped for SurrealDB — chunks in temporal
+                    # store). The chunks are already durable in pgvector above, so a Neo4j
+                    # mirror failure degrades (counter + Degradation) rather than aborting
+                    # ingest (ADR-001).
+                    await _mirror_chunks_or_degrade(dual_nodes, temporal_chunks, document.namespace_id, out_diagnostics)
 
                     # Skeleton-based entity extraction (for core chunks only)
                     if self._config.pipeline.extract_entities:
@@ -1778,6 +1802,10 @@ class VectorCypherEngine:
                 )
             )
 
+        # A mirror-only Neo4j failure degrades rather than failing the document;
+        # collect any such Degradation here to surface on the result metadata.
+        replace_diagnostics: dict[str, Any] = {}
+
         try:
             # Wipe old VectorCypher-owned state.
             await temporal_store.delete_chunks_by_document(existing.id, namespace_id)
@@ -1793,8 +1821,11 @@ class VectorCypherEngine:
                 for tc, stored, chunk in zip(new_temporal_chunks, stored_temporal, new_chunks):
                     tc.id = stored.id
                     chunk.id = stored.id
-                if dual_nodes is not None:
-                    await dual_nodes.create_chunk_nodes_batch(new_temporal_chunks, namespace_id)
+                # Mirror the new chunks to Neo4j. A mirror-only failure degrades
+                # (counter + Degradation) instead of marking the document FAILED —
+                # pgvector already holds the chunks and the coordinator's #884 path
+                # below handles any remaining graph divergence.
+                await _mirror_chunks_or_degrade(dual_nodes, new_temporal_chunks, namespace_id, replace_diagnostics)
         except Exception as e:
             # Self-heal: mark FAILED and re-raise unwrapped so the next
             # successful replace against the same external_id heals the row.
@@ -1859,7 +1890,8 @@ class VectorCypherEngine:
                             "reason": "graph_mirror_failed_after_pg_commit",
                             "exception": graph_mirror_err.original_exception_type,
                             "issue": "884",
-                        }
+                        },
+                        *replace_diagnostics.get("degradations", []),
                     ],
                 },
             )
@@ -1953,13 +1985,17 @@ class VectorCypherEngine:
             if rel_reset_rows:
                 await reset_rel_source_chunk_ids(namespace_id, rel_reset_rows)
 
+        replace_metadata: dict[str, Any] = {"replaced": True, "old_document_id": str(existing.id)}
+        mirror_degradations = replace_diagnostics.get("degradations")
+        if mirror_degradations:
+            replace_metadata["degradations"] = list(mirror_degradations)
         return RememberResult(
             document_id=replace_result.document_id,
             namespace_id=namespace_id,
             chunks_created=replace_result.chunks_created,
             entities_extracted=replace_result.entities_created + replace_result.entities_updated,
             relationships_created=replace_result.relationships_created,
-            metadata={"replaced": True, "old_document_id": str(existing.id)},
+            metadata=replace_metadata,
         )
 
     def _validate_recall_results(
@@ -2854,9 +2890,10 @@ class VectorCypherEngine:
             for i, s in enumerate(stored):
                 all_temporal_chunks[i].id = s.id
 
-            # Batch create Neo4j chunk nodes (skipped for SurrealDB)
-            if dual_nodes is not None:
-                await dual_nodes.create_chunk_nodes_batch(all_temporal_chunks, namespace_id)
+            # Mirror the batch's chunks to Neo4j (skipped for SurrealDB). Chunks are
+            # already durable in pgvector, so a mirror failure degrades (counter +
+            # WARNING) rather than aborting the batch (ADR-001).
+            await _mirror_chunks_or_degrade(dual_nodes, all_temporal_chunks, namespace_id)
 
             _stage3_ms += (_time.perf_counter() - _t0) * 1000
 

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -87,6 +87,25 @@ _VC_ABSTENTION_COMBINED_SCORE_HISTOGRAM = metric_histogram(
     description="VectorCypher abstention combined-score (0.0=confident, 1.0=should-abstain).",
 )
 
+# Chunk graph-mirror degradation counter (ADR-001). The create path mirrors
+# pgvector-stored chunks into Neo4j Chunk nodes; a Neo4j write failure must not
+# abort the document ingest now that pgvector already holds the chunks. On
+# failure we record a Degradation, increment this counter, and continue - the
+# graph is left without the chunk mirror for this window. NO namespace_id label
+# - cardinality rule.
+_CHUNK_MIRROR_DEGRADED_COUNTER = metric_counter(
+    "khora.vectorcypher.chunk_mirror.degraded_total",
+    unit="1",
+    description=(
+        "VectorCypher Neo4j chunk-mirror silent fallback. Incremented when the "
+        "create-path Chunk-node write to Neo4j raises and ingest continues with "
+        "chunks persisted only in pgvector. The same event is also appended to "
+        "RememberResult.metadata['degradations']. Labels: channel (graph), "
+        "reason (neo4j_write_failed). NO namespace_id label - cardinality rule. "
+        "See docs/architecture/failure-observability-contract.md."
+    ),
+)
+
 
 def _ensure_tags(value: Any) -> list[str]:
     """Coerce tags to a list — handles JSON strings from PostgreSQL metadata."""
@@ -1118,9 +1137,30 @@ class VectorCypherEngine:
                     for i, stored in enumerate(stored_chunks):
                         temporal_chunks[i].id = stored.id
 
-                    # Create Chunk nodes in Neo4j (skipped for SurrealDB — chunks in temporal store)
+                    # Create Chunk nodes in Neo4j (skipped for SurrealDB — chunks in temporal store).
+                    # The chunks are already durably stored in pgvector above, so a Neo4j
+                    # mirror failure must not abort ingest (ADR-001): record a Degradation,
+                    # increment the counter, and continue without the graph-side mirror.
                     if dual_nodes is not None:
-                        await dual_nodes.create_chunk_nodes_batch(temporal_chunks, document.namespace_id)
+                        try:
+                            await dual_nodes.create_chunk_nodes_batch(temporal_chunks, document.namespace_id)
+                        except Exception as exc:
+                            logger.warning(
+                                "Neo4j chunk-mirror write failed, continuing with chunks in pgvector only",
+                                exc_info=True,
+                            )
+                            _CHUNK_MIRROR_DEGRADED_COUNTER.add(
+                                1, attributes={"channel": "graph", "reason": "neo4j_write_failed"}
+                            )
+                            if out_diagnostics is not None:
+                                out_diagnostics.setdefault("degradations", []).append(
+                                    Degradation(
+                                        component="vectorcypher.chunk_mirror",
+                                        reason="neo4j_write_failed",
+                                        detail=str(exc)[:200] or None,
+                                        exception=type(exc).__name__,
+                                    )
+                                )
 
                     # Skeleton-based entity extraction (for core chunks only)
                     if self._config.pipeline.extract_entities:

--- a/tests/unit/engines/test_dual_nodes.py
+++ b/tests/unit/engines/test_dual_nodes.py
@@ -58,6 +58,45 @@ def _make_neo4j_driver() -> tuple[MagicMock, AsyncMock]:
     return driver, session
 
 
+def _make_capturing_driver() -> tuple[MagicMock, AsyncMock, MagicMock]:
+    """Driver whose ``execute_write`` runs the write closure against a real mock tx.
+
+    The default ``_make_neo4j_driver`` mocks ``execute_write`` so the inner
+    ``_work(tx)`` closure never runs — that proves the method completes, but it
+    cannot observe what params reach ``tx.run``. The create paths bind the chunk
+    properties as Cypher params, so to assert on those we must actually invoke
+    the closure. Here ``execute_write`` calls ``await work_fn(tx)`` with a mock
+    ``tx`` whose ``run`` is an AsyncMock; the caller inspects ``tx.run.call_args``.
+
+    Returns:
+        Tuple of (driver, session, tx). ``tx.run`` is the AsyncMock to inspect.
+    """
+    driver, session = _make_neo4j_driver()
+    tx = MagicMock()
+    tx.run = AsyncMock()
+
+    async def _run_work(work_fn):
+        return await work_fn(tx)
+
+    session.execute_write = AsyncMock(side_effect=_run_work)
+    return driver, session, tx
+
+
+# The eight denormalized document-grained keys projected onto the Neo4j Chunk
+# node. ``source_timestamp`` is datetime-typed and serialized as an
+# ISO string at write time; the other seven are plain string properties.
+_DENORM_STRING_KEYS = (
+    "source_type",
+    "source_name",
+    "source_url",
+    "external_id",
+    "content_type",
+    "source",
+    "title",
+)
+_DENORM_KEYS = (*_DENORM_STRING_KEYS, "source_timestamp")
+
+
 class TestChunkNode:
     """Tests for ChunkNode dataclass."""
 
@@ -178,6 +217,27 @@ class TestDualNodeManagerEnsureIndexes:
         assert session.run.call_count >= 9  # At least 9 indexes defined
 
     @pytest.mark.asyncio
+    async def test_ensure_indexes_creates_denorm_filter_indexes(self) -> None:
+        """The 5 new denorm-key filter indexes are issued.
+
+        Recall pushdown filters land on these Chunk properties, so each needs a
+        backing index. We assert one ``CREATE INDEX ... ON (c.<key>)`` statement
+        per new key reached ``session.run`` (matched loosely on the property
+        reference so an index-name rename doesn't break the test).
+        """
+        driver, session = _make_neo4j_driver()
+        session.run = AsyncMock()
+
+        manager = DualNodeManager(driver)
+        await manager.ensure_indexes()
+
+        issued = " || ".join(call.args[0] for call in session.run.call_args_list)
+        # source/title/source_url are filterable but were intentionally NOT
+        # indexed in this change — assert exactly the 5 the spec lists.
+        for key in ("source_type", "source_name", "source_timestamp", "external_id", "content_type"):
+            assert f"FOR (c:Chunk) ON (c.{key})" in issued, f"ensure_indexes missing CREATE INDEX on c.{key}"
+
+    @pytest.mark.asyncio
     async def test_ensure_indexes_handles_errors(self) -> None:
         """Test that index creation errors are handled gracefully."""
         driver, session = _make_neo4j_driver()
@@ -267,6 +327,123 @@ class TestDualNodeManagerBatchOperations:
         """Test batch creation with empty list."""
         ids = await manager.create_chunk_nodes_batch([], uuid4())
         assert ids == []
+
+
+@pytest.mark.unit
+class TestDualNodeManagerDenormProjection:
+    """The 8 denormalized document keys reach Neo4j on both create paths.
+
+    A recall filter on ``source_type`` / ``title`` / ... pushes down to a Cypher
+    property compare on the Chunk node (see test_compile_cypher), so the create
+    paths MUST actually persist those properties — otherwise the pushed-down
+    predicate always matches NULL. These tests run the write closure against a
+    capturing tx and assert every denorm key is present in the bound params, with
+    ``source_timestamp`` serialized as an ``.isoformat()`` string (the datetime is
+    not bindable as-is and the Cypher compiler compares it lexicographically).
+    """
+
+    @staticmethod
+    def _chunk(**overrides):
+        from khora.engines.skeleton.backends import TemporalChunk
+
+        base = dict(
+            id=uuid4(),
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="body",
+            occurred_at=datetime.now(UTC),
+            source_type="document",
+            source_name="linear",
+            source_url="https://example.test/x",
+            source_timestamp=datetime(2026, 2, 3, 4, 5, 6, tzinfo=UTC),
+            external_id="ext-42",
+            content_type="text/markdown",
+            source="slack",
+            title="Quarterly plan",
+        )
+        base.update(overrides)
+        return TemporalChunk(**base)
+
+    @pytest.mark.asyncio
+    async def test_create_chunk_node_binds_all_denorm_keys(self) -> None:
+        """Single-create binds all 8 denorm keys; source_timestamp is isoformat."""
+        driver, _session, tx = _make_capturing_driver()
+        manager = DualNodeManager(driver)
+        ts = datetime(2026, 2, 3, 4, 5, 6, tzinfo=UTC)
+        chunk = self._chunk(source_timestamp=ts)
+
+        await manager.create_chunk_node(chunk)
+
+        tx.run.assert_awaited_once()
+        params = tx.run.await_args.kwargs
+        # All 8 denorm keys reached the param dict — none silently dropped.
+        for key in _DENORM_KEYS:
+            assert key in params, f"create_chunk_node dropped denorm key {key!r}"
+        assert params["source_type"] == "document"
+        assert params["source_name"] == "linear"
+        assert params["source_url"] == "https://example.test/x"
+        assert params["external_id"] == "ext-42"
+        assert params["content_type"] == "text/markdown"
+        assert params["source"] == "slack"
+        assert params["title"] == "Quarterly plan"
+        # The one datetime-typed key binds as its ISO string, NOT a datetime.
+        assert params["source_timestamp"] == ts.isoformat()
+        assert isinstance(params["source_timestamp"], str)
+        # Cypher CREATE references each denorm property by name.
+        cypher = tx.run.await_args.args[0]
+        for key in _DENORM_KEYS:
+            assert f"{key}:" in cypher
+
+    @pytest.mark.asyncio
+    async def test_create_chunk_node_none_source_timestamp_binds_none(self) -> None:
+        """A None source_timestamp binds None (not a crash on .isoformat())."""
+        driver, _session, tx = _make_capturing_driver()
+        manager = DualNodeManager(driver)
+
+        await manager.create_chunk_node(self._chunk(source_timestamp=None))
+
+        params = tx.run.await_args.kwargs
+        assert params["source_timestamp"] is None
+
+    @pytest.mark.asyncio
+    async def test_create_chunk_nodes_batch_binds_all_denorm_keys(self) -> None:
+        """Batch-create stamps all 8 denorm keys on each UNWIND row."""
+        driver, _session, tx = _make_capturing_driver()
+        manager = DualNodeManager(driver)
+        ts = datetime(2026, 2, 3, 4, 5, 6, tzinfo=UTC)
+        ns = uuid4()
+        chunks = [self._chunk(source_timestamp=ts, title=f"doc {i}", external_id=f"ext-{i}") for i in range(3)]
+
+        await manager.create_chunk_nodes_batch(chunks, ns)
+
+        tx.run.assert_awaited_once()
+        # Batch passes the row dicts as the ``chunks`` kwarg to UNWIND.
+        rows = tx.run.await_args.kwargs["chunks"]
+        assert len(rows) == 3
+        for i, row in enumerate(rows):
+            for key in _DENORM_KEYS:
+                assert key in row, f"batch row {i} dropped denorm key {key!r}"
+            assert row["source_timestamp"] == ts.isoformat()
+            assert isinstance(row["source_timestamp"], str)
+            assert row["title"] == f"doc {i}"
+            assert row["external_id"] == f"ext-{i}"
+            assert row["source_type"] == "document"
+            assert row["content_type"] == "text/markdown"
+        # The UNWIND CREATE references each denorm property.
+        cypher = tx.run.await_args.args[0]
+        for key in _DENORM_KEYS:
+            assert f"{key}:" in cypher
+
+    @pytest.mark.asyncio
+    async def test_create_chunk_nodes_batch_none_source_timestamp_binds_none(self) -> None:
+        """Batch path also tolerates a None source_timestamp (no .isoformat())."""
+        driver, _session, tx = _make_capturing_driver()
+        manager = DualNodeManager(driver)
+
+        await manager.create_chunk_nodes_batch([self._chunk(source_timestamp=None)], uuid4())
+
+        row = tx.run.await_args.kwargs["chunks"][0]
+        assert row["source_timestamp"] is None
 
 
 @pytest.mark.unit

--- a/tests/unit/engines/test_vectorcypher_engine.py
+++ b/tests/unit/engines/test_vectorcypher_engine.py
@@ -2301,6 +2301,102 @@ class TestProcessDocumentWindowing:
         persisted_doc = engine._storage.update_document.await_args.args[0]
         assert persisted_doc.relationship_count == rels
 
+    @pytest.mark.asyncio
+    async def test_neo4j_chunk_mirror_failure_does_not_abort_ingest(self, engine: VectorCypherEngine) -> None:
+        """A Neo4j chunk-mirror write failure degrades, it does not propagate (ADR-001).
+
+        Chunks are already durably stored in pgvector before the Neo4j mirror, so
+        a graph-side write failure must NOT abort the document ingest. The create
+        path catches the exception, records a ``vectorcypher.chunk_mirror``
+        Degradation in ``out_diagnostics['degradations']``, and the document still
+        completes with its full chunk count.
+        """
+        engine._vc_config = VectorCypherConfig(max_chunks_in_flight=None)
+
+        raw_chunks = [self._make_raw_chunk(f"chunk {i}") for i in range(3)]
+        doc = MagicMock()
+        doc.id = uuid4()
+        doc.namespace_id = uuid4()
+        doc.content = "test content"
+        doc.metadata = {}
+
+        mock_chunker = MagicMock()
+        mock_chunker.chunk.return_value = raw_chunks
+        engine._embedder.embed_batch = AsyncMock(side_effect=lambda texts: [[0.1] * 1536] * len(texts))
+        engine._temporal_store.create_chunks_batch = AsyncMock(
+            side_effect=lambda chunks: [MagicMock(id=uuid4()) for _ in chunks]
+        )
+        # The graph mirror raises — the failure mode under test.
+        engine._dual_nodes.create_chunk_nodes_batch = AsyncMock(side_effect=RuntimeError("neo4j connection reset"))
+
+        out_diagnostics: dict[str, object] = {}
+        with (
+            patch("khora.extraction.chunkers.create_chunker", return_value=mock_chunker),
+            patch("khora.engines.vectorcypher.engine._CHUNK_MIRROR_DEGRADED_COUNTER") as mock_counter,
+        ):
+            total_chunks, _, _ = await engine._process_document(
+                doc,
+                skill_name="default",
+                occurred_at=datetime.now(UTC),
+                entity_types=[],
+                relationship_types=[],
+                out_diagnostics=out_diagnostics,
+            )
+
+        # The mirror was attempted and failed, but ingest still completed with the
+        # full chunk count from pgvector — the exception did NOT propagate.
+        engine._dual_nodes.create_chunk_nodes_batch.assert_awaited_once()
+        assert total_chunks == 3
+        engine._storage.update_document.assert_awaited()
+
+        # The degradation is recorded for downstream observability (ADR-001).
+        degradations = out_diagnostics.get("degradations", [])
+        chunk_mirror = [d for d in degradations if d.get("component") == "vectorcypher.chunk_mirror"]
+        assert len(chunk_mirror) == 1, f"expected one chunk_mirror degradation, got {degradations}"
+        entry = chunk_mirror[0]
+        assert entry["reason"] == "neo4j_write_failed"
+        assert entry["exception"] == "RuntimeError"
+        assert "neo4j connection reset" in (entry.get("detail") or "")
+
+        # The degraded_total counter is incremented with the bounded labels —
+        # this is part of the observable telemetry contract for the failure.
+        mock_counter.add.assert_called_once_with(1, attributes={"channel": "graph", "reason": "neo4j_write_failed"})
+
+    @pytest.mark.asyncio
+    async def test_neo4j_chunk_mirror_success_records_no_degradation(self, engine: VectorCypherEngine) -> None:
+        """Happy path: a successful mirror leaves no chunk_mirror degradation."""
+        engine._vc_config = VectorCypherConfig(max_chunks_in_flight=None)
+
+        raw_chunks = [self._make_raw_chunk("chunk 0")]
+        doc = MagicMock()
+        doc.id = uuid4()
+        doc.namespace_id = uuid4()
+        doc.content = "test content"
+        doc.metadata = {}
+
+        mock_chunker = MagicMock()
+        mock_chunker.chunk.return_value = raw_chunks
+        engine._embedder.embed_batch = AsyncMock(side_effect=lambda texts: [[0.1] * 1536] * len(texts))
+        engine._temporal_store.create_chunks_batch = AsyncMock(
+            side_effect=lambda chunks: [MagicMock(id=uuid4()) for _ in chunks]
+        )
+        engine._dual_nodes.create_chunk_nodes_batch = AsyncMock(return_value=[uuid4()])
+
+        out_diagnostics: dict[str, object] = {}
+        with patch("khora.extraction.chunkers.create_chunker", return_value=mock_chunker):
+            total_chunks, _, _ = await engine._process_document(
+                doc,
+                skill_name="default",
+                occurred_at=datetime.now(UTC),
+                entity_types=[],
+                relationship_types=[],
+                out_diagnostics=out_diagnostics,
+            )
+
+        assert total_chunks == 1
+        degradations = out_diagnostics.get("degradations", [])
+        assert not [d for d in degradations if d.get("component") == "vectorcypher.chunk_mirror"]
+
 
 @pytest.mark.unit
 class TestVectorCypherEngineApiTemporalFilter:

--- a/tests/unit/engines/test_vectorcypher_engine.py
+++ b/tests/unit/engines/test_vectorcypher_engine.py
@@ -14,6 +14,7 @@ from khora.engines.vectorcypher.engine import (
     ExtractionQualityMetrics,
     VectorCypherConfig,
     VectorCypherEngine,
+    _mirror_chunks_or_degrade,
 )
 from khora.khora import RecallResult
 
@@ -2544,3 +2545,58 @@ class TestRerankingConfigReconcile:
         cfg = self._config()
         cfg.query.enable_reranking = False
         assert VectorCypherEngine(cfg)._vc_config.enable_reranking is False
+
+
+@pytest.mark.unit
+class TestMirrorChunksOrDegrade:
+    """The shared chunk-mirror helper used by the create, replace, and batch
+    ingest paths — uniform degrade-and-continue behavior + observability."""
+
+    @pytest.mark.asyncio
+    async def test_none_dual_nodes_is_noop(self) -> None:
+        """No graph backend (e.g. SurrealDB) → no-op: no counter, no degradation."""
+        out: dict = {}
+        with patch("khora.engines.vectorcypher.engine._CHUNK_MIRROR_DEGRADED_COUNTER") as counter:
+            await _mirror_chunks_or_degrade(None, [MagicMock()], uuid4(), out)
+        counter.add.assert_not_called()
+        assert out == {}
+
+    @pytest.mark.asyncio
+    async def test_success_records_nothing(self) -> None:
+        """A successful mirror write leaves no counter increment / degradation."""
+        dual = MagicMock()
+        dual.create_chunk_nodes_batch = AsyncMock(return_value=[uuid4()])
+        out: dict = {}
+        with patch("khora.engines.vectorcypher.engine._CHUNK_MIRROR_DEGRADED_COUNTER") as counter:
+            await _mirror_chunks_or_degrade(dual, [MagicMock()], uuid4(), out)
+        dual.create_chunk_nodes_batch.assert_awaited_once()
+        counter.add.assert_not_called()
+        assert out == {}
+
+    @pytest.mark.asyncio
+    async def test_failure_degrades_and_counts_without_raising(self) -> None:
+        """A mirror failure increments the counter, records a Degradation, and does NOT raise."""
+        dual = MagicMock()
+        dual.create_chunk_nodes_batch = AsyncMock(side_effect=RuntimeError("neo4j down"))
+        out: dict = {}
+        with patch("khora.engines.vectorcypher.engine._CHUNK_MIRROR_DEGRADED_COUNTER") as counter:
+            # Must not raise.
+            await _mirror_chunks_or_degrade(dual, [MagicMock(), MagicMock()], uuid4(), out)
+        counter.add.assert_called_once_with(1, attributes={"channel": "graph", "reason": "neo4j_write_failed"})
+        degradations = out["degradations"]
+        assert len(degradations) == 1
+        entry = degradations[0]
+        assert entry["component"] == "vectorcypher.chunk_mirror"
+        assert entry["reason"] == "neo4j_write_failed"
+        assert entry["exception"] == "RuntimeError"
+        assert "neo4j down" in (entry.get("detail") or "")
+
+    @pytest.mark.asyncio
+    async def test_failure_without_diagnostics_sink_still_counts(self) -> None:
+        """When no out_diagnostics is supplied (batch path), the counter still fires."""
+        dual = MagicMock()
+        dual.create_chunk_nodes_batch = AsyncMock(side_effect=RuntimeError("boom"))
+        with patch("khora.engines.vectorcypher.engine._CHUNK_MIRROR_DEGRADED_COUNTER") as counter:
+            # No diagnostics dict, must not raise.
+            await _mirror_chunks_or_degrade(dual, [MagicMock()], uuid4(), None)
+        counter.add.assert_called_once_with(1, attributes={"channel": "graph", "reason": "neo4j_write_failed"})

--- a/tests/unit/filter/test_compile_cypher.py
+++ b/tests/unit/filter/test_compile_cypher.py
@@ -124,6 +124,56 @@ def test_system_eq_on_string_key_with_ops_form() -> None:
     assert compiled.params == {"f_0": "slack"}
 
 
+# ===========================================================================
+# Pushdown guard — all 8 denormalized document keys lower to Cypher.
+# ===========================================================================
+#
+# The eight document-grained keys are projected onto the recall Chunk
+# node so a recall filter on any of them is pushed down to Cypher (not left to a
+# post-filter). SYSTEM_KEYS already contains all ten filterable keys, and the
+# compiler handles them generically via the system-key path — so this guard pins
+# the *contract* (each denorm key pushes down to a `c.<key>` property predicate
+# AND lands in consumed_keys), independent of which individual keys other tests
+# happen to exercise. It catches a regression that drops one of the eight from
+# SYSTEM_KEYS (it would then fall through to `_unsupported` and stop pushing
+# down) and locks the source_timestamp datetime → .isoformat() string binding.
+_DENORM_STRING_KEYS = (
+    "source_type",
+    "source_name",
+    "source_url",
+    "external_id",
+    "content_type",
+    "source",
+    "title",
+)
+
+
+@pytest.mark.parametrize("key", _DENORM_STRING_KEYS)
+def test_denorm_string_key_pushes_down(key: str) -> None:
+    # Each of the seven string-valued denorm keys compiles to a coalesced `=`
+    # property compare on the chunk node, binds the operand, and is reported in
+    # consumed_keys (engine applies no post-filter for a pushed-down key).
+    compiled = compile_cypher(_ast({key: "v"}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert f"coalesce(c.{key} = $f_0, false)" in sql
+    assert compiled.params == {"f_0": "v"}
+    assert key in compiled.consumed_keys
+    # A denorm key is a typed node property, never a serialized-metadata lookup.
+    assert "metadata" not in sql
+
+
+def test_denorm_source_timestamp_pushes_down_as_iso_string() -> None:
+    # source_timestamp is the one datetime-typed denorm key. It pushes down like
+    # the string keys but binds its operand as the UTC-normalized .isoformat()
+    # string (lexicographic compare), matching how dual_nodes serializes it at
+    # write time. Completes the 8-key set with the string-key guard above.
+    compiled = compile_cypher(_ast({"source_timestamp": "2026-02-03T00:00:00Z"}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "coalesce(c.source_timestamp = $f_0, false)" in sql
+    assert compiled.params["f_0"].startswith("2026-02-03")
+    assert "source_timestamp" in compiled.consumed_keys
+
+
 def test_system_gt_is_property_compare() -> None:
     # A system DATE key takes a plain ISO-8601 string operand (DateOps parses it to
     # a datetime); the operand binds as its .isoformat() string.

--- a/tests/unit/test_extraction_error_surfacing.py
+++ b/tests/unit/test_extraction_error_surfacing.py
@@ -193,6 +193,31 @@ class TestRememberResultExtractionMetadata:
         assert metadata["extraction_errors"] == 1
         assert metadata["degradations"] == degradations
 
+    def test_chunk_mirror_degradation_surfaces_without_extraction_errors(self) -> None:
+        """A chunk-mirror degradation alone (errors=0) still reaches metadata.
+
+        The Neo4j chunk-mirror failure appends a Degradation to
+        ``out_diagnostics['degradations']`` but is NOT an extraction error, so
+        ``extraction_errors`` stays 0. This guards that ``degradations`` surfaces
+        on ``RememberResult.metadata`` on its own — the existing failure test
+        always pairs degradations with a non-zero error count, which would mask a
+        regression that only emits ``degradations`` when ``extraction_errors``.
+        """
+        from khora.engines.vectorcypher.engine import _build_remember_metadata
+
+        degradations = [
+            {
+                "component": "vectorcypher.chunk_mirror",
+                "reason": "neo4j_write_failed",
+                "detail": "neo4j connection reset",
+                "exception": "RuntimeError",
+            }
+        ]
+        metadata = _build_remember_metadata({"extraction_errors": 0, "degradations": degradations})
+        assert metadata["degradations"] == degradations
+        # No extraction error occurred, so that key is absent (not 0).
+        assert "extraction_errors" not in metadata
+
     def test_none_or_empty_input_returns_empty(self) -> None:
         """Pre-fix callers that don't allocate a dict still get an empty payload."""
         from khora.engines.vectorcypher.engine import _build_remember_metadata


### PR DESCRIPTION
## Summary
- Project the eight denormalized document keys (`source_type`, `source_name`, `source_url`, `source_timestamp`, `external_id`, `content_type`, `source`, `title`) onto the Neo4j `Chunk` node at ingest — on both the single and batch create paths — so the Cypher recall-filter compiler can push them down as first-class node properties. `source_timestamp` is stored as an ISO-8601 string to match the compiler's lexicographic date comparison.
- Add five Neo4j filter indexes on the `Chunk` node covering `source_type`, `source_name`, `source_timestamp`, `external_id`, and `content_type`.
- Make the non-atomic create-path dual-write observable: when the Neo4j `Chunk`-node mirror write fails *after* the chunks are already committed to pgvector, record a failure-observability degradation, increment a new `khora.vectorcypher.chunk_mirror.degraded_total{channel,reason}` counter, and continue instead of aborting ingest. The chunk stays queryable on the pgvector/BM25 channel and the graph-side divergence is surfaced on `RememberResult.metadata['degradations']`.
- Update the telemetry contract with the new public counter.

## Test plan
- [x] Unit tests pass (`make test-unit`): denorm-key projection on both create paths (incl. `source_timestamp` ISO serialization), the five new indexes, the create-path degradation path (Neo4j write failure does not abort ingest; degradation recorded + counter emitted), Cypher pushdown of all eight keys with no `UnsupportedFilterError`, and telemetry-contract drift.
- [ ] Integration tests pass (CI — require Postgres/Neo4j via Docker)
- [x] Lint/format/typecheck clean (`make lint`, ruff-format, ty); pre-commit hooks green