### PR TITLE
Persist and read occurred_at on the embedded chunk write path

### DIFF
--- a/src/khora/db/migrations/versions/046_chunks_occurred_at.py
+++ b/src/khora/db/migrations/versions/046_chunks_occurred_at.py
@@ -1,0 +1,31 @@
+"""Add nullable occurred_at column to chunks.
+
+Revision ID: 046_chunks_occurred_at
+Revises: 045_khora_try_timestamptz
+Create Date: 2026-06-09
+
+Each chunk gains a nullable ``occurred_at`` TIMESTAMPTZ column recording the
+real-world event time the chunk's content refers to, distinct from its
+ingestion ``created_at``. The column is nullable - existing chunks land at
+NULL until a value is supplied. The plain ``op.add_column`` is
+dialect-portable, so it materializes on both PostgreSQL and SQLite (the
+sqlite_lance test fixtures run the full Alembic chain against SQLite).
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import Column, DateTime
+
+revision: str = "046_chunks_occurred_at"
+down_revision: str | Sequence[str] | None = "045_khora_try_timestamptz"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("chunks", Column("occurred_at", DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("chunks", "occurred_at")

--- a/src/khora/db/models.py
+++ b/src/khora/db/models.py
@@ -253,6 +253,8 @@ class ChunkModel(Base):
     # decay path treats ``max(source_timestamp, last_accessed_at)`` as the
     # effective event time so frequently-recalled chunks stay fresh.
     last_accessed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # Real-world event time the chunk's content refers to, distinct from created_at.
+    occurred_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Session attribution for agentic-framework adapters (#620).
     # Inherited from the parent document at chunking time.

--- a/src/khora/storage/backends/sqlite_lance/vector.py
+++ b/src/khora/storage/backends/sqlite_lance/vector.py
@@ -193,6 +193,7 @@ class SQLiteLanceVectorAdapter:
                     c.embedding_model,
                     _dt_to_str(c.created_at) or now,
                     _dt_to_str(c.source_timestamp),
+                    _dt_to_str(c.occurred_at),
                     _dt_to_str(c.last_accessed_at),
                     uuid_to_text(c.session_id) if c.session_id is not None else None,
                 )
@@ -220,8 +221,8 @@ class SQLiteLanceVectorAdapter:
             "INSERT INTO chunks "
             "(id, namespace_id, document_id, content, chunk_index, start_char, "
             "end_char, token_count, metadata, chunker_info, embedding_model, "
-            "created_at, source_timestamp, last_accessed_at, session_id) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "created_at, source_timestamp, occurred_at, last_accessed_at, session_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             sqlite_rows,
         )
         await self._sqlite.commit()
@@ -947,6 +948,7 @@ class SQLiteLanceVectorAdapter:
             embedding_model=row["embedding_model"] or "",
             created_at=_parse_dt(row["created_at"]) or datetime.now(UTC),
             source_timestamp=_parse_dt(row["source_timestamp"]),
+            occurred_at=_parse_dt(_row_get("occurred_at")),
             last_accessed_at=_parse_dt(_row_get("last_accessed_at")),
             session_id=(UUID(row["session_id"]) if row["session_id"] else None),
         )

--- a/tests/integration/db/test_migration_032_dream_runs.py
+++ b/tests/integration/db/test_migration_032_dream_runs.py
@@ -303,7 +303,7 @@ class TestMigration032OnSqlite:
                 async with engine.connect() as conn:
                     # Chain reached head (sanity).
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "045_khora_try_timestamptz"
+                    assert result.scalar() == "046_chunks_occurred_at"
 
                     # khora_dream_runs exists on SQLite (#896) so dream_history /
                     # dream_status work on the embedded sqlite_lance stack.

--- a/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
+++ b/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
@@ -210,6 +210,11 @@ class TestMigration041OnPostgres:
                     await conn.execute(
                         sa.text("UPDATE khora_alembic_version SET version_num = '040_chunks_last_accessed_at'")
                     )
+                    # The step-back above is metadata-only, so chunks.occurred_at
+                    # (added by migration 046 during the first upgrade-to-head)
+                    # survives. Drop it so the replayed ``upgrade head`` re-applies
+                    # 046 cleanly — mirrors the drop+recreate of khora_chunks above.
+                    await conn.execute(sa.text("ALTER TABLE chunks DROP COLUMN IF EXISTS occurred_at"))
             finally:
                 await engine.dispose()
 
@@ -272,6 +277,11 @@ class TestMigration041OnPostgres:
                     await conn.execute(
                         sa.text("UPDATE khora_alembic_version SET version_num = '040_chunks_last_accessed_at'")
                     )
+                    # The step-back above is metadata-only, so chunks.occurred_at
+                    # (added by migration 046 during the first upgrade-to-head)
+                    # survives. Drop it so the replayed ``upgrade head`` re-applies
+                    # 046 cleanly — mirrors the drop+recreate of khora_chunks above.
+                    await conn.execute(sa.text("ALTER TABLE chunks DROP COLUMN IF EXISTS occurred_at"))
             finally:
                 await engine.dispose()
 
@@ -312,7 +322,7 @@ class TestMigration041OnPostgres:
                 async with engine.connect() as conn:
                     # Chain reached head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "045_khora_try_timestamptz"
+                    assert result.scalar() == "046_chunks_occurred_at"
 
                     # The migration did not create the table.
                     result = await conn.execute(
@@ -343,7 +353,7 @@ class TestMigration041OnSqlite:
             try:
                 async with engine.connect() as conn:
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "045_khora_try_timestamptz"
+                    assert result.scalar() == "046_chunks_occurred_at"
             finally:
                 await engine.dispose()
 

--- a/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
+++ b/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
@@ -69,7 +69,7 @@ pytestmark = pytest.mark.integration
 
 
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
-_HEAD = "045_khora_try_timestamptz"
+_HEAD = "046_chunks_occurred_at"
 _PREV = "041_khora_chunks_denormalized_columns"
 
 
@@ -131,6 +131,11 @@ async def _seed_legacy_table_at_baseline(url: str) -> None:
             await conn.execute(sa.text(_TSV_FUNCTION_DDL))
             await conn.execute(sa.text(_TSV_TRIGGER_DDL))
             await conn.execute(sa.text("UPDATE khora_alembic_version SET version_num = '040_chunks_last_accessed_at'"))
+            # The step-back above is metadata-only, so chunks.occurred_at (added by
+            # migration 046 during the first upgrade-to-head) survives. Drop it so
+            # the replayed ``upgrade head`` re-applies 046 cleanly — mirrors the
+            # drop+recreate of khora_chunks above.
+            await conn.execute(sa.text("ALTER TABLE chunks DROP COLUMN IF EXISTS occurred_at"))
     finally:
         await engine.dispose()
 

--- a/tests/integration/db/test_migration_044_chunks_backfill.py
+++ b/tests/integration/db/test_migration_044_chunks_backfill.py
@@ -93,7 +93,7 @@ pytestmark = pytest.mark.integration
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
 
 _PREV_REVISION = "043_khora_chunks_metadata_backfill"
-_HEAD_REVISION = "045_khora_try_timestamptz"
+_HEAD_REVISION = "046_chunks_occurred_at"
 
 _TSV_TRIGGER = "khora_chunks_content_tsv_update"
 
@@ -302,6 +302,11 @@ async def _step_version_back(conn: AsyncConnection) -> None:
         sa.text("UPDATE khora_alembic_version SET version_num = :prev"),
         {"prev": _PREV_REVISION},
     )
+    # The step-back above is metadata-only, so chunks.occurred_at (added by
+    # migration 046 during the first upgrade-to-head) survives. Drop it so the
+    # replayed ``upgrade head`` re-applies 046 cleanly — mirrors the
+    # drop+recreate of khora_chunks the seed helpers perform.
+    await conn.execute(sa.text("ALTER TABLE chunks DROP COLUMN IF EXISTS occurred_at"))
 
 
 # A >255-char source and external_id: each fits in full now that the columns

--- a/tests/integration/test_chronicle_filter_embedded.py
+++ b/tests/integration/test_chronicle_filter_embedded.py
@@ -11,8 +11,11 @@ break:
   evaluated against a genuinely round-tripped blob, not a hand-built dict.
 * **Date columns** — ``source_timestamp`` pushes down to the real recency window
   (``COALESCE(source_timestamp, created_at)``) at the SQL layer, and ``occurred_at`` is
-  enforced by the post-filter against the chunk read back from storage (the
-  ``COALESCE(occurred_at, source_timestamp)`` recovery against real columns).
+  enforced by the post-filter against the chunk read back from storage. The embedded
+  sqlite_lance write path now persists a distinct ``occurred_at`` column (migration
+  ``046``), so a chunk's effective event time ``COALESCE(occurred_at, source_timestamp)``
+  honors an in-range ``occurred_at`` even when ``source_timestamp`` is out of range, and
+  falls back to ``source_timestamp`` when ``occurred_at`` is unset.
 
 Seeding goes through the coordinator's own write API (``create_chunks_batch``) with
 deterministic fake embeddings, exactly like the sibling sqlite_lance ingest suite, so
@@ -197,19 +200,21 @@ async def test_source_timestamp_pushdown_narrows_against_real_window(tmp_path: P
 @pytest.mark.asyncio
 async def test_occurred_at_coalesce_recovery_against_real_columns(tmp_path: Path) -> None:
     # occurred_at is post-filtered against the chunk read back from storage, using
-    # the effective event time COALESCE(occurred_at, source_timestamp). The key
-    # guard is that an occurred_at filter does NOT false-empty when occurred_at is
-    # absent on the stored row — it recovers via source_timestamp.
+    # the effective event time COALESCE(occurred_at, source_timestamp). The embedded
+    # sqlite_lance write path now persists a distinct occurred_at column (migration
+    # 046 → create_chunks_batch / _row_to_chunk in sqlite_lance/vector.py), so this
+    # asserts two halves of the contract against what the store actually round-trips:
     #
-    # Real-storage truth this surfaces (which a mocked candidate list hides): the
-    # embedded sqlite_lance chunk write path persists source_timestamp but NOT a
-    # distinct occurred_at column (it is read back as NULL — see
-    # sqlite_lance/vector.py create_chunks_batch). So on this backend the effective
-    # event time collapses to source_timestamp, and a chunk seeded with an
-    # occurred_at value but an out-of-range source_timestamp is still dropped. That
-    # write-path gap is independent of this filter and tracked separately; here we
-    # assert the filter's observable contract against what the store actually
-    # round-trips.
+    #   1. HONORED: a chunk whose occurred_at is in range but whose source_timestamp
+    #      is out of range still SURVIVES — the effective event time resolves to the
+    #      in-range occurred_at, NOT the out-of-range source_timestamp. This is the
+    #      regression guard for the persist-occurred_at fix: if the write path dropped
+    #      occurred_at (read back as NULL), COALESCE would collapse to the out-of-range
+    #      source_timestamp and this chunk would be (wrongly) filtered out.
+    #   2. FALLBACK: a chunk with NO occurred_at but an in-range source_timestamp still
+    #      SURVIVES — COALESCE recovers via source_timestamp (no false-empty).
+    #
+    # A chunk with neither anchor in range is dropped (negative case).
     coord = await build_sqlite_lance_coordinator(tmp_path)
     try:
         ns = await coord.create_namespace(MemoryNamespace())
@@ -217,24 +222,72 @@ async def test_occurred_at_coalesce_recovery_against_real_columns(tmp_path: Path
             coord,
             ns.id,
             [
-                # source_timestamp in range → effective event time in range → survives
-                # (the recovery path; proves NO false-empty when occurred_at is unset).
+                # occurred_at in range, source_timestamp out of range → effective event
+                # time honors the persisted occurred_at → survives. Drops to a false
+                # negative if occurred_at is not round-tripped (the regression guard).
+                {"content": "occurred honored", "occurred_at": _IN_RANGE, "source_timestamp": _OUT_OF_RANGE},
+                # no occurred_at, source_timestamp in range → COALESCE recovers via
+                # source_timestamp → survives (proves NO false-empty when occurred_at
+                # is unset).
                 {"content": "fallback recover", "source_timestamp": _IN_RANGE},
-                # occurred_at seeded in range but NOT persisted by the embedded write
-                # path; source_timestamp out of range → effective event time out of
-                # range → dropped.
-                {"content": "occurred not persisted", "occurred_at": _IN_RANGE, "source_timestamp": _OUT_OF_RANGE},
-                # no in-range anchor at all → dropped.
+                # neither anchor in range → dropped.
                 {"content": "no anchor in range", "source_timestamp": _OUT_OF_RANGE},
             ],
         )
-        recovered_id = chunks[0].id
+        honored_id = chunks[0].id
+        fallback_id = chunks[1].id
 
         returned = await _recall_ids(_engine_over(coord), ns.id, {"occurred_at": {"$gte": _FILTER_LB}})
-        assert returned == {recovered_id}, (
-            "occurred_at filter must recover event time from source_timestamp "
-            "(no false-empty) and drop rows whose effective event time is out of range"
+        assert returned == {honored_id, fallback_id}, (
+            "occurred_at filter must (1) honor a persisted in-range occurred_at even when "
+            "source_timestamp is out of range, and (2) recover event time from "
+            "source_timestamp when occurred_at is unset (no false-empty); rows whose "
+            "effective event time is out of range are dropped"
         )
+        # Explicit regression guard: the honored chunk would be dropped if the write
+        # path failed to round-trip occurred_at (effective time would fall back to its
+        # out-of-range source_timestamp). Assert it survives on its own merits.
+        assert honored_id in returned, (
+            "chunk with in-range occurred_at + out-of-range source_timestamp must survive "
+            "— a regression in occurred_at persistence would drop it"
+        )
+    finally:
+        await coord.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_occurred_at_round_trips_through_real_store(tmp_path: Path) -> None:
+    # Direct write→read round-trip of the distinct occurred_at column through the real
+    # coordinator/vector adapter (no filter, no engine). A chunk seeded with an
+    # occurred_at that differs from both created_at and source_timestamp must read back
+    # with that exact occurred_at — proving migration 046 + create_chunks_batch /
+    # _row_to_chunk persist and restore the column, not silently coalesce it away.
+    coord = await build_sqlite_lance_coordinator(tmp_path)
+    try:
+        ns = await coord.create_namespace(MemoryNamespace())
+        chunks = await _seed(
+            coord,
+            ns.id,
+            [
+                {
+                    "content": "distinct occurred_at",
+                    "occurred_at": _IN_RANGE,
+                    "source_timestamp": _OUT_OF_RANGE,
+                },
+            ],
+        )
+        written = chunks[0]
+        assert written.occurred_at == _IN_RANGE  # sanity: seeded as expected
+
+        read_back = await coord.get_chunk(written.id, namespace_id=ns.id)
+        assert read_back is not None
+        assert read_back.occurred_at == _IN_RANGE, (
+            "occurred_at must round-trip through the real store unchanged "
+            f"(wrote {written.occurred_at!r}, read back {read_back.occurred_at!r})"
+        )
+        # source_timestamp stays distinct — occurred_at is not derived from it.
+        assert read_back.source_timestamp == _OUT_OF_RANGE
+        assert read_back.occurred_at != read_back.source_timestamp
     finally:
         await coord.disconnect()
 

--- a/tests/unit/storage/backends/sqlite_lance/test_vector.py
+++ b/tests/unit/storage/backends/sqlite_lance/test_vector.py
@@ -253,6 +253,37 @@ class TestChunkCRUD:
         assert fetched.chunker_info == {"strategy": "fixed", "tokens": 256}
         assert fetched.metadata == {"doc_key": "doc_val"}
 
+    async def test_occurred_at_roundtrip(self, adapter: SQLiteLanceVectorAdapter):
+        """occurred_at persists and reads back, distinct from created_at/source_timestamp."""
+        ns, doc = uuid4(), uuid4()
+        occurred = datetime(2023, 7, 4, 12, 30, tzinfo=UTC)
+        c = _make_chunk(
+            ns,
+            doc,
+            embedding=_unit(8, 0),
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            source_timestamp=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+        c.occurred_at = occurred
+        await adapter.create_chunk(c)
+
+        fetched = await adapter.get_chunk(c.id, namespace_id=ns)
+        assert fetched is not None
+        assert fetched.occurred_at == occurred
+        # Distinct from the other two timestamps.
+        assert fetched.created_at != occurred
+        assert fetched.source_timestamp != occurred
+
+    async def test_occurred_at_defaults_none(self, adapter: SQLiteLanceVectorAdapter):
+        """A chunk without occurred_at reads back NULL."""
+        ns, doc = uuid4(), uuid4()
+        c = _make_chunk(ns, doc, embedding=_unit(8, 0))
+        await adapter.create_chunk(c)
+
+        fetched = await adapter.get_chunk(c.id, namespace_id=ns)
+        assert fetched is not None
+        assert fetched.occurred_at is None
+
     async def test_delete_chunks_by_document_with_session_skips_commit(self, adapter: SQLiteLanceVectorAdapter):
         """When a session is provided the caller owns commits.
 

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -442,14 +442,14 @@ class TestMigrationPackageStructure:
         assert env_path.exists(), f"env.py not found at {env_path}"
 
     @pytest.mark.unit
