### PR TITLE
Make Postgres migration integration tests shared-DB-safe and fix stale namespace API

### DIFF
--- a/tests/integration/db/test_migration_032_dream_runs.py
+++ b/tests/integration/db/test_migration_032_dream_runs.py
@@ -32,7 +32,7 @@ import pytest
 import sqlalchemy as sa
 from alembic import command
 from alembic.config import Config
-from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from khora.db.session import run_migrations
 
@@ -75,49 +75,56 @@ def _make_config(url: str) -> Config:
 
 
 # ---------------------------------------------------------------------------
-# Postgres fixture — schema-isolated per test so the four tests can run in
-# arbitrary order without leaking state. We point the async engine at a
-# unique schema, run the chain there, then drop it on teardown.
+# Postgres fixture — wipe ``public`` and re-migrate to head per test so the
+# tests run in arbitrary order against a shared PostgreSQL (the integration
+# job migrates the service DB to head up front) without leaking state.
 # ---------------------------------------------------------------------------
+
+
+async def _reset_public_schema(eng: AsyncEngine) -> None:
+    """Wipe ``public`` and pre-create the wide khora_alembic_version table.
+
+    Mirrors ``test_migration_033_bitemporal.py``: alembic creates
+    ``khora_alembic_version`` with the default ``VARCHAR(32)`` but several
+    revision ids are wider. Pre-create the table with VARCHAR(64) so the chain
+    applies cleanly.
+    """
+    async with eng.begin() as conn:
+        r = await conn.execute(
+            sa.text("SELECT typname FROM pg_type WHERE typnamespace = 'public'::regnamespace AND typtype = 'e'")
+        )
+        for (typname,) in r.fetchall():
+            await conn.execute(sa.text(f"DROP TYPE IF EXISTS public.{typname} CASCADE"))
+        await conn.execute(sa.text("DROP SCHEMA public CASCADE"))
+        await conn.execute(sa.text("CREATE SCHEMA public"))
+        await conn.execute(sa.text("CREATE EXTENSION IF NOT EXISTS vector"))
+        await conn.execute(
+            sa.text(
+                "CREATE TABLE khora_alembic_version ("
+                "  version_num VARCHAR(64) NOT NULL,"
+                "  CONSTRAINT khora_alembic_version_pkc PRIMARY KEY (version_num)"
+                ")"
+            )
+        )
 
 
 @pytest.fixture
 def pg_url() -> Iterator[str]:
-    """Yield the base Postgres URL; drop ``khora_dream_runs`` on teardown.
-
-    We don't isolate per-schema because asyncpg rejects URL-embedded
-    ``server_settings`` and threading per-test ``connect_args`` through the
-    Alembic command API is fragile. Integration tests run serially anyway
-    (per CLAUDE.md — `tests/integration/matrix/*` already DROP SCHEMA on
-    shared PostgreSQL).
-    """
+    """Wipe ``public``, re-migrate to head, and yield the base Postgres URL."""
     if not _pg_reachable():
         pytest.skip("PostgreSQL not reachable (run `make dev` first)")
 
-    async def _reset() -> None:
-        """Drop dream_runs table and reset alembic_version to 031 so tests
-        don't poison each other via leftover stamps."""
-        admin = create_async_engine(DATABASE_URL, isolation_level="AUTOCOMMIT")
+    async def _setup() -> None:
+        eng = create_async_engine(DATABASE_URL)
         try:
-            async with admin.connect() as conn:
-                await conn.execute(sa.text("DROP TABLE IF EXISTS khora_dream_runs CASCADE"))
-                # Reset alembic head to 031 so the next test's upgrade is a no-op
-                # (032 is the head once migration lands; we want a clean baseline).
-                await conn.execute(
-                    sa.text(
-                        "UPDATE khora_alembic_version SET version_num = "
-                        "'031_session_id_indexes' WHERE version_num != "
-                        "'031_session_id_indexes'"
-                    )
-                )
+            await _reset_public_schema(eng)
         finally:
-            await admin.dispose()
+            await eng.dispose()
+        result = await run_migrations(DATABASE_URL)
+        assert result.success, f"migrations failed: {result.error}"
 
-    asyncio.run(_reset())
-    try:
-        yield DATABASE_URL
-    finally:
-        asyncio.run(_reset())
+    asyncio.run(_setup())
+    yield DATABASE_URL
 
 
 @pytest.fixture
@@ -130,12 +137,6 @@ def sqlite_url(tmp_path: Path) -> str:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    reason="migration test not yet CI-shared-DB-safe: resets the alembic pointer without "
-    "dropping sibling tables, so it collides with the integration job's up-front "
-    "`alembic upgrade head` on the shared service DB; tracked in #1020",
-    strict=False,
-)
 class TestMigration032OnPostgres:
     def test_migration_032_creates_dream_runs_table(self, pg_url: str) -> None:
         """Upgrade head on fresh PG creates the table with all 16 columns + index."""

