### PR TITLE
Push recall filter into VectorCypher vector and BM25 channels

### DIFF
--- a/src/khora/engines/skeleton/backends/__init__.py
+++ b/src/khora/engines/skeleton/backends/__init__.py
@@ -202,11 +202,17 @@ class TemporalVectorStore(Protocol):
         limit: int = 10,
         created_after: datetime | None = None,
         created_before: datetime | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> list[tuple[Chunk, float]]:
         """Full-text search over the temporal store's chunk table.
 
         Returns ``[]`` by default; backends with a populated fulltext
         column override this.
+
+        ``filter_ast`` is the canonical recall-filter AST. The pgvector
+        backend compiles it to the SAME ``khora_chunks`` WHERE predicate the
+        vector path uses; the other backends accept it for protocol parity
+        and ignore it (no compilation yet).
         """
         return []
 

--- a/src/khora/engines/skeleton/backends/pgvector.py
+++ b/src/khora/engines/skeleton/backends/pgvector.py
@@ -573,6 +573,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
         limit: int = 10,
         created_after: datetime | None = None,
         created_before: datetime | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> list[tuple[Chunk, float]]:
         """Public BM25 / ts_rank lookup over ``khora_chunks`` for the
         StorageCoordinator dispatch path.
@@ -582,6 +583,12 @@ class PgVectorTemporalStore(TemporalVectorStore):
         ``TemporalChunk`` is adapted via :func:`temporal_chunk_to_chunk`
         so the retriever sees a uniform ``Chunk`` shape regardless of
         whether the data came from ``chunks`` or ``khora_chunks``.
+
+        ``filter_ast`` is the deterministic recall-filter AST. When provided
+        it is compiled to a single-table ``khora_chunks`` WHERE predicate and
+        AND-ed into the conditions — the SAME compile context the vector path
+        uses (``_search_inner``), so the BM25 channel honors the identical
+        filter and cannot return filter-violating chunks.
         """
         if not query_text or not query_text.strip():
             return []
@@ -598,6 +605,18 @@ class PgVectorTemporalStore(TemporalVectorStore):
             conditions.append(
                 func.coalesce(khora_chunks_table.c.occurred_at, khora_chunks_table.c.created_at) <= created_before
             )
+        # Deterministic recall-filter AST: compile to a single khora_chunks
+        # WHERE predicate and AND it into the conditions, using the SAME
+        # context as the vector path (`_search_inner`).
+        if filter_ast is not None:
+            from khora.filter import CompileContext
+            from khora.filter.compilers.postgres import compile_postgres
+
+            compiled = compile_postgres(
+                filter_ast,
+                CompileContext(backend_target="khora_chunks", on_unsupported="raise"),
+            )
+            conditions.append(compiled.predicate)
         async with self._get_session() as session:
             results = await self._bm25_search(session, query_text, conditions, limit)
         return [(temporal_chunk_to_chunk(r.chunk), float(r.bm25_score or 0.0)) for r in results]

--- a/src/khora/engines/skeleton/backends/sqlite_lance.py
+++ b/src/khora/engines/skeleton/backends/sqlite_lance.py
@@ -519,10 +519,14 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         limit: int = 10,
         created_after: datetime | None = None,
         created_before: datetime | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> list[tuple[Chunk, float]]:
         """Public BM25 (SQLite FTS5) lookup over ``khora_chunks`` for the
         StorageCoordinator dispatch path. See :func:`temporal_chunk_to_chunk`
         for the ``TemporalChunk`` → ``Chunk`` adaptation.
+
+        ``filter_ast`` is accepted for protocol parity; this backend does not
+        compile the recall-filter AST yet, so it is ignored.
         """
         if not query_text or not query_text.strip():
             return []

--- a/src/khora/engines/skeleton/backends/surrealdb.py
+++ b/src/khora/engines/skeleton/backends/surrealdb.py
@@ -454,12 +454,16 @@ class SurrealDBTemporalStore(TemporalVectorStore):
         limit: int = 10,
         created_after: datetime | None = None,
         created_before: datetime | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> list[tuple[Chunk, float]]:
         """Public BM25 lookup over the SurrealDB temporal-chunk table.
 
         See :func:`temporal_chunk_to_chunk` for the ``TemporalChunk`` →
         ``Chunk`` adaptation. Falls back to ``[]`` on backends without
         a BM25 index configured (``optimize_storage()`` not yet run).
+
+        ``filter_ast`` is accepted for protocol parity; this backend does not
+        compile the recall-filter AST yet, so it is ignored.
         """
         if not query_text or not query_text.strip():
             return []

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -2087,8 +2087,9 @@ class VectorCypherEngine:
             temporal_filter: Temporal constraints
             graph_depth: Override graph traversal depth
             hybrid_alpha: Blend factor (0=graph, 1=vector)
-            filter_ast: Canonical recall-filter AST. Accepted for protocol
-                parity; VectorCypher does not push filters down yet (ignored).
+            filter_ast: Canonical recall-filter AST. Compiled to a
+                ``khora_chunks`` WHERE predicate and pushed down into both the
+                vector channel and the independent BM25 channel.
 
         Returns:
             RecallResult with chunks, entities, and context
@@ -2167,6 +2168,7 @@ class VectorCypherEngine:
                 limit=limit,
                 min_similarity=min_similarity,
                 mode=mode,
+                filter_ast=filter_ast,
             )
         finally:
             retriever._config.hybrid_alpha = original_alpha

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -1454,7 +1454,20 @@ class VectorCypherRetriever:
         # to ensure both past and present evidence are retrieved. The original
         # query naturally retrieves past-state chunks ("used to", "previously"),
         # while the decomposed sub-query targets current-state chunks.
-        if temporal_signal and temporal_signal.category == TemporalCategory.CHANGE and version_history:
+        #
+        # Gated off when a caller filter_ast is in flight. The CHANGE signal is
+        # derived from the query string (not from temporal_filter), so this
+        # sub-search can fire under a filtered recall. It runs with
+        # temporal_filter=None and does not yet thread filter_ast (follow-up
+        # scope), so merging its results into the vector pool would smuggle
+        # filter-violating chunks into RRF and break the deterministic
+        # pre-filter contract. Skip it entirely until the filter is threaded.
+        if (
+            temporal_signal
+            and temporal_signal.category == TemporalCategory.CHANGE
+            and version_history
+            and filter_ast is None
+        ):
             current_state_query = self._decompose_change_query(query)
             if current_state_query and current_state_query != query:
                 with trace_span(
@@ -1470,10 +1483,8 @@ class VectorCypherRetriever:
                         query_text=current_state_query,
                         limit=limit,
                         min_similarity=min_similarity,
-                        # Carrying the caller filter across this CHANGE-
-                        # decomposition sub-search is deferred to follow-up
-                        # work; for now it is left unthreaded so this path
-                        # stays byte-identical to today.
+                        # Reached only when filter_ast is None (gated above), so
+                        # there is no caller filter to thread here.
                     )
                     # Merge sub-query results, deduplicating by chunk ID
                     existing_ids = {c[0] for c in vector_chunks}
@@ -1515,6 +1526,14 @@ class VectorCypherRetriever:
             and temporal_signal.is_temporal
             and _tp.default_window_days is not None
             and not synthesis_vetoed
