### PR TITLE
Compose recall filter across VectorCypher adaptive sub-searches

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -259,6 +259,7 @@ Prefix: `KHORA_QUERY_`. See [query-engine/retrieval-tuning.md](query-engine/retr
 | `KHORA_QUERY_HYDE_CYPHER_LIMIT` | `20` | Max entities returned per HyDE-Cypher template execution. |
 | `KHORA_QUERY_ENABLE_RERANKING` | `true` | Cross-encoder reranking of top candidates. |
 | `KHORA_QUERY_TEMPORAL_SQL_PUSHDOWN` | `true` | Push relative-date filters into SQL WHERE clauses. |
+| `KHORA_QUERY_METADATA_OVERFETCH_MULTIPLIER` | `3` | Over-fetch multiplier (2–10) for the VectorCypher graph chunk channel when a caller filter has a metadata predicate that can't push down to Cypher and must be post-filtered in memory. The graph fetch widens to `min(limit * multiplier, 200)` so fusion still has candidates after filtering; no effect for no-filter or system-key-only filters. |
 
 ## Tenancy
 

--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -1046,6 +1046,17 @@
       "description": "Issue #904 (ADR-001). VectorCypher relationship-fetch silent fallback - incremented when the parallel rels_task raises and the retrieve path continues without relationships. The same event is also appended to RecallResult.engine_info['degradations']. Asymmetric prior art: _cypher_expand failure already sets engine_info['graph_fallback'] / 'graph_error'; this counter closes the rel-fetch gap. NO namespace_id label - cardinality rule. See docs/architecture/failure-observability-contract.md."
     },
     {
+      "name": "khora.vectorcypher.graph_channel.empty_total",
+      "type": "counter",
+      "stability": "public",
+      "unit": "1",
+      "owner": "vectorcypher",
+      "labels": [
+        {"name": "reason", "values": ["empty_under_filter"], "_comment": "Low-cardinality enum; extend when adding new graph-channel-empty paths."}
+      ],
+      "description": "ADR-001. VectorCypher graph chunk channel emptied by the in-memory metadata post-filter while the SQL-pushed vector/BM25 channels returned filtered rows - i.e. the graph side under-recalled relative to the completeness backstop (metadata is not pushable to Cypher, so a metadata predicate is enforced in memory after the graph fetch). The same event is also appended to RecallResult.engine_info['degradations']. NO namespace_id label - cardinality rule. See docs/architecture/failure-observability-contract.md."
+    },
+    {
       "name": "khora.vectorcypher.chunk_mirror.degraded_total",
       "type": "counter",
       "stability": "public",

--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -1046,17 +1046,6 @@
       "description": "Issue #904 (ADR-001). VectorCypher relationship-fetch silent fallback - incremented when the parallel rels_task raises and the retrieve path continues without relationships. The same event is also appended to RecallResult.engine_info['degradations']. Asymmetric prior art: _cypher_expand failure already sets engine_info['graph_fallback'] / 'graph_error'; this counter closes the rel-fetch gap. NO namespace_id label - cardinality rule. See docs/architecture/failure-observability-contract.md."
     },
     {
-      "name": "khora.vectorcypher.graph_channel.empty_total",
-      "type": "counter",
-      "stability": "public",
-      "unit": "1",
-      "owner": "vectorcypher",
-      "labels": [
-        {"name": "reason", "values": ["empty_under_filter"], "_comment": "Low-cardinality enum; extend when adding new graph-channel-empty paths."}
-      ],
-      "description": "VectorCypher graph chunk channel emptied by the in-memory metadata post-filter while the SQL-pushed vector/BM25 channels returned filtered rows - i.e. the graph side under-recalled relative to the completeness backstop (metadata is not pushable to Cypher, so a metadata predicate is enforced in memory after the graph fetch). The same event is also appended to RecallResult.engine_info['degradations']. NO namespace_id label - cardinality rule. See docs/architecture/failure-observability-contract.md."
-    },
-    {
       "name": "khora.vectorcypher.chunk_mirror.degraded_total",
       "type": "counter",
       "stability": "public",

--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -1054,7 +1054,7 @@
       "labels": [
         {"name": "reason", "values": ["empty_under_filter"], "_comment": "Low-cardinality enum; extend when adding new graph-channel-empty paths."}
       ],
-      "description": "ADR-001. VectorCypher graph chunk channel emptied by the in-memory metadata post-filter while the SQL-pushed vector/BM25 channels returned filtered rows - i.e. the graph side under-recalled relative to the completeness backstop (metadata is not pushable to Cypher, so a metadata predicate is enforced in memory after the graph fetch). The same event is also appended to RecallResult.engine_info['degradations']. NO namespace_id label - cardinality rule. See docs/architecture/failure-observability-contract.md."
+      "description": "VectorCypher graph chunk channel emptied by the in-memory metadata post-filter while the SQL-pushed vector/BM25 channels returned filtered rows - i.e. the graph side under-recalled relative to the completeness backstop (metadata is not pushable to Cypher, so a metadata predicate is enforced in memory after the graph fetch). The same event is also appended to RecallResult.engine_info['degradations']. NO namespace_id label - cardinality rule. See docs/architecture/failure-observability-contract.md."
     },
     {
       "name": "khora.vectorcypher.chunk_mirror.degraded_total",

--- a/src/khora/config/schema.py
+++ b/src/khora/config/schema.py
@@ -1640,6 +1640,14 @@ class QuerySettings(BaseSettings):
     chronicle_overfetch_multiplier: int = Field(
         default=4, ge=2, le=10, description="Over-fetch multiplier for Chronicle retrieval channels"
     )
+    metadata_overfetch_multiplier: int = Field(
+        default=3,
+        ge=2,
+        le=10,
+        description="Over-fetch multiplier for the VectorCypher graph chunk channel when a "
+        "residual metadata predicate must be applied as a Python post-filter (metadata is not "
+        "pushable to Cypher). Capped at min(limit*multiplier, 200).",
+    )
     chronicle_rrf_semantic_weight: float = Field(
         default=1.0, ge=0.0, le=2.0, description="RRF weight for semantic channel in Chronicle fusion"
     )

--- a/src/khora/engines/vectorcypher/dual_nodes.py
+++ b/src/khora/engines/vectorcypher/dual_nodes.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from neo4j import AsyncDriver, AsyncSession
 
     from khora.engines.skeleton.backends import TemporalChunk, TemporalFilter
+    from khora.filter import FilterNode
     from khora.storage.backends.neo4j import Neo4jBackend
 
 
@@ -473,6 +474,7 @@ class DualNodeManager:
         temporal_sort: bool = False,
         prefer_current: bool = False,
         limit: int = 50,
+        filter_ast: FilterNode | None = None,
     ) -> list[dict[str, Any]]:
         """Get chunks connected to the given entities via MENTIONED_IN.
 
@@ -484,6 +486,12 @@ class DualNodeManager:
                 has not passed (for temporal queries). Entities without
                 valid_until are kept (NULL = still valid).
             limit: Maximum chunks to return
+            filter_ast: Canonical recall-filter AST. The system-key slice
+                (the projected document/date keys on the Chunk node) is
+                pushed down here as an extra ``WHERE`` predicate; any metadata
+                leaf is not expressible in Cypher and is left to the engine's
+                in-memory post-filter. A predicate this backend cannot honor at
+                all raises :class:`RecallFilterUnsupportedError`.
 
         Returns:
             List of chunk dicts with entity connection info.
@@ -523,6 +531,29 @@ class DualNodeManager:
         # comparison yields NULL and would drop every current entity.
         if prefer_current:
             temporal_conditions.append("(e.valid_until IS NULL OR datetime(e.valid_until) > datetime())")
+
+        # Push the caller filter's system-key slice down to Cypher. The MATCH
+        # below binds the chunk as ``c`` (the compiler's default node variable),
+        # so the compiled predicate references ``c.<key>`` directly. Metadata
+        # leaves are not Cypher-expressible and are dropped here (the engine
+        # post-filters them); a predicate the backend cannot honor at all raises
+        # ``RecallFilterUnsupportedError`` from this call — deliberately OUTSIDE
+        # the ClientError/timeout handler below so a capability gap surfaces to
+        # the caller rather than being masked as a transient Neo4j failure.
+        if filter_ast is not None:
+            from khora.filter.compilers.cypher import compile_cypher
+            from khora.filter.execute import build_compile_context
+
+            compiled = compile_cypher(
+                filter_ast,
+                build_compile_context("Chunk", table_alias="c", on_unsupported="split"),
+            )
+            # Only splice when at least one leaf actually pushed down. A
+            # metadata-only filter consumes nothing here (every leaf collapses to
+            # a non-constraining ``true``); leave it entirely to the post-filter.
+            if compiled.consumed_keys:
+                temporal_conditions.append(compiled.predicate)
+                params.update(compiled.params)
 
         where_clause = ""
         if temporal_conditions:

--- a/src/khora/engines/vectorcypher/dual_nodes.py
+++ b/src/khora/engines/vectorcypher/dual_nodes.py
@@ -534,12 +534,15 @@ class DualNodeManager:
 
         # Push the caller filter's system-key slice down to Cypher. The MATCH
         # below binds the chunk as ``c`` (the compiler's default node variable),
-        # so the compiled predicate references ``c.<key>`` directly. Metadata
-        # leaves are not Cypher-expressible and are dropped here (the engine
-        # post-filters them); a predicate the backend cannot honor at all raises
-        # ``RecallFilterUnsupportedError`` from this call — deliberately OUTSIDE
-        # the ClientError/timeout handler below so a capability gap surfaces to
-        # the caller rather than being masked as a transient Neo4j failure.
+        # so the compiled predicate references ``c.<key>`` directly. ``"split"``
+        # mode means a leaf this backend cannot express (any metadata predicate)
+        # is NOT raised here — it is omitted from ``consumed_keys`` and left to
+        # the engine's full-AST in-memory post-filter, which enforces every leaf.
+        # So in normal operation this call does not raise. It is still placed
+        # OUTSIDE the ClientError/timeout handler below so that if the compiler
+        # ever does raise ``RecallFilterUnsupportedError`` (an internal failure
+        # on a genuinely non-splittable predicate) it surfaces to the caller
+        # rather than being masked as a transient Neo4j failure.
         if filter_ast is not None:
             from khora.filter.compilers.cypher import compile_cypher
             from khora.filter.execute import build_compile_context

--- a/src/khora/engines/vectorcypher/dual_nodes.py
+++ b/src/khora/engines/vectorcypher/dual_nodes.py
@@ -536,13 +536,9 @@ class DualNodeManager:
         # below binds the chunk as ``c`` (the compiler's default node variable),
         # so the compiled predicate references ``c.<key>`` directly. ``"split"``
         # mode means a leaf this backend cannot express (any metadata predicate)
-        # is NOT raised here — it is omitted from ``consumed_keys`` and left to
-        # the engine's full-AST in-memory post-filter, which enforces every leaf.
-        # So in normal operation this call does not raise. It is still placed
-        # OUTSIDE the ClientError/timeout handler below so that if the compiler
-        # ever does raise ``RecallFilterUnsupportedError`` (an internal failure
-        # on a genuinely non-splittable predicate) it surfaces to the caller
-        # rather than being masked as a transient Neo4j failure.
+        # is omitted from ``consumed_keys`` and left to the engine's full-AST
+        # in-memory post-filter, which enforces every leaf — so this call does
+        # not raise.
         if filter_ast is not None:
             from khora.filter.compilers.cypher import compile_cypher
             from khora.filter.execute import build_compile_context

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -2187,6 +2187,13 @@ class VectorCypherEngine:
         finally:
             retriever._config.hybrid_alpha = original_alpha
 
+        # When a caller filter narrowed the candidate set below the requested k,
+        # emit the service-level under-filled counter (owner: filter) once.
+        if filter_ast is not None and len(result.chunks) < limit:
+            from khora.filter.telemetry import record_under_filled
+
+            record_under_filled()
+
         # Validate and filter retrieval results
         validated_chunks = self._validate_recall_results(result.chunks, query)
 

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -780,6 +780,7 @@ class VectorCypherEngine:
             ppr_max_iter=self._config.query.ppr_max_iter,
             ppr_tol=self._config.query.ppr_tol,
             ppr_top_entities=self._config.query.ppr_top_entities,
+            metadata_overfetch_multiplier=self._config.query.metadata_overfetch_multiplier,
         )
         self._retriever = VectorCypherRetriever(
             vector_store=self._temporal_store,
@@ -2105,7 +2106,20 @@ class VectorCypherEngine:
         # Always run temporal detection (dictionary-based, <10μs, deterministic);
         # temporal category detection is critical for recency weighting and sort order.
         temporal_signal: TemporalSignal | None = None
-        if temporal_filter is not None:
+        # A caller filter that constrains a date system key (occurred_at /
+        # created_at) is an explicit temporal intent, just like an
+        # API-supplied temporal_filter — gate the EXPLICIT synthesis on either
+        # source. A non-date caller filter (e.g. pure metadata.channel) must NOT
+        # trigger EXPLICIT: it runs the normal detector and rides alongside as
+        # filter_ast. When only filter_ast carries the date, the synthesized
+        # signal's temporal_filter stays None (the date predicate is applied via
+        # filter_ast on the channels; the version-filter block no-ops on None).
+        from khora.filter.execute import filter_constrains_date_key
+
+        explicit_from_date = temporal_filter is not None or (
+            filter_ast is not None and filter_constrains_date_key(filter_ast)
+        )
+        if explicit_from_date:
             # API-asserted bounds: synthesize an EXPLICIT signal so downstream
             # behavior (skip-fallback in retriever, version filter, recency
             # weighting) treats the caller-supplied predicate as a high-confidence

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -38,6 +38,7 @@ except ImportError:
 
 from khora.core.diagnostics import Degradation
 from khora.core.models import Chunk, Entity, Relationship
+from khora.filter.telemetry import record_graph_channel_empty
 from khora.query import SearchMode
 from khora.telemetry import bounded_text_hash, trace_span
 from khora.telemetry.metrics import metric_counter
@@ -115,22 +116,6 @@ _REL_FETCH_DEGRADED_COUNTER = metric_counter(
         "path continues without relationships. The same event is also "
         "appended to RecallResult.engine_info['degradations']. Labels: "
         "reason (fetch_failed). NO namespace_id label - cardinality rule."
-    ),
-)
-
-# Graph-channel-empty-under-filter counter. Incremented when the
-# in-memory metadata post-filter empties the graph chunk channel while the
-# SQL-pushed vector/BM25 channels returned filtered rows — i.e. the graph side
-# under-recalled relative to the completeness backstop. The same event is also
-# appended to RecallResult.engine_info['degradations']. NO namespace_id label -
-# cardinality rule.
-_GRAPH_CHANNEL_EMPTY_COUNTER = metric_counter(
-    "khora.vectorcypher.graph_channel.empty_total",
-    unit="1",
-    description=(
-        "VectorCypher graph chunk channel emptied by the in-memory metadata "
-        "post-filter while the vector/BM25 channels returned filtered rows. "
-        "Labels: reason (empty_under_filter). NO namespace_id label - cardinality rule."
     ),
 )
 
@@ -1659,23 +1644,26 @@ class VectorCypherRetriever:
             ).predicate
             graph_chunks_before = len(graph_chunks)
             graph_chunks = [(cid, s, ch) for (cid, s, ch) in graph_chunks if graph_post_filter(ch)]
-            # When the post-filter empties the graph channel but the SQL-pushed
-            # vector/BM25 channels returned filtered rows, the graph side
-            # under-recalled relative to the completeness backstop. Record one
-            # degradation so callers can see the channel was dropped.
-            if not graph_chunks and graph_chunks_before and (vector_chunks or bm25_chunks):
-                logger.warning(
-                    f"Graph chunk channel emptied by metadata post-filter "
-                    f"({graph_chunks_before} dropped); vector/BM25 channels returned rows"
-                )
-                degradations.append(
-                    Degradation(
-                        component="vectorcypher.graph_channel",
-                        reason="empty_under_filter",
-                        detail=f"{graph_chunks_before} graph chunks dropped by metadata post-filter",
+            if not graph_chunks:
+                # The caller filter narrowed the graph channel to empty (it held
+                # candidates before the post-filter). Emit the service-level
+                # filter counter for every such recall.
+                record_graph_channel_empty()
+                # When the SQL-pushed vector/BM25 channels still returned filtered
+                # rows, the graph side under-recalled relative to the completeness
+                # backstop: record one degradation so callers see the dropped channel.
+                if vector_chunks or bm25_chunks:
+                    logger.warning(
+                        f"Graph chunk channel emptied by metadata post-filter "
+                        f"({graph_chunks_before} dropped); vector/BM25 channels returned rows"
                     )
-                )
-                _GRAPH_CHANNEL_EMPTY_COUNTER.add(1, attributes={"reason": "empty_under_filter"})
+                    degradations.append(
+                        Degradation(
+                            component="vectorcypher.graph_channel",
+                            reason="empty_under_filter",
+                            detail=f"{graph_chunks_before} graph chunks dropped by metadata post-filter",
+                        )
+                    )
 
         # Step 7: RRF fusion with score normalization and dynamic weights
         fused_results = self._fuse_results(

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -118,6 +118,22 @@ _REL_FETCH_DEGRADED_COUNTER = metric_counter(
     ),
 )
 
+# Graph-channel-empty-under-filter counter (ADR-001). Incremented when the
+# in-memory metadata post-filter empties the graph chunk channel while the
+# SQL-pushed vector/BM25 channels returned filtered rows — i.e. the graph side
+# under-recalled relative to the completeness backstop. The same event is also
+# appended to RecallResult.engine_info['degradations']. NO namespace_id label -
+# cardinality rule.
+_GRAPH_CHANNEL_EMPTY_COUNTER = metric_counter(
+    "khora.vectorcypher.graph_channel.empty_total",
+    unit="1",
+    description=(
+        "VectorCypher graph chunk channel emptied by the in-memory metadata "
+        "post-filter while the vector/BM25 channels returned filtered rows. "
+        "Labels: reason (empty_under_filter). NO namespace_id label - cardinality rule."
+    ),
+)
+
 
 def _decode_chunker_info(value: Any) -> dict[str, Any]:
     """Normalize the value of ``chunker_info`` returned by a record dict.
