### PR TITLE
Use exact JSONB equality for $in/$nin metadata object elements

### DIFF
--- a/src/khora/filter/compilers/postgres.py
+++ b/src/khora/filter/compilers/postgres.py
@@ -279,7 +279,7 @@ class _Builder:
                 # (so $in would wrongly match all), and sa.not_() of that empty
                 # chain is invalid SQL (so $nin would error at execute time).
                 return sa.false() if op == Op.IN else sa.true()
-            chain = sa.or_(*(self._md_containment(segs, v) for v in operand))
+            chain = sa.or_(*(self._md_in_element(segs, v) for v in operand))
             return chain if op == Op.IN else sa.not_(chain)
 
         if op == Op.EQ:
@@ -323,6 +323,21 @@ class _Builder:
             node = self._md_json(segs)
             return sa.func.coalesce(node == _jsonb_literal(dict(operand)), sa.false())
         return self._md_containment(segs, operand)
+
+    def _md_in_element(self, segs: tuple[str, ...], value: Any) -> ColumnElement[bool]:
+        """One ``$in`` / ``$nin`` operand element — total boolean.
+
+        A dict element is EXACT ``object_equal`` (``#> = '{...}'::jsonb``, NOT
+        ``@>`` containment) — mirroring the dict branch of :meth:`_md_eq`, so a
+        stored superset object does not satisfy membership. Any other element
+        (scalar / array / null) routes through array-aware ``@>`` containment.
+        Both forms are total booleans, so the OR chain (and its ``$nin``
+        negation) stays negation-safe.
+        """
+        if isinstance(value, Mapping):
+            node = self._md_json(segs)
+            return sa.func.coalesce(node == _jsonb_literal(dict(value)), sa.false())
+        return self._md_containment(segs, value)
 
     def _md_range(self, segs: tuple[str, ...], op: Op, operand: Any) -> ColumnElement[bool]:
         """A metadata range op — jsonb_typeof-gated cast, coalesced to total."""

--- a/src/khora/filter/conformance.py
+++ b/src/khora/filter/conformance.py
@@ -773,6 +773,28 @@ def f_objeq_cases() -> list[ConformanceCase]:
             backends=_OP_BACKENDS,
             exercises=("F-OBJEQ", "metadata.labels", "$ne", "dict"),
         ),
+        ConformanceCase(
+            id="F-OBJEQ-metadata-labels-in",
+            # A dict $in element is EXACT object_equal per element, NOT @>
+            # containment: only the record whose subdocument EQUALS the operand
+            # survives — the superset (extra key) must NOT match.
+            filter={"metadata.labels": {"$in": [{"team": "x"}]}},
+            seed_records=seed,
+            expected_ids=frozenset({"exact"}),
+            backends=_OP_BACKENDS,
+            exercises=("F-OBJEQ", "metadata.labels", "$in", "dict"),
+        ),
+        ConformanceCase(
+            id="F-OBJEQ-metadata-labels-nin",
+            # $nin negates the per-element exact form: the complement (superset,
+            # other) plus the absent record survive (Rule 2 polarity — absent
+            # satisfies $nin).
+            filter={"metadata.labels": {"$nin": [{"team": "x"}]}},
+            seed_records=seed,
+            expected_ids=frozenset({"superset", "other", "absent"}),
+            backends=_OP_BACKENDS,
+            exercises=("F-OBJEQ", "metadata.labels", "$nin", "dict"),
+        ),
     ]
 
 

--- a/tests/unit/filter/test_compile_postgres.py
+++ b/tests/unit/filter/test_compile_postgres.py
@@ -368,6 +368,94 @@ def test_metadata_nested_dict_operand_eq_is_exact_object_match() -> None:
 
 
 # ===========================================================================