+            # Gated off when a caller filter_ast is in flight. The recency
+            # channel is gated on the query-string-derived temporal signal, so
+            # it can fire under a filtered recall; it pulls chunks with
+            # temporal_filter=None and does not yet thread filter_ast (follow-up
+            # scope). Merging its results into the vector pool would smuggle
+            # filter-violating chunks into RRF and break the deterministic
+            # pre-filter contract. Skip it until the filter is threaded.
+            and filter_ast is None
         ):
             # Intentionally pass temporal_filter=None: the recency channel's
             # job is to surface today's chunks even when the cosine channel

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
 
     from khora.engines.skeleton.backends import TemporalFilter, TemporalVectorStore
     from khora.extraction.embedders import EmbedderProtocol  # type: ignore[unresolved-import]
+    from khora.filter import FilterNode
     from khora.query.reranking import CrossEncoderReranker, LLMReranker
     from khora.storage import StorageCoordinator
 
@@ -551,6 +552,7 @@ class VectorCypherRetriever:
         limit: int | None = None,
         min_similarity: float = 0.0,
         mode: SearchMode = SearchMode.HYBRID,
+        filter_ast: FilterNode | None = None,
     ) -> VectorCypherResult:
         """Retrieve relevant chunks using VectorCypher hybrid approach.
 
@@ -571,6 +573,13 @@ class VectorCypherRetriever:
                 skips vector + graph (BM25 only). The engine is responsible
                 for validating this against ``supported_modes`` before
                 calling retrieve.
+            filter_ast: Canonical recall-filter AST. When set, it is pushed
+                down into the vector channel (``_vector_search_chunks`` ->
+                ``TemporalVectorStore.search``) and the independent BM25
+                channel (``_bm25_search_chunks`` -> ``search_fulltext``),
+                where the pgvector backend compiles it to the SAME
+                ``khora_chunks`` WHERE predicate. ``None`` leaves every path
+                byte-identical to the no-filter behaviour.
 
         Returns:
             VectorCypherResult with chunks, entities, and metadata
@@ -736,6 +745,7 @@ class VectorCypherRetriever:
                     graph_depth=graph_depth,
                     limit=limit,
                     routing=routing,
+                    filter_ast=filter_ast,
                 )
             elif force_simple or (not force_graph and routing.complexity == QueryComplexity.SIMPLE):
                 # Simple path: direct chunk retrieval. Also the destination
@@ -754,6 +764,7 @@ class VectorCypherRetriever:
                     temporal_signal=temporal_signal,
                     min_similarity=min_similarity,
                     mode=mode,
+                    filter_ast=filter_ast,
                 )
             else:
                 # Complex/moderate path: VectorCypher with parallel execution.
@@ -773,6 +784,7 @@ class VectorCypherRetriever:
                         temporal_signal=temporal_signal,
                         min_similarity=min_similarity,
                         mode=mode,
+                        filter_ast=filter_ast,
                     )
                 except _NEO4J_TRANSIENT_ERRORS as e:
                     logger.warning(f"Graph search failed, falling back to vector-only: {e}")
@@ -835,6 +847,8 @@ class VectorCypherRetriever:
         graph_depth: int | None,
         limit: int,
         routing: RoutingDecision,
+        *,
+        filter_ast: FilterNode | None = None,
     ) -> VectorCypherResult:
         """Phase C fast path (#569): typed-entity recency in one Cypher query.
 
@@ -877,6 +891,7 @@ class VectorCypherRetriever:
                 graph_depth=graph_depth,
                 limit=limit,
                 routing=routing,
+                filter_ast=filter_ast,
             )
 
         # No graph layer → fall back.
@@ -889,6 +904,7 @@ class VectorCypherRetriever:
                 graph_depth=graph_depth,
                 limit=limit,
                 routing=routing,
+                filter_ast=filter_ast,
             )
             fallback.metadata["typed_entity_fast_path_fallback"] = True
             fallback.metadata["typed_entity_type"] = entity_type
@@ -937,6 +953,7 @@ class VectorCypherRetriever:
                     graph_depth=graph_depth,
                     limit=limit,
                     routing=routing,
+                    filter_ast=filter_ast,
                 )
                 fallback.metadata["typed_entity_fast_path_fallback"] = True
                 fallback.metadata["typed_entity_type"] = entity_type
@@ -952,6 +969,7 @@ class VectorCypherRetriever:
                     graph_depth=graph_depth,
                     limit=limit,
                     routing=routing,
+                    filter_ast=filter_ast,
                 )
                 fallback.metadata["typed_entity_fast_path_fallback"] = True
                 fallback.metadata["typed_entity_type"] = entity_type
@@ -1020,6 +1038,7 @@ class VectorCypherRetriever:
         temporal_signal: TemporalSignal | None = None,
         min_similarity: float = 0.0,
         mode: SearchMode = SearchMode.HYBRID,
+        filter_ast: FilterNode | None = None,
     ) -> VectorCypherResult:
         """Internal VectorCypher retrieval with graph traversal.
 
@@ -1069,6 +1088,7 @@ class VectorCypherRetriever:
                     limit=limit,
                     hybrid_alpha_override=effective_hybrid_alpha,
                     min_similarity=min_similarity,
+                    filter_ast=filter_ast,
                 )
             )
 
@@ -1080,6 +1100,7 @@ class VectorCypherRetriever:
                     query=query,
                     namespace_id=namespace_id,
                     limit=self._config.bm25_top_k,
+                    filter_ast=filter_ast,
                 )
             )
 
@@ -1119,6 +1140,7 @@ class VectorCypherRetriever:
                 temporal_signal=temporal_signal,
                 min_similarity=min_similarity,
                 mode=mode,
+                filter_ast=filter_ast,
             )
 
         # Step 3b: Session-aware parallel retrieval
@@ -1186,6 +1208,11 @@ class VectorCypherRetriever:
                     else:
                         session_tf = _TF(channel=ch)
 
+                    # Session fan-out is PRIMARY retrieval (per-session
+                    # partitioning of the same query — it replaces the cancelled
+                    # global vector task), so it carries the caller filter.
+                    # filter_ast composes orthogonally with the per-session
+                    # TemporalFilter (both AND in the same conditions list).
                     session_tasks.append(
                         asyncio.create_task(
                             self._vector_search_chunks(
@@ -1196,6 +1223,7 @@ class VectorCypherRetriever:
                                 limit=per_session_limit,
                                 hybrid_alpha_override=effective_hybrid_alpha,
                                 min_similarity=min_similarity,
+                                filter_ast=filter_ast,
                             )
                         )
                     )
@@ -1213,6 +1241,7 @@ class VectorCypherRetriever:
                             limit=fallback_limit,
                             hybrid_alpha_override=effective_hybrid_alpha,
                             min_similarity=min_similarity,
+                            filter_ast=filter_ast,
                         )
                     )
                 )
@@ -1407,6 +1436,9 @@ class VectorCypherRetriever:
                 limit=limit,
                 hybrid_alpha_override=effective_hybrid_alpha,
                 min_similarity=min_similarity,
+                # Carrying the caller filter across this restrictive-fallback
+                # sub-search is deferred to follow-up work; for now it is left
+                # unthreaded so this path stays byte-identical to today.
             )
 
         # Await BM25 results (also launched in parallel at the beginning)
@@ -1438,6 +1470,10 @@ class VectorCypherRetriever:
                         query_text=current_state_query,
                         limit=limit,
                         min_similarity=min_similarity,
+                        # Carrying the caller filter across this CHANGE-
+                        # decomposition sub-search is deferred to follow-up
+                        # work; for now it is left unthreaded so this path
+                        # stays byte-identical to today.
                     )
                     # Merge sub-query results, deduplicating by chunk ID
                     existing_ids = {c[0] for c in vector_chunks}
@@ -2221,6 +2257,7 @@ class VectorCypherRetriever:
         temporal_signal: TemporalSignal | None = None,
         min_similarity: float = 0.0,
         mode: SearchMode = SearchMode.HYBRID,
+        filter_ast: FilterNode | None = None,
     ) -> VectorCypherResult:
         """Simple retrieval path - vector search only.
 
