### PR TITLE
Fix Neo4j-backed integration tests and the graph bugs they exposed

### DIFF
--- a/src/khora/engines/_forget_cascade.py
+++ b/src/khora/engines/_forget_cascade.py
@@ -103,6 +103,17 @@ async def cascade_forget_extraction(
     entities = await primary.list_entities(namespace_id, limit=_SCAN_LIMIT)
     relationships = await primary.list_relationships(namespace_id, limit=_SCAN_LIMIT)
 
+    # Relationships are classified from whichever store actually holds them.
+    # On a PG+graph stack the vector ``relationships`` table is not written
+    # (relationships live in the graph backend), so the pgvector primary
+    # returns an empty list and every survivor relationship would silently
+    # keep the forgotten doc id. When the primary holds no relationships but
+    # the mirror (graph) can list them, classify off the mirror's rows so
+    # their ids match the graph nodes the strip/delete targets. Entities stay
+    # anchored on the primary unchanged.
+    if not relationships and mirror is not None and callable(getattr(mirror, "list_relationships", None)):
+        relationships = await mirror.list_relationships(namespace_id, limit=_SCAN_LIMIT)
+
     orphan_ent_ids = [e.id for e in entities if _is_orphan(e, document_id)]
     survive_ent_ids = [e.id for e in entities if _is_survivor(e, document_id)]
     orphan_rel_ids = [r.id for r in relationships if _is_orphan(r, document_id)]

--- a/src/khora/engines/_forget_cascade.py
+++ b/src/khora/engines/_forget_cascade.py
@@ -193,7 +193,7 @@ async def _strip_relationships(store: Any, ids: list[UUID], document_id: UUID, n
     if store is None:
         return
     if callable(getattr(store, "remove_document_from_relationship_sources_batch", None)):
-        await store.remove_document_from_relationship_sources_batch(ids, document_id)
+        await store.remove_document_from_relationship_sources_batch(ids, document_id, namespace_id)
     elif callable(getattr(store, "remove_document_from_relationship_sources", None)):
         await store.remove_document_from_relationship_sources(ids, document_id)
     elif callable(getattr(store, "strip_document_from_relationships", None)):

--- a/src/khora/engines/vectorcypher/dual_nodes.py
+++ b/src/khora/engines/vectorcypher/dual_nodes.py
@@ -517,9 +517,12 @@ class DualNodeManager:
                 temporal_conditions.append("c.channel = $channel")
                 params["channel"] = temporal_filter.channel
 
-        # For temporal queries, prefer entities whose validity hasn't expired
+        # For temporal queries, prefer entities whose validity hasn't expired.
+        # valid_until is stored as an ISO string, so coerce with datetime()
+        # before comparing against the ZONED DATETIME — a bare string > datetime
+        # comparison yields NULL and would drop every current entity.
         if prefer_current:
-            temporal_conditions.append("(e.valid_until IS NULL OR e.valid_until > datetime())")
+            temporal_conditions.append("(e.valid_until IS NULL OR datetime(e.valid_until) > datetime())")
 
         where_clause = ""
         if temporal_conditions:
@@ -634,13 +637,20 @@ class DualNodeManager:
         # validity has expired. NULL valid_until is kept (no known end = still valid).
         # Hoist datetime() into a WITH clause so it is evaluated once per row,
         # not once per relationship in the all() predicate.
+        #
+        # valid_until is persisted as an ISO STRING (``.isoformat()`` at the
+        # neo4j backend boundary), so coerce it with Cypher datetime() before
+        # comparing against the ZONED DATETIME ``_now``. A bare ``string > datetime``
+        # comparison yields NULL, which would silently drop every future-dated
+        # edge from the neighborhood.
         temporal_preamble = ""
         temporal_clause = ""
         if prefer_current:
             temporal_preamble = "WITH e, datetime() AS _now"
             temporal_clause = (
-                "AND (related.valid_until IS NULL OR related.valid_until > _now)"
-                "\n          AND all(r IN relationships(path) WHERE r.valid_until IS NULL OR r.valid_until > _now)"
+                "AND (related.valid_until IS NULL OR datetime(related.valid_until) > _now)"
+                "\n          AND all(r IN relationships(path) "
+                "WHERE r.valid_until IS NULL OR datetime(r.valid_until) > _now)"
             )
 
         # OPTIMIZATION: Single query fetches all neighborhoods in batch

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -3596,11 +3596,13 @@ RETURN count(r) AS updated
         self,
         relationship_ids: list[UUID],
         document_id: UUID,
+        namespace_id: UUID,
     ) -> int:
         """Strip ``document_id`` from survivor relationships' source arrays.
 
         Sibling to :meth:`remove_document_from_entity_sources_batch` for
-        the edge side of the cascade.
+        the edge side of the cascade. The match is scoped to ``namespace_id``
+        so a strip never crosses the namespace boundary.
 
         Returns the number of relationships updated.
         """
@@ -3611,13 +3613,14 @@ RETURN count(r) AS updated
             result = await tx.run(
                 """
                 UNWIND $relationship_ids AS rid
-                MATCH ()-[r {id: rid}]-()
+                MATCH ()-[r {id: rid, namespace_id: $namespace_id}]-()
                 WITH DISTINCT r
                 SET r.source_document_ids =
                         [d IN coalesce(r.source_document_ids, []) WHERE d <> $doc_id]
                 RETURN count(r) AS updated
                 """,
                 relationship_ids=[str(rid) for rid in relationship_ids],
+                namespace_id=str(namespace_id),
                 doc_id=str(document_id),
             )
             record = await result.single()

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -3443,16 +3443,22 @@ RETURN count(r) AS updated
             async def _remap_entities(tx: AsyncManagedTransaction) -> None:
                 # Single-branch, tolerant form:
                 #   filtered = array with every occurrence of old_doc_id removed
-                #   append new_doc_id only if not already present
+                #   append new_doc_id only when old_doc_id was actually present
+                #   AND new_doc_id is not already present
                 # Idempotent on retry AND tolerant of pre-existing duplicates
                 # (e.g. ``[old, old, new]`` from a partially-written prior run
                 # collapses cleanly to ``[new]`` instead of ``[new, new]``).
+                # When old_doc_id is absent the remap is a no-op: appending
+                # new_doc_id then would grow an array that never referenced the
+                # remapped document.
                 query = """
                 UNWIND $survivors AS s
                 MATCH (e:Entity {id: s.entity_id, namespace_id: $namespace_id})
-                WITH e, s, [x IN coalesce(e.source_document_ids, []) WHERE x <> s.old_doc_id] AS filtered
+                WITH e, s, coalesce(e.source_document_ids, []) AS original
+                WITH e, s, original, [x IN original WHERE x <> s.old_doc_id] AS filtered
                 SET e.source_document_ids = filtered +
-                    CASE WHEN s.new_doc_id IN filtered THEN [] ELSE [s.new_doc_id] END
+                    CASE WHEN s.old_doc_id IN original AND NOT s.new_doc_id IN filtered
+                        THEN [s.new_doc_id] ELSE [] END
                 """
                 await tx.run(query, survivors=entity_survivors, namespace_id=ns_str)
 
@@ -3471,9 +3477,11 @@ RETURN count(r) AS updated
                 UNWIND $survivors AS s
                 MATCH ()-[rel {id: s.relationship_id, namespace_id: $namespace_id}]-()
                 WITH DISTINCT rel, s
-                WITH rel, s, [x IN coalesce(rel.source_document_ids, []) WHERE x <> s.old_doc_id] AS filtered
+                WITH rel, s, coalesce(rel.source_document_ids, []) AS original
+                WITH rel, s, original, [x IN original WHERE x <> s.old_doc_id] AS filtered
                 SET rel.source_document_ids = filtered +
-                    CASE WHEN s.new_doc_id IN filtered THEN [] ELSE [s.new_doc_id] END
+                    CASE WHEN s.old_doc_id IN original AND NOT s.new_doc_id IN filtered
+                        THEN [s.new_doc_id] ELSE [] END
                 """
                 await tx.run(query, survivors=relationship_survivors, namespace_id=ns_str)
 

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -620,6 +620,12 @@ class StorageCoordinator:
             entity_retirement_rows: list[dict[str, str]] = []
             entity_survivor_keys: set[tuple[str, str]] = set()
             entity_survivor_remap_rows: list[dict[str, str]] = []
+            # Co-sourced entities that the NEW extraction no longer mentions:
+            # another document still sources them (source_document_count > 1),
+            # so they must survive — but the replaced document's id must be
+            # stripped from their source_document_ids. Without this they keep a
+            # dangling reference to a document that no longer extracts them.
+            entity_survivor_strip_ids: list[UUID] = []
             for rec in old_entity_records:
                 # Belt-and-suspenders: skip cross-namespace leaks even though
                 # the prefetch Cypher is already namespace-scoped.
@@ -646,6 +652,10 @@ class StorageCoordinator:
                             "retired_at": retired_at_iso,
                         }
                     )
+                else:
+                    # Co-sourced (count > 1) and dropped from the new
+                    # extraction: keep the node, strip the old document id.
+                    entity_survivor_strip_ids.append(UUID(rec["id"]))
 
             # For relationships, identity is (src_entity, tgt_entity,
             # sanitized_type).  Both sides of the comparison are now
@@ -653,6 +663,10 @@ class StorageCoordinator:
             # correctly as survivors instead of leaking into net-new + retire.
             relationship_retirement_rows: list[dict[str, Any]] = []
             relationship_survivor_remap_rows: list[dict[str, str]] = []
+            # Mirror of entity_survivor_strip_ids for the edge side: co-sourced
+            # relationships dropped from the new extraction survive but must
+            # lose the replaced document id from their source arrays.
+            relationship_survivor_strip_ids: list[UUID] = []
             for rec in old_relationship_records:
                 rel_id = rec["id"]
                 rel_key = (
@@ -676,6 +690,10 @@ class StorageCoordinator:
                             "retired_at": retired_at,
                         }
                     )
+                else:
+                    # Co-sourced (count > 1) and dropped from the new
+                    # extraction: keep the edge, strip the old document id.
+                    relationship_survivor_strip_ids.append(UUID(rel_id))
 
             # 2. Postgres transaction: atomic chunk hard-replace.
             #    Embedding (OpenAI roundtrip) happened before this block - the
@@ -733,6 +751,20 @@ class StorageCoordinator:
                         entity_survivors=entity_survivor_remap_rows,
                         relationship_survivors=relationship_survivor_remap_rows,
                         namespace_id=namespace_id,
+                    )
+
+                # Strip the replaced document id from co-sourced survivors the
+                # new extraction no longer mentions (entities/relationships with
+                # source_document_count > 1). Unlike remap (swap old->new), these
+                # keys are absent from the new extraction, so there is no new
+                # doc id to swap in — the old id is simply removed.
+                if entity_survivor_strip_ids:
+                    await self._graph.remove_document_from_entity_sources_batch(  # type: ignore[unresolved-attribute]
+                        entity_survivor_strip_ids, old_document_id, namespace_id
+                    )
+                if relationship_survivor_strip_ids:
+                    await self._graph.remove_document_from_relationship_sources_batch(  # type: ignore[unresolved-attribute]
+                        relationship_survivor_strip_ids, old_document_id
                     )
 
                 net_new_entities = [e for e in new_entities if (e.name, e.entity_type) not in entity_survivor_keys]

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -764,7 +764,7 @@ class StorageCoordinator:
                     )
                 if relationship_survivor_strip_ids:
                     await self._graph.remove_document_from_relationship_sources_batch(  # type: ignore[unresolved-attribute]
-                        relationship_survivor_strip_ids, old_document_id
+                        relationship_survivor_strip_ids, old_document_id, namespace_id
                     )
 
                 net_new_entities = [e for e in new_entities if (e.name, e.entity_type) not in entity_survivor_keys]

--- a/tests/integration/test_coordinator_replace_document_extraction.py
+++ b/tests/integration/test_coordinator_replace_document_extraction.py
@@ -38,7 +38,7 @@ from khora.storage.backends.pgvector import PgVectorBackend
 from khora.storage.backends.postgresql import PostgreSQLBackend
 from khora.storage.coordinator import ReplaceResult, StorageCoordinator
 
-EMBED_DIM = 4
+EMBED_DIM = 1536
 
 
 def _chunks(namespace_id, document_id, count=2) -> list[Chunk]:
@@ -88,13 +88,15 @@ class TestReplaceDocumentExtractionIntegration:
     async def namespace_id(self, coord: StorageCoordinator):
         ns = MemoryNamespace()
         created = await coord.create_namespace(ns)
-        return created.namespace_id
+        # Coordinator primitives (create_document, upsert_entities_batch, ...)
+        # write the passed id verbatim into FK columns referencing
+        # memory_namespaces.id (the row PK), so resolve the stable
+        # namespace_id to the active version's row id first. Production
+        # Khora.remember() does this resolution before reaching the
+        # coordinator; these coordinator-level tests must do it explicitly.
+        return await coord.resolve_namespace(created.namespace_id)
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="tracked in #1033: PG namespace FK violation (namespace_id_fkey) on first CI run; quarantined pending triage against a live stack.",
-        strict=False,
-    )
     async def test_happy_path_mixed_retire_survive_net_new(self, coord: StorageCoordinator, namespace_id) -> None:
         """Full lifecycle: orphan retires, survivor remaps, net-new is created."""
         # Seed: old document with 2 chunks, a survivor entity (alice), an orphan entity (bob)
@@ -173,7 +175,7 @@ class TestReplaceDocumentExtractionIntegration:
         assert result.relationships_created == 0
 
         # Document is COMPLETED
-        persisted = await coord.get_document(new_doc.id)
+        persisted = await coord.get_document(new_doc.id, namespace_id=namespace_id)
         assert persisted is not None
         assert persisted.status == DocumentStatus.COMPLETED
 
@@ -181,12 +183,14 @@ class TestReplaceDocumentExtractionIntegration:
         chunks = await coord.get_chunks_by_document(new_doc.id, namespace_id=namespace_id)
         assert len(chunks) == 3
 
-        # Graph state: alice's source_document_ids has new_doc.id (swap happened),
-        # bob is retired (valid_until set), carol is net-new.
+        # Graph state: alice survives the replace, bob is retired (valid_until
+        # set), carol is net-new. This is an in-place replace
+        # (new_doc.id == old_doc.id), so the survivor remap leaves the shared
+        # doc id present rather than swapping one UUID for another; assert
+        # alice is still associated with the surviving doc id.
         alice_fetched = await coord.get_entity(alice.id, namespace_id=namespace_id)
         assert alice_fetched is not None
         assert new_doc.id in alice_fetched.source_document_ids
-        assert old_doc.id not in alice_fetched.source_document_ids
 
         bob_fetched = await coord.get_entity(bob.id, namespace_id=namespace_id)
         assert bob_fetched is not None
@@ -199,10 +203,6 @@ class TestReplaceDocumentExtractionIntegration:
         assert knows[0].valid_until is not None
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="tracked in #1033: PG namespace FK violation (namespace_id_fkey) on first CI run; quarantined pending triage against a live stack.",
-        strict=False,
-    )
     async def test_graph_failure_keeps_document_completed_then_next_replace_succeeds(
         self, coord: StorageCoordinator, namespace_id, monkeypatch
     ) -> None:
@@ -240,7 +240,12 @@ class TestReplaceDocumentExtractionIntegration:
         )
         await coord.upsert_entities_batch(namespace_id, [sole])
 
-        orig_retire = coord.graph.retire_orphaned_entities_batch  # type: ignore[union-attr]
+        # ``coord.graph`` is a NamespaceRequiredProxy (the coordinator wraps
+        # every public backend attr in __setattr__ regardless of how it was
+        # constructed); it has no __dict__ and rejects setattr, so patch the
+        # real backend behind it.
+        graph_backend = getattr(coord.graph, "_backend", coord.graph)
+        orig_retire = graph_backend.retire_orphaned_entities_batch  # type: ignore[union-attr]
         call_count = {"n": 0}
 
         async def flaky_retire(*args, **kwargs):
@@ -250,7 +255,7 @@ class TestReplaceDocumentExtractionIntegration:
             return await orig_retire(*args, **kwargs)
 
         monkeypatch.setattr(
-            coord.graph,  # type: ignore[arg-type]
+            graph_backend,
             "retire_orphaned_entities_batch",
             flaky_retire,
         )
@@ -276,7 +281,7 @@ class TestReplaceDocumentExtractionIntegration:
         assert isinstance(exc_info.value.__cause__, RuntimeError)
         assert "injected graph failure" in str(exc_info.value.__cause__)
 
-        after_graph_fail = await coord.get_document(new_doc.id)
+        after_graph_fail = await coord.get_document(new_doc.id, namespace_id=namespace_id)
         assert after_graph_fail is not None
         assert after_graph_fail.status == DocumentStatus.COMPLETED
         assert after_graph_fail.error_message is None
@@ -303,6 +308,6 @@ class TestReplaceDocumentExtractionIntegration:
         )
         assert result.document_id == new_doc2.id
 
-        healed = await coord.get_document(new_doc2.id)
+        healed = await coord.get_document(new_doc2.id, namespace_id=namespace_id)
         assert healed is not None
         assert healed.status == DocumentStatus.COMPLETED

--- a/tests/integration/test_forget_cascade_orphans_integration.py
+++ b/tests/integration/test_forget_cascade_orphans_integration.py
@@ -43,7 +43,7 @@ from khora.extraction.extractors.base import (
 )
 from khora.khora import Khora
 
-EMBED_DIM = 4
+EMBED_DIM = 1536
 
 _EXTRACTION_REGISTRY: dict[str, ExtractionResult] = {}
 
@@ -98,10 +98,6 @@ async def _run_cypher(driver: Any, query: str, **params: Any) -> list[dict[str, 
     not os.environ.get("NEO4J_INTEGRATION_TEST"),
     reason="set NEO4J_INTEGRATION_TEST=1 to run against real backends (requires make dev)",
 )
-@pytest.mark.xfail(
-    reason="tracked in #1033: never-run-in-CI replace/forget lifecycle; first CI run hit fixture event-loop binding + downstream PG/graph failures. Quarantined pending triage against a live PG+Neo4j stack.",
-    strict=False,
-)
 class TestForgetCascadeOrphansIntegration:
     """End-to-end forget()-cascade behaviour against real Postgres + Neo4j."""
 
@@ -155,7 +151,12 @@ class TestForgetCascadeOrphansIntegration:
     def _graph_driver(self, kb: Khora) -> Any:
         graph = kb.storage.graph
         assert graph is not None, "graph backend must be configured"
-        driver = getattr(graph, "_driver", None)
+        # ``kb.storage.graph`` is a NamespaceRequiredProxy (IDOR hardening,
+        # PR #769) whose __getattr__ raises for any "_"-prefixed name, so
+        # unwrap to the real backend first; ``_backend`` is a real slot found
+        # by plain getattr before __getattr__ is consulted.
+        backend = getattr(graph, "_backend", graph)
+        driver = getattr(backend, "_driver", None)
         assert driver is not None, "Neo4j driver must be connected"
         return driver
 
@@ -174,6 +175,10 @@ class TestForgetCascadeOrphansIntegration:
         )
 
     @pytest.mark.asyncio
+    @pytest.mark.xfail(
+        reason="tracked in #1039: pgvector entity upsert clobbers source_document_ids on conflict, so the forget cascade misclassifies the co-sourced survivor and never strips the forgotten doc id. Fix is a hot ingest-path change tracked separately from #1033.",
+        strict=False,
+    )
     async def test_forget_removes_orphan_entity_from_search_and_explore(self, kb: Khora, namespace_id: UUID) -> None:
         """Orphan entity disappears from entity_search and find_related_entities
         after forget().
@@ -221,7 +226,7 @@ class TestForgetCascadeOrphansIntegration:
         )
 
         # Sanity: pre-forget — all 3 entities surface via entity_search.
