### PR TITLE
Add recall-filter conformance harness and shared compile/execute seams

### DIFF
--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -1716,23 +1716,14 @@ class ChronicleEngine:
         # whole filter.
         filter_pushed_keys: frozenset[str] = frozenset()
         if filter_ast is not None:
-            from khora.filter import CompileContext
-            from khora.filter.compilers.chronicle import compile_chronicle
-            from khora.filter.compilers.python import compile_python
+            from khora.filter.execute import plan_chronicle_filter
 
-            compiled_bound = compile_chronicle(
-                filter_ast,
-                CompileContext(backend_target="chunks", on_unsupported="split"),
-            )
-            date_bound = compiled_bound.predicate
-            filter_pushed_keys = compiled_bound.consumed_keys
+            plan = plan_chronicle_filter(filter_ast)
+            date_bound = plan.date_bound
+            filter_pushed_keys = plan.pushed_keys
             created_after = _intersect_lower(created_after, date_bound.created_after)
             created_before = _intersect_upper(created_before, date_bound.created_before)
-
-            post_filter = compile_python(
-                filter_ast,
-                CompileContext(backend_target="chunks", on_unsupported="split"),
-            ).predicate
+            post_filter = plan.post_filter
 
         # ── Phase 1: Embed query + BM25 in parallel ───────────────────
         # BM25 needs only the query text (no embedding), so start it

--- a/src/khora/engines/skeleton/backends/pgvector.py
+++ b/src/khora/engines/skeleton/backends/pgvector.py
@@ -457,12 +457,12 @@ class PgVectorTemporalStore(TemporalVectorStore):
             # compiler aliases nothing here (the store queries the base table),
             # so ``table_alias`` stays None.
             if filter_ast is not None:
-                from khora.filter import CompileContext
                 from khora.filter.compilers.postgres import compile_postgres
+                from khora.filter.execute import build_compile_context
 
                 compiled = compile_postgres(
                     filter_ast,
-                    CompileContext(backend_target="khora_chunks", on_unsupported="raise"),
+                    build_compile_context("khora_chunks", on_unsupported="raise"),
                 )
                 conditions.append(compiled.predicate)
 