@@ -2264,6 +2301,7 @@ class VectorCypherRetriever:
                         query=query,
                         namespace_id=namespace_id,
                         limit=self._config.bm25_top_k if mode != SearchMode.KEYWORD else max(limit, 50),
+                        filter_ast=filter_ast,
                     )
                 )
 
@@ -2278,6 +2316,7 @@ class VectorCypherRetriever:
                     temporal_filter=temporal_filter,
                     hybrid_alpha=effective_alpha,
                     query_text=query,
+                    filter_ast=filter_ast,
                 )
 
             chunk_results: list[tuple[Chunk, float]] = []
@@ -2970,6 +3009,7 @@ class VectorCypherRetriever:
         *,
         hybrid_alpha_override: float | None = None,
         min_similarity: float = 0.0,
+        filter_ast: FilterNode | None = None,
     ) -> list[tuple[UUID, float, Chunk]]:
         """Direct vector search on chunks via pgvector.
 
@@ -2984,6 +3024,9 @@ class VectorCypherRetriever:
                                    channel is active to avoid double-counting.
             min_similarity: Per-call cosine-similarity floor applied at the
                 storage layer. Forwarded to ``TemporalVectorStore.search``.
+            filter_ast: Canonical recall-filter AST. Forwarded to
+                ``TemporalVectorStore.search``, where the pgvector backend
+                compiles it to a ``khora_chunks`` WHERE predicate.
 
         Returns:
             List of (chunk_id, score, chunk) tuples
@@ -2998,6 +3041,7 @@ class VectorCypherRetriever:
                 temporal_filter=temporal_filter,
                 hybrid_alpha=effective_alpha,
                 query_text=query_text,
+                filter_ast=filter_ast,
             )
 
             span.set_attribute("chunk_count", len(results))
@@ -3129,6 +3173,8 @@ class VectorCypherRetriever:
         query: str,
         namespace_id: UUID,
         limit: int,
+        *,
+        filter_ast: FilterNode | None = None,
     ) -> list[tuple[UUID, float, Chunk]]:
         """Full-text BM25 search on chunks.
 
@@ -3143,6 +3189,16 @@ class VectorCypherRetriever:
             query: Original query text
             namespace_id: Namespace to search
             limit: Maximum results
+            filter_ast: Canonical recall-filter AST. When set, the search is
+                pushed down through the temporal store's ``search_fulltext``
+                (which compiles it to the SAME ``khora_chunks`` WHERE the
+                vector channel uses). The coordinator ``chunks``-table
+                fallback is then NOT used: that legacy table cannot honor a
+                ``khora_chunks``-compiled predicate, so falling back would
+                smuggle filter-violating chunks into RRF. When the temporal
+                path is unavailable/empty under a filter, BM25 returns ``[]``
+                rather than unfiltered rows. ``None`` keeps the
+                temporal-first-then-coordinator behaviour byte-identical.
 
         Returns:
             List of (chunk_id, score, chunk) tuples
@@ -3157,7 +3213,7 @@ class VectorCypherRetriever:
                 source = "coordinator"
                 temporal_fulltext = getattr(self._vector_store, "search_fulltext", None)
                 if callable(temporal_fulltext):
-                    raw = await temporal_fulltext(namespace_id, query, limit=limit)
+                    raw = await temporal_fulltext(namespace_id, query, limit=limit, filter_ast=filter_ast)
                     # Real backends return ``list[tuple[Chunk, float]]``; the
                     # ``isinstance`` check rejects the bare-AsyncMock case
                     # (and any other non-list return) so we fall through to
@@ -3166,7 +3222,12 @@ class VectorCypherRetriever:
                     if isinstance(raw, list) and raw:
                         results = raw
                         source = "temporal_store"
-                if not results and self._storage is not None:
+                # Coordinator fallback reads the legacy ``chunks`` table, whose
+                # schema cannot carry the ``khora_chunks``-compiled predicate.
+                # Only take it when NO deterministic filter is set — otherwise
+                # it would smuggle filter-violating chunks into RRF (the
+                # filtered path forbids a PG post-filter backstop).
+                if not results and filter_ast is None and self._storage is not None:
                     coord_results = await self._storage.search_fulltext_chunks(
                         namespace_id,
                         query,

--- a/src/khora/storage/backends/base.py
+++ b/src/khora/storage/backends/base.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     )
     from khora.core.models.document import DocumentSource
     from khora.core.models.recall import DocumentProjection
+    from khora.filter.ast import FilterNode
 
 
 @dataclass(frozen=True)
@@ -509,12 +510,19 @@ class VectorBackendProtocol(Protocol):
         *,
         limit: int = 10,
         language: str = "english",
+        filter_ast: FilterNode | None = None,
     ) -> list[tuple[Chunk, float]]:
         """Search chunks using PostgreSQL full-text search.
 
         Uses ts_rank on the content_tsv generated column.
 
         Returns list of (chunk, rank_score) tuples.
+
+        ``filter_ast`` is the canonical recall-filter AST. The relational
+        ``chunks`` table lacks the denormalized filter columns, so backends
+        REFUSE under an active filter (return ``[]``) rather than smuggle
+        unfiltered rows; the filtered BM25 path is the ``khora_chunks``
+        temporal store.
         """
         ...
 

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -16,6 +16,7 @@ from sqlalchemy import delete, func, literal_column, select, text, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 from tenacity import AsyncRetrying, retry_if_exception, stop_after_attempt, wait_exponential
 