-        results = await kb.search_entities(namespace_id=namespace_id, query="anyone", limit=50)
+        results = await kb.search_entities(query="anyone", namespace=namespace_id, limit=50)
         names_before = {e.name for e in results}
         assert alice in names_before
         assert mallory in names_before, (
@@ -248,7 +253,7 @@ class TestForgetCascadeOrphansIntegration:
         # ----- Assertions: orphan entity gone, survivor remains -----
 
         # 1. mallory (single-source on doc_a) gone from entity_search.
-        results_after = await kb.search_entities(namespace_id=namespace_id, query="anyone", limit=50)
+        results_after = await kb.search_entities(query="anyone", namespace=namespace_id, limit=50)
         names_after = {e.name for e in results_after}
         assert mallory not in names_after, (
             f"orphan entity {mallory!r} still surfaced by entity_search after forget(doc_a). Got names: {names_after}"
@@ -309,7 +314,7 @@ class TestForgetCascadeOrphansIntegration:
         alice_id = UUID(alice_row_after[0]["id"])
         related = await kb.find_related_entities(
             entity_id=alice_id,
-            namespace_id=namespace_id,
+            namespace=namespace_id,
             max_depth=1,
             limit=20,
         )

--- a/tests/integration/test_graph_namespace_isolation_integration.py
+++ b/tests/integration/test_graph_namespace_isolation_integration.py
@@ -36,7 +36,7 @@ from khora.storage.backends.pgvector import PgVectorBackend
 from khora.storage.backends.postgresql import PostgreSQLBackend
 from khora.storage.coordinator import StorageCoordinator
 
-EMBED_DIM = 4
+EMBED_DIM = 1536
 
 
 @pytest.mark.integration
@@ -72,13 +72,15 @@ class TestGraphNamespaceIsolationIntegration:
     async def two_namespaces(self, coord: StorageCoordinator):
         ns_a = await coord.create_namespace(MemoryNamespace())
         ns_b = await coord.create_namespace(MemoryNamespace())
-        return ns_a.namespace_id, ns_b.namespace_id
+        # Coordinator primitives write the passed id verbatim into FK
+        # columns referencing memory_namespaces.id (the row PK), so resolve
+        # each stable namespace_id to its active version's row id first.
+        return (
+            await coord.resolve_namespace(ns_a.namespace_id),
+            await coord.resolve_namespace(ns_b.namespace_id),
+        )
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="tracked in #1033: PG namespace FK violation (namespace_id_fkey) on first CI run; quarantined pending triage against a live stack.",
-        strict=False,
-    )
     async def test_get_entity_isolated_across_namespaces(self, coord: StorageCoordinator, two_namespaces) -> None:
         """Entity created in ns A is invisible to ns B even with the ID."""
         ns_a, ns_b = two_namespaces
@@ -99,10 +101,6 @@ class TestGraphNamespaceIsolationIntegration:
         assert fetched_cross is None
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="tracked in #1033: PG namespace FK violation (namespace_id_fkey) on first CI run; quarantined pending triage against a live stack.",
-        strict=False,
-    )
     async def test_get_relationship_isolated_across_namespaces(self, coord: StorageCoordinator, two_namespaces) -> None:
         """Relationship created in ns A is invisible to ns B."""
         ns_a, ns_b = two_namespaces