@@ -336,6 +352,11 @@ class RetrieverConfig:
     max_chunks: int = 50
     max_entities: int = 30
     max_relationships: int = 90  # ~3x max_entities
+
+    # Over-fetch multiplier for the graph chunk channel when a residual metadata
+    # predicate must be applied as an in-memory post-filter (metadata is not
+    # pushable to Cypher). Capped at min(limit*multiplier, 200).
+    metadata_overfetch_multiplier: int = 3
 
 
 def _extract_occurred_at(item: Any) -> str | None:
@@ -1065,6 +1086,33 @@ class VectorCypherRetriever:
         # failures without changing signatures.
         degradations: list[Degradation] = []
 
+        # When the caller filter has a leaf the Cypher chunk channel cannot push
+        # down (any metadata predicate — metadata is a serialized JSON property
+        # on the Chunk node, not pushable to Cypher), the graph channel applies
+        # an in-memory post-filter after the fetch. Over-fetch the graph channel
+        # so the post-filter still has enough candidates to fuse. The probe runs
+        # the Cypher compiler in split mode (never raises) and compares its
+        # consumed keys to every leaf key; system-key-only and no-filter recalls
+        # leave the fetch limit unchanged (those push down exactly).
+        graph_overfetch = False
+        if filter_ast is not None:
+            from khora.filter.compilers.cypher import compile_cypher
+            from khora.filter.execute import build_compile_context, has_residual_metadata
+
+            graph_overfetch = has_residual_metadata(
+                filter_ast,
+                compile_cypher(
+                    filter_ast,
+                    build_compile_context("Chunk", table_alias="c", on_unsupported="split"),
+                ).consumed_keys,
+            )
+        # Graph + PPR fetch budget: widen to make room for the post-filter when a
+        # residual metadata predicate is present, capped to keep the over-fetch
+        # bounded; otherwise the historical ``limit * 2`` fetch is preserved.
+        graph_fetch_limit = (
+            min(limit * self._config.metadata_overfetch_multiplier, 200) if graph_overfetch else limit * 2
+        )
+
         # #833 channel-skip: GRAPH mode drops vector + BM25 chunk channels
         # (entry entities still come from the entity-level vector index,
         # since the cypher expansion needs seeds).
@@ -1171,7 +1219,26 @@ class VectorCypherRetriever:
                     logger.warning(f"Session discovery failed, using global search: {e}")
                     entity_channels = []
 
-            if len(entity_channels) >= 2:
+            # Best-effort efficiency guard: when the caller pins a
+            # ``metadata.channel`` at the top level of its filter, fan out only
+            # over the discovered sessions that intersect it. NOTE: the
+            # discovered ``channel`` (a Chunk-node column) and the caller's
+            # ``metadata.channel`` (a JSONB blob key) are distinct fields — this
+            # intersect is purely an efficiency narrowing. Correctness never
+            # depends on it: filter_ast is AND-composed into every per-session
+            # search, so even when the two fields differ the result row-set is
+            # still correct (possibly empty). A disjoint or empty intersect
+            # skips the fan-out and keeps the global vector task (which already
+            # carries filter_ast).
+            from khora.filter.execute import caller_channel_constraint
+
+            caller_channels = caller_channel_constraint(filter_ast) if filter_ast is not None else None
+            if caller_channels is not None:
+                fanout_channels = [ch for ch in entity_channels if ch in caller_channels]
+            else:
+                fanout_channels = entity_channels
+
+            if len(fanout_channels) >= 2:
                 # Cancel the original global vector search
                 if vector_chunks_task is not None:
                     vector_chunks_task.cancel()
@@ -1182,15 +1249,15 @@ class VectorCypherRetriever:
 
                 # Fan out per-session vector searches + one unscoped fallback
                 session_aware_activated = True
-                per_session_limit = max(3, limit // len(entity_channels))
+                per_session_limit = max(3, limit // len(fanout_channels))
                 logger.info(
-                    f"Session-aware search: {len(entity_channels)} sessions, {per_session_limit} chunks/session"
+                    f"Session-aware search: {len(fanout_channels)} sessions, {per_session_limit} chunks/session"
                 )
 
                 from khora.engines.skeleton.backends import TemporalFilter as _TF
 
                 session_tasks: list[asyncio.Task[list[tuple[UUID, float, Chunk]]]] = []
-                for ch in entity_channels:
+                for ch in fanout_channels:
                     # Build a per-session temporal filter, preserving any existing
                     # time-range constraints from the original filter.
                     if temporal_filter is not None:
@@ -1253,7 +1320,7 @@ class VectorCypherRetriever:
                 merged: dict[UUID, tuple[UUID, float, Chunk]] = {}
                 for i, result in enumerate(all_session_results):
                     if isinstance(result, Exception):
-                        ch_label = entity_channels[i] if i < len(entity_channels) else "fallback"
+                        ch_label = fanout_channels[i] if i < len(fanout_channels) else "fallback"
                         logger.warning(f"Session search failed for channel={ch_label}: {result}")
                         continue
                     for chunk_id, score, chunk in result:
@@ -1265,7 +1332,7 @@ class VectorCypherRetriever:
                 _session_aware_chunks = list(merged.values())
                 logger.info(
                     f"Session-aware search merged {len(merged)} unique chunks "
-                    f"from {len(entity_channels)} sessions + fallback"
+                    f"from {len(fanout_channels)} sessions + fallback"
                 )
 
         # Compute adaptive depth based on entry entity count
@@ -1380,7 +1447,7 @@ class VectorCypherRetriever:
                 tol=self._config.ppr_tol,
                 top_entities=self._config.ppr_top_entities,
                 chunk_similarity=chunk_similarity,
-                limit=limit * 2,
+                limit=graph_fetch_limit,
             )
             graph_chunks = ppr_chunks
             ppr_path_used = bool(ppr_chunks)
@@ -1394,9 +1461,10 @@ class VectorCypherRetriever:
                 entity_ids=all_entity_ids,
                 namespace_id=namespace_id,
                 temporal_filter=temporal_filter,
-                limit=limit * 2,  # Fetch more for fusion
+                limit=graph_fetch_limit,  # Fetch more for fusion (widened on residual metadata)
                 temporal_sort=_tp.temporal_sort,
                 prefer_current=_tp.prefer_current,
+                filter_ast=filter_ast,
             )
 
         # Step 6: Wait for parallel vector chunk search to complete
@@ -1426,6 +1494,12 @@ class VectorCypherRetriever:
             and temporal_filter
             and len(vector_chunks) < limit // 2
             and not is_explicit_with_date
+            # Skip under ANY caller filter: the re-run intentionally drops the
+            # caller filter (it re-searches with temporal_filter=None and does
+            # not thread filter_ast), so re-running it would smuggle
+            # filter-violating chunks into RRF. Under a caller filter, sparse
+            # vector results are the correct (deterministic) signal.
+            and filter_ast is None
         ):
             logger.debug(f"Temporal filter too restrictive ({len(vector_chunks)} results), falling back to unfiltered")
             vector_chunks = await self._vector_search_chunks(
@@ -1436,9 +1510,9 @@ class VectorCypherRetriever:
                 limit=limit,
                 hybrid_alpha_override=effective_hybrid_alpha,
                 min_similarity=min_similarity,
-                # Carrying the caller filter across this restrictive-fallback
-                # sub-search is deferred to follow-up work; for now it is left
-                # unthreaded so this path stays byte-identical to today.
+                # Reached only when filter_ast is None (gated above); the re-run
+                # drops the temporal filter, so there is no caller filter to
+                # thread here.
             )
 
         # Await BM25 results (also launched in parallel at the beginning)
@@ -1455,19 +1529,12 @@ class VectorCypherRetriever:
         # query naturally retrieves past-state chunks ("used to", "previously"),
         # while the decomposed sub-query targets current-state chunks.
         #