+# $in / $nin with a DICT element — exact object_equal per element, not @>.
+#
+# A dict element of a metadata $in is a whole-subdocument exact match (mirroring
+# the dict branch of $eq), NOT @> containment — so a stored superset object does
+# NOT satisfy membership. Scalar / array elements are unchanged (array-aware @>
+# containment); only the dict element switched. $nin negates the per-element OR
+# chain, so superset / absent rows are INCLUDED.
+# ===========================================================================
+
+
+def test_metadata_in_dict_element_is_exact_object_match_not_containment() -> None:
+    # A single dict element of $in compiles to the exact #> = <jsonb object> form
+    # (the same object_equal shape $eq emits for a dict operand) — NEVER @>
+    # containment, so a stored object with extra keys does not match.
+    sql = _sql_norm(_ast({"metadata.labels": {"$in": [{"team": "x"}]}}))
+    assert "#>" in sql
+    # Exact equality against a jsonb object literal — not array-aware @>.
+    assert "@>" not in sql
+    assert "labels" in sql
+    assert '{"team": "x"}' in sql
+
+
+def test_metadata_in_nested_path_dict_element_is_exact_object_match() -> None:
+    # Same exact-object match through a nested metadata path: the dict element
+    # addresses the subdocument via #> and compares it exactly, not via @>.
+    sql = _sql_norm(_ast({"metadata.outer.inner": {"$in": [{"team": "x"}]}}))
+    assert "#>" in sql
+    assert "outer" in sql and "inner" in sql
+    assert "@>" not in sql
+    assert '{"team": "x"}' in sql
+
+
+def test_metadata_nin_dict_element_negates_exact_object_match() -> None:
+    # $nin with a dict element is the per-element exact-equality chain wrapped in
+    # NOT. The positive form is total (coalesced to FALSE on absent/wrong-type), so
+    # NOT flips superset / absent rows to TRUE — they are INCLUDED by $nin
+    # (Rule 2 polarity: a superset is "not equal" to the operand, an absent key
+    # satisfies $nin).
+    sql = _sql_norm(_ast({"metadata.labels": {"$nin": [{"team": "x"}]}}))
+    assert sql.startswith("not ")
+    assert "#>" in sql
+    assert "@>" not in sql
+    # The total guard (coalesce → false) under the NOT is what admits the absent
+    # row — assert it is present, not merely the negation token.
+    assert "coalesce(" in sql
+    assert '{"team": "x"}' in sql
+
+
+def test_metadata_in_mixed_dict_and_scalar_elements() -> None:
+    # A mixed $in list [{dict}, scalar] emits ONE OR chain combining the dict
+    # element's exact object match with the scalar element's array-aware
+    # containment. Both forms coexist: the dict arm is #> = <jsonb> (no @>), the
+    # scalar arm is the OR of the scalar-doc and array-wrapped @> containments.
+    sql = _sql_norm(_ast({"metadata.labels": {"$in": [{"team": "x"}, "scalar"]}}))
+    assert " or " in sql
+    # Dict element → exact object match.
+    assert "#>" in sql
+    assert '{"team": "x"}' in sql
+    # Scalar element → array-aware @> containment (both scalar-doc and array-doc).
+    assert "@>" in sql
+    assert '{"labels": "scalar"}' in sql
+    assert '{"labels": ["scalar"]}' in sql
+
+
+def test_metadata_in_scalar_elements_still_use_containment() -> None:
+    # Regression: a scalar-only $in is unchanged by the dict-element fix — every
+    # element still compiles to array-aware @> containment (scalar-doc OR
+    # array-wrapped), with NO #> exact-equality leaking in.
+    sql = _sql_norm(_ast({"metadata.tier": {"$in": ["gold", "silver"]}}))
+    assert "@>" in sql
+    assert "#>" not in sql
+    assert '{"tier": "gold"}' in sql
+    assert '{"tier": ["gold"]}' in sql
+    assert '{"tier": "silver"}' in sql
+    assert '{"tier": ["silver"]}' in sql
+
+
+def test_metadata_in_array_element_still_uses_containment() -> None:
+    # Regression: an array (list) element of $in is NOT a dict, so it stays on the
+    # array-aware @> containment path — only dict elements switched to exact
+    # equality. A list operand element lowers through the same containment doc as
+    # a scalar (its leaf value is the list).
+    sql = _sql_norm(_ast({"metadata.tags": {"$in": [["x", "y"]]}}))
+    assert "@>" in sql
+    assert "#>" not in sql
+
+
+# ===========================================================================
 # Rule 4 — $exists / null on metadata use key-presence, not value extraction.
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

- The Postgres recall-filter compiler routed **every** `$in`/`$nin` metadata operand element through `@>` containment. For a **dict** element this is superset-containment, so a stored superset object (e.g. `{"team": "x", "y": 2}`) wrongly satisfied `{"metadata.labels": {"$in": [{"team": "x"}]}}`. The Python oracle compiler uses **exact** object equality for a dict `$in` element, so the two compilers diverged.
- Route a `Mapping` (dict) element to exact `#> = '{...}'::jsonb` object-equality (key-order-insensitive, total-boolean via `coalesce(..., false())`), mirroring the existing sub-path `$eq` dict branch. Scalar and array elements keep their array-aware `@>` containment semantics. `$nin` negates the per-element OR chain, so both operators are fixed by the single per-element routing change.
- Added object-equality conformance cases (`$in`/`$nin` dict element vs a stored superset → no match; vs an exact object → match) asserting the Postgres compiler agrees with the Python oracle, plus unit tests pinning the compiled SQL shape (`#>`-extract + `::jsonb` equality, not `@>`) for single-segment and nested paths, `$nin` polarity, mixed dict/scalar lists, and scalar/array regression.

## Test plan

- [x] Unit tests pass — `tests/unit/filter/` + `tests/recall/` (723 passed, 16 skipped)
- [x] Conformance oracle-equivalence passes — both new dict `$in`/`$nin` cases agree `compile_postgres == compile_python`
- [ ] Integration matrix (live Postgres) — gated to the per-backend CI conformance job
- [x] Lint + format clean