+from khora.core.diagnostics import Degradation
 from khora.core.models import Chunk
 from khora.db.models import (
     Base,
@@ -30,7 +31,7 @@ from khora.storage.backends.mixins import AsyncSessionMixin
 from khora.telemetry import trace
 
 if TYPE_CHECKING:
-    pass
+    from khora.filter.ast import FilterNode
 
 try:
     import numpy as np
@@ -760,12 +761,42 @@ class PgVectorBackend(AsyncSessionMixin):
         language: str = "english",
         created_after: datetime | None = None,
         created_before: datetime | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> list[tuple[Chunk, float]]:
         """Search chunks using PostgreSQL full-text search with ts_rank.
 
         Uses the content_tsv generated column and GIN index for efficient
         full-text matching.
+
+        ``filter_ast`` REFUSAL (ADR-001): this backend reads the relational
+        ``chunks`` table, which lacks the denormalized filter columns the
+        recall-filter compiler targets (``khora_chunks``). It therefore CANNOT
+        honor a recall filter here. When ``filter_ast`` is present we return
+        ``[]`` and log a WARNING rather than attempt to compile the
+        ``khora_chunks`` predicate (would SQL-error) or return unfiltered rows
+        (would smuggle filter-violating chunks into RRF — forbidden, no PG
+        post-filter backstop). The filtered BM25 path is the ``khora_chunks``
+        temporal store's ``search_fulltext``; callers route the filtered query
+        there (the VectorCypher retriever skips this fallback under a filter).
         """
+        if filter_ast is not None:
+            # Deliberate refusal, not a caught exception: WARNING + Degradation
+            # (ADR-001), no result carrier on this bare-list method so the log
+            # is the surfaced signal. No new metric (telemetry-contract churn).
+            degradation = Degradation(
+                component="pgvector.search_fulltext",
+                reason="recall_filter_unsupported_on_relational_chunks",
+                detail=(
+                    "filter_ast present but relational chunks table lacks denormalized "
+                    "filter columns; use khora_chunks temporal store"
+                ),
+                exception=None,
+            )
+            logger.warning(
+                "Relational chunks BM25 search refused under an active recall filter: {}",
+                degradation,
+            )
+            return []
         async with self._get_session() as session:
             # OR the query terms instead of plainto_tsquery's implicit AND: a
             # full-sentence question rarely has every content word in one chunk,

--- a/src/khora/storage/backends/sqlite.py
+++ b/src/khora/storage/backends/sqlite.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from loguru import logger
@@ -25,6 +25,9 @@ from khora.core.models.recall import DocumentProjection
 from khora.core.models.tenancy import TenancyMode
 from khora.storage.backends._fts5 import escape_fts5_query
 from khora.storage.backends.base import PaginatedResult
+
+if TYPE_CHECKING:
+    from khora.filter.ast import FilterNode
 
 # ---------------------------------------------------------------------------
 # Schema DDL
@@ -1202,8 +1205,14 @@ class SQLiteVectorBackend:
         *,
         limit: int = 10,
         language: str = "english",
+        filter_ast: FilterNode | None = None,
     ) -> list[tuple[Chunk, float]]:
-        """Full-text search via FTS5."""
+        """Full-text search via FTS5.
+
+        ``filter_ast`` is accepted for protocol parity (the coordinator
+        forwards it uniformly); this backend does not compile the recall
+        filter, so it is ignored.
+        """
         match_expr = escape_fts5_query(query_text)
         if not match_expr:
             return []

--- a/src/khora/storage/backends/sqlite_lance/vector.py
+++ b/src/khora/storage/backends/sqlite_lance/vector.py
@@ -41,6 +41,8 @@ from ._helpers import from_json_text, to_json_text, uuid_to_text
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
+    from khora.filter.ast import FilterNode
+
     from .connection import EmbeddedStorageHandle
 
 
@@ -523,6 +525,7 @@ class SQLiteLanceVectorAdapter:
         language: str = "english",  # noqa: ARG002 — accepted for protocol parity
         created_after: datetime | None = None,
         created_before: datetime | None = None,
+        filter_ast: FilterNode | None = None,  # noqa: ARG002 — accepted for protocol parity
     ) -> list[tuple[Chunk, float]]:
         """FTS5 BM25 ranking.
 

--- a/src/khora/storage/backends/surrealdb/vector.py
+++ b/src/khora/storage/backends/surrealdb/vector.py
@@ -26,6 +26,7 @@ from khora.storage.backends.surrealdb._helpers import (
 from khora.telemetry import trace
 
 if TYPE_CHECKING:
+    from khora.filter.ast import FilterNode
     from khora.storage.backends.surrealdb.connection import SurrealDBConnection
 
 try:
@@ -340,11 +341,16 @@ class SurrealDBVectorAdapter:
         language: str = "english",
         created_after: datetime | None = None,
         created_before: datetime | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> list[tuple[Chunk, float]]:
         """Full-text (BM25) search on chunk content.
 
         Uses SurrealDB's ``@1@`` match operator and ``search::score(1)``
         for BM25 ranking.