--- a/src/khora/filter/conformance.py
+++ b/src/khora/filter/conformance.py
@@ -1,0 +1,741 @@
+"""Recall-filter conformance harness — ``@internal``.
+
+The conformance harness drives one **catalog of filter cases** through every
+backend compiler and asserts they all agree with the in-memory Python oracle
+(:func:`~khora.filter.compilers.python.compile_python`). It is the machinery a
+sibling catalog ticket fills with hand-authored cases and a sibling CI ticket
+wires into a marked pytest job; this module owns the *machinery* only — the
+case schema, the corpus runner, the three backend executors, the live-store
+seeder, and the fully-generated ``F-OP`` (system-key operator-coverage) family.
+
+The oracle contract is the whole point: a backend compiler is *conformant* iff,
+for every case, the set of records its predicate keeps equals the set the Python
+oracle keeps (or it raises :class:`RecallFilterUnsupportedError` on exactly the
+backends a case marks unsupported). The runner never reconstructs a predicate —
+it always lowers through the **real** validator
+(:meth:`RecallFilter.model_validate`), the **real** :func:`parse_to_ast`, and the
+**real** per-backend compiler, so a harness pass is evidence about production code,
+not about a parallel re-implementation.
+
+**Layout of a case.** A :class:`ConformanceCase` carries a filter (wire dict or a
+constructed :class:`RecallFilter`), a small deterministic ``seed_records`` set,
+the ``expected_ids`` survivors (:class:`SeedRecord` ids, resolved to live UUIDs by
+the seeder), the ``backends`` it applies to, the ``expect_unsupported`` backends,
+and an ``exercises`` tag tuple the coverage meta-test reads.
+
+**The three executors.**
+
+* :class:`PythonExecutor` — compiles the AST with :func:`compile_python` and runs
+  the resulting callable against each record. This is the **oracle**.
+* :class:`ChronicleExecutor` — delegates to the Chronicle plan/run seam in
+  :mod:`khora.filter.execute` (the date-bound pushdown + Python post-filter).
+* :class:`PostgresExecutor` — invokes the **real** :func:`compile_postgres` and
+  hands the compiled predicate to an injected callable that runs it against a
+  seeded coordinator. The live-Postgres wiring is the CI ticket's concern; this
+  module defines only the seam.
+
+``@internal``. Reachable as ``khora.filter.conformance`` for khora's own test
+suite; **not** re-exported from :mod:`khora.__init__` or :mod:`khora.filter`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Protocol
+from uuid import UUID, uuid5
+
+import pytest
+
+from khora.core.models import Chunk, Document, MemoryNamespace
+from khora.filter import (
+    RecallFilter,
+    RecallFilterUnsupportedError,
+)
+from khora.filter.ast import FilterNode, parse_to_ast
+from khora.filter.compilers.postgres import compile_postgres
+from khora.filter.compilers.python import compile_python
+
+# Cross-file import boundary: conformance.py depends on execute.py (the production
+# compile/execute seam); execute.py imports NOTHING back (one-way). ``build_compile_context``
+# is the one production CompileContext builder; ``run_chronicle_filter`` is the
+# Chronicle date-bound-pushdown + full-AST post-filter applied to in-memory records.
+from khora.filter.execute import build_compile_context, run_chronicle_filter
+from khora.storage.coordinator import StorageCoordinator
+
+__all__ = [
+    "BackendExecutor",
+    "ChronicleExecutor",
+    "ConformanceCase",
+    "PostgresExecutor",
+    "PostgresRunner",
+    "PythonExecutor",
+    "SeedRecord",
+    "assert_case",
+    "f_op_cases",
+    "oracle_survivors",
+    "run_case_for_backend",
+    "seed_case",
+]
+
+# The three backend names a case may target / a runner may dispatch on.
+BACKENDS: frozenset[str] = frozenset({"python", "postgres", "chronicle"})
+
+# The eight denormalized document system keys carried on the seed Document, in
+# the order ``parse_to_ast`` lowers them (the three date keys live on the chunk).
+_DOC_STRING_KEYS: tuple[str, ...] = (
+    "source_type",
+    "source_name",
+    "source_url",
+    "external_id",
+    "content_type",
+    "source",
+    "title",
+)
+# The three date system keys, carried as real datetime columns on the chunk.
+_DATE_KEYS: tuple[str, ...] = ("occurred_at", "created_at", "source_timestamp")
+
+
+# --------------------------------------------------------------------------- #
+# Case schema.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class SeedRecord:
+    """One record to seed (one Document + one Chunk) and its filterable fields.
+
+    ``@internal``. ``id`` is a stable, human-readable handle (NOT a UUID) the
+    case's ``expected_ids`` reference; the seeder maps it to the live chunk UUID.
+    ``content`` defaults to a fixed anchor so every chunk shares an embedding (the
+    vector channel returns the whole set and the filter is the only narrowing
+    force). The remaining fields populate the eight denormalized document system
+    keys, the three date columns, and the chunk ``metadata`` blob — the surface a
+    filter can address. A field left ``None`` / empty is simply absent from that
+    record (the missing-value semantics each compiler must agree on).
+    """
+
+    id: str
+    content: str = "conformance anchor"
+    metadata: dict[str, Any] = field(default_factory=dict)
+    source_timestamp: datetime | None = None
+    occurred_at: datetime | None = None
+    created_at: datetime | None = None
+    source_type: str | None = None
+    source_name: str | None = None
+    source_url: str | None = None
+    external_id: str | None = None
+    content_type: str | None = None
+    source: str | None = None
+    title: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ConformanceCase:
+    """One filter + seed + expectation, run against a set of backends.
+
+    ``@internal``.
+
+    * ``id`` — stable, unique case handle (also the per-case namespace key, so the
+      seeder is xdist-safe: each case owns its own namespace).
+    * ``filter`` — the filter under test, as a wire ``dict`` (validated through
+      :meth:`RecallFilter.model_validate`) or an already-constructed
+      :class:`RecallFilter`.
+    * ``seed_records`` — the records to seed; the filter selects a subset.
+    * ``expected_ids`` — the :class:`SeedRecord` ids that must survive the filter,
+      or ``None`` when the case only asserts an unsupported outcome.
+    * ``backends`` — the backends this case applies to (subset of
+      :data:`BACKENDS`).
+    * ``expect_unsupported`` — the backends on which the filter must raise
+      :class:`RecallFilterUnsupportedError` rather than return survivors.
+    * ``exercises`` — free-form coverage tags (e.g. ``("F-OP", "occurred_at",
+      "$gte")``); the coverage meta-test asserts the union of these over the
+      generated corpus covers every :data:`SYSTEM_KEYS` member.
+    """
+
+    id: str
+    filter: dict[str, Any] | RecallFilter
+    seed_records: tuple[SeedRecord, ...]
+    expected_ids: frozenset[str] | None
+    backends: frozenset[str]
+    expect_unsupported: frozenset[str] = frozenset()
+    exercises: tuple[str, ...] = ()
+
+
+# --------------------------------------------------------------------------- #
+# AST resolution.
+# --------------------------------------------------------------------------- #
+
+
+def _resolve_ast(filter_: dict[str, Any] | RecallFilter) -> FilterNode:
+    """Lower a case filter to its canonical AST through the real pipeline.
+
+    A wire ``dict`` is validated with :meth:`RecallFilter.model_validate`; an
+    already-constructed :class:`RecallFilter` is used as-is. Both then lower via
+    the real :func:`parse_to_ast`. Never reconstructs or mocks the AST.
+    """
+    model = filter_ if isinstance(filter_, RecallFilter) else RecallFilter.model_validate(filter_)
+    return parse_to_ast(model)
+
+
+def _record_mapping(record: SeedRecord) -> dict[str, Any]:
+    """Build the in-memory record mapping the Python oracle reads.
+
+    Mirrors the engine's ``_chunk_to_record`` shape so the oracle sees the same
+    surface a real recall post-filter would: the effective event time
+    ``COALESCE(occurred_at, source_timestamp)``, the literal ``created_at`` /
+    ``source_timestamp`` columns, the ``metadata`` blob, and any populated
+    denormalized document key. A document key left ``None`` stays absent (the
+    missing-value semantics the compilers must agree on).
+    """
+    mapping: dict[str, Any] = {
+        "occurred_at": record.occurred_at if record.occurred_at is not None else record.source_timestamp,
+        "created_at": record.created_at,
+        "source_timestamp": record.source_timestamp,
+        "metadata": record.metadata or {},
+    }
+    for key in _DOC_STRING_KEYS:
+        value = getattr(record, key)
+        if value is not None:
+            mapping[key] = value
+    return mapping
+
+
+# --------------------------------------------------------------------------- #
+# Backend executors.
+# --------------------------------------------------------------------------- #
+
+
+class BackendExecutor(Protocol):
+    """The seam each backend implements: AST + records -> surviving ids.
+
+    ``@internal``. ``records`` is a sequence of ``(seed_id, mapping)`` pairs;
+    ``survivors`` returns the subset of ``seed_id`` values the backend's predicate
+    keeps. An executor that cannot express a clause raises
+    :class:`RecallFilterUnsupportedError` (the harness asserts that against
+    ``ConformanceCase.expect_unsupported``).
+    """
+
+    def survivors(
+        self,
+        filter_ast: FilterNode,
+        records: Sequence[tuple[str, Mapping[str, Any]]],
+    ) -> frozenset[str]: ...
+
+
+class PythonExecutor:
+    """The oracle: run :func:`compile_python` against each record.
+
+    ``@internal``. Compiles the AST with the real
+    :func:`~khora.filter.compilers.python.compile_python` (``on_unsupported``
+    ``"raise"`` — the oracle must express the whole filter or surface the gap) and
+    applies the resulting callable to each record mapping. The survivor set this
+    returns is the reference every other backend is checked against.
+    """
+
+    def survivors(
+        self,
+        filter_ast: FilterNode,
+        records: Sequence[tuple[str, Mapping[str, Any]]],
+    ) -> frozenset[str]:
+        ctx = build_compile_context("chunks", on_unsupported="raise")
+        predicate = compile_python(filter_ast, ctx).predicate
+        return frozenset(seed_id for seed_id, mapping in records if predicate(mapping))
+
+
+class ChronicleExecutor:
+    """Run a filter through the Chronicle plan/run seam.
+
+    ``@internal``. Delegates to :func:`khora.filter.execute.run_chronicle_filter`,
+    which applies the Chronicle ``source_timestamp`` date-bound pushdown and the
+    :func:`compile_python` post-filter (the full-AST safety net) — the same path
+    the Chronicle engine drives. The harness passes the in-memory record mappings
+    so the executor needs no live store; ``run_chronicle_filter`` returns the
+    surviving record mappings (the same dict objects, in order), which this maps
+    back to their ``seed_id`` by object identity.
+    """
+
+    def survivors(
+        self,
+        filter_ast: FilterNode,
+        records: Sequence[tuple[str, Mapping[str, Any]]],
+    ) -> frozenset[str]:
+        # ``run_chronicle_filter`` filters by reference and returns the same mapping
+        # objects, so identity (``id(...)``) recovers the seed_id unambiguously even
+        # when two records carry equal field values.
+        by_identity = {id(mapping): seed_id for seed_id, mapping in records}
+        survivors = run_chronicle_filter(filter_ast, [mapping for _, mapping in records])
+        return frozenset(by_identity[id(mapping)] for mapping in survivors)
+
+
+class PostgresRunner(Protocol):
+    """Run a compiled Postgres predicate against a seeded store -> surviving ids.
+
+    ``@internal``. The injected seam :class:`PostgresExecutor` calls after it has
+    compiled the AST with the real :func:`compile_postgres`. Wiring this to a live
+    coordinator (seed → emit ``WHERE`` → collect surviving chunk ids → map back to
+    ``seed_id``) is the CI ticket's concern; the harness defines only the contract.
+    ``predicate`` is the SQLAlchemy ``ColumnElement[bool]`` and ``params`` its bind
+    parameters; ``records`` is the ``(seed_id, mapping)`` list under test.
+    """
+
+    def __call__(
+        self,
+        predicate: Any,
+        params: Mapping[str, Any],
+        records: Sequence[tuple[str, Mapping[str, Any]]],
+    ) -> frozenset[str]: ...
+
+
+class PostgresExecutor:
+    """Compile with the real :func:`compile_postgres`; run via an injected runner.
+
+    ``@internal``. The real compiler IS invoked (this is what conformance checks);
+    execution against a live Postgres is delegated to the injected
+    :class:`PostgresRunner` so the harness stays storage-agnostic. ``compile_postgres``
+    is driven with ``on_unsupported`` ``"raise"`` so a clause Postgres cannot push
+    down surfaces as :class:`RecallFilterUnsupportedError` (matched against
+    ``expect_unsupported``), rather than being silently dropped.
+    """
+
+    def __init__(self, runner: PostgresRunner) -> None:
+        self._runner = runner
+
+    def survivors(
+        self,
+        filter_ast: FilterNode,
+        records: Sequence[tuple[str, Mapping[str, Any]]],
+    ) -> frozenset[str]:
+        # ``"khora_chunks"`` is the production Postgres target the skeleton pgvector
+        # backend compiles against (build_compile_context("khora_chunks",
+        # on_unsupported="raise")). Matching it here means the harness exercises the
+        # exact compiler invocation prod runs, not a context-only shim.
+        ctx = build_compile_context("khora_chunks", on_unsupported="raise")
+        compiled = compile_postgres(filter_ast, ctx)
+        return self._runner(compiled.predicate, compiled.params, records)
+
+
+# --------------------------------------------------------------------------- #
+# Corpus runner.
+# --------------------------------------------------------------------------- #
+
+
+def run_case_for_backend(
+    case: ConformanceCase,
+    backend: str,
+    *,
+    executor: BackendExecutor,
+) -> frozenset[str]:
+    """Resolve a case's filter to an AST and run it through one backend.
+
+    ``@internal``. Lowers ``case.filter`` via the real validator + ``parse_to_ast``,
+    builds the ``(seed_id, mapping)`` record list from ``case.seed_records``, runs
+    it through ``executor``, and returns the surviving :class:`SeedRecord` ids.
+    Raises :class:`RecallFilterUnsupportedError` straight through when the executor
+    cannot express the filter (the caller asserts that against
+    ``expect_unsupported``).
+    """
+    filter_ast = _resolve_ast(case.filter)
+    records = [(rec.id, _record_mapping(rec)) for rec in case.seed_records]
+    return executor.survivors(filter_ast, records)
+
+
+def assert_case(case: ConformanceCase, backend: str, executor: BackendExecutor) -> None:
+    """Assert a case's outcome on one backend (the per-(case, backend) check).
+
+    ``@internal``. When ``backend`` is in ``case.expect_unsupported`` the filter
+    must raise :class:`RecallFilterUnsupportedError`; otherwise the surviving id
+    set must equal ``case.expected_ids``. ``expected_ids`` must be set for a
+    survivor assertion (a case that only asserts an unsupported outcome lists the
+    backend in ``expect_unsupported`` instead).
+    """
+    if backend in case.expect_unsupported:
+        with pytest.raises(RecallFilterUnsupportedError):
+            run_case_for_backend(case, backend, executor=executor)
+        return
+    if case.expected_ids is None:
+        raise ValueError(f"case {case.id!r} on backend {backend!r}: expected_ids is required for a survivor assertion")
+    assert run_case_for_backend(case, backend, executor=executor) == case.expected_ids
+
+
+def oracle_survivors(case: ConformanceCase) -> frozenset[str]:
+    """Run the Python oracle against a case — an **authoring-time** sanity helper.
+
+    ``@internal``. Returns the :class:`SeedRecord` ids the
+    :class:`PythonExecutor` keeps for ``case.filter`` over ``case.seed_records``.
+    A case author can compare this against the ids they *declared* in
+    ``expected_ids`` to catch a hand-counting slip while authoring a case.
+
+    **This is deliberately NOT used inside** :func:`assert_case`. The assertion
+    target is always the hand-declared ``case.expected_ids`` — never the oracle's
+    live output — so a wrong :func:`compile_python` fails its own ``"python"``
+    case (the oracle is itself falsifiable) instead of silently redefining every
+    expectation to whatever it currently computes.
+    """
+    return run_case_for_backend(case, "python", executor=PythonExecutor())
+
+
+# --------------------------------------------------------------------------- #
+# Live-store seeder.
+# --------------------------------------------------------------------------- #
+
+
+# Fixed namespace root for deriving a deterministic per-case namespace_id. Any
+# constant UUID works — it only needs to be stable so the same case.id always maps
+# to the same namespace (xdist-safe) and distinct case ids never collide.
+_CONFORMANCE_NS_ROOT = UUID("00000000-0000-0000-0000-0000000c0fee")
+
+
+def _case_namespace_id(case: ConformanceCase) -> UUID:
+    """Derive a deterministic namespace_id from ``case.id`` (xdist-safe).
+
+    Same ``case.id`` → same namespace on every worker; distinct ``case.id`` →
+    distinct namespace → no cross-worker collision. Never a random ``uuid4``.
+    """
+    return uuid5(_CONFORMANCE_NS_ROOT, case.id)
+
+
+async def seed_case(coord: StorageCoordinator, case: ConformanceCase) -> dict[str, UUID]:
+    """Seed a case's records into a live coordinator; return ``seed_id -> chunk UUID``.
+
+    ``@internal``. Writes one :class:`Document` + one :class:`Chunk` per
+    :class:`SeedRecord` through the coordinator's **write API only**
+    (:meth:`create_namespace`, :meth:`create_document`, :meth:`create_chunks_batch`)
+    — never raw SQL/Cypher. The namespace ``namespace_id`` is derived
+    deterministically from ``case.id`` (:func:`_case_namespace_id`), so the same
+    case maps to the same namespace on every xdist worker and distinct cases never
+    collide — no random ``uuid4`` that could clash across workers. The namespace is
+    write-once and read-only after seeding.
+
+    Every chunk shares one embedding derived from its content (all records use the
+    same default content, so the vector channel returns the whole seed set and the
+    filter is the only narrowing force). The Document carries the eight
+    denormalized document system keys; the Chunk carries the ``metadata`` blob and
+    the three date columns. Returns the ``seed_id -> chunk.id`` map the runner uses
+    to translate ``expected_ids`` (SeedRecord ids) into live chunk UUIDs.
+    """
+    # Lazy import: the seeder runs only under the live-store integration job, and
+    # the fixture helper lives under ``tests/`` (not importable in a bare install).
+    from tests.integration._sqlite_lance_fixtures import EMBED_DIM, fake_embedding
+
+    # Deterministic, per-case namespace_id (xdist-safe). create_namespace honors a
+    # caller-supplied namespace_id (it passes the model straight to the relational
+    # backend). Seed every row under ns.namespace_id — the stable external id the
+    # recall read path scopes on.
+    ns = await coord.create_namespace(
+        MemoryNamespace(
+            namespace_id=_case_namespace_id(case),
+            metadata={"conformance_case": case.id},
+        )
+    )
+    namespace_id = ns.namespace_id
+
+    id_map: dict[str, UUID] = {}
+    chunks: list[Chunk] = []
+    for record in case.seed_records:
+        doc = Document(
+            namespace_id=namespace_id,
+            content=record.content,
+            source_type=record.source_type if record.source_type is not None else "library",
+            source_name=record.source_name,
+            source_url=record.source_url,
+            external_id=record.external_id,
+            content_type=record.content_type,
+            source=record.source,
+            title=record.title,
+        )
+        await coord.create_document(doc)
+
+        chunk_kwargs: dict[str, Any] = {
+            "namespace_id": namespace_id,
+            "document_id": doc.id,
+            "content": record.content,
+            "chunk_index": 0,
+            "embedding": fake_embedding(record.content, dim=EMBED_DIM),
+            "embedding_model": "fake",
+            "metadata": dict(record.metadata),
+        }
+        for date_key in _DATE_KEYS:
+            value = getattr(record, date_key)
+            if value is not None:
+                chunk_kwargs[date_key] = value
+        chunk = Chunk(**chunk_kwargs)
+        id_map[record.id] = chunk.id
+        chunks.append(chunk)
+
+    await coord.create_chunks_batch(chunks)
+    return id_map
+
+
+# --------------------------------------------------------------------------- #
+# Case-family generators.
+# --------------------------------------------------------------------------- #
+#
+# The catalog ticket fills the F-COERCE / F-EXISTS / F-LOGIC / F-SUGAR / F-DATES
+# / F-NULLVAL / F-SEL / F-OBJEQ / F-DOTKEY / F-UNSUP families with hand-authored
+# expected_ids. This module fully implements only the F-OP system-key
+# operator-coverage family (every SYSTEM_KEYS member × its operators), with
+# expected_ids computed BY CONSTRUCTION from a known seed so the runner's
+# python-oracle cross-check can confirm — never define — them.
+
+
+# Fixed seed anchors for the date F-OP cases. ``_HIT`` is in range of every
+# generated date bound, ``_MISS`` out of range; the third record carries no date
+# at all (the absent-value record). UTC, matching the validator's normalization.
+_DATE_HIT = datetime(2026, 6, 1, tzinfo=UTC)
+_DATE_MISS = datetime(2020, 1, 1, tzinfo=UTC)
+_DATE_BOUND = "2026-01-01T00:00:00Z"
+
+# The string F-OP cases compare against this value; ``_STR_OTHER`` is a distinct
+# value and the third record leaves the key unset (the absent-value record).
+_STR_HIT = "match-me"
+_STR_OTHER = "other-value"
+
+# All three backends are oracle-comparable for the F-OP family on the embedded
+# date/metadata surface; the catalog/CI tickets prune per-backend as needed (the
+# eight denorm document keys are not carried on the legacy chronicle DTO, so a
+# positive predicate on them is chronicle-empty — flagged via ``backends`` there).
+_OP_BACKENDS: frozenset[str] = frozenset({"python", "postgres", "chronicle"})
+
+
+def _date_field_seed(key: str) -> tuple[SeedRecord, SeedRecord, SeedRecord]:
+    """Three records for a date-key F-OP case: in-range, out-of-range, absent.
+
+    The date is stamped on ``key`` (one of the three date columns). All three
+    share the default content so they share an embedding.
+    """
+    return (
+        SeedRecord(id=f"{key}-hit", **{key: _DATE_HIT}),
+        SeedRecord(id=f"{key}-miss", **{key: _DATE_MISS}),
+        SeedRecord(id=f"{key}-absent"),
+    )
+
+
+def _string_field_seed(key: str) -> tuple[SeedRecord, SeedRecord, SeedRecord]:
+    """Three records for a string-key F-OP case: matching, other, absent."""
+    return (
+        SeedRecord(id=f"{key}-hit", **{key: _STR_HIT}),
+        SeedRecord(id=f"{key}-other", **{key: _STR_OTHER}),
+        SeedRecord(id=f"{key}-absent"),
+    )
+
+
+def _date_op_cases(key: str) -> list[ConformanceCase]:
+    """Every date-key F-OP case: range + set ops over one date key.
+
+    ``expected_ids`` is computed by construction from the known three-record seed
+    (hit @ 2026-06-01, miss @ 2020-01-01, absent). The bound is 2026-01-01, so the
+    lower-bound ops (``$gt``/``$gte``) keep only the hit; the upper-bound ops keep
+    only the miss; ``$eq`` against the bound keeps neither; ``$ne`` keeps the
+    complement (negations include the absent record); ``$in`` keeps the hit, ``$nin``
+    its complement.
+
+    Date keys deliberately have **no** ``$exists`` case: ``DateOps`` carries no
+    ``$exists`` field, so ``$exists`` on a date key is a *validation* failure (not
+    a compile-time unsupported outcome) — the presence operator is exercised on the
+    string keys instead. The operand is a plain ISO-8601 string (the system-key
+    ``DateOps`` form), not the ``{"$date": ...}`` typed literal (that form is the
+    metadata grammar's).
+    """
+    seed = _date_field_seed(key)
+    hit, miss, absent = (r.id for r in seed)
+    bound = _DATE_BOUND
+
+    def case(suffix: str, predicate: dict[str, Any], expected: frozenset[str], op_tag: str) -> ConformanceCase:
+        return ConformanceCase(
+            id=f"F-OP-{key}-{suffix}",
+            filter={key: predicate},
+            seed_records=seed,
+            expected_ids=expected,
+            backends=_OP_BACKENDS,
+            exercises=("F-OP", key, op_tag),
+        )
+
+    return [
+        case("gt", {"$gt": bound}, frozenset({hit}), "$gt"),
+        case("gte", {"$gte": bound}, frozenset({hit}), "$gte"),
+        case("lt", {"$lt": bound}, frozenset({miss}), "$lt"),
+        case("lte", {"$lte": bound}, frozenset({miss}), "$lte"),
+        case("eq", {"$eq": bound}, frozenset(), "$eq"),
+        case("ne", {"$ne": bound}, frozenset({hit, miss, absent}), "$ne"),
+        case("in", {"$in": [bound]}, frozenset(), "$in"),
+        case("nin", {"$nin": [bound]}, frozenset({hit, miss, absent}), "$nin"),
+    ]
+
+
+def _string_op_cases(key: str) -> list[ConformanceCase]:
+    """Every string-key F-OP case: ``$eq``/``$ne``/``$in``/``$nin``/``$exists``.
+
+    ``expected_ids`` is computed by construction from the known three-record seed
+    (hit == ``match-me``, other == ``other-value``, absent == key unset). The eight
+    denormalized document keys are always present columns at the SQL layer (NULL when
+    unset), so ``$exists`` is trivially all-records — its coverage is the
+    presence-operator tag, not a narrowing assertion.
+    """
+    seed = _string_field_seed(key)
+    hit, other, absent = (r.id for r in seed)
+
+    def case(suffix: str, predicate: dict[str, Any], expected: frozenset[str], op_tag: str) -> ConformanceCase:
+        return ConformanceCase(
+            id=f"F-OP-{key}-{suffix}",
+            filter={key: predicate},
+            seed_records=seed,
+            expected_ids=expected,
+            backends=_OP_BACKENDS,
+            exercises=("F-OP", key, op_tag),
+        )
+
+    return [
+        case("eq", {"$eq": _STR_HIT}, frozenset({hit}), "$eq"),
+        case("ne", {"$ne": _STR_HIT}, frozenset({other, absent}), "$ne"),
+        case("in", {"$in": [_STR_HIT]}, frozenset({hit}), "$in"),
+        case("nin", {"$nin": [_STR_HIT]}, frozenset({other, absent}), "$nin"),
+        case("exists-true", {"$exists": True}, frozenset({hit, other, absent}), "$exists"),
+    ]
+
+
+def _metadata_op_case() -> ConformanceCase:
+    """A representative metadata-scalar F-OP case (``metadata.tier == "gold"``).
+
+    The system-key families above cover every :data:`SYSTEM_KEYS` member;
+    ``metadata`` is intentionally excluded from ``SYSTEM_KEYS`` (it is the free-form
+    blob, not a system key), so this single representative scalar case rounds out
+    the F-OP family's surface without enumerating the metadata grammar (that is the
+    catalog ticket's F-OBJEQ / F-DOTKEY territory).
+    """
+    seed = (
+        SeedRecord(id="meta-gold", metadata={"tier": "gold"}),
+        SeedRecord(id="meta-silver", metadata={"tier": "silver"}),
+        SeedRecord(id="meta-absent"),
+    )
+    return ConformanceCase(
+        id="F-OP-metadata-tier-eq",
+        filter={"metadata.tier": "gold"},
+        seed_records=seed,
+        expected_ids=frozenset({"meta-gold"}),
+        backends=_OP_BACKENDS,
+        exercises=("F-OP", "metadata.tier", "$eq"),
+    )
+
+
+def f_op_cases() -> list[ConformanceCase]:
+    """The fully-generated ``F-OP`` family: every system key × its operators.
+
+    ``@internal``. Iterates every :data:`SYSTEM_KEYS` member — the three date keys
+    (``occurred_at`` / ``created_at`` / ``source_timestamp``) across range / set /
+    ``$exists`` ops, and the seven string keys (``source_type`` / ``source_name`` /
+    ``source_url`` / ``external_id`` / ``content_type`` / ``source`` / ``title``)
+    across ``$eq`` / ``$ne`` / ``$in`` / ``$nin`` / ``$exists`` — plus one
+    representative metadata scalar. Every case tags the system key it exercises in
+    ``exercises`` so the coverage meta-test can assert the union covers
+    :data:`SYSTEM_KEYS`. ``expected_ids`` is computed by construction from each
+    case's known seed (the runner confirms, never defines, them via the oracle).
+    """
+    cases: list[ConformanceCase] = []
+    for key in _DATE_KEYS:
+        cases.extend(_date_op_cases(key))
+    for key in _DOC_STRING_KEYS:
+        cases.extend(_string_op_cases(key))
+    cases.append(_metadata_op_case())
+    return cases
+
+
+# --------------------------------------------------------------------------- #
+# Case-family generator stubs (filled by the catalog ticket).
+# --------------------------------------------------------------------------- #
+#
+# Each stub returns ``[]`` so the corpus assembler can already iterate every
+# family; the catalog ticket replaces the body with hand-authored cases (filter +
+# seed + expected_ids) per the family's intent described in each docstring.
+
+
+def f_coerce_cases() -> list[ConformanceCase]:
+    """F-COERCE: cross-type operand coercion (e.g. numeric string vs. number).
+
+    Filled by the catalog ticket. Asserts the compilers agree on how an operand
+    whose type differs from the stored value is compared (or excluded).
+    """
+    return []
+
+
+def f_exists_cases() -> list[ConformanceCase]:
+    """F-EXISTS: ``$exists`` presence semantics across absent / present-null / present.
+
+    Filled by the catalog ticket. The absent-vs-present-null distinction on a
+    metadata path is the load-bearing case.
+    """
+    return []
+
+
+def f_logic_cases() -> list[ConformanceCase]:
+    """F-LOGIC: ``$and`` / ``$or`` / ``$not`` / ``$nor`` composition and nesting.
+
+    Filled by the catalog ticket. Includes de Morgan equivalences and the
+    negation-includes-absent polarity rule under logical composition.
+    """
+    return []
+
+
+def f_sugar_cases() -> list[ConformanceCase]:
+    """F-SUGAR: bare-value / bare-list / implicit-AND desugaring equivalence.
+
+    Filled by the catalog ticket. A bare scalar must match its ``$eq`` form; a
+    bare list its ``$eq`` exact-array form (NOT ``$in``); sibling keys their
+    explicit ``$and``.
+    """
+    return []
+
+
+def f_dates_cases() -> list[ConformanceCase]:
+    """F-DATES: ``$date`` typed-literal handling and timezone normalization.
+
+    Filled by the catalog ticket. Covers naive-vs-aware operands and the
+    cross-axis date-key pushdown rules (only ``source_timestamp`` pushes down).
+    """
+    return []
+
+
+def f_nullval_cases() -> list[ConformanceCase]:
+    """F-NULLVAL: explicit-``null`` operand (null-or-missing match) semantics.
+
+    Filled by the catalog ticket. A ``{key: null}`` matches absent-or-present-null;
+    a ``$ne null`` its complement.
+    """
+    return []
+
+
+def f_sel_cases() -> list[ConformanceCase]:
+    """F-SEL: selectivity / multi-record narrowing across mixed predicates.
+
+    Filled by the catalog ticket. Larger seeds where several predicates intersect,
+    stress-testing the conjunction narrowing.
+    """
+    return []
+
+
+def f_objeq_cases() -> list[ConformanceCase]:
+    """F-OBJEQ: whole-subdocument / whole-blob object equality (exact ``=``).
+
+    Filled by the catalog ticket. A metadata sub-path dict operand is EXACT
+    equality, NOT ``@>`` containment.
+    """
+    return []
+
+
+def f_dotkey_cases() -> list[ConformanceCase]:
+    """F-DOTKEY: folded ``metadata.<path>`` multi-segment path addressing.
+
+    Filled by the catalog ticket. Nested path descent and array-aware containment
+    on metadata sub-paths.
+    """
+    return []
+
+
+def f_unsup_cases() -> list[ConformanceCase]:
+    """F-UNSUP: predicates a backend cannot push down (``expect_unsupported``).
+
+    Filled by the catalog ticket. Each case lists the backends that must raise
+    :class:`RecallFilterUnsupportedError` under ``on_unsupported='raise'``.
+    """
+    return []

--- a/src/khora/filter/execute.py
+++ b/src/khora/filter/execute.py
@@ -1,0 +1,111 @@
+"""Production filter compile/execute seams — ``@internal``.
+
+Two thin helpers that pull the engines' inline filter-compile plumbing into a
+single named place so the same construction can be exercised outside an engine:
+
+* :func:`build_compile_context` — the one production
+  :class:`~khora.filter.context.CompileContext` builder. Its keyword defaults
+  mirror ``CompileContext``'s own field defaults exactly, so a call with only a
+  ``backend_target`` (plus the engine's ``on_unsupported``) yields a dataclass
+  field-for-field identical to the previous inline construction.
+* :func:`plan_chronicle_filter` / :func:`run_chronicle_filter` — the Chronicle
+  engine's two-compile composition (a pushdown date-bound + a full-AST in-memory
+  post-filter) captured as a reusable plan. Both compiles run under
+  ``on_unsupported="split"``, so neither raises.
+
+``@internal``. Reachable as ``khora.filter.execute`` for khora's own engines; not
+in any public ``__all__`` and not re-exported from :mod:`khora.__init__`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from khora.filter.ast import FilterNode
+from khora.filter.compilers.chronicle import ChronicleDateBound, compile_chronicle
+from khora.filter.compilers.python import compile_python
+from khora.filter.context import CompileContext, SchemaCapabilities
+
+
+def build_compile_context(
+    backend_target: str,
+    *,
+    table_alias: str | None = None,
+    param_namespace: str = "f",
+    field_mapping: Mapping[str, str] | None = None,
+    schema_capabilities: SchemaCapabilities = SchemaCapabilities.DEFAULTS,
+    on_unsupported: Literal["raise", "split"] = "raise",
+) -> CompileContext:
+    """Build the per-compile-pass :class:`CompileContext` for a backend target.
+
+    The keyword defaults mirror ``CompileContext``'s own field defaults exactly,
+    so ``build_compile_context("khora_chunks", on_unsupported="raise")`` is
+    identical to constructing ``CompileContext`` with the same two arguments.
+    """
+    return CompileContext(
+        backend_target=backend_target,
+        table_alias=table_alias,
+        param_namespace=param_namespace,
+        field_mapping=field_mapping,
+        schema_capabilities=schema_capabilities,
+        on_unsupported=on_unsupported,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ChronicleFilterPlan:
+    """The two compiled halves of a Chronicle filter pass.
+
+    ``@internal``. Chronicle is partial-pushdown by design: only a conjunctive
+    ``source_timestamp`` bound folds into the recency window; the full filter is
+    always enforced in memory. This pairs the pushdown half with the post-filter
+    half so the engine narrows its candidate reads and still re-checks every
+    predicate.
+
+    * ``date_bound`` — the narrowing window distilled from the consumed
+      ``source_timestamp`` clauses (either side ``None`` for unbounded).
+    * ``pushed_keys`` — the AST keys folded into ``date_bound`` (the
+      ``source_timestamp`` subset), for the engine's honest pushdown report.
+    * ``post_filter`` — an in-memory ``callable(record) -> bool`` over the FULL
+      AST, the safety net that enforces every predicate against the field each
+      candidate record carries.
+    """
+
+    date_bound: ChronicleDateBound
+    pushed_keys: frozenset[str]
+    post_filter: Callable[[Any], bool]
+
+
+def plan_chronicle_filter(filter_ast: FilterNode) -> ChronicleFilterPlan:
+    """Compose the Chronicle pushdown bound and full-AST post-filter for ``filter_ast``.
+
+    Runs the same two compiles the engine drives inline, both under
+    ``on_unsupported="split"`` (so neither raises): ``compile_chronicle`` for the
+    ``source_timestamp`` date-bound + its consumed keys, and ``compile_python``
+    over the whole AST for the in-memory post-filter.
+    """
+    ctx = build_compile_context("chunks", on_unsupported="split")
+    compiled_bound = compile_chronicle(filter_ast, ctx)
+    post_filter = compile_python(filter_ast, ctx).predicate
+    return ChronicleFilterPlan(
+        date_bound=compiled_bound.predicate,
+        pushed_keys=compiled_bound.consumed_keys,
+        post_filter=post_filter,
+    )
+
+
+def run_chronicle_filter(
+    filter_ast: FilterNode,
+    records: Iterable[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    """Apply the full-AST post-filter to in-memory candidate ``records``.
+
+    The pushdown ``date_bound`` is a recency-window narrowing that the engine
+    applies to its channel reads; over already-materialized candidate records it
+    is a no-op, because the full-AST post-filter re-checks ``source_timestamp``
+    (and every other predicate) directly. Returns the surviving records in order.
+    """
+    post_filter = plan_chronicle_filter(filter_ast).post_filter
+    return [record for record in records if post_filter(record)]

--- a/tests/unit/filter/test_conformance_harness.py
+++ b/tests/unit/filter/test_conformance_harness.py
@@ -1,0 +1,308 @@
+"""Meta-tests for the recall-filter conformance harness machinery — ``@internal``.
+
+These guard the *machinery* in :mod:`khora.filter.conformance` (the case schema,
+the runner, the executors, the F-OP generator, the oracle-falsifiability
+contract), NOT the ~263-case catalog (a sibling ticket) nor the CI marked job
+(another sibling ticket). A handful of hand-declared in-file smoke cases exercise
+each moving part:
+
+* the runner lowers through the REAL validator + ``parse_to_ast`` + real
+  compilers and ``assert_case`` compares survivors against the **hand-declared**
+  ``expected_ids`` — for every backend, the Python oracle included (so a wrong
+  ``compile_python`` fails its own ``"python"`` case);
+* the Python oracle and the Chronicle plan/run seam agree on the smoke cases;
+* the F-OP generator covers every system key (the coverage assertion QA reuses)
+  and its by-construction ``expected_ids`` survive the oracle cross-check;
+* ``oracle_survivors`` is an authoring aid, not the assertion target.
+
+The live-store seeder (:func:`~khora.filter.conformance.seed_case`) and the
+``PostgresExecutor`` live-run path are integration concerns covered elsewhere;
+here ``PostgresExecutor`` is only checked to invoke the real ``compile_postgres``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from sqlalchemy.sql.elements import ColumnElement
+
+from khora.filter import RecallFilterUnsupportedError
+from khora.filter.ast import FilterNode
+from khora.filter.conformance import (
+    ChronicleExecutor,
+    ConformanceCase,
+    PostgresExecutor,
+    PythonExecutor,
+    SeedRecord,
+    assert_case,
+    f_op_cases,
+    oracle_survivors,
+    run_case_for_backend,
+)
+from khora.filter.model import SYSTEM_KEYS
+
+_HIT = datetime(2026, 6, 1, tzinfo=UTC)
+_MISS = datetime(2020, 1, 1, tzinfo=UTC)
+_BOUND = "2026-01-01T00:00:00Z"
+
+
+# A handful of hand-declared smoke cases. expected_ids is counted by hand from the
+# seed (NOT computed by running a compiler) — the whole point of the falsifiability
+# contract is that these are an independent oracle.
+_SMOKE_CASES: tuple[ConformanceCase, ...] = (
+    ConformanceCase(
+        id="SMOKE-source_timestamp-gte",
+        filter={"source_timestamp": {"$gte": _BOUND}},
+        seed_records=(
+            SeedRecord(id="recent", source_timestamp=_HIT),
+            SeedRecord(id="ancient", source_timestamp=_MISS),
+            SeedRecord(id="undated"),
+        ),
+        expected_ids=frozenset({"recent"}),
+        backends=frozenset({"python", "chronicle"}),
+        exercises=("SMOKE", "source_timestamp", "$gte"),
+    ),
+    ConformanceCase(
+        id="SMOKE-metadata-eq",
+        filter={"metadata.tier": "gold"},
+        seed_records=(
+            SeedRecord(id="gold", metadata={"tier": "gold"}),
+            SeedRecord(id="silver", metadata={"tier": "silver"}),
+            SeedRecord(id="untagged"),
+        ),
+        expected_ids=frozenset({"gold"}),
+        backends=frozenset({"python", "chronicle"}),
+        exercises=("SMOKE", "metadata.tier", "$eq"),
+    ),
+    ConformanceCase(
+        id="SMOKE-source_name-ne",
+        filter={"source_name": {"$ne": "linear"}},
+        seed_records=(
+            SeedRecord(id="from-linear", source_name="linear"),
+            SeedRecord(id="from-slack", source_name="slack"),
+            SeedRecord(id="no-source-name"),
+        ),
+        # $ne includes absent / non-equal: everything except the exact match.
+        expected_ids=frozenset({"from-slack", "no-source-name"}),
+        backends=frozenset({"python", "chronicle"}),
+        exercises=("SMOKE", "source_name", "$ne"),
+    ),
+    ConformanceCase(
+        id="SMOKE-empty-matches-all",
+        filter={},
+        seed_records=(
+            SeedRecord(id="a"),
+            SeedRecord(id="b"),
+        ),
+        expected_ids=frozenset({"a", "b"}),
+        backends=frozenset({"python", "chronicle"}),
+        exercises=("SMOKE", "empty"),
+    ),
+)
+
+
+@pytest.fixture
+def python_executor() -> PythonExecutor:
+    return PythonExecutor()
+
+
+@pytest.fixture
+def chronicle_executor() -> ChronicleExecutor:
+    return ChronicleExecutor()
+
+
+# --------------------------------------------------------------------------- #
+# The runner + assert_case on the hand-declared smoke cases.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("case", _SMOKE_CASES, ids=lambda c: c.id)
+def test_python_oracle_matches_declared_expected_ids(case: ConformanceCase, python_executor: PythonExecutor) -> None:
+    # assert_case compares the Python oracle's survivors against the HAND-DECLARED
+    # expected_ids — the oracle is falsifiable against an independent count.
+    assert_case(case, "python", python_executor)
+
+
+@pytest.mark.parametrize("case", _SMOKE_CASES, ids=lambda c: c.id)
+def test_chronicle_agrees_with_declared_expected_ids(
+    case: ConformanceCase, chronicle_executor: ChronicleExecutor
+) -> None:
+    # The Chronicle plan/run seam (date-bound pushdown + full-AST post-filter)
+    # returns the same survivors the case declares.
+    assert_case(case, "chronicle", chronicle_executor)
+
+
+@pytest.mark.parametrize("case", _SMOKE_CASES, ids=lambda c: c.id)
+def test_chronicle_agrees_with_python_oracle(
+    case: ConformanceCase, python_executor: PythonExecutor, chronicle_executor: ChronicleExecutor
+) -> None:
+    py = run_case_for_backend(case, "python", executor=python_executor)
+    chron = run_case_for_backend(case, "chronicle", executor=chronicle_executor)
+    assert chron == py
+
+
+# --------------------------------------------------------------------------- #
+# Falsifiability: a wrong declared expected_ids must make assert_case fail.
+# --------------------------------------------------------------------------- #
+
+
+def test_assert_case_fails_on_wrong_expected_ids(python_executor: PythonExecutor) -> None:
+    # A deliberately wrong hand-declared expectation must be caught — proving the
+    # assertion target is the declared set, not whatever the oracle computes.
+    wrong = ConformanceCase(
+        id="SMOKE-wrong",
+        filter={"metadata.tier": "gold"},
+        seed_records=(
+            SeedRecord(id="gold", metadata={"tier": "gold"}),
+            SeedRecord(id="silver", metadata={"tier": "silver"}),
+        ),
+        expected_ids=frozenset({"silver"}),  # WRONG on purpose (gold is the match)
+        backends=frozenset({"python"}),
+    )
+    with pytest.raises(AssertionError):
+        assert_case(wrong, "python", python_executor)
+
+
+def test_assert_case_requires_expected_ids_for_survivor_assertion(python_executor: PythonExecutor) -> None:
+    case = ConformanceCase(
+        id="SMOKE-none-expected",
+        filter={"metadata.tier": "gold"},
+        seed_records=(SeedRecord(id="gold", metadata={"tier": "gold"}),),
+        expected_ids=None,
+        backends=frozenset({"python"}),
+    )
+    with pytest.raises(ValueError, match="expected_ids is required"):
+        assert_case(case, "python", python_executor)
+
+
+# --------------------------------------------------------------------------- #
+# oracle_survivors is an authoring aid, not the assertion target.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("case", _SMOKE_CASES, ids=lambda c: c.id)
+def test_oracle_survivors_helper_agrees_with_declared_ids(case: ConformanceCase) -> None:
+    assert oracle_survivors(case) == case.expected_ids
+
+
+# --------------------------------------------------------------------------- #
+# F-OP generator: coverage + by-construction expected_ids survive the oracle.
+# --------------------------------------------------------------------------- #
+
+
+def test_f_op_corpus_is_non_empty() -> None:
+    assert f_op_cases(), "the F-OP generator must produce cases"
+
+
+def test_f_op_exercises_cover_every_system_key() -> None:
+    # The coverage meta-test QA reuses: the union of every case's `exercises` tags
+    # must be a superset of SYSTEM_KEYS.
+    covered = {tag for case in f_op_cases() for tag in case.exercises}
+    assert SYSTEM_KEYS <= covered, f"F-OP exercises miss system keys: {sorted(SYSTEM_KEYS - covered)}"
+
+
+def test_f_op_coverage_check_is_falsifiable() -> None:
+    # Teeth for the coverage assertion above: drop every case tagging one covered
+    # key and confirm the SAME `SYSTEM_KEYS <= covered` check then FAILS for that
+    # key — so the coverage test is demonstrably not a tautology.
+    cases = f_op_cases()
+    covered = {tag for case in cases for tag in case.exercises}
+    target = sorted(SYSTEM_KEYS & covered)[0]
+
+    depleted = [case for case in cases if target not in case.exercises]
+    assert depleted != cases, "expected to drop at least one case for the target key"
+
+    depleted_covered = {tag for case in depleted for tag in case.exercises}
+    assert not (SYSTEM_KEYS <= depleted_covered), "coverage check stayed green with a key removed — no teeth"
+    assert target in (SYSTEM_KEYS - depleted_covered)
+
+
+def test_f_op_expected_ids_confirmed_by_oracle() -> None:
+    # Each F-OP case's BY-CONSTRUCTION expected_ids must survive the Python oracle
+    # cross-check (the generator declares them; the oracle confirms — never defines).
+    for case in f_op_cases():
+        assert oracle_survivors(case) == case.expected_ids, case.id
+
+
+def test_f_op_chronicle_agrees_with_python_oracle() -> None:
+    py = PythonExecutor()
+    chron = ChronicleExecutor()
+    for case in f_op_cases():
+        py_ids = run_case_for_backend(case, "python", executor=py)
+        chron_ids = run_case_for_backend(case, "chronicle", executor=chron)
+        assert chron_ids == py_ids, case.id
+
+
+# --------------------------------------------------------------------------- #
+# PostgresExecutor invokes the REAL compile_postgres.
+# --------------------------------------------------------------------------- #
+
+
+def test_postgres_executor_invokes_real_compiler() -> None:
+    captured: dict[str, Any] = {}
+
+    def runner(predicate: Any, params: Any, records: Any) -> frozenset[str]:
+        captured["predicate"] = predicate
+        return frozenset()
+
+    executor = PostgresExecutor(runner)
+    run_case_for_backend(_SMOKE_CASES[1], "postgres", executor=executor)
+
+    # The injected runner received a genuine compiled SQLAlchemy predicate — proof
+    # the real compile_postgres ran, not a context-only shim.
+    assert isinstance(captured["predicate"], ColumnElement)
+
+
+# --------------------------------------------------------------------------- #
+# assert_case's expect_unsupported branch (harness control flow).
+# --------------------------------------------------------------------------- #
+#
+# The validator and the python/postgres compilers share one expressiveness
+# envelope by design, so no VALIDATED wire filter naturally diverges between them
+# (the catalog's F-UNSUP family carves out the real unsupported clauses end to end).
+# To exercise the harness's own unsupported handling here, in process, a synthetic
+# executor raises RecallFilterUnsupportedError and assert_case is checked to (a)
+# accept it when the backend is declared unsupported and (b) NOT swallow it
+# otherwise.
+
+
+class _RaisingExecutor:
+    """A BackendExecutor (structural) that always raises unsupported.
+
+    Stands in for a real compiler that cannot express a clause; the filter it is
+    handed only needs to lower through ``parse_to_ast`` (a trivially valid one).
+    """
+
+    def survivors(
+        self,
+        filter_ast: FilterNode,
+        records: Sequence[tuple[str, Mapping[str, Any]]],
+    ) -> frozenset[str]:
+        raise RecallFilterUnsupportedError(("source_name",), "synthetic: backend cannot express this clause")
+
+
+def _unsupported_self_test_case(*, expect_unsupported: bool) -> ConformanceCase:
+    return ConformanceCase(
+        id="SMOKE-unsupported",
+        filter={"source_name": "x"},
+        seed_records=(SeedRecord(id="a", source_name="x"),),
+        expected_ids=None if expect_unsupported else frozenset({"a"}),
+        backends=frozenset({"postgres"}),
+        expect_unsupported=frozenset({"postgres"}) if expect_unsupported else frozenset(),
+    )
+
+
+def test_assert_case_accepts_declared_unsupported() -> None:
+    # When the backend is in expect_unsupported AND the executor raises, the case
+    # passes — assert_case wraps the run in pytest.raises for that backend.
+    assert_case(_unsupported_self_test_case(expect_unsupported=True), "postgres", _RaisingExecutor())
+
+
+def test_assert_case_propagates_unexpected_unsupported() -> None:
+    # A raise from a backend NOT listed in expect_unsupported must surface — the
+    # harness never silently swallows an unsupported error it did not expect.
+    with pytest.raises(RecallFilterUnsupportedError):
+        assert_case(_unsupported_self_test_case(expect_unsupported=False), "postgres", _RaisingExecutor())

--- a/tests/unit/filter/test_system_keys_coverage.py
+++ b/tests/unit/filter/test_system_keys_coverage.py
@@ -1,0 +1,61 @@
+"""Coverage meta-test: every system key has at least one generated operator case.
+
+The generated ``F-OP`` family is meant to exercise *every* system key the filter
+grammar whitelists (:data:`~khora.filter.SYSTEM_KEYS`) across its operators. This
+meta-test reads the ``exercises`` tag tuple each generated case carries and asserts
+their union is a superset of :data:`SYSTEM_KEYS` — so the day a new system key is
+added without a matching operator case, this goes red.
+
+A meta-test that can never fail is worthless, so the second test proves the teeth:
+it drops every case tagging one key, then asserts the same coverage check *would*
+fail for the depleted corpus. That makes the falsifiability explicit rather than
+assumed.
+
+No DB, no infra — this runs in the fast unit suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from khora.filter import SYSTEM_KEYS
+from khora.filter.conformance import ConformanceCase, f_op_cases
+
+pytestmark = pytest.mark.unit
+
+
+def _covered_keys(cases: list[ConformanceCase]) -> frozenset[str]:
+    """The union of every ``exercises`` tag across ``cases``.
+
+    The ``exercises`` tuple is free-form (``("F-OP", "occurred_at", "$gte")``); the
+    system-key member is whichever tag also lives in :data:`SYSTEM_KEYS`. Returning
+    the whole tag union and intersecting against ``SYSTEM_KEYS`` at the assertion
+    site keeps this helper agnostic to tag position.
+    """
+    return frozenset(tag for case in cases for tag in case.exercises)
+
+
+def test_every_system_key_has_an_operator_case() -> None:
+    """Each :data:`SYSTEM_KEYS` member is exercised by at least one generated case."""
+    cases = f_op_cases()
+    covered = _covered_keys(cases)
+    missing = SYSTEM_KEYS - covered
+    assert not missing, f"system keys with no F-OP case: {sorted(missing)}"
+
+
+def test_coverage_check_is_falsifiable() -> None:
+    """The coverage assertion has teeth: deplete one key and it must fail.
+
+    Removing every case that tags one arbitrary system key leaves that key
+    uncovered; the same superset check must then report it as missing. If this
+    *passed* on the depleted corpus, the real coverage test above would be vacuous.
+    """
+    cases = f_op_cases()
+    # Pick a key the corpus genuinely covers, so dropping its cases is a real change.
+    target = sorted(SYSTEM_KEYS & _covered_keys(cases))[0]
+
+    depleted = [case for case in cases if target not in case.exercises]
+    assert depleted != cases, "expected to remove at least one case for the target key"
+
+    missing = SYSTEM_KEYS - _covered_keys(depleted)
+    assert target in missing, f"coverage check failed to notice {target!r} went uncovered — the meta-test has no teeth"


### PR DESCRIPTION
## Summary

Adds the machinery for a cross-backend recall-filter **conformance corpus** — a storage-filter integration harness that runs the *real* validator and the *real* per-backend compilers, replacing only engine orchestration with a minimal seeded-row executor, to prove every backend returns the **same row set** for the same filter.

- **`filter/conformance.py`** (new, internal): a frozen `ConformanceCase` / `SeedRecord` schema; a backend-agnostic runner (`run_case_for_backend` / `assert_case`); a write-API seeder that partitions each case into its own namespace (deterministic `uuid5`, read-only after seed, so cases fan out safely under `pytest-xdist`); `Python` / `Chronicle` / `Postgres` executors; and a fully generated **F-OP** case family covering every filterable system key. The remaining case families are documented stubs for a follow-up change.
- **`filter/execute.py`** (new, internal): two extracted production seams so the harness and the engines compile through identical code —
  - `build_compile_context()` — a single `CompileContext` builder, and
  - `plan_chronicle_filter()` / `run_chronicle_filter()` — the compile + date-bound pushdown + Python post-filter combine used by the Chronicle path.
- **Engine routing**: the skeleton-pgvector and Chronicle compile sites now go through the new seams. This is a **pure extraction** — the constructed context is field-for-field identical to the previous inline construction, and the Chronicle engine preserves its degradation records, filter `engine_info`, and telemetry byte-for-byte (telemetry contract unchanged; drift gate green).
- **Tests**: a system-key **coverage meta-test** that fails if any filterable system key lacks an operator case (with a falsifiability guard proving the check has teeth), plus in-process harness self-tests that exercise the real compile path and the oracle-falsifiable expected-id contract (the Python oracle is checked against hand-declared row sets, never the reverse).

A third inline context builder in the legacy metadata-range path is intentionally left untouched (not a seam site) and noted as a follow-up.

## Test plan

- [x] Unit tests pass — harness self-tests + coverage meta-test (28), filter + recall suites (542) green locally; scoped `khora/filter` coverage 92%
- [ ] Integration / e2e tests pass — deferred to CI (require Postgres + Neo4j service containers, not available in the dev sandbox)
- [x] Telemetry contract drift gate green (no span/metric/export change)
- [x] Manual verification: both production compile sites route through the shared seams with field-identical context and no behavior change