### PR TITLE
Match array-valued metadata fields in Postgres JSONB containment filter

### DIFF
--- a/src/khora/filter/compilers/postgres.py
+++ b/src/khora/filter/compilers/postgres.py
@@ -362,16 +362,36 @@ class _Builder:
     def _md_containment(self, segs: tuple[str, ...], value: Any) -> ColumnElement[bool]:
         """Array-aware ``@>`` containment rooted at the metadata column.
 
-        For a single-segment path ``("tags",)`` this is ``metadata @> '{"tags":
-        v}'`` — which matches both a scalar field equal to ``v`` and an array
-        field containing ``v``. For a nested path the one-key doc is wrapped at
-        each segment (``{"a": {"tags": v}}``). ``@>`` returns a total boolean
-        (``FALSE`` on absent/mismatch, never ``NULL``), so it is negation-safe.
+        JSONB ``@>`` does NOT treat ``'{"tags": "x"}'`` as contained by
+        ``'{"tags": ["x"]}'`` — the array-contains-primitive exception applies
+        only when the operand itself is an array, not at a nested object key. So
+        a single ``metadata @> '{"tags": v}'`` misses an array-valued field. To
+        match BOTH a scalar field equal to ``v`` and an array field containing
+        ``v``, OR the scalar-doc form with an array-wrapped form whose leaf value
+        is a one-element list:
+
+            ``metadata @> '{"tags": v}'  OR  metadata @> '{"tags": [v]}'``
+
+        For a nested path the one-key doc is wrapped at each segment; the array
+        form wraps the LEAF value (``{"a": {"tags": v}}`` / ``{"a": {"tags":
+        [v]}}``). Each ``@>`` is a total boolean (``FALSE`` on absent/mismatch,
+        never ``NULL``), so the OR of two totals is total and negation-safe.
         """
-        doc: Any = _date_to_jsonable(value)
+        leaf = _date_to_jsonable(value)
+        scalar_doc: Any = leaf
+        array_doc: Any = [leaf]
         for seg in reversed(segs):