+
+        ``filter_ast`` is accepted for protocol parity (the coordinator
+        forwards it uniformly); this backend does not compile the recall
+        filter, so it is ignored.
         """
         ns_rid = _rid("memory_namespace", namespace_id)
         where_clauses = [

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -36,6 +36,8 @@ from khora.storage.backends.base import PaginatedResult
 from khora.telemetry import get_collector, metric_counter, trace_span
 
 if TYPE_CHECKING:
+    from khora.filter.ast import FilterNode
+
     from .backends.base import (
         EventStoreProtocol,
         GraphBackendProtocol,
@@ -1042,8 +1044,17 @@ class StorageCoordinator:
         language: str = "english",
         created_after: datetime | None = None,
         created_before: datetime | None = None,
+        filter_ast: FilterNode | None = None,
     ) -> list[tuple[Chunk, float]]:
-        """Search chunks using PostgreSQL full-text search."""
+        """Search chunks using PostgreSQL full-text search.
+
+        ``filter_ast`` is the canonical recall-filter AST. It is forwarded to
+        the relational vector backend's ``search_fulltext`` — which queries the
+        legacy ``chunks`` table (no denormalized filter columns) and therefore
+        REFUSES to return rows under an active filter rather than risk
+        smuggling unfiltered chunks. The filtered BM25 path is the
+        ``khora_chunks`` temporal store (``TemporalVectorStore.search_fulltext``).
+        """
         if not self._vector:
             raise RuntimeError("Vector backend not configured")
         return await self._vector.search_fulltext(
@@ -1053,6 +1064,7 @@ class StorageCoordinator:
             language=language,
             created_after=created_after,
             created_before=created_before,
+            filter_ast=filter_ast,
         )
 
     async def count_chunks(self, namespace_id: UUID) -> int:

--- a/tests/unit/engines/test_vectorcypher_filter_pushdown.py
+++ b/tests/unit/engines/test_vectorcypher_filter_pushdown.py
@@ -1,0 +1,529 @@
+"""VectorCypher pushes the recall-filter WHERE into BOTH chunk channels.
+
+`compile_postgres` now lowers the public ``filter=`` document to a single
+``khora_chunks`` WHERE predicate that VectorCypher pushes down into BOTH of its
+chunk channels:
+
+* the VECTOR channel (``_vector_search_chunks`` -> ``vector_store.search``), and
+* the BM25 channel (``_bm25_search_chunks`` -> the temporal store's
+  ``search_fulltext`` / the coordinator's ``search_fulltext_chunks``).
+
+Both channels must apply the SAME WHERE so that no filter-violating chunk
+reaches RRF fusion from either side.
+
+Why mock/spy level (no live Postgres): this file runs in the main ``test`` job,
+which provisions no database. It pins the engine->channel WIRING contract: that
+the validated ``filter_ast`` (built exactly as the facade builds it —
+``RecallFilter.model_validate`` then ``parse_to_ast``, see khora.py:2045-2046)
+is threaded into both channel calls. The end-to-end row-set proof (that the
+emitted SQL actually narrows live rows) is the job of the Postgres matrix /
+filter-conformance suite — deliberately NOT duplicated here. We DO compile the
+AST to a SQL string via ``compile_postgres`` and assert byte-equality between the
+two channels, so "same WHERE" is proven, not merely "a WHERE on each side".
+
+Scope guard: this exercises ONLY the two chunk channels touched by the primary
+filtered-recall path. It is NOT the broader multi-channel pushdown-spy harness.
+
+The representative filter under test (3 predicates, one per emission kind —
+typed system column, a date range, and a JSONB array-membership):
+
+    {"source_name": "linear",
+     "occurred_at": {"$gte": "2026-04-05"},
+     "metadata.tag": {"$in": ["urgent", "release"]}}
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from loguru import logger as loguru_logger
+from sqlalchemy import ColumnElement
+from sqlalchemy.dialects import postgresql
+
+from khora.engines.vectorcypher.retriever import (
+    RetrieverConfig,
+    VectorCypherRetriever,
+)
+from khora.engines.vectorcypher.router import QueryComplexity, RoutingDecision
+from khora.filter import CompileContext, FilterNode, RecallFilter, parse_to_ast
+from khora.filter.compilers.postgres import compile_postgres
+from khora.storage.backends.pgvector import PgVectorBackend
+
+pytestmark = pytest.mark.unit
+
+
+# Bridge loguru into pytest caplog. The relational backend's Layer-B refusal
+# WARNING is emitted via loguru (``from loguru import logger``), but pytest's
+# ``caplog`` only captures stdlib ``logging`` records by default — without this
+# bridge a caplog assertion would silently pass-by-absence (vacuous). Mirrors the
+# established fixture in tests/unit/engines/chronicle/test_channel_degradation.py.
+@pytest.fixture
+def loguru_caplog() -> Iterator[str]:
+    bridge_name = "khora.test.filter_pushdown"
+
+    def _sink(message: Any) -> None:
+        record = message.record
+        logging.getLogger(bridge_name).log(record["level"].no, record["message"])
+
+    sink_id = loguru_logger.add(_sink, level="WARNING", format="{message}")
+    try:
+        yield bridge_name
+    finally:
+        loguru_logger.remove(sink_id)
+
+
+# The representative three-predicate filter (one predicate per emission kind).
+_RECALL_FILTER: dict[str, Any] = {
+    "source_name": "linear",
+    "occurred_at": {"$gte": "2026-04-05"},
+    "metadata.tag": {"$in": ["urgent", "release"]},
+}
+
+
+def _build_filter_ast() -> FilterNode:
+    """Build the canonical AST exactly as the public facade does (khora.py:2045)."""
+    return parse_to_ast(RecallFilter.model_validate(_RECALL_FILTER))
+
+
+def _compiled_where_sql(ast: FilterNode) -> str:
+    """Compile an AST to the literal-bound ``khora_chunks`` WHERE SQL string.
+
+    Mirrors the backend's own compile call (pgvector.py:463-466): same
+    ``backend_target`` / ``on_unsupported``. ``literal_binds=True`` inlines the
+    operands so two predicates that differ only by bind-parameter numbering still
+    compare equal — what we assert is the SQL shape, not asyncpg's ``$N`` slots.
+    """
+    compiled = compile_postgres(
+        ast,
+        CompileContext(backend_target="khora_chunks", on_unsupported="raise"),
+    )
+    return str(
+        compiled.predicate.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+def _predicate_to_sql(predicate: ColumnElement[Any]) -> str:
+    """Render a captured ``ColumnElement`` predicate to literal-bound SQL."""
+    return str(
+        predicate.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+def _make_retriever(
+    ns_id: UUID,
+    *,
+    complexity: QueryComplexity = QueryComplexity.MODERATE,
+) -> VectorCypherRetriever:
+    """A retriever wired so BOTH the vector and BM25 chunk channels fire.
+
+    Mirrors ``TestGracefulDegradation.retriever`` /
+    ``TestExplicitTemporalSignalSkipsFallback`` in
+    ``test_vectorcypher_retriever.py``.
+
+    ``complexity`` selects which PRIMARY filtered-recall path a plain
+    ``recall(query, filter=...)`` HYBRID routes through (this ticket's scope is
+    the primary path only — carrying the filter across the adaptive sub-searches,
+    session fan-out / restrictive-fallback / CHANGE-recency / vector-only
+    fallback, is deferred follow-up work and is deliberately NOT exercised here):
+
+    * ``MODERATE`` (``use_graph=True``) -> ``_vectorcypher_retrieve`` (vector +
+      BM25 channels launch in parallel). Graph helpers are stubbed so the path
+      completes without Neo4j.
+    * ``SIMPLE`` -> ``_simple_retrieve`` (vector + BM25 channels, no graph).
+
+    Common wiring:
+
+    * ``storage.search_similar_entities`` returns one entry entity, so the
+      moderate path stays on ``_vectorcypher_retrieve`` instead of dropping to
+      the no-entry-entities fallback.
+    * ``enable_bm25_channel=True`` so ``_bm25_search_chunks`` actually launches.
+    * ``enable_session_aware_search=False`` so the per-session fan-out (a
+      deferred-scope sub-search) doesn't issue extra channel calls and muddy the spy.
+    """
+    vector_store = AsyncMock()
+    neo4j_driver = AsyncMock()
+    embedder = AsyncMock()
+    embedder.embed = AsyncMock(return_value=[0.1] * 1536)
+    embedder.model_name = "test-model"
+    embedder.dimension = 1536
+
+    # Vector channel result (consumed by _vector_search_chunks).
+    vec_result = MagicMock()
+    vec_result.chunk = MagicMock()
+    vec_result.chunk.id = uuid4()
+    vec_result.chunk.namespace_id = ns_id
+    vec_result.chunk.document_id = uuid4()
+    vec_result.chunk.content = "vector channel chunk"
+    vec_result.chunk.occurred_at = None
+    vec_result.chunk.created_at = None
+    vec_result.chunk.source_timestamp = None
+    vec_result.chunk.metadata = {}
+    vec_result.chunk.chunker_info = {}
+    vec_result.combined_score = 0.85
+    vec_result.similarity = 0.85
+    vector_store.search = AsyncMock(return_value=[vec_result])
+
+    # BM25 channel result (consumed by _bm25_search_chunks via the temporal
+    # store's search_fulltext). Returns list[(Chunk, score)].
+    from khora.core.models import Chunk
+
+    bm25_chunk = Chunk(id=uuid4(), namespace_id=ns_id, document_id=uuid4(), content="bm25 channel chunk")
+    vector_store.search_fulltext = AsyncMock(return_value=[(bm25_chunk, 1.0)])
+
+    storage = AsyncMock()
+    storage.search_similar_entities = AsyncMock(return_value=[(uuid4(), 0.9)])
+    storage.get_entities_batch = AsyncMock(return_value={})
+    storage.search_fulltext_chunks = AsyncMock(return_value=[(bm25_chunk, 1.0)])
+
+    config = RetrieverConfig(
+        enable_bm25_channel=True,
+        enable_session_aware_search=False,
+    )
+    retriever = VectorCypherRetriever(
+        vector_store=vector_store,
+        neo4j_driver=neo4j_driver,
+        embedder=embedder,
+        config=config,
+        storage=storage,
+    )
+
+    # Route per ``complexity``: SIMPLE -> _simple_retrieve (use_graph=False);
+    # MODERATE -> _vectorcypher_retrieve (use_graph=True). HYBRID mode (the
+    # default) honours the router's complexity for both.
+    use_graph = complexity is not QueryComplexity.SIMPLE
+    retriever._router = MagicMock()
+    retriever._router.route = AsyncMock(
+        return_value=RoutingDecision(
+            complexity=complexity,
+            use_graph=use_graph,
+            graph_depth=2 if use_graph else 0,
+            confidence=0.8,
+            reasoning=complexity.value,
+        )
+    )
+    retriever._router.compute_adaptive_depth = MagicMock(return_value=2)
+
+    # Stub graph helpers so the cypher-expansion path completes without Neo4j.
+    retriever._cypher_expand = AsyncMock(return_value=({}, {}))
+    retriever._fetch_chunks_from_entities = AsyncMock(return_value=[])
+    retriever._version_filter_entities = AsyncMock(return_value=[])
+
+    return retriever
+
+
+def _capture_bm25_predicate(retriever: VectorCypherRetriever, sink: dict[str, Any]) -> None:
+    """Wrap the BM25 fulltext seams so their call kwargs are captured.
+
+    The BM25 channel prefers the temporal store's ``search_fulltext`` and falls
+    back to the coordinator's ``search_fulltext_chunks`` (retriever.py:3158-3177).
+    Whichever fires, we record its kwargs; the test then asserts the filter
+    predicate reached it.
+    """
+    store = retriever._vector_store
+    coord = retriever._storage
+
+    real_store_ft = store.search_fulltext
+    real_coord_ft = coord.search_fulltext_chunks
+
+    async def _store_spy(*args: Any, **kwargs: Any) -> Any:
+        sink["search_fulltext"] = kwargs
+        return await real_store_ft(*args, **kwargs)
+
+    async def _coord_spy(*args: Any, **kwargs: Any) -> Any:
+        sink["search_fulltext_chunks"] = kwargs
+        return await real_coord_ft(*args, **kwargs)
+
+    store.search_fulltext = _store_spy  # type: ignore[method-assign]
+    coord.search_fulltext_chunks = _coord_spy  # type: ignore[method-assign]
+
+
+# The backend implementation threads ``filter_ast`` from ``retrieve()`` all the
+# way down through ``_vectorcypher_retrieve`` into both channel methods. The
+# gate below stays SKIPPED only while that chain is STRUCTURALLY incomplete
+# (including any transient half-edit where ``retrieve`` has the param but the
+# channels don't — which would otherwise raise a confusing ``TypeError``
+# mid-recall). Once the full chain is present the gate activates and
+# the tests run for real: a behaviourally-broken impl (filter dropped, or a
+# different WHERE on the BM25 side) then FAILS LOUDLY. The gate gates on STRUCTURE
+# (signatures) only — it never inspects behaviour, so it cannot mask a real bug.
+_THREADING_CHAIN = (
+    "retrieve",
+    "_vectorcypher_retrieve",
+    "_vector_search_chunks",
+    "_bm25_search_chunks",
+)
+
+
+def _pushdown_chain_ready() -> bool:
+    return all(
+        "filter_ast" in inspect.signature(getattr(VectorCypherRetriever, m)).parameters for m in _THREADING_CHAIN
+    )
+
+
+_PUSHDOWN_READY = _pushdown_chain_ready()
+_pushdown_gate = pytest.mark.skipif(
+    not _PUSHDOWN_READY,
+    reason=(
+        "filter_ast is not yet threaded through the "
+        "full VectorCypher channel chain "
+        "(retrieve -> _vectorcypher_retrieve -> _vector_search_chunks / _bm25_search_chunks)"
+    ),
+)
+
+
+# The two PRIMARY filtered-recall paths a plain ``recall(query, filter=...)``
+# HYBRID routes through (this ticket's scope). SIMPLE -> ``_simple_retrieve``;
+# MODERATE -> ``_vectorcypher_retrieve``. Both run the vector + BM25 channels and
+# forward the filter; the core (a)/(b)/(c) assertions hold on BOTH, so they are
+# parametrized over the pair.
+@_pushdown_gate
+@pytest.mark.parametrize(
+    "complexity",
+    [QueryComplexity.SIMPLE, QueryComplexity.MODERATE],
+    ids=["simple_path", "moderate_path"],
+)
+class TestVectorCypherFilterPushdownBothChannels:
+    """The compiled WHERE reaches BOTH the vector and BM25 channels."""
+
+    async def test_vector_channel_applies_where(self, complexity: QueryComplexity) -> None:
+        """(a) The VECTOR channel forwards the filter into ``vector_store.search``."""
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, complexity=complexity)
+        ast = _build_filter_ast()
+
+        await retriever.retrieve(
+            "alpha bravo charlie",
+            ns_id,
+            limit=10,
+            filter_ast=ast,
+        )
+
+        # vector_store.search must have been called carrying the filter.
+        assert retriever._vector_store.search.await_count >= 1, "vector channel did not run"
+        kwargs = retriever._vector_store.search.await_args.kwargs
+        forwarded = _extract_channel_filter(kwargs)
+        assert forwarded is not None, f"VECTOR channel dropped the filter; vector_store.search kwargs={sorted(kwargs)}"
+        # The forwarded filter resolves to the canonical khora_chunks WHERE,
+        # whether the impl threads the raw FilterNode or a precompiled ColumnElement.
+        assert _channel_where_sql(forwarded) == _compiled_where_sql(ast)
+
+    async def test_bm25_channel_applies_same_where(self, complexity: QueryComplexity) -> None:
+        """(b) The BM25 channel applies the SAME WHERE as the vector channel.
+
+        Proven by byte-equality of the literal-bound SQL, so no filter-violating
+        chunk can reach RRF from the keyword side.
+        """
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, complexity=complexity)
+        ast = _build_filter_ast()
+
+        bm25_calls: dict[str, Any] = {}
+        _capture_bm25_predicate(retriever, bm25_calls)
+
+        await retriever.retrieve(
+            "alpha bravo charlie",
+            ns_id,
+            limit=10,
+            filter_ast=ast,
+        )
+
+        assert bm25_calls, "BM25 channel issued no fulltext call (search_fulltext / search_fulltext_chunks)"
+        # Whichever fulltext seam fired must carry the filter as a predicate that
+        # compiles to the SAME WHERE the vector channel applied.
+        forwarded = None
+        for kwargs in bm25_calls.values():
+            forwarded = _extract_channel_filter(kwargs)
+            if forwarded is not None:
+                break
+        assert forwarded is not None, f"BM25 channel dropped the filter; captured kwargs={bm25_calls}"
+        assert _channel_where_sql(forwarded) == _compiled_where_sql(ast), (
+            "BM25 channel applied a DIFFERENT WHERE than the vector channel"
+        )
+
+    async def test_no_filter_adds_no_where_on_either_channel(self, complexity: QueryComplexity) -> None:
+        """(c) Regression guard: ``filter_ast=None`` -> NO WHERE on either channel.
+
+        Behaviour must be unchanged for the no-filter path: the vector channel
+        passes ``filter_ast=None`` (or omits it) and the BM25 channel adds no
+        filter predicate.
+        """
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, complexity=complexity)
+
+        bm25_calls: dict[str, Any] = {}
+        _capture_bm25_predicate(retriever, bm25_calls)
+
+        await retriever.retrieve(
+            "alpha bravo charlie",
+            ns_id,
+            limit=10,
+            filter_ast=None,
+        )
+
+        # Vector channel: no filter forwarded.
+        assert retriever._vector_store.search.await_count >= 1
+        vec_kwargs = retriever._vector_store.search.await_args.kwargs
+        assert vec_kwargs.get("filter_ast") is None, (
+            f"no-filter recall leaked a filter into the vector channel: {vec_kwargs.get('filter_ast')!r}"
+        )
+
+        # BM25 channel: no filter predicate forwarded.
+        for kwargs in bm25_calls.values():
+            forwarded = _extract_channel_filter(kwargs)
+            assert forwarded is None, f"no-filter recall leaked a filter into the BM25 channel: {forwarded!r}"
+
+    async def test_bm25_filter_disables_unfilterable_coordinator_fallback(self, complexity: QueryComplexity) -> None:
+        """(b, smuggling guard): under a filter, BM25 must NOT fall back to the
+        coordinator's legacy ``chunks`` table.
+
+        The coordinator fallback (``search_fulltext_chunks``) reads the legacy
+        ``chunks`` table, whose schema cannot carry the ``khora_chunks``-compiled
+        WHERE. If BM25 fell back to it under a filter, it would return UNFILTERED
+        rows that smuggle filter-violating chunks into RRF — exactly the PG
+        post-filter backstop the filtered path forbids. So when the temporal fulltext path
+        yields nothing AND a filter is present, BM25 must return ``[]`` instead of
+        taking the fallback (retriever.py:3229 guard).
+        """
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, complexity=complexity)
+        ast = _build_filter_ast()
+
+        # Temporal fulltext path returns EMPTY so the fallback decision is reached.
+        retriever._vector_store.search_fulltext = AsyncMock(return_value=[])
+
+        await retriever.retrieve(
+            "alpha bravo charlie",
+            ns_id,
+            limit=10,
+            filter_ast=ast,
+        )
+
+        # The temporal path WAS consulted (and carried the filter)...
+        assert retriever._vector_store.search_fulltext.await_count >= 1
+        ft_kwargs = retriever._vector_store.search_fulltext.await_args.kwargs
+        assert _extract_channel_filter(ft_kwargs) is not None, "temporal fulltext path did not carry the filter"
+        # ...but the unfilterable coordinator fallback must NOT have been used.
+        retriever._storage.search_fulltext_chunks.assert_not_awaited()
+
+    async def test_bm25_no_filter_still_uses_coordinator_fallback(self, complexity: QueryComplexity) -> None:
+        """(c, control): with NO filter, the coordinator fallback path is unchanged.
+
+        The smuggling guard is filter-gated, so the legacy
+        ``search_fulltext_chunks`` fallback still fires when the temporal path is
+        empty and no filter is supplied — proving the guard adds no regression to
+        the no-filter behaviour.
+        """
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, complexity=complexity)
+
+        # Temporal path empty -> fallback decision reached; no filter -> allowed.
+        retriever._vector_store.search_fulltext = AsyncMock(return_value=[])
+
+        await retriever.retrieve(
+            "alpha bravo charlie",
+            ns_id,
+            limit=10,
+            filter_ast=None,
+        )
+
+        retriever._storage.search_fulltext_chunks.assert_awaited()
+
+
+# A channel may forward the filter under any of these kwarg names. The
+# implementation contract threads ``filter_ast``; we also accept a precompiled-
+# predicate spelling so the assertion targets the VALUE, not the name.
+_FILTER_KWARG_NAMES = ("filter_ast", "filter_predicate", "where_predicate", "compiled_filter")
+
+
+def _extract_channel_filter(kwargs: dict[str, Any]) -> Any:
+    """Pull the forwarded filter argument out of a captured channel call.
+
+    The implementation may thread either the raw ``filter_ast`` (``FilterNode``)
+    or a precompiled ``ColumnElement`` predicate. Accept either kwarg name; return
+    ``None`` when no filter was forwarded (the no-filter regression path).
+    """
+    for key in _FILTER_KWARG_NAMES:
+        if kwargs.get(key) is not None:
+            return kwargs[key]
+    return None
+
+
+def _channel_where_sql(forwarded: Any) -> str:
+    """Render a forwarded filter to a comparable WHERE SQL string.
+
+    Handles both implementation shapes: a raw ``FilterNode`` (compiled here,
+    exactly as the backend would compile it) or an already-compiled
+    ``ColumnElement`` predicate.
+    """
+    if isinstance(forwarded, FilterNode):
+        return _compiled_where_sql(forwarded)
+    return _predicate_to_sql(forwarded)
+
+
+# Layer B is independent of the retriever threading chain — it lives on the
+# relational backend and is always present once the backend change lands. Gate it
+# on that method signature so a stale build skips loudly rather than erroring.
+_LAYER_B_READY = "filter_ast" in inspect.signature(PgVectorBackend.search_fulltext).parameters
+_layer_b_gate = pytest.mark.skipif(
+    not _LAYER_B_READY,
+    reason="relational backend refusal not landed: PgVectorBackend.search_fulltext has no filter_ast param yet",
+)
+
+
+@_layer_b_gate
+class TestRelationalBackendRefusesFilter:
+    """Layer B: the relational ``chunks`` backend REFUSES a recall filter.
+
+    The relational ``chunks`` table lacks the denormalized filter columns the
+    ``khora_chunks`` compiler targets, so it cannot honor a recall filter. Rather
+    than compile (SQL error) or return unfiltered rows (smuggling — forbidden,
+    no PG post-filter backstop), ``PgVectorBackend.search_fulltext`` returns
+    ``[]`` and logs an ADR-001 ``Degradation`` WARNING when a filter is present.
+
+    This is the backstop for any caller that reaches the relational backend
+    directly with a filter (the VectorCypher BM25 channel's Layer-A guard already
+    keeps the normal path off this method under a filter — see
+    ``test_bm25_filter_disables_unfilterable_coordinator_fallback``).
+
+    No live PG: the ``filter_ast is not None`` branch returns before
+    ``_get_session()``, so the backend is built via ``__new__`` (no ``__init__``,
+    no engine) and called directly.
+    """
+
+    async def test_search_fulltext_refuses_and_warns_under_filter(
+        self, caplog: pytest.LogCaptureFixture, loguru_caplog: str
+    ) -> None:
+        """With a filter present, the relational backend returns [] + logs the
+        ADR-001 refusal WARNING (reason=recall_filter_unsupported_on_relational_chunks)."""
+        backend = PgVectorBackend.__new__(PgVectorBackend)  # no __init__ -> no DB engine
+        ast = _build_filter_ast()
+
+        with caplog.at_level(logging.WARNING, logger=loguru_caplog):
+            result = await backend.search_fulltext(uuid4(), "alpha bravo charlie", filter_ast=ast)
+
+        # Refusal: empty result, no smuggled rows.
+        assert result == [], "relational backend must return [] (no unfiltered rows) under a filter"
+
+        # ADR-001 surfaced signal: a WARNING carrying the documented reason.
+        warns = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.WARNING and "recall_filter_unsupported_on_relational_chunks" in r.getMessage()
+        ]
+        assert warns, (
+            "expected an ADR-001 refusal WARNING with reason "
+            "'recall_filter_unsupported_on_relational_chunks'; "
+            f"records={[r.getMessage() for r in caplog.records]}"
+        )

