### PR TITLE
Use exact JSONB equality for metadata sub-path object filters

### DIFF
--- a/src/khora/filter/compilers/postgres.py
+++ b/src/khora/filter/compilers/postgres.py
@@ -39,6 +39,7 @@ for khora's own engines; not re-exported from :mod:`khora.__init__`.
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from datetime import datetime
 from typing import Any
 
@@ -304,8 +305,9 @@ class _Builder:
         """Positive metadata equality — always a total boolean.
 
         A ``$date`` literal compares through the guarded timestamptz gate; a tuple
-        is an exact-array equality on the extracted node; any other scalar is
-        array-aware ``@>`` containment.
+        is an exact-array equality on the extracted node; a dict (sub-path
+        subdocument operand) is EXACT ``object_equal`` — ``#> = '{...}'::jsonb``,
+        NOT ``@>`` containment; any other scalar is array-aware ``@>`` containment.
         """
         if isinstance(operand, DateLiteral):
             return self._md_date_compare(segs, Op.EQ, operand)
@@ -314,6 +316,12 @@ class _Builder:
             # the path is absent, so coalesce the comparison to FALSE for totality.
             node = self._md_json(segs)
             return sa.func.coalesce(node == _jsonb_literal(list(operand)), sa.false())
+        if isinstance(operand, Mapping):
+            # Subdocument equality: EXACT object_equal, not containment. `_jsonb_literal`
+            # sorts keys, so the compare is key-order-insensitive (PG JSONB `=` is
+            # structural). `#>` is NULL on an absent path, so coalesce to FALSE.
+            node = self._md_json(segs)
+            return sa.func.coalesce(node == _jsonb_literal(dict(operand)), sa.false())
         return self._md_containment(segs, operand)
 
     def _md_range(self, segs: tuple[str, ...], op: Op, operand: Any) -> ColumnElement[bool]:

