### PR TITLE
Add SurrealDB recall-filter compiler with native nested-path descent and type gates

### DIFF
--- a/src/khora/engines/skeleton/backends/surrealdb.py
+++ b/src/khora/engines/skeleton/backends/surrealdb.py
@@ -22,11 +22,11 @@ from khora.engines.skeleton.backends import (
     TemporalVectorStore,
     temporal_chunk_to_chunk,
 )
+from khora.filter.model import Op
 from khora.storage.backends.surrealdb._helpers import (
     _parse_dt,
     _parse_uuid,
     _rid,
-    _sanitize_field_name,
 )
 from khora.storage.backends.surrealdb.connection import SurrealDBConnection
 from khora.telemetry import trace, trace_span
@@ -95,6 +95,22 @@ _TEMPORAL_CHUNK_SEARCH_INDEXES = """
 DEFINE INDEX IF NOT EXISTS idx_tc_embedding ON temporal_chunk FIELDS embedding HNSW DIMENSION 1536 DIST COSINE TYPE F32 EFC 128 M 24;
 DEFINE INDEX IF NOT EXISTS idx_tc_content_ft ON temporal_chunk FIELDS content SEARCH ANALYZER khora_fulltext BM25;
 """
+
+# Legacy ``TemporalFilter.additional`` range-op names → the canonical filter Op,
+# so the deterministic-filter compiler can build a type-gated metadata compare.
+_LEGACY_RANGE_OPS: dict[str, Op] = {
+    "gt": Op.GT,
+    "gte": Op.GTE,
+    "lt": Op.LT,
+    "lte": Op.LTE,
+}
+
+# Every legacy ``additional`` op routed through the deterministic-filter compiler.
+# ``eq`` is included so the bare-equality path is validated through the same
+# injection guard as the range ops — its $eq metadata emission is a plain
+# ``(metadata_.<path> = $b)`` (no type-gate), preserving the equality semantics
+# callers depend on while no longer interpolating an unvalidated user key.
+_LEGACY_OPS: dict[str, Op] = {"eq": Op.EQ, **_LEGACY_RANGE_OPS}
 
 
 class SurrealDBTemporalStore(TemporalVectorStore):
@@ -320,8 +336,9 @@ class SurrealDBTemporalStore(TemporalVectorStore):
     ) -> list[TemporalSearchResult]:
         """Search temporal chunks with optional hybrid (vector + BM25) ranking.
 
-        ``filter_ast`` is accepted for protocol parity; this backend does not
-        compile the recall-filter AST yet, so it is ignored.
+        ``filter_ast`` is the deterministic recall-filter AST. When provided it
+        is compiled to a SurrealQL ``WHERE`` predicate and AND-ed alongside the
+        legacy ``temporal_filter`` clauses.
         """
         with trace_span(
             "khora.temporal_store.search",
@@ -337,6 +354,7 @@ class SurrealDBTemporalStore(TemporalVectorStore):
                 temporal_filter=temporal_filter,
                 hybrid_alpha=hybrid_alpha,
                 query_text=query_text,
+                filter_ast=filter_ast,
             )
             _span.set_attribute("result_count", len(results))
             return results
@@ -351,9 +369,32 @@ class SurrealDBTemporalStore(TemporalVectorStore):
         temporal_filter: TemporalFilter | None = None,
         hybrid_alpha: float | None = None,
         query_text: str | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> list[TemporalSearchResult]:
         # Build shared WHERE clauses from temporal_filter
         filter_clauses, filter_bindings = self._build_filter_clauses(namespace_id, temporal_filter)
+
+        # Deterministic recall-filter AST: compile to a SurrealQL predicate and
+        # AND it into the shared clauses. ``field_mapping`` maps the ``metadata``
+        # root to the physical ``metadata_`` column so a metadata path descends
+        # natively; system keys map identity (the table stores them as bare
+        # columns). The compiler runs in on_unsupported="raise" mode — the
+        # skeleton engine has no post-filter path, so partial pushdown ("split")
+        # is never consumed here.
+        if filter_ast is not None:
+            from khora.filter import CompileContext
+            from khora.filter.compilers.surrealdb import compile_surrealdb
+
+            compiled = compile_surrealdb(
+                filter_ast,
+                CompileContext(
+                    backend_target="temporal_chunk",
+                    field_mapping={"metadata": "metadata_"},
+                    on_unsupported="raise",
+                ),
+            )
+            filter_clauses.append(compiled.predicate)
+            filter_bindings.update(compiled.params)
 
         # Determine search strategy
         pure_bm25 = hybrid_alpha is not None and hybrid_alpha == 0.0
@@ -709,31 +750,72 @@ class SurrealDBTemporalStore(TemporalVectorStore):
             clauses.append("tags CONTAINSALL $filter_tags")
             bindings["filter_tags"] = f.tags
 
-        # Additional structured filters
+        # Additional structured filters. EVERY user key is routed through the
+        # deterministic-filter SurrealDB compiler so its injection guard validates
+        # each path segment (``TemporalFilter.additional`` keys are NOT
+        # char-restricted upstream — interpolating one verbatim is an injection
+        # surface). Range comparisons additionally get a ``type::is::*`` gate
+        # (numeric ordering, not lexicographic; wrong-typed values gated out);
+        # ``eq`` emits a plain ``(metadata_.<path> = $b)``, preserving the
+        # equality semantics callers depend on. This replaces the old
+        # ``_sanitize_field_name`` string mangling.
         for i, (key, value) in enumerate(f.additional.items()):
-            safe_key = _sanitize_field_name(key)
             if isinstance(value, dict):
                 for op, val in value.items():
-                    param = f"af_{i}_{op}"
-                    if op == "eq":
-                        clauses.append(f"metadata_.{safe_key} = ${param}")
-                    elif op == "gte":
-                        clauses.append(f"metadata_.{safe_key} >= ${param}")
-                    elif op == "lte":
-                        clauses.append(f"metadata_.{safe_key} <= ${param}")
-                    elif op == "gt":
-                        clauses.append(f"metadata_.{safe_key} > ${param}")
-                    elif op == "lt":
-                        clauses.append(f"metadata_.{safe_key} < ${param}")
-                    else:
+                    if op not in _LEGACY_OPS:
                         continue
-                    bindings[param] = val
+                    predicate, binds = SurrealDBTemporalStore._legacy_metadata_predicate(key, op, val, f"af_{i}_{op}")
+                    clauses.append(predicate)
+                    bindings.update(binds)
             else:
-                param = f"af_{i}"
-                clauses.append(f"metadata_.{safe_key} = ${param}")
-                bindings[param] = value
+                predicate, binds = SurrealDBTemporalStore._legacy_metadata_predicate(key, "eq", value, f"af_{i}_eq")
+                clauses.append(predicate)
+                bindings.update(binds)
 
         return clauses, bindings
 
+    @staticmethod
+    def _legacy_metadata_predicate(key: str, op: str, val: Any, param_namespace: str) -> tuple[str, dict[str, Any]]:
+        """Compile a legacy ``additional`` metadata predicate via the recall-filter compiler.
+
+        Reuses the deterministic-filter SurrealDB compiler so the (possibly
+        dotted) ``key`` is validated through the compiler's injection guard before
+        any interpolation — an unsafe segment raises
+        :class:`~khora.filter.context.CompileError`. ``op`` is one of
+        ``eq``/``gt``/``gte``/``lt``/``lte`` (an :data:`_LEGACY_OPS` key); a range
+        op also emits a ``type::is::*`` gate so a numeric value orders numerically
+        and a wrong-typed value is excluded, while ``eq`` emits a plain
+        ``(metadata_.<path> = $b)`` equality. ``key`` is split on ``.`` into a
+        nested path. Returns the SurrealQL fragment + its binds, named under
+        ``param_namespace`` so concurrent legacy keys never collide.
+        """
+        from khora.filter.ast import FilterClause
+        from khora.filter.compilers.surrealdb import _Builder
+        from khora.filter.context import CompileContext
+
+        builder = _Builder(
+            ctx=CompileContext(
+                backend_target="temporal_chunk",
+                param_namespace=param_namespace,
+                field_mapping={"metadata": "metadata_"},
+            ),
+            consumed=set(),
+        )
+        clause = FilterClause(path=("metadata", *key.split(".")), op=_LEGACY_OPS[op], operand=val)
+        predicate = builder.compile_clause(clause)
+        return predicate, builder.params
+
 
 __all__ = ["SurrealDBTemporalStore"]
+
+
+# Register the deterministic recall-filter compiler for this engine/target at
+# import time (idempotent — same function object). ``surrealdb.py`` is imported
+# lazily by ``create_temporal_store("surrealdb", ...)``, so registration happens
+# exactly when the SurrealDB backend is first constructed — no eager cost, and no
+# registration when the backend is unused. Mirrors ``pgvector.py``'s
+# ``skeleton.pgvector`` registration.
+from khora.filter import CompilerRegistry  # noqa: E402
+from khora.filter.compilers.surrealdb import compile_surrealdb  # noqa: E402
+
+CompilerRegistry.register("skeleton.surrealdb", "temporal_chunk", compile_surrealdb)

--- a/src/khora/filter/compilers/__init__.py
+++ b/src/khora/filter/compilers/__init__.py
@@ -16,6 +16,7 @@ from khora.filter.compilers.chronicle import ChronicleDateBound, compile_chronic
 from khora.filter.compilers.lance import compile_lance
 from khora.filter.compilers.postgres import compile_postgres
 from khora.filter.compilers.python import compile_python