--- a/tests/integration/test_neo4j_neighborhood_valid_until_integration.py
+++ b/tests/integration/test_neo4j_neighborhood_valid_until_integration.py
@@ -53,10 +53,6 @@ class TestDualNodeManagerValidUntilFiltering:
     """End-to-end tests for valid_until filtering in get_entity_neighborhoods."""
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="tracked in #1033: prefer_current future valid_until filtering returned empty on first CI run; quarantined pending triage.",
-        strict=False,
-    )
     async def test_future_valid_until_surfaces_with_prefer_current_true(self) -> None:
         """Relationship with valid_until in future is included when prefer_current=True."""
         url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")

--- a/tests/integration/test_neo4j_remap_source_document_ids_integration.py
+++ b/tests/integration/test_neo4j_remap_source_document_ids_integration.py
@@ -87,10 +87,6 @@ class TestNeo4jRemapSourceDocumentIdsIntegration:
             await backend.disconnect()
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="tracked in #1033: source-document-id remap count mismatch (got 3, expected 2) on first CI run; quarantined pending triage.",
-        strict=False,
-    )
     async def test_entity_remap_old_doc_not_in_array(self) -> None:
         """Remap with old_doc_id absent from array leaves source_document_ids unchanged."""
         url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
@@ -339,10 +335,6 @@ class TestNeo4jRemapSourceDocumentIdsIntegration:
             await backend.disconnect()
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="tracked in #1033: source-document-id remap count mismatch (got 3, expected 2) on first CI run; quarantined pending triage.",
-        strict=False,
-    )
     async def test_relationship_remap_old_doc_not_in_array(self) -> None:
         """Remap with old_doc_id absent from array leaves relationship source_document_ids unchanged."""
         url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")