--- a/src/khora/filter/conformance.py
+++ b/src/khora/filter/conformance.py
@@ -73,6 +73,7 @@ __all__ = [
     "PythonExecutor",
     "SeedRecord",
     "assert_case",
+    "f_objeq_cases",
     "f_op_cases",
     "oracle_survivors",
     "run_case_for_backend",
@@ -715,12 +716,42 @@ def f_sel_cases() -> list[ConformanceCase]:
 
 
 def f_objeq_cases() -> list[ConformanceCase]:
-    """F-OBJEQ: whole-subdocument / whole-blob object equality (exact ``=``).
+    """F-OBJEQ: metadata sub-path dict operand is EXACT ``object_equal`` (``=``).
 
-    Filled by the catalog ticket. A metadata sub-path dict operand is EXACT
-    equality, NOT ``@>`` containment.
+    A metadata sub-path dict operand is EXACT object equality, NOT ``@>``
+    containment: a stored object with EXTRA keys (the ``superset`` record) must NOT
+    survive. ``expected_ids`` is computed by construction from the four-record seed
+    (exact / superset / other / absent). The full metadata-grammar enumeration is
+    the catalog ticket's territory — this is the focused F-OBJEQ smoke set.
     """
-    return []
+    seed = (
+        SeedRecord(id="exact", metadata={"labels": {"team": "x"}}),
+        SeedRecord(id="superset", metadata={"labels": {"team": "x", "y": 2}}),
+        SeedRecord(id="other", metadata={"labels": {"team": "y"}}),
+        SeedRecord(id="absent"),
+    )
+    return [
+        ConformanceCase(
+            id="F-OBJEQ-metadata-labels-eq",
+            # Exact object_equal: only the record whose subdocument EQUALS the
+            # operand survives — the superset (extra key) must NOT match.
+            filter={"metadata.labels": {"team": "x"}},
+            seed_records=seed,
+            expected_ids=frozenset({"exact"}),
+            backends=_OP_BACKENDS,
+            exercises=("F-OBJEQ", "metadata.labels", "$eq", "dict"),
+        ),
+        ConformanceCase(
+            id="F-OBJEQ-metadata-labels-ne",
+            # $ne negates the total exact form: the complement (superset, other) plus
+            # the absent record survive (Rule 2 polarity — absent satisfies $ne).
+            filter={"metadata.labels": {"$ne": {"team": "x"}}},
+            seed_records=seed,
+            expected_ids=frozenset({"superset", "other", "absent"}),
+            backends=_OP_BACKENDS,
+            exercises=("F-OBJEQ", "metadata.labels", "$ne", "dict"),
+        ),
+    ]
 
 
 def f_dotkey_cases() -> list[ConformanceCase]:

--- a/tests/unit/filter/test_compile_postgres.py
+++ b/tests/unit/filter/test_compile_postgres.py
@@ -335,6 +335,38 @@ def test_metadata_array_operand_eq_is_exact_jsonb_match() -> None:
     assert "jsonb" in sql or "::json" in sql or "[" in sql
 
 
+def test_metadata_dict_operand_eq_is_exact_object_match_not_containment() -> None:
+    # A dict on a metadata path is $eq object_equal: the extracted node must EXACTLY
+    # equal the subdocument, emitted as #> = <jsonb object> (NOT @> containment, so a
+    # stored object with extra keys does NOT match). Keys render sorted, so the
+    # compare is key-order-insensitive (PG JSONB `=` is structural).
+    sql = _sql_norm(_ast({"metadata.labels": {"tier": "gold", "team": "x"}}))
+    assert "#>" in sql
+    # Exact equality, never @> containment, for the dict operand.
+    assert "@>" not in sql
+    # Keys are sorted in the jsonb literal (order-insensitive structural compare).
+    assert '{"team": "x", "tier": "gold"}' in sql
+
+
+def test_metadata_dict_operand_ne_negates_exact_object_match() -> None:
+    # $ne on a dict operand negates the total exact-object form. The positive form
+    # is coalesced to FALSE, so NOT flips absent / wrong-type rows to TRUE (Rule 2
+    # polarity — a row missing the key satisfies $ne).
+    sql = _sql_norm(_ast({"metadata.labels": {"$ne": {"team": "x"}}}))
+    assert "not" in sql
+    assert "#>" in sql
+    assert "@>" not in sql
+
+
+def test_metadata_nested_dict_operand_eq_is_exact_object_match() -> None:
+    # A nested metadata path with a dict operand addresses through #> and compares
+    # the extracted node exactly against the subdocument.
+    sql = _sql_norm(_ast({"metadata.outer.inner": {"team": "x"}}))
+    assert "#>" in sql
+    assert "outer" in sql and "inner" in sql
+    assert "@>" not in sql
+
+
 # ===========================================================================
 # Rule 4 — $exists / null on metadata use key-presence, not value extraction.
 # ===========================================================================

--- a/tests/unit/filter/test_conformance_harness.py
+++ b/tests/unit/filter/test_conformance_harness.py
@@ -38,6 +38,7 @@ from khora.filter.conformance import (
     PythonExecutor,
     SeedRecord,
     assert_case,
+    f_objeq_cases,
     f_op_cases,
     oracle_survivors,
     run_case_for_backend,
@@ -237,8 +238,26 @@ def test_f_op_chronicle_agrees_with_python_oracle() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# PostgresExecutor invokes the REAL compile_postgres.
+# F-OBJEQ: a metadata sub-path dict operand is EXACT object_equal, NOT @>.
 # --------------------------------------------------------------------------- #
+#
+# These ACTUALLY RUN the f_objeq_cases() corpus through the Python oracle (the
+# reference compile_postgres is checked against). The superset record (extra key)
+# must NOT survive the $eq — that is the bug the postgres _md_eq fix closes; the
+# matching postgres-side SQL shape (exact `#> = sorted-jsonb`, no `@>`) is asserted
+# in test_compile_postgres.py, and the same case runs end-to-end against the live
+# PostgresExecutor under the integration-gated harness.
+
+
+def test_f_objeq_corpus_is_non_empty() -> None:
+    assert f_objeq_cases(), "the F-OBJEQ generator must produce cases"
+
+
+@pytest.mark.parametrize("case", f_objeq_cases(), ids=lambda c: c.id)
+def test_f_objeq_python_oracle_matches_declared_expected_ids(case: ConformanceCase) -> None:
+    # The oracle's survivors must equal the HAND-DECLARED expected_ids — proving the
+    # superset record (extra key) does NOT match the exact object_equal $eq.
+    assert_case(case, "python", PythonExecutor())
 
 
 def test_postgres_executor_invokes_real_compiler() -> None:


### PR DESCRIPTION
## Summary
- A metadata sub-path dict operand (e.g. `{"metadata.labels": {"team": "x"}}`) is whole-subdocument **exact** equality (object-equal), not containment. The PostgreSQL recall-filter compiler routed a dict operand through `@>` containment, so a stored superset `{"team": "x", "y": 2}` wrongly matched the operand `{"team": "x"}`.
- Route a `Mapping` operand in `_md_eq` to exact `#> = '{...}'::jsonb` — key-order-insensitive (sorted-key literal) and coalesced to `FALSE` on an absent path for totality, matching the Python reference compiler. `$ne` negates it, so rows missing the key are correctly included.
- Fill the object-equality conformance case family and add unit tests asserting the exact-match SQL shape (never `@>`), `$ne` polarity, nested-path addressing, and Python-oracle equivalence.

## Test plan
- [x] Unit tests pass (`tests/unit/filter/`, `tests/recall/`: 715 passed, 10 skipped)
- [x] Lint + format clean (`make lint`, `make format`)
- [ ] Integration tests pass — the live-Postgres filter-conformance job in CI runs the new object-equality cases end-to-end through the real compiler
- [x] Manual verification: compiled SQL inspected — a dict operand emits `(metadata #> ARRAY[...]) = CAST('{...sorted...}' AS JSONB)`, never `@>`