### PR TITLE
Add Chronicle recall-filter compiler with date-bound pushdown and Python post-filter

### DIFF
--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -349,6 +349,104 @@ def _extract_temporal_bounds(temporal_filter: Any | None) -> tuple[datetime | No
     return _to_utc(start), _to_utc(end)
 
 
+def _intersect_lower(window: datetime | None, filter_bound: datetime | None) -> datetime | None:
+    """Intersect a lower bound with a filter's lower bound — narrow only.
+
+    Returns the LATER of the two (the tighter lower bound); ``None`` on either
+    side means unbounded below, so the other wins. The result is always >= the
+    incoming ``window`` lower bound — the filter can shrink the recency window
+    but never widen it. Both operands are coerced to tz-aware UTC so a zoneless
+    bound never raises against an aware one.
+    """
+    fb = _to_utc(filter_bound)
+    if fb is None:
+        return window
+    if window is None:
+        return fb
+    return max(window, fb)
+
+
+def _intersect_upper(window: datetime | None, filter_bound: datetime | None) -> datetime | None:
+    """Intersect an upper bound with a filter's upper bound — narrow only.
+
+    Returns the EARLIER of the two (the tighter upper bound); ``None`` on either
+    side means unbounded above, so the other wins. The result is always <= the
+    incoming ``window`` upper bound — narrow only, never widening.
+    """
+    fb = _to_utc(filter_bound)
+    if fb is None:
+        return window
+    if window is None:
+        return fb
+    return min(window, fb)
+
+
+# System keys the recall-filter post-filter reads off a chunk record. The eight
+# denormalized document keys live on the chunk's ``source_document`` projection
+# when present; ``DocumentSource`` only carries a subset (title / source /
+# source_type), so the rest resolve to absent on the legacy ``chunks`` path —
+# a documented limitation (positive predicates on them return empty there).
+_DOC_PROJECTION_KEYS: tuple[str, ...] = (
+    "source_type",
+    "source_name",
+    "source_url",
+    "external_id",
+    "content_type",
+    "source",
+    "title",
+)
+
+
+def _chunk_to_record(chunk: Chunk) -> dict[str, Any]:
+    """Map a :class:`Chunk` to the record dict the recall-filter post-filter reads.
+
+    The post-filter (``compile_python``) evaluates the full filter against this
+    record; ``compile_chronicle`` pushes the ``source_timestamp`` bound into the
+    recency window (its primary axis):
+
+    * ``occurred_at`` is the effective EVENT time ``COALESCE(occurred_at,
+      source_timestamp)`` — the chunk's real ``occurred_at`` column when carried
+      (sqlite_lance), recovered from ``source_timestamp`` when the literal field is
+      ``None`` (the legacy pgvector ``chunks`` DTO has no ``occurred_at`` column, so
+      the faithful event time there IS ``source_timestamp``). This recovery is why
+      an ``occurred_at`` filter does NOT false-empty on PG. Mirrors the engine's
+      ``RecallChunk.occurred_at`` surface derivation. ``occurred_at`` is enforced by
+      this post-filter, not pushed (it is the event-time axis, not the window axis).
+    * ``created_at`` and ``source_timestamp`` are the LITERAL column values (a
+      filter on those names is post-filtered against the real column).
+
+    The eight denormalized document keys are read off ``chunk.source_document``
+    when present (``DocumentSource`` carries only a subset; the rest stay absent,
+    so a positive predicate on them returns empty on the legacy path — documented
+    limitation, no faithful fallback exists). ``metadata`` is the chunk's own dict.
+    """
+    record: dict[str, Any] = {
+        # Effective event time = COALESCE(occurred_at, source_timestamp). occurred_at
+        # is conceptually PRESENT (it's the event time, == source_timestamp on the
+        # legacy path where the DTO leaves the literal field None); the adapter
+        # recovers it so an occurred_at filter does not false-empty. No created_at
+        # fallback — ingest time is not event time.
+        "occurred_at": chunk.occurred_at if chunk.occurred_at is not None else chunk.source_timestamp,
+        "created_at": chunk.created_at,
+        "source_timestamp": chunk.source_timestamp,
+        "metadata": chunk.metadata or {},
+    }
+    # Resolve each denorm doc key defensively: chunk attr → chunk.source_document
+    # attr → absent. The Chunk dataclass does not carry these today (they live on
+    # the source_document projection), but trying the chunk first is robust if a
+    # future DTO denormalizes them onto the chunk. A key found nowhere stays absent
+    # → compile_python's §4 missing-semantics → positive predicate empty
+    # (documented (v) limitation; no faithful fallback exists for these).
+    source_doc = chunk.source_document
+    for key in _DOC_PROJECTION_KEYS:
+        value = getattr(chunk, key, None)
+        if value is None and source_doc is not None:
+            value = getattr(source_doc, key, None)
+        if value is not None:
+            record[key] = value
+    return record
+
+
 def _temporal_proximity(
     referenced_date: datetime | None,
     start: datetime | None,
@@ -1484,8 +1582,12 @@ class ChronicleEngine:
             min_similarity: Minimum similarity threshold
             temporal_filter: Reserved for Phase 2 temporal filtering
             recency_bias: Override temporal decay weight (0.0-1.0)
-            filter_ast: Canonical recall-filter AST. Accepted for protocol
-                parity; Chronicle does not push filters down yet (ignored).
+            filter_ast: Canonical recall-filter AST. When supplied,
+                Chronicle pushes the conjunctive ``occurred_at`` / ``created_at``
+                date bounds into the recency window (narrow only) and post-filters
+                every retrieved chunk against the full filter — the eight
+                denormalized document keys and all metadata — before top-k. When
+                ``None``, the recency behavior is unchanged.
 
         Returns:
             RecallResult with fused and decay-scored chunks
@@ -1587,6 +1689,50 @@ class ChronicleEngine:
         # search_fulltext already pushdown COALESCE(source_timestamp,
         # created_at) when these are set; we just need to pass them in.
         created_after, created_before = _extract_temporal_bounds(temporal_filter)
+
+        # ── Deterministic recall filter ──────────────────────────────
+        # When a filter AST is supplied, compile it two ways:
+        #   1. compile_chronicle distills the conjunctive source_timestamp clauses
+        #      into a narrowing date-bound we intersect with the recency window
+        #      above (narrow only — max of lowers, min of uppers — never widening
+        #      it). Only source_timestamp pushes down: it is the window's own
+        #      primary axis COALESCE(source_timestamp, created_at), so the pushdown
+        #      is same-axis and superset-safe. occurred_at (the event-time axis)
+        #      and created_at (the window's fallback) are post-filter-only.
+        #   2. compile_python compiles the FULL AST to an in-memory predicate that
+        #      post-filters the retrieved chunk candidates (each mapped via
+        #      _chunk_to_record) — the safety net that enforces every predicate
+        #      (occurred_at as COALESCE(occurred_at, source_timestamp), created_at,
+        #      source_timestamp, the eight denormalized document keys, metadata)
+        #      against the field each record carries. Pushdown is only a
+        #      candidate-narrowing optimization on top.
+        # When filter_ast is None, both stay None and the recency behavior is
+        # unchanged.
+        post_filter: Callable[[Any], bool] | None = None
+        # Date keys the date-bound actually pushed into the recency window, for the
+        # honest engine_info["filter"] report below. Chronicle is partial-pushdown
+        # by design (only source_timestamp pushes down; the full filter is always
+        # enforced by the post-filter), so this is the source_timestamp subset, not the
+        # whole filter.
+        filter_pushed_keys: frozenset[str] = frozenset()
+        if filter_ast is not None:
+            from khora.filter import CompileContext
+            from khora.filter.compilers.chronicle import compile_chronicle
+            from khora.filter.compilers.python import compile_python
+
+            compiled_bound = compile_chronicle(
+                filter_ast,
+                CompileContext(backend_target="chunks", on_unsupported="split"),
+            )
+            date_bound = compiled_bound.predicate
+            filter_pushed_keys = compiled_bound.consumed_keys
+            created_after = _intersect_lower(created_after, date_bound.created_after)
+            created_before = _intersect_upper(created_before, date_bound.created_before)
+
+            post_filter = compile_python(
+                filter_ast,
+                CompileContext(backend_target="chunks", on_unsupported="split"),
+            ).predicate
 
         # ── Phase 1: Embed query + BM25 in parallel ───────────────────
         # BM25 needs only the query text (no embedding), so start it
@@ -1851,6 +1997,20 @@ class ChronicleEngine:
         )
         timings["cross_session_ms"] = (time.perf_counter() - start) * 1000
 
+        # ── Deterministic recall-filter post-filter ─────────────────────
+        # Applied ONCE here — AFTER cross-session expansion (which fetches
+        # entity-source chunks via get_chunks_batch that bypass the channel-level
+        # recency window) and BEFORE the final top-k trim — so the filter is the
+        # exact final narrowing force over EVERY candidate path. The date-bound
+        # was already pushed into the recency window for the channel reads above;
+        # this predicate covers the denormalized document keys + metadata
+        # Chronicle cannot push down, and re-checks the date bounds on
+        # window-bypassing expansion chunks.
+        if post_filter is not None:
+            start = time.perf_counter()
+            chunks_with_scores = [pair for pair in chunks_with_scores if post_filter(_chunk_to_record(pair[0]))]
+            timings["post_filter_ms"] = (time.perf_counter() - start) * 1000
+
         # Trim to requested limit
         chunks_with_scores = chunks_with_scores[:limit]
 
@@ -1993,6 +2153,19 @@ class ChronicleEngine:
                 "max_raw_vector_score": max_raw_cosine,
                 "abstention_signals": abstention_signals,
                 "timings": timings,
+                # Honest recall-filter pushdown report (mirrors the skeleton
+                # precedent #1022). Chronicle is partial-pushdown by design: only
+                # the source_timestamp date bound pushes into the recency window;
+                # the full filter (occurred_at / created_at / denorm doc keys /
+                # metadata) is always enforced by the in-memory post-filter. So we
+                # report both halves honestly rather than a single all-or-nothing
+                # flag. ``pushed_down`` is True only when a source_timestamp bound
+                # actually narrowed the window; ``post_filtered`` is True whenever a
+                # constraint-bearing filter was supplied (the post-filter ran).
+                "filter": {
+                    "pushed_down": bool(filter_pushed_keys),
+                    "post_filtered": filter_ast is not None and bool(filter_ast.children),
+                },
                 # ADR-001: callers can detect silent channel failures /
                 # fallbacks via this list. Empty when nothing degraded.
                 "degradations": degradations,
@@ -3153,3 +3326,15 @@ class ChronicleEngine:
             health["status"] = "degraded"
 
         return health
+
+
+# Register the deterministic recall-filter compiler for this engine/target at
+# import time (idempotent — same function object). The storage target is "chunks":
+# the filter attaches to the chunk read path, so "chunks" is the honest label.
+# Chronicle pushes down only the conjunctive source_timestamp date bound (the
+# recency window's primary stored axis); the engine post-filters the remainder via
+# compile_python. Mirrors the skeleton.pgvector registration site.
+from khora.filter import CompilerRegistry  # noqa: E402
+from khora.filter.compilers.chronicle import compile_chronicle  # noqa: E402
+
+CompilerRegistry.register("chronicle", "chunks", compile_chronicle)

--- a/src/khora/filter/compilers/__init__.py
+++ b/src/khora/filter/compilers/__init__.py
@@ -12,6 +12,13 @@ backend's query fragment. A compiler is a stateless
 
 from __future__ import annotations
 
+from khora.filter.compilers.chronicle import ChronicleDateBound, compile_chronicle
 from khora.filter.compilers.postgres import compile_postgres
+from khora.filter.compilers.python import compile_python
 
-__all__ = ["compile_postgres"]
+__all__ = [
+    "ChronicleDateBound",
+    "compile_chronicle",
+    "compile_postgres",
+    "compile_python",
+]

--- a/src/khora/filter/compilers/chronicle.py
+++ b/src/khora/filter/compilers/chronicle.py
@@ -217,10 +217,13 @@ def _consumable_date_clause(
 ) -> tuple[str, Op, datetime] | None:
     """Return ``(key, op, datetime)`` if ``node`` is a pushdownable date clause, else ``None``.
 
-    A pushdownable clause is a leaf on ``occurred_at`` / ``created_at`` with a
-    range op (``$gt``/``$gte``/``$lt``/``$lte``) or ``$eq`` and a datetime /
-    :class:`DateLiteral` operand. ``$ne`` / ``$in`` / ``$nin`` / ``{k: null}`` and
-    any logical sub-node return ``None`` (not a single contiguous window).
+    A pushdownable clause is a leaf on ``source_timestamp`` (the window's primary axis,
+    ``COALESCE(source_timestamp, created_at)``) with a range op (``$gt``/``$gte``/
+    ``$lt``/``$lte``) or ``$eq`` and a datetime / :class:`DateLiteral` operand.
+    ``occurred_at`` (event-time axis) and ``created_at`` (window's fallback, not
+    primary axis) are cross-dimensional and post-filtered instead. ``$ne`` / ``$in``
+    / ``$nin`` / ``{k: null}`` on any date key, and any logical sub-node, return
+    ``None`` (not a single contiguous window).
     """
     if not isinstance(node, FilterClause):
         return None

--- a/src/khora/filter/compilers/chronicle.py
+++ b/src/khora/filter/compilers/chronicle.py
@@ -1,0 +1,284 @@
+"""Chronicle recall-filter compiler — ``@internal``.
+
+Lowers a canonical :class:`~khora.filter.ast.FilterNode` to a narrowing
+**date-bound** the Chronicle engine intersects with its recency window. Chronicle
+has no general predicate-pushdown surface (its retrieval fans out across four
+channels through the storage coordinator), but every channel already honors a
+``created_after`` / ``created_before`` window that narrows on
+``COALESCE(source_timestamp, created_at)`` (pgvector + sqlite_lance alike) — the
+**source_timestamp axis** with a ``created_at`` fallback. The one key this
+compiler can push down same-axis-safely is a bound on ``source_timestamp``.
+Everything else is left **unconsumed** for the engine's
+:func:`~khora.filter.compilers.python.compile_python` post-filter (the full-AST
+safety net), so no constraint is ever silently dropped.
+
+The output is a :class:`~khora.filter.registry.CompiledFilter` whose
+``predicate`` is a :class:`ChronicleDateBound` (a small frozen ``(created_after,
+created_before)`` pair, either side ``None`` for unbounded) and whose
+``consumed_keys`` are exactly the date keys folded into that bound.
+
+**Why only ``source_timestamp`` pushes down (the same-axis rule).** The recency
+window column is ``COALESCE(source_timestamp, created_at)``. Pushing a bound on a
+different axis would apply it to the wrong timestamp and silently drop rows:
+
+* ``source_timestamp`` is the window's primary axis — for every row a
+  ``source_timestamp >= A`` filter keeps, ``source_timestamp`` is non-null and
+  equals the window value, so the pushdown agrees with the filter; a null-
+  ``source_timestamp`` row is admitted by the window's ``created_at`` fallback and
+  then dropped by the post-filter (superset-safe — the pushed set ⊇ the
+  post-filtered set, never the reverse). **Pushed down.**
+* ``occurred_at`` is the EVENT-time axis — ``record.occurred_at`` is
+  ``COALESCE(occurred_at, source_timestamp)`` (the chunk's real ``occurred_at``
+  when carried, else ``source_timestamp``; see the engine's ``_chunk_to_record``
+  and the matching ``RecallChunk.occurred_at`` surface derivation). That differs
+  from the window's ``COALESCE(source_timestamp, created_at)`` axis, so pushing it
+  would false-exclude. **Not pushed**; enforced by the post-filter against the
+  event-time value.
+* ``created_at`` == the literal ingest column. The window uses ``created_at`` only
+  as a *fallback*, so a ``created_at`` bound is cross-axis. **Not pushed**;
+  post-filtered against the literal ``created_at``.
+
+**Per-key support matrix (Chronicle chunk read path).**
+
+* ``source_timestamp`` — a *conjunctive* range / ``$eq`` clause folds into the
+  date-bound and is **consumed** (``$gt`` / ``$gte`` tighten ``created_after``;
+  ``$lt`` / ``$lte`` tighten ``created_before``; ``$eq`` pins both to a point
+  window). "Conjunctive" means the clause sits in the top-level ``AND``; under an
+  ``$or`` / ``$not`` it is **not** consumed (folding a bound out of a disjunction
+  / negation would wrongly narrow the other branch). ``$ne`` / ``$in`` / ``$nin``
+  / ``{k: null}`` are not a single contiguous window, so they are also left
+  unconsumed. In every unconsumed case the post-filter still enforces the
+  predicate against the literal ``source_timestamp``.
+* ``occurred_at`` — NOT pushed (event-time axis, distinct from the window);
+  post-filtered against ``record.occurred_at`` = ``COALESCE(occurred_at,
+  source_timestamp)`` (honors the real event time; matches ``RecallChunk``).
+* ``created_at`` — NOT pushed (cross-axis with the coalesced window); post-filtered
+  against the literal ``created_at`` field (carried on both backends → correct).
+* the eight denormalized document keys (``source_type`` / ``source_name`` /
+  ``source_url`` / ``external_id`` / ``content_type`` / ``source`` / ``title``)
+  — NOT pushed; left for the post-filter. Carried on the ``khora_chunks`` schema
+  but NOT on the legacy pgvector ``chunks`` DTO, so positive predicates on them
+  return empty on the legacy path (documented limitation — the ADR
+  population-caveat / no ``chunks`` migration in V3-a).
+* ``metadata.<path>`` — NOT pushed; post-filtered against the carried
+  ``chunk.metadata`` dict (carried on every backend → correct).
+
+This compiler raises :class:`RecallFilterUnsupportedError` only when
+``ctx.on_unsupported == "raise"`` and a clause is not a consumable date bound —
+the Chronicle engine always drives it with ``"split"``, so in practice nothing
+raises and the unconsumed remainder is handed to the post-filter.
+
+``@internal``. Reachable as ``khora.filter.compilers.chronicle.compile_chronicle``
+for khora's own engines; not re-exported from :mod:`khora.__init__`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from khora.filter import (
+    CompileContext,
+    CompiledFilter,
+    RecallFilterUnsupportedError,
+)
+from khora.filter.ast import (
+    DateLiteral,
+    FilterClause,
+    FilterNode,
+    canonical_hash,
+)
+from khora.filter.model import Op
+
+__all__ = ["ChronicleDateBound", "compile_chronicle"]
+
+
+# The ONLY date key that pushes down. The recency window narrows on
+# ``COALESCE(source_timestamp, created_at)`` — the source_timestamp axis with a
+# created_at fallback — so only a ``source_timestamp`` bound is same-axis-safe
+# (for every row a ``source_timestamp >= A`` filter keeps, source_timestamp is
+# non-null and equals the window value; null-source_timestamp rows are admitted
+# via the created_at fallback and then dropped by the post-filter — superset-safe,
+# never a false-exclude). ``occurred_at`` is the EVENT-time axis
+# (COALESCE(occurred_at, source_timestamp); see the engine's _chunk_to_record /
+# RecallChunk.occurred_at), a different dimension than the window, so it is NOT
+# pushed — it is enforced by the post-filter. ``created_at`` (the window's
+# fallback, not its primary axis) is likewise post-filter-only.
+_PUSHDOWN_DATE_KEYS: frozenset[str] = frozenset({"source_timestamp"})
+
+# Range ops that tighten the lower / upper bound of the window.
+_LOWER_OPS: frozenset[Op] = frozenset({Op.GT, Op.GTE})
+_UPPER_OPS: frozenset[Op] = frozenset({Op.LT, Op.LTE})
+
+
+@dataclass(frozen=True, slots=True)
+class ChronicleDateBound:
+    """A narrowing date window distilled from the consumed date-key clauses.
+
+    ``@internal``. ``created_after`` is the inclusive/exclusive lower bound and
+    ``created_before`` the upper bound (either ``None`` for unbounded on that
+    side). Both are tz-aware UTC datetimes (the AST's ``DateLiteral`` / system
+    datetime operands are UTC-normalized by the validator).
+
+    The engine intersects this with its existing recency window by taking the
+    ``max`` of the two lower bounds and the ``min`` of the two upper bounds
+    (narrow only — the filter can shrink the window but never widen it). The
+    bound is distilled ONLY from ``source_timestamp`` clauses, the window's
+    primary axis (``COALESCE(source_timestamp, created_at)``), so the pushdown is
+    same-axis and superset-safe: the pushed candidate set ⊇ the post-filtered set
+    (never the reverse) — no false-exclude. A null-``source_timestamp`` row is
+    admitted via the window's ``created_at`` fallback and then dropped by the
+    post-filter.
+
+    The boundary strictness of the range op (``$gt`` vs ``$gte``) is intentionally
+    NOT carried: the window narrows to the bound instant, and
+    :func:`compile_python` re-checks the exact strict/non-strict comparison on
+    every surviving candidate, so an off-by-one-instant row at the boundary is
+    dropped by the post-filter. This keeps the pushed-down window a safe
+    over-approximation (it never drops a row the filter would keep).
+    """
+
+    created_after: datetime | None = None
+    created_before: datetime | None = None
+
+
+def compile_chronicle(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[ChronicleDateBound]:
+    """Compile a canonical AST to a Chronicle :class:`ChronicleDateBound`.
+
+    ``ast`` is always a :class:`FilterNode` (the ``parse_to_ast`` root invariant).
+    Only conjunctive ``source_timestamp`` range / ``$eq`` clauses (the direct
+    children of the top-level ``AND``) fold into the bound and are added to
+    ``consumed_keys`` — ``source_timestamp`` is the recency window's primary axis
+    (``COALESCE(source_timestamp, created_at)``), so its pushdown is same-axis and
+    superset-safe. Every other key — ``occurred_at`` (event-time axis) /
+    ``created_at`` (the window's fallback), a ``source_timestamp`` clause under an
+    ``$or`` / ``$not``, the eight denormalized document keys, and all metadata —
+    is left unconsumed for the engine's :func:`compile_python` post-filter.
+    ``params`` is always empty (the bound carries the datetimes directly).
+
+    ``ctx.on_unsupported`` governs the unconsumed remainder: ``"split"`` (the
+    Chronicle engine's mode) omits it silently; ``"raise"`` raises
+    :class:`RecallFilterUnsupportedError` for the first non-consumable clause.
+    """
+    consumed: set[str] = set()
+    lower, upper = _fold_top_level_dates(ast, ctx, consumed)
+    return CompiledFilter(
+        predicate=ChronicleDateBound(created_after=lower, created_before=upper),
+        params={},
+        consumed_keys=frozenset(consumed),
+        canonical_hash=canonical_hash(ast),
+    )
+
+
+def _fold_top_level_dates(
+    ast: FilterNode,
+    ctx: CompileContext,
+    consumed: set[str],
+) -> tuple[datetime | None, datetime | None]:
+    """Fold the conjunctive date-key clauses into a ``(lower, upper)`` window.
+
+    Only the top-level ``AND`` conjunction is safe to push down (see
+    :class:`ChronicleDateBound`). A non-``AND`` root (a bare ``$or`` / ``$not``)
+    pushes nothing down; under ``"raise"`` mode it surfaces its first clause as
+    unsupported.
+    """
+    lower: datetime | None = None
+    upper: datetime | None = None
+
+    if ast.op != Op.AND:
+        # A bare $or / $not root is not a conjunction — nothing folds into the
+        # window. Honor on_unsupported for the (non-date or non-conjunctive)
+        # content the engine must post-filter.
+        _reject_if_raise(ast, ctx)
+        return lower, upper
+
+    for child in ast.children:
+        bound = _consumable_date_clause(child)
+        if bound is None:
+            # Not a consumable conjunctive date clause — leave it unconsumed for
+            # the post-filter (or raise under "raise" mode).
+            _reject_if_raise(child, ctx)
+            continue
+        key, op, value = bound
+        if op == Op.EQ:
+            lower = _max_lower(lower, value)
+            upper = _min_upper(upper, value)
+        elif op in _LOWER_OPS:
+            lower = _max_lower(lower, value)
+        else:  # op in _UPPER_OPS
+            upper = _min_upper(upper, value)
+        consumed.add(key)
+
+    return lower, upper
+
+
+def _consumable_date_clause(
+    node: FilterNode | FilterClause,
+) -> tuple[str, Op, datetime] | None:
+    """Return ``(key, op, datetime)`` if ``node`` is a pushdownable date clause, else ``None``.
+
+    A pushdownable clause is a leaf on ``occurred_at`` / ``created_at`` with a
+    range op (``$gt``/``$gte``/``$lt``/``$lte``) or ``$eq`` and a datetime /
+    :class:`DateLiteral` operand. ``$ne`` / ``$in`` / ``$nin`` / ``{k: null}`` and
+    any logical sub-node return ``None`` (not a single contiguous window).
+    """
+    if not isinstance(node, FilterClause):
+        return None
+    if len(node.path) != 1 or node.path[0] not in _PUSHDOWN_DATE_KEYS:
+        return None
+    if node.op != Op.EQ and node.op not in _LOWER_OPS and node.op not in _UPPER_OPS:
+        return None
+    value = _as_datetime(node.operand)
+    if value is None:
+        return None
+    return node.path[0], node.op, value
+
+
+def _as_datetime(operand: object) -> datetime | None:
+    """Coerce a date-clause operand to a datetime, or ``None`` if it is not one.
+
+    A bare ``$eq`` exact-array (tuple) operand, a ``None`` (``{k: null}``), or any
+    non-datetime value is not a window bound.
+    """
+    if isinstance(operand, DateLiteral):
+        return operand.value
+    if isinstance(operand, datetime):
+        return operand
+    return None
+
+
+def _max_lower(current: datetime | None, candidate: datetime) -> datetime:
+    """Tighten a lower bound: the later of the two (``None`` = unbounded below)."""
+    if current is None:
+        return candidate
+    return max(current, candidate)
+
+
+def _min_upper(current: datetime | None, candidate: datetime) -> datetime:
+    """Tighten an upper bound: the earlier of the two (``None`` = unbounded above)."""
+    if current is None:
+        return candidate
+    return min(current, candidate)
+
+
+def _reject_if_raise(node: FilterNode | FilterClause, ctx: CompileContext) -> None:
+    """Raise :class:`RecallFilterUnsupportedError` for unconsumed content under ``"raise"``.
+
+    A no-op under ``"split"`` (the Chronicle engine's mode) — the engine
+    post-filters the unconsumed remainder. Under ``"raise"`` it surfaces a
+    representative path so a caller that demanded full pushdown sees the gap.
+    """
+    if ctx.on_unsupported != "raise":
+        return
+    path = _representative_path(node)
+    raise RecallFilterUnsupportedError(
+        path,
+        "Chronicle pushes down only conjunctive source_timestamp date bounds; this clause must be post-filtered",
+    )
+
+
+def _representative_path(node: FilterNode | FilterClause) -> str:
+    """A human-readable path for an unsupported-error message (best-effort)."""
+    if isinstance(node, FilterClause):
+        return ".".join(node.path)
+    return f"${node.op.value.lstrip('$')}"

--- a/src/khora/filter/compilers/python.py
+++ b/src/khora/filter/compilers/python.py
@@ -1,0 +1,662 @@
+"""In-memory Python recall-filter predicate compiler — ``@internal``.
+
+Lowers a canonical :class:`~khora.filter.ast.FilterNode` to a pure
+``Callable[[Any], bool]`` that evaluates the *whole* filter against one
+in-memory record. The output is a :class:`~khora.filter.registry.CompiledFilter`
+whose ``predicate`` is that callable; the engine applies it to each retrieved
+candidate as a post-filter (the half of a deterministic recall filter a backend
+could not push down).
+
+It is the Python sibling of :func:`~khora.filter.compilers.postgres.compile_postgres`
+and is the **oracle** the SQL/Cypher compilers are checked against: it speaks the
+same four §4 emission rules, so a record that the predicate accepts is exactly a
+row the SQL ``WHERE`` would have returned.
+
+1. **Never abort.** A comparison against a wrong-typed or absent value evaluates
+   to ``False`` (a positive op) — never an exception. A ``$date`` operand that
+   fails to parse excludes the record rather than raising.
+2. **Polarity.** Negations include absent/null/wrong-type records: ``$ne`` /
+   ``$nin`` match a record missing the key or holding a wrong-typed value; a
+   ``$ne`` against a present, equal value is the only exclusion.
+3. **Impossible pairs (narrow).** An ``$eq`` exact-array (tuple) operand against
+   a scalar system value never matches (a scalar is not a list), so it excludes;
+   its ``$ne`` mirror includes. ``$in`` / ``$nin`` are normal membership.
+4. **Presence/null.** ``$exists`` and a ``{k: null}`` match distinguish absent
+   from present-null on a metadata path (``seg in d`` vs ``d.get(seg) is None``,
+   per segment). System keys are treated as always-present (their ``$exists`` is
+   trivially all/none), and a system value of ``None`` is the null-or-missing
+   case for ``{k: null}`` / ``$ne null``.
+
+**Record shape.** The predicate is deliberately defensive about the record it is
+handed, so one callable serves both a chronicle ``Chunk`` dataclass and a plain
+``dict`` event row. A system key is resolved by trying the record's own
+attribute, then its ``source_document`` projection's attribute, then mapping
+access — the first hit wins, and a key found nowhere is treated as a ``None``
+system value (the always-present-but-null case). The ``metadata`` blob is read
+the same way and coalesced to ``{}`` when absent or ``None``.
+
+**Per-key support matrix** (Python evaluates *every* key — there is no pushdown
+split here; the Chronicle compiler decides what it pushes down, and this
+predicate re-checks the whole AST):
+
+* ``occurred_at`` / ``created_at`` / ``source_timestamp`` — system datetime
+  compare (``$eq``/``$ne``/range/``$in``/``$nin``/``{k:null}``).
+* the eight denormalized document keys (``source_type`` / ``source_name`` /
+  ``source_url`` / ``external_id`` / ``content_type`` / ``source`` / ``title``)
+  — system scalar compare, resolved defensively (missing ⇒ ``None``).
+* ``metadata.<path>`` — scalar array-aware containment / exact-array (bare list)
+  / EXACT ``object_equal`` (sub-path dict operand) / range / presence. Mirrors
+  the ADR §4 match-mode taxonomy (the sub-path dict case is exact ``=``, NOT
+  ``@>`` containment).
+
+``@internal``. Reachable as ``khora.filter.compilers.python.compile_python`` for
+khora's own engines; not re-exported from :mod:`khora.__init__`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from datetime import datetime
+from typing import Any
+
+from khora.filter import (
+    CompileContext,
+    CompiledFilter,
+    RecallFilterUnsupportedError,
+)
+from khora.filter.ast import (
+    DateLiteral,
+    FilterClause,
+    FilterNode,
+    canonical_hash,
+)
+from khora.filter.model import SYSTEM_KEYS, Op
+from khora.filter.telemetry import record_unindexed_metadata
+
+__all__ = ["compile_python"]
+
+
+# A sentinel distinct from ``None``: ``None`` is a legitimate stored value
+# (an explicit JSON null / a NULL system column), so "absent" needs its own
+# marker. Used for metadata path extraction where absent vs present-null is
+# load-bearing (Rule 4).
+class _Missing:
+    """Singleton marker for an absent value (distinct from a present ``None``)."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid only
+        return "<MISSING>"
+
+
+MISSING = _Missing()
+
+
+# Python operator callables for the range ops, keyed by AST op.
+_RANGE_FN: dict[Op, Callable[[Any, Any], bool]] = {
+    Op.GT: lambda a, b: a > b,
+    Op.GTE: lambda a, b: a >= b,
+    Op.LT: lambda a, b: a < b,
+    Op.LTE: lambda a, b: a <= b,
+}
+
+
+def compile_python(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[Callable[[Any], bool]]:
+    """Compile a canonical AST to an in-memory ``callable(record) -> bool``.
+
+    ``ast`` is always a :class:`FilterNode` (the ``parse_to_ast`` root invariant).
+    An empty ``AND`` (the match-everything root of a bare filter) compiles to a
+    predicate that accepts every record. ``params`` is always empty (the
+    predicate closes over the operands directly). ``consumed_keys`` is every leaf
+    in the AST — this compiler evaluates the whole filter, so it consumes
+    everything (it is the post-filter, not a pushdown that splits).
+
+    ``ctx.field_mapping`` remaps a logical system key to the record attribute /
+    mapping key to read (identity when ``None``). ``ctx.on_unsupported`` is
+    honored for the (post-validation unreachable) clause this compiler cannot
+    express: ``"raise"`` raises :class:`RecallFilterUnsupportedError`; ``"split"``
+    drops the clause from ``consumed_keys`` and treats it as match-all so it does
+    not narrow the record set.
+
+    The ``khora.recall.filter.unindexed_metadata`` counter fires once per metadata
+    leaf **at compile time** (during this AST walk), mirroring
+    :func:`compile_postgres` — never inside the returned per-record callable.
+    """
+    consumed: set[str] = set()
+    builder = _Builder(ctx=ctx, consumed=consumed)
+    predicate = builder.compile_node(ast)
+    return CompiledFilter(
+        predicate=predicate,
+        params={},
+        consumed_keys=frozenset(consumed),
+        canonical_hash=canonical_hash(ast),
+    )
+
+
+def _path_str(path: tuple[str, ...]) -> str:
+    """Render an AST path as the dotted key string used for diagnostics/consumed."""
+    return ".".join(path)
+
+
+class _Builder:
+    """Per-compile-pass state: the :class:`CompileContext` and consumed set.
+
+    Mirrors the postgres compiler's ``_Builder`` — a small object that threads
+    the ``ctx`` (field remapping) and the ``consumed`` accumulator through the
+    recursion so each leaf-compile method need not pass the pair down. Each
+    ``compile_*`` method returns a ``callable(record) -> bool``; the logical-node
+    walk composes them with ``all`` / ``any`` / negation.
+    """
+
+    def __init__(self, *, ctx: CompileContext, consumed: set[str]) -> None:
+        self._ctx = ctx
+        self._consumed = consumed
+
+    # ----- logical node walk ---------------------------------------------- #
+
+    def compile_node(self, node: FilterNode | FilterClause) -> Callable[[Any], bool]:
+        """Compile a logical node or leaf to a ``callable(record) -> bool``."""
+        if isinstance(node, FilterClause):
+            return self.compile_clause(node)
+        if node.op == Op.AND:
+            if not node.children:
+                # The empty match-everything root — no constraint.
+                return lambda _record: True
+            child_fns = [self.compile_node(c) for c in node.children]
+            return lambda record: all(fn(record) for fn in child_fns)
+        if node.op == Op.OR:
+            if not node.children:
+                # The validator forbids an empty $or; guard defensively.
+                return lambda _record: False
+            child_fns = [self.compile_node(c) for c in node.children]
+            return lambda record: any(fn(record) for fn in child_fns)
+        # Op.NOT — exactly one child per the AST contract. Leaves are built total
+        # (every callable returns a real bool, never raises) so this negation
+        # flips absent/wrong-type records correctly (Rule 2).
+        child_fn = self.compile_node(node.children[0])
+        return lambda record: not child_fn(record)
+
+    # ----- leaf key-kind split -------------------------------------------- #
+
+    def compile_clause(self, clause: FilterClause) -> Callable[[Any], bool]:
+        """Dispatch a leaf on key-kind (system key vs metadata path)."""
+        path = clause.path
+        if len(path) == 1 and path[0] in SYSTEM_KEYS:
+            fn = self._compile_system_clause(clause)
+        elif path and path[0] == "metadata":
+            fn = self._compile_metadata_clause(clause)
+            # A metadata leaf reads an unindexed blob. Emit once per metadata
+            # leaf at compile time (a filter with N metadata predicates emits N
+            # times) — matching compile_postgres. NOT inside ``fn`` (that would
+            # fire per record).
+            record_unindexed_metadata(op=clause.op.value)
+        else:
+            return self._unsupported(clause, "path is neither a system key nor a metadata path")
+        self._consumed.add(_path_str(path))
+        return fn
+
+    # ----- value resolution ----------------------------------------------- #
+
+    def _resolve_system(self, record: Any, key: str) -> Any:
+        """Resolve a system key on a record to its value (``None`` if absent).
+
+        ``field_mapping`` remaps the logical key to the physical attribute /
+        mapping key (identity when ``None``). Resolution is defensive so one
+        predicate serves both a chunk dataclass and a dict event row: try the
+        record's own attribute, then its ``source_document`` projection (where
+        the denormalized document keys live on a chunk), then mapping access.
+        A key found nowhere resolves to ``None`` — the always-present-but-null
+        case for a system key (Rule 4), never an exception.
+        """
+        physical = (self._ctx.field_mapping or {}).get(key, key)
+        value = _getattr_or_missing(record, physical)
+        if value is not MISSING:
+            return value
+        source_doc = _getattr_or_missing(record, "source_document")
+        if source_doc is not MISSING and source_doc is not None:
+            value = _getattr_or_missing(source_doc, physical)
+            if value is not MISSING:
+                return value
+        value = _getitem_or_missing(record, physical)
+        if value is not MISSING:
+            return value
+        return None
+
+    def _resolve_metadata(self, record: Any) -> Mapping[str, Any]:
+        """Resolve the ``metadata`` blob on a record, coalescing absent/None to ``{}``.
+
+        Reads ``record.metadata`` then ``record["metadata"]``; a non-mapping or
+        absent/``None`` blob coalesces to an empty dict so every metadata
+        operator is total against a record with no metadata.
+        """
+        value = _getattr_or_missing(record, "metadata")
+        if value is MISSING:
+            value = _getitem_or_missing(record, "metadata")
+        if isinstance(value, Mapping):
+            return value
+        return {}
+
+    # ----- system-key leaves ---------------------------------------------- #
+
+    def _compile_system_clause(self, clause: FilterClause) -> Callable[[Any], bool]:
+        key = clause.path[0]
+        op = clause.op
+        operand = clause.operand
+
+        if op == Op.EXISTS:
+            # A system key is always present on the record (an absent one
+            # resolves to None, which still counts as present-with-null for
+            # $exists). $exists is therefore constant — true / false.
+            return (lambda _record: True) if operand else (lambda _record: False)
+
+        if op in (Op.IN, Op.NIN):
+            values = [_system_value(v) for v in operand]
+            if op == Op.IN:
+                return lambda record: _system_in(self._resolve_system(record, key), values)
+            # $nin includes a record whose value is None or wrong-type / not in
+            # the set (Rule 2 polarity).
+            return lambda record: _system_nin(self._resolve_system(record, key), values)
+
+        # Rule 3 (NARROW): an $eq EXACT-ARRAY (tuple) operand against a scalar
+        # system value never matches; its $ne mirror always matches. (A bare
+        # list on a system key lowers to EQ-with-tuple; the $ne complement is
+        # unreachable via the validator but kept uniform.)
+        if op == Op.EQ and isinstance(operand, tuple):
+            return lambda _record: False
+        if op == Op.NE and isinstance(operand, tuple):
+            return lambda _record: True
+
+        if operand is None:
+            # {k: null} → active null-or-missing match. A system value of None is
+            # "null"; $ne null → value is not None.
+            if op == Op.NE:
+                return lambda record: self._resolve_system(record, key) is not None
+            return lambda record: self._resolve_system(record, key) is None
+
+        value = _system_value(operand)
+        if op == Op.NE:
+            # Include None / wrong-type records (Rule 2): a record whose value is
+            # None, or whose value cannot be compared, satisfies $ne.
+            return lambda record: _system_ne(self._resolve_system(record, key), value)
+        if op == Op.EQ:
+            return lambda record: _system_eq(self._resolve_system(record, key), value)
+        # Range ops — type-safe scalar compare; None / uncomparable excludes.
+        range_fn = _RANGE_FN[op]
+        return lambda record: _system_range(self._resolve_system(record, key), value, range_fn)
+
+    # ----- metadata leaves ------------------------------------------------ #
+
+    def _compile_metadata_clause(self, clause: FilterClause) -> Callable[[Any], bool]:
+        path = clause.path
+        op = clause.op
+        operand = clause.operand
+
+        # Bare-blob metadata $eq (whole-document equality). Normalized JSON
+        # equality (dict compare is structural in Python). Coalesced metadata
+        # ({} for a record with none) keeps this total.
+        if len(path) == 1:
+            if op != Op.EQ:
+                return self._unsupported(clause, "only $eq is defined on the bare metadata blob")
+            expected = _jsonable(operand)
+            return lambda record: _json_eq(_jsonable(dict(self._resolve_metadata(record))), expected)
+
+        segs = path[1:]  # drop the leading "metadata" root
+
+        if op == Op.EXISTS:
+            if operand:
+                return lambda record: _md_present(self._resolve_metadata(record), segs)
+            return lambda record: not _md_present(self._resolve_metadata(record), segs)
+
+        if op in (Op.IN, Op.NIN):
+            if not operand:
+                # $in over ∅ matches nothing; $nin over ∅ matches everything.
+                return (lambda _record: False) if op == Op.IN else (lambda _record: True)
+            values = list(operand)
+            if op == Op.IN:
+                return lambda record: any(_md_contains(self._md_extract(record, segs), v) for v in values)
+            # $nin: NOT in the set. Containment is total (False on absent/
+            # mismatch), so the negation includes absent / wrong-type (Rule 2).
+            return lambda record: not any(_md_contains(self._md_extract(record, segs), v) for v in values)
+
+        if op == Op.EQ:
+            if operand is None:
+                return lambda record: _md_is_null(self._resolve_metadata(record), segs)
+            return self._md_eq_fn(segs, operand)
+        if op == Op.NE:
+            if operand is None:
+                # $ne null → present AND not a JSON null value.
+                return lambda record: not _md_is_null(self._resolve_metadata(record), segs)
+            eq_fn = self._md_eq_fn(segs, operand)
+            # Negate the (total) positive equality form so absent / wrong-type
+            # records are included (Rule 2).
+            return lambda record: not eq_fn(record)
+
+        # Range ops ($gt/$gte/$lt/$lte) — type-gated scalar compare.
+        return self._md_range_fn(segs, op, operand)
+
+    def _md_extract(self, record: Any, segs: tuple[str, ...]) -> Any:
+        """Extract the metadata node at ``segs`` (``MISSING`` if the path is absent)."""
+        return _md_dig(self._resolve_metadata(record), segs)
+
+    def _md_eq_fn(self, segs: tuple[str, ...], operand: Any) -> Callable[[Any], bool]:
+        """Positive metadata equality — total boolean.
+
+        Match-mode by operand kind (ADR §4 taxonomy):
+
+        * a ``$date`` literal compares the stored value as a UTC datetime;
+        * a ``tuple`` (bare-list ``$eq``) is exact-array equality on the node;
+        * a ``dict`` (sub-path subdocument operand) is ``object_equal`` — EXACT
+          structural equality on the extracted node (mirrors the ADR's
+          ``metadata #> '{path}' = '{...}'::jsonb``), order-insensitive on keys
+          via :func:`_json_eq`. NOT ``@>`` containment;
+        * any other scalar is array-aware containment (a scalar matches the node
+          or an element of a stored list).
+        """
+        if isinstance(operand, DateLiteral):
+            return lambda record: _md_date_compare(self._md_extract(record, segs), Op.EQ, operand)
+        if isinstance(operand, tuple):
+            expected = [_jsonable(item) for item in operand]
+            return lambda record: _exact_array_eq(self._md_extract(record, segs), expected)
+        if isinstance(operand, Mapping):
+            # Subdocument equality: EXACT object_equal, not containment.
+            expected_obj = _jsonable(operand)
+            return lambda record: _md_object_eq(self._md_extract(record, segs), expected_obj)
+        return lambda record: _md_contains(self._md_extract(record, segs), operand)
+
+    def _md_range_fn(self, segs: tuple[str, ...], op: Op, operand: Any) -> Callable[[Any], bool]:
+        """A metadata range op — type-gated scalar compare, total.
+
+        A ``$date`` operand compares via UTC-datetime parse-or-exclude. Otherwise
+        the stored node must match the operand's type-gate (number vs number,
+        bool vs bool, str vs str) before comparing — a mismatch or absent node
+        excludes (Rule 1), so the positive op never matches a wrong-typed value.
+        """
+        range_fn = _RANGE_FN[op]
+        if isinstance(operand, DateLiteral):
+            return lambda record: _md_date_compare(self._md_extract(record, segs), op, operand)
+        return lambda record: _md_range_compare(self._md_extract(record, segs), operand, range_fn)
+
+    # ----- unsupported ---------------------------------------------------- #
+
+    def _unsupported(self, clause: FilterClause, reason: str) -> Callable[[Any], bool]:
+        """Handle a clause this compiler cannot express per ``ctx.on_unsupported``.
+
+        ``"raise"`` raises the public :class:`RecallFilterUnsupportedError`;
+        ``"split"`` leaves the clause out of ``consumed_keys`` and emits a
+        non-constraining match-all so it does not narrow the record set.
+        """
+        path = _path_str(clause.path)
+        if self._ctx.on_unsupported == "raise":
+            raise RecallFilterUnsupportedError(path, reason)
+        return lambda _record: True
+
+
+# --------------------------------------------------------------------------- #
+# Module-level helpers (no per-pass state).
+# --------------------------------------------------------------------------- #
+
+
+def _getattr_or_missing(obj: Any, name: str) -> Any:
+    """Return ``getattr(obj, name)`` or :data:`MISSING` if absent / unreadable."""
+    try:
+        return getattr(obj, name)
+    except AttributeError:
+        return MISSING
+
+
+def _getitem_or_missing(obj: Any, key: str) -> Any:
+    """Return ``obj[key]`` (mapping access) or :data:`MISSING` if absent / not subscriptable."""
+    if isinstance(obj, Mapping):
+        if key in obj:
+            return obj[key]
+        return MISSING
+    return MISSING
+
+
+def _system_value(value: Any) -> Any:
+    """Unwrap a :class:`DateLiteral` to its datetime; pass other values through."""
+    if isinstance(value, DateLiteral):
+        return value.value
+    return value
+
+
+def _is_number(value: Any) -> bool:
+    """True for an int / float operand, excluding bool (a number type-gate).
+
+    ``bool`` is an ``int`` subclass; the §4 number gate treats a bool as a
+    boolean, never a number, so it is excluded here (matching ``compile_postgres``
+    ``_operand_json_type``).
+    """
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _comparable(stored: Any, operand: Any) -> bool:
+    """True when ``stored`` and ``operand`` are order-comparable under §4's gate.
+
+    Numbers compare with numbers (int/float, bool excluded), bools with bools,
+    strings with strings, datetimes with datetimes. Any cross-family pair is
+    NOT comparable — the positive op excludes it (Rule 1: never abort, exclude
+    instead of raising a ``TypeError`` on ``str < int``).
+    """
+    if _is_number(operand):
+        return _is_number(stored)
+    if isinstance(operand, bool):
+        return isinstance(stored, bool)
+    if isinstance(operand, datetime):
+        return isinstance(stored, datetime)
+    if isinstance(operand, str):
+        return isinstance(stored, str)
+    # Any other operand type (shouldn't reach range/scalar compare) — only an
+    # exact same-type pair is comparable.
+    return type(stored) is type(operand)
+
+
+# ----- system-key value comparisons (None / wrong-type aware) -------------- #
+
+
+def _system_eq(stored: Any, value: Any) -> bool:
+    """System ``$eq``: present, comparable, and equal. Excludes None / wrong-type."""
+    if stored is None:
+        return False
+    if not _comparable(stored, value):
+        return False
+    return stored == value
+
+
+def _system_ne(stored: Any, value: Any) -> bool:
+    """System ``$ne``: include None / wrong-type (Rule 2); exclude only equal."""
+    if stored is None:
+        return True
+    if not _comparable(stored, value):
+        return True
+    return stored != value
+
+
+def _system_in(stored: Any, values: list[Any]) -> bool:
+    """System ``$in``: present, comparable to, and equal to some member."""
+    if stored is None:
+        return False
+    return any(_comparable(stored, v) and stored == v for v in values)
+
+
+def _system_nin(stored: Any, values: list[Any]) -> bool:
+    """System ``$nin``: include None / wrong-type; exclude only an in-set match."""
+    if stored is None:
+        return True
+    return not any(_comparable(stored, v) and stored == v for v in values)
+
+
+def _system_range(stored: Any, value: Any, range_fn: Callable[[Any, Any], bool]) -> bool:
+    """System range op: present, comparable, and in range. Excludes None / wrong-type."""
+    if stored is None:
+        return False
+    if not _comparable(stored, value):
+        return False
+    return range_fn(stored, value)
+
+
+# ----- metadata extraction + comparisons ----------------------------------- #
+
+
+def _md_dig(blob: Mapping[str, Any], segs: tuple[str, ...]) -> Any:
+    """Extract the node at ``segs`` from a metadata blob, or :data:`MISSING`.
+
+    Descends one mapping per segment. A path that runs off a non-mapping or an
+    absent key yields :data:`MISSING` (the absent case, distinct from a stored
+    ``None``).
+    """
+    node: Any = blob
+    for seg in segs:
+        if isinstance(node, Mapping) and seg in node:
+            node = node[seg]
+        else:
+            return MISSING
+    return node
+
+
+def _md_present(blob: Mapping[str, Any], segs: tuple[str, ...]) -> bool:
+    """True iff the metadata path resolves (an explicit ``None`` value counts as present).
+
+    Mirrors ``compile_postgres._md_exists``: ``#>`` is NULL only when the path is
+    missing; an explicit JSON ``null`` is present. So presence is "the path
+    resolves to a value", whether that value is ``None`` or not.
+    """
+    return _md_dig(blob, segs) is not MISSING
+
+
+def _md_is_null(blob: Mapping[str, Any], segs: tuple[str, ...]) -> bool:
+    """Active null-or-missing match: an explicit ``None`` value OR an absent path.
+
+    Mirrors ``compile_postgres._md_null``. ``{k: null}`` matches both.
+    """
+    node = _md_dig(blob, segs)
+    return node is MISSING or node is None
+
+
+def _md_contains(node: Any, value: Any) -> bool:
+    """Array-aware containment: a scalar matches the node, or an element of a node list.
+
+    Mirrors the Postgres ``@>`` semantics: ``metadata @> '{"k": v}'`` matches a
+    scalar field equal to ``v`` AND a list field containing ``v``. An absent node
+    (:data:`MISSING`) never matches (total — False, not an error).
+    """
+    if node is MISSING:
+        return False
+    target = _jsonable(value)
+    if isinstance(node, list):
+        return any(_json_eq(_jsonable(item), target) for item in node)
+    return _json_eq(_jsonable(node), target)
+
+
+def _exact_array_eq(node: Any, expected: list[Any]) -> bool:
+    """Exact-array equality: the stored node is a list equal to ``expected`` (ordered).
+
+    Mirrors ``compile_postgres._md_eq`` tuple branch (``#> = '[...]'::jsonb``). An
+    absent node or a non-list node never matches.
+    """
+    if node is MISSING or not isinstance(node, list):
+        return False
+    return _json_eq([_jsonable(item) for item in node], expected)
+
+
+def _md_object_eq(node: Any, expected: Any) -> bool:
+    """Subdocument ``object_equal``: the stored node EXACTLY equals ``expected``.
+
+    The ADR §4 ``object_equal`` match-mode for a sub-path dict operand —
+    ``metadata #> '{path}' = '{...}'::jsonb``, exact structural equality (NOT
+    ``@>`` containment), order-insensitive on keys via :func:`_json_eq`. An absent
+    node (:data:`MISSING`) or a non-mapping node never matches. ``expected`` is
+    already :func:`_jsonable`-normalized.
+    """
+    if node is MISSING or not isinstance(node, Mapping):
+        return False
+    return _json_eq(_jsonable(node), expected)
+
+
+def _md_range_compare(node: Any, operand: Any, range_fn: Callable[[Any, Any], bool]) -> bool:
+    """Type-gated metadata range compare — total (excludes absent / wrong-type).
+
+    Mirrors ``compile_postgres._md_range``: the stored node must match the
+    operand's type-gate (number/bool/string) before comparing. A list operand is
+    not a range operand (the validator never produces one here), so it is
+    excluded by the comparability gate.
+    """
+    if node is MISSING:
+        return False
+    if not _comparable(node, operand):
+        return False
+    return range_fn(node, operand)
+
+
+def _md_date_compare(node: Any, op: Op, operand: DateLiteral) -> bool:
+    """Guarded ``$date`` compare on a metadata node — parse-or-exclude, total.
+
+    Mirrors ``compile_postgres._md_date_compare``: the stored value is parsed as
+    an ISO-8601 datetime (normalized to UTC) and compared to the operand's
+    UTC-normalized datetime. A node that is absent, non-string, or unparseable
+    excludes the record (Rule 1) — never raises.
+    """
+    if node is MISSING or not isinstance(node, str):
+        return False
+    parsed = _try_parse_utc(node)
+    if parsed is None:
+        return False
+    cmp = operand.value
+    if op == Op.EQ:
+        return parsed == cmp
+    return _RANGE_FN[op](parsed, cmp)
+
+
+def _try_parse_utc(text: str) -> datetime | None:
+    """Parse an ISO-8601 string to a UTC-aware datetime, or ``None`` on failure."""
+    from datetime import UTC
+
+    try:
+        parsed = datetime.fromisoformat(text)
+    except (ValueError, TypeError):
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _jsonable(value: Any) -> Any:
+    """Coerce a value to a JSON-comparable form for containment / equality.
+
+    A :class:`DateLiteral` / :class:`~datetime.datetime` renders as its ISO-8601
+    string (matching ``compile_postgres._date_to_jsonable``); a mapping / list is
+    coerced recursively; other scalars pass through. This keeps a metadata
+    ``$date`` operand comparable to a stored ISO string and a dict / list operand
+    comparable structurally.
+    """
+    if isinstance(value, DateLiteral):
+        return value.value.isoformat()
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Mapping):
+        return {k: _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def _json_eq(a: Any, b: Any) -> bool:
+    """Type-strict JSON equality, mirroring Postgres JSONB ``@>`` / ``=`` semantics.
+
+    Both operands are already :func:`_jsonable`-normalized. JSONB distinguishes a
+    boolean from a number (``true`` is not ``1``), so a Python ``True == 1`` must
+    NOT match here — exactly one operand being a ``bool`` is unequal. Otherwise
+    the comparison is structural: dicts compare key-sets + per-key values, lists
+    compare ordered + element-wise, scalars compare with ``==``.
+    """
+    if isinstance(a, bool) or isinstance(b, bool):
+        # JSONB bool/number distinction: equal only if BOTH are bools and equal.
+        return isinstance(a, bool) and isinstance(b, bool) and a == b
+    if isinstance(a, Mapping) and isinstance(b, Mapping):
+        if a.keys() != b.keys():
+            return False
+        return all(_json_eq(a[k], b[k]) for k in a)
+    if isinstance(a, list) and isinstance(b, list):
+        return len(a) == len(b) and all(_json_eq(x, y) for x, y in zip(a, b))
+    # A list / dict never equals a scalar (and vice versa); == handles that too.
+    return a == b

--- a/tests/integration/test_chronicle_filter_embedded.py
+++ b/tests/integration/test_chronicle_filter_embedded.py
@@ -1,0 +1,282 @@
+"""End-to-end recall-filter tests for the Chronicle engine over a real embedded store.
+
+Exercises the deterministic recall filter against a live SQLite + LanceDB pair in
+``tmp_path`` — no storage-layer mocks. This complements the mocked engine-composition
+unit tests (``tests/recall/test_chronicle_filter_composition.py``) by driving the
+filter through real persistence, which is where the storage-coupled parts most likely
+break:
+
+* **Metadata serialization round-trip** — chunk ``metadata`` is written to and read
+  back from the real ``chunks.metadata`` column, so a ``metadata.<path>`` predicate is
+  evaluated against a genuinely round-tripped blob, not a hand-built dict.
+* **Date columns** — ``source_timestamp`` pushes down to the real recency window
+  (``COALESCE(source_timestamp, created_at)``) at the SQL layer, and ``occurred_at`` is
+  enforced by the post-filter against the chunk read back from storage (the
+  ``COALESCE(occurred_at, source_timestamp)`` recovery against real columns).
+
+Seeding goes through the coordinator's own write API (``create_chunks_batch``) with
+deterministic fake embeddings, exactly like the sibling sqlite_lance ingest suite, so
+the suite stays hermetic (no LLM, no network). All seed chunks share one embedding so
+the vector channel returns the whole seed set and the filter is the only narrowing
+force.
+
+Cross-compiler parity (the Chronicle path agreeing with the in-process
+``compile_python`` oracle for the same filter) is asserted in
+``test_engine_recall_matches_compile_python_oracle``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+try:
+    import aiosqlite  # noqa: F401
+    import lancedb  # noqa: F401
+
+    _HAS_EMBEDDED = True
+except ImportError:
+    _HAS_EMBEDDED = False
+
+from khora.config import KhoraConfig
+from khora.config.schema import QuerySettings
+from khora.core.models import Chunk, Document, MemoryNamespace
+from khora.engines.chronicle.engine import ChronicleEngine
+from khora.filter import RecallFilter
+from khora.filter.ast import parse_to_ast
+from khora.filter.compilers.python import compile_python
+from khora.filter.context import CompileContext
+from khora.query import SearchMode
+from tests.integration._sqlite_lance_fixtures import (
+    EMBED_DIM,
+    build_sqlite_lance_coordinator,
+    fake_embedding,
+)
+
+pytestmark = [
+    pytest.mark.embedded,
+    pytest.mark.integration,
+    pytest.mark.skipif(not _HAS_EMBEDDED, reason="aiosqlite/lancedb not installed"),
+]
+
+# One shared embedding so every seed chunk matches the query equally — the vector
+# channel returns the whole seed set, leaving the filter as the only narrowing force.
+_QUERY_TEXT = "shared retrieval anchor"
+_SHARED_EMBEDDING = fake_embedding(_QUERY_TEXT, dim=EMBED_DIM)
+
+_IN_RANGE = datetime(2026, 6, 1, tzinfo=UTC)
+_OUT_OF_RANGE = datetime(2020, 1, 1, tzinfo=UTC)
+_FILTER_LB = "2026-01-01T00:00:00Z"
+
+
+def _filter_ast(wire: dict) -> Any:
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+async def _seed(
+    coord: Any,
+    namespace_id: UUID,
+    specs: list[dict[str, Any]],
+) -> list[Chunk]:
+    """Insert one document + one chunk per spec via the real coordinator write API.
+
+    Each ``spec`` carries ``content`` plus any of ``metadata`` / ``source_timestamp`` /
+    ``occurred_at`` / ``created_at``. All chunks share ``_SHARED_EMBEDDING`` so the
+    vector channel returns them all.
+    """
+    chunks: list[Chunk] = []
+    for spec in specs:
+        doc = Document(
+            namespace_id=namespace_id,
+            content=spec["content"],
+            source="test",
+            title=spec["content"][:32],
+        )
+        await coord.create_document(doc)
+        chunk_kwargs: dict[str, Any] = {
+            "namespace_id": namespace_id,
+            "document_id": doc.id,
+            "content": spec["content"],
+            "chunk_index": 0,
+            "embedding": _SHARED_EMBEDDING,
+            "embedding_model": "fake",
+            "metadata": spec.get("metadata", {}),
+        }
+        for date_key in ("source_timestamp", "occurred_at", "created_at"):
+            if date_key in spec:
+                chunk_kwargs[date_key] = spec[date_key]
+        chunks.append(Chunk(**chunk_kwargs))
+    await coord.create_chunks_batch(chunks)
+    return chunks
+
+
+def _engine_over(coord: Any) -> ChronicleEngine:
+    """A ChronicleEngine bound to the real embedded coordinator.
+
+    Reranking is disabled (it would lazily pull a cross-encoder on first recall);
+    it only reorders candidates, never adds/drops a row, so the filter contract is
+    unaffected. The embedder returns the shared query embedding so the vector channel
+    retrieves the whole seed set.
+    """
+    engine = ChronicleEngine(KhoraConfig(query=QuerySettings(enable_reranking=False)))
+    engine._storage = coord
+    embedder = _FakeEmbedder()
+    engine._embedder = embedder
+    engine._connected = True
+    return engine
+
+
+class _FakeEmbedder:
+    async def embed(self, _text: str) -> list[float]:
+        return _SHARED_EMBEDDING
+
+
+async def _recall_ids(engine: ChronicleEngine, namespace_id: UUID, wire: dict) -> set[UUID]:
+    result = await engine.recall(
+        _QUERY_TEXT,
+        namespace_id,
+        limit=50,
+        mode=SearchMode.VECTOR,
+        filter_ast=_filter_ast(wire),
+    )
+    return {c.id for c in result.chunks}
+
+
+@pytest.mark.asyncio
+async def test_metadata_filter_round_trips_through_real_store(tmp_path: Path) -> None:
+    # metadata.tier == "gold" must select exactly the gold chunks after a real
+    # write→read round-trip of the metadata blob.
+    coord = await build_sqlite_lance_coordinator(tmp_path)
+    try:
+        ns = await coord.create_namespace(MemoryNamespace())
+        chunks = await _seed(
+            coord,
+            ns.id,
+            [
+                {"content": "gold one", "metadata": {"tier": "gold"}},
+                {"content": "gold two", "metadata": {"tier": "gold"}},
+                {"content": "silver one", "metadata": {"tier": "silver"}},
+                {"content": "no tier", "metadata": {}},
+            ],
+        )
+        gold_ids = {chunks[0].id, chunks[1].id}
+
+        returned = await _recall_ids(_engine_over(coord), ns.id, {"metadata.tier": "gold"})
+        assert returned == gold_ids
+    finally:
+        await coord.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_source_timestamp_pushdown_narrows_against_real_window(tmp_path: Path) -> None:
+    # source_timestamp >= 2026-01-01 pushes down to the real recency window; only the
+    # in-range chunk survives.
+    coord = await build_sqlite_lance_coordinator(tmp_path)
+    try:
+        ns = await coord.create_namespace(MemoryNamespace())
+        chunks = await _seed(
+            coord,
+            ns.id,
+            [
+                {"content": "recent", "source_timestamp": _IN_RANGE},
+                {"content": "ancient", "source_timestamp": _OUT_OF_RANGE},
+            ],
+        )
+        in_range_id = chunks[0].id
+
+        returned = await _recall_ids(_engine_over(coord), ns.id, {"source_timestamp": {"$gte": _FILTER_LB}})
+        assert returned == {in_range_id}
+    finally:
+        await coord.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_occurred_at_coalesce_recovery_against_real_columns(tmp_path: Path) -> None:
+    # occurred_at is post-filtered against the chunk read back from storage, using
+    # the effective event time COALESCE(occurred_at, source_timestamp). The key
+    # guard is that an occurred_at filter does NOT false-empty when occurred_at is
+    # absent on the stored row — it recovers via source_timestamp.
+    #
+    # Real-storage truth this surfaces (which a mocked candidate list hides): the
+    # embedded sqlite_lance chunk write path persists source_timestamp but NOT a
+    # distinct occurred_at column (it is read back as NULL — see
+    # sqlite_lance/vector.py create_chunks_batch). So on this backend the effective
+    # event time collapses to source_timestamp, and a chunk seeded with an
+    # occurred_at value but an out-of-range source_timestamp is still dropped. That
+    # write-path gap is independent of this filter and tracked separately; here we
+    # assert the filter's observable contract against what the store actually
+    # round-trips.
+    coord = await build_sqlite_lance_coordinator(tmp_path)
+    try:
+        ns = await coord.create_namespace(MemoryNamespace())
+        chunks = await _seed(
+            coord,
+            ns.id,
+            [
+                # source_timestamp in range → effective event time in range → survives
+                # (the recovery path; proves NO false-empty when occurred_at is unset).
+                {"content": "fallback recover", "source_timestamp": _IN_RANGE},
+                # occurred_at seeded in range but NOT persisted by the embedded write
+                # path; source_timestamp out of range → effective event time out of
+                # range → dropped.
+                {"content": "occurred not persisted", "occurred_at": _IN_RANGE, "source_timestamp": _OUT_OF_RANGE},
+                # no in-range anchor at all → dropped.
+                {"content": "no anchor in range", "source_timestamp": _OUT_OF_RANGE},
+            ],
+        )
+        recovered_id = chunks[0].id
+
+        returned = await _recall_ids(_engine_over(coord), ns.id, {"occurred_at": {"$gte": _FILTER_LB}})
+        assert returned == {recovered_id}, (
+            "occurred_at filter must recover event time from source_timestamp "
+            "(no false-empty) and drop rows whose effective event time is out of range"
+        )
+    finally:
+        await coord.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_engine_recall_matches_compile_python_oracle(tmp_path: Path) -> None:
+    # Cross-compiler parity: the Chronicle engine's real-storage recall returns the
+    # SAME surviving chunk IDs as the in-process compile_python oracle applied to the
+    # same seed, for the same composed filter. The oracle is the reference all
+    # per-backend compilers must agree with.
+    coord = await build_sqlite_lance_coordinator(tmp_path)
+    try:
+        ns = await coord.create_namespace(MemoryNamespace())
+        specs = [
+            {"content": "gold recent", "metadata": {"tier": "gold"}, "source_timestamp": _IN_RANGE},
+            {"content": "gold ancient", "metadata": {"tier": "gold"}, "source_timestamp": _OUT_OF_RANGE},
+            {"content": "silver recent", "metadata": {"tier": "silver"}, "source_timestamp": _IN_RANGE},
+        ]
+        chunks = await _seed(coord, ns.id, specs)
+
+        wire = {"metadata.tier": "gold", "source_timestamp": {"$gte": _FILTER_LB}}
+        ast = _filter_ast(wire)
+
+        # Oracle: apply compile_python directly to the seed records.
+        predicate = compile_python(ast, CompileContext(backend_target="chunks")).predicate
+        oracle_ids = {
+            c.id
+            for c in chunks
+            if predicate(
+                {
+                    "metadata": c.metadata,
+                    "source_timestamp": c.source_timestamp,
+                    "occurred_at": c.occurred_at if c.occurred_at is not None else c.source_timestamp,
+                    "created_at": c.created_at,
+                }
+            )
+        }
+
+        engine_ids = await _recall_ids(_engine_over(coord), ns.id, wire)
+
+        assert engine_ids == oracle_ids
+        # Sanity: exactly the gold + in-range chunk.
+        assert engine_ids == {chunks[0].id}
+    finally:
+        await coord.disconnect()

--- a/tests/recall/test_chronicle_filter_composition.py
+++ b/tests/recall/test_chronicle_filter_composition.py
@@ -1,0 +1,499 @@
+"""Engine-composition tests for the Chronicle recall-filter (Layer 4 → engine).
+
+``@internal``. Pins task part (c): how the Chronicle engine *composes* the two
+compiled halves of a recall filter at ``recall()`` time —
+
+1. **Date bounds intersect the recency window (narrow only).** The
+   :func:`compile_chronicle` date-bound is folded into the engine's existing
+   ``created_after`` / ``created_before`` recency window via ``_intersect_lower`` /
+   ``_intersect_upper`` — ``max`` of the lower bounds, ``min`` of the upper bounds.
+   The filter can only SHRINK the window, never widen it.
+2. **The metadata predicate post-filters chunk candidates.** The
+   :func:`compile_python` predicate is applied to the fused candidates so an
+   out-of-scope chunk is dropped before top-k.
+3. **``khora.recall.filter.unindexed_metadata`` increments on the post-filter
+   path.** ``compile_python`` emits the counter per metadata leaf at compile time
+   (mirroring ``compile_postgres``), so a metadata-bearing filter recall fires it.
+
+The window-intersection assertions exercise the pure ``_intersect_*`` helpers
+directly (deterministic, no infra). The post-filter / telemetry assertions drive
+``ChronicleEngine.recall()`` over a mocked storage + embedder (the established
+unit pattern from ``tests/unit/engines/test_chronicle_abstention_signals.py``):
+the semantic channel returns a known in-scope / out-of-scope chunk mix and the
+filter must narrow the result.
+
+INTERIM SKIP: self-skips if the filter compilers / engine wiring are not yet on
+the branch, so the suite stays green until Backend's slice lands.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# Self-skip until the engine wiring + compilers are on the branch.
+pytest.importorskip(
+    "khora.filter.compilers.python",
+    reason="recall-filter compilers not yet on the branch (Backend task in flight)",
+)
+pytest.importorskip(
+    "khora.filter.compilers.chronicle",
+    reason="Chronicle compiler not yet on the branch (Backend task in flight)",
+)
+
+from khora.config import KhoraConfig  # noqa: E402
+from khora.config.schema import QuerySettings  # noqa: E402
+from khora.core.models import Chunk  # noqa: E402
+from khora.engines.chronicle import engine as chronicle_engine  # noqa: E402
+from khora.engines.chronicle.engine import ChronicleEngine  # noqa: E402
+from khora.filter import telemetry as filter_telemetry  # noqa: E402
+from khora.query import SearchMode  # noqa: E402
+
+# The narrow-only intersection helpers are required for part (c) assertion 1; if
+# they are renamed this import (and the tests) need a one-line update.
+_intersect_lower = chronicle_engine._intersect_lower
+_intersect_upper = chronicle_engine._intersect_upper
+
+
+# ===========================================================================
+# (1) Date bounds intersect the recency window — NARROW ONLY.
+# ===========================================================================
+#
+# The engine folds the compiled date-bound into the existing recency window with
+# _intersect_lower (max of lowers) / _intersect_upper (min of uppers). These pure
+# helpers are the load-bearing "narrow only" guarantee.
+
+
+_EARLY = datetime(2026, 1, 1, tzinfo=UTC)
+_MID = datetime(2026, 6, 1, tzinfo=UTC)
+_LATE = datetime(2026, 12, 1, tzinfo=UTC)
+
+
+def test_lower_intersection_takes_the_later_bound() -> None:
+    # max of the two lower bounds — the filter tightens the window's start.
+    assert _intersect_lower(_EARLY, _MID) == _MID
+    assert _intersect_lower(_MID, _EARLY) == _MID
+
+
+def test_upper_intersection_takes_the_earlier_bound() -> None:
+    # min of the two upper bounds — the filter tightens the window's end.
+    assert _intersect_upper(_LATE, _MID) == _MID
+    assert _intersect_upper(_MID, _LATE) == _MID
+
+
+def test_none_filter_bound_leaves_window_unchanged() -> None:
+    # No filter bound on a side → that side of the window is untouched.
+    assert _intersect_lower(_MID, None) == _MID
+    assert _intersect_upper(_MID, None) == _MID
+
+
+def test_none_window_adopts_filter_bound() -> None:
+    # An unbounded window side adopts the filter's bound (still a narrowing — it
+    # goes from "unbounded" to "bounded").
+    assert _intersect_lower(None, _MID) == _MID
+    assert _intersect_upper(None, _MID) == _MID
+
+
+@pytest.mark.parametrize("filter_lo", [_EARLY, _MID, _LATE, None])
+def test_lower_intersection_never_widens(filter_lo: datetime | None) -> None:
+    # Property: the resulting lower bound is always >= the incoming window lower
+    # bound (a None result only when BOTH sides are unbounded).
+    window = _MID
+    result = _intersect_lower(window, filter_lo)
+    assert result is not None
+    assert result >= window, "lower-bound intersection must never move the window start earlier"
+
+
+@pytest.mark.parametrize("filter_hi", [_EARLY, _MID, _LATE, None])
+def test_upper_intersection_never_widens(filter_hi: datetime | None) -> None:
+    # Property: the resulting upper bound is always <= the incoming window upper.
+    window = _MID
+    result = _intersect_upper(window, filter_hi)
+    assert result is not None
+    assert result <= window, "upper-bound intersection must never move the window end later"
+
+
+# ===========================================================================
+# Mocked-engine harness for the post-filter / telemetry assertions.
+# ===========================================================================
+
+
+def _chunk(
+    content: str,
+    *,
+    metadata: dict[str, Any] | None = None,
+    occurred_at: datetime | None = None,
+    created_at: datetime | None = None,
+    source_timestamp: datetime | None = None,
+) -> Chunk:
+    """A minimal Chunk with optional metadata + the three date fields.
+
+    ``created_at`` defaults to now() when unset (the dataclass default); the
+    explicit param lets a test pin a specific created_at for the literal-date-key
+    assertions.
+    """
+    return Chunk(
+        id=uuid4(),
+        namespace_id=uuid4(),
+        document_id=uuid4(),
+        content=content,
+        created_at=created_at if created_at is not None else datetime.now(UTC),
+        metadata=metadata or {},
+        occurred_at=occurred_at,
+        source_timestamp=source_timestamp,
+    )
+
+
+def _engine_with_semantic(results: list[tuple[Chunk, float]]) -> ChronicleEngine:
+    """A connected ChronicleEngine whose semantic channel returns ``results``.
+
+    BM25 / entity channels return empty so the semantic channel is the only
+    candidate source; VECTOR mode is used at the call site to keep retrieval
+    purely embedding + filter (no keyword channel), so the filter is the only
+    narrowing force on the candidate set.
+
+    Reranking is disabled (``enable_reranking=False``): it defaults to True and
+    would lazily download / load the BAAI/bge-reranker-v2-m3 cross-encoder on the
+    first recall, making these tests slow, network-dependent, and cold-cache
+    flaky. The reranker only reorders candidates — it never adds or drops a row —
+    so disabling it leaves the filter-narrowing contract under test unchanged
+    while keeping the tests hermetic.
+    """
+    engine = ChronicleEngine(KhoraConfig(query=QuerySettings(enable_reranking=False)))
+    storage = MagicMock()
+    storage.search_fulltext_chunks = AsyncMock(return_value=[])
+    storage.search_similar_chunks = AsyncMock(return_value=results)
+    storage.search_similar_entities = AsyncMock(return_value=[])
+    engine._storage = storage
+
+    embedder = MagicMock()
+    embedder.embed = AsyncMock(return_value=[0.1] * 1536)
+    engine._embedder = embedder
+    engine._connected = True
+    return engine
+
+
+def _filter_ast(wire: dict) -> Any:
+    from khora.filter import RecallFilter
+    from khora.filter.ast import parse_to_ast
+
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+# ===========================================================================
+# (2) The metadata predicate post-filters chunk candidates.
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_metadata_filter_drops_out_of_scope_chunks() -> None:
+    # Two in-scope (tier=gold) + two out-of-scope (tier=silver / missing). A
+    # metadata.tier == gold filter must return ONLY the in-scope chunks.
+    in1 = _chunk("alpha gold one", metadata={"tier": "gold"})
+    in2 = _chunk("alpha gold two", metadata={"tier": "gold"})
+    out_silver = _chunk("alpha silver", metadata={"tier": "silver"})
+    out_missing = _chunk("alpha none", metadata={})
+    results = [(in1, 0.9), (in2, 0.85), (out_silver, 0.8), (out_missing, 0.75)]
+
+    engine = _engine_with_semantic(results)
+    result = await engine.recall(
+        "alpha",
+        uuid4(),
+        limit=10,
+        mode=SearchMode.VECTOR,
+        filter_ast=_filter_ast({"metadata.tier": "gold"}),
+    )
+
+    returned = {c.id for c in result.chunks}
+    assert returned == {in1.id, in2.id}, f"metadata post-filter must keep exactly the in-scope chunks; got {returned}"
+
+
+@pytest.mark.asyncio
+async def test_no_filter_returns_all_candidates() -> None:
+    # Control: without a filter, the same candidate set comes back in full — so the
+    # narrowing above is attributable to the FILTER, not retrieval reachability.
+    chunks = [_chunk(f"alpha-{i}", metadata={"tier": "silver"}) for i in range(4)]
+    results = [(c, 0.9 - 0.1 * i) for i, c in enumerate(chunks)]
+
+    engine = _engine_with_semantic(results)
+    result = await engine.recall("alpha", uuid4(), limit=10, mode=SearchMode.VECTOR)
+
+    assert {c.id for c in result.chunks} == {c.id for c in chunks}
+
+
+@pytest.mark.asyncio
+async def test_filter_excluding_all_yields_empty() -> None:
+    # A filter no candidate satisfies narrows the result to empty (the post-filter
+    # is applied even when it removes everything).
+    chunks = [_chunk(f"alpha-{i}", metadata={"tier": "silver"}) for i in range(3)]
+    results = [(c, 0.9) for c in chunks]
+
+    engine = _engine_with_semantic(results)
+    result = await engine.recall(
+        "alpha",
+        uuid4(),
+        limit=10,
+        mode=SearchMode.VECTOR,
+        filter_ast=_filter_ast({"metadata.tier": "gold"}),
+    )
+
+    assert result.chunks == []
+
+
+# ===========================================================================
+# occurred_at filtering narrows (not empties) — against the EFFECTIVE event time.
+# ===========================================================================
+#
+# Semantics (engine._chunk_to_record): the post-filter
+# record's occurred_at is the EFFECTIVE EVENT TIME = COALESCE(occurred_at,
+# source_timestamp) — the chunk's literal occurred_at, falling back to
+# source_timestamp when occurred_at is None (the pgvector DTO always nulls
+# occurred_at). There is deliberately NO created_at fallback: ingest time is not
+# event time, so a chunk with neither occurred_at nor source_timestamp has no
+# effective occurred_at and a positive filter excludes it. These tests drive scope
+# via occurred_at / source_timestamp (the COALESCE inputs) accordingly. (Contrast:
+# the eight denormalized document keys are NOT carried on the legacy DTO, so a
+# positive predicate on them returns empty — an accepted, documented limitation we
+# deliberately do NOT assert as "returns rows".)
+
+
+@pytest.mark.asyncio
+async def test_occurred_at_filter_narrows_against_effective_event_time() -> None:
+    # The record's occurred_at = source_timestamp or created_at. Drive in/out of
+    # scope via source_timestamp (the precedence input). in_scope's source_timestamp
+    # is after the bound; too_old's is before it; both have created_at irrelevant
+    # because source_timestamp takes precedence in the COALESCE.
+    in_scope = _chunk(
+        "alpha recent",
+        source_timestamp=datetime(2026, 6, 1, tzinfo=UTC),
+        created_at=datetime(2026, 6, 1, tzinfo=UTC),
+    )
+    too_old = _chunk(
+        "alpha old",
+        source_timestamp=datetime(2020, 1, 1, tzinfo=UTC),
+        created_at=datetime(2020, 1, 1, tzinfo=UTC),
+    )
+    results = [(in_scope, 0.9), (too_old, 0.8)]
+
+    engine = _engine_with_semantic(results)
+    result = await engine.recall(
+        "alpha",
+        uuid4(),
+        limit=10,
+        mode=SearchMode.VECTOR,
+        filter_ast=_filter_ast({"occurred_at": {"$gte": "2026-01-01T00:00:00Z"}}),
+    )
+
+    returned = {c.id for c in result.chunks}
+    assert in_scope.id in returned, "occurred_at filtering must NOT silently drop the in-scope row"
+    assert returned == {in_scope.id}, "the pre-bound row (source_timestamp too old) must be excluded"
+
+
+@pytest.mark.asyncio
+async def test_occurred_at_upper_bound_filter_narrows() -> None:
+    # The upper-bound direction also narrows (not empties): the row whose effective
+    # event time is at/before the bound survives, the later one is dropped.
+    in_scope = _chunk("alpha early", source_timestamp=datetime(2026, 1, 1, tzinfo=UTC))
+    too_new = _chunk("alpha late", source_timestamp=datetime(2026, 12, 1, tzinfo=UTC))
+    results = [(in_scope, 0.9), (too_new, 0.8)]
+
+    engine = _engine_with_semantic(results)
+    result = await engine.recall(
+        "alpha",
+        uuid4(),
+        limit=10,
+        mode=SearchMode.VECTOR,
+        filter_ast=_filter_ast({"occurred_at": {"$lte": "2026-06-01T00:00:00Z"}}),
+    )
+
+    returned = {c.id for c in result.chunks}
+    assert in_scope.id in returned
+    assert returned == {in_scope.id}
+
+
+@pytest.mark.asyncio
+async def test_occurred_at_filter_falls_back_to_source_timestamp_pg_shape() -> None:
+    # REGRESSION (formerly the masked PG-shape bug, now fixed by _chunk_to_record):
+    # the pgvector DTO has chunk.occurred_at=None, so the record's occurred_at falls
+    # back to source_timestamp (record["occurred_at"] = occurred_at or
+    # source_timestamp). A PG row whose source_timestamp is in range MUST survive an
+    # occurred_at filter (not false-empty); one whose source_timestamp is out of
+    # range is dropped. This is the case my earlier populated-occurred_at fixture
+    # MASKED. (created_at is deliberately set out of range to prove it is NOT a
+    # fallback — see the no-anchor test below.)
+    pg_in_scope = _chunk(
+        "alpha pg in",
+        occurred_at=None,
+        source_timestamp=datetime(2026, 6, 1, tzinfo=UTC),
+        created_at=datetime(2020, 1, 1, tzinfo=UTC),
+    )
+    pg_too_old = _chunk(
+        "alpha pg old",
+        occurred_at=None,
+        source_timestamp=datetime(2020, 1, 1, tzinfo=UTC),
+        created_at=datetime(2026, 6, 1, tzinfo=UTC),
+    )
+    results = [(pg_in_scope, 0.9), (pg_too_old, 0.8)]
+
+    engine = _engine_with_semantic(results)
+    result = await engine.recall(
+        "alpha",
+        uuid4(),
+        limit=10,
+        mode=SearchMode.VECTOR,
+        filter_ast=_filter_ast({"occurred_at": {"$gte": "2026-01-01T00:00:00Z"}}),
+    )
+
+    returned = {c.id for c in result.chunks}
+    assert pg_in_scope.id in returned, "PG-shape occurred_at filter must fall back to source_timestamp, not empty"
+    # The out-of-range PG row is dropped EVEN THOUGH its created_at is in range —
+    # proving created_at is NOT part of the occurred_at fallback.
+    assert returned == {pg_in_scope.id}, "occurred_at fallback is source_timestamp only; created_at must not rescue"
+
+
+@pytest.mark.asyncio
+async def test_occurred_at_filter_excludes_unanchored_chunk_no_created_at_fallback() -> None:
+    # A chunk with NO event-time anchor (occurred_at=None AND source_timestamp=None)
+    # has record["occurred_at"] = None, so a positive occurred_at $gte EXCLUDES it —
+    # even though created_at is in range. Ingest time is deliberately NOT an
+    # occurred_at fallback (engine._chunk_to_record: "No created_at fallback —
+    # ingest time is not event time").
+    unanchored = _chunk(
+        "alpha unanchored",
+        occurred_at=None,
+        source_timestamp=None,
+        created_at=datetime(2026, 6, 1, tzinfo=UTC),  # in range, but NOT a fallback
+    )
+    results = [(unanchored, 0.9)]
+
+    engine = _engine_with_semantic(results)
+    result = await engine.recall(
+        "alpha",
+        uuid4(),
+        limit=10,
+        mode=SearchMode.VECTOR,
+        filter_ast=_filter_ast({"occurred_at": {"$gte": "2026-01-01T00:00:00Z"}}),
+    )
+
+    assert result.chunks == [], (
+        "an unanchored chunk must be excluded by a positive occurred_at filter (no created_at fallback)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_created_at_filter_works_against_literal_created_at() -> None:
+    # created_at is post-filtered (cross-dimension, not pushed) against the chunk's
+    # LITERAL created_at field — the filter narrows correctly and does not empty.
+    in_scope = _chunk("alpha recent", created_at=datetime(2026, 6, 1, tzinfo=UTC))
+    too_old = _chunk("alpha old", created_at=datetime(2020, 1, 1, tzinfo=UTC))
+    results = [(in_scope, 0.9), (too_old, 0.8)]
+
+    engine = _engine_with_semantic(results)
+    result = await engine.recall(
+        "alpha",
+        uuid4(),
+        limit=10,
+        mode=SearchMode.VECTOR,
+        filter_ast=_filter_ast({"created_at": {"$gte": "2026-01-01T00:00:00Z"}}),
+    )
+
+    returned = {c.id for c in result.chunks}
+    assert in_scope.id in returned, "created_at filtering must narrow, not silently empty"
+    assert returned == {in_scope.id}
+
+
+# ===========================================================================
+# (3) unindexed_metadata counter increments on the post-filter path.
+# ===========================================================================
+
+
+class _RecordingCounter:
+    """Captures ``.add(value, attributes=...)`` calls for assertions."""
+
+    def __init__(self) -> None:
+        self.adds: list[tuple[float, dict[str, Any]]] = []
+
+    def add(self, value: float, attributes: Any = None) -> None:
+        self.adds.append((value, dict(attributes or {})))
+
+
+@pytest.fixture
+def recording_counters(monkeypatch: pytest.MonkeyPatch) -> dict[str, _RecordingCounter]:
+    """Replace the filter-telemetry counter singletons with recording fakes.
+
+    Same monkeypatch-the-singleton hook the existing recall-filter telemetry tests
+    use (tests/unit/filter/test_filter_telemetry.py): pre-seeding each module
+    global makes ``record_unindexed_metadata`` land on the fake.
+    """
+    counters = {
+        "unindexed_metadata": _RecordingCounter(),
+        "under_filled": _RecordingCounter(),
+        "graph_channel_empty": _RecordingCounter(),
+    }
+    monkeypatch.setattr(filter_telemetry, "_unindexed_metadata_counter", counters["unindexed_metadata"])
+    monkeypatch.setattr(filter_telemetry, "_under_filled_counter", counters["under_filled"])
+    monkeypatch.setattr(filter_telemetry, "_graph_channel_empty_counter", counters["graph_channel_empty"])
+    return counters
+
+
+@pytest.mark.asyncio
+async def test_unindexed_metadata_fires_on_post_filter_recall(
+    recording_counters: dict[str, _RecordingCounter],
+) -> None:
+    # A metadata-bearing filter recall fires the unindexed_metadata counter (the
+    # post-filter compiles the metadata leaf to a Python predicate). Assert >= 1
+    # observation carrying the leaf's op — robust whether emission is per-compile
+    # or (hypothetically) per-evaluation.
+    chunks = [_chunk("alpha", metadata={"tier": "gold"})]
+    engine = _engine_with_semantic([(chunks[0], 0.9)])
+
+    await engine.recall(
+        "alpha",
+        uuid4(),
+        limit=10,
+        mode=SearchMode.VECTOR,
+        filter_ast=_filter_ast({"metadata.tier": "gold"}),
+    )
+
+    adds = recording_counters["unindexed_metadata"].adds
+    assert len(adds) >= 1, "a metadata-bearing filter recall must fire unindexed_metadata"
+    assert any(a[1].get("op") == "$eq" for a in adds)
+
+
+@pytest.mark.asyncio
+async def test_unindexed_metadata_silent_for_system_key_only_recall(
+    recording_counters: dict[str, _RecordingCounter],
+) -> None:
+    # A system-key-only filter (occurred_at date bound) does not touch metadata, so
+    # the unindexed_metadata counter stays quiet on the post-filter path.
+    chunks = [_chunk("alpha", metadata={"tier": "gold"})]
+    engine = _engine_with_semantic([(chunks[0], 0.9)])
+
+    await engine.recall(
+        "alpha",
+        uuid4(),
+        limit=10,
+        mode=SearchMode.VECTOR,
+        filter_ast=_filter_ast({"occurred_at": {"$gte": "2020-01-01T00:00:00Z"}}),
+    )
+
+    assert recording_counters["unindexed_metadata"].adds == []
+
+
+@pytest.mark.asyncio
+async def test_no_filter_recall_does_not_fire_unindexed_metadata(
+    recording_counters: dict[str, _RecordingCounter],
+) -> None:
+    # No filter → no compile → no counter.
+    chunks = [_chunk("alpha", metadata={"tier": "gold"})]
+    engine = _engine_with_semantic([(chunks[0], 0.9)])
+
+    await engine.recall("alpha", uuid4(), limit=10, mode=SearchMode.VECTOR)
+
+    assert recording_counters["unindexed_metadata"].adds == []

--- a/tests/recall/test_chronicle_filter_composition.py
+++ b/tests/recall/test_chronicle_filter_composition.py
@@ -50,6 +50,7 @@ pytest.importorskip(
 from khora.config import KhoraConfig  # noqa: E402
 from khora.config.schema import QuerySettings  # noqa: E402
 from khora.core.models import Chunk  # noqa: E402
+from khora.core.models.document import DocumentSource  # noqa: E402
 from khora.engines.chronicle import engine as chronicle_engine  # noqa: E402
 from khora.engines.chronicle.engine import ChronicleEngine  # noqa: E402
 from khora.filter import telemetry as filter_telemetry  # noqa: E402
@@ -497,3 +498,81 @@ async def test_no_filter_recall_does_not_fire_unindexed_metadata(
     await engine.recall("alpha", uuid4(), limit=10, mode=SearchMode.VECTOR)
 
     assert recording_counters["unindexed_metadata"].adds == []
+
+
+# ===========================================================================
+# Denorm doc-key carrier resolution (engine._chunk_to_record).
+# ===========================================================================
+#
+# The post-filter record resolves a system key off chunk.source_document
+# (DocumentSource carries ONLY id/title/source/source_type/created_at/
+# source_timestamp). So on the Chronicle path:
+#   * title / source / source_type RESOLVE from source_document when present.
+#   * source_name / source_url / external_id / content_type have NO carrier and
+#     are ALWAYS absent — a DOCUMENTED gap, not a bug. A positive predicate on a
+#     no-carrier key returns empty; a negative predicate ($ne) matches all.
+# We do NOT assert the no-carrier keys "return rows" (the lead's documented
+# limitation); we assert exactly the absent-key polarity.
+
+
+@pytest.mark.asyncio
+async def test_source_document_fallback_resolves_projected_keys() -> None:
+    # A chunk with source_document populated resolves source/source_type/title from
+    # it, so a filter on those keys narrows correctly.
+    sd = DocumentSource(id=uuid4(), title="Release notes", source="linear", source_type="issue")
+    match = _chunk("alpha match")
+    match.source_document = sd
+    other = _chunk("alpha other")
+    other.source_document = DocumentSource(id=uuid4(), title="x", source="slack", source_type="msg")
+    results = [(match, 0.9), (other, 0.8)]
+
+    engine = _engine_with_semantic(results)
+    result = await engine.recall(
+        "alpha",
+        uuid4(),
+        limit=10,
+        mode=SearchMode.VECTOR,
+        filter_ast=_filter_ast({"source": "linear"}),
+    )
+
+    assert {c.id for c in result.chunks} == {match.id}, "source must resolve off source_document for the post-filter"
+
+
+@pytest.mark.asyncio
+async def test_no_carrier_doc_key_positive_predicate_returns_empty() -> None:
+    # source_name has NO carrier (not on DocumentSource), so it is always absent on
+    # the Chronicle path → a positive $eq predicate returns empty. DOCUMENTED gap.
+    sd = DocumentSource(id=uuid4(), title="t", source="linear", source_type="issue")
+    chunk = _chunk("alpha")
+    chunk.source_document = sd
+    engine = _engine_with_semantic([(chunk, 0.9)])
+
+    result = await engine.recall(
+        "alpha",
+        uuid4(),
+        limit=10,
+        mode=SearchMode.VECTOR,
+        filter_ast=_filter_ast({"source_name": "linear"}),
+    )
+
+    assert result.chunks == [], "a positive predicate on a no-carrier key returns empty (documented gap)"
+
+
+@pytest.mark.asyncio
+async def test_no_carrier_doc_key_negative_predicate_matches_all() -> None:
+    # The $ne mirror: a no-carrier (always-absent) key satisfies $ne <value> for
+    # every row (Rule 2 polarity — absent is "not equal"), so the row survives.
+    sd = DocumentSource(id=uuid4(), title="t", source="linear", source_type="issue")
+    chunk = _chunk("alpha")
+    chunk.source_document = sd
+    engine = _engine_with_semantic([(chunk, 0.9)])
+
+    result = await engine.recall(
+        "alpha",
+        uuid4(),
+        limit=10,
+        mode=SearchMode.VECTOR,
+        filter_ast=_filter_ast({"source_name": {"$ne": "linear"}}),
+    )
+
+    assert {c.id for c in result.chunks} == {chunk.id}, "$ne on a no-carrier key matches all (absent is not-equal)"

--- a/tests/recall/test_chronicle_filter_composition.py
+++ b/tests/recall/test_chronicle_filter_composition.py
@@ -21,9 +21,6 @@ directly (deterministic, no infra). The post-filter / telemetry assertions drive
 unit pattern from ``tests/unit/engines/test_chronicle_abstention_signals.py``):
 the semantic channel returns a known in-scope / out-of-scope chunk mix and the
 filter must narrow the result.
-
-INTERIM SKIP: self-skips if the filter compilers / engine wiring are not yet on
-the branch, so the suite stays green until Backend's slice lands.
 """
 
 from __future__ import annotations
@@ -35,26 +32,16 @@ from uuid import uuid4
 
 import pytest
 
+from khora.config import KhoraConfig
+from khora.config.schema import QuerySettings
+from khora.core.models import Chunk
+from khora.core.models.document import DocumentSource
+from khora.engines.chronicle import engine as chronicle_engine
+from khora.engines.chronicle.engine import ChronicleEngine
+from khora.filter import telemetry as filter_telemetry
+from khora.query import SearchMode
+
 pytestmark = pytest.mark.unit
-
-# Self-skip until the engine wiring + compilers are on the branch.
-pytest.importorskip(
-    "khora.filter.compilers.python",
-    reason="recall-filter compilers not yet on the branch (Backend task in flight)",
-)
-pytest.importorskip(
-    "khora.filter.compilers.chronicle",
-    reason="Chronicle compiler not yet on the branch (Backend task in flight)",
-)
-
-from khora.config import KhoraConfig  # noqa: E402
-from khora.config.schema import QuerySettings  # noqa: E402
-from khora.core.models import Chunk  # noqa: E402
-from khora.core.models.document import DocumentSource  # noqa: E402
-from khora.engines.chronicle import engine as chronicle_engine  # noqa: E402
-from khora.engines.chronicle.engine import ChronicleEngine  # noqa: E402
-from khora.filter import telemetry as filter_telemetry  # noqa: E402
-from khora.query import SearchMode  # noqa: E402
 
 # The narrow-only intersection helpers are required for part (c) assertion 1; if
 # they are renamed this import (and the tests) need a one-line update.

--- a/tests/recall/test_compile_chronicle.py
+++ b/tests/recall/test_compile_chronicle.py
@@ -1,0 +1,367 @@
+"""Unit tests for the Chronicle recall-filter compiler pushdown split (Layer 4).
+
+``@internal``. The Chronicle compiler lowers a canonical
+:class:`~khora.filter.ast.FilterNode` into a narrowing **date-bound** the engine
+intersects with its recency window. Chronicle has no general predicate-pushdown
+surface, but every retrieval channel already honors a ``created_after`` /
+``created_before`` window on the indexed event timestamp — so the one thing this
+compiler pushes down is exactly that bound. Everything else (the eight
+denormalized document keys + all metadata) is left UNCONSUMED for the engine to
+post-filter with :func:`~khora.filter.compilers.python.compile_python`.
+
+These tests pin the SPLIT CONTRACT (task part b), against the actual implemented
+shape:
+
+* The compiler pushes ONLY the recency window's PRIMARY dimension —
+  ``source_timestamp`` — and only a *conjunctive* (top-level ``AND``) range /
+  ``$eq`` clause on it. The window narrows on ``COALESCE(source_timestamp,
+  created_at)``, so a bound on ``created_at`` (the fallback axis) or ``occurred_at``
+  (a different dimension the window never references) is cross-dimension and would
+  false-exclude — both are left unconsumed and enforced by the post-filter instead.
+* The unconsumed system keys (the 7 string denorm doc keys + the post-filtered
+  date keys ``occurred_at`` / ``created_at``) and every metadata predicate are NOT
+  pushed down — absent from ``consumed_keys``.
+* The exact pushed set is pinned in the single :data:`_PUSHED_DATE_KEYS` constant
+  (one edit point if Backend's final DTO confirmation shifts it).
+* ``predicate`` is a :class:`ChronicleDateBound(created_after, created_before)`
+  frozen dataclass (NOT a query string). ``$gt``/``$gte`` tighten the lower bound,
+  ``$lt``/``$lte`` the upper, ``$eq`` pins a point window; ``max``/``min`` combine
+  multiple clauses. Boundary strictness is intentionally dropped (the window is a
+  safe over-approximation; ``compile_python`` re-checks strictness on survivors).
+* A date clause under ``$or`` / ``$not``, and ``$ne``/``$in``/``$nin``/``{k:null}``
+  on a date key, are NOT a single contiguous window → left unconsumed.
+* The :class:`CompiledFilter` envelope: ``params`` empty, ``consumed_keys`` a
+  frozenset, ``canonical_hash`` present.
+
+INTERIM SKIP: self-skips if the Chronicle compiler is not importable (it lands
+with Backend's compiler slice), so the suite stays green until then.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from khora.filter import RecallFilter
+from khora.filter.ast import FilterNode, parse_to_ast
+from khora.filter.context import CompileContext
+from khora.filter.model import SYSTEM_KEYS
+
+pytestmark = pytest.mark.unit
+
+# Interim self-skip until Backend's Chronicle compiler lands (see module docstring).
+_chronicle_mod = pytest.importorskip(
+    "khora.filter.compilers.chronicle",
+    reason="Chronicle compiler not yet on the branch (Backend task in flight); test activates when it lands",
+)
+compile_chronicle = _chronicle_mod.compile_chronicle
+ChronicleDateBound = _chronicle_mod.ChronicleDateBound
+
+
+# ---------------------------------------------------------------------------
+# Key-set constants — THE SINGLE EDIT POINT for the pushdown date-key set.
+# ---------------------------------------------------------------------------
+#
+# Pinned to the implemented contract: the recency
+# window narrows on COALESCE(source_timestamp, created_at), so a bound on
+# source_timestamp is the only same-axis-safe pushdown — for every row a
+# source_timestamp filter keeps, the window value equals source_timestamp. The
+# event-time key occurred_at and the fallback key created_at are NOT the window
+# axis, so they are post-filtered (cross-dimension), never folded into the window.
+# This one frozenset is the single edit point; the parametrized tests below derive
+# from it (with _DATE_TYPED) so a pushdown-set change stays self-consistent.
+_PUSHED_DATE_KEYS = frozenset({"source_timestamp"})
+
+# The three date-typed system keys (the candidate pushdown universe). The
+# un-pushed date keys are exactly this set minus _PUSHED_DATE_KEYS, so date-key
+# tests derive from these two constants and stay correct across a pushdown flip.
+_DATE_TYPED = frozenset({"occurred_at", "created_at", "source_timestamp"})
+
+# Everything NOT pushed down: the 7 string (denormalized document) system keys
+# PLUS the date keys that are post-filtered = the complement of _PUSHED_DATE_KEYS.
+_UNCONSUMED_SYSTEM_KEYS = SYSTEM_KEYS - _PUSHED_DATE_KEYS
+
+
+def test_unconsumed_system_key_set_complements_pushed() -> None:
+    # The unconsumed set is exactly SYSTEM_KEYS minus the pushed date key(s): the
+    # 7 string keys + the post-filtered (non-pushed) date keys.
+    assert _UNCONSUMED_SYSTEM_KEYS == SYSTEM_KEYS - _PUSHED_DATE_KEYS
+    assert len(_UNCONSUMED_SYSTEM_KEYS) == len(SYSTEM_KEYS) - len(_PUSHED_DATE_KEYS)
+    # The date-typed keys NOT pushed are post-filtered (cross-dimension), not folded.
+    assert (_DATE_TYPED - _PUSHED_DATE_KEYS) <= _UNCONSUMED_SYSTEM_KEYS
+
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+# The Chronicle engine registers + drives the compiler with the "chunks" storage
+# target and on_unsupported="split" so the unconsumed remainder is post-filtered
+# rather than raised (CompilerRegistry.register("chronicle", "chunks", ...)).
+# compile_chronicle does not read backend_target, but matching the engine's value
+# keeps the unit-test context faithful to production usage.
+_CTX = CompileContext(backend_target="chunks", on_unsupported="split")
+_RAISE_CTX = CompileContext(backend_target="chunks", on_unsupported="raise")
+
+
+def _ast(wire: dict) -> FilterNode:
+    """Validate a wire-form filter and lower it to the canonical AST."""
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+def _compiled(wire: dict, ctx: CompileContext = _CTX) -> Any:
+    return compile_chronicle(_ast(wire), ctx)
+
+
+_LB = "2026-01-01T00:00:00Z"  # a lower-bound instant
+_UB = "2026-12-31T00:00:00Z"  # an upper-bound instant
+_LB_DT = datetime(2026, 1, 1, tzinfo=UTC)
+_UB_DT = datetime(2026, 12, 31, tzinfo=UTC)
+
+# A representative pushable date key for single-key tests (driven by the constant
+# so a change to _PUSHED_DATE_KEYS flows through without editing every test).
+_PUSHED_KEY = sorted(_PUSHED_DATE_KEYS)[0]
+
+
+# ===========================================================================
+# Pushed date keys → consumed + folded into the bound.
+# ===========================================================================
+
+
+@pytest.mark.parametrize("key", sorted(_PUSHED_DATE_KEYS))
+def test_pushed_date_key_lower_bound_is_consumed(key: str) -> None:
+    compiled = _compiled({key: {"$gte": _LB}})
+    assert key in compiled.consumed_keys
+    assert isinstance(compiled.predicate, ChronicleDateBound)
+    assert compiled.predicate.created_after == _LB_DT
+    assert compiled.predicate.created_before is None
+
+
+@pytest.mark.parametrize("key", sorted(_PUSHED_DATE_KEYS))
+def test_pushed_date_key_upper_bound_is_consumed(key: str) -> None:
+    compiled = _compiled({key: {"$lte": _UB}})
+    assert key in compiled.consumed_keys
+    assert compiled.predicate.created_before == _UB_DT
+    assert compiled.predicate.created_after is None
+
+
+@pytest.mark.parametrize("op", ["$gt", "$gte"])
+def test_lower_ops_tighten_lower_bound(op: str) -> None:
+    # Boundary strictness ($gt vs $gte) is intentionally NOT carried — both fold to
+    # the same lower bound instant (the post-filter re-checks the strict compare).
+    compiled = _compiled({_PUSHED_KEY: {op: _LB}})
+    assert compiled.predicate.created_after == _LB_DT
+    assert compiled.predicate.created_before is None
+
+
+@pytest.mark.parametrize("op", ["$lt", "$lte"])
+def test_upper_ops_tighten_upper_bound(op: str) -> None:
+    compiled = _compiled({_PUSHED_KEY: {op: _UB}})
+    assert compiled.predicate.created_before == _UB_DT
+    assert compiled.predicate.created_after is None
+
+
+def test_eq_pins_point_window() -> None:
+    # $eq on a pushed date key pins BOTH bounds to the same instant.
+    compiled = _compiled({_PUSHED_KEY: _LB})
+    assert compiled.predicate.created_after == _LB_DT
+    assert compiled.predicate.created_before == _LB_DT
+    assert _PUSHED_KEY in compiled.consumed_keys
+
+
+def test_two_sided_range_on_one_key_folds_both_bounds() -> None:
+    compiled = _compiled({_PUSHED_KEY: {"$gte": _LB, "$lte": _UB}})
+    assert compiled.predicate.created_after == _LB_DT
+    assert compiled.predicate.created_before == _UB_DT
+    assert _PUSHED_KEY in compiled.consumed_keys
+
+
+def test_multiple_lower_bounds_on_pushed_key_intersect_via_max() -> None:
+    # Two conjunctive lower bounds on the same pushed key → the LATER (max) wins.
+    early_lb = "2026-01-01T00:00:00Z"
+    late_lb = "2026-06-01T00:00:00Z"
+    compiled = _compiled({_PUSHED_KEY: {"$gt": early_lb, "$gte": late_lb}})
+    assert compiled.predicate.created_after == datetime(2026, 6, 1, tzinfo=UTC)
+    assert compiled.consumed_keys == frozenset({_PUSHED_KEY})
+
+
+def test_date_literal_operand_folds() -> None:
+    # The compiler accepts a DateLiteral operand directly off the AST (the AST is a
+    # valid compiler input independent of the wire validator — the {"$date": ...}
+    # wire form is metadata-only, so a date-key DateLiteral is reached by building
+    # the clause directly, as the postgres/cypher unit tests also do).
+    from khora.filter.ast import DateLiteral, FilterClause
+    from khora.filter.model import Op
+
+    clause = FilterClause(path=(_PUSHED_KEY,), op=Op.GTE, operand=DateLiteral(value=_LB_DT))
+    node = FilterNode(op=Op.AND, children=(clause,))
+    compiled = compile_chronicle(node, _CTX)
+    assert compiled.predicate.created_after == _LB_DT
+    assert _PUSHED_KEY in compiled.consumed_keys
+
+
+# ===========================================================================
+# Date keys that DON'T fold into a contiguous window → unconsumed.
+# ===========================================================================
+
+
+def test_cross_dimension_date_keys_are_not_pushed() -> None:
+    # The date-typed keys that are NOT the pushed window axis are cross-dimension —
+    # pushing them would false-exclude against COALESCE(source_timestamp,
+    # created_at) — so they are post-filtered, never folded into the bound. Driven
+    # by the _PUSHED_DATE_KEYS constant so it stays correct across a pushdown-set
+    # change (the un-pushed date keys are exactly the date-typed keys minus the
+    # pushed one).
+    for key in sorted(_DATE_TYPED - _PUSHED_DATE_KEYS):
+        compiled = _compiled({key: {"$gte": _LB}})
+        assert key not in compiled.consumed_keys, f"{key} must be post-filtered, not pushed"
+        assert compiled.predicate == ChronicleDateBound()
+
+
+def test_pushed_date_key_ne_is_not_pushed() -> None:
+    # $ne is not a single contiguous window — left unconsumed even on the pushed key.
+    compiled = _compiled({_PUSHED_KEY: {"$ne": _LB}})
+    assert _PUSHED_KEY not in compiled.consumed_keys
+    assert compiled.predicate == ChronicleDateBound()
+
+
+def test_pushed_date_key_in_is_not_pushed() -> None:
+    compiled = _compiled({_PUSHED_KEY: {"$in": [_LB, _UB]}})
+    assert _PUSHED_KEY not in compiled.consumed_keys
+    assert compiled.predicate == ChronicleDateBound()
+
+
+def test_pushed_date_key_null_match_is_not_pushed() -> None:
+    compiled = _compiled({_PUSHED_KEY: None})
+    assert _PUSHED_KEY not in compiled.consumed_keys
+
+
+def test_pushed_date_key_under_or_is_not_pushed() -> None:
+    # A pushed date clause inside an $or is NOT conjunctive — folding a bound out of
+    # a disjunction would wrongly narrow the other branch, so it is left unconsumed.
+    compiled = _compiled({"$or": [{_PUSHED_KEY: {"$gte": _LB}}, {"source_name": "linear"}]})
+    assert compiled.consumed_keys == frozenset()
+    assert compiled.predicate == ChronicleDateBound()
+
+
+def test_pushed_date_key_under_not_is_not_pushed() -> None:
+    compiled = _compiled({"$not": {_PUSHED_KEY: {"$gte": _LB}}})
+    assert compiled.consumed_keys == frozenset()
+    assert compiled.predicate == ChronicleDateBound()
+
+
+# ===========================================================================
+# Denorm doc keys + metadata → NEVER pushed.
+# ===========================================================================
+
+
+@pytest.mark.parametrize("key", sorted(_UNCONSUMED_SYSTEM_KEYS))
+def test_unconsumed_system_key_is_not_pushed(key: str) -> None:
+    # Each unconsumed system key (the 7 string keys + the post-filtered date keys)
+    # is left for the post-filter, never folded into the date bound. A date-typed
+    # unconsumed key takes a range operand; a string key takes a scalar.
+    wire: dict[str, Any] = {key: {"$gte": _LB}} if key in _DATE_TYPED else {key: "x"}
+    compiled = _compiled(wire)
+    assert key not in compiled.consumed_keys
+
+
+def test_metadata_path_is_not_pushed() -> None:
+    compiled = _compiled({"metadata.tier": "gold"})
+    assert not compiled.consumed_keys
+    assert compiled.predicate == ChronicleDateBound()
+
+
+def test_bare_metadata_blob_is_not_pushed() -> None:
+    compiled = _compiled({"metadata": {"a": 1}})
+    assert compiled.consumed_keys == frozenset()
+
+
+# ===========================================================================
+# Mixed filter — only the conjunctive date key(s) are consumed.
+# ===========================================================================
+
+
+def test_mixed_filter_consumes_only_pushed_date_key() -> None:
+    # The pushed date key folds; source_name + metadata.tier stay unconsumed.
+    wire = {
+        _PUSHED_KEY: {"$gte": _LB},
+        "source_name": "linear",
+        "metadata.tier": "gold",
+    }
+    compiled = _compiled(wire)
+    assert compiled.consumed_keys == frozenset({_PUSHED_KEY})
+    assert compiled.predicate.created_after == _LB_DT
+
+
+def test_consumed_keys_subset_of_pushed_date_keys() -> None:
+    # STRUCTURAL invariant: the compiler never consumes a non-pushable key, even
+    # when the filter spans all three date-typed keys + string keys + metadata.
+    wire = {
+        "created_at": {"$gte": _LB},
+        "occurred_at": {"$lte": _UB},
+        "source_timestamp": {"$gte": _LB},
+        "source_name": "linear",
+        "title": "x",
+        "metadata.tier": "gold",
+    }
+    compiled = _compiled(wire)
+    assert compiled.consumed_keys <= _PUSHED_DATE_KEYS
+    assert not (compiled.consumed_keys & _UNCONSUMED_SYSTEM_KEYS)
+    assert not any(str(k).startswith("metadata") for k in compiled.consumed_keys)
+
+
+# ===========================================================================
+# on_unsupported policy.
+# ===========================================================================
+
+
+def test_split_mode_does_not_raise_on_unconsumed() -> None:
+    # The engine's mode: unconsumed content is silently left for the post-filter.
+    compiled = _compiled({"source_name": "linear", "metadata.tier": "gold"})
+    assert compiled.consumed_keys == frozenset()
+
+
+def test_raise_mode_raises_on_unpushable_clause() -> None:
+    from khora.filter import RecallFilterUnsupportedError
+
+    with pytest.raises(RecallFilterUnsupportedError):
+        _compiled({"source_name": "linear"}, _RAISE_CTX)
+
+
+def test_raise_mode_allows_pure_pushed_date_filter() -> None:
+    # A filter that is entirely consumable (pushed-key) date bounds does not raise
+    # even in "raise" mode (there is no unconsumed remainder).
+    compiled = _compiled({_PUSHED_KEY: {"$gte": _LB}}, _RAISE_CTX)
+    assert compiled.consumed_keys == frozenset({_PUSHED_KEY})
+
+
+# ===========================================================================
+# CompiledFilter envelope.
+# ===========================================================================
+
+
+def test_empty_filter_consumes_nothing_and_is_unbounded() -> None:
+    compiled = _compiled({})
+    assert compiled.consumed_keys == frozenset()
+    assert compiled.predicate == ChronicleDateBound()
+
+
+def test_params_is_empty_dict() -> None:
+    # The bound carries datetimes directly; no out-of-band binds.
+    compiled = _compiled({_PUSHED_KEY: {"$gte": _LB}})
+    assert compiled.params == {}
+
+
+def test_consumed_keys_is_frozenset() -> None:
+    compiled = _compiled({_PUSHED_KEY: {"$gte": _LB}})
+    assert isinstance(compiled.consumed_keys, frozenset)
+
+
+def test_carries_canonical_hash() -> None:
+    from khora.filter.ast import canonical_hash
+
+    node = _ast({_PUSHED_KEY: {"$gte": _LB}})
+    compiled = compile_chronicle(node, _CTX)
+    assert compiled.canonical_hash == canonical_hash(node)

--- a/tests/recall/test_compile_chronicle.py
+++ b/tests/recall/test_compile_chronicle.py
@@ -32,9 +32,6 @@ shape:
   on a date key, are NOT a single contiguous window → left unconsumed.
 * The :class:`CompiledFilter` envelope: ``params`` empty, ``consumed_keys`` a
   frozenset, ``canonical_hash`` present.
-
-INTERIM SKIP: self-skips if the Chronicle compiler is not importable (it lands
-with Backend's compiler slice), so the suite stays green until then.
 """
 
 from __future__ import annotations
@@ -46,18 +43,11 @@ import pytest
 
 from khora.filter import RecallFilter
 from khora.filter.ast import FilterNode, parse_to_ast
+from khora.filter.compilers.chronicle import ChronicleDateBound, compile_chronicle
 from khora.filter.context import CompileContext
 from khora.filter.model import SYSTEM_KEYS
 
 pytestmark = pytest.mark.unit
-
-# Interim self-skip until Backend's Chronicle compiler lands (see module docstring).
-_chronicle_mod = pytest.importorskip(
-    "khora.filter.compilers.chronicle",
-    reason="Chronicle compiler not yet on the branch (Backend task in flight); test activates when it lands",
-)
-compile_chronicle = _chronicle_mod.compile_chronicle
-ChronicleDateBound = _chronicle_mod.ChronicleDateBound
 
 
 # ---------------------------------------------------------------------------

--- a/tests/recall/test_compile_python.py
+++ b/tests/recall/test_compile_python.py
@@ -1,0 +1,689 @@
+"""Unit tests for the in-memory ``compile_python`` recall-filter compiler (Layer 4).
+
+``@internal``. ``compile_python(ast, ctx)`` lowers a canonical
+:class:`~khora.filter.ast.FilterNode` into an in-memory ``callable(record) -> bool``
+predicate carried on :attr:`CompiledFilter.predicate`. It is the engine-side
+post-filter half of the partial-pushdown split: a backend pushes down what it can
+(e.g. the Chronicle compiler pushes the indexed date keys), and the engine
+evaluates the rest of the §4 *Field-match contract* against each candidate record
+in Python.
+
+These tests pin the §4 Field-match contract at the Python level: each test builds
+an AST (by validating a :class:`~khora.filter.RecallFilter` and lowering it with
+:func:`~khora.filter.ast.parse_to_ast`), compiles it to a predicate, and asserts
+on the *boolean result* of calling that predicate against crafted records — never
+re-implementing the compiler, only inspecting whether a given record matches.
+
+The contract these tests lock (§4), mirroring ``compile_postgres`` / ``compile_cypher``:
+
+* Type-gate: a positive op ($eq/$gt/$gte/$lt/$lte/$in) EXCLUDES a wrong-typed or
+  absent value; ``number`` means ``int``/``float`` and NOT ``bool``.
+* Polarity: $ne / $nin INCLUDE a missing key AND a wrong-typed value (Mongo-faithful);
+  never drop an absent/null row on a negation.
+* Metadata array containment: a scalar operand matches a stored-array element; a
+  bare list operand is exact-array equality (NOT membership); $in = contains-any.
+* Scalar range ($gt/$gte/$lt/$lte) type-gating: a comparison against a wrong-typed
+  stored value is False (the gate yields exclude, never an error).
+* ``$date`` parse-or-exclude: a malformed stored date string is excluded under a
+  positive ``$date`` compare.
+* ``$exists`` and ``{k: null}`` distinguish ABSENT from PRESENT-NULL; a system-key
+  ``$exists`` is trivially all/none (system columns are always present), distinct
+  from a metadata ``$exists`` which tests key presence in the metadata dict.
+* AND / OR / NOT nesting; the empty filter matches everything.
+
+RECORD-SHAPE DEFENSIVENESS (interface point A): the predicate must accept BOTH a
+dict-like record and an attribute-style record (chunk/event dataclasses). Each
+semantic is asserted against both shapes via :func:`_both`. A key is ABSENT when
+neither attribute nor mapping access yields it; PRESENT-NULL when access yields
+Python ``None``. ``metadata`` is resolved the same way and defaults to ``{}``.
+
+INTERIM SKIP: ``compile_python`` lands with Backend's compiler slice. Until the
+module is importable, this whole module SELF-SKIPS (a clean collection-time skip,
+never an erroring import) so the suite stays green; it activates the instant the
+implementation lands. This mirrors the "implementation lands separately" idiom
+already used in the filter unit suite. It is NOT a permanent skip — once the
+compiler is on the branch the import succeeds and every test runs.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from khora.filter import RecallFilter
+from khora.filter.ast import FilterClause, FilterNode, parse_to_ast
+from khora.filter.context import CompileContext
+from khora.filter.model import Op
+
+pytestmark = pytest.mark.unit
+
+# Interim self-skip until Backend's compile_python lands (see module docstring).
+# A failed import is a clean module skip here, not a LOUD error: this slice is
+# explicitly gated on a sibling task that is still in flight.
+compile_python = pytest.importorskip(
+    "khora.filter.compilers.python",
+    reason="compile_python not yet on the branch (Backend task in flight); test activates when it lands",
+).compile_python
+
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+_CTX = CompileContext(backend_target="chronicle")
+
+
+def _ast(wire: dict) -> FilterNode:
+    """Validate a wire-form filter and lower it to the canonical AST."""
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+def _pred(wire: dict, ctx: CompileContext = _CTX) -> Any:
+    """Compile a wire filter and return its in-memory ``callable(record) -> bool``."""
+    compiled = compile_python(_ast(wire), ctx)
+    return compiled.predicate
+
+
+def _attr_record(d: dict[str, Any]) -> SimpleNamespace:
+    """An attribute-style record (chunk/event dataclass shape) from a dict.
+
+    Mirrors a chunk/event dataclass: system keys are attributes and ``metadata``
+    is an attribute holding the dict. Absent keys are simply not set as
+    attributes, so attribute access raises ``AttributeError`` (the ABSENT signal).
+    """
+    return SimpleNamespace(**d)
+
+
+def _both(wire: dict, record: dict[str, Any]) -> bool:
+    """Evaluate the predicate against BOTH a dict and an attr record; assert agreement.
+
+    The §4 contract is record-shape-agnostic (interface point A): a dict-like and
+    an attribute-style record describing the same fields MUST yield the same
+    match. Asserting agreement in one place lets every semantic test below call
+    ``_both`` once and trust both shapes are covered.
+    """
+    pred = _pred(wire)
+    via_dict = pred(dict(record))
+    via_attr = pred(_attr_record(record))
+    assert via_dict == via_attr, (
+        f"dict-record and attr-record disagree for filter={wire!r} record={record!r}: dict={via_dict} attr={via_attr}"
+    )
+    return via_dict
+
+
+# ===========================================================================
+# Empty filter → match-everything.
+# ===========================================================================
+
+
+def test_empty_filter_matches_everything() -> None:
+    # A bare RecallFilter() (no predicates) lowers to the empty match-everything
+    # AND; the predicate must return True for any record, including {}.
+    pred = _pred({})
+    assert pred({}) is True
+    assert pred({"source_name": "anything"}) is True
+    assert pred(_attr_record({"metadata": {"x": 1}})) is True
+
+
+def test_empty_and_node_matches_everything() -> None:
+    # Construct the empty AND directly — same match-everything contract.
+    pred = compile_python(FilterNode(op=Op.AND, children=()), _CTX).predicate
+    assert pred({}) is True
+
+
+# ===========================================================================
+# §4 type-gate — positive ops EXCLUDE wrong-type / absent.
+# ===========================================================================
+
+
+def test_system_eq_matches_equal_value() -> None:
+    assert _both({"source_name": "linear"}, {"source_name": "linear"}) is True
+
+
+def test_system_eq_excludes_different_value() -> None:
+    assert _both({"source_name": "linear"}, {"source_name": "slack"}) is False
+
+
+def test_system_eq_excludes_absent_key() -> None:
+    # $eq is a positive op: an absent system value cannot equal the operand.
+    assert _both({"source_name": "linear"}, {}) is False
+
+
+def test_metadata_numeric_gt_excludes_string_stored_value() -> None:
+    # Number type-gate: $gt 5 against a STRING stored value is a wrong-type compare
+    # → excluded (the gate yields exclude, never a TypeError).
+    assert _both({"metadata.score": {"$gt": 5}}, {"metadata": {"score": "high"}}) is False
+
+
+def test_metadata_numeric_gt_matches_number_stored_value() -> None:
+    assert _both({"metadata.score": {"$gt": 5}}, {"metadata": {"score": 9}}) is True
+    assert _both({"metadata.score": {"$gt": 5}}, {"metadata": {"score": 3}}) is False
+
+
+def test_metadata_numeric_gate_rejects_bool_as_number() -> None:
+    # number type-gate = isinstance int/float AND NOT bool. A stored True must NOT
+    # satisfy a numeric range even though `True == 1` in Python.
+    assert _both({"metadata.score": {"$gt": 0}}, {"metadata": {"score": True}}) is False
+
+
+def test_metadata_eq_bool_matches_only_bool() -> None:
+    # $eq True matches a stored bool True, and a stored 1 must NOT match True
+    # (bool is type-distinct from number on the equality path too).
+    assert _both({"metadata.flag": True}, {"metadata": {"flag": True}}) is True
+    assert _both({"metadata.flag": True}, {"metadata": {"flag": 1}}) is False
+
+
+# ===========================================================================
+# §4 polarity — $ne / $nin INCLUDE missing & wrong-type.
+# ===========================================================================
+
+
+def test_system_ne_matches_different_value() -> None:
+    assert _both({"source_name": {"$ne": "linear"}}, {"source_name": "slack"}) is True
+
+
+def test_system_ne_excludes_equal_value() -> None:
+    assert _both({"source_name": {"$ne": "linear"}}, {"source_name": "linear"}) is False
+
+
+def test_system_ne_includes_absent_key() -> None:
+    # Rule 2 polarity: an absent system value is "not equal" → $ne matches it.
+    assert _both({"source_name": {"$ne": "linear"}}, {}) is True
+
+
+def test_system_ne_includes_present_null() -> None:
+    # A present-but-None system value also satisfies $ne <non-null>.
+    assert _both({"source_name": {"$ne": "linear"}}, {"source_name": None}) is True
+
+
+def test_metadata_ne_includes_missing_key() -> None:
+    # $ne on a metadata path includes a row missing the key entirely (Mongo-faithful).
+    assert _both({"metadata.tier": {"$ne": "gold"}}, {"metadata": {}}) is True
+
+
+def test_metadata_ne_includes_wrong_type() -> None:
+    # A wrong-typed stored value is "not equal" to the operand → $ne includes it.
+    assert _both({"metadata.tier": {"$ne": "gold"}}, {"metadata": {"tier": 7}}) is True
+
+
+def test_metadata_ne_excludes_equal_value() -> None:
+    assert _both({"metadata.tier": {"$ne": "gold"}}, {"metadata": {"tier": "gold"}}) is False
+
+
+def test_system_nin_includes_absent_key() -> None:
+    assert _both({"source_name": {"$nin": ["a", "b"]}}, {}) is True
+
+
+def test_system_nin_excludes_member() -> None:
+    assert _both({"source_name": {"$nin": ["a", "b"]}}, {"source_name": "a"}) is False
+
+
+def test_system_nin_matches_non_member() -> None:
+    assert _both({"source_name": {"$nin": ["a", "b"]}}, {"source_name": "c"}) is True
+
+
+def test_system_empty_in_matches_nothing() -> None:
+    # $in over ∅ on a system key matches nothing (positive membership over empty).
+    assert _both({"source_name": {"$in": []}}, {"source_name": "a"}) is False
+
+
+def test_system_empty_nin_matches_everything() -> None:
+    # $nin over ∅ matches everything (negation over empty), present or absent.
+    assert _both({"source_name": {"$nin": []}}, {"source_name": "a"}) is True
+    assert _both({"source_name": {"$nin": []}}, {}) is True
+
+
+def test_metadata_nin_includes_missing_key() -> None:
+    assert _both({"metadata.tag": {"$nin": ["x", "y"]}}, {"metadata": {}}) is True
+
+
+# ===========================================================================
+# §4 metadata array containment.
+# ===========================================================================
+
+
+def test_metadata_scalar_eq_matches_stored_array_element() -> None:
+    # A scalar operand matches a stored ARRAY that contains it (array-aware
+    # containment, mirroring Postgres `@>`).
+    assert _both({"metadata.tags": "urgent"}, {"metadata": {"tags": ["urgent", "p1"]}}) is True
+
+
+def test_metadata_scalar_eq_matches_stored_scalar() -> None:
+    # The same scalar operand also matches a stored scalar equal to it.
+    assert _both({"metadata.tags": "urgent"}, {"metadata": {"tags": "urgent"}}) is True
+
+
+def test_metadata_scalar_eq_excludes_array_without_element() -> None:
+    assert _both({"metadata.tags": "urgent"}, {"metadata": {"tags": ["p1", "later"]}}) is False
+
+
+def test_metadata_bare_list_is_exact_array_equality() -> None:
+    # A bare list operand is EXACT-ARRAY equality (NOT membership): it matches only
+    # a stored array equal element-for-element, in order.
+    assert _both({"metadata.tags": ["a", "b"]}, {"metadata": {"tags": ["a", "b"]}}) is True
+
+
+def test_metadata_bare_list_excludes_superset_array() -> None:
+    # Exact-array, so a stored superset does NOT match (distinguishes it from $in).
+    assert _both({"metadata.tags": ["a", "b"]}, {"metadata": {"tags": ["a", "b", "c"]}}) is False
+
+
+def test_metadata_bare_list_excludes_reordered_array() -> None:
+    # Order is significant for exact-array equality.
+    assert _both({"metadata.tags": ["a", "b"]}, {"metadata": {"tags": ["b", "a"]}}) is False
+
+
+def test_metadata_bare_list_excludes_scalar_store() -> None:
+    # An exact-array operand never equals a stored scalar.
+    assert _both({"metadata.tags": ["a", "b"]}, {"metadata": {"tags": "a"}}) is False
+
+
+def test_metadata_in_is_contains_any() -> None:
+    # $in is contains-any: matches if the stored value (scalar) is one of the set,
+    # OR if the stored array shares ANY element with the set.
+    assert _both({"metadata.tag": {"$in": ["x", "y"]}}, {"metadata": {"tag": "y"}}) is True
+    assert _both({"metadata.tag": {"$in": ["x", "y"]}}, {"metadata": {"tag": ["y", "z"]}}) is True
+    assert _both({"metadata.tag": {"$in": ["x", "y"]}}, {"metadata": {"tag": "z"}}) is False
+
+
+def test_metadata_in_excludes_missing_key() -> None:
+    # Positive membership over an absent key → excluded.
+    assert _both({"metadata.tag": {"$in": ["x", "y"]}}, {"metadata": {}}) is False
+
+
+def test_metadata_empty_in_matches_nothing() -> None:
+    # $in over an empty set is a valid filter (validator accepts it): positive
+    # membership over ∅ matches nothing — even a present value (mirrors the
+    # cypher/postgres compilers' empty-$in => constant-false).
+    assert _both({"metadata.tag": {"$in": []}}, {"metadata": {"tag": "x"}}) is False
+
+
+def test_metadata_empty_nin_matches_everything() -> None:
+    # $nin over ∅ is the polarity mirror — matches every row, including a present
+    # value (negation over ∅), so it never excludes.
+    assert _both({"metadata.tag": {"$nin": []}}, {"metadata": {"tag": "x"}}) is True
+    # ...and a missing key too (negation includes absent).
+    assert _both({"metadata.tag": {"$nin": []}}, {"metadata": {}}) is True
+
+
+# ===========================================================================
+# §4 scalar range ($gt/$gte/$lt/$lte) type-gating.
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    ("op", "stored", "expected"),
+    [
+        ("$gt", 6, True),
+        ("$gt", 5, False),
+        ("$gte", 5, True),
+        ("$gte", 4, False),
+        ("$lt", 4, True),
+        ("$lt", 5, False),
+        ("$lte", 5, True),
+        ("$lte", 6, False),
+    ],
+)
+def test_metadata_numeric_range_boundaries(op: str, stored: int, expected: bool) -> None:
+    assert _both({"metadata.score": {op: 5}}, {"metadata": {"score": stored}}) is expected
+
+
+def test_metadata_range_excludes_absent_key() -> None:
+    # A range op over an absent key is a positive op → excluded.
+    assert _both({"metadata.score": {"$gte": 5}}, {"metadata": {}}) is False
+
+
+def test_metadata_range_excludes_wrong_type() -> None:
+    # A numeric range against a non-numeric stored value is type-gated out.
+    assert _both({"metadata.score": {"$lt": 100}}, {"metadata": {"score": "n/a"}}) is False
+
+
+# ===========================================================================
+# §4 $date parse-or-exclude.
+# ===========================================================================
+
+
+def test_metadata_date_compare_matches_valid_iso() -> None:
+    # A $date literal compared against a valid ISO-8601 stored string.
+    wire = {"metadata.due": {"$gte": {"$date": "2026-01-01T00:00:00Z"}}}
+    assert _both(wire, {"metadata": {"due": "2026-06-01T00:00:00Z"}}) is True
+    assert _both(wire, {"metadata": {"due": "2025-12-01T00:00:00Z"}}) is False
+
+
+def test_metadata_date_compare_excludes_malformed_stored_value() -> None:
+    # parse-or-exclude: a malformed stored date string under a positive $date
+    # compare is EXCLUDED (it cannot be parsed, so it cannot satisfy the bound).
+    wire = {"metadata.due": {"$gte": {"$date": "2026-01-01T00:00:00Z"}}}
+    assert _both(wire, {"metadata": {"due": "not-a-date"}}) is False
+
+
+def test_metadata_date_compare_excludes_absent_key() -> None:
+    wire = {"metadata.due": {"$lte": {"$date": "2026-01-01T00:00:00Z"}}}
+    assert _both(wire, {"metadata": {}}) is False
+
+
+# ===========================================================================
+# §4 $exists and {k: null} — absent vs present-null.
+# ===========================================================================
+
+
+def test_metadata_exists_true_matches_present_key() -> None:
+    assert _both({"metadata.tier": {"$exists": True}}, {"metadata": {"tier": "gold"}}) is True
+
+
+def test_metadata_exists_true_matches_present_null() -> None:
+    # PRESENT-NULL is still PRESENT: $exists True matches a key explicitly set to null.
+    assert _both({"metadata.tier": {"$exists": True}}, {"metadata": {"tier": None}}) is True
+
+
+def test_metadata_exists_true_excludes_absent_key() -> None:
+    assert _both({"metadata.tier": {"$exists": True}}, {"metadata": {}}) is False
+
+
+def test_metadata_exists_false_matches_absent_key() -> None:
+    assert _both({"metadata.tier": {"$exists": False}}, {"metadata": {}}) is True
+
+
+def test_metadata_exists_false_excludes_present_key() -> None:
+    assert _both({"metadata.tier": {"$exists": False}}, {"metadata": {"tier": "gold"}}) is False
+
+
+def test_metadata_exists_false_excludes_present_null() -> None:
+    # A present-null key is PRESENT, so $exists False excludes it.
+    assert _both({"metadata.tier": {"$exists": False}}, {"metadata": {"tier": None}}) is False
+
+
+def test_metadata_null_match_matches_present_null() -> None:
+    # {k: null} is an active null-or-missing match: a present-null value matches.
+    assert _both({"metadata.tier": None}, {"metadata": {"tier": None}}) is True
+
+
+def test_metadata_null_match_matches_absent_key() -> None:
+    # ...and an absent key also matches {k: null} (null-OR-missing).
+    assert _both({"metadata.tier": None}, {"metadata": {}}) is True
+
+
+def test_metadata_null_match_excludes_present_value() -> None:
+    assert _both({"metadata.tier": None}, {"metadata": {"tier": "gold"}}) is False
+
+
+# ----- system-key $exists is trivially all/none -----------------------------
+
+
+def test_system_exists_true_is_trivially_all() -> None:
+    # System columns are always present in a row, so $exists True is a tautology —
+    # it matches regardless of whether the record carries a value (mirrors
+    # compile_postgres returning a constant true).
+    assert _both({"source_name": {"$exists": True}}, {"source_name": "linear"}) is True
+    assert _both({"source_name": {"$exists": True}}, {}) is True
+
+
+def test_system_exists_false_is_trivially_none() -> None:
+    assert _both({"source_name": {"$exists": False}}, {"source_name": "linear"}) is False
+    assert _both({"source_name": {"$exists": False}}, {}) is False
+
+
+def test_system_null_match_uses_value_null_not_presence() -> None:
+    # Distinct from $exists: a system {k: null} match is about the VALUE being
+    # null-or-missing (a None-valued or absent system value matches), NOT the
+    # trivial column-presence test.
+    assert _both({"source_name": None}, {"source_name": None}) is True
+    assert _both({"source_name": None}, {}) is True
+    assert _both({"source_name": None}, {"source_name": "linear"}) is False
+
+
+# ===========================================================================
+# §4 logical composition — AND / OR / NOT nesting.
+# ===========================================================================
+
+
+def test_and_requires_all_predicates() -> None:
+    wire = {"source_name": "linear", "metadata.tier": "gold"}
+    assert _both(wire, {"source_name": "linear", "metadata": {"tier": "gold"}}) is True
+    # One predicate failing fails the AND.
+    assert _both(wire, {"source_name": "linear", "metadata": {"tier": "silver"}}) is False
+    assert _both(wire, {"source_name": "slack", "metadata": {"tier": "gold"}}) is False
+
+
+def test_or_requires_any_predicate() -> None:
+    wire = {"$or": [{"source_name": "linear"}, {"source_type": "slack"}]}
+    assert _both(wire, {"source_name": "linear", "source_type": "x"}) is True
+    assert _both(wire, {"source_name": "x", "source_type": "slack"}) is True
+    assert _both(wire, {"source_name": "x", "source_type": "y"}) is False
+
+
+def test_not_negates_with_null_inclusion() -> None:
+    # $not($eq) behaves like $ne: it flips an absent/wrong row IN (Rule 2 totality).
+    wire = {"$not": {"source_name": "linear"}}
+    assert _both(wire, {"source_name": "linear"}) is False
+    assert _both(wire, {"source_name": "slack"}) is True
+    assert _both(wire, {}) is True  # absent → NOT(excluded) → included
+
+
+def test_nested_and_or() -> None:
+    wire = {
+        "source_name": "linear",
+        "$or": [{"source_type": "slack"}, {"content_type": "text/plain"}],
+    }
+    assert _both(wire, {"source_name": "linear", "source_type": "slack", "content_type": "x"}) is True
+    assert _both(wire, {"source_name": "linear", "source_type": "x", "content_type": "x"}) is False
+    assert _both(wire, {"source_name": "other", "source_type": "slack", "content_type": "x"}) is False
+
+
+def test_nor_excludes_all_branches() -> None:
+    # $nor desugars to $not($or(...)): matches only when NONE of the branches match.
+    wire = {"$nor": [{"source_name": "linear"}, {"source_type": "slack"}]}
+    assert _both(wire, {"source_name": "other", "source_type": "other"}) is True
+    assert _both(wire, {"source_name": "linear", "source_type": "other"}) is False
+
+
+# ===========================================================================
+# Bare-blob metadata equality.
+# ===========================================================================
+
+
+def test_bare_metadata_blob_equality() -> None:
+    # A bare metadata dict is whole-blob $eq equality (key-order-insensitive object
+    # equality, mirroring Mongo embedded-doc equality / Postgres JSONB `=`).
+    wire = {"metadata": {"a": 1, "b": 2}}
+    assert _both(wire, {"metadata": {"b": 2, "a": 1}}) is True
+    assert _both(wire, {"metadata": {"a": 1}}) is False
+    assert _both(wire, {"metadata": {"a": 1, "b": 2, "c": 3}}) is False
+
+
+def test_bare_metadata_blob_against_absent_metadata() -> None:
+    # An absent / None metadata defaults to {} — only an empty-blob operand matches.
+    assert _both({"metadata": {"a": 1}}, {}) is False
+    assert _both({"metadata": {}}, {}) is True
+
+
+# ===========================================================================
+# Nested-subdocument equality is EXACT (whole-object ==), NOT containment.
+# ===========================================================================
+#
+# A dict operand on a metadata SUB-PATH (e.g. {"metadata.labels": {"team": "x"}})
+# is whole-subdocument equality: the stored object must equal the operand EXACTLY
+# (order-insensitive), so a stored SUPERSET does NOT match. This is the ADR
+# object_equal / Python "dict ==" rule.
+#
+# NOTE: compile_postgres currently uses @> (containment) on this case — a separate
+# pre-existing bug, NOT this slice's target. So these tests pin compile_python's
+# OWN exact-equality behavior and deliberately do NOT assert python == postgres
+# here. (Everywhere else compile_python mirrors compile_postgres; this one cell of
+# the matrix is the documented exception.)
+
+
+def test_nested_subdocument_equality_is_exact_match() -> None:
+    wire = {"metadata.labels": {"team": "x"}}
+    assert _both(wire, {"metadata": {"labels": {"team": "x"}}}) is True
+
+
+def test_nested_subdocument_equality_rejects_superset() -> None:
+    # EXACT, not containment: a stored superset must NOT match (this is the line
+    # that separates object-equality from @> containment).
+    wire = {"metadata.labels": {"team": "x"}}
+    assert _both(wire, {"metadata": {"labels": {"team": "x", "y": 2}}}) is False
+
+
+def test_nested_subdocument_equality_is_order_insensitive() -> None:
+    # Object equality ignores key order (normalized dict ==), so a reordered stored
+    # object with the same key-set + values still matches.
+    wire = {"metadata.labels": {"a": 1, "b": 2}}
+    assert _both(wire, {"metadata": {"labels": {"b": 2, "a": 1}}}) is True
+
+
+def test_nested_subdocument_equality_rejects_subset_and_value_diff() -> None:
+    wire = {"metadata.labels": {"team": "x", "tier": 1}}
+    assert _both(wire, {"metadata": {"labels": {"team": "x"}}}) is False  # subset
+    assert _both(wire, {"metadata": {"labels": {"team": "y", "tier": 1}}}) is False  # value diff
+
+
+def test_nested_subdocument_equality_excludes_absent_path() -> None:
+    # A positive $eq over an absent sub-path excludes (Rule 1: missing → no match).
+    assert _both({"metadata.labels": {"team": "x"}}, {"metadata": {}}) is False
+
+
+# ===========================================================================
+# Direct-clause construction (AST is a valid input independent of the validator).
+# ===========================================================================
+
+
+def test_direct_datetime_clause() -> None:
+    # Build a leaf clause directly with a tz-aware datetime operand on a system
+    # date key — the AST is a valid compiler input independent of the wire path.
+    clause = FilterClause(path=("occurred_at",), op=Op.GTE, operand=datetime(2026, 1, 1, tzinfo=UTC))
+    node = FilterNode(op=Op.AND, children=(clause,))
+    pred = compile_python(node, _CTX).predicate
+    assert pred({"occurred_at": datetime(2026, 6, 1, tzinfo=UTC)}) is True
+    assert pred({"occurred_at": datetime(2025, 1, 1, tzinfo=UTC)}) is False
+
+
+# ===========================================================================
+# CompiledFilter envelope — predicate is callable, canonical_hash present.
+# ===========================================================================
+
+
+def test_compiled_filter_predicate_is_callable() -> None:
+    compiled = compile_python(_ast({"source_name": "linear"}), _CTX)
+    assert callable(compiled.predicate)
+
+
+def test_compiled_filter_carries_canonical_hash() -> None:
+    from khora.filter.ast import canonical_hash
+
+    node = _ast({"source_name": "linear"})
+    compiled = compile_python(node, _CTX)
+    assert compiled.canonical_hash == canonical_hash(node)
+
+
+# ===========================================================================
+# unindexed_metadata telemetry — emitted PER METADATA LEAF at COMPILE time.
+# ===========================================================================
+#
+# Contract (confirmed against the binding precedent, tests/unit/filter/
+# test_filter_telemetry.py): the in-memory post-filter compiler emits
+# ``record_unindexed_metadata(op=...)`` ONCE PER METADATA LEAF while building the
+# predicate (the AST walk), mirroring ``compile_postgres`` at postgres.py:187 —
+# NOT inside the returned callable, and NOT per candidate record. So the count is
+# stable regardless of how many records the predicate is later evaluated against,
+# and a system-key-only filter emits nothing. The fixture monkeypatches the same
+# three module-level singletons in ``khora.filter.telemetry`` the postgres
+# telemetry tests use.
+
+
+class _RecordingCounter:
+    """Captures ``.add(value, attributes=...)`` calls for assertions."""
+
+    def __init__(self) -> None:
+        self.adds: list[tuple[float, dict[str, Any]]] = []
+
+    def add(self, value: float, attributes: Any = None) -> None:
+        self.adds.append((value, dict(attributes or {})))
+
+
+@pytest.fixture
+def recording_counters(monkeypatch: pytest.MonkeyPatch) -> dict[str, _RecordingCounter]:
+    """Replace the three filter-telemetry counter singletons with recording fakes.
+
+    The ``_get_*`` helpers return the singleton if already set, so pre-seeding each
+    module global makes ``record_unindexed_metadata`` (and any ``.add()`` site)
+    land on the fake. Identical shape to test_filter_telemetry.py::recording_counters.
+    """
+    from khora.filter import telemetry as filter_telemetry
+
+    counters = {
+        "unindexed_metadata": _RecordingCounter(),
+        "under_filled": _RecordingCounter(),
+        "graph_channel_empty": _RecordingCounter(),
+    }
+    monkeypatch.setattr(filter_telemetry, "_unindexed_metadata_counter", counters["unindexed_metadata"])
+    monkeypatch.setattr(filter_telemetry, "_under_filled_counter", counters["under_filled"])
+    monkeypatch.setattr(filter_telemetry, "_graph_channel_empty_counter", counters["graph_channel_empty"])
+    return counters
+
+
+def test_unindexed_metadata_fires_once_per_metadata_leaf_at_compile(
+    recording_counters: dict[str, _RecordingCounter],
+) -> None:
+    # Compiling (not evaluating) a single metadata predicate emits exactly one
+    # observation, with the leaf's op as the bounded attribute.
+    compile_python(_ast({"metadata.tier": "gold"}), _CTX)
+
+    adds = recording_counters["unindexed_metadata"].adds
+    assert len(adds) == 1
+    assert adds[0] == (1, {"op": "$eq"})
+
+
+def test_unindexed_metadata_counts_each_metadata_leaf(
+    recording_counters: dict[str, _RecordingCounter],
+) -> None:
+    # N metadata leaves → N observations; a sibling system key does NOT add.
+    wire = {
+        "source_name": "linear",  # system key — no emit
+        "metadata.tier": "gold",  # $eq metadata leaf
+        "metadata.score": {"$gt": 5},  # $gt metadata leaf
+    }
+    compile_python(_ast(wire), _CTX)
+
+    adds = recording_counters["unindexed_metadata"].adds
+    assert len(adds) == 2
+    assert sorted(a[1]["op"] for a in adds) == ["$eq", "$gt"]
+    assert all(a[0] == 1 for a in adds)
+
+
+def test_unindexed_metadata_silent_for_system_key_only(
+    recording_counters: dict[str, _RecordingCounter],
+) -> None:
+    # A system-key-only filter post-filters typed columns — no JSONB/metadata access.
+    compile_python(_ast({"source_name": "linear"}), _CTX)
+    assert recording_counters["unindexed_metadata"].adds == []
+
+
+def test_unindexed_metadata_not_emitted_per_record_evaluation(
+    recording_counters: dict[str, _RecordingCounter],
+) -> None:
+    # The load-bearing contract: emission is at COMPILE time, not per evaluation.
+    # Build the predicate once, then call it on several records — the count must
+    # NOT grow (emission happened during the compile AST walk, not in the callable).
+    pred = compile_python(_ast({"metadata.tier": "gold"}), _CTX).predicate
+    baseline = len(recording_counters["unindexed_metadata"].adds)
+    assert baseline == 1
+
+    for tier in ("gold", "silver", "bronze", "gold", "gold"):
+        pred({"metadata": {"tier": tier}})
+
+    assert len(recording_counters["unindexed_metadata"].adds) == baseline, (
+        "the counter must not fire per candidate record — emission is compile-time only"
+    )
+
+
+def test_v1_only_counters_stay_quiet_on_compile(
+    recording_counters: dict[str, _RecordingCounter],
+) -> None:
+    # The two V1-only counters have no call site on the compile path here.
+    compile_python(_ast({"metadata.tier": "gold"}), _CTX)
+    assert recording_counters["under_filled"].adds == []
+    assert recording_counters["graph_channel_empty"].adds == []

--- a/tests/recall/test_compile_python.py
+++ b/tests/recall/test_compile_python.py
@@ -36,13 +36,6 @@ dict-like record and an attribute-style record (chunk/event dataclasses). Each
 semantic is asserted against both shapes via :func:`_both`. A key is ABSENT when
 neither attribute nor mapping access yields it; PRESENT-NULL when access yields
 Python ``None``. ``metadata`` is resolved the same way and defaults to ``{}``.
-
-INTERIM SKIP: ``compile_python`` lands with Backend's compiler slice. Until the
-module is importable, this whole module SELF-SKIPS (a clean collection-time skip,
-never an erroring import) so the suite stays green; it activates the instant the
-implementation lands. This mirrors the "implementation lands separately" idiom
-already used in the filter unit suite. It is NOT a permanent skip — once the
-compiler is on the branch the import succeeds and every test runs.
 """
 
 from __future__ import annotations
@@ -55,18 +48,11 @@ import pytest
 
 from khora.filter import RecallFilter
 from khora.filter.ast import FilterClause, FilterNode, parse_to_ast
+from khora.filter.compilers.python import compile_python
 from khora.filter.context import CompileContext
 from khora.filter.model import Op
 
 pytestmark = pytest.mark.unit
-
-# Interim self-skip until Backend's compile_python lands (see module docstring).
-# A failed import is a clean module skip here, not a LOUD error: this slice is
-# explicitly gated on a sibling task that is still in flight.
-compile_python = pytest.importorskip(
-    "khora.filter.compilers.python",
-    reason="compile_python not yet on the branch (Backend task in flight); test activates when it lands",
-).compile_python
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add deterministic recall-filter support to the Chronicle engine: system date-key bounds push down to the engine's recency window, and all other predicates are enforced by an in-memory post-filter (default post-filter; no schema migration).
- New internal `compile_python` compiler — a pure `record -> bool` predicate that evaluates the canonical filter AST in-process, mirroring the Postgres compiler's field-match semantics: runtime type-gating, operator polarity with Mongo-style missing-key handling (`$ne`/`$nin` include absent/wrong-type), array-aware metadata containment, exact sub-document equality, typed-date parse-or-exclude, and presence/null distinctions. It is the in-process reference oracle for the filter compilers.
- New internal `compile_chronicle` compiler — lowers conjunctive `source_timestamp` range/`$eq` clauses into a narrowing `ChronicleDateBound`. `source_timestamp` is the only key whose bound is safe to push against the engine's `COALESCE(source_timestamp, created_at)` recency window; `occurred_at`/`created_at`, the denormalized document keys, and all metadata are left unconsumed and post-filtered (pushing a cross-dimension bound would silently drop matching rows).
- Wire both into `ChronicleEngine.recall()`: intersect the compiled date-bound with the recency window (narrow-only, never widening) before retrieval, then apply the `compile_python` post-filter to candidates after cross-session expansion and before top-k. A record adapter maps each chunk to the predicate's record shape, anchoring `occurred_at` to the chunk's event time (falling back to `source_timestamp` where the chunk row leaves it unset).
- Report an honest per-engine pushdown matrix on `RecallResult.engine_info["filter"]` (`pushed_down` / `post_filtered`), and document the per-key support matrix (pushdown / post-filter) in the engine + compiler docstrings.
- The unindexed-metadata recall counter increments on the post-filter path (once per metadata leaf, at compile time).
- Engine behavior is unchanged when no filter is supplied. The new compilers are internal (not exported from the top-level package surface).

## Test plan
- [x] Unit tests pass locally: `compile_python` field-match semantics, the Chronicle compiler pushdown split, and the engine composition (narrow-only window intersection, metadata post-filter, telemetry) — 577 passed / 8 skipped.
- [x] Lint + format clean (`make format`, `make lint`).
- [ ] Unit + integration jobs pass in CI (CI-provisioned Postgres).
- [ ] Manual verification: `recall(filter={"source_timestamp": {"$gte": ...}, "metadata.tag": {"$in": [...]}})` narrows correctly on a Chronicle lake.