+from khora.filter.compilers.surrealdb import compile_surrealdb
 from khora.filter.compilers.weaviate import compile_weaviate
 
 __all__ = [
@@ -24,5 +25,6 @@ __all__ = [
     "compile_lance",
     "compile_postgres",
     "compile_python",
+    "compile_surrealdb",
     "compile_weaviate",
 ]

--- a/src/khora/filter/compilers/surrealdb.py
+++ b/src/khora/filter/compilers/surrealdb.py
@@ -29,6 +29,20 @@ explicit JSON null value. A ``{k: null}`` match resolves to ``(p = NULL OR p IS
 NONE)``; ``$exists: true`` is ``(p IS NOT NONE)`` and ``$exists: false`` is
 ``(p IS NONE)``.
 
+**Metadata equality / membership is array-aware.** A scalar ``$eq`` operand
+matches **both** a scalar field equal to it **and** an array field that contains
+it — ``(path = $b OR (type::is::array(path) AND path CONTAINS $b))`` — mirroring
+the Postgres ``@>`` two-arm form and the ``compile_python`` oracle's
+``_md_contains``. ``$in`` is contains-any (``path INSIDE $list OR
+(type::is::array(path) AND path CONTAINSANY $list)``); ``$ne`` / ``$nin`` are the
+negations (which therefore admit absent / wrong-type rows). The
+``type::is::array`` guard is load-bearing: SurrealQL ``CONTAINS`` / ``CONTAINSANY``
+do *substring* matching on a string left operand, so gating them to real arrays
+keeps element matching exact. A bare-list ``$eq`` (exact-array) and a sub-document
+dict ``$eq`` keep **exact** structural equality (``=``), not containment — this is
+the canonical ``tags: list[str]`` case, so array-awareness is the common path, not
+an edge case.
+
 **Range ops on metadata are type-gated.** A range op on a metadata path emits
 ``(type::is::<t>(path) AND path <op> $b)`` — the ``AND`` short-circuits so a
 wrong-typed / absent value never participates in the compare (``type::is::*``
@@ -304,9 +318,10 @@ class _Builder:
             if not operand:
                 return "false" if op == Op.IN else "true"
             values_bind = self._bind([_metadata_value(v) for v in operand])
-            if op == Op.IN:
-                return f"({node} INSIDE {values_bind})"
-            return f"!({node} INSIDE {values_bind})"
+            inner = self._md_contains_any(node, values_bind)
+            # $nin admits absent / wrong-type rows: the inner is total, so the
+            # negation is true for them (Rule 2 polarity).
+            return inner if op == Op.IN else f"!{inner}"
 
         if operand is None:
             # {k: null} → explicit json null OR absent path. $ne null → present
@@ -316,14 +331,50 @@ class _Builder:
             return f"({node} = NULL OR {node} IS NONE)"
 
         if op == Op.EQ:
-            return f"({node} = {self._bind(_metadata_value(operand))})"
+            return self._md_eq(node, operand)
         if op == Op.NE:
-            # ``!=`` already admits an absent / wrong-type path as true.
-            return f"({node} != {self._bind(_metadata_value(operand))})"
+            # Negate the (total) positive equality/containment form so an absent /
+            # wrong-type path is admitted (Rule 2) — same polarity as the oracle.
+            return f"!{self._md_eq(node, operand)}"
 
         # Range ops ($gt/$gte/$lt/$lte) — type-gated. The AND short-circuits so a
         # wrong-typed / absent value never reaches the compare.
         return self._md_range(node, op, operand)
+
+    def _md_eq(self, node: str, operand: Any) -> str:
+        """Positive metadata equality / containment for a non-null ``$eq`` operand.
+
+        Array-aware for a plain scalar (mirrors the oracle's ``_md_contains`` and
+        the Postgres ``@>`` two-arm form): a scalar operand matches **both** a
+        scalar field equal to it **and** an array field that contains it —
+        ``(node = $b OR (type::is::array(node) AND node CONTAINS $b))``. The
+        ``type::is::array`` guard is load-bearing: SurrealQL ``CONTAINS`` does
+        *substring* matching when its left operand is a string, so without the
+        guard a scalar field ``"xyz"`` would wrongly match operand ``"x"``;
+        gating to real arrays keeps element matching exact (verified on the
+        embedded engine). Both arms reuse a single bind.
+
+        A ``$date`` / ``datetime``, an exact-array ``tuple`` (bare-list ``$eq``),
+        and a sub-document ``dict`` keep **exact** equality — SurrealQL object /
+        array ``=`` is structural — matching the oracle's date-compare /
+        ``_exact_array_eq`` / ``_md_object_eq`` modes (NOT containment).
+        """
+        if isinstance(operand, (DateLiteral, datetime, tuple, dict)):
+            return f"({node} = {self._bind(_metadata_value(operand))})"
+        bind = self._bind(_metadata_value(operand))
+        return f"({node} = {bind} OR (type::is::array({node}) AND {node} CONTAINS {bind}))"
+
+    def _md_contains_any(self, node: str, values_bind: str) -> str:
+        """Array-aware contains-any for ``$in`` (mirrors ``any(_md_contains(node, v))``).
+
+        A scalar field that is a member of the operand list (``node INSIDE
+        $list`` — exact membership, since the right operand is a list) **or** an
+        array field sharing any element with it (``node CONTAINSANY $list``,
+        guarded to real arrays so a scalar string's substring ``CONTAINSANY``
+        never fires). Total against absent / wrong-type paths, so the ``$nin``
+        negation admits them.
+        """
+        return f"({node} INSIDE {values_bind} OR (type::is::array({node}) AND {node} CONTAINSANY {values_bind}))"
 
     def _md_range(self, node: str, op: Op, operand: Any) -> str:
         """A type-gated metadata range op: ``(type::is::<t>(node) AND node <op> $b)``.

--- a/src/khora/filter/compilers/surrealdb.py
+++ b/src/khora/filter/compilers/surrealdb.py
@@ -1,0 +1,414 @@
+"""SurrealDB SurrealQL recall-filter compiler — ``@internal``.
+
+Lowers a canonical :class:`~khora.filter.ast.FilterNode` to a single SurrealQL
+boolean *string* the engine splices into its own ``WHERE``, paired with a
+``params`` dict of ``$name`` binds the connection passes through to the SDK. The
+output is a :class:`~khora.filter.registry.CompiledFilter` whose ``predicate`` is
+that string.
+
+The compiler is the Layer-4 half of the §4/§7 filter contract, mirroring
+:func:`~khora.filter.compilers.cypher.compile_cypher` structurally — a string
+predicate plus an out-of-band ``params`` dict named ``{param_namespace}_{n}``.
+It speaks the four emission rules (never abort, polarity, narrow impossible
+pairs, presence/null), but with **one deliberate divergence from cypher and
+postgres: there is NO ``coalesce`` / totality wrapper.**
+
+**Why no totality wrapper (verified on embedded SurrealDB).** SurrealQL
+comparisons against an absent (``NONE``) path return a *total* boolean rather
+than a propagating ``NULL``: ``absent = x`` → ``false``, ``absent != x`` →
+``true``, ``absent > 5`` → ``false``, and ``!(...)`` flips an absent row
+correctly. Cypher and Postgres wrap every leaf that *could* produce ``NULL`` in
+``coalesce(expr, false)`` precisely because ``NOT NULL`` is ``NULL`` (which would
+drop a row from a negation); SurrealQL has no such hazard, so the wrapper is
+omitted by design. A reviewer expecting the cypher/postgres coalesce should read
+this as intentional, not an oversight — the totality the wrapper buys elsewhere
+is already a property of SurrealQL's NONE-boolean algebra.
+
+**NONE vs NULL are distinct.** ``NONE`` is an absent path; ``NULL`` is an
+explicit JSON null value. A ``{k: null}`` match resolves to ``(p = NULL OR p IS
+NONE)``; ``$exists: true`` is ``(p IS NOT NONE)`` and ``$exists: false`` is
+``(p IS NONE)``.
+
+**Range ops on metadata are type-gated.** A range op on a metadata path emits
+``(type::is::<t>(path) AND path <op> $b)`` — the ``AND`` short-circuits so a
+wrong-typed / absent value never participates in the compare (``type::is::*``
+returns ``false``, not an error, for a missing / wrong-type / whole-metadata-NONE
+path). ``type::is::bool`` is checked *before* ``type::is::number`` because a bool
+is an int subclass in Python and SurrealDB agrees a bool is not a number. System
+datetime columns (``occurred_at`` / ``created_at``) are typed columns, so their
+range ops are **ungated**.
+
+**Dates.** A system datetime column binds the real Python :class:`~datetime.datetime`
+directly — the SDK encodes it as a SurrealQL datetime (unlike cypher, which binds
+``.isoformat()``). A metadata ``$date`` / datetime operand is gated with
+``type::is::string`` and bound as its ``.isoformat()`` string: metadata datetimes
+round-trip through the FLEXIBLE ``object`` column as ISO strings, and ISO-8601's
+fixed-width big-endian layout makes a lexicographic string compare agree with
+chronological order for the UTC-normalized values the validator produces.
+
+**Injection guard.** User-supplied metadata path segments are interpolated into
+the predicate string (SurrealQL cannot bind a field name as a parameter), so each
+segment is validated against a strict identifier regex before interpolation; an
+unsafe segment raises :class:`~khora.filter.context.CompileError`. System keys
+come from the closed :data:`~khora.filter.model.SYSTEM_KEYS` whitelist and are
+safe. User *values* always bind via ``$params``, never interpolate.
+
+``@internal``. Reachable as ``khora.filter.compilers.surrealdb.compile_surrealdb``
+for khora's own engines; not re-exported from :mod:`khora.__init__`.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any
+
+from khora.filter import (
+    CompileContext,
+    CompiledFilter,
+    RecallFilterUnsupportedError,
+)
+from khora.filter.ast import (
+    DateLiteral,
+    FilterClause,
+    FilterNode,
+    canonical_hash,
+)
+from khora.filter.context import CompileError
+from khora.filter.model import SYSTEM_KEYS, Op
+from khora.filter.telemetry import record_unindexed_metadata
+
+__all__ = ["compile_surrealdb"]
+
+
+# SurrealQL comparison operator strings for the range ops, keyed by AST op.
+_RANGE_OP = {
+    Op.GT: ">",
+    Op.GTE: ">=",
+    Op.LT: "<",
+    Op.LTE: "<=",
+}
+
+# A safe SurrealQL identifier for a metadata path segment: a leading letter or
+# underscore, then alphanumerics / underscores. Stricter than the storage-layer
+# ``_sanitize_field_name`` (no dots — each AST path segment is already a single
+# field name) and kept self-contained so the compiler embeds no storage import.
+_SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def compile_surrealdb(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[str]:
+    """Compile a canonical AST to a SurrealQL ``WHERE`` fragment + bind dict.
+
+    ``ast`` is always a :class:`FilterNode` (the ``parse_to_ast`` root invariant).
+    An empty ``AND`` (the match-everything root of a bare filter) compiles to the
+    literal ``"true"``. Binds are returned out-of-band in ``params`` as a
+    ``{name: value}`` dict; each ``$name`` placeholder in the predicate string has
+    a matching entry. Bind names are generated as ``{param_namespace}_{n}`` so
+    they cannot collide with the engine's own query parameters.
+
+    Field references are derived from ``ctx`` alone: a system key is the bare
+    physical name (``ctx.field_mapping`` remaps, identity when ``None``), prefixed
+    with ``ctx.table_alias`` only when set; a metadata path descends natively
+    through the remapped ``metadata`` root (``metadata`` → ``metadata_`` on the
+    live recall path). Honors ``ctx.on_unsupported``: on a clause this backend
+    cannot express, ``"raise"`` raises :class:`RecallFilterUnsupportedError`;
+    ``"split"`` omits it from ``consumed_keys`` and emits a non-constraining
+    ``"true"`` placeholder. A metadata path segment that is not a safe SurrealQL
+    identifier raises :class:`CompileError` regardless of mode (an injection
+    guard, not a capability gap).
+    """
+    consumed: set[str] = set()
+    builder = _Builder(ctx=ctx, consumed=consumed)
+    predicate = builder.compile_node(ast)
+    return CompiledFilter(
+        predicate=predicate,
+        params=builder.params,
+        consumed_keys=frozenset(consumed),
+        # canonical_hash over the whole AST. In on_unsupported="raise" mode (the
+        # only mode the skeleton engine uses) every leaf is consumed, so the whole
+        # tree == the consumed slice.
+        canonical_hash=canonical_hash(ast),
+    )
+
+
+def _path_str(path: tuple[str, ...]) -> str:
+    """Render an AST path as the dotted key string used for diagnostics/consumed."""
+    return ".".join(path)
+
+
+class _Builder:
+    """Per-compile-pass state: the :class:`CompileContext`, consumed set, binds.
+
+    A compile pass threads the ``ctx`` (field references are derived from it), the
+    ``consumed`` accumulator, and the ``params`` bind dict every leaf appends to.
+    Keeping them on a small object avoids passing the triple through every
+    recursion frame. A monotonic counter names each bind ``{param_namespace}_{n}``
+    so two clauses on the same key never collide.
+    """
+
+    def __init__(self, *, ctx: CompileContext, consumed: set[str]) -> None:
+        self._ctx = ctx
+        self._consumed = consumed
+        self._alias = ctx.table_alias
+        self.params: dict[str, Any] = {}
+        self._counter = 0
+
+    # ----- bind allocation ------------------------------------------------ #
+
+    def _bind(self, value: Any) -> str:
+        """Allocate a fresh ``$name`` placeholder bound to ``value``."""
+        name = f"{self._ctx.param_namespace}_{self._counter}"
+        self._counter += 1
+        self.params[name] = value
+        return f"${name}"
+
+    def _system_field(self, key: str) -> str:
+        """Render a system-key field reference for a logical key.
+
+        ``field_mapping`` remaps a logical key to its physical field name
+        (identity when ``None``); ``table_alias`` prefixes it only when set (the
+        live recall path queries the base table unaliased, matching
+        ``_build_filter_clauses``' bare ``source_system`` / ``occurred_at``).
+        ``key`` is always a controlled token (a system key from the closed
+        ``SYSTEM_KEYS`` whitelist) — never free user text, so the field access is
+        not an injection surface.
+        """
+        physical = (self._ctx.field_mapping or {}).get(key, key)
+        return f"{self._alias}.{physical}" if self._alias else physical
+
+    def _metadata_path(self, segs: tuple[str, ...]) -> str:
+        """Render a native dot-descent metadata path, validating each segment.
+
+        The ``metadata`` root is remapped via ``field_mapping`` (``metadata`` →
+        ``metadata_`` on the live recall path); each sub-segment is user-supplied,
+        so it is validated against :data:`_SAFE_SEGMENT_RE` and interpolated into
+        the path string — an unsafe segment raises :class:`CompileError` (the
+        injection guard). SurrealQL has no field-name bind, so interpolation is
+        unavoidable; the regex is the defense.
+        """
+        root = (self._ctx.field_mapping or {}).get("metadata", "metadata")
+        parts = [root]
+        for seg in segs:
+            if not _SAFE_SEGMENT_RE.match(seg):
+                raise CompileError(f"unsafe metadata path segment {seg!r} (not a SurrealQL identifier)")
+            parts.append(seg)
+        return ".".join(parts)
+
+    # ----- logical node walk ---------------------------------------------- #
+
+    def compile_node(self, node: FilterNode | FilterClause) -> str:
+        """Compile a logical node or leaf to a SurrealQL boolean string."""
+        if isinstance(node, FilterClause):
+            return self.compile_clause(node)
+        if node.op == Op.AND:
+            if not node.children:
+                # The empty match-everything root — no constraint.
+                return "true"
+            return "(" + " AND ".join(self.compile_node(c) for c in node.children) + ")"
+        if node.op == Op.OR:
+            if not node.children:
+                # The validator forbids an empty $or; guard defensively.
+                return "false"
+            return "(" + " OR ".join(self.compile_node(c) for c in node.children) + ")"
+        # Op.NOT — exactly one child per the AST contract. SurrealQL's NONE-boolean
+        # algebra makes every leaf total, so this negation flips absent rows
+        # correctly without a coalesce wrapper.
+        return f"!({self.compile_node(node.children[0])})"
+
+    # ----- leaf key-kind split -------------------------------------------- #
+
+    def compile_clause(self, clause: FilterClause) -> str:
+        """Dispatch a leaf on key-kind (system key vs metadata path)."""
+        path = clause.path
+        if len(path) == 1 and path[0] in SYSTEM_KEYS:
+            expr = self._compile_system_clause(clause)
+        elif path and path[0] == "metadata":
+            expr = self._compile_metadata_clause(clause)
+            # A metadata leaf reads the FLEXIBLE ``object`` column (no index).
+            # Emit once per metadata leaf (a filter with N metadata predicates
+            # emits N times) — mirrors compile_postgres / compile_python.
+            record_unindexed_metadata(op=clause.op.value)
+        else:
+            return self._unsupported(clause, "path is neither a system key nor a metadata path")
+        self._consumed.add(_path_str(path))
+        return expr
+
+    # ----- system-key leaves (typed columns) ------------------------------ #
+
+    def _compile_system_clause(self, clause: FilterClause) -> str:
+        field = self._system_field(clause.path[0])
+        op = clause.op
+        operand = clause.operand
+
+        if op == Op.EXISTS:
+            # The 8 unwritten document keys read NONE on the SCHEMAFULL table, so
+            # presence is IS NOT NONE (true) / IS NONE (false).
+            return f"({field} IS NOT NONE)" if operand else f"({field} IS NONE)"
+
+        if op in (Op.IN, Op.NIN):
+            if not operand:
+                # $in over ∅ matches nothing; $nin over ∅ matches everything.
+                # Emit the constant explicitly (INSIDE [] already yields this, but
+                # the explicit form mirrors the cypher/postgres compilers).
+                return "false" if op == Op.IN else "true"
+            values_bind = self._bind([_system_value(v) for v in operand])
+            if op == Op.IN:
+                return f"({field} INSIDE {values_bind})"
+            # $nin includes absent rows (Rule 2 polarity): an absent field is not
+            # INSIDE the set, so the negation is true — already total.
+            return f"!({field} INSIDE {values_bind})"
+
+        # Rule 3 (NARROW): a bare list on a system key lowers to EQ-with-tuple. A
+        # scalar column never equals a list, so the compare is false at query time
+        # — no special-cased constant needed (the list binds like any operand).
+        if operand is None:
+            # {k: null} → active null-or-missing match. NONE (absent) and NULL
+            # (explicit json null) are distinct, so cover both. $ne null → present
+            # and not null.
+            if op == Op.NE:
+                return f"({field} IS NOT NONE AND {field} != NULL)"
+            return f"({field} = NULL OR {field} IS NONE)"
+
+        value_bind = self._bind(_system_value(operand))
+        if op == Op.NE:
+            # ``!=`` against an absent field already returns true in SurrealQL, so
+            # this admits absent rows without an extra ``OR IS NONE`` (Rule 2).
+            return f"({field} != {value_bind})"
+        # $eq and the range ops compare directly. An absent / wrong-type field
+        # yields a total false (no coalesce needed), and a wrapping $not flips it.
+        symbol = "=" if op == Op.EQ else _RANGE_OP[op]
+        return f"({field} {symbol} {value_bind})"
+
+    # ----- metadata leaves (native object descent) ------------------------ #
+
+    def _compile_metadata_clause(self, clause: FilterClause) -> str:
+        path = clause.path
+        op = clause.op
+        operand = clause.operand
+
+        # Bare-blob metadata $eq (whole-document equality). SurrealQL object
+        # equality is structural / key-order-insensitive.
+        if len(path) == 1:
+            if op != Op.EQ:
+                return self._unsupported(clause, "only $eq is defined on the bare metadata blob")
+            root = (self._ctx.field_mapping or {}).get("metadata", "metadata")
+            return f"({root} = {self._bind(operand)})"
+
+        segs = path[1:]  # drop the leading "metadata" root
+        node = self._metadata_path(segs)
+
+        if op == Op.EXISTS:
+            return f"({node} IS NOT NONE)" if operand else f"({node} IS NONE)"
+
+        if op in (Op.IN, Op.NIN):
+            if not operand:
+                return "false" if op == Op.IN else "true"
+            values_bind = self._bind([_metadata_value(v) for v in operand])
+            if op == Op.IN:
+                return f"({node} INSIDE {values_bind})"
+            return f"!({node} INSIDE {values_bind})"
+
+        if operand is None:
+            # {k: null} → explicit json null OR absent path. $ne null → present
+            # and not null.
+            if op == Op.NE:
+                return f"({node} IS NOT NONE AND {node} != NULL)"
+            return f"({node} = NULL OR {node} IS NONE)"
+
+        if op == Op.EQ:
+            return f"({node} = {self._bind(_metadata_value(operand))})"
+        if op == Op.NE:
+            # ``!=`` already admits an absent / wrong-type path as true.
+            return f"({node} != {self._bind(_metadata_value(operand))})"
+
+        # Range ops ($gt/$gte/$lt/$lte) — type-gated. The AND short-circuits so a
+        # wrong-typed / absent value never reaches the compare.
+        return self._md_range(node, op, operand)
+
+    def _md_range(self, node: str, op: Op, operand: Any) -> str:
+        """A type-gated metadata range op: ``(type::is::<t>(node) AND node <op> $b)``.
+
+        The gate function is chosen by the operand's Python type. A ``$date`` /
+        datetime operand is gated as a string and bound as its ISO-8601 form
+        (metadata datetimes round-trip as ISO strings; lexicographic compare
+        agrees with chronological order for UTC-normalized values). ``bool`` is
+        gated before ``number`` (a bool is an int subclass, and SurrealDB agrees a
+        bool is not a number).
+        """
+        if isinstance(operand, (DateLiteral, datetime)):
+            gate = "string"
+            bound = self._bind(_metadata_value(operand))
+        else:
+            gate = _range_gate(operand)
+            bound = self._bind(operand)
+        symbol = _RANGE_OP[op]
+        return f"(type::is::{gate}({node}) AND {node} {symbol} {bound})"
+
+    # ----- unsupported ---------------------------------------------------- #
+
+    def _unsupported(self, clause: FilterClause, reason: str) -> str:
+        """Handle a clause this backend cannot express per ``ctx.on_unsupported``.
+
+        ``"raise"`` raises the public :class:`RecallFilterUnsupportedError`;
+        ``"split"`` leaves the clause out of ``consumed_keys`` (the engine
+        post-filters it) and emits a non-constraining ``"true"`` so it does not
+        narrow the result set.
+        """
+        path = _path_str(clause.path)
+        if self._ctx.on_unsupported == "raise":
+            raise RecallFilterUnsupportedError(path, reason)
+        return "true"
+
+
+# --------------------------------------------------------------------------- #
+# Module-level helpers (no per-pass state).
+# --------------------------------------------------------------------------- #
+
+
+def _system_value(value: Any) -> Any:
+    """Coerce a system-key operand to an SDK-bindable value.
+
+    A typed datetime column binds a real :class:`~datetime.datetime` — the SDK
+    encodes it as a SurrealQL datetime, so a :class:`DateLiteral` is unwrapped to
+    its ``.value`` rather than stringified (unlike cypher). An exact-array
+    ``tuple`` (a bare-list ``$eq`` operand) binds as a ``list``, each element
+    coerced the same way. Other scalars pass through.
+    """
+    if isinstance(value, DateLiteral):
+        return value.value
+    if isinstance(value, tuple):
+        return [_system_value(item) for item in value]
+    return value
+
+
+def _metadata_value(value: Any) -> Any:
+    """Coerce a metadata operand to an SDK-bindable value.
+
+    A metadata datetime round-trips through the FLEXIBLE ``object`` column as an
+    ISO-8601 *string*, so a :class:`DateLiteral` / :class:`~datetime.datetime`
+    binds as its ``.isoformat()`` string (the gated string compare relies on
+    lexicographic order). A ``tuple`` (exact-array / ``$in`` list) binds as a
+    ``list`` with each element coerced the same way. Other scalars pass through.
+    """
+    if isinstance(value, DateLiteral):
+        return value.value.isoformat()
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, tuple):
+        return [_metadata_value(item) for item in value]
+    return value
+
+
+def _range_gate(operand: Any) -> str:
+    """Map a range operand's Python type to its ``type::is::*`` gate function.
+
+    ``bool`` → ``bool`` (checked first — a bool is an ``int`` subclass);
+    ``int`` / ``float`` → ``number``; everything else → ``string`` (lexicographic
+    text compare). Mirrors ``compile_postgres._operand_json_type`` / the python
+    compiler's ``_comparable`` type-gate.
+    """
+    if isinstance(operand, bool):
+        return "bool"
+    if isinstance(operand, (int, float)):
+        return "number"
+    return "string"

--- a/tests/integration/filter/test_compile_surrealdb_embedded.py
+++ b/tests/integration/filter/test_compile_surrealdb_embedded.py
@@ -32,6 +32,7 @@ from khora.engines.skeleton.backends import TemporalFilter  # noqa: E402
 from khora.engines.skeleton.backends.surrealdb import SurrealDBTemporalStore  # noqa: E402
 from khora.filter import RecallFilter  # noqa: E402
 from khora.filter.ast import parse_to_ast  # noqa: E402
+from khora.filter.compilers.python import compile_python  # noqa: E402
 from khora.filter.compilers.surrealdb import compile_surrealdb  # noqa: E402
 from khora.filter.context import CompileContext  # noqa: E402
 from khora.storage.backends.surrealdb._helpers import _rid  # noqa: E402
@@ -225,3 +226,91 @@ async def test_legacy_additional_eq_matches_only_exact_value(conn: SurrealDBConn
     # and matches only the exact row — the wrong-typed "mismatch" row does not
     # coincidentally match a bound scalar.
     assert await _legacy_matching_content(conn, {"score": 10}) == ["ten"]
+
+
+# ===========================================================================
+# (6) Array-valued metadata fields + cross-backend parity with the oracle.
+# ===========================================================================
+#
+# The canonical connector metadata shape is ``tags: list[str]``, so a scalar
+# ``$eq`` / ``$in`` must match an ARRAY field that *contains* the value, not only
+# a scalar field equal to it (SurrealQL ``=`` / ``INSIDE`` are scalar). These
+# tests pin the array-aware row-sets AND assert they equal the ``compile_python``
+# oracle's row-set for the same corpus — the parity check that keeps the five
+# compilers from drifting (and that would have caught the scalar-only bug).
+
+# (content, metadata) corpus exercising scalar/array/missing/null/wrong-type plus
+# the substring traps (``CONTAINS`` does substring on a string operand, so a
+# scalar ``"xyz"`` and an array element ``"xyz"`` must NOT match operand ``"x"``).
+_TAGS_CORPUS: list[tuple[str, dict]] = [
+    ("scalar", {"tags": "x"}),
+    ("scalar_other", {"tags": "z"}),
+    ("scalar_super", {"tags": "xyz"}),  # substring trap
+    ("array", {"tags": ["x", "y"]}),
+    ("array_other", {"tags": ["z"]}),
+    ("array_super", {"tags": ["xyz"]}),  # element-substring trap
+    ("missing", {"foo": 1}),
+    ("null", {"tags": None}),
+    ("num", {"tags": 5}),
+]
+
+# The oracle reads ``record["metadata"]`` and resolves system keys by identity,
+# so it runs under a default context (no ``metadata`` → ``metadata_`` remap).
+_ORACLE_CTX = CompileContext(backend_target="temporal_chunk")
+
+
+@pytest.fixture
+async def tags_conn() -> AsyncIterator[SurrealDBConnection]:
+    """An embedded connection seeded with the array-valued ``tags`` corpus."""
+    connection = SurrealDBConnection(mode="memory")
+    await connection.connect()
+    try:
+        await connection.execute(_SCHEMA)
+        rows = [
+            {"id": _rid("temporal_chunk", uuid4()), "content": content, "metadata_": md} for content, md in _TAGS_CORPUS
+        ]
+        await connection.execute("INSERT INTO temporal_chunk $records", {"records": rows})
+        yield connection
+    finally:
+        await connection.disconnect()
+
+
+def _oracle_content(wire: dict) -> list[str]:
+    """Row-set the ``compile_python`` oracle accepts over ``_TAGS_CORPUS``."""
+    predicate = compile_python(parse_to_ast(RecallFilter.model_validate(wire)), _ORACLE_CTX).predicate
+    return sorted(content for content, md in _TAGS_CORPUS if predicate({"metadata": md}))
+
+
+async def test_scalar_eq_matches_scalar_and_array_fields(tags_conn: SurrealDBConnection) -> None:
+    # A scalar operand matches BOTH the scalar field equal to it AND the array
+    # field containing it — but NOT the substring traps (scalar "xyz" / element
+    # "xyz") which a naive string CONTAINS would wrongly include.
+    assert await _matching_content(tags_conn, {"metadata.tags": "x"}) == ["array", "scalar"]
+
+
+async def test_scalar_in_is_contains_any_over_scalar_and_array(tags_conn: SurrealDBConnection) -> None:
+    # $in is contains-any: scalar membership ("scalar"=x, "scalar_other"=z) plus
+    # array share-any (["x","y"], ["z"]). Substring traps stay excluded.
+    assert await _matching_content(tags_conn, {"metadata.tags": {"$in": ["x", "z"]}}) == sorted(
+        ["scalar", "scalar_other", "array", "array_other"]
+    )
+
+
+@pytest.mark.parametrize(
+    "wire",
+    [
+        {"metadata.tags": "x"},  # scalar $eq vs array field
+        {"metadata.tags": {"$in": ["x", "z"]}},  # contains-any
+        {"metadata.tags": {"$ne": "x"}},  # negated containment (admits absent/wrong-type)
+        {"metadata.tags": {"$nin": ["x", "z"]}},  # negated contains-any
+    ],
+)
+async def test_parity_with_python_oracle(tags_conn: SurrealDBConnection, wire: dict) -> None:
+    # The SurrealDB compiler must return the SAME rows as the compile_python
+    # oracle for the same corpus — the cross-backend parity guard. A divergence
+    # (e.g. scalar-only $eq missing array fields) fails here immediately. Scoped to
+    # the array-aware equality / membership ops: ``$exists`` is intentionally
+    # excluded because SurrealDB drops an explicit-null field inside a FLEXIBLE
+    # object on write (so present-null differs from the in-memory oracle) — a
+    # storage representation difference, not a compiler divergence.
+    assert await _matching_content(tags_conn, wire) == _oracle_content(wire)

--- a/tests/integration/filter/test_compile_surrealdb_embedded.py
+++ b/tests/integration/filter/test_compile_surrealdb_embedded.py
@@ -1,0 +1,227 @@
+"""Embedded-SurrealDB integration test for the recall-filter compiler.
+
+The unit corpus (``tests/unit/filter/test_compile_surrealdb.py``) pins the
+*emitted string* shape; this test pins the *row-set semantics* by running the
+compiled predicate against a real embedded SurrealDB (``memory://``). It is the
+cheapest guard against the negation/totality confusion recurring: SurrealQL's
+NONE-boolean algebra means the compiler emits NO ``coalesce`` wrapper, and the
+only way to prove that is total (and that the metadata type-gate actually
+excludes wrong-typed values) is to ask the engine for the real row-set.
+
+Each test seeds a few ``temporal_chunk`` rows, compiles a wire filter through the
+real :func:`~khora.filter.compilers.surrealdb.compile_surrealdb` (using the live
+recall path's :class:`CompileContext`), splices the predicate into a
+``SELECT ... WHERE`` exactly as the skeleton engine does, and asserts on the
+``content`` values that come back.
+
+The ``surrealdb`` SDK is an optional dependency, so this module self-skips when
+it is absent (``pytest.importorskip``) — it is NOT a hard dependency of the main
+test job and adds no Docker requirement (embedded ``memory://`` runs in-process).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("surrealdb")
+
+from khora.engines.skeleton.backends import TemporalFilter  # noqa: E402
+from khora.engines.skeleton.backends.surrealdb import SurrealDBTemporalStore  # noqa: E402
+from khora.filter import RecallFilter  # noqa: E402
+from khora.filter.ast import parse_to_ast  # noqa: E402
+from khora.filter.compilers.surrealdb import compile_surrealdb  # noqa: E402
+from khora.filter.context import CompileContext  # noqa: E402
+from khora.storage.backends.surrealdb._helpers import _rid  # noqa: E402
+from khora.storage.backends.surrealdb.connection import SurrealDBConnection  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+
+# The live recall path's context: ``metadata`` root → physical ``metadata_``
+# column; system keys map identity (bare columns on the table).
+_CTX = CompileContext(backend_target="temporal_chunk", field_mapping={"metadata": "metadata_"})
+
+# A trimmed temporal_chunk shape — only the columns these row-set assertions
+# touch. Keeping it minimal (no namespace/document record links, no HNSW index)
+# avoids needing the full skeleton schema while exercising the exact column kinds
+# the compiler emits against: bare string/datetime system columns and the
+# FLEXIBLE ``metadata_`` object.
+_SCHEMA = """
+DEFINE TABLE IF NOT EXISTS temporal_chunk SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS content ON temporal_chunk TYPE string;
+DEFINE FIELD IF NOT EXISTS source_name ON temporal_chunk TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS source_url ON temporal_chunk TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS metadata_ ON temporal_chunk FLEXIBLE TYPE option<object>;
+"""
+
+
+def _seed_rows() -> list[dict]:
+    """Rows that exercise absent-key, explicit-null, matching, non-matching, and
+    wrong-typed metadata values, plus a deeply-nested object path.
+
+    ``content`` is the row's stable label — every assertion compares the returned
+    ``content`` set.
+    """
+    return [
+        # ``score`` key entirely absent from the object.
+        {"id": _rid("temporal_chunk", uuid4()), "content": "absent", "metadata_": {}},
+        # ``score`` present as an explicit JSON null.
+        {"id": _rid("temporal_chunk", uuid4()), "content": "null", "metadata_": {"score": None}},
+        # numeric ``score`` that satisfies ``> 5``.
+        {"id": _rid("temporal_chunk", uuid4()), "content": "ten", "metadata_": {"score": 10}},
+        # numeric ``score`` that does NOT satisfy ``> 5``.
+        {"id": _rid("temporal_chunk", uuid4()), "content": "three", "metadata_": {"score": 3}},
+        # ``score`` present but the WRONG type (string) — must be gated out of a
+        # numeric range without erroring.
+        {"id": _rid("temporal_chunk", uuid4()), "content": "mismatch", "metadata_": {"score": "high"}},
+        # a deeply-nested object path for the dot-descent assertion.
+        {"id": _rid("temporal_chunk", uuid4()), "content": "deep", "metadata_": {"a": {"b": {"c": "x"}}}},
+    ]
+
+
+@pytest.fixture
+async def conn() -> AsyncIterator[SurrealDBConnection]:
+    """An embedded (in-memory) SurrealDB connection seeded with the test rows.
+
+    ``memory://`` runs in-process — no server, no Docker. Each test gets its own
+    fresh database. The connection's auto schema-init runs the full khora schema;
+    we add the trimmed temporal_chunk table on top (idempotent).
+    """
+    connection = SurrealDBConnection(mode="memory")
+    await connection.connect()
+    try:
+        await connection.execute(_SCHEMA)
+        await connection.execute("INSERT INTO temporal_chunk $records", {"records": _seed_rows()})
+        yield connection
+    finally:
+        await connection.disconnect()
+
+
+async def _matching_content(connection: SurrealDBConnection, wire: dict) -> list[str]:
+    """Compile ``wire`` through the real compiler, run it, return sorted contents.
+
+    The predicate + binds are spliced into the ``WHERE`` exactly as
+    ``SurrealDBTemporalStore._search_inner`` does — this exercises the live
+    compile path, not a hand-written predicate.
+    """
+    ast = parse_to_ast(RecallFilter.model_validate(wire))
+    compiled = compile_surrealdb(ast, _CTX)
+    rows = await connection.query(
+        f"SELECT content FROM temporal_chunk WHERE {compiled.predicate}",  # noqa: S608 - predicate is compiler-emitted, values bind
+        compiled.params,
+    )
+    return sorted(row["content"] for row in rows)
+
+
+async def _legacy_matching_content(connection: SurrealDBConnection, additional: dict) -> list[str]:
+    """Run a legacy ``TemporalFilter.additional`` predicate, return sorted contents.
+
+    Builds the WHERE through ``_build_filter_clauses`` (the legacy channel, which
+    routes each ``additional`` key through the recall-filter compiler's guarded
+    builder), drops the namespace-scoping clause/binds, and queries — proving the
+    legacy path's row-set semantics, not just the emitted string.
+    """
+    clauses, binds = SurrealDBTemporalStore._build_filter_clauses(
+        uuid4(),
+        TemporalFilter(additional=additional),
+    )
+    legacy_clauses = [c for c in clauses if "namespace" not in c]
+    legacy_binds = {k: v for k, v in binds.items() if k.startswith("af_")}
+    where = " AND ".join(legacy_clauses)
+    rows = await connection.query(
+        f"SELECT content FROM temporal_chunk WHERE {where}",  # noqa: S608 - clauses are compiler-emitted, values bind
+        legacy_binds,
+    )
+    return sorted(row["content"] for row in rows)
+
+
+# ===========================================================================
+# (1) Nested dot-path descent returns the right row.
+# ===========================================================================
+
+
+async def test_nested_dot_path_descent_matches_only_the_nested_row(conn: SurrealDBConnection) -> None:
+    # metadata.a.b.c descends to metadata_.a.b.c — only the "deep" row carries
+    # that nested value. Proves the path is NOT collapsed/mangled into a single
+    # key that would match nothing (or the wrong row).
+    assert await _matching_content(conn, {"metadata.a.b.c": "x"}) == ["deep"]
+
+
+# ===========================================================================
+# (2) A type-mismatched value is EXCLUDED by a numeric range (the spike's gap).
+# ===========================================================================
+
+
+async def test_numeric_range_gate_excludes_wrong_typed_value(conn: SurrealDBConnection) -> None:
+    # ``metadata.score > 5`` is type-gated: only the numeric "ten" row qualifies.
+    # The string "mismatch" row, the explicit-null row, and the absent-key row are
+    # all excluded by the ``type::is::number`` gate (never erroring on the wrong
+    # type), and "three" (3 > 5 is false) is excluded by the compare. This is the
+    # exact behaviour the original spike could not achieve.
+    assert await _matching_content(conn, {"metadata.score": {"$gt": 5}}) == ["ten"]
+
+
+# ===========================================================================
+# (3) $not over a metadata range KEEPS absent + null rows, EXCLUDES the match.
+# ===========================================================================
+
+
+async def test_not_over_range_keeps_absent_and_null_excludes_match(conn: SurrealDBConnection) -> None:
+    # ``$not(metadata.score > 5)`` flips the total gated leaf. SurrealQL's
+    # NONE-boolean algebra (no coalesce) means the negation admits the absent-key
+    # row, the explicit-null row, the wrong-typed row, and the non-matching "three"
+    # row — and EXCLUDES the one row that matched the inner range ("ten"). A
+    # coalesce-style or NULL-propagating negation would wrongly drop the absent /
+    # null rows; the only row that must be gone is "ten".
+    kept = await _matching_content(conn, {"$not": {"metadata.score": {"$gt": 5}}})
+    assert "ten" not in kept
+    assert set(kept) == {"absent", "null", "mismatch", "three", "deep"}
+
+
+# ===========================================================================
+# (4) An always-absent system key: $eq drops all rows / $ne keeps all rows.
+# ===========================================================================
+
+
+async def test_always_absent_system_key_eq_drops_all(conn: SurrealDBConnection) -> None:
+    # ``source_url`` is never written on these rows, so it reads NONE. A bare
+    # ``=`` compare against an absent column is a total false → no rows.
+    assert await _matching_content(conn, {"source_url": "anything"}) == []
+
+
+async def test_always_absent_system_key_ne_keeps_all(conn: SurrealDBConnection) -> None:
+    # Polarity (Rule 2): ``!=`` against an absent column is total TRUE, so $ne on
+    # an always-absent key keeps every row — no null guard needed.
+    assert await _matching_content(conn, {"source_url": {"$ne": "anything"}}) == sorted(
+        ["absent", "null", "ten", "three", "mismatch", "deep"]
+    )
+
+
+# ===========================================================================
+# (5) Legacy ``additional`` path — a range op EXCLUDES a wrong-typed value.
+# ===========================================================================
+#
+# The legacy ``TemporalFilter.additional`` channel routes every key through the
+# same guarded compiler builder, so the type-gate that excludes wrong-typed
+# values must hold here too. This is the row-set proof for the legacy path the
+# behavioral unit tests (tests/unit/engines/.../test_surrealdb_legacy_additional.py)
+# pin at the emitted-string level — it guards the eq-path regression that slipped
+# through for lack of any test on this channel.
+
+
+async def test_legacy_additional_range_excludes_wrong_typed_value(conn: SurrealDBConnection) -> None:
+    # Legacy ``{"score": {"gt": 5}}`` is type-gated: only the numeric "ten" row
+    # qualifies. The string "mismatch" row is gated out (not lexicographically
+    # compared, not an error), and the absent-key / non-matching "three" rows fall
+    # away — matching the deterministic-filter path's exclusion semantics.
+    assert await _legacy_matching_content(conn, {"score": {"gt": 5}}) == ["ten"]
+
+
+async def test_legacy_additional_eq_matches_only_exact_value(conn: SurrealDBConnection) -> None:
+    # The legacy eq path (the one the injection regression touched) binds its value
+    # and matches only the exact row — the wrong-typed "mismatch" row does not
+    # coincidentally match a bound scalar.
+    assert await _legacy_matching_content(conn, {"score": 10}) == ["ten"]

--- a/tests/unit/engines/skeleton/backends/test_surrealdb_legacy_additional.py
+++ b/tests/unit/engines/skeleton/backends/test_surrealdb_legacy_additional.py
@@ -11,8 +11,10 @@ lack of a test.
 
 These tests pin the *emitted SurrealQL* (the behavioral/semantic contract):
 
-* ``eq`` (scalar value form AND explicit ``{"eq": ...}`` form) → a plain
-  ``(metadata_.<path> = $bind)`` equality, NO type gate;
+* ``eq`` (scalar value form AND explicit ``{"eq": ...}`` form) → array-aware
+  containment ``(metadata_.<path> = $bind OR (type::is::array(...) AND ...
+  CONTAINS $bind))``, matching the recall-filter path so a scalar value also
+  matches an array field (the canonical ``tags: list[str]`` shape);
 * each range op (``gt`` / ``gte`` / ``lt`` / ``lte``) → a type-gated
   ``(type::is::<t>(metadata_.<path>) AND metadata_.<path> <op> $bind)`` so a
   numeric value orders numerically and a wrong-typed value is excluded;
@@ -76,24 +78,26 @@ def _norm(surql: str) -> str:
 # ===========================================================================
 
 
-def test_legacy_eq_scalar_form_is_plain_equality() -> None:
-    # A bare scalar value (no op dict) is the ``eq`` sugar: a plain ``=`` compare
-    # on the metadata path, the operand bound (never interpolated). NO type gate.
+def test_legacy_eq_scalar_form_is_array_aware() -> None:
+    # A bare scalar value (no op dict) is the ``eq`` sugar: array-aware containment
+    # on the metadata path (a scalar field equal to the value OR an array field
+    # containing it), matching the recall-filter path. The operand is bound once
+    # and reused across both arms, never interpolated.
     clauses, binds = _legacy_clauses({"tier": "gold"})
     assert len(clauses) == 1
     sql = _norm(clauses[0])
-    assert "(metadata_.tier = $" in sql
-    assert "type::is::" not in sql
+    assert "metadata_.tier = $" in sql
+    assert "type::is::array(metadata_.tier) and metadata_.tier contains $" in sql
     assert list(binds.values()) == ["gold"]
 
 
-def test_legacy_eq_dict_form_is_plain_equality() -> None:
+def test_legacy_eq_dict_form_is_array_aware() -> None:
     # The explicit ``{"eq": ...}`` dict form lowers identically to the scalar form.
     clauses, binds = _legacy_clauses({"tier": {"eq": "gold"}})
     assert len(clauses) == 1
     sql = _norm(clauses[0])
-    assert "(metadata_.tier = $" in sql
-    assert "type::is::" not in sql
+    assert "metadata_.tier = $" in sql
+    assert "type::is::array(metadata_.tier) and metadata_.tier contains $" in sql
     assert list(binds.values()) == ["gold"]
 
 

--- a/tests/unit/engines/skeleton/backends/test_surrealdb_legacy_additional.py
+++ b/tests/unit/engines/skeleton/backends/test_surrealdb_legacy_additional.py
@@ -1,0 +1,193 @@
+"""Behavioral coverage for the legacy ``TemporalFilter.additional`` path.
+
+``SurrealDBTemporalStore._build_filter_clauses`` lowers the legacy
+``additional`` dict (the pre-deterministic-filter metadata-predicate channel)
+into SurrealQL ``WHERE`` fragments. Every ``additional`` key is now routed
+through the recall-filter SurrealDB compiler's guarded builder
+(``_legacy_metadata_predicate``) so the path segment is validated against the
+injection guard before any interpolation — the ``eq`` branch in particular used
+to interpolate the key verbatim, which is the regression that slipped through for
+lack of a test.
+
+These tests pin the *emitted SurrealQL* (the behavioral/semantic contract):
+
+* ``eq`` (scalar value form AND explicit ``{"eq": ...}`` form) → a plain
+  ``(metadata_.<path> = $bind)`` equality, NO type gate;
+* each range op (``gt`` / ``gte`` / ``lt`` / ``lte``) → a type-gated
+  ``(type::is::<t>(metadata_.<path>) AND metadata_.<path> <op> $bind)`` so a
+  numeric value orders numerically and a wrong-typed value is excluded;
+* a dotted ``additional`` key descends natively (``labels.priority`` →
+  ``metadata_.labels.priority``), not collapsed/mangled into one token;
+* the type-gate function tracks the operand's Python type (number / string / bool).
+
+The injection-*rejection* unit case (an unsafe key raising ``CompileError``)
+lives with the compiler's injection guard; this module owns the
+happy-path/semantic side. The embedded-SurrealDB row-set proof that a range op
+actually *excludes* a wrong-typed legacy value lives in
+``tests/integration/filter/test_compile_surrealdb_embedded.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from khora.engines.skeleton.backends import TemporalFilter
+from khora.engines.skeleton.backends.surrealdb import SurrealDBTemporalStore
+
+# Hard import (NOT importorskip): ``_build_filter_clauses`` is a pure static
+# string-builder — it imports the recall-filter compiler (pure Python, no SDK)
+# and only inspects the emitted predicate, so an import failure must be a LOUD
+# test error, never a silent skip.
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+
+def _legacy_clauses(additional: dict[str, Any]) -> tuple[list[str], dict[str, Any]]:
+    """Build clauses+binds for an ``additional`` dict, dropping the namespace scope.
+
+    ``_build_filter_clauses`` always prepends the namespace-scoping clause and its
+    two binds (``ns_rid`` / ``ns_str``); strip those so assertions see only the
+    legacy ``additional`` predicates and their ``af_*`` binds.
+    """
+    clauses, binds = SurrealDBTemporalStore._build_filter_clauses(
+        uuid4(),
+        TemporalFilter(additional=additional),
+    )
+    legacy_clauses = [c for c in clauses if "namespace" not in c]
+    legacy_binds = {k: v for k, v in binds.items() if k.startswith("af_")}
+    return legacy_clauses, legacy_binds
+
+
+def _norm(surql: str) -> str:
+    """Collapse whitespace and lowercase for resilient substring matching."""
+    return " ".join(surql.split()).lower()
+
+
+# ===========================================================================
+# eq — plain equality, no type gate.
+# ===========================================================================
+
+
+def test_legacy_eq_scalar_form_is_plain_equality() -> None:
+    # A bare scalar value (no op dict) is the ``eq`` sugar: a plain ``=`` compare
+    # on the metadata path, the operand bound (never interpolated). NO type gate.
+    clauses, binds = _legacy_clauses({"tier": "gold"})
+    assert len(clauses) == 1
+    sql = _norm(clauses[0])
+    assert "(metadata_.tier = $" in sql
+    assert "type::is::" not in sql
+    assert list(binds.values()) == ["gold"]
+
+
+def test_legacy_eq_dict_form_is_plain_equality() -> None:
+    # The explicit ``{"eq": ...}`` dict form lowers identically to the scalar form.
+    clauses, binds = _legacy_clauses({"tier": {"eq": "gold"}})
+    assert len(clauses) == 1
+    sql = _norm(clauses[0])
+    assert "(metadata_.tier = $" in sql
+    assert "type::is::" not in sql
+    assert list(binds.values()) == ["gold"]
+
+
+def test_legacy_eq_value_binds_not_interpolated() -> None:
+    # The value must be carried as a bind, never spliced into the predicate string
+    # — the property the guarded builder restored for the eq path.
+    clauses, binds = _legacy_clauses({"tier": "gold"})
+    assert "gold" not in clauses[0]
+    assert "gold" in binds.values()
+
+
+# ===========================================================================
+# Range ops — type-gated, numeric ordering.
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    ("legacy_op", "surql_op"),
+    [
+        ("gt", ">"),
+        ("gte", ">="),
+        ("lt", "<"),
+        ("lte", "<="),
+    ],
+)
+def test_legacy_range_op_is_number_gated(legacy_op: str, surql_op: str) -> None:
+    # Each legacy range op emits the type-gated pair: a ``type::is::number`` gate
+    # AND-ed (short-circuit) ahead of the compare, so a wrong-typed / absent value
+    # never reaches the compare and a numeric value orders numerically.
+    clauses, binds = _legacy_clauses({"score": {legacy_op: 5}})
+    assert len(clauses) == 1
+    sql = _norm(clauses[0])
+    assert f"(type::is::number(metadata_.score) and metadata_.score {surql_op} $" in sql
+    assert list(binds.values()) == [5]
+
+
+def test_legacy_range_op_gate_prefix_present() -> None:
+    # The type-gate prefix is the load-bearing guarantee (the bug was a path that
+    # bypassed it). Assert the ``type::is::`` prefix leads every range predicate.
+    for op in ("gt", "gte", "lt", "lte"):
+        clauses, _ = _legacy_clauses({"score": {op: 1}})
+        assert _norm(clauses[0]).startswith("(type::is::")
+
+
+def test_legacy_range_string_operand_picks_string_gate() -> None:
+    # A string operand gates on ``type::is::string`` (lexicographic text compare).
+    clauses, binds = _legacy_clauses({"name": {"gt": "m"}})
+    sql = _norm(clauses[0])
+    assert "(type::is::string(metadata_.name) and metadata_.name > $" in sql
+    assert list(binds.values()) == ["m"]
+
+
+def test_legacy_range_bool_operand_picks_bool_gate() -> None:
+    # A bool operand gates on ``type::is::bool`` — NOT number (a bool is an int
+    # subclass in Python, and SurrealDB agrees a bool is not a number).
+    clauses, _ = _legacy_clauses({"flag": {"gt": True}})
+    sql = _norm(clauses[0])
+    assert "type::is::bool(metadata_.flag)" in sql
+    assert "type::is::number" not in sql
+
+
+# ===========================================================================
+# Nested dotted keys descend natively.
+# ===========================================================================
+
+
+def test_legacy_dotted_key_descends_natively() -> None:
+    # A dotted ``additional`` key (``labels.priority``) descends to
+    # ``metadata_.labels.priority`` — NOT collapsed/mangled into a single token
+    # (the bad sanitizer would have produced ``metadata_labels`` or similar).
+    clauses, _ = _legacy_clauses({"labels.priority": {"gte": 3}})
+    sql = _norm(clauses[0])
+    assert "metadata_.labels.priority" in sql
+    assert "metadata_labels" not in sql
+
+
+def test_legacy_dotted_key_eq_descends_natively() -> None:
+    # The eq path descends a dotted key the same way (the eq branch is the one the
+    # regression touched).
+    clauses, _ = _legacy_clauses({"labels.tier": "gold"})
+    sql = _norm(clauses[0])
+    assert "(metadata_.labels.tier = $" in sql
+
+
+# ===========================================================================
+# Multiple additional keys never collide on bind names.
+# ===========================================================================
+
+
+def test_legacy_multiple_keys_distinct_bind_names() -> None:
+    # Two additional keys allocate distinct ``af_<i>_<op>_<n>`` bind names so
+    # concurrent legacy predicates never overwrite each other.
+    clauses, binds = _legacy_clauses({"a": "x", "b": {"gt": 1}})
+    assert len(clauses) == 2
+    assert len(binds) == 2
+    assert len(set(binds)) == 2  # no bind-name collision
+    assert set(binds.values()) == {"x", 1}

--- a/tests/unit/filter/test_compile_surrealdb.py
+++ b/tests/unit/filter/test_compile_surrealdb.py
@@ -1,0 +1,680 @@
+"""Unit tests for the SurrealDB SurrealQL recall-filter compiler (Layer 4) — ``@internal``.
+
+``compile_surrealdb(ast, ctx)`` lowers a canonical :class:`~khora.filter.ast.FilterNode`
+into a SurrealQL ``WHERE``-fragment *string* (plus an out-of-band ``params`` bind dict)
+over the recall ``temporal_chunk`` table. These tests pin the §4 *Field-match contract*
+at the SurrealQL level: each test builds an AST (by validating a
+:class:`~khora.filter.RecallFilter` and lowering it with
+:func:`~khora.filter.ast.parse_to_ast`), compiles it, and asserts on the emitted
+predicate string and bind dict — never re-implementing the compiler, only inspecting
+what it emits.
+
+Like the Cypher compiler (and unlike Postgres, which inlines literals into a SQLAlchemy
+expression), the SurrealDB compiler returns a plain string with ``$name`` placeholders
+and carries the values out-of-band in ``params``. So the assertions match against the
+string directly and check ``params`` for the bound values.
+
+The contract these tests lock (§4), and the one deliberate divergence from Cypher:
+
+* Every operator ``$eq``/``$ne``/``$gt``/``$gte``/``$lt``/``$lte``/``$in``/``$nin``/``$exists``.
+* System key (typed column) emission; the empty AST → match-everything (``true``).
+* A *nested* metadata path descends natively (``metadata.a.b.c`` → ``metadata_.a.b.c``),
+  never collapsed/mangled into a single token.
+* The four field-match rules, as SurrealQL expresses them via its NONE-boolean algebra
+  (**no coalesce / totality wrapper** — SurrealQL comparisons against an absent path are
+  already total, so a negation flips an absent row in correctly):
+  1. never-abort: a metadata range op is type-gated (``type::is::<t>(node) AND ...``) so a
+     wrong-typed / absent value never participates in the compare;
+  2. polarity: ``$ne``/``$nin``/``$not`` admit absent rows (``!=`` and ``!(... INSIDE ...)``
+     are already true for an absent path);
+  3. a bare-list (exact-array) operand binds as a list against a scalar column — false at
+     query time, no special-cased constant;
+  4. presence/null: ``$exists`` → ``IS [NOT] NONE``; ``{k: null}`` → ``(= NULL OR IS NONE)``
+     (NONE = absent path, NULL = explicit json null — distinct).
+* Dates: a system datetime column binds the real :class:`~datetime.datetime` (the SDK
+  encodes it as a SurrealQL datetime); a metadata ``$date`` operand is gated as a string
+  and binds its ``.isoformat()`` form (lexicographic compare on the FLEXIBLE object column).
+* The :class:`CompiledFilter` envelope: ``params`` binds, ``consumed_keys`` frozenset,
+  ``canonical_hash``.
+* ``field_mapping`` / ``param_namespace`` honored — one compiler, many schemas, no
+  per-engine branching.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from khora.filter import RecallFilter
+from khora.filter.ast import FilterClause, FilterNode, canonical_hash, parse_to_ast
+from khora.filter.compilers.surrealdb import compile_surrealdb
+from khora.filter.context import CompileContext
+from khora.filter.model import Op
+
+# Hard import (NOT importorskip): the compiler is pure-Python string emission with
+# no SurrealDB SDK dependency, so an import failure here must be a LOUD test error,
+# never a silent module skip that would pass CI green with zero coverage.
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+# The live recall path's context: the ``metadata`` root maps to the physical
+# ``metadata_`` column; system keys map identity (bare columns on the table).
+_CTX = CompileContext(backend_target="temporal_chunk", field_mapping={"metadata": "metadata_"})
+
+
+def _ast(wire: dict) -> FilterNode:
+    """Validate a wire-form filter and lower it to the canonical AST."""
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+def _norm(surql: str) -> str:
+    """Collapse whitespace and lowercase for resilient substring matching."""
+    return " ".join(surql.split()).lower()
+
+
+def _surql_norm(node: FilterNode | FilterClause, ctx: CompileContext = _CTX) -> str:
+    """Compile an AST and return the predicate string, whitespace-collapsed.
+
+    The predicate is already a SurrealQL boolean string (the bind values live in
+    the sibling ``params`` dict), so there is no compile step — normalize and
+    assert substrings directly.
+    """
+    return _norm(compile_surrealdb(node, ctx).predicate)
+
+
+# ===========================================================================
+# Empty AST → match-everything.
+# ===========================================================================
+
+
+def test_empty_filter_compiles_to_true() -> None:
+    # A bare RecallFilter() (no predicates) lowers to the empty match-everything
+    # AND. The compiler emits the literal tautology so the engine applies no
+    # constraint (the bare "true", NOT a wrapped "(true)").
+    assert _surql_norm(_ast({})) == "true"
+
+
+def test_empty_and_node_compiles_to_true() -> None:
+    # Construct the empty AND directly — same match-everything contract.
+    assert _surql_norm(FilterNode(op=Op.AND, children=())) == "true"
+
+
+def test_empty_filter_binds_nothing() -> None:
+    assert compile_surrealdb(_ast({}), _CTX).params == {}
+
+
+# ===========================================================================
+# Scalar operators on a SYSTEM (typed column) key.
+# ===========================================================================
+
+
+def test_system_eq_is_bare_property_equals() -> None:
+    compiled = compile_surrealdb(_ast({"source_name": "linear"}), _CTX)
+    sql = _norm(compiled.predicate)
+    # $eq is a total boolean in SurrealQL: a plain ``=`` compare (no coalesce — an
+    # absent column compares false, and a wrapping $not flips it). The operand is
+    # bound, not inlined. The system key is a bare physical column, not metadata.
+    assert "(source_name = $f_0)" in sql
+    assert "coalesce" not in sql
+    assert "metadata" not in sql
+    assert compiled.params == {"f_0": "linear"}
+
+
+def test_system_eq_with_ops_form() -> None:
+    compiled = compile_surrealdb(_ast({"source_type": {"$eq": "slack"}}), _CTX)
+    assert "(source_type = $f_0)" in _norm(compiled.predicate)
+    assert compiled.params == {"f_0": "slack"}
+
+
+def test_system_ne_is_bare_not_equals() -> None:
+    # Rule 2 (polarity): ``!=`` against an absent column already returns true in
+    # SurrealQL, so $ne admits absent rows without an extra ``OR IS NONE`` — no
+    # null guard needed (the divergence from Cypher's ``IS NULL OR ...``).
+    compiled = compile_surrealdb(_ast({"source_name": {"$ne": "linear"}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "(source_name != $f_0)" in sql
+    assert "is none" not in sql
+    assert compiled.params == {"f_0": "linear"}
+
+
+def test_system_gt_is_property_compare() -> None:
+    # A system DATE key takes a plain ISO-8601 string operand (DateOps parses it to
+    # a datetime); the operand binds as a real datetime (the SDK encodes it as a
+    # SurrealQL datetime — the system-column divergence from the metadata path).
+    compiled = compile_surrealdb(_ast({"created_at": {"$gt": "2026-01-01T00:00:00Z"}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "(created_at > $f_0)" in sql
+    assert isinstance(compiled.params["f_0"], datetime)
+
+
+@pytest.mark.parametrize(
+    ("wire_op", "surql_op"),
+    [
+        ("$gt", ">"),
+        ("$gte", ">="),
+        ("$lt", "<"),
+        ("$lte", "<="),
+    ],
+)
+def test_system_date_range_operators(wire_op: str, surql_op: str) -> None:
+    # System datetime columns are typed, so their range ops are UNGATED (no
+    # ``type::is::*`` prefix — the gate is metadata-only).
+    sql = _surql_norm(_ast({"occurred_at": {wire_op: "2026-03-04T05:06:07Z"}}))
+    assert f"(occurred_at {surql_op} $f_0)" in sql
+    assert "type::is::" not in sql
+
+
+# ===========================================================================
+# All ten system keys lower to a bare field ref (incl. the 8 always-absent ones).
+# ===========================================================================
+#
+# Eight of the ten system keys (source_timestamp / source_type / source_name /
+# source_url / external_id / content_type / source / title) are not written onto
+# the temporal_chunk table, so they read NONE at query time — but the compiler
+# still emits a bare field ref for each (an undefined-field ref does not error in
+# SurrealQL). The two date keys (occurred_at / created_at) are real columns. This
+# pins that EVERY system key pushes down to a ``<key> = $bind`` compare and lands
+# in consumed_keys, independent of whether the column is physically present.
+_ALWAYS_ABSENT_SYSTEM_KEYS = (
+    "source_type",
+    "source_name",
+    "source_url",
+    "external_id",
+    "content_type",
+    "source",
+    "title",
+)
+
+
+@pytest.mark.parametrize("key", _ALWAYS_ABSENT_SYSTEM_KEYS)
+def test_always_absent_string_key_emits_bare_field_ref(key: str) -> None:
+    compiled = compile_surrealdb(_ast({key: "v"}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert f"({key} = $f_0)" in sql
+    assert compiled.params == {"f_0": "v"}
+    assert key in compiled.consumed_keys
+    # A system key is a bare column ref, never a serialized-metadata lookup.
+    assert "metadata" not in sql
+
+
+def test_source_timestamp_emits_bare_field_ref() -> None:
+    # source_timestamp is the one always-absent datetime-typed system key. It
+    # pushes down as a bare ``=`` compare and binds a real datetime (system-column
+    # binding), completing the 8-key always-absent set with the string keys above.
+    compiled = compile_surrealdb(_ast({"source_timestamp": "2026-02-03T00:00:00Z"}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "(source_timestamp = $f_0)" in sql
+    assert isinstance(compiled.params["f_0"], datetime)
+    assert "source_timestamp" in compiled.consumed_keys
+
+
+# ===========================================================================
+# $in / $nin on a SYSTEM key → INSIDE / !(INSIDE) membership.
+# ===========================================================================
+
+
+def test_system_in_is_inside_list() -> None:
+    compiled = compile_surrealdb(_ast({"source_name": {"$in": ["a", "b", "c"]}}), _CTX)
+    assert "(source_name inside $f_0)" in _norm(compiled.predicate)
+    assert compiled.params == {"f_0": ["a", "b", "c"]}
+
+
+def test_system_nin_is_negated_inside() -> None:
+    # Rule 2 (polarity): $nin is the negated INSIDE. An absent column is not INSIDE
+    # the set, so the negation is true — absent rows are admitted, total without an
+    # extra null guard (the divergence from Cypher's ``IS NULL OR NOT ... IN``).
+    compiled = compile_surrealdb(_ast({"source_type": {"$nin": ["spam", "junk"]}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "!(source_type inside $f_0)" in sql
+    assert "is none" not in sql
+    assert compiled.params == {"f_0": ["spam", "junk"]}
+
+
+def test_system_empty_in_is_constant_false() -> None:
+    # An empty $in operand list is a valid filter with a defined row-set: positive
+    # membership over ∅ matches nothing. The compiler emits the constant explicitly
+    # (the single-clause filter normalizes to AND([leaf]), rendering as the wrapped
+    # "(false)") and binds nothing.
+    compiled = compile_surrealdb(_ast({"source_name": {"$in": []}}), _CTX)
+    assert _norm(compiled.predicate) == "(false)"
+    assert compiled.params == {}
+
+
+def test_system_empty_nin_is_constant_true() -> None:
+    # An empty $nin operand list matches everything (negation over ∅) — the polarity
+    # mirror of the empty-$in case. Emitted as the wrapped constant "(true)".
+    compiled = compile_surrealdb(_ast({"source_name": {"$nin": []}}), _CTX)
+    assert _norm(compiled.predicate) == "(true)"
+    assert compiled.params == {}
+
+
+# ===========================================================================
+# Rule 3 — bare-list (exact-array) operand vs scalar SYSTEM column.
+# ===========================================================================
+
+
+def test_system_eq_array_operand_binds_as_list() -> None:
+    # A bare list on a scalar system key lowers to $eq EXACT-ARRAY. The compiler
+    # binds the operand as a SurrealQL list and emits the same plain ``=`` compare;
+    # a scalar column never equals a list, so it yields false at query time — no
+    # special-cased constant, the list binds like any other operand. (The AST
+    # carries a tuple; it is bound as a driver list, not a tuple.)
+    compiled = compile_surrealdb(_ast({"source_name": ["a", "b"]}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "(source_name = $f_0)" in sql
+    assert "inside" not in sql  # exact-array $eq, NOT membership
+    assert compiled.params == {"f_0": ["a", "b"]}
+
+
+def test_system_in_is_membership_not_exact_array() -> None:
+    # $in on a system key is membership (INSIDE), NOT exact-array — distinct from
+    # the bare-list $eq case above.
+    compiled = compile_surrealdb(_ast({"occurred_at": {"$in": ["2026-01-01T00:00:00Z"]}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "(occurred_at inside $f_0)" in sql
+    assert "!=" not in sql
+
+
+# ===========================================================================
+# Rule 4 — $exists / null resolve to IS [NOT] NONE / (= NULL OR IS NONE).
+# ===========================================================================
+
+
+def test_system_exists_true_is_is_not_none() -> None:
+    # An unwritten column reads NONE, so $exists is a presence test (IS NOT NONE),
+    # binding nothing.
+    compiled = compile_surrealdb(_ast({"source_name": {"$exists": True}}), _CTX)
+    assert "(source_name is not none)" in _norm(compiled.predicate)
+    assert compiled.params == {}
+
+
+def test_system_exists_false_is_is_none() -> None:
+    compiled = compile_surrealdb(_ast({"source_name": {"$exists": False}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "(source_name is none)" in sql
+    assert "is not none" not in sql
+    assert compiled.params == {}
+
+
+def test_system_null_operand_is_null_or_none() -> None:
+    # An explicit null is an active null-or-missing match. NONE (absent path) and
+    # NULL (explicit json null) are distinct in SurrealQL, so the match covers both.
+    compiled = compile_surrealdb(_ast({"source_name": None}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "(source_name = null or source_name is none)" in sql
+    assert compiled.params == {}
+
+
+def test_system_ne_null_is_present_and_not_null() -> None:
+    # $ne null → present (IS NOT NONE) and not explicit-null (!= NULL).
+    compiled = compile_surrealdb(_ast({"source_name": {"$ne": None}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "(source_name is not none and source_name != null)" in sql
+    assert compiled.params == {}
+
+
+# ===========================================================================
+# Dates — system column binds a datetime; metadata gates+binds an ISO string.
+# ===========================================================================
+
+
+def test_system_date_binds_real_datetime() -> None:
+    # A system date key takes a plain ISO string (the `$date` typed literal is a
+    # metadata-only form). It compiles to a plain ``=`` compare; the operand binds
+    # as a real, UTC-normalized datetime (the SDK encodes it as a SurrealQL
+    # datetime — NOT an .isoformat() string, unlike Cypher and unlike the metadata
+    # path).
+    compiled = compile_surrealdb(_ast({"source_timestamp": "2026-02-03T00:00:00Z"}), _CTX)
+    assert "(source_timestamp = $f_0)" in _norm(compiled.predicate)
+    bound = compiled.params["f_0"]
+    assert isinstance(bound, datetime)
+    assert bound == datetime(2026, 2, 3, tzinfo=UTC)
+
+
+def test_direct_datetime_clause_binds_real_datetime() -> None:
+    # Build a leaf clause directly with a tz-aware datetime operand — a valid
+    # compiler input independent of the validator path. A system datetime column
+    # binds the datetime object verbatim.
+    clause = FilterClause(path=("occurred_at",), op=Op.GTE, operand=datetime(2026, 1, 1, tzinfo=UTC))
+    node = FilterNode(op=Op.AND, children=(clause,))
+    compiled = compile_surrealdb(node, _CTX)
+    assert "(occurred_at >= $f_0)" in _norm(compiled.predicate)
+    assert compiled.params["f_0"] == datetime(2026, 1, 1, tzinfo=UTC)
+
+
+# ===========================================================================
+# Nested metadata paths — native dot-descent (NOT collapsed to one token).
+# ===========================================================================
+
+
+def test_metadata_nested_path_descends_natively() -> None:
+    # metadata.a.b.c → metadata_.a.b.c: the path DESCENDS through the remapped
+    # object root, never collapsed or mangled into a single token (the old
+    # single-token sanitizer would have treated "a.b.c" as one key). Assert the
+    # full descended substring is present.
+    compiled = compile_surrealdb(_ast({"metadata.a.b.c": "v"}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "metadata_.a.b.c" in sql
+    assert "(metadata_.a.b.c = $f_0)" in sql
+    assert compiled.params == {"f_0": "v"}
+    assert "metadata.a.b.c" in compiled.consumed_keys
+
+
+def test_metadata_deep_path_not_mangled_into_single_token() -> None:
+    # A path with several segments the old single-token sanitizer would have
+    # treated as one key. Each segment must appear as its own dotted descent
+    # component — assert the descent reaches the leaf and the parent prefixes are
+    # all present as substrings (no underscore-mangled single token).
+    compiled = compile_surrealdb(_ast({"metadata.labels.region.code": {"$exists": True}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "metadata_.labels.region.code" in sql
+    # The collapsed/mangled forms the bad sanitizer would have produced must NOT
+    # appear.
+    assert "metadata_labels" not in sql
+    assert "labels_region" not in sql
+
+
+def test_metadata_eq_single_segment_descends() -> None:
+    compiled = compile_surrealdb(_ast({"metadata.tier": "gold"}), _CTX)
+    assert "(metadata_.tier = $f_0)" in _norm(compiled.predicate)
+    assert compiled.params == {"f_0": "gold"}
+
+
+def test_bare_metadata_blob_eq() -> None:
+    # The bare ``metadata`` blob is whole-object $eq (structural, key-order
+    # insensitive). It binds against the remapped ``metadata_`` root directly.
+    compiled = compile_surrealdb(_ast({"metadata": {"a": 1}}), _CTX)
+    assert "(metadata_ = $f_0)" in _norm(compiled.predicate)
+    assert compiled.params == {"f_0": {"a": 1}}
+
+
+# ===========================================================================
+# Metadata range type-gate — every range leaf emits the type::is::<t> prefix.
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    ("wire_op", "surql_op"),
+    [
+        ("$gt", ">"),
+        ("$gte", ">="),
+        ("$lt", "<"),
+        ("$lte", "<="),
+    ],
+)
+def test_metadata_numeric_range_is_number_gated(wire_op: str, surql_op: str) -> None:
+    # Rule 1 (never-abort): a numeric metadata range op gates on type::is::number;
+    # the AND short-circuits so a wrong-typed / absent value never reaches the
+    # compare. The whole leaf is the gated pair — no coalesce wrapper.
+    compiled = compile_surrealdb(_ast({"metadata.score": {wire_op: 5}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert f"(type::is::number(metadata_.score) and metadata_.score {surql_op} $f_0)" in sql
+    assert compiled.params == {"f_0": 5}
+
+
+def test_metadata_bool_range_picks_bool_gate() -> None:
+    # A bool operand picks type::is::bool, NOT number — a bool is an int subclass
+    # in Python, and SurrealDB agrees a bool is not a number, so the gate must be
+    # ``bool`` (checked before ``number``).
+    compiled = compile_surrealdb(_ast({"metadata.flag": {"$gt": True}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "type::is::bool(metadata_.flag)" in sql
+    assert "type::is::number" not in sql
+    assert compiled.params == {"f_0": True}
+
+
+def test_metadata_string_range_is_string_gated() -> None:
+    # A string operand gates on type::is::string (lexicographic text compare).
+    compiled = compile_surrealdb(_ast({"metadata.name": {"$gte": "m"}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "(type::is::string(metadata_.name) and metadata_.name >= $f_0)" in sql
+    assert compiled.params == {"f_0": "m"}
+
+
+def test_metadata_date_range_is_string_gated_and_binds_isoformat() -> None:
+    # A metadata $date / datetime operand is gated as a STRING (metadata datetimes
+    # round-trip through the FLEXIBLE object column as ISO strings) and binds its
+    # .isoformat() form — the documented divergence from the system-column path
+    # (which binds a real datetime).
+    compiled = compile_surrealdb(_ast({"metadata.ts": {"$gt": {"$date": "2026-01-01T00:00:00Z"}}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "type::is::string(metadata_.ts)" in sql
+    assert "metadata_.ts > $f_0" in sql
+    bound = compiled.params["f_0"]
+    assert isinstance(bound, str)
+    assert bound == datetime(2026, 1, 1, tzinfo=UTC).isoformat()
+
+
+def test_metadata_direct_datetime_range_is_string_gated() -> None:
+    # A raw datetime operand (built directly on the AST) on a metadata range is
+    # also string-gated and bound as its .isoformat() string.
+    clause = FilterClause(path=("metadata", "ts"), op=Op.LT, operand=datetime(2026, 5, 6, tzinfo=UTC))
+    node = FilterNode(op=Op.AND, children=(clause,))
+    compiled = compile_surrealdb(node, _CTX)
+    sql = _norm(compiled.predicate)
+    assert "type::is::string(metadata_.ts)" in sql
+    assert compiled.params["f_0"] == datetime(2026, 5, 6, tzinfo=UTC).isoformat()
+
+
+# ===========================================================================
+# Metadata field-match rules — polarity / presence / null on a metadata leaf.
+# ===========================================================================
+
+
+def test_metadata_ne_is_bare_not_equals() -> None:
+    # Rule 2 (polarity): a metadata $ne is a plain ``!=`` — already true for an
+    # absent / wrong-type path, so absent rows are admitted without a null guard.
+    compiled = compile_surrealdb(_ast({"metadata.tier": {"$ne": "gold"}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "(metadata_.tier != $f_0)" in sql
+    assert "is none" not in sql
+    assert compiled.params == {"f_0": "gold"}
+
+
+def test_metadata_nin_is_negated_inside() -> None:
+    # Rule 2: metadata $nin is the negated INSIDE — absent paths are not INSIDE,
+    # so the negation is true (admits absent rows).
+    compiled = compile_surrealdb(_ast({"metadata.tier": {"$nin": ["a", "b"]}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "!(metadata_.tier inside $f_0)" in sql
+    assert compiled.params == {"f_0": ["a", "b"]}
+
+
+def test_metadata_exists_true_is_is_not_none() -> None:
+    # Rule 4: presence on a metadata path → IS NOT NONE.
+    compiled = compile_surrealdb(_ast({"metadata.tier": {"$exists": True}}), _CTX)
+    assert "(metadata_.tier is not none)" in _norm(compiled.predicate)
+    assert compiled.params == {}
+
+
+def test_metadata_exists_false_is_is_none() -> None:
+    compiled = compile_surrealdb(_ast({"metadata.tier": {"$exists": False}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "(metadata_.tier is none)" in sql
+    assert "is not none" not in sql
+
+
+def test_metadata_null_operand_is_null_or_none() -> None:
+    # Rule 4: {k: null} → explicit json NULL OR absent (NONE) path.
+    compiled = compile_surrealdb(_ast({"metadata.tier": None}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "(metadata_.tier = null or metadata_.tier is none)" in sql
+    assert compiled.params == {}
+
+
+def test_metadata_ne_null_is_present_and_not_null() -> None:
+    compiled = compile_surrealdb(_ast({"metadata.tier": {"$ne": None}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "(metadata_.tier is not none and metadata_.tier != null)" in sql
+    assert compiled.params == {}
+
+
+def test_metadata_eq_array_operand_binds_as_list() -> None:
+    # Rule 3: a bare list on a metadata path is $eq EXACT-ARRAY, not membership.
+    compiled = compile_surrealdb(_ast({"metadata.tags": ["a", "b"]}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert "(metadata_.tags = $f_0)" in sql
+    assert "inside" not in sql
+    assert compiled.params == {"f_0": ["a", "b"]}
+
+
+def test_metadata_empty_in_is_constant_false() -> None:
+    compiled = compile_surrealdb(_ast({"metadata.tier": {"$in": []}}), _CTX)
+    assert _norm(compiled.predicate) == "(false)"
+    assert compiled.params == {}
+
+
+def test_metadata_empty_nin_is_constant_true() -> None:
+    compiled = compile_surrealdb(_ast({"metadata.tier": {"$nin": []}}), _CTX)
+    assert _norm(compiled.predicate) == "(true)"
+    assert compiled.params == {}
+
+
+# ===========================================================================
+# Logical composition — AND / OR / NOT + totality.
+# ===========================================================================
+
+
+def test_and_node_joins_with_and() -> None:
+    # Two sibling keys compose with " AND ". Child order is normalized (the system
+    # keys lower in a fixed order), not authored order — so do NOT assert order,
+    # only that both leaves and the AND join are present.
+    sql = _surql_norm(_ast({"source_name": "linear", "source_type": "slack"}))
+    assert " and " in sql
+    assert "source_name = $" in sql
+    assert "source_type = $" in sql
+
+
+def test_or_node_joins_with_or() -> None:
+    sql = _surql_norm(_ast({"$or": [{"source_name": "linear"}, {"source_type": "slack"}]}))
+    assert " or " in sql
+    assert "source_name = $" in sql
+    assert "source_type = $" in sql
+
+
+def test_not_node_negates_with_bang_and_plain_child() -> None:
+    # SEMANTICS over tokens: NOT compiles via ``!(<child>)``. SurrealQL's
+    # NONE-boolean algebra makes every leaf total on its own, so — unlike Cypher —
+    # the inner leaf is the PLAIN (un-coalesced) ``=`` compare, and the ``!(...)``
+    # flips an absent/null row IN correctly (Rule 2) without any coalesce wrapper.
+    # We assert the bang-negation SHAPE and that the inner leaf carries NO coalesce.
+    sql = _surql_norm(_ast({"$not": {"source_name": "linear"}}))
+    assert sql.startswith("!(")
+    assert "(source_name = $f_0)" in sql
+    assert "coalesce" not in sql
+
+
+def test_not_over_metadata_range_keeps_plain_gated_leaf() -> None:
+    # $not over a metadata range: the negation wraps the plain type-gated leaf
+    # (no coalesce). The gated pair is the inner total expression that ``!(...)``
+    # flips — so an absent / wrong-typed / non-matching row is kept by the negation.
+    sql = _surql_norm(_ast({"$not": {"metadata.score": {"$gt": 5}}}))
+    assert sql.startswith("!(")
+    assert "type::is::number(metadata_.score) and metadata_.score > $f_0" in sql
+    assert "coalesce" not in sql
+
+
+def test_nested_and_or_structure() -> None:
+    sql = _surql_norm(
+        _ast(
+            {
+                "source_name": "linear",
+                "$or": [{"source_type": "slack"}, {"content_type": "text/plain"}],
+            }
+        )
+    )
+    assert " and " in sql
+    assert " or " in sql
+
+
+def test_composition_binds_are_distinct_per_clause() -> None:
+    # Each leaf allocates a fresh monotonic bind name, so two clauses on different
+    # keys never collide — three keys → f_0, f_1, f_2.
+    compiled = compile_surrealdb(
+        _ast(
+            {
+                "source_name": "linear",
+                "$or": [{"source_type": "slack"}, {"content_type": "text/plain"}],
+            }
+        ),
+        _CTX,
+    )
+    assert set(compiled.params) == {"f_0", "f_1", "f_2"}
+    assert set(compiled.params.values()) == {"linear", "slack", "text/plain"}
+
+
+# ===========================================================================
+# CompiledFilter envelope — consumed_keys / canonical_hash / params.
+# ===========================================================================
+
+
+def test_compiled_filter_carries_canonical_hash() -> None:
+    node = _ast({"source_name": "linear"})
+    compiled = compile_surrealdb(node, _CTX)
+    assert compiled.canonical_hash == canonical_hash(node)
+
+
+def test_compiled_filter_consumed_keys_is_frozenset() -> None:
+    compiled = compile_surrealdb(_ast({"source_name": "linear"}), _CTX)
+    assert isinstance(compiled.consumed_keys, frozenset)
+    assert "source_name" in compiled.consumed_keys
+
+
+def test_consumed_keys_collects_every_leaf() -> None:
+    # A mixed system + nested-metadata filter consumes the dotted metadata key
+    # (its full dot-path string) alongside the system key.
+    compiled = compile_surrealdb(
+        _ast({"source_name": "linear", "metadata.labels.tier": "gold"}),
+        _CTX,
+    )
+    assert compiled.consumed_keys == frozenset({"source_name", "metadata.labels.tier"})
+
+
+def test_empty_filter_consumes_nothing() -> None:
+    compiled = compile_surrealdb(_ast({}), _CTX)
+    assert compiled.consumed_keys == frozenset()
+
+
+# ===========================================================================
+# field_mapping / param_namespace — one compiler, many schemas.
+# ===========================================================================
+
+
+def test_field_mapping_remaps_metadata_root() -> None:
+    # The live recall path remaps the ``metadata`` root to the physical
+    # ``metadata_`` column — the same compiler serves the schema without any
+    # per-engine branching.
+    ctx = CompileContext(backend_target="temporal_chunk", field_mapping={"metadata": "metadata_"})
+    assert "(metadata_.tier = $f_0)" in _surql_norm(_ast({"metadata.tier": "gold"}), ctx)
+
+
+def test_field_mapping_default_metadata_root_unremapped() -> None:
+    # With no field_mapping the ``metadata`` root is the identity ``metadata`` — the
+    # remap is a context choice, not hardcoded into the compiler.
+    ctx = CompileContext(backend_target="temporal_chunk")
+    assert "(metadata.tier = $f_0)" in _surql_norm(_ast({"metadata.tier": "gold"}), ctx)
+
+
+def test_field_mapping_remaps_system_key_name() -> None:
+    # A system-key remap renames the bare column ref (e.g. the legacy schema's
+    # ``source_system`` column behind the ``source`` logical key).
+    ctx = CompileContext(
+        backend_target="temporal_chunk",
+        field_mapping={"source": "source_system"},
+    )
+    assert "(source_system = $f_0)" in _surql_norm(_ast({"source": "slack"}), ctx)
+
+
+def test_param_namespace_prefixes_bind_names() -> None:
+    # param_namespace prefixes every bind name so compiled params cannot collide
+    # with the engine's own query parameters.
+    ctx = CompileContext(backend_target="temporal_chunk", param_namespace="p")
+    compiled = compile_surrealdb(_ast({"source_name": "linear"}), ctx)
+    assert "$p_0" in compiled.predicate
+    assert compiled.params == {"p_0": "linear"}

--- a/tests/unit/filter/test_compile_surrealdb.py
+++ b/tests/unit/filter/test_compile_surrealdb.py
@@ -361,7 +361,9 @@ def test_metadata_nested_path_descends_natively() -> None:
     compiled = compile_surrealdb(_ast({"metadata.a.b.c": "v"}), _CTX)
     sql = _norm(compiled.predicate)
     assert "metadata_.a.b.c" in sql
-    assert "(metadata_.a.b.c = $f_0)" in sql
+    # Scalar $eq is array-aware containment; the descent is intact in both arms,
+    # never collapsed/mangled into a single token.
+    assert "(metadata_.a.b.c = $f_0 or (type::is::array(metadata_.a.b.c) and metadata_.a.b.c contains $f_0))" in sql
     assert compiled.params == {"f_0": "v"}
     assert "metadata.a.b.c" in compiled.consumed_keys
 
@@ -380,9 +382,15 @@ def test_metadata_deep_path_not_mangled_into_single_token() -> None:
     assert "labels_region" not in sql
 
 
-def test_metadata_eq_single_segment_descends() -> None:
+def test_metadata_eq_single_segment_is_array_aware() -> None:
+    # Scalar $eq is array-aware containment (matches a scalar field equal to the
+    # operand OR an array field that contains it), mirroring the Postgres @>
+    # two-arm form and the compile_python oracle. The type::is::array guard keeps
+    # the CONTAINS arm from substring-matching a scalar string.
     compiled = compile_surrealdb(_ast({"metadata.tier": "gold"}), _CTX)
-    assert "(metadata_.tier = $f_0)" in _norm(compiled.predicate)
+    assert "(metadata_.tier = $f_0 or (type::is::array(metadata_.tier) and metadata_.tier contains $f_0))" in _norm(
+        compiled.predicate
+    )
     assert compiled.params == {"f_0": "gold"}
 
 
@@ -467,22 +475,38 @@ def test_metadata_direct_datetime_range_is_string_gated() -> None:
 # ===========================================================================
 
 
-def test_metadata_ne_is_bare_not_equals() -> None:
-    # Rule 2 (polarity): a metadata $ne is a plain ``!=`` — already true for an
-    # absent / wrong-type path, so absent rows are admitted without a null guard.
+def test_metadata_ne_is_negated_array_aware_containment() -> None:
+    # Rule 2 (polarity): a metadata $ne negates the array-aware containment form.
+    # The inner is total (false on absent / wrong-type), so the negation admits
+    # absent rows without a null guard.
     compiled = compile_surrealdb(_ast({"metadata.tier": {"$ne": "gold"}}), _CTX)
     sql = _norm(compiled.predicate)
-    assert "(metadata_.tier != $f_0)" in sql
+    assert "!(metadata_.tier = $f_0 or (type::is::array(metadata_.tier) and metadata_.tier contains $f_0))" in sql
     assert "is none" not in sql
     assert compiled.params == {"f_0": "gold"}
 
 
-def test_metadata_nin_is_negated_inside() -> None:
-    # Rule 2: metadata $nin is the negated INSIDE — absent paths are not INSIDE,
-    # so the negation is true (admits absent rows).
+def test_metadata_in_is_array_aware_contains_any() -> None:
+    # $in is array-aware contains-any: a scalar field that is a member of the
+    # operand list (``INSIDE``) OR an array field sharing any element with it
+    # (``CONTAINSANY``, guarded to real arrays). Mirrors the oracle's
+    # ``any(_md_contains(node, v))`` and the canonical ``tags: list[str]`` shape.
+    compiled = compile_surrealdb(_ast({"metadata.tier": {"$in": ["a", "b"]}}), _CTX)
+    sql = _norm(compiled.predicate)
+    assert (
+        "(metadata_.tier inside $f_0 or (type::is::array(metadata_.tier) and metadata_.tier containsany $f_0))" in sql
+    )
+    assert compiled.params == {"f_0": ["a", "b"]}
+
+
+def test_metadata_nin_is_negated_contains_any() -> None:
+    # Rule 2: metadata $nin negates the array-aware contains-any form — absent
+    # paths match neither arm, so the negation is true (admits absent rows).
     compiled = compile_surrealdb(_ast({"metadata.tier": {"$nin": ["a", "b"]}}), _CTX)
     sql = _norm(compiled.predicate)
-    assert "!(metadata_.tier inside $f_0)" in sql
+    assert (
+        "!(metadata_.tier inside $f_0 or (type::is::array(metadata_.tier) and metadata_.tier containsany $f_0))" in sql
+    )
     assert compiled.params == {"f_0": ["a", "b"]}
 
 
@@ -651,14 +675,19 @@ def test_field_mapping_remaps_metadata_root() -> None:
     # ``metadata_`` column — the same compiler serves the schema without any
     # per-engine branching.
     ctx = CompileContext(backend_target="temporal_chunk", field_mapping={"metadata": "metadata_"})
-    assert "(metadata_.tier = $f_0)" in _surql_norm(_ast({"metadata.tier": "gold"}), ctx)
+    assert (
+        "(metadata_.tier = $f_0 or (type::is::array(metadata_.tier) and metadata_.tier contains $f_0))"
+        in _surql_norm(_ast({"metadata.tier": "gold"}), ctx)
+    )
 
 
 def test_field_mapping_default_metadata_root_unremapped() -> None:
     # With no field_mapping the ``metadata`` root is the identity ``metadata`` — the
     # remap is a context choice, not hardcoded into the compiler.
     ctx = CompileContext(backend_target="temporal_chunk")
-    assert "(metadata.tier = $f_0)" in _surql_norm(_ast({"metadata.tier": "gold"}), ctx)
+    assert "(metadata.tier = $f_0 or (type::is::array(metadata.tier) and metadata.tier contains $f_0))" in _surql_norm(
+        _ast({"metadata.tier": "gold"}), ctx
+    )
 
 
 def test_field_mapping_remaps_system_key_name() -> None:

--- a/tests/unit/filter/test_compile_surrealdb_injection.py
+++ b/tests/unit/filter/test_compile_surrealdb_injection.py
@@ -1,0 +1,133 @@
+"""Injection-guard unit test for the SurrealDB recall-filter compiler.
+
+The recall-filter validator only checks that a folded metadata key
+``startswith("metadata.")`` — it does NOT restrict the characters of the
+sub-path segments. The SurrealDB compiler interpolates those segments into the
+predicate string (SurrealQL cannot bind a field name as a parameter), so it MUST
+validate each segment as a safe identifier and raise a controlled compiler fault
+on anything else. This pins that guard.
+
+(The exhaustive emitted-string assertions live in the QA-owned
+``test_compile_surrealdb.py``; this module isolates the security-critical case so
+it cannot regress unnoticed.)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from khora.filter import RecallFilter
+from khora.filter.ast import parse_to_ast
+from khora.filter.compilers.surrealdb import compile_surrealdb
+from khora.filter.context import CompileContext, CompileError
+
+pytestmark = pytest.mark.unit
+
+_CTX = CompileContext(backend_target="temporal_chunk", field_mapping={"metadata": "metadata_"})
+
+
+@pytest.mark.parametrize(
+    "hostile_key",
+    [
+        "metadata.x = 1 OR true; --",  # SurrealQL break-out attempt
+        "metadata.a b",  # whitespace
+        'metadata.a"b',  # quote
+        "metadata.a)b",  # paren
+        "metadata.1abc",  # leading digit
+        "metadata.a-b",  # hyphen
+        "metadata.a.b c",  # unsafe nested segment
+    ],
+)
+def test_unsafe_metadata_segment_raises_compile_error(hostile_key: str) -> None:
+    """An unsafe metadata path segment is a controlled CompileError, not a query.
+
+    The fault is raised regardless of ``on_unsupported`` mode — it is an injection
+    guard, not a capability gap.
+    """
+    ast = parse_to_ast(RecallFilter.model_validate({hostile_key: "v"}))
+    with pytest.raises(CompileError):
+        compile_surrealdb(ast, _CTX)
+
+
+def test_safe_nested_segment_compiles() -> None:
+    """A well-formed nested path descends natively without raising."""
+    ast = parse_to_ast(RecallFilter.model_validate({"metadata.labels.tier": "gold"}))
+    compiled = compile_surrealdb(ast, _CTX)
+    assert "metadata_.labels.tier" in compiled.predicate
+
+
+# ---------------------------------------------------------------------------
+# Legacy ``TemporalFilter.additional`` integration — the bare-equality path.
+#
+# ``TemporalFilter.additional`` keys are NOT char-restricted upstream, and the
+# skeleton SurrealDB backend interpolates them into a WHERE clause. Both the
+# range-op AND the bare-equality paths in ``_build_filter_clauses`` must route
+# through the compiler's injection guard. These tests exercise that real call
+# surface (the compiler-only tests above did not cover the legacy integration).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="store_module")
+def _store_module():  # noqa: ANN202 - test fixture
+    """The skeleton SurrealDB backend module (importing it registers the compiler)."""
+    from khora.engines.skeleton.backends import surrealdb as mod
+
+    return mod
+
+
+@pytest.mark.parametrize(
+    "additional",
+    [
+        {"a.b; DROP TABLE x; --": {"eq": 1}},  # dict-valued $eq, hostile key
+        {"a.b OR true; --": "scalar"},  # scalar-valued (bare) $eq, hostile key
+        {"a b": {"eq": 1}},  # whitespace in a dict-eq key
+        {"1abc": "v"},  # leading digit in a scalar-eq key
+    ],
+)
+def test_legacy_additional_unsafe_key_raises_compile_error(store_module, additional) -> None:  # noqa: ANN001
+    """A hostile ``additional`` key (equality path) is a controlled CompileError.
+
+    Closes the injection hole on the bare-equality branches of
+    ``_build_filter_clauses`` — the key never reaches an interpolated WHERE clause.
+    """
+    from uuid import uuid4
+
+    from khora.engines.skeleton.backends import TemporalFilter
+
+    tf = TemporalFilter(additional=additional)
+    with pytest.raises(CompileError):
+        store_module.SurrealDBTemporalStore._build_filter_clauses(uuid4(), tf)
+
+
+def test_legacy_additional_eq_routes_through_guard(store_module) -> None:  # noqa: ANN001
+    """A safe ``additional`` filter routes every op through the compiler.
+
+    ``eq`` keeps a plain ``metadata_.<path> = $b`` equality (no type-gate), a range
+    op gains a ``type::is::*`` gate, and a nested dotted key descends natively —
+    all with binds carried out-of-band (never the raw user value interpolated).
+    """
+    from uuid import uuid4
+
+    from khora.engines.skeleton.backends import TemporalFilter
+
+    tf = TemporalFilter(
+        additional={
+            "tier": {"eq": "gold"},  # dict-valued $eq
+            "score": {"gte": 5},  # range op (gated)
+            "nested.key": {"gt": 1},  # nested dotted key
+            "flat": "x",  # scalar (bare) $eq
+        }
+    )
+    clauses, bindings = store_module.SurrealDBTemporalStore._build_filter_clauses(uuid4(), tf)
+    joined = " ".join(clauses)
+
+    # Equality paths: plain ``= $bind`` (no type-gate), key descended natively.
+    assert "(metadata_.tier = $af_0_eq_0)" in joined
+    assert "(metadata_.flat = $af_3_eq_0)" in joined
+    # Range path: type-gated.
+    assert "(type::is::number(metadata_.score) AND metadata_.score >= $af_1_gte_0)" in joined
+    # Nested dotted key descends natively.
+    assert "metadata_.nested.key" in joined
+    # User values bind out-of-band, never interpolated.
+    assert bindings["af_0_eq_0"] == "gold"
+    assert bindings["af_3_eq_0"] == "x"

--- a/tests/unit/filter/test_compile_surrealdb_injection.py
+++ b/tests/unit/filter/test_compile_surrealdb_injection.py
@@ -102,9 +102,10 @@ def test_legacy_additional_unsafe_key_raises_compile_error(store_module, additio
 def test_legacy_additional_eq_routes_through_guard(store_module) -> None:  # noqa: ANN001
     """A safe ``additional`` filter routes every op through the compiler.
 
-    ``eq`` keeps a plain ``metadata_.<path> = $b`` equality (no type-gate), a range
-    op gains a ``type::is::*`` gate, and a nested dotted key descends natively —
-    all with binds carried out-of-band (never the raw user value interpolated).
+    ``eq`` is array-aware containment (matching the recall-filter path: a scalar
+    field equal to the value OR an array field containing it), a range op gains a
+    ``type::is::*`` gate, and a nested dotted key descends natively — all with
+    binds carried out-of-band (never the raw user value interpolated).
     """
     from uuid import uuid4
 
@@ -121,9 +122,15 @@ def test_legacy_additional_eq_routes_through_guard(store_module) -> None:  # noq
     clauses, bindings = store_module.SurrealDBTemporalStore._build_filter_clauses(uuid4(), tf)
     joined = " ".join(clauses)
 
-    # Equality paths: plain ``= $bind`` (no type-gate), key descended natively.
-    assert "(metadata_.tier = $af_0_eq_0)" in joined
-    assert "(metadata_.flat = $af_3_eq_0)" in joined
+    # Equality paths: array-aware containment, key descended natively, value bound.
+    assert (
+        "(metadata_.tier = $af_0_eq_0 OR (type::is::array(metadata_.tier) AND metadata_.tier CONTAINS $af_0_eq_0))"
+        in joined
+    )
+    assert (
+        "(metadata_.flat = $af_3_eq_0 OR (type::is::array(metadata_.flat) AND metadata_.flat CONTAINS $af_3_eq_0))"
+        in joined
+    )
     # Range path: type-gated.
     assert "(type::is::number(metadata_.score) AND metadata_.score >= $af_1_gte_0)" in joined
     # Nested dotted key descends natively.


### PR DESCRIPTION
## Summary
- Add `compile_surrealdb`, the SurrealDB half of the deterministic recall-filter compiler family, alongside the existing Postgres and Cypher compilers. It lowers the canonical filter AST to a SurrealQL `WHERE` predicate string plus an out-of-band bind dict.
- **Native nested dot-path descent:** a metadata path like `metadata.a.b.c` descends natively to `metadata_.a.b.c` instead of being collapsed into a single mangled key.
- **`type::is::*` runtime type-gate:** metadata range comparisons emit `(type::is::<t>(path) AND path <op> $b)` so a wrong-typed or absent value is excluded rather than ordered lexicographically or erroring. `bool` is gated before `number` (a bool is not a number).
- **No totality wrapper, by design:** unlike the Postgres/Cypher compilers, there is no `coalesce(..., false)` wrapper. SurrealQL comparisons against an absent (`NONE`) path already return a total boolean, so negation flips absent rows correctly. This divergence is documented in the module docstring (verified against embedded SurrealDB).
- **Wired into the Skeleton SurrealDB backend:** the recall-filter AST is now compiled and AND-ed into the search `WHERE` (previously accepted but ignored), and the compiler is registered for the backend's engine/target.
- **Dropped the legacy single-segment field-name string mangling** in the backend's additional-filter path. Every legacy key now routes through the compiler, gaining native nested descent, numeric (not lexicographic) range ordering, and a strict path-segment injection guard. User-supplied metadata path segments are validated as identifiers before interpolation; user values always bind as parameters.

## Test plan
- [x] Unit tests pass (full unit suite: 7378 passed, 0 failed)
- [x] Conformance corpus for the new compiler (operators, nested descent, type-gates, the field-match rules, negation, envelope)
- [x] Injection-rejection suite (hostile metadata keys on both the compiler and the legacy path raise)
- [x] Legacy additional-filter behavioral coverage (eq + range type-gating, nested descent, distinct binds)
- [x] Embedded-SurrealDB integration test: nested descent, type-mismatch exclusion, and negation row-sets verified against a live in-memory engine
- [ ] Full Dockerized Postgres/Neo4j integration suite — runs in CI (no Docker in the local authoring environment)