-    def test_versions_dir_has_46_files(self):
-        """versions/ directory contains 46 migration files."""
+    def test_versions_dir_has_47_files(self):
+        """versions/ directory contains 47 migration files."""
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
         # Filter out __pycache__ and __init__
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
-        assert len(migration_files) == 46, (
-            f"Expected 46 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
+        assert len(migration_files) == 47, (
+            f"Expected 47 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
         )
 
     @pytest.mark.unit

--- a/tests/unit/test_sqlite_migrations.py
+++ b/tests/unit/test_sqlite_migrations.py
@@ -82,7 +82,7 @@ class TestSqliteMigrations:
                     # Version table must point at head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
                     version = result.scalar()
-                    assert version == "045_khora_try_timestamptz"
+                    assert version == "046_chunks_occurred_at"
             finally:
                 await engine.dispose()
 
@@ -118,6 +118,8 @@ class TestSqliteMigrations:
                     result = await conn.execute(sa.text("PRAGMA table_info(chunks)"))
                     chunk_cols = {r[1] for r in result}
                     assert "embedding" not in chunk_cols
+                    # occurred_at (046) is added on both dialects.
+                    assert "occurred_at" in chunk_cols
                     result = await conn.execute(sa.text("PRAGMA table_info(entities)"))
                     entity_cols = {r[1] for r in result}
                     assert "embedding" not in entity_cols


### PR DESCRIPTION
## Summary
- The embedded sqlite_lance chunk write path persisted `source_timestamp` but dropped `occurred_at`: a chunk written with a distinct event time read back with `occurred_at = NULL`, so an `occurred_at` recall filter silently evaluated against `source_timestamp` instead of the real event time.
- Add a nullable `occurred_at` column to the `chunks` table via a new dialect-portable migration. It materializes on both PostgreSQL and SQLite (the embedded test fixtures run the full Alembic chain against SQLite); existing rows land at `NULL`.
- Declare `occurred_at` on the `ChunkModel` ORM for parity with the migration and the sibling timestamp columns. PostgreSQL read/write population of the column is intentionally left for a separate change — this PR only adds the column for schema parity.
- Persist `occurred_at` in `create_chunks_batch` and read it back in `_row_to_chunk`, so a distinct event time now round-trips through the embedded store and is honored by the Chronicle event-time filter (`COALESCE(occurred_at, source_timestamp)`). The LanceDB rows are unchanged — SQLite remains the source of truth for chunk timestamps.

## Test plan
- [x] Unit tests pass (`make test-unit`: full unit + recall suite green, including migration-drift, migration-bundling, and SQLite-migration head checks)
- [x] Embedded recall-filter e2e + round-trip tests pass (`tests/integration/test_chronicle_filter_embedded.py`, `tests/unit/storage/backends/sqlite_lance/test_vector.py`)
- [ ] Full integration suite (PostgreSQL + Neo4j) — runs in CI
- Regression guard: the strengthened e2e test asserts a chunk with a distinct in-range `occurred_at` and an out-of-range `source_timestamp` now survives the `occurred_at` filter; verified to fail when the write path drops the column (mutation-checked) and pass with the fix. A direct write→read round-trip test asserts the stored `occurred_at` reads back equal to the written value and distinct from `source_timestamp`.