--- a/tests/integration/test_replace_document_extraction.py
+++ b/tests/integration/test_replace_document_extraction.py
@@ -45,8 +45,9 @@ Connection parameters (env overrides, sensible ``make dev`` defaults)::
     KHORA_NEO4J_PASSWORD     (default: password)
     KHORA_DATABASE_URL       (default: postgresql+asyncpg://khora:khora@localhost:5432/khora)
 
-Embedding dimension is pinned to 4 (matching the sibling test) via an
-``embed_batch`` monkeypatch. All entity extraction is driven by a
+Embedding dimension is pinned to 1536 (matching the sibling test and the
+``chunks.embedding`` / ``entities.embedding`` ``vector(1536)`` columns) via
+an ``embed_batch`` monkeypatch. All entity extraction is driven by a
 registry-based stub that matches markers in the document content.
 """
 
@@ -70,7 +71,7 @@ from khora.extraction.extractors.base import (
 )
 from khora.khora import Khora, RememberResult
 
-EMBED_DIM = 4
+EMBED_DIM = 1536
 
 # Module-scoped extraction registry. ``plan_extraction`` stages the
 # ExtractionResult returned for any text containing ``marker``; the
@@ -228,10 +229,6 @@ async def _get_relationship(
     not os.environ.get("NEO4J_INTEGRATION_TEST"),
     reason="set NEO4J_INTEGRATION_TEST=1 to run against real backends (requires make dev)",
 )
-@pytest.mark.xfail(
-    reason="tracked in #1033: never-run-in-CI replace/forget lifecycle; first CI run hit fixture event-loop binding + downstream PG/graph failures. Quarantined pending triage against a live PG+Neo4j stack.",
-    strict=False,
-)
 class TestReplaceViaRememberIntegration:
     """End-to-end replace lifecycle through ``Khora.remember()``."""
 
@@ -302,7 +299,12 @@ class TestReplaceViaRememberIntegration:
     def _graph_driver(self, kb: Khora) -> Any:
         graph = kb.storage.graph
         assert graph is not None, "graph backend must be configured"
-        driver = getattr(graph, "_driver", None)
+        # ``kb.storage.graph`` is a NamespaceRequiredProxy (IDOR hardening,
+        # PR #769) whose __getattr__ raises for any "_"-prefixed name, so
+        # unwrap to the real backend first; ``_backend`` is a real slot found
+        # by plain getattr before __getattr__ is consulted.
+        backend = getattr(graph, "_backend", graph)
+        driver = getattr(backend, "_driver", None)
         assert driver is not None, "Neo4j driver must be connected"
         return driver
 
@@ -363,7 +365,7 @@ class TestReplaceViaRememberIntegration:
         # Same document id reused across replacements.
         assert v1.document_id == v2.document_id
 
-        doc = await kb.get_document(v2.document_id)
+        doc = await kb.get_document(v2.document_id, namespace=namespace_id)
         assert doc is not None
         assert doc.status == DocumentStatus.COMPLETED
         assert doc.external_id == ext
@@ -428,27 +430,31 @@ class TestReplaceViaRememberIntegration:
         dave = f"dave-{uuid4().hex[:6]}"
         eve = f"eve-{uuid4().hex[:6]}"
 
+        # Markers must be pairwise non-substring: the extraction stub matches
+        # the FIRST registered marker found in the text, so the doc-A v2 marker
+        # below must not contain the doc-A v1 marker (else v2 re-extracts dave
+        # and the replace never drops him). Use disjoint tokens.
         plan_extraction(
-            "cs-doc-a",
+            "csdocaOrig",
             entities=[(dave, "PERSON")],
             relationships=[],
         )
         result_a = await self._remember(
             kb,
             namespace_id=namespace_id,
-            content=f"cs-doc-a mentions {dave}.",
+            content=f"csdocaOrig mentions {dave}.",
             external_id=ext_a,
         )
 
         plan_extraction(
-            "cs-doc-b",
+            "csdocb",
             entities=[(dave, "PERSON")],
             relationships=[],
         )
         result_b = await self._remember(
             kb,
             namespace_id=namespace_id,
-            content=f"cs-doc-b also mentions {dave}.",
+            content=f"csdocb also mentions {dave}.",
             external_id=ext_b,
         )
         # Confirm co-sourcing before replacing.
@@ -457,16 +463,18 @@ class TestReplaceViaRememberIntegration:
         assert str(result_a.document_id) in dave_pre["sdids"]
         assert str(result_b.document_id) in dave_pre["sdids"]
 
-        # Replace doc A with extraction that drops Dave entirely.
+        # Replace doc A with extraction that drops Dave entirely. The v2 marker
+        # "csdocaRevision" is not a superset of the v1 marker "csdocaOrig", so
+        # the stub matches v2 → extracts eve (not dave).
         plan_extraction(
-            "cs-doc-a-v2",
+            "csdocaRevision",
             entities=[(eve, "PERSON")],
             relationships=[],
         )
         await self._remember(
             kb,
             namespace_id=namespace_id,
-            content=f"cs-doc-a-v2 no longer mentions the original person; {eve} stepped in.",
+            content=f"csdocaRevision no longer mentions the original person; {eve} stepped in.",
             external_id=ext_a,
         )
 
@@ -576,7 +584,9 @@ class TestReplaceViaRememberIntegration:
         # aborted replace (PG rollback is the invariant).
         chunks_before = await kb.storage.get_chunks_by_document(v1.document_id, namespace_id=namespace_id)
 
-        vector_backend = kb.storage.vector
+        # ``kb.storage.vector`` is a NamespaceRequiredProxy (no __dict__,
+        # rejects setattr); patch the real backend behind it.
+        vector_backend = getattr(kb.storage.vector, "_backend", kb.storage.vector)
         assert vector_backend is not None
         call_count = {"n": 0}
 
@@ -618,7 +628,7 @@ class TestReplaceViaRememberIntegration:
         # rolled-back transaction also reverts the in-tx status stamp, so
         # the row keeps its prior (v1) COMPLETED status.  The exception
         # still propagates to the caller.
-        post_rollback = await kb.get_document(v1.document_id)
+        post_rollback = await kb.get_document(v1.document_id, namespace=namespace_id)
         assert post_rollback is not None
         assert post_rollback.status != DocumentStatus.FAILED
 
@@ -661,7 +671,9 @@ class TestReplaceViaRememberIntegration:
             external_id=ext,
         )
 
-        graph = kb.storage.graph
+        # ``kb.storage.graph`` is a NamespaceRequiredProxy (no __dict__,
+        # rejects setattr); patch the real backend behind it.
+        graph = getattr(kb.storage.graph, "_backend", kb.storage.graph)
         assert graph is not None
         orig_retire = graph.retire_orphaned_entities_batch  # type: ignore[unresolved-attribute]
         call_count = {"n": 0}
@@ -674,23 +686,29 @@ class TestReplaceViaRememberIntegration:
 
         monkeypatch.setattr(graph, "retire_orphaned_entities_batch", flaky_retire)
 
-        # v2 retirement fails mid-way → document lands in FAILED.
+        # v2 retirement fails mid-graph. Per #884, _remember_via_replace catches
+        # GraphMirrorFailedAfterPGCommitError (the PG tx already committed) and
+        # returns a degraded RememberResult instead of re-raising; the
+        # divergence is surfaced via metadata["degradations"] (ADR-001).
         plan_extraction(
             "heal-v2",
             entities=[],  # orphans doomed
             relationships=[],
         )
-        with pytest.raises(RuntimeError, match="injected graph failure"):
-            await self._remember(
-                kb,
-                namespace_id=namespace_id,
-                content="heal-v2 no entities at all.",
-                external_id=ext,
-            )
+        degraded = await self._remember(
+            kb,
+            namespace_id=namespace_id,
+            content="heal-v2 no entities at all.",
+            external_id=ext,
+        )
+        degradations = degraded.metadata.get("degradations", [])
+        assert any(d.get("issue") == "884" for d in degradations), (
+            f"expected a #884 graph-mirror degradation in result metadata; got {degradations!r}"
+        )
 
         # #887: PG tx committed (chunks + status stamp persisted), so the
         # document stays COMPLETED even though the graph-side retire raised.
-        post_graph_fail = await kb.get_document(v1.document_id)
+        post_graph_fail = await kb.get_document(v1.document_id, namespace=namespace_id)
         assert post_graph_fail is not None
         assert post_graph_fail.status == DocumentStatus.COMPLETED
         assert post_graph_fail.error_message is None
@@ -709,7 +727,7 @@ class TestReplaceViaRememberIntegration:
             external_id=ext,
         )
 
-        healed = await kb.get_document(v1.document_id)
+        healed = await kb.get_document(v1.document_id, namespace=namespace_id)
         assert healed is not None
         assert healed.status == DocumentStatus.COMPLETED
         assert healed.error_message is None

--- a/tests/integration/test_windowed_processing_submit_batch.py
+++ b/tests/integration/test_windowed_processing_submit_batch.py
@@ -233,10 +233,6 @@ class TestWindowedProcessingIntegration:
     # 9. Cross-window entity count not inflated
     # ------------------------------------------------------------------
 
-    @pytest.mark.xfail(
-        reason="tracked in #1033: cross-window entity count returned 0 (expected 2) on first CI run; quarantined pending triage.",
-        strict=False,
-    )
     async def test_cross_window_entity_count_not_inflated(self) -> None:
         """BatchResult.entities must not double-count shared entities across windows.
 
@@ -262,10 +258,16 @@ class TestWindowedProcessingIntegration:
             _plan_extraction(marker_unique, entities=[("UniqueEntity", "CONCEPT")])
             _plan_extraction(marker_alice, entities=[("Alice", "PERSON")])
 
+            # Each content must exceed the windowed-extraction min_extraction_tokens
+            # gate (50 words; engine.py skips docs whose chunks are all shorter).
+            # Pad with filler while keeping the marker substring so the extraction
+            # stub still matches. The marker still drives which entity is extracted;
+            # the padding only carries the chunk over the word-count gate.
+            _pad = " ".join(f"context detail line number {n} for this record" for n in range(12))
             docs = [
-                {"content": f"{marker_unique} only in doc 0", "external_id": f"cw-{ext}-0"},
-                {"content": f"{marker_alice} first time", "external_id": f"cw-{ext}-1"},
-                {"content": f"{marker_alice} second time", "external_id": f"cw-{ext}-2"},
+                {"content": f"{marker_unique} only in doc 0. {_pad}", "external_id": f"cw-{ext}-0"},
+                {"content": f"{marker_alice} first time. {_pad}", "external_id": f"cw-{ext}-1"},
+                {"content": f"{marker_alice} second time. {_pad}", "external_id": f"cw-{ext}-2"},
             ]
 
             result = await kb.remember_batch(

--- a/tests/unit/engines/test_chronicle_engine.py
+++ b/tests/unit/engines/test_chronicle_engine.py
@@ -169,7 +169,7 @@ class TestChronicleEngineForget:
             [survivor_rel_id], doc_id
         )
         connected_engine._storage.graph.remove_document_from_relationship_sources_batch.assert_awaited_once_with(
-            [survivor_rel_id], doc_id
+            [survivor_rel_id], doc_id, namespace_id
         )
         connected_engine._storage.vector.delete_relationships_batch.assert_not_called()
 

--- a/tests/unit/engines/test_chronicle_engine.py
+++ b/tests/unit/engines/test_chronicle_engine.py
@@ -64,6 +64,7 @@ class TestChronicleEngineForget:
         engine._storage.vector.remove_document_from_relationship_sources = AsyncMock()
         # Graph backend exposes the Neo4j-style batch helpers (mirror).
         engine._storage.graph = MagicMock()
+        engine._storage.graph.list_relationships = AsyncMock(return_value=[])
         engine._storage.graph.delete_entities_batch = AsyncMock()
         engine._storage.graph.delete_relationships_batch = AsyncMock()
         engine._storage.graph.remove_document_from_entity_sources_batch = AsyncMock()

--- a/tests/unit/engines/test_vectorcypher_engine.py
+++ b/tests/unit/engines/test_vectorcypher_engine.py
@@ -1433,6 +1433,7 @@ class TestVectorCypherEngineForget:
         engine._storage.vector.remove_document_from_entity_sources = AsyncMock()
         engine._storage.vector.remove_document_from_relationship_sources = AsyncMock()
         engine._storage.graph = MagicMock()
+        engine._storage.graph.list_relationships = AsyncMock(return_value=[])
         engine._storage.graph.delete_entities_batch = AsyncMock()
         engine._storage.graph.delete_relationships_batch = AsyncMock()
         engine._storage.graph.remove_document_from_entity_sources_batch = AsyncMock()

--- a/tests/unit/engines/test_vectorcypher_engine.py
+++ b/tests/unit/engines/test_vectorcypher_engine.py
@@ -1605,7 +1605,7 @@ class TestVectorCypherEngineForget:
             [survivor_rel_id], doc_id
         )
         connected_engine._storage.graph.remove_document_from_relationship_sources_batch.assert_awaited_once_with(
-            [survivor_rel_id], doc_id
+            [survivor_rel_id], doc_id, namespace_id
         )
         connected_engine._storage.graph.delete_relationships_batch.assert_not_called()
         connected_engine._storage.vector.delete_relationships_batch.assert_not_called()

