### PR TITLE
Remove PyMuPDF dependency; stop bundling PDF text extraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Docker Compose is always available. Always run `make test` before opening a PR. 
 - `storage/backends/surrealdb/` - Unified SurrealDB backend
 - `db/models.py` - SQLAlchemy ORM (UUID columns use `as_uuid=True`)
 - `_accel.py` - Rust/NumPy acceleration (MMR, cosine, pagerank, entity resolution, community detection, temporal)
-- `extraction/binary_readers.py` - PDF/xlsx/docx/parquet readers; stable public boundary.
+- `extraction/binary_readers.py` - xlsx/docx/parquet readers; stable public boundary (`.pdf` raises `NotImplementedError` — preprocess upstream or use khora-cli).
 - `pipelines/flows/ingest.py` - Document ingestion pipeline (3-phase: stage → enrich → expand)
 - `db/migrations/env.py` - Alembic with advisory locking
 - `config/schema.py` - `KhoraConfig` Pydantic settings (storage, LLM, pipeline, query, tenancy)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,7 +55,7 @@ Programmatic values take priority over environment variables.
 | `lancedb` | LanceDB embedded vector store | `lancedb>=0.30.0`, `pyarrow>=24.0.0` |
 | `sqlite-lance` | **[experimental]** Unified SQLite + LanceDB embedded backend. Recommended embedded stack; covers VectorCypher / Skeleton / Chronicle | `lancedb>=0.30.0`, `aiosqlite>=0.21.0`, `pyarrow>=24.0.0` |
 | `reranking` | Neural reranking via cross-encoders | `sentence-transformers>=5.4.1` |