--- a/tests/unit/engines/test_vectorcypher_filter_pushdown.py
+++ b/tests/unit/engines/test_vectorcypher_filter_pushdown.py
@@ -53,6 +53,7 @@ from khora.engines.vectorcypher.retriever import (
 from khora.engines.vectorcypher.router import QueryComplexity, RoutingDecision
 from khora.filter import CompileContext, FilterNode, RecallFilter, parse_to_ast
 from khora.filter.compilers.postgres import compile_postgres
+from khora.query.temporal_detection import TemporalCategory, TemporalSignal
 from khora.storage.backends.pgvector import PgVectorBackend
 
 pytestmark = pytest.mark.unit
@@ -527,3 +528,90 @@ class TestRelationalBackendRefusesFilter:
             "'recall_filter_unsupported_on_relational_chunks'; "
             f"records={[r.getMessage() for r in caplog.records]}"
         )
+
+
+def _change_recency_retriever(ns_id: UUID) -> VectorCypherRetriever:
+    """A MODERATE-path retriever wired so BOTH adaptive sub-searches CAN fire.
+
+    Builds on ``_make_retriever`` but enables the recency channel and stubs the
+    two adaptive sub-search entry points so we can assert whether they run:
+
+    * ``_decompose_change_query`` — the CHANGE-decomposition entry (gated on the
+      query-string-derived CHANGE signal + truthy ``version_history``).
+    * ``_recency_channel_chunks`` — the recency-channel entry (gated on the
+      query-string-derived ``is_temporal`` signal + a category ``default_window``).
+
+    ``temporal_recency_floor_enabled=False`` keeps ``synthesis_vetoed`` False so
+    the recency gate is reachable; ``_fetch_version_history`` returns a truthy
+    list so the CHANGE gate is reachable. With those satisfied, ``filter_ast`` is
+    the only remaining deciding condition on each gate.
+    """
+    retriever = _make_retriever(ns_id, complexity=QueryComplexity.MODERATE)
+    retriever._config = RetrieverConfig(
+        enable_bm25_channel=True,
+        enable_session_aware_search=False,
+        temporal_recency_channel_enabled=True,
+        temporal_recency_floor_enabled=False,
+    )
+    retriever._fetch_version_history = AsyncMock(return_value=[{"entity": "x"}])
+    retriever._decompose_change_query = MagicMock(return_value="current state of the config")
+    retriever._recency_channel_chunks = AsyncMock(return_value=[])
+    return retriever
+
+
+_CHANGE_SIGNAL = TemporalSignal(
+    is_temporal=True,
+    category=TemporalCategory.CHANGE,
+    confidence=0.9,
+    source="dictionary",
+)
+
+
+@_pushdown_gate
+class TestFilterGatesAdaptiveSubSearches:
+    """Adaptive sub-searches must NOT contaminate RRF under a ``filter_ast`` recall.
+
+    The CHANGE-decomposition and recency channels run ``temporal_filter=None``
+    sub-searches and merge their results into the vector pool that feeds RRF.
+    They are gated on the query-string-derived temporal signal, NOT on
+    ``temporal_filter`` — so a CHANGE/RECENCY-classified query combined with a
+    caller ``RecallFilter`` would otherwise smuggle filter-violating chunks into
+    the fused top-k (the deterministic pre-filter contract is violated). Until
+    ``filter_ast`` is threaded through those sub-searches (follow-up scope), they
+    must be skipped entirely when a filter is in flight.
+    """
+
+    async def test_change_and_recency_skipped_under_filter(self) -> None:
+        """With a filter present, neither adaptive sub-search runs (no merge)."""
+        ns_id = uuid4()
+        retriever = _change_recency_retriever(ns_id)
+
+        await retriever.retrieve(
+            "what changed in the config",
+            ns_id,
+            limit=10,
+            temporal_signal=_CHANGE_SIGNAL,
+            filter_ast=_build_filter_ast(),
+        )
+
+        retriever._decompose_change_query.assert_not_called()
+        retriever._recency_channel_chunks.assert_not_awaited()
+
+    async def test_change_and_recency_fire_without_filter(self) -> None:
+        """Control: with NO filter and the SAME CHANGE signal, both adaptive
+        sub-searches run — proving the ``filter_ast`` gate (not some unrelated
+        condition) is what suppresses them above. Without this control the
+        skip-assertion could pass vacuously."""
+        ns_id = uuid4()
+        retriever = _change_recency_retriever(ns_id)
+
+        await retriever.retrieve(
+            "what changed in the config",
+            ns_id,
+            limit=10,
+            temporal_signal=_CHANGE_SIGNAL,
+            filter_ast=None,
+        )
+
+        retriever._decompose_change_query.assert_called()
+        retriever._recency_channel_chunks.assert_awaited()


