### PR TITLE
Add SQLite recall-filter compiler with json_extract metadata pushdown

### DIFF
--- a/src/khora/engines/skeleton/backends/sqlite_lance.py
+++ b/src/khora/engines/skeleton/backends/sqlite_lance.py
@@ -25,6 +25,7 @@ Hybrid mode fuses ranks via RRF (same constants as the PG backend).
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
@@ -160,6 +161,13 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         self._handle = handle
         self._connected = False
         self._chunks_vec: Any = None
+        # Whether the SQLite build has the JSON1 functions (json_extract /
+        # json_type / json_each). Probed once in connect(); gates metadata
+        # pushdown in compile_lance. Defaults False so a build without JSON1
+        # (or before connect()) routes every metadata predicate to the
+        # compile_python post-filter. Tests may monkeypatch this to False to
+        # exercise the fallback path.
+        self._has_json1 = False
         # LanceDB is a single-writer store — serialize add/delete on the
         # khora_chunks_vec table per-instance to mirror the main vector
         # adapter's policy.
@@ -182,6 +190,17 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         for stmt in _KHORA_CHUNKS_SCHEMA:
             await sqlite.execute(stmt)
         await sqlite.commit()
+
+        # Probe once for the JSON1 functions so compile_lance knows whether it
+        # can push metadata predicates down into the JSON-text ``metadata``
+        # column. A build without JSON1 raises on json_valid(); we degrade to
+        # the compile_python post-filter for all metadata leaves.
+        try:
+            cur = await sqlite.execute("SELECT json_valid('{}')")
+            row = await cur.fetchone()
+            self._has_json1 = bool(row and row[0] == 1)
+        except Exception:
+            self._has_json1 = False
 
         # Create the LanceDB vector table for khora_chunks. exist_ok keeps
         # this idempotent across processes/test runs.
@@ -371,8 +390,9 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         query_text: str | None = None,
         filter_ast: FilterNode | None = None,
     ) -> list[TemporalSearchResult]:
-        # ``filter_ast`` is accepted for protocol parity; this backend does not
-        # compile the recall-filter AST yet, so it is ignored.
+        # ``filter_ast`` is the deterministic recall-filter AST. compile_lance
+        # pushes what JSON1 supports into the SQLite WHERE; a compile_python
+        # post-filter then enforces the full AST (the exactness guarantee).
         with trace_span(
             "khora.temporal_store.search",
             namespace_id=str(namespace_id),
@@ -387,6 +407,7 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
                 temporal_filter=temporal_filter,
                 hybrid_alpha=hybrid_alpha,
                 query_text=query_text,
+                filter_ast=filter_ast,
             )
             _span.set_attribute("result_count", len(results))
             return results
@@ -401,7 +422,17 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         temporal_filter: TemporalFilter | None,
         hybrid_alpha: float | None,
         query_text: str | None,
+        filter_ast: FilterNode | None = None,
     ) -> list[TemporalSearchResult]:
+        # Build the compile_python post-filter ONCE per recall (it is
+        # alias-independent — it runs on decoded TemporalChunks). compile_python
+        # fires the public ``khora.recall.filter.unindexed_metadata`` counter at
+        # build time, so building it per-pass would double-count it on a hybrid
+        # recall; one build per recall keeps that contract. The compile_lance
+        # pushdown is still compiled per-pass inside each pass (its column
+        # qualifier differs, and it fires zero unindexed_metadata).
+        post_filter = self._ast_post_filter(filter_ast)
+
         # Vector pass.  Fetch 2× when fusion is requested so RRF has a
         # broader rank corpus.
         vector_results = await self._vector_search(
@@ -410,6 +441,8 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
             temporal_filter,
             limit * 2 if hybrid_alpha is not None else limit,
             min_similarity,
+            filter_ast,
+            post_filter,
         )
 
         if hybrid_alpha is not None and query_text:
@@ -418,6 +451,8 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
                 query_text,
                 temporal_filter,
                 limit * 2,
+                filter_ast,
+                post_filter,
             )
             return self._rrf_fusion(vector_results, bm25_results, hybrid_alpha, limit)
 
@@ -433,6 +468,8 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
                 query_text,
                 temporal_filter,
                 needed + len(existing_ids),
+                filter_ast,
+                post_filter,
             )
             for bm25_result in bm25_results:
                 cid = str(bm25_result.chunk.id)
@@ -453,6 +490,8 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         temporal_filter: TemporalFilter | None,
         limit: int,
         min_similarity: float,
+        filter_ast: FilterNode | None = None,
+        post_filter: Callable[[TemporalChunk], bool] | None = None,
     ) -> list[TemporalSearchResult]:
         tbl = await self._vec_table()
         ns_text = uuid_to_text(namespace_id)
@@ -480,10 +519,23 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         if filter_sql:
             sql += f" AND {filter_sql}"
             params.extend(filter_params)
+        # Recall-filter AST pushdown. The base table is unaliased here, so the
+        # compiler qualifies system columns with backend_target (alias=None).
+        ast_sql, ast_params = self._build_ast_clause(filter_ast, alias=None)
+        if ast_sql:
+            sql += f" AND {ast_sql}"
+            params.extend(ast_params)
 
         cur = await self._sqlite.execute(sql, params)
         meta_rows = await cur.fetchall()
         by_id = {row["id"]: row for row in meta_rows}
+
+        # compile_python oracle: enforces the leaves compile_lance deferred,
+        # applied to the SAME decoded chunk that is returned. Built once per
+        # recall in _search_inner; default to a match-all if a direct caller
+        # (search_fulltext) didn't supply one.
+        if post_filter is None:
+            post_filter = self._ast_post_filter(filter_ast)
 
         out: list[TemporalSearchResult] = []
         for cid in ordered_ids:
@@ -499,6 +551,8 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
             if temporal_filter and temporal_filter.tags:
                 if not all(t in chunk.tags for t in temporal_filter.tags):
                     continue