-            doc = {seg: doc}
-        return self._md.op("@>")(_jsonb_literal(doc))
+            scalar_doc = {seg: scalar_doc}
+            array_doc = {seg: array_doc}
+        # Both arms are `@>` probes, so a GIN index on `metadata` still serves
+        # this OR (the planner bitmap-ORs the two index scans) — do not collapse
+        # it into a non-`@>` form that loses the index. ``value is None`` only
+        # reaches here from `{k: {$in: [null, ...]}}` (a `{k: null}` $eq is routed
+        # to `_md_null` before this), where the array arm just adds `@> {k:[null]}`.
+        return sa.or_(
+            self._md.op("@>")(_jsonb_literal(scalar_doc)),
+            self._md.op("@>")(_jsonb_literal(array_doc)),
+        )
 
     def _md_exists(self, segs: tuple[str, ...]) -> ColumnElement[bool]:
         """Presence test for a metadata path — total boolean.

--- a/tests/integration/test_compile_postgres_rowset.py
+++ b/tests/integration/test_compile_postgres_rowset.py
@@ -80,23 +80,6 @@ pytestmark = [
     pytest.mark.skipif(not _pg_reachable(), reason="PostgreSQL not reachable (run `make dev`)"),
 ]
 
-# These cases assert array-aware ``@>`` containment: a scalar operand (``$eq`` /
-# ``$in`` / negated ``$ne``) should match BOTH a scalar field and an array field
-# that contains the value. On real Postgres the compiler's ``metadata @> '{k: v}'``
-# form does NOT match an array-valued field — the JSONB array-contains-primitive
-# exception does not apply at the nested-object key level, so a row whose ``tier``
-# is ``["gold", ...]`` is missed by ``tier == "gold"``. This is a SEPARATE compiler
-# defect from the ``#> varchar`` path-operand bug (the ``@>`` form never routes
-# through ``_jpath``); fixing it requires changing ``_md_containment`` to OR an
-# array-wrapped form, which also changes the unit-test SQL contract. Tracked in #1027.
-_xfail_array_containment = pytest.mark.xfail(
-    reason="compile_postgres `@>` containment does not match nested array membership on "
-    "real Postgres (scalar operand vs array-valued field); separate from the #> path "
-    "fix, requires a _md_containment change. Tracked in #1027",
-    strict=False,
-)
-
-
 # The compiler qualifies columns with ``ctx.backend_target`` (``_col`` derives
 # ``<backend_target>.<col>`` from ctx alone), so a predicate built with
 # ``backend_target="khora_chunks"`` references ``khora_chunks.<col>``. To run that
@@ -267,7 +250,6 @@ async def test_numeric_range_band(seeded) -> None:
 # ===========================================================================
 
 
-@_xfail_array_containment
 async def test_metadata_ne_includes_missing_key(seeded) -> None:
     # tier != "gold" compiles to NOT(metadata @> {"tier":"gold"}). Containment is
     # array-aware, so the array-tier row ("arr": ["gold","silver"]) DOES contain
@@ -315,7 +297,6 @@ async def test_not_eq_admits_null_row_like_ne(seeded) -> None:
 # ===========================================================================
 
 
-@_xfail_array_containment
 async def test_metadata_in_matches_scalar_and_array_membership(seeded) -> None:
     # tier $in ["silver"] → every row whose tier is the scalar "silver" (num2,
     # baddate) AND the array-tier row (arr contains "silver"). Containment
@@ -324,7 +305,6 @@ async def test_metadata_in_matches_scalar_and_array_membership(seeded) -> None:
     assert labels == {"num2", "baddate", "arr"}
 
 
-@_xfail_array_containment
 async def test_metadata_in_multiple_values(seeded) -> None:
     labels = await _matching_labels(seeded, {"metadata.tier": {"$in": ["silver", "bronze"]}})
     # silver: num2, baddate, arr (contains silver). bronze: numstr.
@@ -399,7 +379,6 @@ async def test_metadata_exists_true_includes_null_valued_array_and_string(seeded
 # ===========================================================================
 
 
-@_xfail_array_containment
 async def test_metadata_scalar_eq_matches_array_membership(seeded) -> None:
     # tier == "gold" via @> containment matches the scalar-gold rows AND the
     # array-tier row that contains "gold".

--- a/tests/unit/filter/test_compile_postgres.py
+++ b/tests/unit/filter/test_compile_postgres.py
@@ -21,8 +21,10 @@ The contract these tests lock (§4):
      for metadata;
   3. a list operand against a scalar system column → constant ``false``;
   4. ``$exists`` / null use ``?`` / ``#>``-vs-``null``, not ``->>`` value extraction.
-* Array containment: scalar ``$eq`` on metadata → ``@>``; ``$in`` → OR of
-  containments / ``?|``; array operand ``$eq`` → exact ``#>`` = jsonb.
+* Array containment: scalar ``$eq`` on metadata → OR of the scalar-doc ``@>``
+  and the array-wrapped ``@>`` (so it matches both a scalar field and an
+  array-valued field containing the value); ``$in`` → OR of those containments;
+  array operand ``$eq`` → exact ``#>`` = jsonb.
 
 If the compiler module is not yet on the branch (implementation lands separately),
 the whole module skips cleanly so the suite stays green.
@@ -257,11 +259,17 @@ def test_system_null_operand_is_is_null() -> None:
 
 
 def test_metadata_eq_scalar_uses_containment() -> None:
-    # Array-containment rule: a scalar $eq on a metadata field is emitted as a
-    # JSONB containment (@>) so it matches both a scalar value AND membership in
-    # an array-valued field — never a brittle ->> text compare.
+    # Array-containment rule: a scalar $eq on a metadata field is emitted as the
+    # OR of two JSONB containments (@>) — the scalar-doc form AND an
+    # array-wrapped form — so it matches both a scalar value AND membership in an
+    # array-valued field (JSONB @> does not treat {"tier":"gold"} as contained by
+    # {"tier":["gold"]}, so the array-wrapped form is required). Never a brittle
+    # ->> text compare.
     sql = _sql_norm(_ast({"metadata.tier": "gold"}))
     assert "@>" in sql
+    # Both the scalar-doc and the array-wrapped containment docs are emitted.
+    assert '{"tier": "gold"}' in sql
+    assert '{"tier": ["gold"]}' in sql
 
 
 def test_metadata_nested_path_extraction() -> None:
@@ -288,10 +296,17 @@ def test_metadata_all_ranges_gate_on_typeof(wire_op: str) -> None:
 
 
 def test_metadata_in_is_or_of_containments_or_overlap() -> None:
-    # $in on a metadata field is membership across scalar and array fields:
-    # either an OR of @> containments or the ?| overlap operator.
+    # $in on a metadata field is membership across scalar and array fields: an OR
+    # of @> containments — each $in value contributing BOTH a scalar-doc and an
+    # array-wrapped containment so membership spans scalar- and array-valued
+    # fields.
     sql = _sql_norm(_ast({"metadata.tier": {"$in": ["gold", "silver"]}}))
-    assert "@>" in sql or "?|" in sql
+    assert "@>" in sql
+    # Each operand value emits its scalar-doc and array-wrapped containment.
+    assert '{"tier": "gold"}' in sql
+    assert '{"tier": ["gold"]}' in sql
+    assert '{"tier": "silver"}' in sql
+    assert '{"tier": ["silver"]}' in sql
 
 
 def test_metadata_empty_in_is_constant_false() -> None:


### PR DESCRIPTION
## Summary
- The Postgres recall-filter compiler's metadata containment (`_md_containment`) emitted only `metadata @> '{"k": v}'` for a scalar operand. On real Postgres, JSONB containment does **not** treat `{"k": "x"}` as contained by a row whose `k` holds an array `["x", …]` — the array-contains-primitive exception (`'["x"]'::jsonb @> '"x"'`) applies only when the operand itself is an array, not at a nested object key. So scalar `$eq`/`$in` (and the negated `$ne`/`$nin`) silently missed array-valued metadata fields — e.g. `metadata.tags $in [...]` against the common `tags: list[str]` shape matched nothing.
- **Fix:** OR the scalar-doc containment with an array-wrapped form whose leaf is a one-element list — `metadata @> '{"k": v}' OR metadata @> '{"k": [v]}'` — so a scalar operand matches both a scalar field equal to `v` and an array field containing `v`. Nested paths wrap the one-key doc at each segment. Both arms are `@>` probes, so a GIN index on `metadata` still serves the OR (the planner bitmap-ORs the two index scans), and each arm is a total boolean, so the `$ne`/`$nin` negation still admits absent-key rows.
- Strengthened the compiler unit tests to assert **both** `@>` doc forms are emitted for scalar `$eq` and for each `$in` value; left the exact-array `$eq` (`#> = jsonb`) and `$ne` negation assertions intact.
- Removed the integration `xfail` markers that quarantined the four array-membership row-set cases.
- **No Cypher change needed:** the Cypher backend post-filters metadata predicates in Python (Neo4j stores metadata as a serialized JSON string property, not a nested map), so array membership is already handled there; only scalar system keys compile to Cypher. The pgvector skeleton backend reuses this compiler directly and inherits the fix.

## Test plan
- [x] Unit tests pass — `uv run pytest tests/unit/filter/` → 111 passed; rendered SQL verified to emit both containment forms for `$eq`/`$in`/`$ne`/`$nin`; exact-array `$eq` still routes to `#> = jsonb`
- [x] Lint + format clean — `make lint`, `make format`
- [ ] Integration tests pass on real Postgres — the four previously-xfailed array-membership row-set cases run in the `test-integration` CI job (Postgres not reachable in the local dev environment)

Fixes #1027