### PR TITLE
Add Weaviate recall-filter compiler with superset-safe pushdown and Python post-filter

### DIFF
--- a/src/khora/engines/skeleton/backends/weaviate.py
+++ b/src/khora/engines/skeleton/backends/weaviate.py
@@ -33,6 +33,7 @@ is preserved for back-compat; it wraps the URL in a default
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -56,6 +57,13 @@ if TYPE_CHECKING:
 
 # Collection name for temporal chunks
 COLLECTION_NAME = "KhoraChunk"
+
+# Over-fetch multiplier applied when a ``filter_ast`` post-filter runs. Only the
+# two DATE properties (``occurred_at`` / ``created_at``) push down to Weaviate;
+# every other predicate is re-checked in Python against each candidate and may
+# drop rows. We fetch ``limit * _FILTER_OVERFETCH`` candidates so the trimmed
+# survivor set can still reach ``limit`` after the post-filter prunes.
+_FILTER_OVERFETCH = 4
 
 
 @dataclass(frozen=True)
@@ -399,13 +407,86 @@ class WeaviateTemporalStore(TemporalVectorStore):
         - alpha=0: Pure BM25 search
         - 0 < alpha < 1: Blend of both
 
-        ``filter_ast`` is accepted for protocol parity; this backend does not
-        compile the recall-filter AST yet, so it is ignored.
+        ``filter_ast`` is the deterministic recall-filter AST. When provided it is
+        handled in two halves:
+
+        1. **Push-down.** ``compile_weaviate`` lowers the pushable slice of the
+           AST to a native Weaviate :class:`~weaviate.classes.query.Filter` (only
+           the two DATE properties ``occurred_at`` / ``created_at`` are stored as
+           queryable Weaviate properties, so only date predicates push down). That
+           filter is AND-ed alongside the legacy ``temporal_filter`` result and
+           passed as ``filters=``; the two coexist during the ``TemporalFilter``
+           deprecation window.
+        2. **Post-filter.** ``compile_python`` compiles the *whole* AST to an
+           in-memory predicate that is re-applied to every returned chunk. Because
+           the post-filter prunes rows, the query over-fetches
+           ``limit * _FILTER_OVERFETCH`` candidates and the survivor set is trimmed
+           back to ``limit`` afterwards (ranking order preserved). Re-checking the
+           pushed-down date keys in Python is idempotent — this guarantees the
+           backend honors the filter and never raises.
+
+        Stale-collection-schema limitation: the eight document-grained system keys
+        (``source_type`` / ``source_name`` / ``source_url`` / ``source_timestamp``
+        / ``external_id`` / ``content_type`` / ``source`` / ``title``) are NOT
+        stored on the ``KhoraChunk`` collection, nor is the structured ``metadata``
+        blob (it is serialized to a single ``metadata_json`` string property). A
+        predicate on any of those post-filters against an absent field, so
+        ``compile_python``'s absent-key semantics apply (a positive op excludes the
+        chunk, a negation includes it). Pushing those down would need a separate
+        collection-projection change and is out of scope here.
+
+        Two edge cases worth knowing:
+
+        * **May return fewer than** ``limit``. A predicate Weaviate cannot
+          pre-narrow (any ``metadata`` path — metadata is not a queryable property)
+          is enforced only by the python post-filter, which prunes from the
+          ``limit * _FILTER_OVERFETCH`` candidate pool. A highly selective such
+          filter can leave fewer than ``limit`` survivors. This is superset-safe
+          (never a wrong row, only possibly fewer) and inherent to post-filtering;
+          a caller needing exactly ``limit`` under heavy metadata selectivity must
+          widen the candidate budget (raise ``limit`` upstream).
+        * **A positive predicate on an unstored key returns ZERO rows.** Because
+          the eight document-grained system keys above are absent on every stored
+          object, a positive predicate such as ``{"source_name": "foo"}``
+          post-filters to an empty result (absent == not-equal under §4); only the
+          negation form (``$ne`` / ``$nin``) admits those rows. Not a silent bug —
+          a direct consequence of the stale-collection-schema limitation.
         """
         from weaviate.classes.query import HybridFusion, MetadataQuery
 
         collection = await self._get_collection(namespace_id)
         weaviate_filter = self._build_weaviate_filter(temporal_filter) if temporal_filter else None
+
+        # Deterministic recall-filter AST: compile the pushable date slice to a
+        # native Weaviate filter and AND it into the legacy temporal filter; build
+        # an in-memory predicate over the whole AST for the post-filter pass.
+        post_filter: Callable[[Any], bool] | None = None
+        if filter_ast is not None:
+            from khora.filter import CompileContext
+            from khora.filter.compilers.python import compile_python
+            from khora.filter.compilers.weaviate import compile_weaviate
+
+            compiled = compile_weaviate(
+                filter_ast,
+                CompileContext(
+                    backend_target=COLLECTION_NAME,
+                    on_unsupported="split",
+                    field_mapping={"occurred_at": "occurred_at", "created_at": "created_at"},
+                ),
+            )
+            if compiled.predicate is not None:
+                weaviate_filter = (
+                    compiled.predicate if weaviate_filter is None else weaviate_filter & compiled.predicate
+                )
+
+            post_filter = compile_python(
+                filter_ast,
+                CompileContext(backend_target=COLLECTION_NAME, on_unsupported="split"),
+            ).predicate
+
+        # Over-fetch when a post-filter runs — it prunes rows, so we need a larger
+        # candidate pool to still satisfy ``limit`` after trimming.
+        fetch_limit = limit * _FILTER_OVERFETCH if post_filter is not None else limit
 
         if hybrid_alpha is not None and query_text:
             result = await collection.query.hybrid(
@@ -413,7 +494,7 @@ class WeaviateTemporalStore(TemporalVectorStore):
                 vector=query_embedding,
                 alpha=hybrid_alpha,
                 filters=weaviate_filter,
-                limit=limit,
+                limit=fetch_limit,
                 return_metadata=MetadataQuery(score=True, distance=True),
                 include_vector=True,
                 fusion_type=HybridFusion.RELATIVE_SCORE,
@@ -422,7 +503,7 @@ class WeaviateTemporalStore(TemporalVectorStore):
             result = await collection.query.near_vector(
                 near_vector=query_embedding,
                 filters=weaviate_filter,
-                limit=limit,
+                limit=fetch_limit,
                 return_metadata=MetadataQuery(distance=True),
                 include_vector=True,
             )
@@ -430,6 +511,9 @@ class WeaviateTemporalStore(TemporalVectorStore):
         search_results = []
         for obj in result.objects:
             chunk = self._object_to_chunk(obj, namespace_id)
+            # Post-filter the whole AST in Python (idempotent on pushed-down keys).
+            if post_filter is not None and not post_filter(chunk):
+                continue
             distance = obj.metadata.distance if obj.metadata else 0
             similarity = 1 - distance if distance else 0
             if similarity >= min_similarity:
@@ -441,6 +525,11 @@ class WeaviateTemporalStore(TemporalVectorStore):
                         combined_score=obj.metadata.score if obj.metadata else similarity,
                     )
                 )
+
+        # Trim survivors back to ``limit`` — over-fetch padded the candidate pool;
+        # ranking order is preserved (Weaviate returns best-scored first).
+        if post_filter is not None:
+            search_results = search_results[:limit]
 
         return search_results
 
@@ -638,3 +727,18 @@ def _chunk_to_properties(chunk: TemporalChunk) -> dict[str, Any]:
 
 
 __all__ = ["WeaviateBackendConfig", "WeaviateTemporalStore"]
+
+
+# Register the deterministic recall-filter push-down compiler for this
+# engine/target at import time (idempotent — same function object). ``weaviate.py``
+# is imported lazily by ``create_temporal_store("weaviate", ...)``, so registration
+# happens exactly when the Weaviate backend is first constructed — no eager cost,
+# and no registration when the backend is unused. Mirrors
+# ``pgvector.py``/``chronicle`` engine.py: the registry holds the backend's
+# push-down compiler keyed by its storage target (the collection name); the
+# ``compile_python`` post-filter is imported and applied directly in ``search()``,
+# never looked up via the registry (no engine registers a post-filter key).
+from khora.filter import CompilerRegistry  # noqa: E402
+from khora.filter.compilers.weaviate import compile_weaviate  # noqa: E402
+
+CompilerRegistry.register("skeleton.weaviate", COLLECTION_NAME, compile_weaviate)

--- a/src/khora/filter/compilers/__init__.py
+++ b/src/khora/filter/compilers/__init__.py
@@ -15,10 +15,12 @@ from __future__ import annotations
 from khora.filter.compilers.chronicle import ChronicleDateBound, compile_chronicle
 from khora.filter.compilers.postgres import compile_postgres
 from khora.filter.compilers.python import compile_python
+from khora.filter.compilers.weaviate import compile_weaviate
 
 __all__ = [
     "ChronicleDateBound",
     "compile_chronicle",
     "compile_postgres",
     "compile_python",
+    "compile_weaviate",
 ]

--- a/src/khora/filter/compilers/weaviate.py
+++ b/src/khora/filter/compilers/weaviate.py
@@ -1,0 +1,356 @@
+"""Weaviate recall-filter compiler — ``@internal``.
+
+Lowers a canonical :class:`~khora.filter.ast.FilterNode` to a Weaviate v4
+``Filter`` combinator tree (``Filter.all_of`` / ``Filter.any_of`` /
+``Filter.by_property(p).equal(...)`` ...) against a recall chunk collection. The
+output is a :class:`~khora.filter.registry.CompiledFilter` whose ``predicate`` is
+a weaviate ``_Filters`` object the engine hands to its query call, or ``None`` for
+a match-all (no constraint).
+
+Unlike the Postgres / Cypher compilers — which are *total* (every leaf lowers to
+a boolean expression, and a wrapping ``NOT`` flips absent rows in via a
+coalesced total boolean) — this compiler is a **superset-safe partial pushdown**.
+Weaviate has no SQL-style three-valued logic the compiler can wrap to make a
+negation null-inclusive: a server-side negation (``$ne`` / ``$nin`` /
+``$exists:false`` / ``$not``) silently drops rows where the property is
+null/absent, which would FALSE-EXCLUDE rows the filter should keep. So the
+compiler pushes down ONLY *monotone-narrowing* predicates — ones that, when
+applied server-side, can only ever return a SUPERSET of the true result set — and
+leaves everything else to the engine's post-filter (``compile_python`` re-checks
+the whole AST against each candidate). Over-returning is always safe (the
+post-filter narrows); under-returning (dropping a valid row server-side) is a
+correctness bug, so the routing is deliberately conservative.
+
+The superset-safe routing rules:
+
+* **Pushable leaf** (declared property + monotone-narrowing op): ``$eq``,
+  ``$gt`` / ``$gte`` / ``$lt`` / ``$lte`` (range), ``$in`` (→ ``any_of`` of scalar
+  ``equal`` checks). Each pushes a ``Filter.by_property`` constraint and is added
+  to ``consumed_keys``.
+* **Unpushable leaf** (``$ne`` / ``$nin`` / a ``$not`` over a leaf, ``$exists`` /
+  ``{k: null}``, ANY metadata path, or any undeclared key): contributes NO
+  constraint (``None``) and is NOT added to ``consumed_keys`` — the engine
+  post-filters it. The negations would drop null/absent rows server-side,
+  false-excluding rows the filter must keep; ``$exists`` / null are left to the
+  post-filter because the oracle treats a system key as always-present (so a
+  server-side ``is_none`` push would diverge — see ``_compile_system_clause``).
+* **``$and``** MAY push its pushable conjuncts and drop the unpushable ones:
+  AND-ing fewer constraints only WIDENS the candidate set, so it stays a
+  superset (the dropped conjuncts are still re-checked by the post-filter).
+* **``$or`` / ``$not``** are ALL-OR-NOTHING: an ``$or`` is pushed only if every
+  child is pushable (dropping one disjunct would NARROW the union and could drop
+  valid rows); a ``$not`` is unpushable as a whole (negation is not
+  monotone-narrowing here).
+
+**Declared, pushable properties** are exactly the keys of ``ctx.field_mapping``
+(identity-mapped to physical property names). A clause whose key is not in
+``field_mapping`` is treated as undeclared and is not pushed.
+
+**Dates** bind as their ``.isoformat()`` string — the chunk's date properties are
+stored ISO-8601 (lexicographic compare agrees with chronological order for the
+UTC-normalized values the validator produces). The v4 ``Filter`` API also accepts
+``datetime`` directly, but the recall chunk stores the value as a string property,
+so the string form matches what is on disk.
+
+``@internal``. Reachable as ``khora.filter.compilers.weaviate.compile_weaviate``
+for khora's own engines; not re-exported from :mod:`khora.__init__`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from khora.filter import (
+    CompileContext,
+    CompiledFilter,
+    RecallFilterUnsupportedError,
+)
+from khora.filter.ast import (
+    DateLiteral,
+    FilterClause,
+    FilterNode,
+    canonical_hash,
+)
+from khora.filter.model import SYSTEM_KEYS, Op
+
+if TYPE_CHECKING:
+    # Only for type hints — the real import is lazy (weaviate-client is an
+    # optional extra; this module must import without it).
+    from weaviate.collections.classes.filters import _Filters
+
+__all__ = ["compile_weaviate"]
+
+
+# The monotone-narrowing range ops, keyed by AST op to the ``_FilterByProperty``
+# method name. Applying any of these server-side can only return a superset of the
+# true result (a row that passes the real predicate also passes the pushed one), so
+# they are safe to push down on a declared property.
+_RANGE_METHOD = {
+    Op.GT: "greater_than",
+    Op.GTE: "greater_or_equal",
+    Op.LT: "less_than",
+    Op.LTE: "less_or_equal",
+}
+
+
+def compile_weaviate(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[Any]:
+    """Compile a canonical AST to a superset-safe Weaviate ``Filter`` tree.
+
+    ``ast`` is always a :class:`FilterNode` (the ``parse_to_ast`` root invariant).
+    Returns a :class:`CompiledFilter` whose ``predicate`` is a weaviate v4
+    ``_Filters`` object, or ``None`` when nothing is pushable (an empty
+    match-everything ``AND``, or a tree all of whose leaves are unpushable) — the
+    engine treats ``None`` as "apply no server-side filter, post-filter everything".
+
+    ``params`` is always empty (weaviate binds operands inline inside the ``Filter``
+    object). ``consumed_keys`` is the set of dotted leaf paths actually pushed
+    down; the engine's ``compile_python`` post-filter re-checks the rest (and, in
+    fact, re-checks the whole AST regardless, which is what makes over-returning
+    safe). Property names are derived from ``ctx.field_mapping`` alone (its keys
+    are the declared+pushable set, identity-mapped to physical names), so the
+    compiler embeds no engine schema.
+
+    Honors ``ctx.on_unsupported``: in ``"raise"`` mode a clause this backend cannot
+    push raises :class:`RecallFilterUnsupportedError`; in ``"split"`` mode (the
+    mode this backend is used in) it is silently dropped from the pushed-down
+    filter and left to the post-filter. Note that *most* unpushable clauses are a
+    correctness requirement here (a pushed negation would false-exclude rows), not
+    a backend gap — so the typical engine wiring uses ``"split"``.
+    """
+    consumed: set[str] = set()
+    builder = _Builder(ctx=ctx, consumed=consumed)
+    predicate = builder.compile_node(ast)
+    return CompiledFilter(
+        predicate=predicate,
+        params={},
+        consumed_keys=frozenset(consumed),
+        # canonical_hash over the whole AST — the engine re-checks the whole AST in
+        # its post-filter (the pushed-down filter is only a superset prefilter), so
+        # the cache key is keyed on the full predicate, not the pushed slice.
+        canonical_hash=canonical_hash(ast),
+    )
+
+
+def _path_str(path: tuple[str, ...]) -> str:
+    """Render an AST path as the dotted key string used for diagnostics/consumed."""
+    return ".".join(path)
+
+
+class _Builder:
+    """Per-compile-pass state: the :class:`CompileContext` and consumed set.
+
+    A compile pass threads the ``ctx`` (declared property names are derived from
+    its ``field_mapping``) and the ``consumed`` accumulator. The weaviate
+    ``Filter`` symbol is imported lazily once per pass (the module must import
+    without the optional ``weaviate-client`` extra installed) and cached on the
+    instance.
+    """
+
+    def __init__(self, *, ctx: CompileContext, consumed: set[str]) -> None:
+        self._ctx = ctx
+        self._consumed = consumed
+        # Declared+pushable property set = the keys of field_mapping, mapped to
+        # physical property names (identity when a key maps to itself). An empty /
+        # absent mapping means nothing is declared, so nothing is pushable.
+        self._declared: dict[str, str] = dict(ctx.field_mapping or {})
+        self._Filter = _import_filter()
+
+    # ----- logical node walk ---------------------------------------------- #
+
+    def compile_node(self, node: FilterNode | FilterClause) -> _Filters | None:
+        """Compile a logical node or leaf to a ``_Filters`` or ``None``.
+
+        ``None`` means "no pushable constraint" — the caller widens around it (an
+        ``$and`` drops it, an ``$or`` / ``$not`` becomes wholly unpushable).
+        """
+        if isinstance(node, FilterClause):
+            return self.compile_clause(node)
+        if node.op == Op.AND:
+            # AND-ing FEWER constraints only widens the candidate set, so an $and
+            # may push the pushable conjuncts and DROP the unpushable ones — the
+            # result stays a superset (the post-filter re-narrows). Drop the None
+            # children (unpushable conjuncts).
+            pushed = [c for c in (self.compile_node(child) for child in node.children) if c is not None]
+            if not pushed:
+                # Empty match-everything AND, or every conjunct was unpushable.
+                return None
+            if len(pushed) == 1:
+                return pushed[0]
+            return self._Filter.all_of(pushed)
+        if node.op == Op.OR:
+            # ALL-OR-NOTHING: dropping a disjunct would NARROW the union and could
+            # false-exclude valid rows. Push the $or only if EVERY child is
+            # pushable; otherwise the whole node is unpushable (post-filter handles
+            # it) and we roll back any leaf this branch speculatively consumed.
+            before = set(self._consumed)
+            children = [self.compile_node(child) for child in node.children]
+            if not children or any(c is None for c in children):
+                self._consumed.intersection_update(before)  # roll back partial consumes
+                return None
+            pushed = [c for c in children if c is not None]  # all non-None by the guard
+            if len(pushed) == 1:
+                return pushed[0]
+            return self._Filter.any_of(pushed)
+        # Op.NOT — a negation is not monotone-narrowing on this backend (a
+        # server-side NOT drops null/absent rows), so it is ALWAYS unpushable as a
+        # whole. Consume nothing under it; the engine post-filters the negation.
+        return None
+
+    # ----- leaf key-kind split -------------------------------------------- #
+
+    def compile_clause(self, clause: FilterClause) -> _Filters | None:
+        """Dispatch a leaf: push it iff it is a declared property + narrowing op."""
+        path = clause.path
+        # Only a single-segment system key that is ALSO declared in field_mapping
+        # is a candidate for pushdown. A metadata path (multi-segment, "metadata"
+        # root) is never pushed — the chunk stores metadata as a serialized JSON
+        # string property, and even on a native-map backend a metadata negation
+        # has the same null-drop hazard, so it is left to the post-filter.
+        if len(path) != 1 or path[0] not in SYSTEM_KEYS or path[0] not in self._declared:
+            return self._unsupported(clause, "key is not a declared, pushable property")
+        expr = self._compile_system_clause(clause)
+        if expr is None:
+            # The op is not monotone-narrowing ($ne / $nin / $exists:false / null).
+            return self._unsupported(clause, "operator is not monotone-narrowing — not superset-safe to push")
+        self._consumed.add(_path_str(path))
+        return expr
+
+    # ----- system-key leaves (declared properties) ----------------------- #
+
+    def _compile_system_clause(self, clause: FilterClause) -> _Filters | None:
+        """Build the ``Filter`` for a declared system key, or ``None`` if not pushable.
+
+        Returns ``None`` for any op that is NOT a superset-safe push — a ``$ne`` /
+        ``$nin`` / ``$not`` negation drops null/absent rows server-side, which would
+        false-exclude rows the filter must keep. The caller routes a ``None`` to the
+        post-filter.
+
+        ``$exists`` and ``{k: null}`` are deliberately NOT pushed, even though the
+        v4 API has ``is_none(...)`` for them. The post-filter oracle
+        (``compile_python``) treats a system key as *always present* — so on a
+        system key ``$exists:true`` is a constant TRUE (every record, including one
+        with a null property, passes). Pushing ``is_none(False)`` would EXCLUDE the
+        null-property rows the oracle keeps → a false-exclusion. Leaving ``$exists``
+        / null to the post-filter is the only superset-safe choice and keeps this
+        compiler exactly aligned with the routing-equivalence oracle.
+        """
+        prop = self._declared[clause.path[0]]
+        by = self._Filter.by_property(prop)
+        op = clause.op
+        operand = clause.operand
+
+        if op == Op.EXISTS:
+            # See the method docstring: $exists on a system key is constant in the
+            # post-filter oracle, so any server-side is_none() push would diverge
+            # ($exists:true would false-exclude null-property rows). Not pushed.
+            return None
+
+        if op in (Op.IN, Op.NIN):
+            if op == Op.NIN:
+                # $nin is a negation — drops null/absent rows server-side. Unpushable.
+                return None
+            if not operand:
+                # $in over an empty list matches NOTHING. There is no
+                # match-nothing Filter primitive, and returning None would WIDEN to
+                # match-all (wrong direction — could false-INCLUDE, but the
+                # post-filter narrows so over-returning stays correct). Pushing
+                # nothing and letting the post-filter (which knows $in [] == ∅)
+                # exclude everything is the superset-safe choice.
+                return None
+            # $in → any_of([equal(x) for x in v]) — membership as an OR of scalar
+            # equals ("prop == x1 OR prop == x2 ..."), which is exact $in semantics
+            # on a SCALAR property. Deliberately NOT contains_any: that is a
+            # Weaviate ARRAY / text-membership operator whose behavior on a scalar
+            # DATE property (the only keys compile_weaviate ever pushes $in on) is
+            # not guaranteed — it could under-return or raise at query time, which
+            # the in-memory parity test cannot catch. The OR-of-equals is
+            # unambiguously superset-exact. (The existing backend's contains_any is
+            # for the `tags` TEXT_ARRAY property — an array case never pushed here.)
+            members = [by.equal(_system_value(v)) for v in operand]
+            if len(members) == 1:
+                # A single-member $in needs no any_of wrapper — the bare equal IS
+                # the membership test.
+                return members[0]
+            return self._Filter.any_of(members)
+
+        if operand is None:
+            # {k: null} ($eq None) / {$ne: None} hinge on null/absent. The oracle
+            # treats a system key as always-present, so these are best left to the
+            # post-filter rather than approximated by a server-side is_none() that
+            # could diverge from the oracle's resolution. Not pushed.
+            return None
+
+        if op == Op.NE:
+            # $ne drops null/absent rows server-side (Weaviate not_equal excludes
+            # them). Unpushable — the post-filter applies it null-inclusively.
+            return None
+
+        if op == Op.EQ:
+            # A bare-list (exact-array) $eq operand is carried as a tuple. A scalar
+            # chunk property never equals an array, so pushing equal([...]) would
+            # match nothing server-side (could false-EXCLUDE the rows the
+            # post-filter would keep via list semantics). Leave it to the
+            # post-filter rather than push a wrong-direction constraint.
+            if isinstance(operand, tuple):
+                return None
+            return by.equal(_system_value(operand))
+
+        # Range ops ($gt/$gte/$lt/$lte) — all monotone-narrowing.
+        method = getattr(by, _RANGE_METHOD[op])
+        return method(_system_value(operand))
+
+    # ----- unsupported ---------------------------------------------------- #
+
+    def _unsupported(self, clause: FilterClause, reason: str) -> _Filters | None:
+        """Handle a clause this backend cannot (safely) push per ``ctx.on_unsupported``.
+
+        ``"raise"`` raises the public :class:`RecallFilterUnsupportedError`;
+        ``"split"`` (the mode this backend runs in) leaves the clause out of
+        ``consumed_keys`` and contributes ``None`` — no server-side constraint, so
+        the engine's post-filter re-checks it. A ``None`` never narrows the pushed
+        filter, keeping it a superset of the true result.
+        """
+        if self._ctx.on_unsupported == "raise":
+            raise RecallFilterUnsupportedError(_path_str(clause.path), reason)
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Module-level helpers (no per-pass state).
+# --------------------------------------------------------------------------- #
+
+
+def _import_filter() -> Any:
+    """Import the weaviate v4 ``Filter`` builder lazily.
+
+    Kept out of module scope so the compiler module imports without the optional
+    ``weaviate-client`` extra. Raises a clear :class:`RecallFilterUnsupportedError`
+    (rather than a bare ``ImportError``) if a caller reaches the compiler without
+    the extra installed — but in normal use only the weaviate engine (which
+    depends on the extra) ever calls this.
+    """
+    try:
+        from weaviate.classes.query import Filter
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra
+        raise RecallFilterUnsupportedError(
+            "<weaviate>",
+            "weaviate-client is not installed; install the 'weaviate' extra to push filters down",
+        ) from exc
+    return Filter
+
+
+def _system_value(value: Any) -> Any:
+    """Coerce a system-key operand to a weaviate-bindable value.
+
+    A chunk stores datetime properties as ISO-8601 strings, so a
+    :class:`DateLiteral` / :class:`~datetime.datetime` binds as its
+    ``.isoformat()`` string (lexicographic compare). Other scalars pass through.
+    Tuples (bare-list ``$eq`` exact-array operands) never reach here — they are
+    routed to the post-filter in :meth:`_Builder._compile_system_clause`.
+    """
+    if isinstance(value, DateLiteral):
+        return value.value.isoformat()
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value

--- a/src/khora/filter/context.py
+++ b/src/khora/filter/context.py
@@ -112,7 +112,11 @@ class CompileContext:
     * ``field_mapping`` — optional system-key → backend column/property name map.
       Lets one compiler serve a different schema (e.g. the legacy
       ``chunks``/``documents`` tables) without per-engine branching. ``None`` =
-      identity mapping (system key name == column name).
+      identity mapping (system key name == column name). A compiler MAY also treat
+      the KEY SET as the backend's declared+pushable property whitelist — a key
+      absent from ``field_mapping`` is then "undeclared" and not pushed down (as
+      :func:`~khora.filter.compilers.weaviate.compile_weaviate` does, leaving
+      undeclared keys to the post-filter).
     * ``schema_capabilities`` — what the backend can do natively
       (:class:`SchemaCapabilities`).
     * ``on_unsupported`` — ``"raise"`` stops on the first node the backend cannot

--- a/tests/unit/engines/skeleton/backends/test_weaviate_async.py
+++ b/tests/unit/engines/skeleton/backends/test_weaviate_async.py
@@ -19,6 +19,7 @@ from pydantic import SecretStr
 
 from khora.engines.skeleton.backends import TemporalChunk
 from khora.engines.skeleton.backends.weaviate import (
+    _FILTER_OVERFETCH,
     COLLECTION_NAME,
     WeaviateBackendConfig,
     WeaviateTemporalStore,
@@ -27,6 +28,8 @@ from khora.engines.skeleton.backends.weaviate import (
     _extract_vector,
     _parse_host_port,
 )
+from khora.filter import RecallFilter
+from khora.filter.ast import parse_to_ast
 
 # ---------------------------------------------------------------------------
 # WeaviateBackendConfig validation
@@ -470,3 +473,274 @@ class TestCRUD:
         ok = await store.delete_chunk(uuid4(), uuid4())
         assert ok is True
         tenant_scoped.data.delete_by_id.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# search() filter_ast wiring (push-down + post-filter)
+# ---------------------------------------------------------------------------
+
+
+class _FakeProperty:
+    """Records the property + op a ``Filter.by_property(p).<op>(v)`` call builds.
+
+    The compiler only needs each chained builder to return *some* object the
+    wiring can hand to the query; the test inspects the recorded structure to
+    confirm a push-down filter was assembled (rather than asserting against the
+    real ``weaviate-client`` ``_Filters`` internals, which are not installed in
+    the unit-test venv).
+    """
+
+    def __init__(self, prop: str) -> None:
+        self.prop = prop
+
+    def _leaf(self, op: str, value: Any) -> _FakeFilter:
+        return _FakeFilter(kind="leaf", prop=self.prop, op=op, value=value)
+
+    def equal(self, value: Any) -> _FakeFilter:
+        return self._leaf("equal", value)
+
+    def greater_than(self, value: Any) -> _FakeFilter:
+        return self._leaf("greater_than", value)
+
+    def greater_or_equal(self, value: Any) -> _FakeFilter:
+        return self._leaf("greater_or_equal", value)
+
+    def less_than(self, value: Any) -> _FakeFilter:
+        return self._leaf("less_than", value)
+
+    def less_or_equal(self, value: Any) -> _FakeFilter:
+        return self._leaf("less_or_equal", value)
+
+    def is_none(self, value: bool) -> _FakeFilter:
+        return self._leaf("is_none", value)
+
+
+class _FakeFilter:
+    """A minimal stand-in for weaviate v4 ``Filter`` / ``_Filters``.
+
+    Supports the builder surface ``compile_weaviate`` uses
+    (``by_property`` / ``all_of`` / ``any_of``) and the ``&`` operator the
+    backend wiring uses to AND the pushed-down filter into the legacy temporal
+    filter.
+    """
+
+    def __init__(
+        self,
+        *,
+        kind: str,
+        prop: str | None = None,
+        op: str | None = None,
+        value: Any = None,
+        children: list[_FakeFilter] | None = None,
+    ) -> None:
+        self.kind = kind
+        self.prop = prop
+        self.op = op
+        self.value = value
+        self.children = children or []
+
+    @staticmethod
+    def by_property(prop: str) -> _FakeProperty:
+        return _FakeProperty(prop)
+
+    @staticmethod
+    def all_of(filters: list[_FakeFilter]) -> _FakeFilter:
+        return _FakeFilter(kind="all_of", children=list(filters))
+
+    @staticmethod
+    def any_of(filters: list[_FakeFilter]) -> _FakeFilter:
+        return _FakeFilter(kind="any_of", children=list(filters))
+
+    def __and__(self, other: _FakeFilter) -> _FakeFilter:
+        return _FakeFilter(kind="all_of", children=[self, other])
+
+    def props_touched(self) -> set[str]:
+        """The set of property names anywhere in the (possibly nested) filter."""
+        if self.kind == "leaf":
+            return {self.prop} if self.prop else set()
+        out: set[str] = set()
+        for child in self.children:
+            out |= child.props_touched()
+        return out
+
+
+def _install_query_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inject ``weaviate.classes.query`` with the fake ``Filter`` + query enums.
+
+    ``compile_weaviate`` lazily imports ``Filter`` from this submodule, and
+    ``search`` imports ``HybridFusion`` / ``MetadataQuery`` from it. The base
+    fake-weaviate installer leaves ``query`` empty, so this layers the symbols on.
+    """
+    import sys
+
+    query_mod = sys.modules["weaviate.classes.query"]
+    query_mod.Filter = _FakeFilter  # type: ignore[attr-defined]
+    query_mod.HybridFusion = SimpleNamespace(RELATIVE_SCORE="relative_score")  # type: ignore[attr-defined]
+    query_mod.MetadataQuery = lambda **kw: SimpleNamespace(**kw)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "weaviate.classes.query", query_mod)
+
+
+def _fake_object(*, occurred_at: datetime, distance: float = 0.1, metadata: dict[str, Any] | None = None) -> Any:
+    """Build a fake Weaviate result object shaped for ``_object_to_chunk``.
+
+    ``metadata`` is serialized into the ``metadata_json`` string property the way
+    real chunks store it, so ``_object_to_chunk`` parses it back onto the chunk's
+    ``metadata`` dict for the python post-filter to read.
+    """
+    import json
+
+    return SimpleNamespace(
+        uuid=str(uuid4()),
+        properties={
+            "content": "hello",
+            "document_id": str(uuid4()),
+            "occurred_at": occurred_at,
+            "created_at": occurred_at,
+            "source_system": "slack",
+            "metadata_json": json.dumps(metadata or {}),
+        },
+        vector=None,
+        metadata=SimpleNamespace(distance=distance, score=1.0 - distance),
+    )
+
+
+async def _store_with_query(
+    monkeypatch: pytest.MonkeyPatch, objects: list[Any]
+) -> tuple[WeaviateTemporalStore, MagicMock]:
+    """A connected store whose tenant-scoped ``query.near_vector`` returns ``objects``."""
+    _weaviate, client = _install_fake_weaviate(monkeypatch)
+    _install_query_filter(monkeypatch)
+
+    collection = MagicMock(name="CollectionAsync")
+    collection.tenants.create = AsyncMock()
+    tenant_scoped = MagicMock(name="TenantScopedCollection")
+    tenant_scoped.query.near_vector = AsyncMock(return_value=SimpleNamespace(objects=objects))
+    tenant_scoped.query.hybrid = AsyncMock(return_value=SimpleNamespace(objects=objects))
+    collection.with_tenant = MagicMock(return_value=tenant_scoped)
+    client.collections.get = MagicMock(return_value=collection)
+
+    store = _build_store("http://localhost:8090")
+    await store.connect()
+    return store, tenant_scoped
+
+
+@pytest.mark.unit
+class TestSearchFilterAstWiring:
+    @pytest.mark.asyncio
+    async def test_no_filter_ast_does_not_overfetch_or_post_filter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Baseline: without filter_ast the query keeps the caller's limit and
+        # passes no AST-derived filter (None when there is no temporal filter).
+        objs = [_fake_object(occurred_at=datetime(2026, 6, i + 1, tzinfo=UTC)) for i in range(3)]
+        store, tenant_scoped = await _store_with_query(monkeypatch, objs)
+
+        results = await store.search(uuid4(), [0.1] * 1536, limit=5)
+
+        tenant_scoped.query.near_vector.assert_awaited_once()
+        kwargs = tenant_scoped.query.near_vector.call_args.kwargs
+        assert kwargs["limit"] == 5  # no over-fetch
+        assert kwargs["filters"] is None
+        assert len(results) == 3
+
+    @pytest.mark.asyncio
+    async def test_filter_ast_pushes_date_filter_and_overfetches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A date predicate on a declared property (occurred_at) must push down to
+        # Weaviate (a non-None filter touching occurred_at) and the query must
+        # over-fetch because a post-filter runs.
+        objs = [_fake_object(occurred_at=datetime(2026, 6, i + 1, tzinfo=UTC)) for i in range(3)]
+        store, tenant_scoped = await _store_with_query(monkeypatch, objs)
+
+        ast = parse_to_ast(RecallFilter.model_validate({"occurred_at": {"$gt": "2026-01-01T00:00:00Z"}}))
+        await store.search(uuid4(), [0.1] * 1536, limit=10, filter_ast=ast)
+
+        kwargs = tenant_scoped.query.near_vector.call_args.kwargs
+        assert kwargs["limit"] == 10 * _FILTER_OVERFETCH
+        pushed = kwargs["filters"]
+        assert pushed is not None
+        assert isinstance(pushed, _FakeFilter)
+        assert "occurred_at" in pushed.props_touched()
+
+    @pytest.mark.asyncio
+    async def test_post_filter_drops_non_matching_rows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The post-filter re-checks the whole AST in Python: candidates whose
+        # occurred_at falls on/before the cutoff are dropped even though the mock
+        # query returned them (the push-down is a superset prefilter).
+        cutoff = datetime(2026, 6, 1, tzinfo=UTC)
+        passing = [_fake_object(occurred_at=datetime(2026, 6, 5, tzinfo=UTC)) for _ in range(2)]
+        failing = [_fake_object(occurred_at=datetime(2026, 5, 1, tzinfo=UTC)) for _ in range(3)]
+        store, _tenant = await _store_with_query(monkeypatch, passing + failing)
+
+        ast = parse_to_ast(RecallFilter.model_validate({"occurred_at": {"$gt": cutoff.isoformat()}}))
+        results = await store.search(uuid4(), [0.1] * 1536, limit=10, filter_ast=ast)
+
+        assert len(results) == 2  # the 3 failing rows are post-filtered out
+        for r in results:
+            assert r.chunk.occurred_at is not None
+            assert r.chunk.occurred_at > cutoff
+
+    @pytest.mark.asyncio
+    async def test_post_filter_trims_survivors_to_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Over-fetch returns more survivors than ``limit``; the result is trimmed
+        # back to ``limit`` while preserving the order the query returned them
+        # (Weaviate ranks best-first, so trimming keeps the top-``limit`` slice).
+        objs = [_fake_object(occurred_at=datetime(2026, 6, 10, tzinfo=UTC), distance=0.05) for _ in range(8)]
+        returned_ids = [obj.uuid for obj in objs]
+        store, _tenant = await _store_with_query(monkeypatch, objs)
+
+        ast = parse_to_ast(RecallFilter.model_validate({"occurred_at": {"$gt": "2026-01-01T00:00:00Z"}}))
+        results = await store.search(uuid4(), [0.1] * 1536, limit=3, filter_ast=ast)
+
+        assert len(results) == 3  # trimmed from 8 survivors
+        # Order preserved: the trimmed slice is the first 3 the query returned.
+        assert [str(r.chunk.id) for r in results] == returned_ids[:3]
+
+    @pytest.mark.asyncio
+    async def test_undeclared_system_key_post_filters_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A predicate on a document-grained key that is NOT a declared Weaviate
+        # property (source_name) pushes NOTHING down (filters stays None), but the
+        # post-filter still applies it — and since that property is absent on the
+        # stored object, compile_python's positive-op semantics exclude every row.
+        objs = [_fake_object(occurred_at=datetime(2026, 6, i + 1, tzinfo=UTC)) for i in range(3)]
+        store, tenant_scoped = await _store_with_query(monkeypatch, objs)
+
+        ast = parse_to_ast(RecallFilter.model_validate({"source_name": "linear"}))
+        results = await store.search(uuid4(), [0.1] * 1536, limit=10, filter_ast=ast)
+
+        # Undeclared key → nothing pushed down (no temporal filter either).
+        assert tenant_scoped.query.near_vector.call_args.kwargs["filters"] is None
+        # source_name is absent on the chunk → positive $eq excludes all rows.
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_selective_metadata_filter_may_return_fewer_than_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A metadata predicate cannot push down (metadata is not a queryable
+        # Weaviate property), so the python post-filter enforces it over the
+        # over-fetched candidate pool. When the filter is highly selective the
+        # result can be FEWER than ``limit`` — superset-safe (only matching rows,
+        # never a wrong one), and the surviving subset keeps the returned order.
+        #
+        # Shape: limit=3 over-fetches 3 * _FILTER_OVERFETCH = 12 candidates; a
+        # selective {"metadata.tag": {"$in": ["rare"]}} matches only 2 of them.
+        matching = [
+            _fake_object(occurred_at=datetime(2026, 6, i + 1, tzinfo=UTC), distance=0.01 * i, metadata={"tag": "rare"})
+            for i in range(2)
+        ]
+        non_matching = [
+            _fake_object(occurred_at=datetime(2026, 6, 10 + i, tzinfo=UTC), distance=0.5, metadata={"tag": "common"})
+            for i in range(10)
+        ]
+        # Interleave so the survivors are not just a contiguous prefix.
+        objs = [non_matching[0], matching[0], *non_matching[1:5], matching[1], *non_matching[5:]]
+        assert len(objs) == 12  # the full over-fetched pool for limit=3
+        match_ids = [matching[0].uuid, matching[1].uuid]
+        store, tenant_scoped = await _store_with_query(monkeypatch, objs)
+
+        ast = parse_to_ast(RecallFilter.model_validate({"metadata.tag": {"$in": ["rare"]}}))
+        results = await store.search(uuid4(), [0.1] * 1536, limit=3, filter_ast=ast)
+
+        # Over-fetched the 12-candidate pool; metadata path is undeclared → nothing
+        # pushed server-side.
+        assert tenant_scoped.query.near_vector.call_args.kwargs["limit"] == 3 * _FILTER_OVERFETCH
+        assert tenant_scoped.query.near_vector.call_args.kwargs["filters"] is None
+        # Exactly the 2 matching rows survive (< limit=3), in returned order.
+        assert [str(r.chunk.id) for r in results] == match_ids
+        assert all(r.chunk.metadata.get("tag") == "rare" for r in results)

--- a/tests/unit/filter/test_compile_weaviate.py
+++ b/tests/unit/filter/test_compile_weaviate.py
@@ -1,0 +1,550 @@
+"""Unit tests for the Weaviate recall-filter compiler (Layer 4) — ``@internal``.
+
+``compile_weaviate(ast, ctx)`` lowers a canonical :class:`~khora.filter.ast.FilterNode`
+into a Weaviate v4 ``Filter`` combinator tree (or ``None`` for match-all) over a recall
+chunk collection. These tests pin the *superset-safe pushdown* contract at the Weaviate
+level: each test builds an AST (by validating a :class:`~khora.filter.RecallFilter` and
+lowering it with :func:`~khora.filter.ast.parse_to_ast`), compiles it, and asserts on the
+emitted ``Filter`` object's structure (``.target`` / ``.operator`` / ``.value`` /
+``.filters``) and on ``consumed_keys`` — never re-implementing the compiler.
+
+The contract these tests lock:
+
+* **Operator translations** (declared property only): ``$eq`` → ``equal``;
+  ``$gt`` / ``$gte`` / ``$lt`` / ``$lte`` → ``greater_than`` / ``greater_or_equal`` /
+  ``less_than`` / ``less_or_equal``; ``$in`` → ``any_of([equal(x), ...])`` (an OR
+  of scalar equals — exact membership on a scalar property, NOT ``contains_any``).
+  Dates bind as ``.isoformat()`` strings.
+* **Superset-safe routing** — the load-bearing correctness rule. Only
+  monotone-narrowing predicates on a declared property push down and land in
+  ``consumed_keys``; ``$ne`` / ``$nin`` / ``$not``, ``$exists`` (both polarities),
+  ``{k: null}``, every metadata path, and every undeclared key are NOT consumed
+  (the engine's ``compile_python`` post-filter re-checks them). ``$exists`` / null
+  are not pushed because the oracle treats a system key as always-present, so a
+  server-side ``is_none`` push would diverge (a ``$exists:true`` push would
+  false-exclude null-property rows). An ``$and`` pushes its pushable conjuncts and
+  drops the rest; an ``$or`` is all-or-nothing.
+* The :class:`CompiledFilter` envelope: ``predicate`` (a ``_Filters`` or ``None``),
+  empty ``params``, ``consumed_keys`` frozenset, ``canonical_hash``.
+
+The weaviate v4 ``Filter`` objects are private dataclasses (``_FilterValue`` /
+``_FilterAnd`` / ``_FilterOr``); the tests read their stable instance attributes
+(``target`` / ``operator`` / ``value`` / ``filters``) and compare the ``operator``
+enum by its ``.value`` string so no private symbol is imported.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from khora.filter import RecallFilter, RecallFilterUnsupportedError
+from khora.filter.ast import FilterClause, FilterNode, canonical_hash, parse_to_ast
+from khora.filter.compilers.weaviate import compile_weaviate
+from khora.filter.context import CompileContext
+from khora.filter.model import Op
+
+# Hard skip (not a silent module skip): the compiler module imports without the
+# weaviate extra, but these tests build real ``Filter`` objects, so they need the
+# extra installed. Skip the module if it is absent rather than fail CI red on a
+# stack that does not install the optional weaviate-client.
+pytest.importorskip("weaviate", reason="weaviate-client extra not installed")
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+# The two date keys are the declared+pushable property set for these tests (the
+# keys of field_mapping ARE the declared set, identity-mapped). Everything else —
+# the 8 doc-grained system keys and every metadata path — is undeclared here, so
+# it is never pushed.
+_FIELD_MAPPING = {"occurred_at": "occurred_at", "created_at": "created_at"}
+# This backend runs in "split" mode: an unpushable clause is silently dropped to
+# the engine's post-filter (not raised). The dedicated on_unsupported tests below
+# construct their own "raise"-mode context.
+_CTX = CompileContext(backend_target="KhoraChunk", field_mapping=_FIELD_MAPPING, on_unsupported="split")
+
+
+def _ast(wire: dict) -> FilterNode:
+    """Validate a wire-form filter and lower it to the canonical AST."""
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+def _compile(wire: dict, ctx: CompileContext = _CTX) -> Any:
+    """Compile a wire-form filter and return the CompiledFilter."""
+    return compile_weaviate(_ast(wire), ctx)
+
+
+def _op(node: Any) -> str:
+    """Return a Filter node's operator as its wire string (e.g. ``"Equal"``)."""
+    # ``_Operator`` is a str-enum; ``.value`` is the wire literal. Read it without
+    # importing the private enum type.
+    return node.operator.value
+
+
+# ===========================================================================
+# Empty AST → match-all (None predicate).
+# ===========================================================================
+
+
+def test_empty_filter_compiles_to_none() -> None:
+    # A bare RecallFilter() (no predicates) lowers to the empty match-everything
+    # AND. With nothing to push, the predicate is None (engine applies no
+    # server-side filter) and nothing is consumed.
+    compiled = _compile({})
+    assert compiled.predicate is None
+    assert compiled.params == {}
+    assert compiled.consumed_keys == frozenset()
+
+
+def test_empty_and_node_compiles_to_none() -> None:
+    compiled = compile_weaviate(FilterNode(op=Op.AND, children=()), _CTX)
+    assert compiled.predicate is None
+
+
+# ===========================================================================
+# Operator translations on a DECLARED property → pushed + consumed.
+# ===========================================================================
+
+
+def test_eq_translates_to_equal() -> None:
+    compiled = _compile({"occurred_at": "2026-02-03T00:00:00Z"})
+    pred = compiled.predicate
+    assert pred.target == "occurred_at"
+    assert _op(pred) == "Equal"
+    # Date binds as its .isoformat() string (lexicographic compare on the stored
+    # ISO string property).
+    assert isinstance(pred.value, str) and pred.value.startswith("2026-02-03")
+    assert "occurred_at" in compiled.consumed_keys
+
+
+@pytest.mark.parametrize(
+    ("wire_op", "weaviate_operator"),
+    [
+        ("$gt", "GreaterThan"),
+        ("$gte", "GreaterThanEqual"),
+        ("$lt", "LessThan"),
+        ("$lte", "LessThanEqual"),
+    ],
+)
+def test_range_operators_translate(wire_op: str, weaviate_operator: str) -> None:
+    compiled = _compile({"occurred_at": {wire_op: "2026-03-04T05:06:07Z"}})
+    pred = compiled.predicate
+    assert pred.target == "occurred_at"
+    assert _op(pred) == weaviate_operator
+    assert pred.value.startswith("2026-03-04")
+    assert "occurred_at" in compiled.consumed_keys
+
+
+def test_in_translates_to_any_of_equal() -> None:
+    # $in is membership → any_of([equal(x) for x in v]) — an OR of scalar equals,
+    # which is exact $in semantics on a scalar property. NOT contains_any (that is
+    # an array-membership operator whose behavior on a scalar DATE prop is not
+    # guaranteed). _FilterOr carries a .filters list of the per-value Equal leaves.
+    compiled = _compile({"created_at": {"$in": ["2026-01-01T00:00:00Z", "2026-02-02T00:00:00Z"]}})
+    pred = compiled.predicate
+    assert _op(pred) == "Or"
+    assert len(pred.filters) == 2
+    assert all(leaf.target == "created_at" for leaf in pred.filters)
+    assert all(_op(leaf) == "Equal" for leaf in pred.filters)
+    assert {leaf.value[:10] for leaf in pred.filters} == {"2026-01-01", "2026-02-02"}
+    assert "created_at" in compiled.consumed_keys
+
+
+def test_in_single_value_collapses_to_bare_equal() -> None:
+    # A single-element $in needs no Or wrapper — it collapses to the bare equal
+    # (the OR-of-one IS just the one membership check).
+    compiled = _compile({"created_at": {"$in": ["2026-01-01T00:00:00Z"]}})
+    pred = compiled.predicate
+    assert _op(pred) == "Equal"
+    assert pred.target == "created_at"
+    assert pred.value[:10] == "2026-01-01"
+    assert "created_at" in compiled.consumed_keys
+
+
+def test_direct_datetime_clause_binds_iso_string() -> None:
+    # A leaf built directly with a tz-aware datetime operand binds as its
+    # .isoformat() string (the AST is a valid compiler input independent of the
+    # validator path).
+    clause = FilterClause(path=("occurred_at",), op=Op.GTE, operand=datetime(2026, 1, 1, tzinfo=UTC))
+    node = FilterNode(op=Op.AND, children=(clause,))
+    compiled = compile_weaviate(node, _CTX)
+    pred = compiled.predicate
+    assert _op(pred) == "GreaterThanEqual"
+    assert pred.value == datetime(2026, 1, 1, tzinfo=UTC).isoformat()
+
+
+# ===========================================================================
+# Superset-safe routing — negations / null are NOT pushed (not consumed).
+# ===========================================================================
+
+
+def test_ne_on_date_is_not_pushed() -> None:
+    # $ne would drop null/absent rows server-side (false-exclude). Unpushable: no
+    # predicate, nothing consumed — the engine post-filter applies it.
+    compiled = _compile({"occurred_at": {"$ne": "2026-02-03T00:00:00Z"}})
+    assert compiled.predicate is None
+    assert "occurred_at" not in compiled.consumed_keys
+
+
+def test_nin_on_date_is_not_pushed() -> None:
+    compiled = _compile({"created_at": {"$nin": ["2026-01-01T00:00:00Z"]}})
+    assert compiled.predicate is None
+    assert "created_at" not in compiled.consumed_keys
+
+
+def test_not_node_is_not_pushed() -> None:
+    # A $not wrapping a (otherwise-pushable) date predicate is a negation — not
+    # monotone-narrowing, so the whole node is unpushable.
+    compiled = _compile({"$not": {"occurred_at": "2026-02-03T00:00:00Z"}})
+    assert compiled.predicate is None
+    assert "occurred_at" not in compiled.consumed_keys
+
+
+def test_ne_null_is_not_pushed() -> None:
+    compiled = _compile({"occurred_at": {"$ne": None}})
+    assert compiled.predicate is None
+    assert "occurred_at" not in compiled.consumed_keys
+
+
+def test_exists_true_is_not_pushed() -> None:
+    # $exists is NOT pushed on a system key. The post-filter oracle (compile_python)
+    # treats a system key as always-present, so $exists:true is a CONSTANT TRUE
+    # there — a record with a null property still passes. A server-side
+    # is_none(False) push would EXCLUDE those null-property rows → false-exclusion.
+    # Left entirely to the post-filter. Built as a direct clause (the validator
+    # forbids $exists on a date key).
+    clause = FilterClause(path=("occurred_at",), op=Op.EXISTS, operand=True)
+    compiled = compile_weaviate(FilterNode(op=Op.AND, children=(clause,)), _CTX)
+    assert compiled.predicate is None
+    assert "occurred_at" not in compiled.consumed_keys
+
+
+def test_exists_false_is_not_pushed() -> None:
+    # $exists:false on a system key is a constant FALSE in the oracle — likewise not
+    # pushed (parity with $exists:true; nothing to gain server-side).
+    clause = FilterClause(path=("occurred_at",), op=Op.EXISTS, operand=False)
+    compiled = compile_weaviate(FilterNode(op=Op.AND, children=(clause,)), _CTX)
+    assert compiled.predicate is None
+    assert "occurred_at" not in compiled.consumed_keys
+
+
+def test_null_match_is_not_pushed() -> None:
+    # {k: null} ($eq None) hinges on null/absent resolution; the oracle treats a
+    # system key as always-present, so this is left to the post-filter rather than
+    # approximated by a server-side is_none() that could diverge.
+    compiled = _compile({"occurred_at": None})
+    assert compiled.predicate is None
+    assert "occurred_at" not in compiled.consumed_keys
+
+
+def test_eq_exact_array_is_not_pushed() -> None:
+    # An $eq EXACT-ARRAY operand (a bare list lowers to a tuple-operand $eq).
+    # Pushing equal([...]) would match nothing server-side (a scalar property never
+    # equals an array) — wrong direction, could false-exclude. Left to the
+    # post-filter. Built as a direct clause (a bare list on a date key fails
+    # validation; the tuple-operand exact-array form is the string-key sugar).
+    clause = FilterClause(path=("occurred_at",), op=Op.EQ, operand=("a", "b"))
+    compiled = compile_weaviate(FilterNode(op=Op.AND, children=(clause,)), _CTX)
+    assert compiled.predicate is None
+    assert "occurred_at" not in compiled.consumed_keys
+
+
+def test_empty_in_is_not_pushed() -> None:
+    # $in over ∅ matches nothing. There is no match-nothing Filter primitive;
+    # pushing nothing and letting the post-filter exclude everything is the
+    # superset-safe choice (None predicate, not consumed).
+    compiled = _compile({"occurred_at": {"$in": []}})
+    assert compiled.predicate is None
+    assert "occurred_at" not in compiled.consumed_keys
+
+
+# ===========================================================================
+# Undeclared keys & metadata → never pushed.
+# ===========================================================================
+
+# The 8 doc-grained system keys are NOT in this test's field_mapping, so they are
+# undeclared and never pushed (a real engine declares only the props its
+# collection actually has). The 7 string-valued keys take a bare string; the one
+# datetime key (source_timestamp) takes an ISO string the validator parses.
+_UNDECLARED_STRING_KEYS = (
+    "source_type",
+    "source_name",
+    "source_url",
+    "external_id",
+    "content_type",
+    "source",
+    "title",
+)
+
+
+@pytest.mark.parametrize("key", _UNDECLARED_STRING_KEYS)
+def test_undeclared_system_key_is_not_pushed(key: str) -> None:
+    # A system key absent from field_mapping is undeclared → not pushable, even with
+    # a monotone-narrowing op. No predicate, not consumed.
+    compiled = _compile({key: "v"})
+    assert compiled.predicate is None
+    assert key not in compiled.consumed_keys
+
+
+def test_undeclared_date_key_is_not_pushed() -> None:
+    # source_timestamp is a date key absent from field_mapping — undeclared, so a
+    # narrowing op on it still does not push.
+    compiled = _compile({"source_timestamp": {"$gte": "2026-01-01T00:00:00Z"}})
+    assert compiled.predicate is None
+    assert "source_timestamp" not in compiled.consumed_keys
+
+
+def test_metadata_path_is_not_pushed() -> None:
+    # A metadata sub-path is never pushed (serialized-JSON-string property; and a
+    # metadata negation has the same null-drop hazard regardless). Post-filter only.
+    compiled = _compile({"metadata.tier": "gold"})
+    assert compiled.predicate is None
+    assert "metadata.tier" not in compiled.consumed_keys
+
+
+def test_bare_metadata_blob_is_not_pushed() -> None:
+    compiled = _compile({"metadata": {"a": 1}})
+    assert compiled.predicate is None
+    assert compiled.consumed_keys == frozenset()
+
+
+def test_declared_key_with_positive_op_pushes() -> None:
+    # Mirror of the undeclared guard: a declared date key WITH a narrowing op DOES
+    # push and land in consumed_keys — proves the gate is the field_mapping
+    # membership, not the op alone.
+    compiled = _compile({"created_at": {"$gte": "2026-01-01T00:00:00Z"}})
+    assert compiled.predicate is not None
+    assert "created_at" in compiled.consumed_keys
+
+
+# ===========================================================================
+# $and — push the pushable conjuncts, DROP the unpushable ones (still a superset).
+# ===========================================================================
+
+
+def test_and_pushes_date_conjunct_drops_metadata() -> None:
+    # An $and may push the pushable date conjunct and DROP the metadata one —
+    # AND-ing fewer constraints only widens the candidate set, so the push stays a
+    # superset. Only the pushed leaf is consumed; the dropped one is post-filtered.
+    compiled = _compile(
+        {
+            "occurred_at": {"$gte": "2026-01-01T00:00:00Z"},
+            "metadata.tier": "gold",
+        }
+    )
+    pred = compiled.predicate
+    # The single surviving conjunct collapses to the bare date leaf (no AND wrap).
+    assert pred.target == "occurred_at"
+    assert _op(pred) == "GreaterThanEqual"
+    assert "occurred_at" in compiled.consumed_keys
+    assert "metadata.tier" not in compiled.consumed_keys
+
+
+def test_and_with_two_pushable_conjuncts_builds_all_of() -> None:
+    # Two pushable date conjuncts compose into an all_of (_FilterAnd). Both consumed.
+    compiled = _compile(
+        {
+            "occurred_at": {"$gte": "2026-01-01T00:00:00Z"},
+            "created_at": {"$lt": "2026-12-31T00:00:00Z"},
+        }
+    )
+    pred = compiled.predicate
+    assert _op(pred) == "And"
+    assert len(pred.filters) == 2
+    targets = {leaf.target for leaf in pred.filters}
+    assert targets == {"occurred_at", "created_at"}
+    assert compiled.consumed_keys == frozenset({"occurred_at", "created_at"})
+
+
+def test_and_all_unpushable_compiles_to_none() -> None:
+    # If every conjunct is unpushable (a $ne and a metadata path), the $and pushes
+    # nothing — None predicate, nothing consumed.
+    compiled = _compile(
+        {
+            "occurred_at": {"$ne": "2026-01-01T00:00:00Z"},
+            "metadata.tier": "gold",
+        }
+    )
+    assert compiled.predicate is None
+    assert compiled.consumed_keys == frozenset()
+
+
+# ===========================================================================
+# $or — ALL-OR-NOTHING (dropping a disjunct would narrow the union).
+# ===========================================================================
+
+
+def test_or_all_pushable_builds_any_of() -> None:
+    # Both disjuncts are pushable date predicates → push the whole $or as any_of.
+    compiled = _compile(
+        {
+            "$or": [
+                {"occurred_at": "2026-01-01T00:00:00Z"},
+                {"created_at": "2026-02-02T00:00:00Z"},
+            ]
+        }
+    )
+    pred = compiled.predicate
+    assert _op(pred) == "Or"
+    assert len(pred.filters) == 2
+    assert compiled.consumed_keys == frozenset({"occurred_at", "created_at"})
+
+
+def test_or_with_metadata_child_is_wholly_unpushable() -> None:
+    # One disjunct is a metadata path (unpushable). Dropping it would NARROW the
+    # union and could false-exclude rows, so the WHOLE $or is unpushable — None
+    # predicate, and the speculatively-consumed date leaf is rolled back (nothing
+    # consumed).
+    compiled = _compile(
+        {
+            "$or": [
+                {"occurred_at": "2026-01-01T00:00:00Z"},
+                {"metadata.tier": "gold"},
+            ]
+        }
+    )
+    assert compiled.predicate is None
+    assert compiled.consumed_keys == frozenset()
+
+
+def test_or_with_undeclared_child_is_wholly_unpushable() -> None:
+    # An undeclared system key as one disjunct makes the whole $or unpushable too.
+    compiled = _compile(
+        {
+            "$or": [
+                {"occurred_at": "2026-01-01T00:00:00Z"},
+                {"source_name": "linear"},
+            ]
+        }
+    )
+    assert compiled.predicate is None
+    assert compiled.consumed_keys == frozenset()
+
+
+def test_single_pushable_or_child_collapses_to_bare_leaf() -> None:
+    # A one-branch $or normalizes (in the AST) to AND([leaf]), so a single pushable
+    # disjunct compiles to the bare leaf predicate (no Or/And wrapper) and is
+    # consumed. Pins the single-child collapse the reviewer flagged as untested.
+    compiled = _compile({"$or": [{"occurred_at": "2026-01-01T00:00:00Z"}]})
+    pred = compiled.predicate
+    assert pred.target == "occurred_at"
+    assert _op(pred) == "Equal"
+    assert compiled.consumed_keys == frozenset({"occurred_at"})
+
+
+def test_deep_and_of_unpushable_or_and_pushable_date() -> None:
+    # Deep AND(OR(pushable, unpushable), pushable): the inner $or is wholly
+    # unpushable (one metadata disjunct) so it is dropped, while the outer $and
+    # keeps its pushable date conjunct. The surviving conjunct collapses to the
+    # bare date leaf; only that key is consumed. Pins the deep-nesting case the
+    # reviewer flagged.
+    compiled = _compile(
+        {
+            "$and": [
+                {"$or": [{"occurred_at": "2026-01-01T00:00:00Z"}, {"metadata.tier": "gold"}]},
+                {"created_at": {"$gte": "2026-01-01T00:00:00Z"}},
+            ]
+        }
+    )
+    pred = compiled.predicate
+    assert pred.target == "created_at"
+    assert _op(pred) == "GreaterThanEqual"
+    assert compiled.consumed_keys == frozenset({"created_at"})
+
+
+# ===========================================================================
+# on_unsupported policy.
+# ===========================================================================
+
+
+def test_unsupported_clause_raises_in_raise_mode() -> None:
+    # In raise mode, an unpushable clause raises the public error rather than
+    # silently dropping to the post-filter.
+    ctx = CompileContext(backend_target="KhoraChunk", field_mapping=_FIELD_MAPPING, on_unsupported="raise")
+    with pytest.raises(RecallFilterUnsupportedError):
+        compile_weaviate(_ast({"metadata.tier": "gold"}), ctx)
+
+
+def test_unsupported_negation_raises_via_clause_in_raise_mode() -> None:
+    # A $ne on a declared key reaches _compile_system_clause, returns None (not
+    # narrowing), then routes through _unsupported → raises in raise mode.
+    ctx = CompileContext(backend_target="KhoraChunk", field_mapping=_FIELD_MAPPING, on_unsupported="raise")
+    with pytest.raises(RecallFilterUnsupportedError):
+        compile_weaviate(_ast({"occurred_at": {"$ne": "2026-01-01T00:00:00Z"}}), ctx)
+
+
+def test_split_mode_drops_unsupported_silently() -> None:
+    # Split mode (the mode this backend runs in) drops the unpushable clause
+    # without raising: None predicate, nothing consumed.
+    ctx = CompileContext(backend_target="KhoraChunk", field_mapping=_FIELD_MAPPING, on_unsupported="split")
+    compiled = compile_weaviate(_ast({"metadata.tier": "gold"}), ctx)
+    assert compiled.predicate is None
+    assert compiled.consumed_keys == frozenset()
+
+
+# ===========================================================================
+# field_mapping remaps the physical property name.
+# ===========================================================================
+
+
+def test_field_mapping_remaps_property_name() -> None:
+    # field_mapping maps the logical key to the physical property name the
+    # collection actually declares — the pushed Filter targets the physical name.
+    ctx = CompileContext(backend_target="KhoraChunk", field_mapping={"occurred_at": "event_ts"})
+    compiled = compile_weaviate(_ast({"occurred_at": "2026-02-03T00:00:00Z"}), ctx)
+    pred = compiled.predicate
+    assert pred.target == "event_ts"
+    # consumed_keys is the LOGICAL path, not the physical name.
+    assert "occurred_at" in compiled.consumed_keys
+
+
+def test_no_field_mapping_pushes_nothing() -> None:
+    # With no field_mapping, NO property is declared, so even a narrowing op on a
+    # system key is not pushed (split mode drops it to the post-filter).
+    ctx = CompileContext(backend_target="KhoraChunk", on_unsupported="split")
+    compiled = compile_weaviate(_ast({"occurred_at": {"$gte": "2026-01-01T00:00:00Z"}}), ctx)
+    assert compiled.predicate is None
+    assert compiled.consumed_keys == frozenset()
+
+
+# ===========================================================================
+# CompiledFilter envelope.
+# ===========================================================================
+
+
+def test_compiled_filter_carries_canonical_hash() -> None:
+    node = _ast({"occurred_at": "2026-02-03T00:00:00Z"})
+    compiled = compile_weaviate(node, _CTX)
+    assert compiled.canonical_hash == canonical_hash(node)
+
+
+def test_params_always_empty() -> None:
+    # Weaviate binds operands inline in the Filter object — params is always empty.
+    compiled = _compile({"occurred_at": "2026-02-03T00:00:00Z"})
+    assert compiled.params == {}
+
+
+def test_consumed_keys_is_frozenset() -> None:
+    compiled = _compile({"occurred_at": "2026-02-03T00:00:00Z"})
+    assert isinstance(compiled.consumed_keys, frozenset)
+
+
+# ===========================================================================
+# Module imports without the weaviate extra (the lazy-import contract).
+# ===========================================================================
+
+
+def test_module_imports_without_weaviate_symbol_at_top_level() -> None:
+    # The compiler module must import even when weaviate-client is absent — the
+    # ``Filter`` symbol is imported lazily inside the builder, never at module
+    # scope. Assert there is no module-level ``weaviate`` / ``Filter`` binding.
+    import khora.filter.compilers.weaviate as mod
+
+    assert not hasattr(mod, "Filter")
+    assert "weaviate" not in vars(mod)

--- a/tests/unit/filter/test_filter_routing_equivalence.py
+++ b/tests/unit/filter/test_filter_routing_equivalence.py
@@ -1,0 +1,667 @@
+"""Routing-equivalence parity tests for the Weaviate recall-filter path — ``@internal``.
+
+The Weaviate backend honors a deterministic recall filter in two halves
+(``engines/skeleton/backends/weaviate.py::search``):
+
+1. **Push-down.** ``compile_weaviate(ast, ctx)`` lowers the *superset-safe* slice
+   of the AST to a native Weaviate v4 ``Filter`` (passed as ``filters=``). Only
+   the two declared DATE properties (``occurred_at`` / ``created_at``) push down;
+   every other predicate is left unconsumed.
+2. **Post-filter.** ``compile_python(WHOLE ast, ctx)`` compiles the *entire* AST
+   to an in-memory ``callable(record) -> bool`` re-applied to every candidate the
+   server returned. ``compile_python`` is the ORACLE — its accept set IS the
+   correct §4 result set (it is the oracle the SQL/Cypher compilers are checked
+   against, see ``compilers/python.py``).
+
+This module proves the ticket AC: *the Weaviate path (pushdown + python
+post-filter) returns the SAME row-set as the pure ``compile_python`` oracle*. The
+two properties, established over a corpus of in-memory records and a battery of
+filters spanning the full operator set, are:
+
+* **Superset-safety** (the part that can actually go wrong): the records the
+  ``compile_weaviate`` pushdown KEEPS must be a SUPERSET of the records the oracle
+  ``compile_python`` accepts. The pushdown must NEVER false-exclude a record the
+  oracle keeps — over-returning is safe (the post-filter narrows), under-returning
+  is a correctness bug. We evaluate the emitted Weaviate ``Filter`` against each
+  in-memory record with a small interpreter for the v4 ``_Filters`` tree
+  (``_weaviate_keeps``), so a real false-exclusion in the pushdown surfaces here.
+* **Post-filter parity** (by construction given superset-safety, but asserted
+  end-to-end so a regression in the pushdown OR the wiring is caught): applying
+  the ``compile_python`` post-filter to the kept candidates yields EXACTLY the
+  oracle's accept set over the whole corpus — i.e. the final result == oracle.
+
+The Weaviate ``Filter`` objects are private dataclasses
+(``_FilterValue`` / ``_FilterAnd`` / ``_FilterOr``); the interpreter reads their
+stable instance attributes (``target`` / ``operator`` / ``value`` / ``filters``)
+and compares the operator enum by its ``.value`` string, importing no private
+symbol — the same convention as ``test_compile_weaviate.py``.
+
+Gated on the weaviate extra with ``importorskip`` (the interpreter builds real
+``Filter`` objects, so it needs the client). The file collects cleanly WITHOUT
+the extra — the module-level skip fires before any ``Filter`` is touched.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from khora.filter import RecallFilter
+from khora.filter.ast import FilterClause, FilterNode, parse_to_ast
+from khora.filter.compilers.python import compile_python
+from khora.filter.compilers.weaviate import compile_weaviate
+from khora.filter.context import CompileContext
+from khora.filter.model import Op
+
+# Hard skip if the weaviate extra is absent: the interpreter introspects real
+# ``Filter`` objects, so it needs the client. Skip rather than fail CI red on a
+# stack that does not install the optional weaviate-client.
+pytest.importorskip("weaviate", reason="weaviate-client extra not installed")
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Compile contexts — mirror the engine wiring (weaviate.py::search).
+# ---------------------------------------------------------------------------
+
+# The push-down declares exactly the two DATE properties the KhoraChunk
+# collection stores as queryable Weaviate properties (identity-mapped). This IS
+# the field_mapping the engine passes; everything else is undeclared → unpushed.
+_FIELD_MAPPING = {"occurred_at": "occurred_at", "created_at": "created_at"}
+_PUSH_CTX = CompileContext(
+    backend_target="KhoraChunk",
+    field_mapping=_FIELD_MAPPING,
+    on_unsupported="split",
+)
+# The post-filter compiles the WHOLE AST with no field_mapping (it reads record
+# attributes directly) — exactly as the engine constructs it.
+_POST_CTX = CompileContext(backend_target="KhoraChunk", on_unsupported="split")
+
+
+# ---------------------------------------------------------------------------
+# Record corpus.
+#
+# Each record is a plain dict (compile_python is record-shape-defensive — it
+# resolves a system key by attribute then mapping access, so a dict event row is
+# a valid record). The two declared date keys carry real datetimes (or are
+# absent, or None) to exercise the range / contains pushdown — and the
+# UNPUSHED null/$exists path — against present / null / missing values. The
+# metadata blob carries arrays, missing keys, wrong-type values, an explicit
+# JSON null, and ISO date strings.
+# ---------------------------------------------------------------------------
+
+
+def _dt(y: int, m: int, d: int) -> datetime:
+    return datetime(y, m, d, tzinfo=UTC)
+
+
+CORPUS: list[dict[str, Any]] = [
+    # 0: both dates present, rich metadata with arrays + nested object.
+    {
+        "occurred_at": _dt(2026, 1, 10),
+        "created_at": _dt(2026, 1, 11),
+        "source_name": "linear",
+        "source_type": "ticket",
+        "metadata": {
+            "tier": "gold",
+            "tags": ["urgent", "backend"],
+            "priority": 5,
+            "labels": {"team": "core"},
+            "score": 4.5,
+            "active": True,
+            "deadline": "2026-03-01T00:00:00Z",
+            "nullable": None,
+        },
+    },
+    # 1: occurred_at later, created_at earlier; different scalar metadata.
+    {
+        "occurred_at": _dt(2026, 6, 1),
+        "created_at": _dt(2026, 1, 1),
+        "source_name": "github",
+        "source_type": "pr",
+        "metadata": {
+            "tier": "silver",
+            "tags": ["backend"],
+            "priority": 2,
+            "score": 9.0,
+            "active": False,
+            "deadline": "2026-02-01T00:00:00Z",
+        },
+    },
+    # 2: occurred_at present, created_at absent (missing key) → resolves to None.
+    {
+        "occurred_at": _dt(2026, 3, 15),
+        "source_name": "linear",
+        "source_type": "ticket",
+        "metadata": {
+            "tier": "gold",
+            "tags": [],  # empty array
+            "priority": "high",  # wrong-type vs a numeric range
+            "labels": {"team": "platform"},
+        },
+    },
+    # 3: occurred_at explicitly None, created_at present.
+    {
+        "occurred_at": None,
+        "created_at": _dt(2026, 5, 5),
+        "source_name": "slack",
+        "metadata": {
+            "tier": "bronze",
+            "tags": ["frontend", "urgent"],
+            "priority": 0,
+            "nullable": None,  # explicit JSON null
+        },
+    },
+    # 4: both dates absent (no keys at all) → both resolve to None. No metadata.
+    {
+        "source_name": "notion",
+        "source_type": "doc",
+    },
+    # 5: both dates present and EQUAL to a probe value; metadata with a list of
+    #    objects + a numeric string deadline.
+    {
+        "occurred_at": _dt(2026, 2, 3),
+        "created_at": _dt(2026, 2, 3),
+        "source_name": "linear",
+        "metadata": {
+            "tier": "gold",
+            "tags": ["backend", "infra"],
+            "priority": 7,
+            "deadline": "not-a-date",  # unparseable → $date excludes
+            "score": 1,  # int (not float)
+        },
+    },
+    # 6: occurred_at present, metadata present but EMPTY dict.
+    {
+        "occurred_at": _dt(2026, 4, 20),
+        "created_at": _dt(2026, 4, 20),
+        "source_name": "github",
+        "metadata": {},
+    },
+    # 7: metadata is None (coalesces to {} in compile_python); dates present.
+    {
+        "occurred_at": _dt(2026, 7, 7),
+        "created_at": _dt(2026, 7, 7),
+        "source_name": "linear",
+        "metadata": None,
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Weaviate ``_Filters`` interpreter.
+#
+# A small, faithful evaluator of the v4 Filter combinator tree against one
+# in-memory record. Reads only the stable instance attributes the compiler
+# emits — ``.filters`` on _FilterAnd/_FilterOr, ``.target`` / ``.operator`` /
+# ``.value`` on _FilterValue — and dispatches on ``operator.value`` (the wire
+# literal). The final compiler emits exactly seven operators, exhaustively
+# enumerated against ``compilers/weaviate.py``: the And / Or combinators plus the
+# five leaf comparisons Equal / GreaterThan / GreaterThanEqual / LessThan /
+# LessThanEqual. It deliberately does NOT push ``is_none`` for $exists / null
+# (that would diverge from the always-present post-filter oracle), and a ``$in``
+# on a declared key lowers to an ``any_of([equal(x)…])`` Or-of-Equals tree (a
+# single-member $in collapses to a bare ``Equal`` leaf) — both handled by the
+# And / Or walk + the Equal leaf, so no ``ContainsAny`` / ``IsNull`` branch is
+# needed. A single-child ``all_of`` / ``any_of`` does not wrap (it returns the
+# bare child leaf); the ``_weaviate_keeps`` recursion treats any node that is not
+# an And / Or as a leaf, so that collapse is handled.
+#
+# Date binding model: the pushdown binds each datetime operand as its
+# ``.isoformat()`` string (the chunk stores DATE props as ISO strings and
+# Weaviate compares lexicographically over the UTC-normalized values). So the
+# interpreter renders the record's stored datetime to its isoformat string and
+# compares string-to-string — exactly what the server does on disk.
+# ---------------------------------------------------------------------------
+
+
+def _record_iso(record: dict[str, Any], target: str) -> str | None:
+    """Render the record's value at ``target`` as the ISO string Weaviate stores.
+
+    Returns ``None`` when the property is absent or explicitly None (the
+    null/absent case a value comparator implicitly drops). The two declared
+    targets are datetimes in the corpus; any other stored type passes through
+    ``str`` defensively.
+    """
+    value = record.get(target)
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _eval_leaf(leaf: Any, record: dict[str, Any]) -> bool:
+    """Evaluate one ``_FilterValue`` leaf against a record (Weaviate semantics).
+
+    The compiler emits exactly five leaf operators (exhaustively enumerated
+    against the final ``compile_weaviate``): ``Equal`` and the four range ops. It
+    does NOT emit ``IsNull`` ($exists / null are left to the post-filter — the
+    oracle treats a system key as always-present, so an ``is_none`` push would
+    diverge) nor ``ContainsAny`` ($in lowers to an ``any_of([equal(x)…])``
+    Or-of-Equals tree the And/Or walk handles). Any other ``operator.value`` is a
+    compiler regression and trips the ``AssertionError`` guard below.
+    """
+    op = leaf.operator.value
+    target = leaf.target
+    stored = _record_iso(record, target)
+
+    if stored is None:
+        # All five emittable leaf ops are value comparisons; Weaviate's value
+        # comparators do NOT match a null/absent property — they implicitly drop
+        # it. This is precisely the null-drop hazard the compiler avoids by never
+        # pushing a negation: a positive op never keeps a null row.
+        return False
+
+    if op == "Equal":
+        return stored == leaf.value
+    if op == "GreaterThan":
+        return stored > leaf.value
+    if op == "GreaterThanEqual":
+        return stored >= leaf.value
+    if op == "LessThan":
+        return stored < leaf.value
+    if op == "LessThanEqual":
+        return stored <= leaf.value
+    raise AssertionError(f"interpreter does not model Weaviate operator {op!r}")
+
+
+def _weaviate_keeps(predicate: Any, record: dict[str, Any]) -> bool:
+    """Evaluate a compiled Weaviate ``Filter`` tree against a record.
+
+    ``None`` predicate (nothing pushable) keeps EVERY record — the over-fetch
+    keeps all candidates and the post-filter does all the narrowing. A combinator
+    node dispatches on ``operator.value`` ("And" / "Or"); anything else (including
+    a single-child ``all_of`` / ``any_of`` that collapsed to a bare leaf) is a
+    leaf, evaluated via :func:`_eval_leaf`.
+    """
+    if predicate is None:
+        return True
+    op = getattr(predicate, "operator", None)
+    if op is not None and op.value == "And":
+        return all(_weaviate_keeps(child, record) for child in predicate.filters)
+    if op is not None and op.value == "Or":
+        return any(_weaviate_keeps(child, record) for child in predicate.filters)
+    return _eval_leaf(predicate, record)
+
+
+# ---------------------------------------------------------------------------
+# Routing helpers — mirror weaviate.py::search exactly.
+# ---------------------------------------------------------------------------
+
+
+def _route(ast: FilterNode) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Run the two-stage Weaviate routing over the corpus.
+
+    Returns ``(kept_candidates, final)``:
+
+    * ``kept_candidates`` — records the push-down KEEPS (the over-fetch
+      candidate pool: a ``None`` predicate keeps everything; otherwise the
+      ``_weaviate_keeps`` interpreter decides).
+    * ``final`` — the post-filter (``compile_python`` over the WHOLE AST) applied
+      to the kept candidates. This is the row-set the engine actually returns.
+    """
+    pushed = compile_weaviate(ast, _PUSH_CTX).predicate
+    post = compile_python(ast, _POST_CTX).predicate
+    kept = [r for r in CORPUS if _weaviate_keeps(pushed, r)]
+    final = [r for r in kept if post(r)]
+    return kept, final
+
+
+def _oracle(ast: FilterNode) -> list[dict[str, Any]]:
+    """The pure ``compile_python`` oracle accept-set over the whole corpus."""
+    predicate = compile_python(ast, _POST_CTX).predicate
+    return [r for r in CORPUS if predicate(r)]
+
+
+def _ids(records: list[dict[str, Any]]) -> set[int]:
+    """Identity set of records (by position in CORPUS) for set comparison."""
+    return {CORPUS.index(r) for r in records}
+
+
+# ---------------------------------------------------------------------------
+# The filter battery.
+#
+# Each entry is a (label, wire-filter-dict) pair spanning the full operator set
+# against the declared date keys, the undeclared system keys, and metadata
+# (arrays, missing keys, wrong-type, JSON null, ISO date strings, exact-array vs
+# $in, mixed declared+metadata). Built via the public RecallFilter so they are
+# real, validated filters lowered through parse_to_ast.
+# ---------------------------------------------------------------------------
+
+_ISO = "2026-02-03T00:00:00Z"
+
+_WIRE_FILTERS: list[tuple[str, dict[str, Any]]] = [
+    ("empty", {}),
+    # --- declared date keys, pushable ops ---
+    ("date_eq", {"occurred_at": _ISO}),
+    ("date_gt", {"occurred_at": {"$gt": "2026-03-01T00:00:00Z"}}),
+    ("date_gte", {"occurred_at": {"$gte": "2026-03-01T00:00:00Z"}}),
+    ("date_lt", {"created_at": {"$lt": "2026-03-01T00:00:00Z"}}),
+    ("date_lte", {"created_at": {"$lte": "2026-02-03T00:00:00Z"}}),
+    ("date_in", {"created_at": {"$in": ["2026-01-01T00:00:00Z", "2026-02-03T00:00:00Z"]}}),
+    ("date_in_single", {"created_at": {"$in": ["2026-02-03T00:00:00Z"]}}),
+    # occurred_at $in where a candidate's date EQUALS an operand and is kept —
+    # exercises the date-$in membership pushdown (an any_of([equal(x)…]) Or-of-Equals
+    # tree) with a real surviving row, so the superset-safety assertion is
+    # non-vacuous.
+    ("date_in_occurred", {"occurred_at": {"$in": ["2026-01-10T00:00:00Z", "2026-06-01T00:00:00Z"]}}),
+    # --- declared date keys, UNPUSHABLE (negation / null) ops ---
+    ("date_ne", {"occurred_at": {"$ne": _ISO}}),
+    ("date_ne_null", {"occurred_at": {"$ne": None}}),
+    ("date_nin", {"created_at": {"$nin": ["2026-01-01T00:00:00Z"]}}),
+    ("date_null", {"occurred_at": None}),
+    # --- undeclared system keys (never pushed) ---
+    ("undeclared_eq", {"source_name": "linear"}),
+    ("undeclared_in", {"source_name": {"$in": ["linear", "github"]}}),
+    ("undeclared_ne", {"source_name": {"$ne": "linear"}}),
+    ("undeclared_exists", {"source_type": {"$exists": True}}),
+    ("undeclared_missing", {"source_type": {"$exists": False}}),
+    # --- metadata: never pushed; full operator set ---
+    ("md_eq_scalar", {"metadata.tier": "gold"}),
+    ("md_array_containment", {"metadata.tags": "urgent"}),
+    ("md_in", {"metadata.tier": {"$in": ["gold", "silver"]}}),
+    ("md_nin", {"metadata.tier": {"$nin": ["bronze"]}}),
+    ("md_range", {"metadata.priority": {"$gte": 5}}),
+    ("md_range_wrong_type", {"metadata.priority": {"$gt": 1}}),  # record 2 has str priority
+    ("md_ne", {"metadata.tier": {"$ne": "gold"}}),
+    ("md_exists_true", {"metadata.labels": {"$exists": True}}),
+    ("md_exists_false", {"metadata.labels": {"$exists": False}}),
+    ("md_null_match", {"metadata.nullable": None}),
+    ("md_ne_null", {"metadata.nullable": {"$ne": None}}),
+    ("md_exact_array", {"metadata.tags": ["urgent", "backend"]}),  # exact-array $eq
+    ("md_exact_array_vs_in", {"metadata.tags": {"$in": ["urgent", "backend"]}}),  # membership
+    ("md_empty_in", {"metadata.tags": {"$in": []}}),  # $in over ∅ → ∅
+    ("md_empty_nin", {"metadata.tags": {"$nin": []}}),  # $nin over ∅ → all
+    ("md_date_str", {"metadata.deadline": {"$date": "2026-03-01T00:00:00Z"}}),
+    ("md_date_range", {"metadata.deadline": {"$gt": {"$date": "2026-01-01T00:00:00Z"}}}),
+    ("md_object_eq", {"metadata.labels": {"team": "core"}}),  # subdocument object_equal
+    ("md_bool", {"metadata.active": True}),
+    # --- mixed declared (pushable) + metadata (post-only) ---
+    ("mixed_and", {"occurred_at": {"$gte": "2026-01-01T00:00:00Z"}, "metadata.tier": "gold"}),
+    (
+        "mixed_and_two_dates_plus_md",
+        {
+            "occurred_at": {"$gte": "2026-01-01T00:00:00Z"},
+            "created_at": {"$lt": "2026-12-31T00:00:00Z"},
+            "metadata.priority": {"$gte": 5},
+        },
+    ),
+    ("mixed_all_unpushable", {"occurred_at": {"$ne": _ISO}, "metadata.tier": "gold"}),
+    # --- explicit logical operators ---
+    (
+        "or_both_pushable",
+        {"$or": [{"occurred_at": "2026-01-10T00:00:00Z"}, {"created_at": "2026-02-03T00:00:00Z"}]},
+    ),
+    (
+        "or_one_metadata",  # one disjunct unpushable → whole $or unpushable
+        {"$or": [{"occurred_at": "2026-01-10T00:00:00Z"}, {"metadata.tier": "gold"}]},
+    ),
+    (
+        "or_one_undeclared",
+        {"$or": [{"occurred_at": "2026-01-10T00:00:00Z"}, {"source_name": "linear"}]},
+    ),
+    (
+        "and_of_or",
+        {
+            "$and": [
+                {"$or": [{"occurred_at": "2026-01-10T00:00:00Z"}, {"created_at": "2026-02-03T00:00:00Z"}]},
+                {"metadata.tier": "gold"},
+            ]
+        },
+    ),
+    (
+        "nor",  # $nor desugars to $not($or(...))
+        {"$nor": [{"metadata.tier": "bronze"}, {"source_name": "slack"}]},
+    ),
+    (
+        "not_date",  # $not over a pushable date → unpushable as a whole
+        {"$not": {"occurred_at": "2026-01-10T00:00:00Z"}},
+    ),
+    (
+        "not_metadata",
+        {"$not": {"metadata.tier": "gold"}},
+    ),
+    (
+        "deeply_nested_mixed",
+        {
+            "$and": [
+                {"created_at": {"$gte": "2026-01-01T00:00:00Z"}},
+                {
+                    "$or": [
+                        {"metadata.tier": "gold"},
+                        {"$not": {"metadata.tier": "silver"}},
+                    ]
+                },
+                {"occurred_at": {"$lt": "2026-12-31T00:00:00Z"}},
+            ]
+        },
+    ),
+]
+
+
+def _ast(wire: dict[str, Any]) -> FilterNode:
+    """Validate a wire-form filter and lower it to the canonical AST."""
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+# Direct-AST filters that the validator path cannot produce (a date key has no
+# $exists field, and a bare-list / exact-array on a date key fails validation) —
+# but which are valid compiler inputs and exercise the $exists / exact-array
+# routing branches (all of which the compiler leaves UNPUSHED). Each is a
+# (label, FilterNode) pair.
+def _clause_node(path: tuple[str, ...], op: Op, operand: Any) -> FilterNode:
+    return FilterNode(op=Op.AND, children=(FilterClause(path=path, op=op, operand=operand),))
+
+
+_DIRECT_AST_FILTERS: list[tuple[str, FilterNode]] = [
+    ("direct_exists_true", _clause_node(("occurred_at",), Op.EXISTS, True)),
+    ("direct_exists_false", _clause_node(("occurred_at",), Op.EXISTS, False)),
+    ("direct_eq_exact_array", _clause_node(("occurred_at",), Op.EQ, ("a", "b"))),
+    ("direct_ne_exact_array", _clause_node(("occurred_at",), Op.NE, ("a", "b"))),
+    (
+        "direct_and_exists_plus_range",
+        FilterNode(
+            op=Op.AND,
+            children=(
+                FilterClause(path=("created_at",), op=Op.EXISTS, operand=True),
+                FilterClause(path=("occurred_at",), op=Op.GTE, operand=datetime(2026, 1, 1, tzinfo=UTC)),
+            ),
+        ),
+    ),
+]
+
+
+def _all_cases() -> list[tuple[str, FilterNode]]:
+    """The full battery: validated wire filters + direct-AST filters."""
+    cases = [(label, _ast(wire)) for label, wire in _WIRE_FILTERS]
+    cases.extend(_DIRECT_AST_FILTERS)
+    return cases
+
+
+_CASES = _all_cases()
+_CASE_IDS = [label for label, _ in _CASES]
+
+
+# ===========================================================================
+# Property 1 — SUPERSET-SAFETY: pushdown keeps ⊇ oracle accepts.
+# ===========================================================================
+
+
+@pytest.mark.parametrize(("label", "ast"), _CASES, ids=_CASE_IDS)
+def test_pushdown_is_superset_of_oracle(label: str, ast: FilterNode) -> None:
+    """The push-down candidate set must be a SUPERSET of the oracle accept set.
+
+    The load-bearing correctness rule: the server-side push-down must never
+    false-exclude a record the oracle (``compile_python``) keeps. A record the
+    oracle accepts but the push-down drops would be lost before the post-filter
+    ever sees it — an under-return bug. (Over-returning is always safe: the
+    post-filter narrows.)
+    """
+    kept, _ = _route(ast)
+    oracle = _oracle(ast)
+    missing = _ids(oracle) - _ids(kept)
+    assert not missing, (
+        f"[{label}] push-down FALSE-EXCLUDED records the oracle keeps: "
+        f"corpus indices {sorted(missing)} (kept={sorted(_ids(kept))}, oracle={sorted(_ids(oracle))})"
+    )
+
+
+# ===========================================================================
+# Property 2 — POST-FILTER PARITY: final result == oracle, end-to-end.
+# ===========================================================================
+
+
+@pytest.mark.parametrize(("label", "ast"), _CASES, ids=_CASE_IDS)
+def test_routed_result_equals_oracle(label: str, ast: FilterNode) -> None:
+    """The two-stage routed result must EXACTLY equal the oracle accept set.
+
+    By construction this follows from superset-safety (the post-filter re-checks
+    the whole AST against the kept candidates, so it recovers exactly the oracle
+    set as long as no candidate was false-excluded). Asserting it end-to-end
+    catches a regression in EITHER the push-down (a dropped row) OR the wiring
+    (a post-filter applied wrong / over-fetch too small in spirit).
+    """
+    _, final = _route(ast)
+    oracle = _oracle(ast)
+    assert _ids(final) == _ids(oracle), (
+        f"[{label}] routed result {sorted(_ids(final))} != oracle {sorted(_ids(oracle))}"
+    )
+
+
+# ===========================================================================
+# Structural superset-safety guard — every CONSUMED leaf is a superset-safe op
+# on a DECLARED key. A second, independent line of defense behind the empirical
+# interpreter: if the compiler ever consumes a $ne / $nin / undeclared / metadata
+# leaf, this fails even if the interpreter happened to agree.
+# ===========================================================================
+
+
+@pytest.mark.parametrize(("label", "ast"), _CASES, ids=_CASE_IDS)
+def test_consumed_keys_are_declared_only(label: str, ast: FilterNode) -> None:
+    """Every consumed key is one of the two DECLARED date keys — never metadata
+    or an undeclared system key."""
+    consumed = compile_weaviate(ast, _PUSH_CTX).consumed_keys
+    assert consumed <= frozenset(_FIELD_MAPPING), (
+        f"[{label}] consumed an undeclared/metadata key: {sorted(consumed - frozenset(_FIELD_MAPPING))}"
+    )
+
+
+# ===========================================================================
+# Cross-cutting edge cases the per-compiler tests do not pin at the routing
+# level. Each asserts the concrete oracle row-set so the empirical corpus
+# semantics are locked, not just the superset relation.
+# ===========================================================================
+
+
+def test_empty_in_matches_nothing() -> None:
+    # $in over ∅ matches nothing; the routed result and oracle are both empty.
+    ast = _ast({"metadata.tags": {"$in": []}})
+    _, final = _route(ast)
+    assert _ids(final) == set()
+    assert _ids(_oracle(ast)) == set()
+
+
+def test_empty_nin_matches_everything() -> None:
+    # $nin over ∅ matches every record (including those without the metadata key).
+    ast = _ast({"metadata.tags": {"$nin": []}})
+    _, final = _route(ast)
+    assert _ids(final) == set(range(len(CORPUS)))
+
+
+def test_exact_array_distinct_from_in() -> None:
+    # An exact-array $eq (bare list) matches ONLY a record whose tags array equals
+    # the list exactly; the $in membership form matches any record sharing an
+    # element. The two must produce different row-sets here (record 0's tags are
+    # exactly ["urgent","backend"]; records 1/3/5 share an element).
+    exact = _oracle(_ast({"metadata.tags": ["urgent", "backend"]}))
+    member = _oracle(_ast({"metadata.tags": {"$in": ["urgent", "backend"]}}))
+    assert _ids(exact) == {0}
+    assert _ids(exact) < _ids(member)  # exact is a strict subset of membership
+
+
+def test_nor_desugars_to_not_or() -> None:
+    # $nor([A, B]) ≡ $not($or(A, B)) — a record matches iff NEITHER A nor B holds.
+    # Negations are unpushable, so the whole filter post-filters; routed == oracle.
+    ast = _ast({"$nor": [{"metadata.tier": "bronze"}, {"source_name": "slack"}]})
+    kept, final = _route(ast)
+    # Nothing pushable → the candidate pool is the whole corpus.
+    assert _ids(kept) == set(range(len(CORPUS)))
+    assert _ids(final) == _ids(_oracle(ast))
+
+
+def test_deeply_nested_and_or_not_mixing_pushable_and_unpushable() -> None:
+    # A deep $and over (a pushable range, an $or mixing metadata + a $not, another
+    # pushable range). The $or is wholly unpushable (a metadata disjunct), so only
+    # the two date ranges push; the post-filter recovers the exact oracle set.
+    ast = _ast(
+        {
+            "$and": [
+                {"created_at": {"$gte": "2026-01-01T00:00:00Z"}},
+                {"$or": [{"metadata.tier": "gold"}, {"$not": {"metadata.tier": "silver"}}]},
+                {"occurred_at": {"$lt": "2026-12-31T00:00:00Z"}},
+            ]
+        }
+    )
+    consumed = compile_weaviate(ast, _PUSH_CTX).consumed_keys
+    # Both date ranges push; the $or's metadata leaf does not.
+    assert consumed == frozenset({"created_at", "occurred_at"})
+    _, final = _route(ast)
+    assert _ids(final) == _ids(_oracle(ast))
+
+
+def test_or_with_unpushable_disjunct_keeps_whole_corpus() -> None:
+    # An $or with one metadata disjunct is ALL-OR-NOTHING unpushable: the push-down
+    # emits no constraint (keeps everything) and the post-filter does all the work.
+    # This is the case where a NAIVE pushdown (pushing only the date disjunct) would
+    # NARROW the union and false-exclude a row matching only the metadata disjunct —
+    # the superset-safety test above guards exactly this, but pin the candidate pool.
+    ast = _ast({"$or": [{"occurred_at": "2026-01-10T00:00:00Z"}, {"metadata.tier": "bronze"}]})
+    pushed = compile_weaviate(ast, _PUSH_CTX).predicate
+    assert pushed is None  # wholly unpushable
+    kept, final = _route(ast)
+    assert _ids(kept) == set(range(len(CORPUS)))
+    assert _ids(final) == _ids(_oracle(ast))
+
+
+def test_null_and_exists_are_not_pushed_and_round_trip() -> None:
+    # {k: null}, $exists:true, and $exists:false hinge on null/absent resolution.
+    # The post-filter oracle treats a system key as ALWAYS present (an absent key
+    # resolves to None, still "present-with-null" for $exists), so any server-side
+    # is_none() push would DIVERGE (a $exists:true → is_none(False) push would
+    # false-exclude the null-property rows the oracle keeps). The compiler therefore
+    # leaves them UNPUSHED (predicate None, nothing consumed) and the post-filter
+    # alone honors them — routed result still equals the oracle.
+    for label, ast in (
+        ("null", _ast({"occurred_at": None})),
+        ("exists_true", _clause_node(("occurred_at",), Op.EXISTS, True)),
+        ("exists_false", _clause_node(("occurred_at",), Op.EXISTS, False)),
+    ):
+        compiled = compile_weaviate(ast, _PUSH_CTX)
+        assert compiled.predicate is None, f"[{label}] expected unpushable (None predicate)"
+        assert compiled.consumed_keys == frozenset(), f"[{label}] expected nothing consumed"
+        _, final = _route(ast)
+        assert _ids(final) == _ids(_oracle(ast)), f"[{label}] routed != oracle"
+
+
+def test_date_in_pushdown_is_pushed_and_keeps_matching_row() -> None:
+    # A $in on a declared date key IS pushable membership — it lowers to an
+    # any_of([equal(x)…]) Or-of-Equals tree (exact scalar $in semantics). Assert
+    # the path is non-vacuous: the date key is CONSUMED (it pushed), the kept set is a
+    # non-empty SUPERSET of the oracle that includes the record whose date equals
+    # an operand, and the routed result equals the oracle. Record 0
+    # (occurred_at=2026-01-10) and record 1 (occurred_at=2026-06-01) each equal an
+    # operand and must survive.
+    ast = _ast({"occurred_at": {"$in": ["2026-01-10T00:00:00Z", "2026-06-01T00:00:00Z"]}})
+    compiled = compile_weaviate(ast, _PUSH_CTX)
+    assert compiled.predicate is not None, "date $in must push a predicate"
+    assert "occurred_at" in compiled.consumed_keys, "date $in must consume the date key"
+    kept, final = _route(ast)
+    oracle = _oracle(ast)
+    assert oracle, "fixture sanity: the date $in must match at least one record"
+    assert _ids(oracle) <= _ids(kept), "pushdown false-excluded a date-$in match"
+    assert {0, 1} <= _ids(kept), "expected the operand-equal records to be kept candidates"
+    assert _ids(final) == _ids(oracle)


### PR DESCRIPTION
## Summary

Wires the Skeleton **Weaviate** backend to honor the deterministic recall-filter AST, completing the non-Postgres skeleton-backend coverage for recall filtering.

- **New `compile_weaviate` compiler** (`khora/filter/compilers/weaviate.py`) — lowers the *pushable* slice of a filter onto the Weaviate v4 `Filter` API for **declared** class properties (the date keys `occurred_at`/`created_at`). Operator-translation table: `equal` / `greater_or_equal` / `greater_than` / `less_or_equal` / `less_than`, `any_of`-of-`equal` for membership (`$in`), and `all_of` / `any_of` for `$and` / `$or`.
- **Superset-safe pushdown.** Only monotone-narrowing positive predicates on declared keys are pushed. Negations (`$ne`/`$nin`/`$not`), presence/null (`$exists`/`{k: null}`), exact-array equality, metadata paths, and undeclared keys are deliberately **left unpushed** so the server-side filter is always a *superset* of the true result — it can never false-exclude a valid row. `$in` compiles to an OR of scalar equals (not `contains_any`, whose behavior on a scalar property is not guaranteed).
- **Whole-AST Python post-filter.** `search()` AND-s the pushed filter into the legacy temporal filter, over-fetches the candidate pool, then re-applies the *entire* filter in-memory via the existing Python predicate compiler over the returned chunks and trims to `limit`. This guarantees undeclared/metadata predicates are honored and the path **never raises** `UnsupportedFilterError`.
- Registers the compiler on the internal compiler registry and documents the `field_mapping`-as-declared-property convention on `CompileContext`.
- Documents two edge cases in `search()`: a highly selective metadata filter may return fewer than `limit` (superset-safe), and a positive predicate on a document-grained key not stored on the collection returns zero rows (absent-key semantics).

The compiler is `@internal` (not exported from the top-level package); the optional `weaviate-client` dependency is imported lazily so the module imports without the extra.

## Test plan
- [x] Unit tests pass — compiler unit suite (operator translations + superset-safe routing), backend `search()` wiring suite (push-down, over-fetch, post-filter, trim, under-return), and a **routing-equivalence** battery proving the pushdown + post-filter path returns the same row-set as the pure Python oracle across a record corpus and the full operator set (gated on the `weaviate` extra; skips cleanly without it).
- [x] Lint/format clean (`ruff check`, `ruff format`).
- [x] No regressions in the wider unit suite (verified byte-identical pre-existing failures with and without this change).
- [ ] Integration tests pass (CI — Docker-provisioned).