+            if not post_filter(chunk):
+                continue
             out.append(
                 TemporalSearchResult(
                     chunk=chunk,
@@ -541,6 +595,8 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         query_text: str,
         temporal_filter: TemporalFilter | None,
         limit: int,
+        filter_ast: FilterNode | None = None,
+        post_filter: Callable[[TemporalChunk], bool] | None = None,
     ) -> list[TemporalSearchResult]:
         # FTS5 MATCH; SQLite's bm25() is lower-is-better — negate so the
         # semantics match the PG/SurrealDB siblings.
@@ -558,14 +614,29 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         if filter_sql:
             sql_parts.append(f"AND {filter_sql}")
             params.extend(filter_params)
-        # Over-fetch when tag filter is set so the post-decode pass still
-        # has enough rows.
-        fetch = limit * 4 if temporal_filter and temporal_filter.tags else limit
+        # Recall-filter AST pushdown. The base table is aliased ``c`` here, so
+        # the compiler qualifies system columns with that alias. Binds slot in
+        # before the trailing LIMIT bind (positional, emit order).
+        ast_sql, ast_params = self._build_ast_clause(filter_ast, alias="c")
+        if ast_sql:
+            sql_parts.append(f"AND {ast_sql}")
+            params.extend(ast_params)
+        # Over-fetch when a tag filter or AST post-filter is set so the
+        # post-decode pass still has enough rows.
+        narrowing = (temporal_filter and temporal_filter.tags) or (filter_ast is not None and filter_ast.children)
+        fetch = limit * 4 if narrowing else limit
         sql_parts.append("ORDER BY bm ASC LIMIT ?")
         params.append(fetch)
 
         cur = await self._sqlite.execute(" ".join(sql_parts), params)
         rows = await cur.fetchall()
+
+        # compile_python oracle: enforces the leaves compile_lance deferred,
+        # applied to the SAME decoded chunk that is returned. Built once per
+        # recall in _search_inner; default to a match-all if a direct caller
+        # (search_fulltext) didn't supply one.
+        if post_filter is None:
+            post_filter = self._ast_post_filter(filter_ast)
 
         out: list[TemporalSearchResult] = []
         for row in rows:
@@ -573,6 +644,8 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
             if temporal_filter and temporal_filter.tags:
                 if not all(t in chunk.tags for t in temporal_filter.tags):
                     continue
+            if not post_filter(chunk):
+                continue
             score = -float(row["bm"])
             out.append(
                 TemporalSearchResult(
@@ -665,6 +738,63 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
 
         return " AND ".join(clauses), params
 
+    def _build_ast_clause(
+        self,
+        filter_ast: FilterNode | None,
+        *,
+        alias: str | None,
+    ) -> tuple[str, list[Any]]:
+        """Compile the recall-filter AST to a SQLite WHERE fragment + binds.
+
+        ``compile_lance`` runs in ``split`` mode: it pushes the system-key and
+        (JSON1-permitting) metadata predicates it can express into SQLite and
+        leaves the rest to the :meth:`_ast_post_filter` callable — so this
+        fragment never wrongly excludes a row (superset-safe). ``alias`` matches
+        the table reference in the host query: ``None`` for the unaliased vector
+        post-fetch, ``"c"`` for the BM25 FTS-join. Returns ``("", [])`` when
+        there is nothing to push (no AST, or a bare match-everything filter).
+        """
+        if filter_ast is None or not filter_ast.children:
+            return "", []
+        from khora.filter import CompileContext, SchemaCapabilities
+        from khora.filter.compilers.lance import compile_lance
+
+        ctx = CompileContext(
+            backend_target="khora_chunks",
+            table_alias=alias,
+            on_unsupported="split",
+            schema_capabilities=SchemaCapabilities(sqlite_json1=self._has_json1),
+        )
+        compiled = compile_lance(filter_ast, ctx)
+        return compiled.predicate, list(compiled.params["args"])
+
+    @staticmethod
+    def _ast_post_filter(filter_ast: FilterNode | None) -> Callable[[TemporalChunk], bool]:
+        """Build the in-memory post-filter callable for the full AST.
+
+        ``compile_python`` is the oracle: it re-checks every leaf (system key
+        and metadata) against a decoded :class:`TemporalChunk`, enforcing the
+        leaves ``compile_lance`` deferred. The SAME decoded chunk that is
+        returned to the caller is passed here — never a re-read row — so the
+        oracle sees the row's true decoded values and the pushed SQL row-set is
+        a superset of the post-filtered set. Returns a match-all predicate when
+        there is no AST.
+
+        Built ONCE per recall in :meth:`_search_inner` and threaded into both
+        passes: ``compile_python`` fires the public
+        ``khora.recall.filter.unindexed_metadata`` counter at build time, so a
+        per-pass build would double-count it on a hybrid recall.
+        """
+        if filter_ast is None or not filter_ast.children:
+            return lambda _chunk: True
+        from khora.filter import CompileContext
+        from khora.filter.compilers.python import compile_python
+
+        return compile_python(
+            filter_ast,
+            CompileContext(backend_target="khora_chunks", on_unsupported="split"),
+        ).predicate
+
     # ------------------------------------------------------------------
     # Decode helpers
     # ------------------------------------------------------------------
@@ -728,3 +858,14 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
 
 
 __all__ = ["SQLiteLanceTemporalStore"]
+
+
+# Register the deterministic recall-filter compiler for this engine/target at
+# import time (idempotent — same function object). ``sqlite_lance.py`` is
+# imported lazily by ``create_temporal_store("sqlite_lance", ...)``, so
+# registration happens exactly when the embedded backend is first constructed —
+# no eager cost, and no registration when the backend is unused.
+from khora.filter import CompilerRegistry  # noqa: E402
+from khora.filter.compilers.lance import compile_lance  # noqa: E402
+
+CompilerRegistry.register("skeleton.sqlite_lance", "khora_chunks", compile_lance)

--- a/src/khora/filter/compilers/__init__.py
+++ b/src/khora/filter/compilers/__init__.py
@@ -13,12 +13,14 @@ backend's query fragment. A compiler is a stateless
 from __future__ import annotations
 
 from khora.filter.compilers.chronicle import ChronicleDateBound, compile_chronicle
+from khora.filter.compilers.lance import compile_lance
 from khora.filter.compilers.postgres import compile_postgres
 from khora.filter.compilers.python import compile_python
 
 __all__ = [
     "ChronicleDateBound",
     "compile_chronicle",
+    "compile_lance",
     "compile_postgres",
     "compile_python",
 ]

--- a/src/khora/filter/compilers/lance.py
+++ b/src/khora/filter/compilers/lance.py
@@ -1,0 +1,624 @@
+"""SQLite recall-filter compiler for the sqlite_lance backend — ``@internal``.
+
+Lowers a canonical :class:`~khora.filter.ast.FilterNode` to a single SQLite
+``WHERE`` fragment against ``khora_chunks`` (no documents join — the filterable
+document columns are denormalized onto the chunk row). The output is a
+:class:`~khora.filter.registry.CompiledFilter` whose ``predicate`` is a SQLite
+boolean *string* the backend ``AND``-s into its own ``WHERE``, paired with
+``params == {"args": [...]}`` — an ordered list of positional binds, one per
+``?`` placeholder in emit (depth-first) order. The host query is positional, so
+binds cannot be named (``:name``) without mixing the two styles.
+
+The compiler is the Layer-4 SQLite sibling of
+:func:`~khora.filter.compilers.postgres.compile_postgres` and is checked for
+row-set parity against :func:`~khora.filter.compilers.python.compile_python` (the
+oracle). It speaks the four emission rules:
+
+1. **Never abort.** A comparison against a wrong-typed or absent value yields
+   SQL ``NULL``; every such leaf is wrapped in ``coalesce(<expr>, 0)`` so it
+   reads ``0`` (false) instead — SQLite has no boolean type, so the totality
+   sentinel is the integer ``0`` (cf. ``false()`` in Postgres / ``false`` in
+   Cypher). A numeric compare on a string value never errors: the
+   ``json_type`` gate excludes it first.
+2. **Polarity.** Negations include absent/null/wrong-type rows: a system ``$ne``
+   is ``(col IS NULL OR col <> ?)``; a ``$nin`` is ``(col IS NULL OR NOT col IN
+   (...))``. Never drop a NULL row on a negation.
+3. **Impossible pairs (narrow).** An ``$eq`` exact-array (tuple) operand against
+   a scalar system column never matches (a scalar column is not a list), so it
+   emits the constant ``0``; its ``$ne`` mirror emits ``1``. ``$in`` / ``$nin``
+   are normal membership.
+4. **Presence/null.** ``$exists`` and a ``{k: null}`` match resolve to constants
+   on a system column (a column is always present in the row) and to
+   ``json_type``-based tests on metadata: ``json_extract`` returns SQL ``NULL``
+   for BOTH an absent path AND a stored JSON ``null``, so the absent-vs-null
+   distinction is read off ``json_type`` (``NULL`` for absent, the string
+   ``'null'`` for a JSON null value) — mirroring the oracle's ``MISSING`` vs
+   ``None``.
+
+**Totality (the rule that makes negation uniform).** ``NOT`` is compiled as
+``(NOT (<child>))``; SQLite ``NOT NULL`` is ``NULL`` (drops the row), which would
+violate Rule 2. So every leaf that *can* produce ``NULL`` (an absent / wrong-type
+compare) is wrapped in ``coalesce(<expr>, 0)`` — a total boolean. The positive
+use is unchanged (``0`` excludes exactly as ``NULL`` would), and a wrapping
+``NOT`` then flips absent rows to true correctly. ``json_type ... IS NULL`` /
+``EXISTS(...)`` are already total.
+
+**Dates compare as ISO strings.** A chunk stores every datetime column as an
+ISO-8601 string (``.isoformat()``), so a :class:`~datetime.datetime` /
+:class:`DateLiteral` operand binds as its ``.isoformat()`` string and compares
+lexicographically — ISO-8601's fixed-width, big-endian layout makes string order
+agree with chronological order for the UTC-normalized values the validator
+produces (same contract as :func:`compile_cypher`).
+
+**Bool-vs-number gate.** SQLite's ``json_extract`` collapses a JSON ``true`` to
+the integer ``1`` and ``false`` to ``0``, so a raw extracted-value compare would
+wrongly match ``True == 1``. The oracle treats a bool and a number as unequal
+(JSONB semantics). Every metadata scalar/range compare therefore type-gates on
+``json_type`` (``'true'``/``'false'`` for a bool operand, ``'integer'``/``'real'``
+for a number, ``'text'`` for a string) before comparing the value — mirroring
+``compile_postgres``'s ``jsonb_typeof`` gate and the oracle's ``_comparable``.
+
+**Metadata pushdown is gated on JSON1.** Metadata predicates require the SQLite
+JSON1 functions (``json_extract`` / ``json_type`` / ``json_each``). When
+``ctx.schema_capabilities.sqlite_json1`` is ``False``, every metadata leaf is
+treated as unsupported (handled per ``on_unsupported`` — the backend drives
+``"split"``, leaving metadata to the ``compile_python`` post-filter while system
+keys still push down). Three metadata cases are *always* unsupported even with
+JSON1, because they cannot match the oracle's row-set in pure SQL: the bare-blob
+``$eq`` (whole-document equality), a sub-path ``object_equal`` (dict-operand)
+``$eq`` — SQLite ``json()`` is key-order-sensitive but the oracle is not — and a
+``$date`` metadata compare. They emit the non-constraining ``"1"`` and are left
+out of ``consumed_keys`` so ``compile_python`` re-checks them.
+
+**Superset-safety invariant.** ``compile_lance`` must NEVER wrongly *exclude* a
+row — the ``compile_python`` post-filter only narrows what the pushdown returned.
+Every NULL-producing leaf coalesces to ``0`` (excludes only on a true mismatch),
+and any op whose SQL semantics risk over-narrowing is left unconsumed (emits
+``"1"``) so the post-filter decides.
+
+``@internal``. Reachable as ``khora.filter.compilers.lance.compile_lance`` for
+khora's own engines; not re-exported from :mod:`khora.__init__`. Registration
+against the ``("skeleton.sqlite_lance", "khora_chunks")`` key lives at the bottom
+of the backend module (``engines/skeleton/backends/sqlite_lance.py``), keeping
+this package registry-import-free.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from khora.filter import (
+    CompileContext,
+    CompiledFilter,
+    RecallFilterUnsupportedError,
+)
+from khora.filter.ast import (
+    DateLiteral,
+    FilterClause,
+    FilterNode,
+    canonical_hash,
+)
+from khora.filter.model import SYSTEM_KEYS, Op
+
+__all__ = ["compile_lance"]
+
+
+# SQLite comparison operator strings for the range ops, keyed by AST op.
+_RANGE_OP = {
+    Op.GT: ">",
+    Op.GTE: ">=",
+    Op.LT: "<",
+    Op.LTE: "<=",
+}
+
+# json_type gate-token sets by operand kind. SQLite reports a JSON bool as
+# 'true'/'false' and a number as 'integer'/'real'; a string is 'text'. The gate
+# preserves the oracle's bool-vs-number distinction (a JSON true is NOT a number).
+_NUMBER_TYPES = "('integer', 'real')"
+_STRING_TYPES = "('text')"
+
+
+def compile_lance(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[str]:
+    """Compile a canonical AST to a SQLite ``WHERE`` fragment + positional binds.
+
+    ``ast`` is always a :class:`FilterNode` (the ``parse_to_ast`` root invariant).
+    An empty ``AND`` (the match-everything root of a bare filter) compiles to the
+    literal ``"1"`` (SQLite truthy). Binds are returned out-of-band in
+    ``params == {"args": [...]}`` as an ordered list, one entry per ``?`` in
+    depth-first emit order; the backend splices the fragment into its positional
+    SELECT and extends its own bind list with ``args``.
+
+    Column references are derived from ``ctx`` alone: the qualifier is
+    ``ctx.table_alias`` if set else ``ctx.backend_target`` (so ``c.occurred_at`` on
+    the aliased FTS-join path, ``khora_chunks.occurred_at`` on the unaliased
+    vector post-fetch path), and ``field_mapping`` remaps a logical key to its
+    physical column name (identity when ``None``), so the compiler embeds no
+    engine schema.
+
+    Honors ``ctx.on_unsupported``: on a clause this backend cannot express,
+    ``"raise"`` raises :class:`RecallFilterUnsupportedError`; ``"split"`` omits it
+    from ``consumed_keys`` and emits the non-constraining ``"1"`` so the engine
+    post-filters it with ``compile_python``. Metadata predicates are unsupported
+    when ``ctx.schema_capabilities.sqlite_json1`` is ``False`` (no JSON1
+    functions), plus three cases that cannot match the oracle in SQL even with
+    JSON1 (bare-blob ``$eq``, ``object_equal`` dict operands, ``$date`` compares).
+
+    This compiler does **not** emit the ``khora.recall.filter.unindexed_metadata``
+    counter. The always-on ``compile_python`` post-filter (run on the full AST for
+    every sqlite_lance recall) is the canonical once-per-leaf emit site, matching
+    chronicle; firing here too would double-count that public metric.
+    """
+    consumed: set[str] = set()
+    builder = _Builder(ctx=ctx, consumed=consumed)
+    predicate = builder.compile_node(ast)
+    return CompiledFilter(
+        predicate=predicate,
+        params={"args": builder.args},
+        consumed_keys=frozenset(consumed),
+        # canonical_hash over the whole AST. In on_unsupported="raise" mode every
+        # leaf is consumed, so the whole tree == the consumed slice. When
+        # split-mode is implemented end-to-end, hash the reconstructed consumed
+        # sub-AST instead, not the whole tree.
+        canonical_hash=canonical_hash(ast),
+    )
+
+
+def _path_str(path: tuple[str, ...]) -> str:
+    """Render an AST path as the dotted key string used for diagnostics/consumed."""
+    return ".".join(path)
+
+
+def _jsonpath(segs: tuple[str, ...]) -> str:
+    """Build a quoted SQLite JSONPath string (``$."a"."b"``) for ``segs``.
+
+    Each segment is wrapped in double quotes with embedded ``"`` and ``\\``
+    escaped, so a segment containing ``.``, ``$``, ``[``, whitespace, or a quote
+    addresses the right key (an unquoted ``$.a.b`` would mis-parse such keys). The
+    returned string is **always bound as a ``?`` parameter** to ``json_extract`` /
+    ``json_type`` / ``json_each`` — it never enters the SQL text, so a
+    user-supplied metadata key is not an injection surface (the framing here is
+    only so the bound JSONPath literal is well-formed).
+    """
+    parts = []
+    for seg in segs:
+        escaped = seg.replace("\\", "\\\\").replace('"', '\\"')
+        parts.append(f'"{escaped}"')
+    return "$." + ".".join(parts)
+
+
+class _Builder:
+    """Per-compile-pass state: the :class:`CompileContext`, consumed set, binds.
+
+    Mirrors the cypher compiler's ``_Builder`` — a small object threading the
+    ``ctx`` (column refs are derived from it), the ``consumed`` accumulator, and
+    the positional ``args`` bind list every leaf appends to. Keeping them on one
+    object avoids passing the triple through every recursion frame. Each
+    ``compile_*`` method returns a SQLite boolean *string*; the logical-node walk
+    composes them with ``AND`` / ``OR`` / ``NOT``.
+    """
+
+    def __init__(self, *, ctx: CompileContext, consumed: set[str]) -> None:
+        self._ctx = ctx
+        self._consumed = consumed
+        self._qualifier = ctx.table_alias or ctx.backend_target
+        self.args: list[Any] = []
+
+    # ----- bind allocation ------------------------------------------------ #
+
+    def _bind(self, value: Any) -> str:
+        """Append ``value`` to the positional bind list and return a ``?`` token."""
+        self.args.append(value)
+        return "?"
+
+    def _col(self, key: str) -> str:
+        """Render a qualified column reference ``qualifier.col`` for a logical key.
+
+        ``field_mapping`` remaps a logical key to its physical column name
+        (identity when ``None``). ``key`` is always a controlled token (a system
+        key from the closed ``SYSTEM_KEYS`` whitelist, or the literal
+        ``"metadata"``) — never free user text, so the column token is not an
+        injection surface. Metadata path segments only ever reach the bound
+        JSONPath literal, never this token.
+        """
+        physical = (self._ctx.field_mapping or {}).get(key, key)
+        return f"{self._qualifier}.{physical}"
+
+    # ----- logical node walk ---------------------------------------------- #
+
+    def compile_node(self, node: FilterNode | FilterClause) -> str:
+        """Compile a logical node or leaf to a SQLite boolean string.
+
+        **Split-mode soundness — "AND distributes; OR/NOT are all-or-nothing."**
+        The match-all placeholder ``"1"`` an unconsumable leaf emits under
+        ``on_unsupported="split"`` is superset-safe only in *positive* position:
+        ``A AND 1`` ≡ ``A`` (still narrows correctly), but ``NOT (A OR 1)`` ≡
+        ``NOT 1`` ≡ ``0`` — which would *drop every row the filter keeps*, breaking
+        the superset invariant (the ``compile_python`` post-filter only narrows;
+        it cannot add a wrongly-excluded row back). So an ``OR`` / ``NOT`` node is
+        pushed down only when its **entire** subtree is consumable; otherwise the
+        whole node emits ``"1"`` and consumes nothing, deferring it wholesale to
+        the post-filter. An ``AND`` still handles each child independently — a
+        non-consumable child becomes ``"1"`` and the consumable siblings still
+        narrow.
+        """
+        if isinstance(node, FilterClause):
+            return self.compile_clause(node)
+        if node.op == Op.AND:
+            if not node.children:
+                # The empty match-everything root — no constraint.
+                return "1"
+            return "(" + " AND ".join(self.compile_node(c) for c in node.children) + ")"
+        if node.op == Op.OR:
+            if not node.children:
+                # The validator forbids an empty $or; guard defensively.
+                return "0"
+            if self._ctx.on_unsupported == "split" and not self._consumable(node):
+                # A non-consumable disjunct would compile to "1", making the whole
+                # OR match-all here while the post-filter still narrows — safe in
+                # positive position but it under-pushes silently AND becomes a
+                # false-exclude if a parent NOT wraps it. Defer the whole OR. In
+                # "raise" mode we instead descend so the offending leaf raises.
+                return "1"
+            return "(" + " OR ".join(self.compile_node(c) for c in node.children) + ")"
+        # Op.NOT — exactly one child per the AST contract. Pushed only when the
+        # child is fully consumable (then its SQL is exact + total in both
+        # polarities, so the negation is sound); otherwise defer the whole NOT
+        # (in "split" mode). In "raise" mode we descend so the offending leaf
+        # raises rather than being silently swallowed by the all-or-nothing gate.
+        if self._ctx.on_unsupported == "split" and not self._consumable(node):
+            return "1"
+        return f"(NOT ({self.compile_node(node.children[0])}))"
+
+    def _consumable(self, node: FilterNode | FilterClause) -> bool:
+        """True iff ``node``'s whole subtree compiles to SQL (no ``"1"`` deferral).
+
+        A pure predicate — no bind allocation, no ``consumed`` mutation, no
+        telemetry. A logical node is consumable iff every child is; a leaf is
+        consumable iff it is a system key or a pushdownable metadata predicate
+        (mirrors :meth:`_clause_unconsumable`). Used to keep an ``OR`` / ``NOT``
+        all-or-nothing: a node is pushed only when nothing inside it would fall to
+        the ``"1"`` placeholder.
+        """
+        if isinstance(node, FilterClause):
+            return not self._clause_unconsumable(node)
+        return all(self._consumable(c) for c in node.children)
+
+    def _clause_unconsumable(self, clause: FilterClause) -> bool:
+        """True iff this leaf cannot be pushed to SQL (would emit ``"1"``).
+
+        Mirrors the leaf dispatch in :meth:`compile_clause` /
+        :meth:`_compile_metadata_clause` without side effects: a system key always
+        pushes; a metadata leaf is unconsumable when JSON1 is unavailable, or when
+        it is one of the three shapes that cannot match the oracle in SQL — the
+        bare-blob ``$eq``, an ``object_equal`` (dict-operand) ``$eq`` / ``$ne``, or
+        a ``$date`` compare. Any non-system, non-metadata path is unconsumable.
+        """
+        path = clause.path
+        if len(path) == 1 and path[0] in SYSTEM_KEYS:
+            return False
+        if not (path and path[0] == "metadata"):
+            return True
+        if not self._ctx.schema_capabilities.sqlite_json1:
+            return True
+        if len(path) == 1:
+            # Bare-blob metadata $eq — never pushdownable.
+            return True
+        operand = clause.operand
+        if isinstance(operand, (DateLiteral, dict)):
+            # $date (any op) and object_equal dict ($eq / $ne) are deferred.
+            return True
+        return False
+
+    # ----- leaf key-kind split -------------------------------------------- #
+
+    def compile_clause(self, clause: FilterClause) -> str:
+        """Dispatch a leaf on key-kind (system key vs metadata path)."""
+        path = clause.path
+        if len(path) == 1 and path[0] in SYSTEM_KEYS:
+            expr = self._compile_system_clause(clause)
+        elif path and path[0] == "metadata":
+            if not self._ctx.schema_capabilities.sqlite_json1:
+                # No JSON1 functions — every metadata leaf falls to the
+                # compile_python post-filter (the backend drives "split").
+                return self._unsupported(clause, "SQLite JSON1 functions are unavailable")
+            expr = self._compile_metadata_clause(clause)
+            if expr is None:
+                # A metadata case that cannot match the oracle in SQL even with
+                # JSON1 (bare-blob $eq, object_equal dict operand, $date compare).
+                # Already reported as unsupported inside the metadata compiler.
+                return self._unsupported(clause, "metadata predicate is not pushed down to SQLite")
+            # NB: deliberately does NOT fire ``record_unindexed_metadata`` here.
+            # The always-on ``compile_python`` post-filter (which sqlite_lance runs
+            # on the full AST for every recall) is the canonical once-per-leaf
+            # emit site, matching chronicle; firing here too would double-count
+            # the public ``khora.recall.filter.unindexed_metadata`` metric on every
+            # metadata recall. Do not re-add.
+        else:
+            return self._unsupported(clause, "path is neither a system key nor a metadata path")
+        self._consumed.add(_path_str(path))
+        return expr
+
+    # ----- system-key leaves (typed columns) ------------------------------ #
+
+    def _compile_system_clause(self, clause: FilterClause) -> str:
+        key = clause.path[0]
+        col = self._col(key)
+        op = clause.op
+        operand = clause.operand
+
+        if op == Op.EXISTS:
+            # A system column is always present in the row — $exists is constant
+            # (parity with compile_python / compile_postgres).
+            return "1" if operand else "0"
+
+        if op in (Op.IN, Op.NIN):
+            if not operand:
+                # Empty $in matches nothing; empty $nin matches everything.
+                return "0" if op == Op.IN else "1"
+            placeholders = ", ".join(self._bind(_system_value(v)) for v in operand)
+            if op == Op.IN:
+                # Made total so a wrapping field-level $not includes NULL rows.
+                return f"coalesce({col} IN ({placeholders}), 0)"
+            # $nin includes NULL rows (Rule 2 polarity). Already a total boolean.
+            return f"({col} IS NULL OR NOT {col} IN ({placeholders}))"
+
+        # Rule 3 (NARROW): an $eq EXACT-ARRAY (tuple) operand against a scalar
+        # column never matches; its $ne mirror always matches.
+        if op == Op.EQ and isinstance(operand, tuple):
+            return "0"
+        if op == Op.NE and isinstance(operand, tuple):
+            return "1"
+
+        if operand is None:
+            # {k: null} → active null-or-missing match. For a system column,
+            # "missing" is NULL. $ne null → IS NOT NULL. Both are total.
+            if op == Op.NE:
+                return f"({col} IS NOT NULL)"
+            return f"({col} IS NULL)"
+
+        value_bind = self._bind(_system_value(operand))
+        if op == Op.NE:
+            # Include NULL rows (Rule 2): a row whose column is NULL satisfies $ne.
+            # Already a total boolean (no coalesce needed).
+            return f"({col} IS NULL OR {col} <> {value_bind})"
+        # $eq and the range ops compare directly. Wrap in coalesce(..., 0) so the
+        # leaf is total: a NULL column reads 0 (same exclusion as the bare NULL
+        # comparison), and a wrapping $not then flips a NULL-column row to true.
+        symbol = "=" if op == Op.EQ else _RANGE_OP[op]
+        return f"coalesce({col} {symbol} {value_bind}, 0)"
+
+    # ----- metadata leaves (JSON-TEXT column) ----------------------------- #
+
+    def _compile_metadata_clause(self, clause: FilterClause) -> str | None:
+        """Compile a metadata leaf, or ``None`` if it is unsupported in SQL.
+
+        Returns ``None`` (not a SQL string) for the three cases that cannot match
+        the ``compile_python`` oracle's row-set in pure SQLite even with JSON1 —
+        the caller turns ``None`` into the ``on_unsupported`` handling.
+        """
+        path = clause.path
+        op = clause.op
+        operand = clause.operand
+
+        # Bare-blob metadata $eq (whole-document equality). SQLite json() is
+        # key-order-sensitive whereas the oracle's whole-blob compare is
+        # structural/order-insensitive — cannot match in SQL, so defer.
+        if len(path) == 1:
+            return None
+
+        segs = path[1:]  # drop the leading "metadata" root
+        json_col = self._col("metadata")
+
+        if op == Op.EXISTS:
+            # json_type is NULL for an absent path, non-NULL (incl. 'null') for a
+            # present value — so presence is "json_type IS NOT NULL", matching the
+            # oracle's "the path resolves" (an explicit JSON null counts present).
+            present = f"json_type({json_col}, {self._jpath_bind(segs)}) IS NOT NULL"
+            return f"({present})" if operand else f"(NOT ({present}))"
+
+        if op in (Op.IN, Op.NIN):
+            if not operand:
+                # $in over ∅ matches nothing; $nin over ∅ matches everything.
+                return "0" if op == Op.IN else "1"
+            chain = " OR ".join(self._md_contains(segs, v) for v in operand)
+            if op == Op.IN:
+                return f"({chain})"
+            # $nin: NOT in the set. Containment is total (0 on absent/mismatch),
+            # so the negation includes absent / wrong-type rows (Rule 2).
+            return f"(NOT ({chain}))"
+
+        if op == Op.EQ:
+            if operand is None:
+                return self._md_null(segs)
+            if isinstance(operand, DateLiteral):
+                # A $date metadata compare needs ISO-string parse-or-exclude that
+                # SQLite cannot replicate to match the oracle — defer.
+                return None
+            if isinstance(operand, dict):
+                # object_equal: SQLite json() is key-order-sensitive, the oracle
+                # is not — defer to the post-filter.
+                return None
+            if isinstance(operand, tuple):
+                # Exact-array equality. Arrays are ordered in both the oracle and
+                # SQLite, so json()-normalized text equality matches.
+                return self._md_exact_array(segs, operand)
+            # Array-aware scalar containment (a scalar matches the node or a list
+            # element). Mirrors the oracle's _md_contains.
+            return self._md_contains(segs, operand)
+        if op == Op.NE:
+            if operand is None:
+                # $ne null → present AND not a JSON null value.
+                return f"(NOT {self._md_null(segs)})"
+            if isinstance(operand, DateLiteral):
+                return None
+            if isinstance(operand, dict):
+                return None
+            if isinstance(operand, tuple):
+                return f"(NOT {self._md_exact_array(segs, operand)})"
+            # Negate the (total) positive containment so absent / wrong-type rows
+            # are included (Rule 2).
+            return f"(NOT {self._md_contains(segs, operand)})"
+
+        # Range ops ($gt/$gte/$lt/$lte). A $date operand cannot be replicated to
+        # match the oracle — defer; otherwise type-gated scalar compare.
+        if isinstance(operand, DateLiteral):
+            return None
+        return self._md_range(segs, op, operand)
+
+    def _jpath_bind(self, segs: tuple[str, ...]) -> str:
+        """Bind the JSONPath for ``segs`` as a ``?`` param and return the token."""
+        return self._bind(_jsonpath(segs))
+
+    def _md_contains(self, segs: tuple[str, ...], value: Any) -> str:
+        """Array-aware, type-strict containment — total boolean (0 on absent).
+
+        Matches the oracle's ``_md_contains``: a scalar matches the node directly
+        OR an element of a stored list node. ``json_each`` over the path yields one
+        row for a scalar node, N rows for an array node, and zero rows for an absent
+        path — so a single ``EXISTS`` subquery covers scalar-eq, array-contains, and
+        the absent case at once. Its per-element ``type`` column is gated against
+        the operand's Python type, which preserves the oracle's bool-vs-number
+        distinction (a JSON ``true`` and the number ``1`` both surface ``value`` 1,
+        but their ``type`` differs — ``'true'`` vs ``'integer'``), even for an
+        element nested inside an array. The wrapping ``coalesce(..., 0)`` keeps the
+        leaf total so a wrapping ``NOT`` includes absent / wrong-type rows.
+        """
+        json_col = self._col("metadata")
+        gate, is_bool = _operand_type_gate(value)
+        # A JSON bool surfaces in ``json_each.value`` as the integer 1 / 0, so bind
+        # that (not a "true"/"false" string); the ``type`` gate is what enforces
+        # the bool-vs-number distinction. Other scalars bind via _jsonable_scalar.
+        bound_value = (1 if value else 0) if is_bool else _jsonable_scalar(value)
+        contains = (
+            # json_col is a controlled token; gate is a module constant; the path +
+            # value are bound ``?`` params (no user text reaches the SQL text).
+            f"EXISTS(SELECT 1 FROM json_each({json_col}, {self._jpath_bind(segs)}) je "  # noqa: S608
+            f"WHERE je.value = {self._bind(bound_value)} AND je.type IN {gate})"
+        )
+        return f"coalesce(({contains}), 0)"
+
+    def _md_exact_array(self, segs: tuple[str, ...], operand: tuple[Any, ...]) -> str:
+        """Exact-array equality (bare-list ``$eq``) — total boolean.
+
+        ``json(json_extract(...))`` re-renders the stored node in canonical form
+        and compares to the ``json()``-normalized operand array. Arrays are
+        ordered in both the oracle and SQLite, so this matches. The node must be a
+        JSON array (gated on ``json_type``) and the path must resolve; otherwise
+        ``coalesce`` reads ``0``.
+        """
+        json_col = self._col("metadata")
+        import json as _json
+
+        operand_json = _json.dumps([_jsonable_scalar(item) for item in operand])
+        gate = (
+            f"json_type({json_col}, {self._jpath_bind(segs)}) = 'array' "
+            f"AND json(json_extract({json_col}, {self._jpath_bind(segs)})) = json({self._bind(operand_json)})"
+        )
+        return f"coalesce(({gate}), 0)"
+
+    def _md_range(self, segs: tuple[str, ...], op: Op, operand: Any) -> str:
+        """A metadata range op — ``json_type``-gated scalar compare, total.
+
+        The stored node must match the operand's type-gate (number vs number,
+        string vs string) before comparing; a mismatch or absent node reads ``0``
+        via ``coalesce`` (Rule 1). Mirrors ``compile_postgres._md_range`` and the
+        oracle's ``_md_range_compare``. A bool operand is not a range operand (the
+        validator never produces one), so only the number / string gates apply.
+        """
+        json_col = self._col("metadata")
+        gate, _is_bool = _operand_type_gate(operand)
+        symbol = _RANGE_OP[op]
+        expr = (
+            f"json_type({json_col}, {self._jpath_bind(segs)}) IN {gate} "
+            f"AND json_extract({json_col}, {self._jpath_bind(segs)}) {symbol} {self._bind(_jsonable_scalar(operand))}"
+        )
+        return f"coalesce(({expr}), 0)"
+
+    def _md_null(self, segs: tuple[str, ...]) -> str:
+        """Active null-or-missing match — total boolean.
+
+        ``json_type`` is SQL ``NULL`` for an absent path and the string ``'null'``
+        for a stored JSON null. ``{k: null}`` matches both — mirroring the oracle's
+        ``_md_is_null`` (``MISSING`` or ``None``).
+        """
+        json_col = self._col("metadata")
+        # Two json_type occurrences → two ``?`` placeholders → bind the path twice
+        # (each ``?`` needs its own positional arg, in emit order).
+        absent = f"json_type({json_col}, {self._jpath_bind(segs)}) IS NULL"
+        is_null = f"json_type({json_col}, {self._jpath_bind(segs)}) = 'null'"
+        return f"({absent} OR {is_null})"
+
+    # ----- unsupported ---------------------------------------------------- #
+
+    def _unsupported(self, clause: FilterClause, reason: str) -> str:
+        """Handle a clause this backend cannot express per ``ctx.on_unsupported``.
+
+        ``"raise"`` raises the public :class:`RecallFilterUnsupportedError`;
+        ``"split"`` leaves the clause out of ``consumed_keys`` (the engine
+        post-filters it with ``compile_python``) and emits the non-constraining
+        ``"1"`` so it does not narrow the result set.
+        """
+        path = _path_str(clause.path)
+        if self._ctx.on_unsupported == "raise":
+            raise RecallFilterUnsupportedError(path, reason)
+        return "1"
+
+
+# --------------------------------------------------------------------------- #
+# Module-level helpers (no per-pass state).
+# --------------------------------------------------------------------------- #
+
+
+def _system_value(value: Any) -> Any:
+    """Coerce a system-key operand to a SQLite-bindable value.
+
+    A chunk stores datetime columns as ISO-8601 strings, so a :class:`DateLiteral`
+    / :class:`~datetime.datetime` binds as its ``.isoformat()`` string
+    (lexicographic compare). Other scalars pass through.
+    """
+    if isinstance(value, DateLiteral):
+        return value.value.isoformat()
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+def _is_number(value: Any) -> bool:
+    """True for an int / float operand, excluding bool (a number type-gate).
+
+    ``bool`` is an ``int`` subclass; the §4 number gate treats a bool as a
+    boolean, never a number, so it is excluded here (matching the oracle's
+    ``_is_number`` and ``compile_postgres._operand_json_type``).
+    """
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _operand_type_gate(operand: Any) -> tuple[str, bool]:
+    """Map an operand to its ``json_type`` gate-token set + a bool flag.
+
+    Returns ``(gate, is_bool)``: ``is_bool`` is ``True`` for a bool operand (the
+    caller binds the collapsed ``json_each`` value — 1 / 0 — and relies on this
+    ``('true', 'false')`` gate to distinguish a JSON bool from the number 1 / 0);
+    otherwise the gate is the number or string ``json_type`` set. ``bool`` is
+    checked before ``int`` (``bool`` is an ``int`` subclass).
+    """
+    if isinstance(operand, bool):
+        return "('true', 'false')", True
+    if _is_number(operand):
+        return _NUMBER_TYPES, False
+    return _STRING_TYPES, False
+
+
+def _jsonable_scalar(value: Any) -> Any:
+    """Coerce a scalar comparison operand to a SQLite-bindable value.
+
+    A :class:`DateLiteral` / :class:`~datetime.datetime` renders as its ISO-8601
+    string (matching how a metadata date is stored); other scalars pass through.
+    Used for the value side of ``json_extract`` / ``json_each`` compares.
+    """
+    if isinstance(value, DateLiteral):
+        return value.value.isoformat()
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value

--- a/src/khora/filter/context.py
+++ b/src/khora/filter/context.py
@@ -71,6 +71,10 @@ class SchemaCapabilities:
     * ``native_map_metadata`` — backend stores metadata as a real nested map/object
       (SurrealDB) rather than a serialized JSON string (Neo4j), so a metadata
       predicate can push down instead of falling to a post-filter.
+    * ``sqlite_json1`` — SQLite backend has the JSON1 functions (``json_extract`` /
+      ``json_type`` / ``json_each``) available, so a metadata predicate can push
+      down into the ``khora_chunks.metadata`` JSON-TEXT column; ``False`` makes the
+      SQLite compiler treat every metadata leaf as unsupported (post-filtered).
 
     ``DEFAULTS`` is the conservative all-``False`` instance — a backend with no
     declared capabilities. Engines pass a richer instance for backends that have
@@ -81,6 +85,7 @@ class SchemaCapabilities:
     jsonb_path_query: bool = False
     full_text: bool = False
     native_map_metadata: bool = False
+    sqlite_json1: bool = False
 
     # Populated after the class is defined (cannot reference the class in its own
     # body). ClassVar is excluded from ``__slots__``.

--- a/tests/integration/matrix/test_skeleton_sqlite_lance.py
+++ b/tests/integration/matrix/test_skeleton_sqlite_lance.py
@@ -491,3 +491,133 @@ async def test_skeleton_recall_handles_punctuated_query(kb: Khora, namespace_id:
     ):
         result = await _recall(kb, query, namespace=namespace_id, limit=3)
         assert isinstance(result.chunks, list), f"recall must not raise on {query!r}"
+
+
+# ---------------------------------------------------------------------------
+# Deterministic recall-filter — metadata pushdown + python-fallback parity.
+# ---------------------------------------------------------------------------
+#
+# These two cases drive the *public* ``Khora.recall(filter=...)`` end-to-end
+# through the skeleton engine into the sqlite_lance backend, where ``compile_lance``
+# pushes the metadata predicate into the SQLite WHERE (when JSON1 is available) and
+# a ``compile_python`` post-filter enforces the full AST. The seed corpus has one
+# in-scope tier and three out-of-scope rows, each violating the filter a DIFFERENT
+# way (wrong value / absent path / present-null), so a leak names how the predicate
+# failed to bite. All rows share embedding-vocabulary so the vector channel returns
+# the whole corpus and the filter is the only narrowing force.
+#
+# The first case exercises the pushdown path (JSON1 present); the second forces the
+# python-fallback by monkeypatching the backend's ``_has_json1`` capability flag to
+# False (the documented test seam — see SQLiteLanceTemporalStore.__init__) so every
+# metadata leaf defers to the compile_python post-filter. The load-bearing contract
+# the brief pins is that BOTH paths return the IDENTICAL in-scope chunk set.
+
+# metadata.tier == "gold" is the in-scope predicate. Each out-of-scope row violates
+# it a distinct way; every row shares "alpha gold" vocabulary so the vector channel
+# does not itself narrow.
+_FILTER_SEED: dict[str, dict[str, Any]] = {
+    "in_one": {"content": "alpha gold document one", "metadata": {"tier": "gold"}},
+    "in_two": {"content": "alpha gold document two", "metadata": {"tier": "gold"}},
+    # wrong value — tier present but != "gold".
+    "out_value": {"content": "alpha gold document silver tier", "metadata": {"tier": "silver"}},
+    # absent path — no "tier" key at all.
+    "out_absent": {"content": "alpha gold document no tier", "metadata": {"other": "x"}},
+    # present-null — tier explicitly null (distinct from absent; must not match $eq).
+    "out_null": {"content": "alpha gold document null tier", "metadata": {"tier": None}},
+}
+_FILTER_WIRE = {"metadata.tier": "gold"}
+
+
+async def _seed_filter_corpus(kb: Khora, namespace_id: UUID) -> dict[str, str]:
+    """Remember the filter corpus; return a ``label -> content`` map.
+
+    Content is distinct per row (skeleton dedupes by content checksum), so each
+    label round-trips to exactly one recallable chunk.
+    """
+    label_to_content: dict[str, str] = {}
+    for label, spec in _FILTER_SEED.items():
+        await _remember(
+            kb,
+            namespace_id=namespace_id,
+            content=spec["content"],
+            title=label,
+            metadata=spec["metadata"],
+        )
+        label_to_content[label] = spec["content"]
+    return label_to_content
+
+
+_IN_SCOPE_LABELS = ("in_one", "in_two")
+
+
+async def test_skeleton_recall_metadata_filter_pushdown(kb: Khora, namespace_id: UUID) -> None:
+    """``recall(filter={"metadata.tier": "gold"})`` narrows to exactly the gold rows.
+
+    Drives the metadata predicate through the JSON1 pushdown path. The three
+    out-of-scope rows (wrong value / absent path / present-null) must all be
+    excluded — proving the compiled SQLite WHERE + post-filter honor §4 exactly,
+    and that present-null does NOT match a positive ``$eq`` (the s4/s7 distinction
+    proven in the oracle, here end-to-end on a real store).
+    """
+    label_to_content = await _seed_filter_corpus(kb, namespace_id)
+
+    result = await kb.recall(
+        "alpha gold document",
+        namespace=namespace_id,
+        limit=20,
+        mode=SearchMode.VECTOR,
+        filter=_FILTER_WIRE,
+    )
+
+    returned = {c.content for c in result.chunks}
+    in_scope = {label_to_content[label] for label in _IN_SCOPE_LABELS}
+    out_of_scope = {label_to_content[label] for label in _FILTER_SEED if label not in _IN_SCOPE_LABELS}
+
+    assert returned == in_scope, (
+        f"metadata filter must return exactly the in-scope chunks; "
+        f"leaked={returned & out_of_scope}, missing={in_scope - returned}"
+    )
+
+    # Control: with no filter the same recall reaches every seeded chunk, proving
+    # the narrowing is the FILTER's doing, not retrieval reachability.
+    unfiltered = await kb.recall("alpha gold document", namespace=namespace_id, limit=20, mode=SearchMode.VECTOR)
+    assert {c.content for c in unfiltered.chunks} == set(label_to_content.values())
+
+
+async def test_skeleton_recall_metadata_filter_python_fallback(
+    kb: Khora,
+    namespace_id: UUID,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Forcing the python-fallback returns the IDENTICAL in-scope chunk set.
+
+    Monkeypatching the backend's ``_has_json1`` capability flag to ``False`` makes
+    ``compile_lance`` treat every metadata leaf as unsupported, so nothing about the
+    metadata predicate pushes into SQLite — the ``compile_python`` post-filter alone
+    enforces it against the decoded chunks. The contract: the fallback row-set is
+    IDENTICAL to the pushdown row-set (the two compilers agree on the §4 contract).
+    """
+    label_to_content = await _seed_filter_corpus(kb, namespace_id)
+    in_scope = {label_to_content[label] for label in _IN_SCOPE_LABELS}
+
+    # Force the fallback: disable JSON1 on the live temporal store. The flag is the
+    # documented test seam (SQLiteLanceTemporalStore.__init__); with it False the
+    # SchemaCapabilities the backend hands compile_lance carry sqlite_json1=False,
+    # so metadata leaves defer to the compile_python post-filter.
+    store = kb._get_engine()._get_temporal_store()  # type: ignore[attr-defined]
+    monkeypatch.setattr(store, "_has_json1", False)
+
+    result = await kb.recall(
+        "alpha gold document",
+        namespace=namespace_id,
+        limit=20,
+        mode=SearchMode.VECTOR,
+        filter=_FILTER_WIRE,
+    )
+
+    returned = {c.content for c in result.chunks}
+    out_of_scope = {label_to_content[label] for label in _FILTER_SEED if label not in _IN_SCOPE_LABELS}
+    assert returned == in_scope, (
+        f"python-fallback must return the SAME in-scope set as pushdown; "
+        f"leaked={returned & out_of_scope}, missing={in_scope - returned}"
+    )

--- a/tests/recall/test_compile_context.py
+++ b/tests/recall/test_compile_context.py
@@ -143,6 +143,7 @@ def test_schema_capabilities_flag_defaults_are_false() -> None:
     assert caps.jsonb_path_query is False
     assert caps.full_text is False
     assert caps.native_map_metadata is False
+    assert caps.sqlite_json1 is False
 
 
 def test_schema_capabilities_defaults_instance_is_all_false() -> None:
@@ -152,7 +153,7 @@ def test_schema_capabilities_defaults_instance_is_all_false() -> None:
 
 def test_schema_capabilities_field_names() -> None:
     names = {f.name for f in dataclasses.fields(SchemaCapabilities)}
-    assert names == {"jsonb_path_query", "full_text", "native_map_metadata"}
+    assert names == {"jsonb_path_query", "full_text", "native_map_metadata", "sqlite_json1"}
 
 
 def test_schema_capabilities_is_frozen() -> None:

--- a/tests/unit/filter/test_compile_lance.py
+++ b/tests/unit/filter/test_compile_lance.py
@@ -1,0 +1,881 @@
+"""Unit + conformance tests for the SQLite ``compile_lance`` compiler (Layer 4).
+
+``@internal``. ``compile_lance(ast, ctx)`` lowers a canonical
+:class:`~khora.filter.ast.FilterNode` into a SQLite ``WHERE``-fragment *string*
+against ``khora_chunks`` (denormalized columns + a JSON-TEXT ``metadata`` column),
+paired with ``params == {"args": [...]}`` — an ordered positional bind list, one
+entry per ``?`` placeholder in depth-first emit order. It is the embedded-stack
+sibling of :func:`~khora.filter.compilers.postgres.compile_postgres` /
+:func:`~khora.filter.compilers.cypher.compile_cypher`.
+
+This module has two halves:
+
+* **EMIT** — build an AST (validate a :class:`RecallFilter`, lower with
+  :func:`parse_to_ast`), compile it, and assert on the emitted predicate string +
+  ``args`` for every operator, the system/metadata key kinds, the four §4 rules,
+  ``$and``/``$or``/``$not``, the empty AST, the :class:`CompiledFilter` envelope,
+  and the ``on_unsupported`` raise/split policy. Never re-implements the compiler,
+  only inspects what it emits.
+* **CONFORMANCE** — materialize a curated record corpus into an in-memory SQLite
+  ``khora_chunks``-shaped table, run the ``compile_lance`` SQL, and assert the
+  returned id-set equals the :func:`~khora.filter.compilers.python.compile_python`
+  oracle row-set (run over the SAME records) for each curated filter. The
+  in-memory ``compile_python`` predicate is the reference every backend compiler
+  must agree with — its own per-rule behavior is pinned in
+  ``tests/recall/test_compile_python.py``; here it is the row-set oracle, proving
+  ``compile_lance``'s SQL partitions a real corpus identically. The F-EXISTS s4/s7
+  presence cases (ABSENT vs PRESENT-NULL vs PRESENT) are exercised on the LANCE
+  side explicitly — they ride the ``json_type`` path, which is the new code.
+
+The SQLite specifics this locks:
+
+* SQLite has no boolean type — the totality sentinel is the integer ``0`` (vs
+  Postgres ``false()`` / Cypher ``false``); the empty AST is the truthy ``1``.
+* Dates bind as ``.isoformat()`` strings (lexicographic compare).
+* Metadata pushdown is gated on ``ctx.schema_capabilities.sqlite_json1``; metadata
+  predicates use ``json_extract`` / ``json_type`` / ``json_each`` and bind the
+  JSONPath as a ``?`` param. Three metadata cases (bare-blob ``$eq``,
+  ``object_equal`` dict operand, ``$date`` compare) are unsupported even with
+  JSON1 — they emit the non-constraining ``1`` and are left to the post-filter.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from khora.filter import RecallFilter, RecallFilterUnsupportedError
+from khora.filter.ast import FilterClause, FilterNode, parse_to_ast
+from khora.filter.compilers.lance import compile_lance
+from khora.filter.compilers.python import compile_python
+from khora.filter.context import CompileContext, SchemaCapabilities
+from khora.filter.model import Op
+
+# Hard import (NOT importorskip): the compiler is on the branch, so an import
+# failure here must be a LOUD test error — never a silent module skip that would
+# pass CI green with zero coverage.
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+# JSON1 is available in the embedded backend's runtime, so the default test
+# context advertises it (matching how the sqlite_lance backend builds its ctx).
+_JSON1 = SchemaCapabilities(sqlite_json1=True)
+_CTX = CompileContext(backend_target="khora_chunks", schema_capabilities=_JSON1)
+# A split-mode context for the deferred-metadata cases (the backend drives
+# "split" so metadata it cannot express falls to the compile_python post-filter).
+_CTX_SPLIT = CompileContext(backend_target="khora_chunks", schema_capabilities=_JSON1, on_unsupported="split")
+
+
+def _ast(wire: dict) -> FilterNode:
+    """Validate a wire-form filter and lower it to the canonical AST."""
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+def _norm(sql: str) -> str:
+    """Collapse whitespace and lowercase for resilient substring matching."""
+    return " ".join(sql.split()).lower()
+
+
+def _lance(wire: dict, ctx: CompileContext = _CTX) -> Any:
+    """Compile a wire filter and return its :class:`CompiledFilter`."""
+    return compile_lance(_ast(wire), ctx)
+
+
+def _lance_norm(wire: dict, ctx: CompileContext = _CTX) -> str:
+    """Compile and return the predicate string, whitespace-collapsed + lowercased."""
+    return _norm(_lance(wire, ctx).predicate)
+
+
+# ===========================================================================
+# Empty AST → match-everything (the SQLite truthy literal "1").
+# ===========================================================================
+
+
+def test_empty_filter_compiles_to_one() -> None:
+    # A bare RecallFilter() lowers to the empty match-everything AND — SQLite has
+    # no boolean, so the tautology is the integer literal "1".
+    assert _lance_norm({}) == "1"
+
+
+def test_empty_and_node_compiles_to_one() -> None:
+    compiled = compile_lance(FilterNode(op=Op.AND, children=()), _CTX)
+    assert compiled.predicate == "1"
+
+
+def test_empty_filter_binds_nothing() -> None:
+    assert _lance({}).params == {"args": []}
+
+
+# ===========================================================================
+# Scalar operators on a SYSTEM (typed-column) key.
+# ===========================================================================
+
+
+def test_system_eq_is_coalesced_column_equals() -> None:
+    # $eq is a total boolean: coalesce(col = ?, 0) so an absent/NULL column reads
+    # 0 (excludes) and a wrapping $not flips it in. The operand binds positionally.
+    compiled = _lance({"source_name": "linear"})
+    sql = _norm(compiled.predicate)
+    assert "coalesce(khora_chunks.source_name = ?, 0)" in sql
+    assert compiled.params == {"args": ["linear"]}
+    # System key is a typed column, NOT a JSON extraction.
+    assert "json_extract" not in sql
+
+
+def test_system_eq_on_string_key_with_ops_form() -> None:
+    compiled = _lance({"source_type": {"$eq": "slack"}})
+    assert "coalesce(khora_chunks.source_type = ?, 0)" in _norm(compiled.predicate)
+    assert compiled.params == {"args": ["slack"]}
+
+
+@pytest.mark.parametrize(
+    ("wire_op", "sql_op"),
+    [
+        ("$gt", ">"),
+        ("$gte", ">="),
+        ("$lt", "<"),
+        ("$lte", "<="),
+    ],
+)
+def test_system_date_range_operators(wire_op: str, sql_op: str) -> None:
+    compiled = _lance({"occurred_at": {wire_op: "2026-03-04T05:06:07Z"}})
+    sql = _norm(compiled.predicate)
+    assert f"coalesce(khora_chunks.occurred_at {sql_op} ?, 0)" in sql
+    # Dates bind as the UTC-normalized .isoformat() string (lexicographic compare).
+    assert compiled.params["args"][0].startswith("2026-03-04")
+
+
+def test_system_date_binds_iso_string() -> None:
+    compiled = _lance({"source_timestamp": "2026-02-03T00:00:00Z"})
+    assert "coalesce(khora_chunks.source_timestamp = ?, 0)" in _norm(compiled.predicate)
+    assert compiled.params["args"][0].startswith("2026-02-03")
+
+
+# ===========================================================================
+# Rule 2 — $ne / $nin include NULL / absent (null-inclusive, no coalesce).
+# ===========================================================================
+
+
+def test_system_ne_includes_null_rows() -> None:
+    compiled = _lance({"source_name": {"$ne": "linear"}})
+    sql = _norm(compiled.predicate)
+    assert "khora_chunks.source_name is null or khora_chunks.source_name <> ?" in sql
+    assert compiled.params == {"args": ["linear"]}
+
+
+def test_system_nin_includes_null_rows() -> None:
+    compiled = _lance({"source_name": {"$nin": ["a", "b"]}})
+    sql = _norm(compiled.predicate)
+    assert "khora_chunks.source_name is null or not khora_chunks.source_name in (?, ?)" in sql
+    assert compiled.params == {"args": ["a", "b"]}
+
+
+# ===========================================================================
+# $in / $nin on a SYSTEM column → coalesced IN / null-guarded NOT IN.
+# ===========================================================================
+
+
+def test_system_in_is_coalesced_in_list() -> None:
+    compiled = _lance({"source_name": {"$in": ["a", "b", "c"]}})
+    assert "coalesce(khora_chunks.source_name in (?, ?, ?), 0)" in _norm(compiled.predicate)
+    assert compiled.params == {"args": ["a", "b", "c"]}
+
+
+def test_system_empty_in_is_constant_zero() -> None:
+    # A positive membership over ∅ matches nothing → the constant 0 (wrapped "(0)"
+    # for the single-clause AND), binding nothing.
+    compiled = _lance({"source_name": {"$in": []}})
+    assert _norm(compiled.predicate) == "(0)"
+    assert compiled.params == {"args": []}
+
+
+def test_system_empty_nin_is_constant_one() -> None:
+    # Negation over ∅ matches everything → the constant 1, binding nothing.
+    compiled = _lance({"source_name": {"$nin": []}})
+    assert _norm(compiled.predicate) == "(1)"
+    assert compiled.params == {"args": []}
+
+
+# ===========================================================================
+# Rule 3 — bare-list (exact-array) operand vs scalar SYSTEM column → const 0.
+# ===========================================================================
+
+
+def test_system_eq_array_operand_is_constant_zero() -> None:
+    # A bare list on a scalar system column lowers to $eq EXACT-ARRAY; a scalar
+    # column never equals a list → unsatisfiable, folds to the constant 0.
+    compiled = _lance({"source_name": ["a", "b"]})
+    assert _norm(compiled.predicate) == "(0)"
+    assert compiled.params == {"args": []}
+
+
+def test_system_in_is_membership_not_exact_array() -> None:
+    compiled = _lance({"occurred_at": {"$in": ["2026-01-01T00:00:00Z"]}})
+    sql = _norm(compiled.predicate)
+    assert "coalesce(khora_chunks.occurred_at in (?), 0)" in sql
+    assert "<>" not in sql
+
+
+# ===========================================================================
+# Rule 4 (system) — $exists is constant; {k: null} / $ne null are IS [NOT] NULL.
+# ===========================================================================
+
+
+def test_system_exists_true_is_constant_one() -> None:
+    # A system column is structurally always present → $exists True is constant 1.
+    compiled = _lance({"source_name": {"$exists": True}})
+    assert _norm(compiled.predicate) == "(1)"
+    assert compiled.params == {"args": []}
+
+
+def test_system_exists_false_is_constant_zero() -> None:
+    compiled = _lance({"source_name": {"$exists": False}})
+    assert _norm(compiled.predicate) == "(0)"
+    assert compiled.params == {"args": []}
+
+
+def test_system_null_operand_is_is_null() -> None:
+    compiled = _lance({"source_name": None})
+    assert "khora_chunks.source_name is null" in _norm(compiled.predicate)
+    assert compiled.params == {"args": []}
+
+
+def test_system_ne_null_is_is_not_null() -> None:
+    compiled = _lance({"source_name": {"$ne": None}})
+    assert "khora_chunks.source_name is not null" in _norm(compiled.predicate)
+    assert compiled.params == {"args": []}
+
+
+def test_direct_datetime_clause_binds_iso_string() -> None:
+    clause = FilterClause(path=("occurred_at",), op=Op.GTE, operand=datetime(2026, 1, 1, tzinfo=UTC))
+    node = FilterNode(op=Op.AND, children=(clause,))
+    compiled = compile_lance(node, _CTX)
+    assert "coalesce(khora_chunks.occurred_at >= ?, 0)" in _norm(compiled.predicate)
+    assert compiled.params["args"][0] == datetime(2026, 1, 1, tzinfo=UTC).isoformat()
+
+
+# ===========================================================================
+# Logical composition — AND / OR / NOT.
+# ===========================================================================
+
+
+def test_and_node_joins_with_and() -> None:
+    sql = _lance_norm({"source_name": "linear", "source_type": "slack"})
+    assert " and " in sql
+    assert "khora_chunks.source_name = ?" in sql
+    assert "khora_chunks.source_type = ?" in sql
+
+
+def test_or_node_joins_with_or() -> None:
+    sql = _lance_norm({"$or": [{"source_name": "linear"}, {"source_type": "slack"}]})
+    assert " or " in sql
+    assert "khora_chunks.source_name = ?" in sql
+    assert "khora_chunks.source_type = ?" in sql
+
+
+def test_not_node_negates_with_total_child() -> None:
+    # NOT compiles via (NOT (<child>)), and the child equality is the TOTAL
+    # coalesce(col = ?, 0) so the negation is NULL-INCLUSIVE — NOT coalesce(NULL=?,
+    # 0) = NOT 0 = true flips a NULL/absent row IN (Rule 2), making $not($eq)
+    # behave like $ne. The coalesce(..., 0) wrap is the load-bearing guarantee.
+    sql = _lance_norm({"$not": {"source_name": "linear"}})
+    assert sql.startswith("(not (")
+    assert "coalesce(khora_chunks.source_name = ?, 0)" in sql
+
+
+def test_composition_binds_are_ordered_depth_first() -> None:
+    # The positional args list follows depth-first emit order — three keys produce
+    # three ordered binds, one per ? in the predicate.
+    compiled = _lance(
+        {
+            "source_name": "linear",
+            "$or": [{"source_type": "slack"}, {"content_type": "text/plain"}],
+        }
+    )
+    args = compiled.params["args"]
+    assert len(args) == 3
+    assert set(args) == {"linear", "slack", "text/plain"}
+    assert compiled.predicate.count("?") == 3
+
+
+# ===========================================================================
+# Metadata (JSON-TEXT) — JSON1-gated pushdown.
+# ===========================================================================
+
+
+def test_metadata_eq_scalar_uses_json_type_gated_containment() -> None:
+    # A scalar $eq on a metadata field is array-aware containment via json_each:
+    # EXISTS over json_each(metadata, ?) matching an element whose value equals the
+    # operand AND whose json_type is in the operand's gate (a string => 'text'),
+    # coalesced to total. json_each iterates the single scalar OR each array element,
+    # so one form covers both. The JSONPath + value bind as ? params (the path never
+    # enters the SQL text), preserving the bool-vs-number type distinction.
+    compiled = _lance({"metadata.tier": "gold"})
+    sql = _norm(compiled.predicate)
+    assert "json_each(khora_chunks.metadata, ?)" in sql
+    assert "je.value = ?" in sql
+    assert "je.type in ('text')" in sql
+    assert "coalesce(" in sql
+    # The bound JSONPath addresses the quoted "tier" key; the operand binds too.
+    assert '$."tier"' in compiled.params["args"]
+    assert "gold" in compiled.params["args"]
+
+
+def test_metadata_numeric_range_gates_on_json_type_number() -> None:
+    # Rule 1: a metadata numeric range gates on json_type IN ('integer','real')
+    # BEFORE comparing, so a string/bool/absent value reads 0 instead of erroring.
+    sql = _lance_norm({"metadata.score": {"$gte": 5}})
+    assert "json_type(khora_chunks.metadata, ?) in ('integer', 'real')" in sql
+    assert ">= ?" in sql
+    assert "coalesce(" in sql
+
+
+def test_metadata_bool_eq_gates_on_json_type_token() -> None:
+    # A bool $eq gates the json_each element's type on ('true','false') so a stored
+    # JSON bool matches but a stored number 1 does NOT — preserving the oracle's
+    # bool-vs-number distinction even though SQLite collapses a JSON bool to 0/1.
+    compiled = _lance({"metadata.flag": True})
+    sql = _norm(compiled.predicate)
+    assert "json_each(khora_chunks.metadata, ?)" in sql
+    assert "je.type in ('true', 'false')" in sql
+    # The type gate is what bites; a bare numeric compare that would match True == 1
+    # must not be the sole guard.
+    assert "je.value = ?" in sql
+
+
+def test_metadata_exists_true_uses_json_type_not_null() -> None:
+    # Rule 4: $exists is presence via json_type IS NOT NULL — json_type is NULL for
+    # an absent path and non-NULL (incl. 'null') for a present value. NOT json_extract
+    # (which is NULL for both absent AND a stored JSON null).
+    compiled = _lance({"metadata.tier": {"$exists": True}})
+    sql = _norm(compiled.predicate)
+    assert "json_type(khora_chunks.metadata, ?) is not null" in sql
+    assert "json_extract" not in sql
+
+
+def test_metadata_exists_false_negates_json_type_presence() -> None:
+    sql = _lance_norm({"metadata.tier": {"$exists": False}})
+    assert "not (json_type(khora_chunks.metadata, ?) is not null)" in sql
+
+
+def test_metadata_null_match_uses_json_type_null_or_missing() -> None:
+    # Rule 4: {k: null} is an active null-OR-missing match — json_type IS NULL
+    # (absent path) OR json_type == 'null' (stored JSON null). Mirrors the oracle's
+    # MISSING-or-None.
+    sql = _lance_norm({"metadata.tier": None})
+    assert "json_type(khora_chunks.metadata, ?) is null" in sql
+    assert "= 'null'" in sql
+
+
+def test_metadata_ne_includes_absent_via_negated_containment() -> None:
+    # Rule 2 for metadata: $ne negates the total containment, so an absent / wrong-
+    # type row (containment = 0) is admitted by the negation.
+    sql = _lance_norm({"metadata.tier": {"$ne": "gold"}})
+    assert sql.startswith("((not")
+    assert "coalesce(" in sql
+
+
+def test_metadata_array_operand_eq_is_exact_json_array_match() -> None:
+    # A bare list on a metadata path is $eq EXACT-ARRAY: the node must be a JSON
+    # array equal to the operand (json()-normalized, order-significant).
+    compiled = _lance({"metadata.tags": ["x", "y"]})
+    sql = _norm(compiled.predicate)
+    assert "json_type(khora_chunks.metadata, ?) = 'array'" in sql
+    assert "json(json_extract(khora_chunks.metadata, ?)) = json(?)" in sql
+    assert json.dumps(["x", "y"]) in compiled.params["args"]
+
+
+def test_metadata_in_is_or_of_containments() -> None:
+    sql = _lance_norm({"metadata.tag": {"$in": ["gold", "silver"]}})
+    assert " or " in sql
+    assert "json_each(khora_chunks.metadata, ?)" in sql
+
+
+def test_metadata_empty_in_is_constant_zero() -> None:
+    compiled = _lance({"metadata.tag": {"$in": []}})
+    assert _norm(compiled.predicate) == "(0)"
+
+
+def test_metadata_empty_nin_is_constant_one() -> None:
+    compiled = _lance({"metadata.tag": {"$nin": []}})
+    assert _norm(compiled.predicate) == "(1)"
+
+
+# ===========================================================================
+# Metadata pushdown gated on JSON1 — absent → unsupported.
+# ===========================================================================
+
+
+def test_metadata_raises_when_json1_unavailable_in_raise_mode() -> None:
+    # Without JSON1 the SQLite compiler cannot express any metadata leaf; the
+    # default "raise" mode surfaces the public unsupported error.
+    ctx = CompileContext(backend_target="khora_chunks", schema_capabilities=SchemaCapabilities(sqlite_json1=False))
+    with pytest.raises(RecallFilterUnsupportedError):
+        compile_lance(_ast({"metadata.tier": "gold"}), ctx)
+
+
+def test_metadata_splits_to_nonconstraining_one_when_json1_unavailable() -> None:
+    # In "split" mode (the backend's mode) a metadata leaf with no JSON1 falls to
+    # the compile_python post-filter: emit the non-constraining "1", bind nothing
+    # constraining, and leave the key OUT of consumed_keys.
+    ctx = CompileContext(
+        backend_target="khora_chunks",
+        schema_capabilities=SchemaCapabilities(sqlite_json1=False),
+        on_unsupported="split",
+    )
+    compiled = compile_lance(_ast({"metadata.tier": "gold"}), ctx)
+    assert _norm(compiled.predicate) == "(1)"
+    assert "metadata.tier" not in compiled.consumed_keys
+
+
+# ===========================================================================
+# Metadata cases unsupported in SQL even WITH JSON1 (deferred to post-filter).
+# ===========================================================================
+#
+# Bare-blob $eq (SQLite json() is key-order-sensitive, the oracle is not),
+# object_equal dict operand (same), and a $date metadata compare (ISO parse-or-
+# exclude SQLite cannot replicate to match the oracle). In raise mode they raise;
+# in split mode they emit "1" and stay out of consumed_keys.
+
+
+@pytest.mark.parametrize(
+    "wire",
+    [
+        {"metadata": {"a": 1}},  # bare-blob $eq
+        {"metadata.labels": {"team": "x"}},  # object_equal dict operand
+        {"metadata.due": {"$date": "2026-01-01T00:00:00Z"}},  # $date metadata compare
+    ],
+)
+def test_metadata_sql_unsupported_cases_raise_in_raise_mode(wire: dict) -> None:
+    with pytest.raises(RecallFilterUnsupportedError):
+        compile_lance(_ast(wire), _CTX)
+
+
+@pytest.mark.parametrize(
+    "wire",
+    [
+        {"metadata": {"a": 1}},
+        {"metadata.labels": {"team": "x"}},
+        {"metadata.due": {"$date": "2026-01-01T00:00:00Z"}},
+    ],
+)
+def test_metadata_sql_unsupported_cases_split_to_nonconstraining_one(wire: dict) -> None:
+    compiled = compile_lance(_ast(wire), _CTX_SPLIT)
+    assert _norm(compiled.predicate) == "(1)"
+    # The key is left to the compile_python post-filter — not consumed here.
+    assert compiled.consumed_keys == frozenset()
+
+
+# ===========================================================================
+# on_unsupported policy on a structurally-unknown key (neither system nor metadata).
+# ===========================================================================
+
+
+def _unknown_key_node() -> FilterNode:
+    return FilterNode(op=Op.AND, children=(FilterClause(path=("not_a_key",), op=Op.EQ, operand="x"),))
+
+
+def test_unsupported_clause_raises_in_raise_mode() -> None:
+    with pytest.raises(RecallFilterUnsupportedError):
+        compile_lance(_unknown_key_node(), _CTX)
+
+
+def test_unsupported_clause_splits_to_nonconstraining_one() -> None:
+    compiled = compile_lance(_unknown_key_node(), _CTX_SPLIT)
+    assert _norm(compiled.predicate) == "(1)"
+    assert "not_a_key" not in compiled.consumed_keys
+
+
+# ===========================================================================
+# All-or-nothing OR / NOT deferral (split mode) — the false-exclude guard.
+# ===========================================================================
+#
+# When ANY descendant leaf of an $or / $not cannot be pushed to SQL, the WHOLE
+# node must defer to the non-constraining "1" (consuming nothing) — pushing only
+# the consumable disjuncts would make the OR match-all here while a wrapping NOT
+# would then FALSE-EXCLUDE. An $and is independent: a non-consumable child becomes
+# "1" and the consumable siblings still narrow. The compile_python post-filter
+# re-checks the deferred remainder (the exactness guarantee). A $date metadata
+# compare and an object_equal dict operand are the canonical unconsumable leaves.
+
+
+def test_or_with_unconsumable_disjunct_defers_whole_node() -> None:
+    # $or mixing a pushable system key with an unconsumable $date metadata leaf:
+    # the whole OR defers to "1" and consumes nothing (all-or-nothing) — the
+    # post-filter narrows. Pushing only source_name would make the OR match-all.
+    compiled = compile_lance(
+        _ast({"$or": [{"source_name": "linear"}, {"metadata.due": {"$date": "2026-01-01T00:00:00Z"}}]}),
+        _CTX_SPLIT,
+    )
+    assert compiled.predicate == "1"
+    assert compiled.consumed_keys == frozenset()
+
+
+def test_not_over_unconsumable_child_defers_whole_node() -> None:
+    # $not over an object_equal dict operand (unconsumable) defers wholesale — a
+    # partial push under a NOT is the false-exclude trap the all-or-nothing gate
+    # closes.
+    compiled = compile_lance(_ast({"$not": {"metadata.labels": {"team": "x"}}}), _CTX_SPLIT)
+    assert compiled.predicate == "1"
+    assert compiled.consumed_keys == frozenset()
+
+
+def test_and_pushes_consumable_sibling_defers_unconsumable() -> None:
+    # $and is independent: the pushable source_name narrows; the $date metadata
+    # leaf becomes "1" and is left to the post-filter. consumed_keys carries only
+    # the pushed key.
+    compiled = compile_lance(
+        _ast({"source_name": "linear", "metadata.due": {"$date": "2026-01-01T00:00:00Z"}}),
+        _CTX_SPLIT,
+    )
+    sql = _norm(compiled.predicate)
+    assert "coalesce(khora_chunks.source_name = ?, 0)" in sql
+    assert " and 1" in sql  # the deferred $date leaf
+    assert compiled.consumed_keys == frozenset({"source_name"})
+
+
+# ===========================================================================
+# CompiledFilter envelope — predicate type / params / consumed_keys / hash.
+# ===========================================================================
+
+
+def test_compiled_predicate_is_str_and_params_carry_args_list() -> None:
+    compiled = _lance({"source_name": "linear"})
+    assert isinstance(compiled.predicate, str)
+    # params is the positional-bind carrier: {"args": [...]}.
+    assert set(compiled.params) == {"args"}
+    assert isinstance(compiled.params["args"], list)
+
+
+def test_compiled_filter_carries_canonical_hash() -> None:
+    from khora.filter.ast import canonical_hash
+
+    node = _ast({"source_name": "linear"})
+    compiled = compile_lance(node, _CTX)
+    assert compiled.canonical_hash == canonical_hash(node)
+
+
+def test_compiled_filter_consumed_keys_is_frozenset() -> None:
+    compiled = _lance({"source_name": "linear"})
+    assert isinstance(compiled.consumed_keys, frozenset)
+    assert "source_name" in compiled.consumed_keys
+
+
+def test_empty_filter_consumes_nothing() -> None:
+    compiled = _lance({})
+    assert compiled.consumed_keys == frozenset()
+
+
+# ===========================================================================
+# field_mapping / table_alias — one compiler, many schemas, no engine branching.
+# ===========================================================================
+
+
+def test_table_alias_qualifies_columns() -> None:
+    # The qualifier is table_alias when set (the aliased FTS-join path); else
+    # backend_target (the unaliased vector post-fetch path).
+    ctx = CompileContext(backend_target="khora_chunks", schema_capabilities=_JSON1, table_alias="c")
+    assert "coalesce(c.source_name = ?, 0)" in _lance_norm({"source_name": "linear"}, ctx)
+
+
+def test_field_mapping_remaps_system_column_name() -> None:
+    ctx = CompileContext(
+        backend_target="khora_chunks",
+        schema_capabilities=_JSON1,
+        field_mapping={"source_name": "src"},
+    )
+    assert "coalesce(khora_chunks.src = ?, 0)" in _lance_norm({"source_name": "linear"}, ctx)
+
+
+# ===========================================================================
+# CONFORMANCE — compile_lance SQL row-set == compile_python oracle row-set.
+# ===========================================================================
+#
+# Materialize a curated record corpus into an in-memory SQLite ``khora_chunks``-
+# shaped table (denormalized columns + a JSON-TEXT ``metadata`` column), run the
+# compile_lance WHERE fragment with its positional binds, and assert the returned
+# id-set equals the compile_python oracle row-set over the SAME records. This is
+# the cross-compiler parity check: a row the SQL returns must be exactly a row the
+# in-memory oracle accepts. (The oracle's own per-rule behavior is pinned in
+# tests/recall/test_compile_python.py; here we use it as the row-set reference.)
+#
+# Uses stdlib sqlite3 only (no aiosqlite / lancedb), so it runs in the unit suite
+# without the embedded extras. SQLite's JSON1 is compiled in by default on modern
+# builds; the conftest-free skip below guards the rare build without it.
+
+
+# Curated corpus spanning ABSENT / PRESENT-NULL / PRESENT for source_name and
+# metadata.tier (the F-EXISTS s4/s7 presence states), plus number/string/bool/
+# array stored shapes and a date string — so the lance ``json_type`` presence path
+# is exercised across the full §4 contract.
+#
+# ``occurred_at`` is a SYSTEM DATE column carrying a tz-aware ``datetime``. It
+# guards the date-precision edge: the backend stores it as an ``.isoformat()``
+# string (lexicographic SQL compare) but decodes it back to a ``datetime`` before
+# the post-filter, and the oracle compares datetimes — so the two views must agree
+# even when stored values carry MICROSECONDS and the operand does not. r1 carries
+# microseconds (``...00.500000+00:00``), r2 does not (``...00:00+00:00``); the
+# ``.`` (0x2E) > ``+`` (0x2B) byte ordering makes the lexicographic string compare
+# agree with chronological order for these UTC-normalized values, which is exactly
+# the invariant the system-date pushdown relies on.
+_MICRO_TS = datetime(2026, 6, 1, 12, 0, 0, 500000, tzinfo=UTC)  # has microseconds
+_PLAIN_TS = datetime(2026, 1, 15, 8, 30, 0, tzinfo=UTC)  # no microseconds
+_OLD_TS = datetime(2025, 3, 1, 0, 0, 0, 999999, tzinfo=UTC)  # before the bound, microseconds
+
+_CORPUS: dict[str, dict[str, Any]] = {
+    "r1": {
+        "source_name": "linear",
+        "source_type": "issue",
+        "occurred_at": _MICRO_TS,
+        "metadata": {"tier": "gold", "score": 9, "tags": ["urgent", "p1"], "flag": True},
+    },
+    "r2": {
+        "source_name": "linear",
+        "source_type": "doc",
+        "occurred_at": _PLAIN_TS,
+        "metadata": {"tier": "silver", "score": 3, "tags": ["later"], "flag": False},
+    },
+    "r3": {
+        "source_name": "slack",
+        "source_type": "msg",
+        "occurred_at": _OLD_TS,
+        "metadata": {"tier": "bronze", "score": "n/a", "tags": ["p1"]},
+    },
+    "r4": {
+        "source_name": None,
+        "source_type": "issue",
+        "occurred_at": _MICRO_TS,
+        "metadata": {"tier": None, "score": 7},
+    },
+    "r5": {
+        "source_type": "issue",
+        # occurred_at ABSENT (NULL column) — a positive date compare must exclude it.
+        "metadata": {"score": 5, "other": "x"},
+    },
+    "r6": {
+        "source_name": "linear",
+        "source_type": "doc",
+        "occurred_at": _PLAIN_TS,
+    },
+    "r7": {
+        "source_name": "github",
+        "source_type": "pr",
+        "occurred_at": _MICRO_TS,
+        "metadata": {"tier": "gold", "score": 5, "flag": 1, "due": "2026-06-01T00:00:00Z"},
+    },
+}
+
+# The string system-key columns the conformance table materializes. ``occurred_at``
+# is materialized separately (as an ISO-string TEXT column) because its oracle
+# value is a ``datetime`` while its stored value is the ``.isoformat()`` string —
+# the production split (SQL compares text, post-filter compares the decoded dt).
+_SYSTEM_COLS = ("source_name", "source_type")
+
+
+def _json1_available() -> bool:
+    """True iff this stdlib SQLite build has the JSON1 functions."""
+    con = sqlite3.connect(":memory:")
+    try:
+        con.execute("SELECT json_extract('{}', '$.x')")
+        return True
+    except sqlite3.OperationalError:
+        return False
+    finally:
+        con.close()
+
+
+def _materialize(con: sqlite3.Connection) -> None:
+    """Create a khora_chunks-shaped table and insert the curated corpus.
+
+    ``metadata`` is stored as JSON-TEXT (the embedded backend's column shape) and
+    ``occurred_at`` as an ISO-string TEXT column (``.isoformat()``, mirroring how
+    the backend persists a datetime) — so the SQL compares the stored string
+    lexicographically while the oracle compares the decoded ``datetime``. An absent
+    system key (string or date) is inserted as SQL NULL; an absent metadata blob is
+    the column DEFAULT ``'{}'`` (coalesced-empty, matching the oracle's read).
+    """
+    cols = ", ".join(f"{c} TEXT" for c in _SYSTEM_COLS)
+    con.execute(
+        f"CREATE TABLE khora_chunks "
+        f"(id TEXT PRIMARY KEY, {cols}, occurred_at TEXT, metadata TEXT NOT NULL DEFAULT '{{}}')"
+    )
+    col_list = ", ".join(("id", *_SYSTEM_COLS, "occurred_at", "metadata"))
+    placeholders = ", ".join(["?"] * (3 + len(_SYSTEM_COLS)))
+    for rid, rec in _CORPUS.items():
+        occurred = rec.get("occurred_at")
+        occurred_text = occurred.isoformat() if occurred is not None else None
+        values = [rid, *(rec.get(c) for c in _SYSTEM_COLS), occurred_text, json.dumps(rec.get("metadata", {}))]
+        con.execute(f"INSERT INTO khora_chunks ({col_list}) VALUES ({placeholders})", values)  # noqa: S608 — controlled tokens
+    con.commit()
+
+
+def _oracle_ids(wire: dict) -> set[str]:
+    """The compile_python oracle row-set for ``wire`` over the curated corpus.
+
+    The oracle reads each record dict directly, so ``occurred_at`` is the
+    tz-aware ``datetime`` (the decoded-chunk view the production post-filter sees),
+    NOT the ISO string the SQLite table stores.
+    """
+    pred = compile_python(_ast(wire), _CTX).predicate
+    return {rid for rid, rec in _CORPUS.items() if pred(rec)}
+
+
+def _lance_ids(con: sqlite3.Connection, wire: dict) -> set[str]:
+    """The compile_lance SQL row-set for ``wire`` over the materialized table.
+
+    Runs in split mode (the backend's mode) so a deferred-metadata leaf emits the
+    non-constraining ``1`` rather than raising; the conformance corpus filters
+    below are all fully pushable, so the SQL alone is the row-set under test.
+    """
+    compiled = compile_lance(_ast(wire), _CTX_SPLIT)
+    sql = f"SELECT id FROM khora_chunks WHERE {compiled.predicate}"  # noqa: S608 — predicate is compiler output, binds are positional
+    rows = con.execute(sql, compiled.params["args"]).fetchall()
+    return {row[0] for row in rows}
+
+
+# Curated filter wires that are FULLY pushable to SQLite (every leaf is a system
+# key or a JSON1-expressible metadata predicate) — so the SQL row-set must equal
+# the oracle row-set exactly. The deferred-metadata cases (bare-blob, object_equal,
+# $date) are intentionally excluded: they fall to the post-filter, so the SQL
+# alone is not expected to match the oracle and the parity is asserted at the
+# engine layer (the integration suite), not here.
+_CONFORMANCE_WIRES: list[dict] = [
+    {},  # match-everything
+    {"source_name": "linear"},  # $eq, excludes present-null + absent
+    {"source_name": {"$ne": "linear"}},  # $ne includes present-null + absent
+    {"source_name": {"$in": ["linear", "github"]}},
+    {"source_name": {"$nin": ["linear", "github"]}},
+    {"source_name": {"$in": []}},  # empty $in → nothing
+    {"source_name": {"$nin": []}},  # empty $nin → everything
+    {"source_name": None},  # {k: null} system: present-null + absent
+    {"source_name": {"$ne": None}},  # $ne null: present concrete
+    {"source_name": {"$exists": True}},  # trivially all
+    {"source_name": {"$exists": False}},  # trivially none
+    {"source_name": ["linear"]},  # exact-array vs scalar → nothing
+    {"metadata.tier": "gold"},  # metadata scalar containment
+    {"metadata.tier": {"$ne": "gold"}},  # metadata $ne includes absent/null/wrong
+    {"metadata.tier": {"$exists": True}},  # present incl present-null
+    {"metadata.tier": {"$exists": False}},  # absent-only
+    {"metadata.tier": None},  # null-or-missing
+    {"metadata.tier": {"$ne": None}},  # present concrete only
+    {"metadata.score": {"$gte": 5}},  # numeric range, type-gated
+    {"metadata.score": {"$gt": 5}},  # strict boundary
+    {"metadata.flag": {"$gte": 1}},  # bool-vs-number gate (only the real int 1)
+    {"metadata.tags": "p1"},  # array-aware containment
+    {"metadata.tags": ["later"]},  # exact-array equality
+    {"metadata.tags": {"$in": ["urgent", "later"]}},  # contains-any over the stored tags array
+    {"metadata.tier": {"$in": []}},  # empty $in
+    {"metadata.tier": {"$nin": []}},  # empty $nin
+    # System-date pushdown — DATE-PRECISION edge. The operand has NO microseconds;
+    # stored values mix microsecond (r1/r4/r7) and non-microsecond (r2/r6) ISO
+    # strings. The lexicographic SQL compare must agree with the oracle's datetime
+    # compare across the fractional-seconds boundary (consumed → exact parity).
+    {"occurred_at": {"$gte": "2026-01-15T08:30:00Z"}},  # bound == r2/r6 instant exactly
+    {"occurred_at": {"$gt": "2026-01-15T08:30:00Z"}},  # strict: excludes the at-bound r2/r6
+    {"occurred_at": {"$gte": "2026-06-01T12:00:00Z"}},  # bound below the .500000 micro rows
+    {"occurred_at": {"$lt": "2026-06-01T12:00:00Z"}},  # upper bound straddling the micro rows
+    {"occurred_at": "2026-06-01T12:00:00Z"},  # $eq vs a stored .500000-micro value (must NOT match)
+    # Composition.
+    {"source_name": "linear", "metadata.tier": "gold"},  # AND intersection
+    {"$or": [{"source_name": "slack"}, {"metadata.tier": "gold"}]},  # OR union
+    {"$not": {"source_name": "linear"}},  # null-inclusive complement
+    {"$nor": [{"source_name": "linear"}, {"metadata.tier": "gold"}]},
+    {"source_name": "linear", "metadata.tier": "gold", "metadata.score": {"$gte": 5}},  # 3-predicate
+    # System date + metadata composed (both consumed): the date pushdown and the
+    # metadata containment must intersect to the oracle row-set exactly.
+    {"occurred_at": {"$gte": "2026-06-01T00:00:00Z"}, "metadata.tier": "gold"},
+]
+
+
+@pytest.mark.skipif(not _json1_available(), reason="stdlib SQLite build lacks JSON1 functions")
+@pytest.mark.parametrize("wire", _CONFORMANCE_WIRES, ids=[json.dumps(w, sort_keys=True) for w in _CONFORMANCE_WIRES])
+def test_compile_lance_sql_matches_compile_python_oracle(wire: dict) -> None:
+    # The compile_lance SQL, run against the materialized corpus, must return the
+    # EXACT id-set the compile_python oracle selects for the same filter. This is
+    # the cross-compiler parity gate for every fully-pushable §4 predicate.
+    con = sqlite3.connect(":memory:")
+    try:
+        _materialize(con)
+        sql_ids = _lance_ids(con, wire)
+        oracle_ids = _oracle_ids(wire)
+        assert sql_ids == oracle_ids, (
+            f"compile_lance / compile_python row-set divergence for {wire!r}: "
+            f"sql={sorted(sql_ids)} oracle={sorted(oracle_ids)}"
+        )
+    finally:
+        con.close()
+
+
+# Mixed-deferral wires: at least one leaf is unconsumable in SQL ($date metadata,
+# object_equal dict, or such a leaf under an $or / $not so the all-or-nothing gate
+# defers the whole node). The SQL alone CANNOT match the oracle (it deliberately
+# emits "1" for the deferred part) — but it must be SUPERSET-SAFE: the SQL row-set
+# ⊇ the oracle row-set, never a false-exclude, because the compile_python
+# post-filter only narrows what the SQL returned. The engine layer (integration
+# suite) then composes SQL ∩ post-filter == oracle; here we pin the invariant the
+# SQL half must uphold so a regression that over-narrows is caught at the unit level.
+_SUPERSET_SAFE_WIRES: list[dict] = [
+    {"metadata.due": {"$date": "2026-06-01T00:00:00Z"}},  # $date metadata — deferred leaf
+    {"metadata.labels": {"team": "x"}},  # object_equal dict — deferred leaf
+    {"metadata": {"tier": "gold"}},  # bare-blob $eq — deferred leaf
+    # $date leaf under $or → whole OR defers to "1" (all-or-nothing); SQL = all rows.
+    {"$or": [{"source_name": "linear"}, {"metadata.due": {"$date": "2026-06-01T00:00:00Z"}}]},
+    # object_equal under $not → whole NOT defers; SQL = all rows.
+    {"$not": {"metadata.labels": {"team": "x"}}},
+    # AND with a pushable sibling + a deferred $date leaf: SQL pushes source_name,
+    # defers the date — SQL ⊇ oracle (the date is enforced by the post-filter).
+    {"source_name": "linear", "metadata.due": {"$date": "2026-06-01T00:00:00Z"}},
+]
+
+
+def _compose_ids(sql_ids: set[str], wire: dict) -> set[str]:
+    """Apply the compile_python post-filter to the SQL row-set (the engine path).
+
+    Mirrors the backend: the SQL fragment narrows to ``sql_ids``, then
+    ``compile_python`` re-checks the full AST against each surviving decoded record
+    (the corpus record, with ``occurred_at`` as a ``datetime``). The composition
+    SQL ∩ post-filter is what the engine actually returns.
+    """
+    pred = compile_python(_ast(wire), _CTX).predicate
+    return {rid for rid in sql_ids if pred(_CORPUS[rid])}
+
+
+@pytest.mark.skipif(not _json1_available(), reason="stdlib SQLite build lacks JSON1 functions")
+@pytest.mark.parametrize(
+    "wire", _SUPERSET_SAFE_WIRES, ids=[json.dumps(w, sort_keys=True) for w in _SUPERSET_SAFE_WIRES]
+)
+def test_compile_lance_sql_is_superset_safe_for_deferred_leaves(wire: dict) -> None:
+    # For a filter with an SQL-unsupported leaf, the compile_lance SQL must NEVER
+    # wrongly exclude an oracle-matching row — the post-filter only narrows. So the
+    # SQL row-set is a (possibly strict) SUPERSET of the oracle row-set (a), AND the
+    # engine composition SQL ∩ compile_python post-filter recovers the oracle row-set
+    # EXACTLY (b). (a) guards against over-narrowing; (b) proves the deferred leaf is
+    # still enforced — together they pin the split-mode contract end-to-end at the
+    # unit level (the integration suite re-checks it over a real store).
+    con = sqlite3.connect(":memory:")
+    try:
+        _materialize(con)
+        sql_ids = _lance_ids(con, wire)
+        oracle_ids = _oracle_ids(wire)
+        # (a) superset-safety — no false-exclude.
+        assert oracle_ids <= sql_ids, (
+            f"compile_lance SQL FALSE-EXCLUDED an oracle-matching row for {wire!r}: "
+            f"sql={sorted(sql_ids)} oracle={sorted(oracle_ids)} missing={sorted(oracle_ids - sql_ids)}"
+        )
+        # (b) composition — SQL pushdown ∩ python post-filter == the oracle.
+        composed = _compose_ids(sql_ids, wire)
+        assert composed == oracle_ids, (
+            f"engine composition (SQL ∩ post-filter) diverged from the oracle for {wire!r}: "
+            f"composed={sorted(composed)} oracle={sorted(oracle_ids)}"
+        )
+    finally:
+        con.close()


### PR DESCRIPTION
## Summary

- Add `compile_lance`, the SQLite WHERE-fragment compiler for the embedded `sqlite_lance` backend, and wire the deterministic recall-filter AST into its vector and BM25 search passes (previously the embedded backend accepted a filter AST but ignored it, deferring all metadata).
- System keys compile to typed-column compares; metadata predicates push down via `json_extract` (values), `json_type` (`$exists` and the absent-vs-JSON-null distinction, plus a bool/number type gate so a JSON `true` never matches a numeric `1`), and `json_each` (array-aware containment). JSON paths are always bound as parameters, never interpolated into SQL.
- Split-mode pushdown is **superset-safe**: an `AND` distributes per child, while `OR`/`NOT` push down only when their whole subtree is expressible — so a deferred leaf under a negation can never wrongly exclude a row. The forms SQLite cannot match the in-memory oracle on (whole-blob equality, subdocument equality, metadata date compares) are deferred to the Python post-filter, which re-checks the full filter.
- A connect-time `json_valid` capability probe gates metadata pushdown. On a SQLite build without JSON support, every metadata predicate falls back to the Python post-filter, so the backend always honors the filter and never raises.
- The Python post-filter is compiled once per search and reused across both passes, keeping the unindexed-metadata metric at exactly one emission per metadata leaf per recall (the compiler itself emits none).

## Test plan

- [x] Unit tests pass — `compile_lance` emit assertions across the full operator set, the four field-match rules, split/raise modes, and the `CompiledFilter` envelope.
- [x] Conformance tests pass — row-set parity: `compile_lance` SQL run over an in-memory table returns the same rows as the Python oracle for fully-pushable filters, and a verified superset (never a false-exclude) for filters with a deferred leaf.
- [x] Integration tests pass — end-to-end metadata-filter pushdown narrows recall results, and forcing the no-JSON fallback returns an identical in-scope set.
- [x] `make format` and `make lint` clean.