--- a/tests/unit/engines/test_vectorcypher_engine.py
+++ b/tests/unit/engines/test_vectorcypher_engine.py
@@ -1611,6 +1611,37 @@ class TestVectorCypherEngineForget:
         connected_engine._storage.vector.delete_relationships_batch.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_forget_cascade_classifies_relationships_from_graph_mirror(
+        self, connected_engine: VectorCypherEngine
+    ) -> None:
+        """On PG+graph stacks the vector relationships table is empty, so the
+        cascade falls back to the graph mirror to classify survivor
+        relationships; the forgotten doc id is still stripped on the mirror."""
+        doc_id = uuid4()
+        namespace_id = uuid4()
+        survivor_rel_id = uuid4()
+        other_doc = uuid4()
+
+        doc_mock = MagicMock()
+        doc_mock.namespace_id = namespace_id
+        connected_engine._storage.get_document = AsyncMock(return_value=doc_mock)
+        connected_engine._storage.delete_document = AsyncMock(return_value=True)
+        # Primary (pgvector) holds no relationships; the mirror (graph) does.
+        connected_engine._storage.vector.list_relationships = AsyncMock(return_value=[])
+        connected_engine._storage.graph.list_relationships = AsyncMock(
+            return_value=[_ent(survivor_rel_id, [doc_id, other_doc])]
+        )
+
+        await connected_engine.forget(doc_id, namespace_id)
+
+        # The survivor relationship is classified off the mirror and stripped
+        # there, scoped to the namespace.
+        connected_engine._storage.graph.remove_document_from_relationship_sources_batch.assert_awaited_once_with(
+            [survivor_rel_id], doc_id, namespace_id
+        )
+        connected_engine._storage.graph.delete_relationships_batch.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_forget_cascade_zero_extraction_skips_backend_calls(
         self, connected_engine: VectorCypherEngine
     ) -> None:

--- a/tests/unit/storage/backends/test_neo4j_coverage.py
+++ b/tests/unit/storage/backends/test_neo4j_coverage.py
@@ -645,7 +645,7 @@ class TestEmptyBatchShortCircuits:
     @pytest.mark.asyncio
     async def test_remove_document_from_relationship_sources_batch_empty(self) -> None:
         b = _backend_with_session_mock(AsyncMock())
-        out = await b.remove_document_from_relationship_sources_batch([], uuid4())
+        out = await b.remove_document_from_relationship_sources_batch([], uuid4(), uuid4())
         assert out == 0
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Enabling Neo4j in the integration CI job ran a set of previously self-skipping tests for the first time (#1033). Triaging the failures fixed both test-harness debt and several **real graph-layer bugs**, and removed the quarantine `xfail` markers.

### Product fixes
- **Source-document-id remap guard** (`storage/backends/neo4j.py`): a new doc id is now appended only when the old id was actually present (and not already in the array), for both the entity and relationship Cypher. The prior "tolerant" rewrite appended unconditionally, leaving stale ids after a remap that didn't touch the array.
- **`valid_until` temporal filtering** (`engines/vectorcypher/dual_nodes.py`): the stored ISO-string `valid_until` is now coerced with Cypher `datetime()` before being compared against `now()` in the entity-neighborhood and chunk-by-entity queries. The string-vs-datetime comparison evaluated to `null` and silently dropped future-dated edges.
- **Co-sourced survivor strip on replace** (`storage/coordinator.py`): when a co-sourced entity/relationship is dropped from the new extraction on a document replace, the replaced document id is now stripped from the surviving record. It previously fell through both the remap and retire branches and kept the stale id.
- **Relationship survivor classification on forget** (`engines/_forget_cascade.py`): when the relational primary stores no relationships (graph-mirror configuration), the orphan/survivor split is computed from the graph mirror so `forget()` strips the removed doc id from surviving relationships.

### Test-harness fixes
- Resolve the stable namespace id to its row id before FK-dependent inserts in coordinator-level tests.
- Unwrap the namespace-required proxy before reaching driver internals and monkeypatch targets; bump the test embedding dimension to match the schema.
- Correct stale public-API keyword arguments, drop a self-contradictory in-place-replace assertion, assert the degraded result on graph-mirror failure instead of expecting a raise, and rename colliding extraction markers.

### Deferred (tracked separately)
- A pre-existing relational-upsert data-integrity issue surfaced during triage — the entity upsert clobbers `source_document_ids` on conflict instead of accumulating — is tracked in #1039 and left under a single scoped `xfail`. Its assertion is unchanged.

## Test plan
- [ ] Unit tests pass
- [ ] Integration tests pass (Postgres + Neo4j) in CI
- [x] Local targeted regression: 72 passed / 1 xfailed (#1039) / 0 failed across the touched files + the broader Neo4j suite (pre-rebase, full live PG+Neo4j stack)
- [x] `ruff format --check`, `ruff check`, and `ty` clean

Fixes #1033