-| `binary-readers` | PDF / docx / xlsx readers (used by downstream ingestors) | `pymupdf>=1.27.2`, `openpyxl>=3.1.0`, `python-docx>=1.2.0` |
+| `binary-readers` | docx / xlsx readers (used by downstream ingestors). PDF extraction is not bundled — preprocess PDFs upstream. | `openpyxl>=3.1.0`, `python-docx>=1.2.0` |
 | `parquet` | Parquet readers | `pyarrow>=24.0.0` |
 | `accel` | Accelerated CPU ops (string-matching fuzz, used by dream-phase centroid recompute) | `rapidfuzz>=3.0.0` |
 | `nlp` | spaCy-based sentence splitting | `spacy>=3.8.0` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,8 +113,8 @@ all-backends = [
 reranking = [
     "sentence-transformers>=5.4.1",
 ]
-# Binary file readers (PDF, Excel, Word text extraction) — used by khora-cli
-binary-readers = ["pymupdf>=1.27.2", "openpyxl>=3.1.0", "python-docx>=1.2.0"]
+# Binary file readers (Excel, Word text extraction) — used by khora-cli
+binary-readers = ["openpyxl>=3.1.0", "python-docx>=1.2.0"]
 # Parquet file support (used by khora-cli)
 parquet = ["pyarrow>=24.0.0"]
 # Accelerated CPU operations (numpy for cosine sim, rapidfuzz for string matching)

--- a/src/khora/extraction/binary_readers.py
+++ b/src/khora/extraction/binary_readers.py
@@ -1,12 +1,16 @@
 """Binary format extraction for ingestion.
 
-Converts PDF, Excel, Word, and Parquet binary formats to text/markdown so
-they can be fed into the standard text-ingest pipeline.  All extractors
-are optional — they degrade gracefully with a warning when dependencies
-are missing.
+Converts Excel, Word, and Parquet binary formats to text/markdown so they
+can be fed into the standard text-ingest pipeline.  Extractors degrade
+gracefully with a warning when optional dependencies are missing.
 
-Install: ``pip install khora[binary-readers]`` for pymupdf + openpyxl +
-python-docx, and ``pip install khora[parquet]`` for pyarrow.
+PDF extraction is not bundled with khora.  Callers passing a ``.pdf`` path
+to :func:`extract_if_needed` get a :class:`NotImplementedError` — preprocess
+PDFs upstream (extract text to ``.txt``/``.md``) or use ``khora-cli``'s PDF
+preprocessing, then pass the extracted text to ``remember()``.
+
+Install: ``pip install khora[binary-readers]`` for openpyxl + python-docx,
+and ``pip install khora[parquet]`` for pyarrow.
 """
 
 from __future__ import annotations
@@ -20,14 +24,6 @@ from loguru import logger
 # ---------------------------------------------------------------------------
 # Optional dependency detection
 # ---------------------------------------------------------------------------
-
-_HAS_PYMUPDF = False
-try:
-    import pymupdf  # noqa: F401
-
-    _HAS_PYMUPDF = True
-except ImportError:
-    pass
 
 _HAS_OPENPYXL = False
 try:
@@ -55,47 +51,27 @@ except ImportError:
 
 
 # ---------------------------------------------------------------------------
-# Extractors
+# PDF sentinel
 # ---------------------------------------------------------------------------
 
+_PDF_REMOVED_MESSAGE = (
+    "khora does not include PDF parsing. "
+    "Preprocess PDFs upstream (e.g. extract text to a .txt or .md file) "
+    "or use khora-cli's PDF preprocessing, then pass the extracted text to remember()."
+)
 
-def extract_pdf_text(path: Path) -> str:
-    """Extract text content from a PDF file.
 
-    Uses pymupdf (PyMuPDF) for fast text extraction.
-    Returns empty string if pymupdf is not installed.
+def _pdf_not_supported(path: Path) -> str:
+    """Dispatcher entry that raises for ``.pdf`` paths.
+
+    PDF parsing is not bundled with khora; see the module docstring.
     """
-    if not _HAS_PYMUPDF:
-        logger.warning(f"pymupdf not installed — cannot extract text from {path.name}. Install: pip install pymupdf")
-        return ""
+    raise NotImplementedError(_PDF_REMOVED_MESSAGE)
 
-    import pymupdf
 
-    try:
-        doc = pymupdf.open(str(path))
-        pages: list[str] = []
-        for page in doc:
-            text = page.get_text()
-            if text.strip():
-                pages.append(text)
-        page_count = doc.page_count
-        doc.close()
-
-        full_text = "\n\n---\n\n".join(pages)
-
-        # Check for scanned PDFs (very little text per page)
-        if page_count > 0:
-            chars_per_page = len(full_text) / page_count
-            if chars_per_page < 50:
-                logger.warning(
-                    f"{path.name}: ~{chars_per_page:.0f} chars/page — "
-                    "possibly a scanned PDF (OCR not supported, text may be incomplete)"
-                )
-
-        return full_text
-    except Exception as e:
-        logger.error(f"PDF extraction failed for {path.name}: {e}")
-        return ""
+# ---------------------------------------------------------------------------
+# Extractors
+# ---------------------------------------------------------------------------
 
 
 def extract_xlsx_text(path: Path) -> str:
@@ -200,7 +176,7 @@ def extract_parquet_text(path: Path) -> str:
 
 #: Map of file extensions to extraction functions
 _EXTRACTORS: dict[str, callable] = {
-    ".pdf": extract_pdf_text,
+    ".pdf": _pdf_not_supported,  # raises NotImplementedError — not a text extractor
     ".xlsx": extract_xlsx_text,
     ".xls": extract_xls_text,
     ".docx": extract_docx_text,
@@ -215,8 +191,8 @@ def get_extraction_warning(path: Path) -> str | None:
     given file extension.  Returns ``None`` when everything looks fine.
     """
     ext = path.suffix.lower()
-    if ext == ".pdf" and not _HAS_PYMUPDF:
-        return f"Cannot extract text from {path.name} — install pymupdf: pip install pymupdf"
+    if ext == ".pdf":
+        return f"Cannot extract text from {path.name} — {_PDF_REMOVED_MESSAGE}"
     if ext in (".xlsx", ".xls") and not _HAS_OPENPYXL:
         return f"Cannot extract text from {path.name} — install openpyxl: pip install openpyxl"
     if ext == ".docx" and not _HAS_DOCX:
@@ -232,6 +208,9 @@ def extract_if_needed(path: Path) -> Path | None:
     If extraction succeeds, writes a `{name}_extracted.md` file alongside
     the original and returns the path to it.  Returns None if no
     extraction was needed or if it failed.
+
+    Raises :class:`NotImplementedError` for ``.pdf`` inputs: PDF parsing is
+    not bundled with khora; preprocess PDFs upstream.
     """
     ext = path.suffix.lower()
     extractor = _EXTRACTORS.get(ext)

--- a/tests/unit/test_binary_readers.py
+++ b/tests/unit/test_binary_readers.py
@@ -1,0 +1,63 @@
+"""Tests for extraction.binary_readers.
+
+Focus is on the PDF boundary: callers hitting a ``.pdf`` path get a clear
+``NotImplementedError``, and ``get_extraction_warning`` surfaces the same
+message for pre-flight checks. Non-PDF behavior (no-op for unknown
+extensions) is preserved.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from khora.extraction.binary_readers import (
+    _PDF_REMOVED_MESSAGE,
+    extract_if_needed,
+    get_extraction_warning,
+)
+
+
+def test_extract_if_needed_raises_on_pdf(tmp_path: Path) -> None:
+    pdf = tmp_path / "example.pdf"
+    pdf.write_bytes(b"%PDF-1.4 not a real pdf")
+
+    with pytest.raises(NotImplementedError) as exc:
+        extract_if_needed(pdf)
+
+    assert _PDF_REMOVED_MESSAGE in str(exc.value)
+
+
+def test_extract_if_needed_raises_on_uppercase_pdf(tmp_path: Path) -> None:
+    """Suffix matching is case-insensitive — .PDF routes like .pdf."""
+    pdf = tmp_path / "example.PDF"
+    pdf.write_bytes(b"%PDF-1.4 not a real pdf")
+
+    with pytest.raises(NotImplementedError):
+        extract_if_needed(pdf)
+
+
+def test_extract_if_needed_returns_none_for_unknown_extension(tmp_path: Path) -> None:
+    """Unknown extensions remain a silent no-op — only .pdf changed."""
+    unknown = tmp_path / "example.unknown"
+    unknown.write_text("text")
+
+    assert extract_if_needed(unknown) is None
+
+
+def test_get_extraction_warning_for_pdf_mentions_removal(tmp_path: Path) -> None:
+    pdf = tmp_path / "example.pdf"
+    pdf.touch()
+
+    warning = get_extraction_warning(pdf)
+    assert warning is not None
+    assert _PDF_REMOVED_MESSAGE in warning
+
+
+def test_get_extraction_warning_none_for_clean_path(tmp_path: Path) -> None:
+    """No warning for an extension that has no registered extractor."""
+    plain = tmp_path / "example.txt"
+    plain.touch()
+
+    assert get_extraction_warning(plain) is None

--- a/uv.lock
+++ b/uv.lock
@@ -2386,7 +2386,6 @@ all-backends = [
 ]
 binary-readers = [
     { name = "openpyxl" },
-    { name = "pymupdf" },
     { name = "python-docx" },
 ]
 crewai = [
@@ -2577,7 +2576,6 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=24.0.0" },
     { name = "pyarrow", marker = "extra == 'sqlite-lance'", specifier = ">=24.0.0" },
     { name = "pydantic-settings", specifier = ">=2.10.1,<3" },
-    { name = "pymupdf", marker = "extra == 'binary-readers'", specifier = ">=1.27.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
@@ -4950,22 +4948,6 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
-]
-
-[[package]]
-name = "pymupdf"
-version = "1.27.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/32/708bedc9dde7b328d45abbc076091769d44f2f24ad151ad92d56a6ec142b/pymupdf-1.27.2.3.tar.gz", hash = "sha256:7a92faa25129e8bbec5e50eeb9214f187665428c31b05c4ef6e36c58c0b1c6d2", size = 85759618, upload-time = "2026-04-24T14:13:14.42Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/09/ddbdfa7ee91fbabd6f63d7d744884cbdfe3e7ff9b8604749fb38bddf5c5d/pymupdf-1.27.2.3-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc1bc3cae6e9e150b0dbb0a9221bdfd411d65f0db2fe359eaa22467d7cc2a05f", size = 24002636, upload-time = "2026-04-24T14:09:17.459Z" },
-    { url = "https://files.pythonhosted.org/packages/01/89/3f8edd6c4f50ca370e2a2f2a3011face36f3760728ffe76dffec91c0fca0/pymupdf-1.27.2.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:660d93cb6da5bbddf11d3982ae27745dd3a9902d9f24cdb69adab83962294b5a", size = 23278238, upload-time = "2026-04-24T14:09:32.882Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/26/b7e5a70eb83bd189f8b5df87ec442746b992f2f632662839b288170d357d/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1dd460a3ae4597a755f00a3bd9771f5ebf1531dc111f6a36bf05dd00a6b84425", size = 24333923, upload-time = "2026-04-24T14:09:47.341Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/a0/aa1ee2240f29481a04a827c313333b4ecd8a14d6ac3e15d3f41a30574781/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:857842b4888827bd6155a1131341b2822a7ebe9a8c15a975fd7d490d7a64a30c", size = 24963198, upload-time = "2026-04-24T14:10:07.408Z" },
-    { url = "https://files.pythonhosted.org/packages/69/49/4f742451f980840829fc00ba158bebb25d389c846d8f4f8c65936ee55de8/pymupdf-1.27.2.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:580983849c64a08d08344ca3d1580e87c01f046a8392421797bc850efd72a5b6", size = 25184609, upload-time = "2026-04-24T14:10:22.911Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/3f/3853d6608f394faf6eec2bd4e8ea9f6a00beea329b071abdb29f4164cc3d/pymupdf-1.27.2.3-cp310-abi3-win32.whl", hash = "sha256:a5c1088a87189891a4946ab314a14b7934ac4c5b6077f7e74ebee956f8906d0e", size = 18019286, upload-time = "2026-04-24T14:10:34.239Z" },
-    { url = "https://files.pythonhosted.org/packages/44/47/5fb10fe73f96b31253a41647c362ea9e0380920bddf16028414a051247fc/pymupdf-1.27.2.3-cp310-abi3-win_amd64.whl", hash = "sha256:d20f68ef15195e073071dbc4ae7455257c7889af7584e39df490c0a92728526e", size = 19249102, upload-time = "2026-04-24T14:10:46.72Z" },
-    { url = "https://files.pythonhosted.org/packages/53/a4/b9e91aac82293f9c954654c85581ee8212b5b05efadc534b581141241e6f/pymupdf-1.27.2.3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:77691604c5d1d0233827139bbcdea61fd57879c84712b8e49b1f45520f7ab9c2", size = 25000393, upload-time = "2026-04-24T14:11:01.669Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Removes the `pymupdf` dependency from khora and stops bundling PDF text extraction. The `binary-readers` optional extra keeps `openpyxl` and `python-docx` (xlsx/docx) — only the PDF path changes.

## Changes

- Remove `pymupdf` from `[project.optional-dependencies].binary-readers` in `pyproject.toml` (and `uv.lock`).
- `src/khora/extraction/binary_readers.py`:
  - Remove `extract_pdf_text()` and the `_HAS_PYMUPDF` detection gate.
  - The `.pdf` branch of `extract_if_needed()` now raises `NotImplementedError` with a clear message pointing users to preprocess PDFs upstream.
  - `get_extraction_warning()` surfaces the same notice for `.pdf` inputs.
- Update `docs/configuration.md` and `CLAUDE.md` to reflect the narrowed extra.
- Add `tests/unit/test_binary_readers.py`.

## Compatibility

`extract_if_needed()` keeps its public signature (stable API). Non-PDF extraction (xlsx, docx, parquet) is unchanged. PDF parsing may be reintroduced later via a separate library.

Fixes #1028