--- a/tests/integration/db/test_migration_034_chronicle_events_bitemporal.py
+++ b/tests/integration/db/test_migration_034_chronicle_events_bitemporal.py
@@ -209,11 +209,6 @@ async def test_migration_034_creates_live_partial_index(
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    reason="not yet CI-shared-DB-safe: fails against the integration job's shared, "
-    "up-front-migrated service DB; tracked in #1020",
-    strict=False,
-)
 async def test_migration_034_self_fk_set_null_on_delete(
     pg_engine: AsyncEngine,
 ) -> None:
@@ -237,8 +232,8 @@ async def test_migration_034_self_fk_set_null_on_delete(
         await conn.execute(
             text(
                 "INSERT INTO documents "
-                "(id, namespace_id, source, status, chunk_count, document_metadata, created_at, updated_at) "
-                "VALUES (:id, :ns, 'test', 'ready', 1, '{}'::jsonb, NOW(), NOW())"
+                "(id, namespace_id, content, source, status, chunk_count, metadata, created_at, updated_at) "
+                "VALUES (:id, :ns, 'doc body', 'test', 'completed', 1, '{}'::jsonb, NOW(), NOW())"
             ),
             {"id": uuid4(), "ns": ns_id},
         )
@@ -247,8 +242,8 @@ async def test_migration_034_self_fk_set_null_on_delete(
         await conn.execute(
             text(
                 "INSERT INTO chunks "
-                "(id, namespace_id, document_id, chunk_index, content, content_hash, created_at) "
-                "SELECT :cid, :ns, id, 0, 'x', 'h', NOW() FROM documents LIMIT 1"
+                "(id, namespace_id, document_id, chunk_index, content, created_at) "
+                "SELECT :cid, :ns, id, 0, 'x', NOW() FROM documents LIMIT 1"
             ),
             {"cid": chunk_id, "ns": ns_id},
         )

--- a/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
+++ b/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
@@ -38,7 +38,9 @@ import pytest
 import sqlalchemy as sa
 from alembic import command
 from alembic.config import Config
-from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from khora.db.session import run_migrations
 
 DATABASE_URL = os.environ.get(
     "KHORA_DATABASE_URL",
@@ -92,7 +94,9 @@ def _make_config(url: str) -> Config:
 
 # A pre-migration ``khora_chunks`` table: the identity/temporal columns the
 # runtime always created, but WITHOUT the eight denormalized columns. Creating
-# this before upgrade exercises the migration's existing-deployment path.
+# this before upgrade exercises the migration's existing-deployment path. The
+# ``content_tsv`` column + trigger mirror the runtime so the full re-run of the
+# chain (043/044 ``DISABLE TRIGGER khora_chunks_content_tsv_update``) succeeds.
 _LEGACY_KHORA_CHUNKS_DDL = """
 CREATE TABLE khora_chunks (
     id UUID PRIMARY KEY,
@@ -101,53 +105,80 @@ CREATE TABLE khora_chunks (
     content TEXT NOT NULL,
     metadata JSONB DEFAULT '{}'::jsonb,
     occurred_at TIMESTAMPTZ,
-    created_at TIMESTAMPTZ
+    created_at TIMESTAMPTZ,
+    content_tsv TSVECTOR
 )
 """
+
+# The runtime's content_tsv trigger, byte-equivalent to
+# ``PgVectorTemporalStore.connect()``. Seeding it lets the full re-run of the
+# chain (043/044) DISABLE/ENABLE it without an UndefinedObjectError.
+_TSV_FUNCTION_DDL = """
+CREATE OR REPLACE FUNCTION khora_chunks_content_tsv_trigger() RETURNS trigger AS $$
+BEGIN
+    NEW.content_tsv := to_tsvector('english', NEW.content);
+    RETURN NEW;
+END
+$$ LANGUAGE plpgsql
+"""
+
+_TSV_TRIGGER_DDL = """
+CREATE TRIGGER khora_chunks_content_tsv_update
+BEFORE INSERT OR UPDATE ON khora_chunks
+FOR EACH ROW EXECUTE FUNCTION khora_chunks_content_tsv_trigger()
+"""
+
+
+async def _reset_public_schema(eng: AsyncEngine) -> None:
+    """Wipe ``public`` and pre-create the wide khora_alembic_version table.
+
+    Mirrors ``test_migration_033_bitemporal.py``: alembic creates
+    ``khora_alembic_version`` with the default ``VARCHAR(32)`` but several
+    revision ids are wider. Pre-create the table with VARCHAR(64) so the chain
+    applies cleanly.
+    """
+    async with eng.begin() as conn:
+        r = await conn.execute(
+            sa.text("SELECT typname FROM pg_type WHERE typnamespace = 'public'::regnamespace AND typtype = 'e'")
+        )
+        for (typname,) in r.fetchall():
+            await conn.execute(sa.text(f"DROP TYPE IF EXISTS public.{typname} CASCADE"))
+        await conn.execute(sa.text("DROP SCHEMA public CASCADE"))
+        await conn.execute(sa.text("CREATE SCHEMA public"))
+        await conn.execute(sa.text("CREATE EXTENSION IF NOT EXISTS vector"))
+        await conn.execute(
+            sa.text(
+                "CREATE TABLE khora_alembic_version ("
+                "  version_num VARCHAR(64) NOT NULL,"
+                "  CONSTRAINT khora_alembic_version_pkc PRIMARY KEY (version_num)"
+                ")"
+            )
+        )
 
 
 @pytest.fixture
 def pg_url() -> Iterator[str]:
-    """Yield the base Postgres URL.
+    """Wipe ``public``, re-migrate to head, and yield the base Postgres URL.
 
-    Each test resets the Alembic head to 040 and drops ``khora_chunks`` on
-    setup and teardown so the four migration-test files can run in arbitrary
-    order against shared PostgreSQL without leaking state.
+    The schema-wipe makes the tests safe to run against shared PostgreSQL (the
+    integration job migrates the service DB to head up front) without leaking
+    state. ``khora_chunks`` is runtime-managed (not Alembic), so after the
+    re-migrate it does not exist — each test seeds the legacy table itself.
     """
     if not _pg_reachable():
         pytest.skip("PostgreSQL not reachable (run `make dev` first)")
 
-    async def _reset() -> None:
-        admin = create_async_engine(DATABASE_URL, isolation_level="AUTOCOMMIT")
+    async def _setup() -> None:
+        eng = create_async_engine(DATABASE_URL)
         try:
-            async with admin.connect() as conn:
-                await conn.execute(sa.text("DROP TABLE IF EXISTS khora_chunks CASCADE"))
-                # Walk the version table back to 040 so the next upgrade re-runs
-                # 041 from a known baseline. Guarded on table existence so the
-                # fixture is also safe against a never-migrated DB (the version
-                # table is created by the first `command.upgrade`).
-                table_exists = await conn.execute(
-                    sa.text(
-                        "SELECT EXISTS(SELECT 1 FROM information_schema.tables "
-                        "WHERE table_name = 'khora_alembic_version')"
-                    )
-                )
-                if table_exists.scalar():
-                    await conn.execute(
-                        sa.text(
-                            "UPDATE khora_alembic_version SET version_num = "
-                            "'040_chunks_last_accessed_at' WHERE version_num != "
-                            "'040_chunks_last_accessed_at'"
-                        )
-                    )
+            await _reset_public_schema(eng)
         finally:
-            await admin.dispose()
+            await eng.dispose()
+        result = await run_migrations(DATABASE_URL)
+        assert result.success, f"migrations failed: {result.error}"
 
-    asyncio.run(_reset())
-    try:
-        yield DATABASE_URL
-    finally:
-        asyncio.run(_reset())
+    asyncio.run(_setup())
+    yield DATABASE_URL
 
 
 @pytest.fixture
@@ -160,11 +191,6 @@ def sqlite_url(tmp_path: Path) -> str:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    reason="migration test not yet CI-shared-DB-safe: collides with the integration job's "
-    "up-front `alembic upgrade head` on the shared service DB; tracked in #1020",
-    strict=False,
-)
 class TestMigration041OnPostgres:
     def test_adds_eight_columns_to_existing_table(self, pg_url: str) -> None:
         """Existing ``khora_chunks`` (missing the columns) gains all eight."""
@@ -177,6 +203,8 @@ class TestMigration041OnPostgres:
                 async with engine.connect() as conn:
                     await conn.execute(sa.text("DROP TABLE IF EXISTS khora_chunks CASCADE"))
                     await conn.execute(sa.text(_LEGACY_KHORA_CHUNKS_DDL))
+                    await conn.execute(sa.text(_TSV_FUNCTION_DDL))
+                    await conn.execute(sa.text(_TSV_TRIGGER_DDL))
                     # Step the version table back so we can re-run 041 against
                     # the table we just created.
                     await conn.execute(
@@ -239,6 +267,8 @@ class TestMigration041OnPostgres:
                 async with engine.connect() as conn:
                     await conn.execute(sa.text("DROP TABLE IF EXISTS khora_chunks CASCADE"))
                     await conn.execute(sa.text(_LEGACY_KHORA_CHUNKS_DDL))
+                    await conn.execute(sa.text(_TSV_FUNCTION_DDL))
+                    await conn.execute(sa.text(_TSV_TRIGGER_DDL))
                     await conn.execute(
                         sa.text("UPDATE khora_alembic_version SET version_num = '040_chunks_last_accessed_at'")
                     )

--- a/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
+++ b/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
@@ -40,7 +40,9 @@ import pytest
 import sqlalchemy as sa
 from alembic import command
 from alembic.config import Config
-from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from khora.db.session import run_migrations
 
 DATABASE_URL = os.environ.get(
     "KHORA_DATABASE_URL",
@@ -84,7 +86,9 @@ def _make_config(url: str) -> Config:
 # A pre-migration ``khora_chunks`` table: the identity/temporal columns the
 # runtime always created, but WITHOUT the eight denormalized columns. Creating
 # this before upgrade lets migration 041 add ``source`` / ``external_id`` at the
-# narrow 255 width, which 042 then widens.
+# narrow 255 width, which 042 then widens. The ``content_tsv`` column + trigger
+# mirror the runtime so the full re-run of the chain (043/044 ``DISABLE TRIGGER
+# khora_chunks_content_tsv_update``) succeeds.
 _LEGACY_KHORA_CHUNKS_DDL = """
 CREATE TABLE khora_chunks (
     id UUID PRIMARY KEY,
@@ -93,8 +97,27 @@ CREATE TABLE khora_chunks (
     content TEXT NOT NULL,
     occurred_at TIMESTAMPTZ,
     created_at TIMESTAMPTZ,
-    metadata JSONB DEFAULT '{}'::jsonb
+    metadata JSONB DEFAULT '{}'::jsonb,
+    content_tsv TSVECTOR
 )
+"""
+
+# The runtime's content_tsv trigger, byte-equivalent to
+# ``PgVectorTemporalStore.connect()``. Seeding it lets the full re-run of the
+# chain (043/044) DISABLE/ENABLE it without an UndefinedObjectError.
+_TSV_FUNCTION_DDL = """
+CREATE OR REPLACE FUNCTION khora_chunks_content_tsv_trigger() RETURNS trigger AS $$
+BEGIN
+    NEW.content_tsv := to_tsvector('english', NEW.content);
+    RETURN NEW;
+END
+$$ LANGUAGE plpgsql
+"""
+
+_TSV_TRIGGER_DDL = """
+CREATE TRIGGER khora_chunks_content_tsv_update
+BEFORE INSERT OR UPDATE ON khora_chunks
+FOR EACH ROW EXECUTE FUNCTION khora_chunks_content_tsv_trigger()
 """
 
 
@@ -105,6 +128,8 @@ async def _seed_legacy_table_at_baseline(url: str) -> None:
         async with engine.connect() as conn:
             await conn.execute(sa.text("DROP TABLE IF EXISTS khora_chunks CASCADE"))
             await conn.execute(sa.text(_LEGACY_KHORA_CHUNKS_DDL))
+            await conn.execute(sa.text(_TSV_FUNCTION_DDL))
+            await conn.execute(sa.text(_TSV_TRIGGER_DDL))
             await conn.execute(sa.text("UPDATE khora_alembic_version SET version_num = '040_chunks_last_accessed_at'"))
     finally:
         await engine.dispose()
@@ -128,46 +153,56 @@ async def _source_external_id_widths(url: str) -> dict[str, tuple[str, int | Non
         await engine.dispose()
 
 
+async def _reset_public_schema(eng: AsyncEngine) -> None:
+    """Wipe ``public`` and pre-create the wide khora_alembic_version table.
+
+    Mirrors ``test_migration_033_bitemporal.py``: alembic creates
+    ``khora_alembic_version`` with the default ``VARCHAR(32)`` but several
+    revision ids are wider. Pre-create the table with VARCHAR(64) so the chain
+    applies cleanly.
+    """
+    async with eng.begin() as conn:
+        r = await conn.execute(
+            sa.text("SELECT typname FROM pg_type WHERE typnamespace = 'public'::regnamespace AND typtype = 'e'")
+        )
+        for (typname,) in r.fetchall():
+            await conn.execute(sa.text(f"DROP TYPE IF EXISTS public.{typname} CASCADE"))
+        await conn.execute(sa.text("DROP SCHEMA public CASCADE"))
+        await conn.execute(sa.text("CREATE SCHEMA public"))
+        await conn.execute(sa.text("CREATE EXTENSION IF NOT EXISTS vector"))
+        await conn.execute(
+            sa.text(
+                "CREATE TABLE khora_alembic_version ("
+                "  version_num VARCHAR(64) NOT NULL,"
+                "  CONSTRAINT khora_alembic_version_pkc PRIMARY KEY (version_num)"
+                ")"
+            )
+        )
+
+
 @pytest.fixture
 def pg_url() -> Iterator[str]:
-    """Yield the base Postgres URL.
+    """Wipe ``public``, re-migrate to head, and yield the base Postgres URL.
 
-    Resets the Alembic head back to ``040`` and drops ``khora_chunks`` on setup
-    and teardown so the migration-test files can run in arbitrary order against
-    shared PostgreSQL without leaking state. The version-table walk-back is
-    guarded on table existence so the fixture is also safe on a never-migrated
-    DB (the version table is created by the first ``command.upgrade``).
+    The schema-wipe makes the tests safe to run against shared PostgreSQL (the
+    integration job migrates the service DB to head up front) without leaking
+    state. ``khora_chunks`` is runtime-managed (not Alembic), so after the
+    re-migrate it does not exist — each test seeds the legacy table itself.
     """
     if not _pg_reachable():
         pytest.skip("PostgreSQL not reachable (run `make dev` first)")
 
-    async def _reset() -> None:
-        admin = create_async_engine(DATABASE_URL, isolation_level="AUTOCOMMIT")
+    async def _setup() -> None:
+        eng = create_async_engine(DATABASE_URL)
         try:
-            async with admin.connect() as conn:
-                await conn.execute(sa.text("DROP TABLE IF EXISTS khora_chunks CASCADE"))
-                table_exists = await conn.execute(
-                    sa.text(
-                        "SELECT EXISTS(SELECT 1 FROM information_schema.tables "
-                        "WHERE table_name = 'khora_alembic_version')"
-                    )
-                )
-                if table_exists.scalar():
-                    await conn.execute(
-                        sa.text(
-                            "UPDATE khora_alembic_version SET version_num = "
-                            "'040_chunks_last_accessed_at' WHERE version_num != "
-                            "'040_chunks_last_accessed_at'"
-                        )
-                    )
+            await _reset_public_schema(eng)
         finally:
-            await admin.dispose()
+            await eng.dispose()
+        result = await run_migrations(DATABASE_URL)
+        assert result.success, f"migrations failed: {result.error}"
 
-    asyncio.run(_reset())
-    try:
-        yield DATABASE_URL
-    finally:
-        asyncio.run(_reset())
+    asyncio.run(_setup())
+    yield DATABASE_URL
 
 
 @pytest.fixture
@@ -180,11 +215,6 @@ def sqlite_url(tmp_path: Path) -> str:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    reason="migration test not yet CI-shared-DB-safe: collides with the integration job's "
-    "up-front `alembic upgrade head` on the shared service DB; tracked in #1020",
-    strict=False,
-)
 class TestMigration042OnPostgres:
     def test_upgrade_widens_source_and_external_id(self, pg_url: str) -> None:
         """Chain to head: ``source`` becomes TEXT, ``external_id`` becomes VARCHAR(512)."""

--- a/tests/integration/db/test_migration_044_chunks_backfill.py
+++ b/tests/integration/db/test_migration_044_chunks_backfill.py
@@ -53,6 +53,7 @@ import asyncio
 import os
 import socket
 from collections.abc import Iterator
+from datetime import datetime
 from pathlib import Path
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -61,7 +62,9 @@ import pytest
 import sqlalchemy as sa
 from alembic import command
 from alembic.config import Config
-from sqlalchemy.ext.asyncio import AsyncConnection, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, create_async_engine
+
+from khora.db.session import run_migrations
 
 DATABASE_URL = os.environ.get(
     "KHORA_DATABASE_URL",
@@ -160,46 +163,57 @@ FOR EACH ROW EXECUTE FUNCTION khora_chunks_content_tsv_trigger()
 """
 
 
+async def _reset_public_schema(eng: AsyncEngine) -> None:
+    """Wipe ``public`` and pre-create the wide khora_alembic_version table.
+
+    Mirrors ``test_migration_033_bitemporal.py``: alembic creates
+    ``khora_alembic_version`` with the default ``VARCHAR(32)`` but several
+    revision ids are wider. Pre-create the table with VARCHAR(64) so the chain
+    applies cleanly.
+    """
+    async with eng.begin() as conn:
+        r = await conn.execute(
+            sa.text("SELECT typname FROM pg_type WHERE typnamespace = 'public'::regnamespace AND typtype = 'e'")
+        )
+        for (typname,) in r.fetchall():
+            await conn.execute(sa.text(f"DROP TYPE IF EXISTS public.{typname} CASCADE"))
+        await conn.execute(sa.text("DROP SCHEMA public CASCADE"))
+        await conn.execute(sa.text("CREATE SCHEMA public"))
+        await conn.execute(sa.text("CREATE EXTENSION IF NOT EXISTS vector"))
+        await conn.execute(
+            sa.text(
+                "CREATE TABLE khora_alembic_version ("
+                "  version_num VARCHAR(64) NOT NULL,"
+                "  CONSTRAINT khora_alembic_version_pkc PRIMARY KEY (version_num)"
+                ")"
+            )
+        )
+
+
 @pytest.fixture
 def pg_url() -> Iterator[str]:
-    """Yield the base Postgres URL.
+    """Wipe ``public``, re-migrate to head, and yield the base Postgres URL.
 
-    Resets the Alembic head to 043 and drops ``khora_chunks`` (+ its trigger
-    function) on setup and teardown so the migration-test files can run in
-    arbitrary order against shared PostgreSQL without leaking state.
+    The schema-wipe makes the tests safe to run against shared PostgreSQL (the
+    integration job migrates the service DB to head up front) without leaking
+    state. ``khora_chunks`` is runtime-managed (not Alembic), so after the
+    re-migrate it does not exist — each test seeds the runtime-shaped table
+    (with its content_tsv trigger) itself.
     """
     if not _pg_reachable():
         pytest.skip("PostgreSQL not reachable (run `make dev` first)")
 
-    async def _reset() -> None:
-        admin = create_async_engine(DATABASE_URL, isolation_level="AUTOCOMMIT")
+    async def _setup() -> None:
+        eng = create_async_engine(DATABASE_URL)
         try:
-            async with admin.connect() as conn:
-                await conn.execute(sa.text("DROP TABLE IF EXISTS khora_chunks CASCADE"))
-                await conn.execute(sa.text("DROP FUNCTION IF EXISTS khora_chunks_content_tsv_trigger() CASCADE"))
-                # Walk the version table back to 043 so the next upgrade re-runs
-                # 044 from a known baseline. Guarded on table existence so the
-                # fixture is also safe against a never-migrated DB (the version
-                # table is created by the first ``command.upgrade``).
-                table_exists = await conn.execute(
-                    sa.text(
-                        "SELECT EXISTS(SELECT 1 FROM information_schema.tables "
-                        "WHERE table_name = 'khora_alembic_version')"
-                    )
-                )
-                if table_exists.scalar():
-                    await conn.execute(
-                        sa.text("UPDATE khora_alembic_version SET version_num = :prev WHERE version_num != :prev"),
-                        {"prev": _PREV_REVISION},
-                    )
+            await _reset_public_schema(eng)
         finally:
-            await admin.dispose()
+            await eng.dispose()
+        result = await run_migrations(DATABASE_URL)
+        assert result.success, f"migrations failed: {result.error}"
 
-    asyncio.run(_reset())
-    try:
-        yield DATABASE_URL
-    finally:
-        asyncio.run(_reset())
+    asyncio.run(_setup())
+    yield DATABASE_URL
 
 
 @pytest.fixture
@@ -224,6 +238,15 @@ async def _seed_namespace(conn: AsyncConnection, ns_row_id) -> None:
     )
 
 
+def _coerce_source_timestamp(values: dict) -> dict:
+    """Return a copy of ``values`` with any ISO-string ``source_timestamp``
+    parsed into a ``datetime`` (asyncpg binds TIMESTAMPTZ from datetime, not str)."""
+    ts = values.get("source_timestamp")
+    if isinstance(ts, str):
+        return {**values, "source_timestamp": datetime.fromisoformat(ts)}
+    return values
+
+
 async def _seed_document(conn: AsyncConnection, doc_id, ns_row_id, values: dict) -> None:
     """Insert a ``documents`` row carrying the provenance the backfill copies."""
     await conn.execute(
@@ -236,7 +259,9 @@ async def _seed_document(conn: AsyncConnection, doc_id, ns_row_id, values: dict)
             " :source_url, :source_timestamp, :external_id, :content_type, "
             " :source, :title, NOW(), NOW())"
         ),
-        {"id": doc_id, "ns": ns_row_id, **values},
+        # asyncpg binds ``source_timestamp`` as a real TIMESTAMPTZ and rejects a
+        # str — parse any ISO string the caller passes into a datetime first.
+        {"id": doc_id, "ns": ns_row_id, **_coerce_source_timestamp(values)},
     )
 
 
@@ -291,11 +316,6 @@ _LONG_EXTERNAL_ID = "ext-" + ("y" * 400)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    reason="migration test not yet CI-shared-DB-safe: collides with the integration job's "
-    "up-front `alembic upgrade head` on the shared service DB; tracked in #1020",
-    strict=False,
-)
 class TestMigration044OnPostgres:
     def test_backfill_happy_path(self, pg_url: str) -> None:
         """Each denormalized chunk col gets the parent document value verbatim,
@@ -486,15 +506,17 @@ class TestMigration044OnPostgres:
             engine = create_async_engine(pg_url)
             try:
                 async with engine.connect() as conn:
-                    return (
-                        await conn.execute(
-                            sa.text(
-                                "SELECT source_type, source_name, external_id, "
-                                "source, title FROM khora_chunks WHERE id = :id"
-                            ),
-                            {"id": chunk_id},
-                        )
-                    ).one()
+                    return tuple(
+                        (
+                            await conn.execute(
+                                sa.text(
+                                    "SELECT source_type, source_name, external_id, "
+                                    "source, title FROM khora_chunks WHERE id = :id"
+                                ),
+                                {"id": chunk_id},
+                            )
+                        ).one()
+                    )
             finally:
                 await engine.dispose()
 
@@ -651,7 +673,9 @@ class TestMigration044OnPostgres:
                     tgenabled = (
                         await conn.execute(
                             sa.text(
-                                "SELECT t.tgenabled FROM pg_trigger t "
+                                # Cast to text so the PG ``"char"`` ``tgenabled`` comes
+                                # back as a str (asyncpg returns the raw type as bytes).
+                                "SELECT t.tgenabled::text FROM pg_trigger t "
                                 "JOIN pg_class c ON c.oid = t.tgrelid "
                                 "WHERE c.relname = 'khora_chunks' "
                                 "AND t.tgname = :trigger"

--- a/tests/integration/storage/test_chunk_namespace_isolation_pg.py
+++ b/tests/integration/storage/test_chunk_namespace_isolation_pg.py
@@ -12,15 +12,19 @@ Connection parameters (env overrides, sensible ``make dev`` defaults)::
 from __future__ import annotations
 
 import os
+from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from khora.core.models import Chunk, Document, MemoryNamespace
 from khora.core.models.document import DocumentStatus
 from khora.db.session import run_migrations
 from khora.storage.backends.pgvector import PgVectorBackend
+from khora.storage.backends.postgresql import PostgreSQLBackend
 
 DATABASE_URL = os.environ.get(
     "KHORA_DATABASE_URL",
@@ -55,15 +59,70 @@ skip_no_pg = pytest.mark.skipif(
 )
 
 
+async def _reset_public_schema(eng: AsyncEngine) -> None:
+    """Wipe ``public`` and pre-create the wide khora_alembic_version table.
+
+    Mirrors ``test_migration_033_bitemporal.py``: alembic creates
+    ``khora_alembic_version`` with the default ``VARCHAR(32)`` but several
+    revision ids are wider. Pre-create the table with VARCHAR(64) so the chain
+    applies cleanly. Dropping the public-schema enum types first keeps a
+    half-present ``document_status`` enum from wedging the re-migrate.
+    """
+    async with eng.begin() as conn:
+        r = await conn.execute(
+            text("SELECT typname FROM pg_type WHERE typnamespace = 'public'::regnamespace AND typtype = 'e'")
+        )
+        for (typname,) in r.fetchall():
+            await conn.execute(text(f"DROP TYPE IF EXISTS public.{typname} CASCADE"))
+        await conn.execute(text("DROP SCHEMA public CASCADE"))
+        await conn.execute(text("CREATE SCHEMA public"))
+        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+        await conn.execute(
+            text(
+                "CREATE TABLE khora_alembic_version ("
+                "  version_num VARCHAR(64) NOT NULL,"
+                "  CONSTRAINT khora_alembic_version_pkc PRIMARY KEY (version_num)"
+                ")"
+            )
+        )
+
+
 @pytest.fixture(scope="module")
-async def _run_migrations_once():
+async def _run_migrations_once() -> AsyncIterator[None]:
+    """Wipe ``public`` and re-migrate to head before this module's tests.
+
+    A schema-wipe (not a bare ``run_migrations``) so the module never inherits
+    a downgraded / partially-dropped shared DB left by a preceding migration
+    test file's downgrade sub-tests (which would make ``run_migrations`` replay
+    forward from a broken middle).
+    """
+    eng = create_async_engine(DATABASE_URL)
+    try:
+        await _reset_public_schema(eng)
+    finally:
+        await eng.dispose()
     result = await run_migrations(DATABASE_URL)
     assert result.success, f"Migrations failed: {result.error}"
+    yield
 
 
 @pytest.fixture
 async def backend(_run_migrations_once):
     be = PgVectorBackend(DATABASE_URL)
+    await be.connect()
+    yield be
+    await be.disconnect()
+
+
+@pytest.fixture
+async def relational(_run_migrations_once):
+    """Relational backend for namespace + document creation.
+
+    ``create_namespace`` and ``create_document`` live on the relational
+    backend; the chunk getters under test stay on ``PgVectorBackend`` so the
+    namespace filter is exercised on the real vector-backend SQL.
+    """
+    be = PostgreSQLBackend(DATABASE_URL)
     await be.connect()
     yield be
     await be.disconnect()
@@ -100,18 +159,15 @@ def _make_doc(namespace_id) -> Document:
 
 
 @skip_no_pg
-@pytest.mark.xfail(
-    reason="stale test API: PgVectorBackend (vector backend) has no create_namespace; "
-    "namespace creation lives on the relational backend; tracked in #1020",
-    strict=False,
-)
 class TestChunkNamespaceIsolationPg:
-    async def test_cross_namespace_get_chunk_returns_none(self, backend: PgVectorBackend) -> None:
-        ns_a = await backend.create_namespace(MemoryNamespace())
-        ns_b = await backend.create_namespace(MemoryNamespace())
+    async def test_cross_namespace_get_chunk_returns_none(
+        self, backend: PgVectorBackend, relational: PostgreSQLBackend
+    ) -> None:
+        ns_a = await relational.create_namespace(MemoryNamespace())
+        ns_b = await relational.create_namespace(MemoryNamespace())
 
         doc = _make_doc(ns_a.id)
-        await backend.create_document(doc)
+        await relational.create_document(doc)
 
         chunk = _make_chunk(ns_a.id, doc.id)
         await backend.create_chunk(chunk)
@@ -121,14 +177,16 @@ class TestChunkNamespaceIsolationPg:
         # Cross-namespace lookup must return None.
         assert (await backend.get_chunk(chunk.id, namespace_id=ns_b.id)) is None
 
-    async def test_cross_namespace_get_chunks_batch_filters(self, backend: PgVectorBackend) -> None:
-        ns_a = await backend.create_namespace(MemoryNamespace())
-        ns_b = await backend.create_namespace(MemoryNamespace())
+    async def test_cross_namespace_get_chunks_batch_filters(
+        self, backend: PgVectorBackend, relational: PostgreSQLBackend
+    ) -> None:
+        ns_a = await relational.create_namespace(MemoryNamespace())
+        ns_b = await relational.create_namespace(MemoryNamespace())
 
         doc_a = _make_doc(ns_a.id)
         doc_b = _make_doc(ns_b.id)
-        await backend.create_document(doc_a)
-        await backend.create_document(doc_b)
+        await relational.create_document(doc_a)
+        await relational.create_document(doc_b)
 
         c_a = _make_chunk(ns_a.id, doc_a.id)
         c_b = _make_chunk(ns_b.id, doc_b.id)
@@ -137,12 +195,14 @@ class TestChunkNamespaceIsolationPg:
         result = await backend.get_chunks_batch([c_a.id, c_b.id], namespace_id=ns_a.id)
         assert set(result.keys()) == {c_a.id}
 
-    async def test_cross_namespace_get_chunks_by_document_returns_empty(self, backend: PgVectorBackend) -> None:
-        ns_a = await backend.create_namespace(MemoryNamespace())
-        ns_b = await backend.create_namespace(MemoryNamespace())
+    async def test_cross_namespace_get_chunks_by_document_returns_empty(
+        self, backend: PgVectorBackend, relational: PostgreSQLBackend
+    ) -> None:
+        ns_a = await relational.create_namespace(MemoryNamespace())
+        ns_b = await relational.create_namespace(MemoryNamespace())
 
         doc = _make_doc(ns_a.id)
-        await backend.create_document(doc)
+        await relational.create_document(doc)
         await backend.create_chunks_batch([_make_chunk(ns_a.id, doc.id) for _ in range(2)])
 
         # ns_B caller asks for doc — even guessing the doc id, namespace
@@ -152,11 +212,11 @@ class TestChunkNamespaceIsolationPg:
         same_ns = await backend.get_chunks_by_document(doc.id, namespace_id=ns_a.id)
         assert len(same_ns) == 2
 
-    async def test_chunker_info_roundtrip(self, backend: PgVectorBackend) -> None:
+    async def test_chunker_info_roundtrip(self, backend: PgVectorBackend, relational: PostgreSQLBackend) -> None:
         """chunker_info round-trips independently of metadata via pgvector."""
-        ns = await backend.create_namespace(MemoryNamespace())
+        ns = await relational.create_namespace(MemoryNamespace())
         doc = _make_doc(ns.id)
-        await backend.create_document(doc)
+        await relational.create_document(doc)
 
         chunk = _make_chunk(ns.id, doc.id)
         chunk.chunker_info = {"strategy": "fixed", "tokens": 256}


### PR DESCRIPTION
## Summary

The new integration CI job runs the previously self-skipping Postgres-backed tests for the first time, against a shared service database already migrated to head. That surfaced two clusters of pre-existing test-harness failures that had been quarantined as `xfail`. This clears them.

**Cluster 1 — migration tests assumed a non-shared DB.** Five migration tests reset the alembic version pointer and dropped a single table, which collided with the up-front `alembic upgrade head` on the shared DB (`DuplicateTableError`). Each test's Postgres setup is now self-contained: it drops public-schema enum types, runs `DROP SCHEMA public CASCADE`, recreates the schema + `vector` extension, pre-creates the version table, and re-migrates — mirroring the existing bitemporal migration test. Downgrade checks pin explicit predecessor revisions rather than a `-1` step count so they stay correct as the chain grows.

**Cluster 2 — stale backend API.** The chunk namespace-isolation test called `create_namespace` on the vector backend, which has no such method. Namespace and document creation now route through the relational backend via a dedicated fixture, while the chunk getters under test stay on the vector backend so SQL-level namespace isolation is still exercised. Stale `INSERT` columns and a couple of asyncpg type-handling issues (timestamptz binding, `"char"` cast) that only surfaced once the tests actually ran against Postgres are corrected.

All `xfail` markers for both clusters are removed; the tests run green, not xfailed.

Fixes #1020

## Test plan
- [x] `make lint` passes (ruff + ty), exit 0
- [x] The 6 affected test files pass against Postgres (33 passed, 0 failed, 0 xfailed), verified repeatedly
- [ ] CI `test-integration` job green on the shared service Postgres
- [ ] CI `test-unit`, lint, security, install, examples-smoke jobs green