### PR TITLE
fix(llm): bound all litellm calls with a wall-clock timeout to prevent build hangs

### DIFF
--- a/src/khora/chat/engine.py
+++ b/src/khora/chat/engine.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 import litellm
 from loguru import logger
+
+from khora.config.llm import DEFAULT_LLM_TIMEOUT_S, llm_call_timeout
 
 from .history import HistoryManager
 from .prompt import PromptGenerator
@@ -171,11 +174,14 @@ class ChatEngine:
         import time as _time
 
         _t0 = _time.perf_counter()
-        response = await litellm.acompletion(
-            model=self.llm_model,
-            messages=messages,
-            max_tokens=self.persona.chat.response.max_tokens,
-            temperature=self.persona.chat.response.temperature,
+        response = await asyncio.wait_for(
+            litellm.acompletion(
+                model=self.llm_model,
+                messages=messages,
+                max_tokens=self.persona.chat.response.max_tokens,
+                temperature=self.persona.chat.response.temperature,
+            ),
+            llm_call_timeout(DEFAULT_LLM_TIMEOUT_S),
         )
         _latency = (_time.perf_counter() - _t0) * 1000
 

--- a/src/khora/chat/history.py
+++ b/src/khora/chat/history.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Literal
 from uuid import UUID, uuid4
+
+from khora.config.llm import DEFAULT_LLM_TIMEOUT_S, llm_call_timeout
 
 if TYPE_CHECKING:
     pass
@@ -150,10 +153,13 @@ class HistoryManager:
         # Generate summary
         summary_prompt = self._build_compression_prompt(to_compress, history.compressed_summary)
 
-        response = await litellm.acompletion(
-            model=self.compression_model,
-            messages=[{"role": "user", "content": summary_prompt}],
-            max_tokens=500,
+        response = await asyncio.wait_for(
+            litellm.acompletion(
+                model=self.compression_model,
+                messages=[{"role": "user", "content": summary_prompt}],
+                max_tokens=500,
+            ),
+            llm_call_timeout(DEFAULT_LLM_TIMEOUT_S),
         )
 
         new_summary = response.choices[0].message.content

--- a/src/khora/config/llm.py
+++ b/src/khora/config/llm.py
@@ -6,6 +6,7 @@ with fallbacks and routing.
 
 from __future__ import annotations
 
+import asyncio
 import os
 from pathlib import Path
 from typing import Annotated, Any
@@ -331,6 +332,40 @@ def get_shared_session() -> Any:
     return _shared_aiohttp_session
 
 
+# Wall-clock headroom added on top of the configured per-request timeout before
+# the asyncio deadline fires — gives litellm's own timeout a chance to act first.
+_LLM_DEADLINE_GRACE_S = 30.0
+
+# Default deadline for litellm calls that carry no configured timeout of their
+# own (e.g. chat responses, chronicle event/fact extraction).
+DEFAULT_LLM_TIMEOUT_S = 60.0
+
+
+def llm_call_timeout(timeout: float | int | None, *, attempts: int = 1) -> float | None:
+    """Wall-clock deadline (seconds) for a litellm call, for ``asyncio.wait_for``.
+
+    litellm's default aiohttp transport (used for every async call unless
+    ``disable_aiohttp_transport`` is set) builds the per-request aiohttp
+    ``ClientTimeout`` with only ``sock_read``/``sock_connect`` and no ``total``,
+    so a connection that completes the TLS handshake then never sends a byte is
+    never cancelled and the ``await`` hangs indefinitely. Wrapping the call in
+    ``asyncio.wait_for(coro, llm_call_timeout(...))`` gives the event loop a
+    deadline it always honours; where the call site has a surrounding retry, a
+    cancelled attempt reconnects on the next one.
+
+    ``attempts`` covers calls that retry *internally* (litellm/router
+    ``num_retries``): the deadline then spans the whole retry budget so it does
+    not pre-empt a legitimate retry. Sites with no internal retries use the
+    default ``attempts=1``.
+
+    Returns ``timeout * attempts`` plus a small grace margin, or ``None`` (no
+    enforced deadline) when no positive timeout is configured.
+    """
+    if timeout is None or timeout <= 0:
+        return None
+    return float(timeout) * max(1, attempts) + _LLM_DEADLINE_GRACE_S
+
+
 async def close_shared_session() -> None:
     """Close the shared aiohttp session. Call on engine/app shutdown."""
     global _shared_aiohttp_session, _connector_settings
@@ -462,13 +497,14 @@ async def acompletion(
     router = _get_router(config)
 
     _t0 = _time.perf_counter()
+    _deadline = llm_call_timeout(config.timeout, attempts=config.max_retries + 1)
     if router is not None:
         # The Router manages its own retries via router_settings; don't double
         # up litellm's per-call num_retries on top of the router's.
         call_kwargs.pop("num_retries", None)
-        response = await router.acompletion(**call_kwargs)
+        response = await asyncio.wait_for(router.acompletion(**call_kwargs), _deadline)
     else:
-        response = await litellm.acompletion(**call_kwargs)
+        response = await asyncio.wait_for(litellm.acompletion(**call_kwargs), _deadline)
     _latency = (_time.perf_counter() - _t0) * 1000
 
     # Record telemetry

--- a/src/khora/engines/chronicle/compression.py
+++ b/src/khora/engines/chronicle/compression.py
@@ -23,6 +23,7 @@ from uuid import UUID, uuid4
 import litellm
 from loguru import logger
 
+from khora.config.llm import DEFAULT_LLM_TIMEOUT_S, llm_call_timeout
 from khora.core.diagnostics import ErrorRecord
 from khora.engines.chronicle.events import (
     _EXTRACTION_FAILED_COUNTER as _CHRONICLE_EXTRACTION_FAILED_COUNTER,
@@ -244,14 +245,17 @@ class FactExtractor:
 
         _t0 = _time.perf_counter()
         try:
-            response = await litellm.acompletion(
-                model=self._model,
-                messages=[
-                    {"role": "system", "content": _FACT_EXTRACTION_SYSTEM},
-                    {"role": "user", "content": text[:4000]},
-                ],
-                temperature=0.0,
-                max_tokens=1500,
+            response = await asyncio.wait_for(
+                litellm.acompletion(
+                    model=self._model,
+                    messages=[
+                        {"role": "system", "content": _FACT_EXTRACTION_SYSTEM},
+                        {"role": "user", "content": text[:4000]},
+                    ],
+                    temperature=0.0,
+                    max_tokens=1500,
+                ),
+                llm_call_timeout(DEFAULT_LLM_TIMEOUT_S),
             )
             content = response.choices[0].message.content or "[]"
             raw_facts = _parse_json_array(content)
@@ -431,14 +435,17 @@ class MemoryCompressor:
 
         _t0 = _time.perf_counter()
         try:
-            response = await litellm.acompletion(
-                model=self._model,
-                messages=[
-                    {"role": "system", "content": _CONTRADICTION_SYSTEM},
-                    {"role": "user", "content": prompt},
-                ],
-                temperature=0.0,
-                max_tokens=200,
+            response = await asyncio.wait_for(
+                litellm.acompletion(
+                    model=self._model,
+                    messages=[
+                        {"role": "system", "content": _CONTRADICTION_SYSTEM},
+                        {"role": "user", "content": prompt},
+                    ],
+                    temperature=0.0,
+                    max_tokens=200,
+                ),
+                llm_call_timeout(DEFAULT_LLM_TIMEOUT_S),
             )
             content = response.choices[0].message.content or "{}"
             result = _parse_json_object(content)

--- a/src/khora/engines/chronicle/events.py
+++ b/src/khora/engines/chronicle/events.py
@@ -19,6 +19,7 @@ from uuid import UUID, uuid4
 import litellm
 from loguru import logger
 
+from khora.config.llm import DEFAULT_LLM_TIMEOUT_S, llm_call_timeout
 from khora.core.diagnostics import ErrorRecord
 from khora.telemetry.metrics import metric_counter
 
@@ -188,14 +189,17 @@ class EventExtractor:
 
         _t0 = _time.perf_counter()
         try:
-            response = await litellm.acompletion(
-                model=self._model,
-                messages=[
-                    {"role": "system", "content": _EVENT_SYSTEM},
-                    {"role": "user", "content": text[:4000]},  # Cap input
-                ],
-                temperature=0.0,
-                max_tokens=1000,
+            response = await asyncio.wait_for(
+                litellm.acompletion(
+                    model=self._model,
+                    messages=[
+                        {"role": "system", "content": _EVENT_SYSTEM},
+                        {"role": "user", "content": text[:4000]},  # Cap input
+                    ],
+                    temperature=0.0,
+                    max_tokens=1000,
+                ),
+                llm_call_timeout(DEFAULT_LLM_TIMEOUT_S),
             )
             content = response.choices[0].message.content or "[]"
             raw_events = self._parse_events(content)

--- a/src/khora/extraction/embedders/litellm.py
+++ b/src/khora/extraction/embedders/litellm.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential
 
-from khora.config.llm import get_shared_session
+from khora.config.llm import get_shared_session, llm_call_timeout
 from khora.exceptions import EmbeddingError
 from khora.telemetry import trace_span
 
@@ -415,12 +415,15 @@ class LiteLLMEmbedder(Embedder):
 
                     _t0 = _time.perf_counter()
                     set_connector_attributes(req_span, get_shared_session())
-                    response = await litellm.aembedding(
-                        model=self._model,
-                        input=sanitized,
-                        timeout=self._timeout,
-                        dimensions=self._dimension,
-                        shared_session=get_shared_session(),
+                    response = await asyncio.wait_for(
+                        litellm.aembedding(
+                            model=self._model,
+                            input=sanitized,
+                            timeout=self._timeout,
+                            dimensions=self._dimension,
+                            shared_session=get_shared_session(),
+                        ),
+                        llm_call_timeout(self._timeout),
                     )
                     set_rate_limit_attributes(req_span, response)
                     _latency = (_time.perf_counter() - _t0) * 1000

--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 from tenacity import AsyncRetrying, stop_after_attempt, stop_after_delay, wait_exponential
 
-from khora.config.llm import get_shared_session
+from khora.config.llm import get_shared_session, llm_call_timeout
 from khora.extraction.embedders._request_telemetry import (
     parse_rate_limit_headers,
     set_connector_attributes,
@@ -801,18 +801,21 @@ class LLMEntityExtractor(EntityExtractor):
 
                         with trace_span("khora.extraction.llm_call", model=self._model, call_type="single") as llm_span:
                             set_connector_attributes(llm_span, get_shared_session())
-                            response = await litellm.acompletion(
-                                model=self._model,
-                                messages=[
-                                    {"role": "system", "content": system_prompt},
-                                    {"role": "user", "content": extraction_prompt},
-                                ],
-                                temperature=self._temperature,
-                                max_tokens=effective_max_tokens,
-                                timeout=self._timeout,
-                                num_retries=0,
-                                response_format=self._get_response_format(),
-                                shared_session=get_shared_session(),
+                            response = await asyncio.wait_for(
+                                litellm.acompletion(
+                                    model=self._model,
+                                    messages=[
+                                        {"role": "system", "content": system_prompt},
+                                        {"role": "user", "content": extraction_prompt},
+                                    ],
+                                    temperature=self._temperature,
+                                    max_tokens=effective_max_tokens,
+                                    timeout=self._timeout,
+                                    num_retries=0,
+                                    response_format=self._get_response_format(),
+                                    shared_session=get_shared_session(),
+                                ),
+                                llm_call_timeout(self._timeout),
                             )
                             set_rate_limit_attributes(llm_span, response)
                         _latency = (_time.perf_counter() - _t0) * 1000
@@ -950,17 +953,20 @@ class LLMEntityExtractor(EntityExtractor):
                     "khora.extraction.llm_call", model=self._model, call_type="relationship_second_pass"
                 ) as llm_span:
                     set_connector_attributes(llm_span, get_shared_session())
-                    response = await litellm.acompletion(
-                        model=self._model,
-                        messages=[
-                            {"role": "system", "content": DEFAULT_SYSTEM_PROMPT},
-                            {"role": "user", "content": prompt},
-                        ],
-                        temperature=self._temperature,
-                        max_tokens=self._max_tokens,
-                        timeout=self._timeout,
-                        response_format=self._get_response_format(),
-                        shared_session=get_shared_session(),
+                    response = await asyncio.wait_for(
+                        litellm.acompletion(
+                            model=self._model,
+                            messages=[
+                                {"role": "system", "content": DEFAULT_SYSTEM_PROMPT},
+                                {"role": "user", "content": prompt},
+                            ],
+                            temperature=self._temperature,
+                            max_tokens=self._max_tokens,
+                            timeout=self._timeout,
+                            response_format=self._get_response_format(),
+                            shared_session=get_shared_session(),
+                        ),
+                        llm_call_timeout(self._timeout),
                     )
                     set_rate_limit_attributes(llm_span, response)
                 _latency = (_time.perf_counter() - _t0) * 1000
@@ -1719,18 +1725,21 @@ Return ONLY valid JSON, no other text."""
                             batch_size=len(texts),
                         ) as llm_span:
                             set_connector_attributes(llm_span, get_shared_session())
-                            response = await litellm.acompletion(
-                                model=self._model,
-                                messages=[
-                                    {"role": "system", "content": system_prompt or DEFAULT_SYSTEM_PROMPT},
-                                    {"role": "user", "content": prompt},
-                                ],
-                                temperature=self._temperature,
-                                max_tokens=self._max_tokens,
-                                timeout=self._timeout,
-                                num_retries=0,
-                                response_format=self._get_multi_response_format(),
-                                shared_session=get_shared_session(),
+                            response = await asyncio.wait_for(
+                                litellm.acompletion(
+                                    model=self._model,
+                                    messages=[
+                                        {"role": "system", "content": system_prompt or DEFAULT_SYSTEM_PROMPT},
+                                        {"role": "user", "content": prompt},
+                                    ],
+                                    temperature=self._temperature,
+                                    max_tokens=self._max_tokens,
+                                    timeout=self._timeout,
+                                    num_retries=0,
+                                    response_format=self._get_multi_response_format(),
+                                    shared_session=get_shared_session(),
+                                ),
+                                llm_call_timeout(self._timeout),
                             )
                             set_rate_limit_attributes(llm_span, response)
                         _latency = (_time.perf_counter() - _t0) * 1000

--- a/tests/unit/test_llm_call_timeout.py
+++ b/tests/unit/test_llm_call_timeout.py
@@ -1,0 +1,80 @@
+"""Regression tests for the LLM-call wall-clock timeout backstop.
+
+See https://github.com/DeytaHQ/khora/issues/1052. A stalled embedding or
+extraction request — TLS handshake completes, the server then sends no bytes —
+must be cancelled by ``asyncio.wait_for(..., llm_call_timeout(...))`` instead of
+hanging the build forever (litellm's shared-session transport builds a
+per-request ``ClientTimeout`` with no ``total``, so the await otherwise never
+unblocks).
+
+Each test patches the litellm call to hang and relies on ``pytest-timeout`` to
+*fail* (rather than hang CI) if the backstop is missing. The grace margin is
+shrunk so the deadline fires quickly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import litellm
+import pytest
+
+from khora.config import llm as llm_config
+from khora.config.llm import llm_call_timeout
+from khora.exceptions import EmbeddingError
+from khora.extraction.embedders.litellm import LiteLLMEmbedder
+from khora.extraction.extractors.llm import LLMEntityExtractor
+
+
+def test_llm_call_timeout_none_when_unset() -> None:
+    """No positive timeout => no enforced deadline (preserves prior behaviour)."""
+    assert llm_call_timeout(None) is None
+    assert llm_call_timeout(0) is None
+    assert llm_call_timeout(-5) is None
+
+
+def test_llm_call_timeout_adds_grace() -> None:
+    """A positive timeout becomes ``timeout`` + a grace margin."""
+    assert llm_call_timeout(60) == 60 + llm_config._LLM_DEADLINE_GRACE_S
+    assert llm_call_timeout(1.5) == pytest.approx(1.5 + llm_config._LLM_DEADLINE_GRACE_S)
+
+
+def test_llm_call_timeout_scales_with_attempts() -> None:
+    """``attempts`` spans the internal-retry budget (litellm/router num_retries sites)."""
+    grace = llm_config._LLM_DEADLINE_GRACE_S
+    assert llm_call_timeout(10, attempts=1) == 10 + grace
+    assert llm_call_timeout(10, attempts=4) == 40 + grace
+    assert llm_call_timeout(None, attempts=4) is None
+
+
+async def _hang(*_args, **_kwargs):
+    """Simulate a connection that completes the handshake then never responds."""
+    await asyncio.Event().wait()
+
+
+@pytest.mark.timeout(20)
+async def test_embedder_cancels_hung_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hung embedding request is cancelled within the deadline, not hung forever."""
+    monkeypatch.setattr(llm_config, "_LLM_DEADLINE_GRACE_S", 0.2)
+    monkeypatch.setattr(litellm, "aembedding", _hang)
+
+    embedder = LiteLLMEmbedder(timeout=1, max_retries=1, cache_max_size=0)
+    with pytest.raises((TimeoutError, EmbeddingError)):
+        await embedder.embed_batch(["hello world"])
+
+
+@pytest.mark.timeout(20)
+async def test_extractor_cancels_hung_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hung extraction request is cancelled within the deadline, not hung forever.
+
+    The extractor may raise or degrade to an empty result; the property under
+    test is that it *returns* within the deadline rather than hanging — enforced
+    by the ``pytest.mark.timeout`` marker.
+    """
+    monkeypatch.setattr(llm_config, "_LLM_DEADLINE_GRACE_S", 0.2)
+    monkeypatch.setattr(litellm, "acompletion", _hang)
+
+    extractor = LLMEntityExtractor(timeout=1, max_retries=1, max_concurrent=1)
+    with contextlib.suppress(Exception):
+        await extractor.extract("Alice met Bob in Paris.")


### PR DESCRIPTION
## Summary
litellm's default aiohttp transport builds each request's `ClientTimeout` with only `sock_read`/`sock_connect` and **no `total`**, so a connection that completes the TLS handshake then never sends a byte is never cancelled — the awaiting coroutine hangs indefinitely (event loop parked in `kevent`). On a large-corpus build/ingest, one stalled connection deadlocks the whole run; `tenacity`/litellm retries cannot interrupt a hung in-flight `await`. Fixes #1052.

The behaviour is independent of the shared-session optimization — the no-`total` `ClientTimeout` is built by litellm's default aiohttp transport for every async call.

## Change
- New `khora.config.llm.llm_call_timeout(timeout, *, attempts=1)` → a wall-clock deadline (`timeout * attempts + grace`, or `None` when no positive timeout) for `asyncio.wait_for`.
- Wrapped every async litellm call in `asyncio.wait_for(coro, llm_call_timeout(...))`:
  - embedding (`embedders/litellm.py`) + entity/relationship extraction ×3 (`extractors/llm.py`) — the ingest path that deadlocked;
  - chat response (`chat/engine.py`) + history compression (`chat/history.py`);
  - chronicle event + fact + contradiction extraction (`engines/chronicle/`);
  - the `config.acompletion` helper (router + direct branches).
- `config.acompletion` retries internally (`num_retries`), so its deadline spans the whole retry budget (`attempts = max_retries + 1`) rather than pre-empting a legitimate retry. Sites with no configured timeout (chat, chronicle) use `DEFAULT_LLM_TIMEOUT_S` (60s). On expiry the call is cancelled, and where a retry loop wraps it, it reconnects on the next attempt.

## Test plan
- New `tests/unit/test_llm_call_timeout.py`: hangs a mocked litellm call and asserts cancellation within the deadline — `pytest-timeout` fails the test (instead of hanging) if the backstop is missing. Covers the helper (`None`/grace/`attempts`), the embedder, and the extractor.
- `ruff` clean; `ty` adds no new diagnostics; the existing suites for the touched modules pass (extraction embedders/llm, chat engine/history, chronicle, litellm config/router).