-        # Gated off when a caller filter_ast is in flight. The CHANGE signal is
-        # derived from the query string (not from temporal_filter), so this
-        # sub-search can fire under a filtered recall. It runs with
-        # temporal_filter=None and does not yet thread filter_ast (follow-up
-        # scope), so merging its results into the vector pool would smuggle
-        # filter-violating chunks into RRF and break the deterministic
-        # pre-filter contract. Skip it entirely until the filter is threaded.
-        if (
-            temporal_signal
-            and temporal_signal.category == TemporalCategory.CHANGE
-            and version_history
-            and filter_ast is None
-        ):
+        # The CHANGE signal is derived from the query string (not from
+        # temporal_filter), so this sub-search can fire under a filtered recall.
+        # It runs with temporal_filter=None (current-state intent) but carries
+        # the caller filter_ast, which _vector_search_chunks pushes down, so its
+        # merged results are filter-correct.
+        if temporal_signal and temporal_signal.category == TemporalCategory.CHANGE and version_history:
             current_state_query = self._decompose_change_query(query)
             if current_state_query and current_state_query != query:
                 with trace_span(
@@ -1483,8 +1550,7 @@ class VectorCypherRetriever:
                         query_text=current_state_query,
                         limit=limit,
                         min_similarity=min_similarity,
-                        # Reached only when filter_ast is None (gated above), so
-                        # there is no caller filter to thread here.
+                        filter_ast=filter_ast,
                     )
                     # Merge sub-query results, deduplicating by chunk ID
                     existing_ids = {c[0] for c in vector_chunks}
@@ -1526,14 +1592,6 @@ class VectorCypherRetriever:
             and temporal_signal.is_temporal
             and _tp.default_window_days is not None
             and not synthesis_vetoed
-            # Gated off when a caller filter_ast is in flight. The recency
-            # channel is gated on the query-string-derived temporal signal, so
-            # it can fire under a filtered recall; it pulls chunks with
-            # temporal_filter=None and does not yet thread filter_ast (follow-up
-            # scope). Merging its results into the vector pool would smuggle
-            # filter-violating chunks into RRF and break the deterministic
-            # pre-filter contract. Skip it until the filter is threaded.
-            and filter_ast is None
         ):
             # Intentionally pass temporal_filter=None: the recency channel's
             # job is to surface today's chunks even when the cosine channel
@@ -1541,10 +1599,19 @@ class VectorCypherRetriever:
             # (temporal_query_relevance_floor) is the safeguard against
             # irrelevant-but-fresh chunks muscling in (Devil's-Advocate
             # follow-up: decouple channel filter from synthesized floor).
+            #
+            # The recency channel reads the relational chunks table, which
+            # cannot push down a khora_chunks-compiled predicate, so the caller
+            # filter is enforced as an in-memory post-filter inside
+            # _recency_channel_chunks. Quality trade-off (accepted): under a
+            # restrictive caller filter the recency channel post-filters in
+            # memory and may return fewer rows, slightly under-recalling the
+            # "current state" intent on a tightly date-filtered namespace.
             recent_chunks = await self._recency_channel_chunks(
                 query_embedding=query_embedding,
                 namespace_id=namespace_id,
                 temporal_filter=None,
+                filter_ast=filter_ast,
             )
             if recent_chunks:
                 existing_ids = {c[0] for c in vector_chunks}
@@ -1572,6 +1639,37 @@ class VectorCypherRetriever:
                 if expanded:
                     graph_chunks = graph_chunks + expanded
                     logger.debug(f"Lazy expansion added {len(expanded)} chunks to graph results")
+
+        # Step 6c: Full-AST in-memory post-filter on the graph chunk channel.
+        # The vector + BM25 channels enforce the caller filter via the pgvector
+        # pushdown; the graph (and PPR) channel reads chunks from Neo4j, where
+        # only the system-key slice pushed down (metadata is a serialized JSON
+        # property, not Cypher-expressible). Re-check the WHOLE AST here so a
+        # metadata leaf — including one inside an ``$or`` whose Cypher side
+        # collapsed to a non-constraining ``true`` — is enforced before fusion.
+        # No-filter recalls leave ``graph_chunks`` untouched.
+        if filter_ast is not None and graph_chunks:
+            from khora.filter.compilers.python import compile_python
+            from khora.filter.execute import build_compile_context
+
+            graph_post_filter = compile_python(
+                filter_ast, build_compile_context("Chunk", on_unsupported="split")
+            ).predicate
+            graph_chunks_before = len(graph_chunks)
+            graph_chunks = [(cid, s, ch) for (cid, s, ch) in graph_chunks if graph_post_filter(ch)]
+            # ADR-001: when the post-filter empties the graph channel but the
+            # SQL-pushed vector/BM25 channels returned filtered rows, the graph
+            # side under-recalled relative to the completeness backstop. Record
+            # one degradation so callers can see the channel was dropped.
+            if not graph_chunks and graph_chunks_before and (vector_chunks or bm25_chunks):
+                degradations.append(
+                    Degradation(
+                        component="vectorcypher.graph_channel",
+                        reason="empty_under_filter",
+                        detail=f"{graph_chunks_before} graph chunks dropped by metadata post-filter",
+                    )
+                )
+                _GRAPH_CHANNEL_EMPTY_COUNTER.add(1, attributes={"reason": "empty_under_filter"})
 
         # Step 7: RRF fusion with score normalization and dynamic weights
         fused_results = self._fuse_results(
@@ -2922,6 +3020,7 @@ class VectorCypherRetriever:
         *,
         temporal_sort: bool = False,
         prefer_current: bool = False,
+        filter_ast: FilterNode | None = None,
     ) -> list[tuple[UUID, float, Chunk]]:
         """Fetch chunks connected to entities via MENTIONED_IN.
 
@@ -2932,6 +3031,9 @@ class VectorCypherRetriever:
             limit: Maximum chunks to return
             temporal_sort: If True, sort by occurred_at DESC (for temporal queries)
             prefer_current: When True, filter out expired entities
+            filter_ast: Canonical recall-filter AST. The system-key slice is
+                pushed down into the Cypher chunk query; metadata leaves are
+                left for the engine's in-memory post-filter.
 
         Returns:
             List of (chunk_id, score, chunk) tuples
@@ -2949,6 +3051,7 @@ class VectorCypherRetriever:
                     temporal_sort=temporal_sort,
                     prefer_current=prefer_current,
                     limit=limit,
+                    filter_ast=filter_ast,
                 )
             elif self._storage:
                 # SurrealDB fallback: get chunks via entity source_chunk_ids
@@ -3092,6 +3195,7 @@ class VectorCypherRetriever:
         query_embedding: list[float],
         namespace_id: UUID,
         temporal_filter: TemporalFilter | None,
+        filter_ast: FilterNode | None = None,
     ) -> list[tuple[UUID, float, Chunk]]:
         """Issue #567 A3 — pure-recency candidate pool.
 
@@ -3101,6 +3205,12 @@ class VectorCypherRetriever:
         similarity against ``query_embedding`` and drops anything below
         ``temporal_query_relevance_floor``. Pool augmentation only — the
         caller merges results into the existing vector pool.
+
+        ``filter_ast``: the caller recall-filter AST. This channel reads the
+        relational chunks table, which cannot push down a khora_chunks-compiled
+        predicate, so the filter is enforced as a full-AST in-memory post-filter
+        — no filter-violating chunk reaches RRF. (Trade-off: under a restrictive
+        caller filter this may return fewer rows; see the call site.)
 
         Returns ``list[tuple[chunk_id, score, Chunk]]`` matching the
         shape of ``_vector_search_chunks`` so RRF can fuse it directly.
@@ -3182,6 +3292,19 @@ class VectorCypherRetriever:
                         ),
                     )
                 )
+
+            # Enforce the caller filter in memory: the recency channel reads the
+            # relational chunks table and cannot push a khora_chunks-compiled
+            # predicate to SQL, so drop any chunk that fails the full AST. This
+            # keeps filter-violating recent chunks out of RRF.
+            if filter_ast is not None:
+                from khora.filter.compilers.python import compile_python
+                from khora.filter.execute import build_compile_context
+
+                recency_post_filter = compile_python(
+                    filter_ast, build_compile_context("Chunk", on_unsupported="split")
+                ).predicate
+                filtered = [(cid, s, ch) for (cid, s, ch) in filtered if recency_post_filter(ch)]
 
             span.set_attribute("raw_count", len(recent_tuples))
             span.set_attribute("filtered_count", len(filtered))

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -118,7 +118,7 @@ _REL_FETCH_DEGRADED_COUNTER = metric_counter(
     ),
 )
 
-# Graph-channel-empty-under-filter counter (ADR-001). Incremented when the
+# Graph-channel-empty-under-filter counter. Incremented when the
 # in-memory metadata post-filter empties the graph chunk channel while the
 # SQL-pushed vector/BM25 channels returned filtered rows — i.e. the graph side
 # under-recalled relative to the completeness backstop. The same event is also
@@ -1659,10 +1659,10 @@ class VectorCypherRetriever:
             ).predicate
             graph_chunks_before = len(graph_chunks)
             graph_chunks = [(cid, s, ch) for (cid, s, ch) in graph_chunks if graph_post_filter(ch)]
-            # ADR-001: when the post-filter empties the graph channel but the
-            # SQL-pushed vector/BM25 channels returned filtered rows, the graph
-            # side under-recalled relative to the completeness backstop. Record
-            # one degradation so callers can see the channel was dropped.
+            # When the post-filter empties the graph channel but the SQL-pushed
+            # vector/BM25 channels returned filtered rows, the graph side
+            # under-recalled relative to the completeness backstop. Record one
+            # degradation so callers can see the channel was dropped.
             if not graph_chunks and graph_chunks_before and (vector_chunks or bm25_chunks):
                 logger.warning(
                     f"Graph chunk channel emptied by metadata post-filter "

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -1107,8 +1107,10 @@ class VectorCypherRetriever:
                 ).consumed_keys,
             )
         # Graph + PPR fetch budget: widen to make room for the post-filter when a
-        # residual metadata predicate is present, capped to keep the over-fetch
-        # bounded; otherwise the historical ``limit * 2`` fetch is preserved.
+        # residual metadata predicate is present; otherwise the historical
+        # ``limit * 2`` fetch is preserved. The absolute ``200`` ceiling caps the
+        # extra graph work so a large multiplier paired with a large limit cannot
+        # blow up the Neo4j fetch (the multiplier is bounded ge=2 le=10).
         graph_fetch_limit = (
             min(limit * self._config.metadata_overfetch_multiplier, 200) if graph_overfetch else limit * 2
         )
@@ -1662,6 +1664,10 @@ class VectorCypherRetriever:
             # side under-recalled relative to the completeness backstop. Record
             # one degradation so callers can see the channel was dropped.
             if not graph_chunks and graph_chunks_before and (vector_chunks or bm25_chunks):