### PR DESCRIPTION
## Summary
- VectorCypher's `recall(..., filter_ast=...)` previously accepted the validated recall-filter AST but ignored it. This threads the filter through the recall path so it is actually applied.
- The **vector channel** and the **BM25 channel** now both push down the *same* compiled `khora_chunks` `WHERE` predicate (system columns + metadata JSONB), compiled via `compile_postgres`. There is no separate Postgres post-filter — the keyword side reuses the vector side's predicate.
- The BM25 channel skips the legacy relational `chunks` full-text fallback when a filter is active, so no filter-violating chunk can enter RRF fusion from the keyword side.
- The relational full-text backend refuses a filter it structurally cannot honor (the legacy `chunks` table lacks the denormalized filter columns): it returns an empty result and records a failure-observability degradation + WARNING, rather than smuggling unfiltered rows.
- `search_fulltext` gains an accept-and-ignore `filter_ast` parameter on the remaining vector backends for protocol parity, so uniform forwarding from the coordinator doesn't break non-Postgres stacks.
- Scope is the primary filtered-recall path only (the plain vector + BM25 channels and the session-aware fan-out). Carrying the filter across the adaptive sub-searches (restrictive-fallback, CHANGE-decomposition, recency, vector-only fallback) is deliberately left to follow-up work; those paths stay byte-identical to today.

## Test plan
- [x] Unit tests pass — new `tests/unit/engines/test_vectorcypher_filter_pushdown.py` (11 tests) proves the same compiled `WHERE` reaches **both** channels (asserted by byte-equality of the literal-bound SQL), the no-filter path adds no `WHERE` on either channel, the BM25 smuggling guard holds, and the relational backend refuses under a filter; filter-compiler suite (`tests/recall`) and VectorCypher engine/retriever unit tests green
- [ ] Integration / matrix tests pass (run in CI — provisions Postgres/Neo4j; not runnable in the local sandbox)
- [x] No-filter path verified byte-identical (regression guard test)