+                logger.warning(
+                    f"Graph chunk channel emptied by metadata post-filter "
+                    f"({graph_chunks_before} dropped); vector/BM25 channels returned rows"
+                )
                 degradations.append(
                     Degradation(
                         component="vectorcypher.graph_channel",

--- a/src/khora/filter/execute.py
+++ b/src/khora/filter/execute.py
@@ -118,9 +118,12 @@ def run_chronicle_filter(
 # An engine composing a caller filter across adaptive sub-searches needs a few
 # cheap structural questions answered about the AST: which keys it constrains,
 # whether any leaf falls outside a backend's pushdown set, whether it touches a
-# date key, and whether it pins a metadata channel at the top level. All four
-# are thin consumers of :func:`iter_leaf_clauses` — the single canonical leaf
-# walk — so the traversal logic lives in exactly one place.
+# date key, and whether it pins a metadata channel at the top level. The
+# key-set detectors (which-keys, residual-pushdown) are thin consumers of
+# :func:`iter_leaf_clauses` — the single canonical leaf walk. The date-key and
+# channel detectors instead inspect ONLY the root ``AND``'s direct children,
+# because a predicate buried under ``$or`` / ``$not`` is not a hard conjunctive
+# constraint and must not drive ranking-mode decisions.
 # --------------------------------------------------------------------------- #
 
 
@@ -159,15 +162,24 @@ def has_residual_metadata(node: FilterNode | FilterClause, consumed_keys: frozen
     return bool(filter_leaf_keys(node) - consumed_keys)
 
 
-def filter_constrains_date_key(node: FilterNode | FilterClause) -> bool:
-    """Return whether any leaf constrains a date system key.
+def filter_constrains_date_key(node: FilterNode) -> bool:
+    """Return whether a top-level conjunctive leaf constrains a date system key.
 
-    Keys on the leaf *path*, not its operator, so it covers every form an
-    ``occurred_at`` / ``created_at`` predicate can take — a bare ``$eq``, a range
-    (``$gte`` / ``$lte``), ``$in``, or ``$exists`` — each of which lowers to a
-    single-segment :class:`FilterClause` on that path.
+    Inspects ONLY the root ``AND``'s direct children — mirroring
+    :func:`caller_channel_constraint`. A date predicate buried inside an
+    ``$or`` / ``$not`` is not a hard conjunctive constraint, so it does not flag
+    (it is still enforced on every channel via the threaded filter; this gate
+    only governs EXPLICIT recency synthesis). Keys on the leaf *path*, not its
+    operator, so it covers every form an ``occurred_at`` / ``created_at``
+    predicate can take — a bare ``$eq``, a range (``$gte`` / ``$lte``), ``$in``,
+    or ``$exists``. A bare single predicate parses to ``AND`` with one child, so
+    the common ``{"occurred_at": {"$gte": ...}}`` case still flags.
     """
-    return any(clause.path in (("occurred_at",), ("created_at",)) for clause in iter_leaf_clauses(node))
+    if node.op != Op.AND:
+        return False
+    return any(
+        isinstance(child, FilterClause) and child.path in (("occurred_at",), ("created_at",)) for child in node.children
+    )
 
 
 def caller_channel_constraint(node: FilterNode) -> frozenset[str] | None:

--- a/src/khora/filter/execute.py
+++ b/src/khora/filter/execute.py
@@ -19,14 +19,15 @@ in any public ``__all__`` and not re-exported from :mod:`khora.__init__`.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from khora.filter.ast import FilterNode
+from khora.filter.ast import FilterClause, FilterNode
 from khora.filter.compilers.chronicle import ChronicleDateBound, compile_chronicle
 from khora.filter.compilers.python import compile_python
 from khora.filter.context import CompileContext, SchemaCapabilities
+from khora.filter.model import Op
 
 
 def build_compile_context(
@@ -109,3 +110,86 @@ def run_chronicle_filter(
     """
     post_filter = plan_chronicle_filter(filter_ast).post_filter
     return [record for record in records if post_filter(record)]
+
+
+# --------------------------------------------------------------------------- #
+# AST leaf inspection — one walk, several thin detectors.
+#
+# An engine composing a caller filter across adaptive sub-searches needs a few
+# cheap structural questions answered about the AST: which keys it constrains,
+# whether any leaf falls outside a backend's pushdown set, whether it touches a
+# date key, and whether it pins a metadata channel at the top level. All four
+# are thin consumers of :func:`iter_leaf_clauses` — the single canonical leaf
+# walk — so the traversal logic lives in exactly one place.
+# --------------------------------------------------------------------------- #
+
+
+def iter_leaf_clauses(node: FilterNode | FilterClause) -> Iterator[FilterClause]:
+    """Yield every :class:`FilterClause` leaf in an AST subtree.
+
+    The one canonical walk: ``AND`` / ``OR`` / ``NOT`` recurse through
+    ``FilterNode.children``; a :class:`FilterClause` is a leaf. The detectors
+    below are thin consumers of this generator so the traversal is defined once.
+    """
+    if isinstance(node, FilterClause):
+        yield node
+        return
+    for child in node.children:
+        yield from iter_leaf_clauses(child)
+
+
+def filter_leaf_keys(node: FilterNode | FilterClause) -> frozenset[str]:
+    """Return the set of dotted keys every leaf in the AST constrains.
+
+    ``".".join(clause.path)`` for each leaf — identical to how the compilers
+    build :attr:`CompiledFilter.consumed_keys` (their ``_path_str`` joins the
+    same segment tuple), so this set can be differenced against ``consumed_keys``
+    to find residual (un-pushed) leaves.
+    """
+    return frozenset(".".join(clause.path) for clause in iter_leaf_clauses(node))
+
+
+def has_residual_metadata(node: FilterNode | FilterClause, consumed_keys: frozenset[str]) -> bool:
+    """Return whether any AST leaf was not pushed down (needs a post-filter).
+
+    ``True`` when at least one leaf key is absent from ``consumed_keys`` — i.e.
+    the backend compiler (run in ``"split"`` mode) could not express it, so the
+    engine must apply an in-memory post-filter and may want to over-fetch first.
+    """
+    return bool(filter_leaf_keys(node) - consumed_keys)
+
+
+def filter_constrains_date_key(node: FilterNode | FilterClause) -> bool:
+    """Return whether any leaf constrains a date system key.
+
+    Keys on the leaf *path*, not its operator, so it covers every form an
+    ``occurred_at`` / ``created_at`` predicate can take — a bare ``$eq``, a range
+    (``$gte`` / ``$lte``), ``$in``, or ``$exists`` — each of which lowers to a
+    single-segment :class:`FilterClause` on that path.
+    """
+    return any(clause.path in (("occurred_at",), ("created_at",)) for clause in iter_leaf_clauses(node))
+
+
+def caller_channel_constraint(node: FilterNode) -> frozenset[str] | None:
+    """Return the channels a top-level ``metadata.channel`` predicate pins, or ``None``.
+
+    Inspects ONLY the root ``AND``'s direct children. A ``metadata.channel``
+    constraint buried inside an ``$or`` / ``$not`` is not a hard conjunctive
+    constraint, so it yields ``None`` (never over-restrict). For a direct child
+    that is a ``metadata.channel`` leaf: ``$eq`` of a string contributes that
+    value; ``$in`` contributes its string members. Any other shape (or no such
+    leaf) yields ``None``. Conservative on purpose — equality / membership only.
+    """
+    if node.op != Op.AND:
+        return None
+    channels: set[str] = set()
+    for child in node.children:
+        if not isinstance(child, FilterClause) or child.path != ("metadata", "channel"):
+            continue
+        if child.op == Op.EQ and isinstance(child.operand, str):
+            channels.add(child.operand)
+        elif child.op == Op.IN:
+            channels.update(item for item in child.operand if isinstance(item, str))
+        else:
+            return None
+    return frozenset(channels) if channels else None

--- a/src/khora/filter/telemetry.py
+++ b/src/khora/filter/telemetry.py
@@ -84,3 +84,21 @@ def record_unindexed_metadata(*, op: str) -> None:
     Never pass ``namespace_id`` or a metadata key-path (both unbounded).
     """
     _get_unindexed_metadata_counter().add(1, attributes={"op": op})
+
+
+def record_under_filled() -> None:
+    """Record one filtered recall that returned fewer results than the requested limit.
+
+    Fired once per recall (no attributes) when a caller filter narrowed the
+    candidate set below the requested ``k``. Never pass ``namespace_id``.
+    """
+    _get_under_filled_counter().add(1)
+
+
+def record_graph_channel_empty() -> None:
+    """Record one filtered recall whose graph channel was narrowed to empty.
+
+    Fired once per recall (no attributes) when a caller filter eliminated every
+    graph-channel candidate. Never pass ``namespace_id``.
+    """
+    _get_graph_channel_empty_counter().add(1)

--- a/tests/unit/engines/test_dual_nodes.py
+++ b/tests/unit/engines/test_dual_nodes.py
@@ -1150,3 +1150,75 @@ class TestDualNodeManagerGetEntityChannels:
         )
 
         assert channels == ["only-session"]
+
+
+class _EmptyAsyncResult:
+    """An async-iterable Neo4j result that yields no records."""
+
+    def __aiter__(self) -> _EmptyAsyncResult:
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+def _make_read_capturing_driver() -> tuple[MagicMock, AsyncMock, MagicMock]:
+    """Driver whose ``execute_read`` runs the read closure against a real mock tx.
+
+    ``get_chunks_by_entities`` reads via ``session.execute_read(_work)`` where
+    ``_work(tx)`` calls ``tx.run(query, **params)``. To observe the query and
+    bound params we must actually invoke the closure: ``execute_read`` here calls
+    ``await work_fn(tx)`` with a mock ``tx`` whose ``run`` returns an empty
+    async result. The caller inspects ``tx.run.await_args``.
+    """
+    driver, session = _make_neo4j_driver()
+    tx = MagicMock()
+    tx.run = AsyncMock(return_value=_EmptyAsyncResult())
+
+    async def _run_work(work_fn):
+        return await work_fn(tx)
+
+    session.execute_read = AsyncMock(side_effect=_run_work)
+    return driver, session, tx
+
+
+class TestGetChunksByEntitiesFilterPushdown:
+    """The caller filter's system-key slice is pushed into the graph Cypher query."""
+
+    @pytest.mark.asyncio
+    async def test_system_key_filter_pushed_as_bound_param(self) -> None:
+        """A system-key predicate is spliced into the WHERE with its value bound.
+
+        The compiled predicate references ``c.<key>`` and the value travels as a
+        Cypher ``$param`` (no string interpolation) — the injection-safe path.
+        """
+        from khora.filter import RecallFilter, parse_to_ast
+
+        driver, _session, tx = _make_read_capturing_driver()
+        manager = DualNodeManager(driver)
+        ast = parse_to_ast(RecallFilter.model_validate({"source_name": "linear"}))
+
+        await manager.get_chunks_by_entities([uuid4()], uuid4(), filter_ast=ast, limit=5)
+
+        tx.run.assert_awaited_once()
+        query = tx.run.await_args.args[0]
+        params = tx.run.await_args.kwargs
+        assert "source_name" in query, "system-key predicate was not pushed into the Cypher WHERE"
+        assert any(v == "linear" for v in params.values()), "filter value was not passed as a bound parameter"
+
+    @pytest.mark.asyncio
+    async def test_metadata_only_filter_not_spliced(self) -> None:
+        """A metadata-only filter consumes nothing on the Cypher side (deferred to post-filter)."""
+        from khora.filter import RecallFilter, parse_to_ast
+
+        driver, _session, tx = _make_read_capturing_driver()
+        manager = DualNodeManager(driver)
+        ast = parse_to_ast(RecallFilter.model_validate({"metadata.tag": "urgent"}))
+
+        await manager.get_chunks_by_entities([uuid4()], uuid4(), filter_ast=ast, limit=5)
+
+        tx.run.assert_awaited_once()
+        params = tx.run.await_args.kwargs
+        assert not any(v == "urgent" for v in params.values()), (
+            "metadata leaf was wrongly pushed to Cypher instead of deferred to the in-memory post-filter"
+        )

--- a/tests/unit/engines/test_vectorcypher_explicit_date_gating.py
+++ b/tests/unit/engines/test_vectorcypher_explicit_date_gating.py
@@ -179,3 +179,36 @@ class TestNonDateFilterDoesNotForceExplicit:
 
         signal = _forwarded_signal(engine)
         assert signal.source != "api"
+
+
+class TestUnderFilledCounter:
+    """A filtered recall returning fewer than the requested limit emits the counter."""
+
+    async def test_under_filled_fires_when_filtered_recall_below_limit(self, monkeypatch: Any) -> None:
+        """The mock retriever returns zero chunks; a filtered recall under k records it.
+
+        Wires the declared ``khora.recall.filter.under_filled`` counter. The
+        engine imports the helper locally inside ``recall``, so patching the
+        source module attribute is picked up at call time.
+        """
+        import khora.filter.telemetry as tel
+
+        calls: list[int] = []
+        monkeypatch.setattr(tel, "record_under_filled", lambda: calls.append(1))
+
+        engine = _connected_engine()  # retriever.retrieve returns 0 chunks
+        await engine.recall("any query", uuid4(), limit=10, filter_ast=_ast({"metadata.channel": "alpha"}))
+
+        assert calls, "under_filled not recorded for a filtered recall that returned fewer than the limit"
+
+    async def test_under_filled_not_fired_without_filter(self, monkeypatch: Any) -> None:
+        """Control: an unfiltered recall never emits the filter under-filled counter."""
+        import khora.filter.telemetry as tel
+
+        calls: list[int] = []
+        monkeypatch.setattr(tel, "record_under_filled", lambda: calls.append(1))
+
+        engine = _connected_engine()
+        await engine.recall("any query", uuid4(), limit=10, filter_ast=None)
+
+        assert not calls, "under_filled fired for an unfiltered recall"

--- a/tests/unit/engines/test_vectorcypher_explicit_date_gating.py
+++ b/tests/unit/engines/test_vectorcypher_explicit_date_gating.py
@@ -1,0 +1,181 @@
+"""A date-constrained caller filter is treated as explicit temporal intent.
+
+When a caller passes a ``filter`` whose AST constrains a date system key
+(``occurred_at`` / ``created_at``), the engine synthesizes an EXPLICIT temporal
+signal — exactly as it does for an API-supplied ``temporal_filter``. That
+EXPLICIT signal drives downstream recency behavior (the version filter, the
+restrictive-fallback skip, recency weighting). A NON-date caller filter (e.g. a
+pure ``metadata.channel`` constraint) must NOT trigger EXPLICIT: it runs the
+normal query-string temporal detector and rides alongside as ``filter_ast``.
+
+These run at the engine layer with a mock-connected retriever; the engine's
+``recall`` builds the temporal signal and forwards it to ``retriever.retrieve``.
+We spy on the ``temporal_signal`` the retriever receives — the observable
+contract — rather than re-deriving the synthesis logic. No database.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from khora.engines.vectorcypher.engine import VectorCypherEngine
+from khora.engines.vectorcypher.retriever import VectorCypherResult
+from khora.engines.vectorcypher.router import QueryComplexity, RoutingDecision
+from khora.filter import RecallFilter, parse_to_ast
+from khora.query.temporal_detection import TemporalCategory
+
+pytestmark = pytest.mark.unit
+
+
+def _ast(doc: dict[str, Any]) -> object:
+    """Lower a wire-form filter document to its canonical AST (as the facade does)."""
+    return parse_to_ast(RecallFilter.model_validate(doc))
+
+
+def _connected_engine() -> VectorCypherEngine:
+    """A mock-connected engine whose retriever.retrieve is an inspectable spy.
+
+    Mirrors ``TestVectorCypherEngineRecall.connected_engine`` in
+    ``test_vectorcypher_engine.py``: the retriever returns an empty
+    ``VectorCypherResult`` so ``recall`` completes, and the engine forwards the
+    temporal_signal it built into ``retriever.retrieve``.
+    """
+    config = MagicMock()
+    config.get_postgresql_url.return_value = "postgresql://localhost/test"
+    config.get_neo4j_url.return_value = "bolt://localhost:7687"
+    config.get_neo4j_user.return_value = "neo4j"
+    config.get_neo4j_password.return_value = "password"
+    config.get_neo4j_database.return_value = "neo4j"
+    config.get_graph_config.return_value = MagicMock()
+    config.get_vector_config.return_value = MagicMock()
+    config.storage.postgresql_pool_size = 5
+    config.storage.postgresql_max_overflow = 10
+    config.storage.embedding_dimension = 1536
+
+    engine = VectorCypherEngine(config)
+    engine._connected = True
+    engine._storage = AsyncMock()
+    engine._temporal_store = AsyncMock()
+    engine._embedder = AsyncMock()
+    engine._dual_nodes = AsyncMock()
+    engine._neo4j_driver = AsyncMock()
+
+    routing = RoutingDecision(
+        complexity=QueryComplexity.SIMPLE,
+        use_graph=False,
+        graph_depth=0,
+        confidence=0.8,
+        reasoning="test",
+    )
+    empty_result = VectorCypherResult(
+        chunks=[],
+        entities=[],
+        routing_decision=routing,
+        metadata={},
+    )
+    engine._retriever = AsyncMock()
+    engine._retriever.retrieve = AsyncMock(return_value=empty_result)
+    engine._router = MagicMock()
+    # ``hybrid_alpha`` is read/restored around the retrieve call; give it a real
+    # float so the save/restore around ``retrieve`` doesn't choke on a MagicMock.
+    engine._retriever._config = MagicMock()
+    engine._retriever._config.hybrid_alpha = 0.7
+    return engine
+
+
+def _forwarded_signal(engine: VectorCypherEngine) -> Any:
+    """Pull the temporal_signal the engine forwarded into retriever.retrieve."""
+    assert engine._retriever.retrieve.await_count >= 1, "retriever.retrieve was never called"
+    return engine._retriever.retrieve.await_args.kwargs["temporal_signal"]
+
+
+class TestDateFilterSynthesizesExplicit:
+    """A date-key caller filter yields an EXPLICIT, high-confidence signal."""
+
+    @pytest.mark.parametrize(
+        "doc",
+        [
+            {"occurred_at": {"$gte": "2026-04-05"}},
+            {"created_at": {"$gte": "2026-04-05"}},
+            {"occurred_at": {"$gte": "2026-04-05", "$lte": "2026-04-30"}},
+        ],
+        ids=["occurred_at_gte", "created_at_gte", "occurred_at_range"],
+    )
+    async def test_date_filter_is_explicit(self, doc: dict[str, Any]) -> None:
+        """A filter that constrains occurred_at / created_at -> EXPLICIT signal.
+
+        EXPLICIT is the engine's "API-asserted temporal intent" category: it
+        carries confidence 1.0 and source 'api', and downstream code applies the
+        recency-weighting / version-filter path that a high-confidence temporal
+        query gets — the same treatment an API ``temporal_filter`` would receive.
+        """
+        engine = _connected_engine()
+        await engine.recall("any phrasing at all", uuid4(), filter_ast=_ast(doc))
+
+        signal = _forwarded_signal(engine)
+        assert signal is not None
+        assert signal.category == TemporalCategory.EXPLICIT, (
+            f"date-key filter did not synthesize EXPLICIT; got {signal.category}"
+        )
+        assert signal.is_temporal is True
+        # API-asserted: confidence 1.0, source 'api' (disambiguates from the
+        # dictionary / semantic / none detector sources in traces).
+        assert signal.confidence == 1.0
+        assert signal.source == "api"
+
+    async def test_date_filter_without_temporal_filter_keeps_signal_filter_none(self) -> None:
+        """When only the caller filter carries the date, the synthesized signal's
+        own ``temporal_filter`` stays None.
+
+        The date predicate is enforced via ``filter_ast`` on the channels; the
+        version-filter block no-ops on a None signal filter, so the date is not
+        double-applied through two different mechanisms.
+        """
+        engine = _connected_engine()
+        await engine.recall("any phrasing", uuid4(), filter_ast=_ast({"occurred_at": {"$gte": "2026-04-05"}}))
+
+        signal = _forwarded_signal(engine)
+        assert signal.category == TemporalCategory.EXPLICIT
+        assert signal.temporal_filter is None
+
+
+class TestNonDateFilterDoesNotForceExplicit:
+    """A non-date caller filter runs the normal detector, not EXPLICIT-from-API."""
+
+    async def test_metadata_channel_filter_is_not_api_explicit(self) -> None:
+        """A pure ``metadata.channel`` filter on a time-blind query is NOT EXPLICIT.
+
+        It must run the normal query-string temporal detector (source != 'api')
+        and ride alongside as ``filter_ast`` — it does not earn the
+        API-asserted high-confidence recency treatment a date predicate gets.
+        """
+        engine = _connected_engine()
+        await engine.recall(
+            "what is the architecture of the system",  # no temporal cue
+            uuid4(),
+            filter_ast=_ast({"metadata.channel": "alpha"}),
+        )
+
+        signal = _forwarded_signal(engine)
+        # The normal detector ran (source is one of dictionary / semantic / none),
+        # NOT the api-asserted EXPLICIT synthesis.
+        assert signal.source != "api", "a non-date metadata filter wrongly triggered the API EXPLICIT synthesis"
+        assert not (signal.category == TemporalCategory.EXPLICIT and signal.confidence == 1.0), (
+            "metadata.channel filter must not be promoted to API-confidence EXPLICIT"
+        )
+
+    async def test_no_filter_time_blind_query_runs_normal_detector(self) -> None:
+        """Control: no filter + a time-blind query -> detector source != 'api'.
+
+        Proves the EXPLICIT synthesis is gated on the date predicate, not a
+        side-effect of the recall path itself.
+        """
+        engine = _connected_engine()
+        await engine.recall("what is the architecture of the system", uuid4(), filter_ast=None)
+
+        signal = _forwarded_signal(engine)
+        assert signal.source != "api"

--- a/tests/unit/engines/test_vectorcypher_filter_pushdown.py
+++ b/tests/unit/engines/test_vectorcypher_filter_pushdown.py
@@ -264,6 +264,7 @@ _THREADING_CHAIN = (
     "_vectorcypher_retrieve",
     "_vector_search_chunks",
     "_bm25_search_chunks",
+    "_recency_channel_chunks",
 )
 
 
@@ -543,8 +544,8 @@ def _change_recency_retriever(ns_id: UUID) -> VectorCypherRetriever:
 
     ``temporal_recency_floor_enabled=False`` keeps ``synthesis_vetoed`` False so
     the recency gate is reachable; ``_fetch_version_history`` returns a truthy
-    list so the CHANGE gate is reachable. With those satisfied, ``filter_ast`` is
-    the only remaining deciding condition on each gate.
+    list so the CHANGE gate is reachable. With those satisfied, both sub-searches
+    run regardless of ``filter_ast`` and carry it through.
     """
     retriever = _make_retriever(ns_id, complexity=QueryComplexity.MODERATE)
     retriever._config = RetrieverConfig(
@@ -568,40 +569,71 @@ _CHANGE_SIGNAL = TemporalSignal(
 
 
 @_pushdown_gate
-class TestFilterGatesAdaptiveSubSearches:
-    """Adaptive sub-searches must NOT contaminate RRF under a ``filter_ast`` recall.
+class TestFilterCarriesIntoAdaptiveSubSearches:
+    """Adaptive sub-searches RUN under a ``filter_ast`` recall and carry it.
 
     The CHANGE-decomposition and recency channels run ``temporal_filter=None``
     sub-searches and merge their results into the vector pool that feeds RRF.
     They are gated on the query-string-derived temporal signal, NOT on
     ``temporal_filter`` — so a CHANGE/RECENCY-classified query combined with a
-    caller ``RecallFilter`` would otherwise smuggle filter-violating chunks into
-    the fused top-k (the deterministic pre-filter contract is violated). Until
-    ``filter_ast`` is threaded through those sub-searches (follow-up scope), they
-    must be skipped entirely when a filter is in flight.
+    caller ``RecallFilter`` still runs them, but now each one carries the caller
+    ``filter_ast`` so no filter-violating chunk reaches RRF:
+
+    * CHANGE-decomposition pushes ``filter_ast`` down through
+      ``_vector_search_chunks`` (pgvector pushdown).
+    * the recency channel reads the relational chunks table (no SQL pushdown), so
+      it enforces ``filter_ast`` as an in-memory post-filter.
     """
 
-    async def test_change_and_recency_skipped_under_filter(self) -> None:
-        """With a filter present, neither adaptive sub-search runs (no merge)."""
+    async def test_change_and_recency_run_under_filter_and_forward_it(self) -> None:
+        """With a filter present, both adaptive sub-searches RUN and forward it.
+
+        The CHANGE-decomposition sub-search pushes ``filter_ast`` down through
+        ``_vector_search_chunks``; the recency channel receives ``filter_ast`` so
+        it can post-filter in memory. (Inverts the previous skip-under-filter
+        premise: the filter is now composed across both, not used to skip them.)
+        """
         ns_id = uuid4()
         retriever = _change_recency_retriever(ns_id)
+        # Spy the CHANGE-decomposition sub-search so we can read its kwargs.
+        change_calls: dict[str, Any] = {}
+        real_vector_search = retriever._vector_search_chunks
 
+        async def _vector_spy(*args: Any, **kwargs: Any) -> Any:
+            # The CHANGE-decomposition sub-search is the one that runs with
+            # temporal_filter=None; capture its filter_ast.
+            if kwargs.get("temporal_filter") is None:
+                change_calls.setdefault("kwargs", kwargs)
+            return await real_vector_search(*args, **kwargs)
+
+        retriever._vector_search_chunks = _vector_spy  # type: ignore[method-assign]
+
+        ast = _build_filter_ast()
         await retriever.retrieve(
             "what changed in the config",
             ns_id,
             limit=10,
             temporal_signal=_CHANGE_SIGNAL,
-            filter_ast=_build_filter_ast(),
+            filter_ast=ast,
         )
 
-        retriever._decompose_change_query.assert_not_called()
-        retriever._recency_channel_chunks.assert_not_awaited()
+        # CHANGE-decomposition ran and forwarded the caller filter.
+        retriever._decompose_change_query.assert_called()
+        assert change_calls, "CHANGE-decomposition sub-search did not run under a filter"
+        assert change_calls["kwargs"].get("filter_ast") is ast, (
+            "CHANGE-decomposition sub-search dropped the caller filter_ast"
+        )
+
+        # Recency channel ran and received the caller filter for its in-memory
+        # post-filter.
+        retriever._recency_channel_chunks.assert_awaited()
+        recency_kwargs = retriever._recency_channel_chunks.await_args.kwargs
+        assert recency_kwargs.get("filter_ast") is ast, "recency channel did not receive the caller filter_ast"
 
     async def test_change_and_recency_fire_without_filter(self) -> None:
         """Control: with NO filter and the SAME CHANGE signal, both adaptive
-        sub-searches run — proving the ``filter_ast`` gate (not some unrelated
-        condition) is what suppresses them above. Without this control the
-        skip-assertion could pass vacuously."""
+        sub-searches still run — and the recency channel receives ``filter_ast=None``.
+        Proves the unfiltered behaviour is unchanged."""
         ns_id = uuid4()
         retriever = _change_recency_retriever(ns_id)
 
@@ -615,3 +647,565 @@ class TestFilterGatesAdaptiveSubSearches:
 
         retriever._decompose_change_query.assert_called()
         retriever._recency_channel_chunks.assert_awaited()
+        recency_kwargs = retriever._recency_channel_chunks.await_args.kwargs
+        assert recency_kwargs.get("filter_ast") is None, "no-filter recall leaked a filter into the recency channel"
+
+    async def test_recency_channel_post_filters_violating_chunk(self) -> None:
+        """The recency channel drops a chunk that violates the caller filter.
+
+        The recency channel reads the relational chunks table and cannot push the
+        filter to SQL, so it post-filters in memory. A recent chunk whose metadata
+        does not satisfy the filter must be dropped before it reaches the pool.
+        """
+        from khora.core.models import Chunk
+
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, complexity=QueryComplexity.MODERATE)
+
+        # Two recent chunks with embeddings above the relevance floor: one matches
+        # the filter's metadata.tag membership, one violates it.
+        matching = Chunk(
+            id=uuid4(),
+            namespace_id=ns_id,
+            document_id=uuid4(),
+            content="matching recent chunk",
+            metadata={"tag": "urgent"},
+        )
+        matching.embedding = [0.1] * 1536
+        violating = Chunk(
+            id=uuid4(),
+            namespace_id=ns_id,
+            document_id=uuid4(),
+            content="violating recent chunk",
+            metadata={"tag": "noise"},
+        )
+        violating.embedding = [0.1] * 1536
+
+        retriever._vector_store.search_recent_chunks = AsyncMock(return_value=[(matching, None), (violating, None)])
+        # Floor of 0.0 so both pass the cosine gate and only the post-filter culls.
+        retriever._config.temporal_query_relevance_floor = 0.0
+
+        # A metadata-only filter so the post-filter (not the system-key columns,
+        # which these synthetic chunks don't carry) is the sole deciding factor.
+        ast = parse_to_ast(RecallFilter.model_validate({"metadata.tag": {"$in": ["urgent", "release"]}}))
+        result = await retriever._recency_channel_chunks(
+            query_embedding=[0.1] * 1536,
+            namespace_id=ns_id,
+            temporal_filter=None,
+            filter_ast=ast,
+        )
+
+        returned_ids = {cid for cid, _, _ in result}
+        assert matching.id in returned_ids, "filter-matching recent chunk was wrongly dropped"
+        assert violating.id not in returned_ids, "filter-violating recent chunk reached the recency pool"
+
+
+# --------------------------------------------------------------------------- #
+# Over-fetch conditional: a residual metadata predicate widens the graph/PPR
+# fetch; a no-filter or system-key-only filter does not.
+# --------------------------------------------------------------------------- #
+
+
+@_pushdown_gate
+class TestGraphChannelOverFetch:
+    """The graph chunk fetch widens ONLY when a metadata predicate is residual.
+
+    Metadata leaves cannot push down to Cypher, so the graph channel must
+    over-fetch to leave the in-memory post-filter enough candidates to fuse.
+    The fetch budget is ``min(limit * multiplier, 200)`` when a metadata leaf is
+    residual, and the historical ``limit * 2`` otherwise. The probe runs the
+    Cypher compiler in split mode (never raises) and compares its consumed keys
+    to the leaf keys — system-key-only and no-filter recalls push down exactly,
+    so they keep the unwidened ``limit * 2`` fetch.
+
+    The fetch limit is observed at ``_fetch_chunks_from_entities`` (the non-PPR
+    graph path, which ``_make_retriever`` leaves enabled — ``enable_ppr_retrieval``
+    is off by default).
+    """
+
+    async def test_residual_metadata_filter_widens_fetch(self) -> None:
+        """A metadata predicate -> fetch widens to min(limit*multiplier, 200)."""
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, complexity=QueryComplexity.MODERATE)
+        # default multiplier is 3 (RetrieverConfig.metadata_overfetch_multiplier)
+        assert retriever._config.metadata_overfetch_multiplier == 3
+        ast = _build_filter_ast()  # carries metadata.tag (residual)
+
+        await retriever.retrieve("alpha bravo charlie", ns_id, limit=10, filter_ast=ast)
+
+        retriever._fetch_chunks_from_entities.assert_awaited()
+        fetch_limit = retriever._fetch_chunks_from_entities.await_args.kwargs["limit"]
+        assert fetch_limit == min(10 * 3, 200), f"residual-metadata fetch not widened: limit={fetch_limit}"
+
+    async def test_residual_metadata_overfetch_capped_at_200(self) -> None:
+        """The widened fetch is capped at 200 regardless of limit * multiplier."""
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, complexity=QueryComplexity.MODERATE)
+        ast = _build_filter_ast()  # residual metadata.tag
+
+        # limit*multiplier = 100*3 = 300 -> capped to 200.
+        await retriever.retrieve("alpha bravo charlie", ns_id, limit=100, filter_ast=ast)
+
+        fetch_limit = retriever._fetch_chunks_from_entities.await_args.kwargs["limit"]
+        assert fetch_limit == 200, f"over-fetch not capped at 200: limit={fetch_limit}"
+
+    async def test_no_filter_keeps_unwidened_fetch(self) -> None:
+        """No filter -> the historical ``limit * 2`` fetch, unchanged."""
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, complexity=QueryComplexity.MODERATE)
+
+        await retriever.retrieve("alpha bravo charlie", ns_id, limit=10, filter_ast=None)
+
+        fetch_limit = retriever._fetch_chunks_from_entities.await_args.kwargs["limit"]
+        assert fetch_limit == 10 * 2, f"no-filter recall changed the fetch budget: limit={fetch_limit}"
+
+    async def test_system_key_only_filter_keeps_unwidened_fetch(self) -> None:
+        """A system-key-only filter (occurred_at) pushes down fully -> no widening.
+
+        The whole filter is Cypher-expressible, so nothing is residual and the
+        in-memory post-filter has no extra work — the fetch stays at ``limit * 2``.
+        """
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, complexity=QueryComplexity.MODERATE)
+        ast = parse_to_ast(RecallFilter.model_validate({"occurred_at": {"$gte": "2026-04-05"}}))
+
+        await retriever.retrieve("alpha bravo charlie", ns_id, limit=10, filter_ast=ast)
+
+        fetch_limit = retriever._fetch_chunks_from_entities.await_args.kwargs["limit"]
+        assert fetch_limit == 10 * 2, f"system-key-only filter wrongly widened the fetch: limit={fetch_limit}"
+
+
+# --------------------------------------------------------------------------- #
+# Session fan-out: a caller metadata.channel constraint narrows the fan-out to
+# the intersection with the discovered entity channels (or skips it entirely).
+# --------------------------------------------------------------------------- #
+
+_RECENCY_SIGNAL = TemporalSignal(
+    is_temporal=True,
+    category=TemporalCategory.RECENCY,
+    confidence=0.9,
+    source="dictionary",
+)
+
+
+def _session_aware_retriever(ns_id: UUID, discovered_channels: list[str]) -> VectorCypherRetriever:
+    """A retriever wired for the session-aware fan-out path.
+
+    ``enable_session_aware_search=True`` plus a temporal signal plus >=1 entry
+    entity reaches the session-discovery block. ``get_entity_channels`` is mocked
+    to return the supplied channels. PPR stays off so the merged session results
+    flow through the normal (non-PPR) graph path.
+    """
+    retriever = _make_retriever(ns_id, complexity=QueryComplexity.MODERATE)
+    retriever._config = RetrieverConfig(
+        enable_bm25_channel=True,
+        enable_session_aware_search=True,
+    )
+    retriever._dual_nodes.get_entity_channels = AsyncMock(return_value=discovered_channels)
+    return retriever
+
+
+def _spy_vector_search_channels(retriever: VectorCypherRetriever, sink: list[str | None]) -> None:
+    """Record the per-call ``temporal_filter.channel`` on ``_vector_search_chunks``.
+
+    The session fan-out launches one ``_vector_search_chunks`` per fanned-out
+    channel (each carrying a per-session ``TemporalFilter(channel=ch)``) plus one
+    unscoped fallback (``channel`` None / inherited). Capturing the channel on
+    every call lets the test read which sessions were actually fanned out.
+    """
+    real = retriever._vector_search_chunks
+
+    async def _spy(*args: Any, **kwargs: Any) -> Any:
+        tf = kwargs.get("temporal_filter")
+        sink.append(getattr(tf, "channel", None) if tf is not None else None)
+        return await real(*args, **kwargs)
+
+    retriever._vector_search_chunks = _spy  # type: ignore[method-assign]
+
+
+@_pushdown_gate
+class TestSessionFanoutChannelIntersect:
+    """A caller ``metadata.channel`` constraint narrows the session fan-out."""
+
+    async def test_fanout_restricted_to_intersection(self) -> None:
+        """Caller channels that intersect discovered channels -> fan out the overlap only.
+
+        Discovered sessions {alpha, beta, gamma}; caller pins {alpha, beta}. The
+        fan-out covers alpha + beta only (2 channels -> fan-out activates); gamma
+        is excluded. filter_ast still rides on every per-session search.
+        """
+        ns_id = uuid4()
+        retriever = _session_aware_retriever(ns_id, ["alpha", "beta", "gamma"])
+        channels_seen: list[str | None] = []
+        _spy_vector_search_channels(retriever, channels_seen)
+
+        ast = parse_to_ast(RecallFilter.model_validate({"metadata.channel": {"$in": ["alpha", "beta"]}}))
+        result = await retriever.retrieve(
+            "what changed recently",
+            ns_id,
+            limit=10,
+            temporal_signal=_RECENCY_SIGNAL,
+            filter_ast=ast,
+        )
+
+        # Per-session searches fanned out over the intersection {alpha, beta} only.
+        fanned = {ch for ch in channels_seen if ch is not None}
+        assert fanned == {"alpha", "beta"}, f"fan-out did not narrow to the intersection: {sorted(fanned)}"
+        assert "gamma" not in fanned, "fan-out included a channel outside the caller constraint"
+        assert result.metadata["session_aware_activated"] is True
+
+    async def test_disjoint_constraint_skips_fanout(self) -> None:
+        """A caller constraint disjoint from discovered channels -> skip the fan-out.
+
+        Discovered {alpha, beta}; caller pins {zeta}. The intersection is empty,
+        so the fan-out (which needs >=2 channels) is skipped and the global
+        filtered vector task is kept — no per-session channel searches run.
+        """
+        ns_id = uuid4()
+        retriever = _session_aware_retriever(ns_id, ["alpha", "beta"])
+        channels_seen: list[str | None] = []
+        _spy_vector_search_channels(retriever, channels_seen)
+
+        ast = parse_to_ast(RecallFilter.model_validate({"metadata.channel": "zeta"}))
+        result = await retriever.retrieve(
+            "what changed recently",
+            ns_id,
+            limit=10,
+            temporal_signal=_RECENCY_SIGNAL,
+            filter_ast=ast,
+        )
+
+        # No per-session (channel-scoped) search ran.
+        assert all(ch is None for ch in channels_seen), (
+            f"disjoint constraint still fanned out channel-scoped searches: {channels_seen}"
+        )
+        assert result.metadata["session_aware_activated"] is False
+
+    async def test_no_channel_constraint_fans_out_all_discovered(self) -> None:
+        """No channel constraint -> fan-out behaviour is unchanged (all discovered).
+
+        A filter with no top-level ``metadata.channel`` leaf (or no filter) keeps
+        the pre-feature behaviour: fan out over every discovered session.
+        """
+        ns_id = uuid4()
+        retriever = _session_aware_retriever(ns_id, ["alpha", "beta"])
+        channels_seen: list[str | None] = []
+        _spy_vector_search_channels(retriever, channels_seen)
+
+        # A metadata.tag filter has no channel pin -> caller_channels is None.
+        ast = parse_to_ast(RecallFilter.model_validate({"metadata.tag": {"$in": ["urgent"]}}))
+        result = await retriever.retrieve(
+            "what changed recently",
+            ns_id,
+            limit=10,
+            temporal_signal=_RECENCY_SIGNAL,
+            filter_ast=ast,
+        )
+
+        fanned = {ch for ch in channels_seen if ch is not None}
+        assert fanned == {"alpha", "beta"}, f"unconstrained fan-out did not cover all discovered: {sorted(fanned)}"
+        assert result.metadata["session_aware_activated"] is True
+
+
+# --------------------------------------------------------------------------- #
+# Full-AST graph post-filter / split-mode: a metadata leaf inside an $or (whose
+# Cypher side collapses to a non-constraining superset) still culls graph chunks;
+# emptying the graph channel records a failure-observability degradation entry.
+# --------------------------------------------------------------------------- #
+
+
+def _graph_chunk(ns_id: UUID, *, tag: str) -> Any:
+    """A chunk that the graph channel returns, carrying a metadata.tag value."""
+    from khora.core.models import Chunk
+
+    return Chunk(
+        id=uuid4(),
+        namespace_id=ns_id,
+        document_id=uuid4(),
+        content=f"graph chunk tagged {tag}",
+        metadata={"tag": tag},
+    )
+
+
+@_pushdown_gate
+class TestGraphChannelFullAstPostFilter:
+    """The graph channel re-checks the WHOLE AST in memory before fusion."""
+
+    async def test_or_with_metadata_leaf_culls_graph_chunk(self) -> None:
+        """A metadata leaf inside an ``$or`` still drops a violating graph chunk.
+
+        The Cypher side of ``$or`` collapses the metadata branch to a
+        non-constraining ``true`` (superset), so a violating chunk can survive the
+        graph fetch. The full-AST in-memory post-filter must re-check the whole
+        ``$or`` and drop a chunk that satisfies NEITHER branch — here a chunk
+        whose tag is not in the metadata branch and whose source_name does not
+        match the other branch.
+        """
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, complexity=QueryComplexity.MODERATE)
+
+        keep = _graph_chunk(ns_id, tag="urgent")  # satisfies the metadata branch
+        drop = _graph_chunk(ns_id, tag="noise")  # satisfies neither branch
+        retriever._fetch_chunks_from_entities = AsyncMock(return_value=[(keep.id, 0.9, keep), (drop.id, 0.8, drop)])
+
+        # $or: a metadata leaf (collapses to superset in Cypher) OR a system key
+        # that none of the synthetic graph chunks carry.
+        ast = parse_to_ast(
+            RecallFilter.model_validate({"$or": [{"metadata.tag": "urgent"}, {"source_name": "nonexistent-source"}]})
+        )
+        result = await retriever.retrieve("alpha bravo charlie", ns_id, limit=10, filter_ast=ast)
+
+        graph_ids = result.metadata["search_methods"]["by_method"]["graph"]["chunk_ids"]
+        assert str(keep.id) in graph_ids, "$or-satisfying graph chunk was wrongly dropped"
+        assert str(drop.id) not in graph_ids, "graph chunk violating the $or reached fusion"
+
+    async def test_graph_channel_emptied_records_degradation(self) -> None:
+        """Emptying the graph channel under a filter records a degradation entry.
+
+        When the metadata post-filter drops ALL graph chunks while the SQL-pushed
+        vector / BM25 channels returned filtered rows, the graph side
+        under-recalled relative to the completeness backstop: one degradation
+        entry (component ``vectorcypher.graph_channel``, reason
+        ``empty_under_filter``) is appended to the result's degradations list.
+        """
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, complexity=QueryComplexity.MODERATE)
+
+        # All graph chunks violate the filter -> post-filter empties the channel.
+        violators = [_graph_chunk(ns_id, tag="noise"), _graph_chunk(ns_id, tag="other")]
+        retriever._fetch_chunks_from_entities = AsyncMock(return_value=[(c.id, 0.9, c) for c in violators])
+        # The vector channel returns a row (it does in _make_retriever), so the
+        # "vector/BM25 returned rows" arm of the degradation condition holds.
+
+        ast = parse_to_ast(RecallFilter.model_validate({"metadata.tag": {"$in": ["urgent", "release"]}}))
+        result = await retriever.retrieve("alpha bravo charlie", ns_id, limit=10, filter_ast=ast)
+
+        degradations = result.metadata.get("degradations", [])
+        graph_empty = [
+            d
+            for d in degradations
+            if d.get("component") == "vectorcypher.graph_channel" and d.get("reason") == "empty_under_filter"
+        ]
+        assert graph_empty, f"graph-channel-empty degradation not recorded; degradations={degradations}"
+        # The graph channel did empty (no graph chunks in the fused provenance).
+        assert result.metadata["graph_chunk_count"] == 0
+
+    async def test_no_degradation_when_graph_channel_survives(self) -> None:
+        """Control: when the post-filter keeps a graph chunk, no degradation fires."""
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, complexity=QueryComplexity.MODERATE)
+
+        survivor = _graph_chunk(ns_id, tag="urgent")  # passes the filter
+        retriever._fetch_chunks_from_entities = AsyncMock(return_value=[(survivor.id, 0.9, survivor)])
+
+        ast = parse_to_ast(RecallFilter.model_validate({"metadata.tag": {"$in": ["urgent", "release"]}}))
+        result = await retriever.retrieve("alpha bravo charlie", ns_id, limit=10, filter_ast=ast)
+
+        degradations = result.metadata.get("degradations", [])
+        graph_empty = [d for d in degradations if d.get("reason") == "empty_under_filter"]
+        assert not graph_empty, f"degradation wrongly fired while a graph chunk survived: {degradations}"
+
+
+# --------------------------------------------------------------------------- #
+# Partial failure: an unsupported-filter compile error surfaces to the caller
+# (no vector-only fallback); a transient Neo4j error degrades to vector-only.
+# --------------------------------------------------------------------------- #
+
+
+@_pushdown_gate
+class TestFilterUnsupportedPartialFailure:
+    """A capability gap surfaces; a transient Neo4j error degrades gracefully."""
+
+    async def test_unsupported_filter_raises_and_skips_vector_only_fallback(self) -> None:
+        """``RecallFilterUnsupportedError`` propagates; ``_vector_only_fallback`` is not used.
+
+        The Cypher compiler raises ``RecallFilterUnsupportedError`` for a
+        predicate the graph backend cannot honor at all — deliberately OUTSIDE
+        the transient-error handler so a capability gap is not masked as a Neo4j
+        blip. ``retrieve`` only catches transient Neo4j errors, so this raises out
+        of ``retrieve`` and the vector-only fallback is NEVER awaited.
+        """
+        from khora.filter.model import RecallFilterUnsupportedError
+
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, complexity=QueryComplexity.MODERATE)
+        retriever._fetch_chunks_from_entities = AsyncMock(
+            side_effect=RecallFilterUnsupportedError("metadata.tag", "unsupported on this backend")
+        )
+        retriever._vector_only_fallback = AsyncMock()  # spy
+
+        ast = _build_filter_ast()
+        with pytest.raises(RecallFilterUnsupportedError):
+            await retriever.retrieve("alpha bravo charlie", ns_id, limit=10, filter_ast=ast)
+
+        retriever._vector_only_fallback.assert_not_awaited()
+
+    async def test_compile_cypher_raise_from_graph_fetch_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The same contract, raised from the REAL graph-fetch Cypher compile.
+
+        Drives the real ``_fetch_chunks_from_entities`` ->
+        ``DualNodeManager.get_chunks_by_entities`` path, where the Cypher compiler
+        is imported locally from ``khora.filter.compilers.cypher`` — so the patch
+        targets that source module. The SAME compiler also runs earlier as the
+        over-fetch probe in ``_vectorcypher_retrieve`` with an identical compile
+        context, so an unconditional patch would raise at the probe instead. A
+        call counter lets the probe (first call) compile normally and raises only
+        on the graph-fetch call (second), which sits BEFORE any Neo4j session use
+        (no live driver needed) and OUTSIDE the transient-error handler. The
+        capability error escapes ``retrieve`` and the fallback is never awaited.
+        """
+        from khora.filter.compilers.cypher import compile_cypher as _real_compile
+        from khora.filter.model import RecallFilterUnsupportedError
+
+        calls = {"n": 0}
+
+        def _raise_on_graph_fetch(ast: Any, ctx: Any, *args: Any, **kwargs: Any) -> Any:
+            calls["n"] += 1
+            # Call 1 is the over-fetch probe; call 2 is the dual_nodes graph
+            # fetch — raise only there so the error genuinely originates from the
+            # graph-fetch chain, not the probe.
+            if calls["n"] >= 2:
+                raise RecallFilterUnsupportedError("metadata.tag", "unsupported on this backend")
+            return _real_compile(ast, ctx, *args, **kwargs)
+
+        monkeypatch.setattr("khora.filter.compilers.cypher.compile_cypher", _raise_on_graph_fetch)
+
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, complexity=QueryComplexity.MODERATE)
+        # Un-stub the graph fetch so the real DualNodeManager path runs and reaches
+        # the patched compiler.
+        del retriever._fetch_chunks_from_entities
+        retriever._vector_only_fallback = AsyncMock()  # spy
+
+        ast = _build_filter_ast()
+        with pytest.raises(RecallFilterUnsupportedError):
+            await retriever.retrieve("alpha bravo charlie", ns_id, limit=10, filter_ast=ast)
+
+        # The probe compiled, then the graph-fetch compile raised: proves the
+        # raise originated from the graph fetch, not the probe.
+        assert calls["n"] >= 2, "graph-fetch Cypher compile was never reached (raise came from the probe)"
+        retriever._vector_only_fallback.assert_not_awaited()
+
+    async def test_transient_neo4j_error_degrades_to_vector_only(self) -> None:
+        """Control: a transient Neo4j error IS caught and degrades to vector-only.
+
+        Proves the unsupported-filter case above is NOT simply "every graph error
+        skips the fallback" — a genuine transient failure still reaches the
+        vector-only fallback path.
+        """
+        from neo4j.exceptions import ServiceUnavailable
+
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, complexity=QueryComplexity.MODERATE)
+        retriever._fetch_chunks_from_entities = AsyncMock(side_effect=ServiceUnavailable("neo4j down"))
+
+        # Stub the fallback so we observe it was awaited without running the
+        # whole simple-retrieve path.
+        from khora.engines.vectorcypher.retriever import VectorCypherResult
+
+        fallback_result = VectorCypherResult(
+            chunks=[],
+            entities=[],
+            routing_decision=retriever._router.route.return_value,
+            metadata={"fallback_mode": "vector_only"},
+        )
+        retriever._vector_only_fallback = AsyncMock(return_value=fallback_result)
+
+        ast = _build_filter_ast()
+        result = await retriever.retrieve("alpha bravo charlie", ns_id, limit=10, filter_ast=ast)
+
+        retriever._vector_only_fallback.assert_awaited()
+        assert result.metadata.get("fallback_mode") == "vector_only"
+
+
+# --------------------------------------------------------------------------- #
+# Restrictive-fallback skip: the unfiltered re-run is suppressed under a caller
+# filter (it would smuggle filter-violating chunks into RRF).
+# --------------------------------------------------------------------------- #
+
+
+def _restrictive_fallback_retriever(ns_id: UUID) -> VectorCypherRetriever:
+    """A retriever whose sparse vector results would normally trigger the
+    restrictive temporal-filter fallback.
+
+    The recency channel stays OFF (``_make_retriever`` default) so the ONLY
+    ``_vector_search_chunks`` call with ``temporal_filter=None`` is the
+    restrictive fallback re-run — making the spy unambiguous. The vector channel
+    returns a single chunk, below ``limit // 2``, so the restrictive-fallback
+    arm (``len(vector_chunks) < limit // 2``) is reached.
+    """
+    return _make_retriever(ns_id, complexity=QueryComplexity.MODERATE)
+
+
+@_pushdown_gate
+class TestRestrictiveFallbackSkippedUnderFilter:
+    """The unfiltered restrictive-fallback re-run is suppressed under a filter."""
+
+    async def test_restrictive_fallback_runs_without_filter(self) -> None:
+        """Control: with NO caller filter, sparse results trigger the unfiltered re-run.
+
+        With a real ``temporal_filter``, sparse vector results (1 < limit//2), a
+        non-EXPLICIT temporal signal, and no caller filter, the engine re-runs the
+        vector search with ``temporal_filter=None`` — observable as a
+        ``_vector_search_chunks`` call carrying ``temporal_filter=None``.
+        """
+        ns_id = uuid4()
+        retriever = _restrictive_fallback_retriever(ns_id)
+        unfiltered_reruns: list[Any] = []
+        real = retriever._vector_search_chunks
+
+        async def _spy(*args: Any, **kwargs: Any) -> Any:
+            if kwargs.get("temporal_filter") is None:
+                unfiltered_reruns.append(kwargs)
+            return await real(*args, **kwargs)
+
+        retriever._vector_search_chunks = _spy  # type: ignore[method-assign]
+
+        from khora.engines.skeleton.backends import TemporalFilter
+
+        await retriever.retrieve(
+            "what happened recently",
+            ns_id,
+            limit=10,
+            temporal_filter=TemporalFilter(channel="ops"),
+            temporal_signal=_RECENCY_SIGNAL,
+            filter_ast=None,
+        )
+
+        assert unfiltered_reruns, "restrictive-fallback unfiltered re-run did not fire without a caller filter"
+
+    async def test_restrictive_fallback_skipped_with_filter(self) -> None:
+        """Under a caller filter, the unfiltered re-run is SKIPPED.
+
+        Same restrictive conditions as the control, but a caller ``filter_ast`` is
+        present: the re-run would drop the caller filter (it re-searches with
+        ``temporal_filter=None`` and threads no ``filter_ast``), smuggling
+        filter-violating chunks into RRF — so it must not run. No
+        ``_vector_search_chunks`` call carries ``temporal_filter=None``.
+        """
+        ns_id = uuid4()
+        retriever = _restrictive_fallback_retriever(ns_id)
+        unfiltered_reruns: list[Any] = []
+        real = retriever._vector_search_chunks
+
+        async def _spy(*args: Any, **kwargs: Any) -> Any:
+            if kwargs.get("temporal_filter") is None:
+                unfiltered_reruns.append(kwargs)
+            return await real(*args, **kwargs)
+
+        retriever._vector_search_chunks = _spy  # type: ignore[method-assign]
+
+        from khora.engines.skeleton.backends import TemporalFilter
+
+        await retriever.retrieve(
+            "what happened recently",
+            ns_id,
+            limit=10,
+            temporal_filter=TemporalFilter(channel="ops"),
+            temporal_signal=_RECENCY_SIGNAL,
+            filter_ast=_build_filter_ast(),
+        )
+
+        assert not unfiltered_reruns, (
+            "restrictive-fallback re-ran unfiltered under a caller filter (would smuggle violating chunks into RRF)"
+        )

--- a/tests/unit/engines/test_vectorcypher_filter_pushdown.py
+++ b/tests/unit/engines/test_vectorcypher_filter_pushdown.py
@@ -1005,6 +1005,29 @@ class TestGraphChannelFullAstPostFilter:
         graph_empty = [d for d in degradations if d.get("reason") == "empty_under_filter"]
         assert not graph_empty, f"degradation wrongly fired while a graph chunk survived: {degradations}"
 
+    async def test_graph_channel_empty_increments_filter_counter(self, monkeypatch) -> None:
+        """Emptying the graph channel under a filter fires the declared filter counter.
+
+        The service-level ``khora.recall.filter.graph_channel_empty`` counter
+        (owner: filter) must actually increment — not the prior engine-private
+        duplicate. Spy on the ``record_graph_channel_empty`` helper the retriever
+        calls.
+        """
+        import khora.engines.vectorcypher.retriever as rmod
+
+        calls: list[int] = []
+        monkeypatch.setattr(rmod, "record_graph_channel_empty", lambda: calls.append(1))
+
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, complexity=QueryComplexity.MODERATE)
+        violators = [_graph_chunk(ns_id, tag="noise")]
+        retriever._fetch_chunks_from_entities = AsyncMock(return_value=[(c.id, 0.9, c) for c in violators])
+
+        ast = parse_to_ast(RecallFilter.model_validate({"metadata.tag": {"$in": ["urgent"]}}))
+        await retriever.retrieve("alpha bravo charlie", ns_id, limit=10, filter_ast=ast)
+
+        assert calls, "record_graph_channel_empty not invoked when the graph channel emptied under a filter"
+
 
 # --------------------------------------------------------------------------- #
 # Partial failure: an unsupported-filter compile error surfaces to the caller

--- a/tests/unit/filter/test_execute_helpers.py
+++ b/tests/unit/filter/test_execute_helpers.py
@@ -125,11 +125,12 @@ def test_has_residual_metadata_false_for_system_only() -> None:
         {"occurred_at": "2026-04-05"},
         {"created_at": {"$gte": "2026-04-05"}},
         {"occurred_at": {"$in": ["2026-04-05", "2026-04-06"]}},
+        {"occurred_at": {"$gte": "2026-04-05"}, "source_name": "linear"},
     ],
-    ids=["gte", "lte", "eq", "created_at", "in"],
+    ids=["gte", "lte", "eq", "created_at", "in", "conjunctive_with_other_key"],
 )
 def test_filter_constrains_date_key_true(doc: dict) -> None:
-    """Any operator on occurred_at / created_at is detected."""
+    """Any operator on a top-level conjunctive occurred_at / created_at is detected."""
     assert filter_constrains_date_key(_ast(doc)) is True
 
 
@@ -139,11 +140,13 @@ def test_filter_constrains_date_key_true(doc: dict) -> None:
         {"metadata.channel": "alpha"},
         {"source_name": "linear"},
         {"source_timestamp": "2026-04-05"},
+        {"$or": [{"occurred_at": {"$gte": "2026-04-05"}}, {"source_name": "linear"}]},
+        {"$not": {"occurred_at": {"$gte": "2026-04-05"}}},
     ],
-    ids=["metadata_only", "system_string_key", "source_timestamp_excluded"],
+    ids=["metadata_only", "system_string_key", "source_timestamp_excluded", "date_under_or", "date_under_not"],
 )
 def test_filter_constrains_date_key_false(doc: dict) -> None:
-    """Non-date keys (including source_timestamp, which is excluded) are not flagged."""
+    """Non-date keys and dates buried under $or/$not (not hard conjunctive) are not flagged."""
     assert filter_constrains_date_key(_ast(doc)) is False
 
 

--- a/tests/unit/filter/test_execute_helpers.py
+++ b/tests/unit/filter/test_execute_helpers.py
@@ -1,0 +1,192 @@
+"""Unit coverage for the AST leaf-inspection helpers in ``khora.filter.execute``.
+
+These five helpers are the thin detectors an engine uses to compose a caller
+filter across adaptive sub-searches:
+
+* :func:`iter_leaf_clauses` — the one canonical leaf walk (AND/OR/NOT recurse).
+* :func:`filter_leaf_keys` — dotted leaf keys, matching ``consumed_keys`` exactly.
+* :func:`has_residual_metadata` — any leaf not in a compiler's consumed set.
+* :func:`filter_constrains_date_key` — touches ``occurred_at`` / ``created_at``.
+* :func:`caller_channel_constraint` — top-level ``metadata.channel`` pin, or None.
+
+No DB, no infra — runs in the fast unit suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from khora.filter import RecallFilter, parse_to_ast
+from khora.filter.compilers.cypher import compile_cypher
+from khora.filter.execute import (
+    build_compile_context,
+    caller_channel_constraint,
+    filter_constrains_date_key,
+    filter_leaf_keys,
+    has_residual_metadata,
+    iter_leaf_clauses,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _ast(doc: dict) -> object:
+    """Lower a wire-form filter document to its canonical AST."""
+    return parse_to_ast(RecallFilter.model_validate(doc))
+
+
+# --------------------------------------------------------------------------- #
+# H1 iter_leaf_clauses
+# --------------------------------------------------------------------------- #
+
+
+def test_iter_leaf_clauses_recurses_and_or_not() -> None:
+    """Every leaf under nested AND/OR/NOT is yielded exactly once."""
+    ast = _ast(
+        {
+            "source_name": "linear",
+            "$or": [
+                {"source_type": "issue"},
+                {"$not": {"content_type": "comment"}},
+            ],
+        }
+    )
+    leaves = list(iter_leaf_clauses(ast))
+    paths = sorted(".".join(leaf.path) for leaf in leaves)
+    assert paths == ["content_type", "source_name", "source_type"]
+
+
+def test_iter_leaf_clauses_single_predicate() -> None:
+    """A single-predicate filter yields its one leaf (root is AND([clause]))."""
+    leaves = list(iter_leaf_clauses(_ast({"source_name": "linear"})))
+    assert len(leaves) == 1
+    assert leaves[0].path == ("source_name",)
+
+
+# --------------------------------------------------------------------------- #
+# H2 filter_leaf_keys — must match CompiledFilter.consumed_keys exactly
+# --------------------------------------------------------------------------- #
+
+
+def test_filter_leaf_keys_dotted_form() -> None:
+    """Leaf keys are the dotted ``".".join(path)`` of each leaf."""
+    keys = filter_leaf_keys(
+        _ast(
+            {
+                "source_name": "linear",
+                "occurred_at": {"$gte": "2026-04-05"},
+                "metadata.tag": {"$in": ["urgent"]},
+            }
+        )
+    )
+    assert keys == frozenset({"source_name", "occurred_at", "metadata.tag"})
+
+
+def test_filter_leaf_keys_match_cypher_consumed_keys_for_system_slice() -> None:
+    """For a system-key-only filter the leaf keys equal the Cypher consumed set."""
+    ast = _ast({"source_name": "linear", "occurred_at": {"$gte": "2026-04-05"}})
+    compiled = compile_cypher(ast, build_compile_context("Chunk", table_alias="c", on_unsupported="split"))
+    assert filter_leaf_keys(ast) == compiled.consumed_keys
+
+
+# --------------------------------------------------------------------------- #
+# H3 has_residual_metadata
+# --------------------------------------------------------------------------- #
+
+
+def test_has_residual_metadata_true_for_metadata_leaf() -> None:
+    """A metadata leaf is not Cypher-pushable, so it is residual."""
+    ast = _ast({"source_name": "linear", "metadata.tag": "urgent"})
+    consumed = compile_cypher(
+        ast, build_compile_context("Chunk", table_alias="c", on_unsupported="split")
+    ).consumed_keys
+    assert has_residual_metadata(ast, consumed) is True
+
+
+def test_has_residual_metadata_false_for_system_only() -> None:
+    """A system-key-only filter pushes down entirely, so nothing is residual."""
+    ast = _ast({"source_name": "linear", "occurred_at": {"$gte": "2026-04-05"}})
+    consumed = compile_cypher(
+        ast, build_compile_context("Chunk", table_alias="c", on_unsupported="split")
+    ).consumed_keys
+    assert has_residual_metadata(ast, consumed) is False
+
+
+# --------------------------------------------------------------------------- #
+# H4 filter_constrains_date_key
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "doc",
+    [
+        {"occurred_at": {"$gte": "2026-04-05"}},
+        {"occurred_at": {"$lte": "2026-04-05"}},
+        {"occurred_at": "2026-04-05"},
+        {"created_at": {"$gte": "2026-04-05"}},
+        {"occurred_at": {"$in": ["2026-04-05", "2026-04-06"]}},
+    ],
+    ids=["gte", "lte", "eq", "created_at", "in"],
+)
+def test_filter_constrains_date_key_true(doc: dict) -> None:
+    """Any operator on occurred_at / created_at is detected."""
+    assert filter_constrains_date_key(_ast(doc)) is True
+
+
+@pytest.mark.parametrize(
+    "doc",
+    [
+        {"metadata.channel": "alpha"},
+        {"source_name": "linear"},
+        {"source_timestamp": "2026-04-05"},
+    ],
+    ids=["metadata_only", "system_string_key", "source_timestamp_excluded"],
+)
+def test_filter_constrains_date_key_false(doc: dict) -> None:
+    """Non-date keys (including source_timestamp, which is excluded) are not flagged."""
+    assert filter_constrains_date_key(_ast(doc)) is False
+
+
+# --------------------------------------------------------------------------- #
+# H5 caller_channel_constraint
+# --------------------------------------------------------------------------- #
+
+
+def test_caller_channel_constraint_eq() -> None:
+    """A top-level ``metadata.channel`` equality pins that one channel."""
+    assert caller_channel_constraint(_ast({"metadata.channel": "alpha"})) == frozenset({"alpha"})
+
+
+def test_caller_channel_constraint_in() -> None:
+    """A top-level ``metadata.channel`` ``$in`` pins its string members."""
+    assert caller_channel_constraint(_ast({"metadata.channel": {"$in": ["alpha", "beta"]}})) == frozenset(
+        {"alpha", "beta"}
+    )
+
+
+def test_caller_channel_constraint_with_other_top_level_keys() -> None:
+    """The channel pin is read alongside other top-level conjuncts."""
+    assert caller_channel_constraint(_ast({"metadata.channel": "alpha", "source_name": "linear"})) == frozenset(
+        {"alpha"}
+    )
+
+
+def test_caller_channel_constraint_buried_in_or_is_none() -> None:
+    """A channel constraint inside an ``$or`` is not a hard AND-constraint."""
+    ast = _ast({"$or": [{"metadata.channel": "alpha"}, {"source_name": "linear"}]})
+    assert caller_channel_constraint(ast) is None
+
+
+def test_caller_channel_constraint_buried_in_not_is_none() -> None:
+    """A channel constraint inside a ``$not`` is not a hard AND-constraint."""
+    assert caller_channel_constraint(_ast({"$not": {"metadata.channel": "alpha"}})) is None
+
+
+def test_caller_channel_constraint_non_eq_in_op_is_none() -> None:
+    """A non-equality / non-membership channel op yields None (conservative)."""
+    assert caller_channel_constraint(_ast({"metadata.channel": {"$gt": "alpha"}})) is None
+
+
+def test_caller_channel_constraint_no_channel_is_none() -> None:
+    """A filter with no channel predicate yields None (no narrowing)."""
+    assert caller_channel_constraint(_ast({"source_name": "linear"})) is None


### PR DESCRIPTION
## Summary

Thread the caller-supplied recall filter through **every** adaptive sub-search in the VectorCypher engine so no retrieval channel silently drops or mis-applies it. Previously several adaptive paths (change-decomposition, the recency channel) bailed out when a filter was present, and the graph chunk channel applied no caller filter at all.

- **Conditional graph over-fetch** — new `query.metadata_overfetch_multiplier` (int, default 3, 2–10). The graph chunk channel over-fetches **only** when a residual metadata predicate needs an in-memory post-filter (detected by comparing the Cypher compiler's consumed keys against the filter's leaf keys); capped at `min(limit * multiplier, 200)`. No over-fetch for an absent filter or a system-key-only filter.
- **Graph-channel filtering** — push system keys into the graph `Chunk` channel via the Cypher compiler, and run a full-AST Python post-filter over graph candidates (covering the PPR path too) so a metadata leaf nested inside an `$or` (which the graph predicate collapses to a non-constraining superset) is correctly re-constrained.
- **Date-gated recency synthesis** — the EXPLICIT temporal category is synthesized only when the filter constrains a date key (`occurred_at` / `created_at`). A non-date filter (e.g. a metadata field) runs the normal temporal detector and no longer triggers recency decay.
- **Restrictive-fallback skip** — the unfiltered fallback re-run is skipped whenever a caller filter is present (sparse-but-correct beats complete-but-wrong).
- **Session fan-out intersect** — when the caller constrains the channel, fan-out is intersected with that constraint (skipped when disjoint); the caller's constraint is never overwritten. Best-effort efficiency guard; correctness rides on filter AND-composition.
- **Carry across sub-searches** — the change-decomposition and recency sub-searches now carry the filter (the recency channel reads the relational table and post-filters in memory).
- **Unsupported-predicate surfacing** — a predicate the Cypher channel cannot express surfaces to the caller instead of silently degrading to a vector-only fallback (which stays reserved for transient graph errors).
- **Observability** — when the graph channel empties under a filter while the SQL channels return rows, a degradation is recorded and a new `*.graph_channel.empty_total` counter increments (telemetry contract updated).

New `filter/execute.py` helpers (single AST walk) back the leaf-key, date-key, residual-metadata, and channel-constraint detection.

## Test plan
- [x] Unit + pushdown-spy tests pass (`make test-unit`): new behavior covered for every item above, including mutation-verified non-vacuity; touched-module coverage 80–100%. Pre-existing failures in this sandbox are limited to optional extras not installed here (`langgraph`, `lancedb`/sqlite_lance) — unrelated to this change.
- [ ] Integration leg + 77% coverage gate (`make test-integration`, requires Docker) — runs in CI.
- [ ] Filter-conformance CI job green.