### PR TITLE
Normalize tz-naive datetimes at the recall-filter comparison boundary

### DIFF
--- a/src/khora/filter/compilers/python.py
+++ b/src/khora/filter/compilers/python.py
@@ -56,7 +56,7 @@ khora's own engines; not re-exported from :mod:`khora.__init__`.
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from khora.filter import (
@@ -437,6 +437,14 @@ def _comparable(stored: Any, operand: Any) -> bool:
     strings with strings, datetimes with datetimes. Any cross-family pair is
     NOT comparable — the positive op excludes it (Rule 1: never abort, exclude
     instead of raising a ``TypeError`` on ``str < int``).
+
+    Two datetimes are comparable regardless of tz-awareness: a naive stored
+    value (some backends — e.g. the embedded sqlite store, whose SQLAlchemy
+    ``DateTime`` column is tz-naive — return naive datetimes) is normalized to
+    UTC at the comparison boundary by :func:`_align_dt`, so the pair both
+    compares and orders without a ``TypeError``. The gate stays a same-family
+    test; the tz alignment is applied to the *values* before ``==`` / ``<`` /
+    membership, never here.
     """
     if _is_number(operand):
         return _is_number(stored)
@@ -451,6 +459,27 @@ def _comparable(stored: Any, operand: Any) -> bool:
     return type(stored) is type(operand)
 
 
+def _to_utc(value: datetime) -> datetime:
+    """Normalize a datetime to UTC-aware — naive is read as UTC (mirrors :func:`_try_parse_utc`)."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _align_dt(stored: Any, value: Any) -> tuple[Any, Any]:
+    """Align a comparable datetime pair to UTC-aware so ``==`` / ``<`` never raise.
+
+    Only rewrites when BOTH operands are datetimes (the sole family where a
+    naive/aware mix raises ``TypeError`` on compare). A naive operand on either
+    side — stored (e.g. the embedded sqlite store) or the filter value — is read
+    as UTC, mirroring :func:`_try_parse_utc` / :func:`_md_date_compare`. Any
+    other pair (already-handled by :func:`_comparable`) passes through unchanged.
+    """
+    if isinstance(stored, datetime) and isinstance(value, datetime):
+        return _to_utc(stored), _to_utc(value)
+    return stored, value
+
+
 # ----- system-key value comparisons (None / wrong-type aware) -------------- #
 
 
@@ -460,6 +489,7 @@ def _system_eq(stored: Any, value: Any) -> bool:
         return False
     if not _comparable(stored, value):
         return False
+    stored, value = _align_dt(stored, value)
     return stored == value
 
 
@@ -469,6 +499,7 @@ def _system_ne(stored: Any, value: Any) -> bool:
         return True
     if not _comparable(stored, value):
         return True
+    stored, value = _align_dt(stored, value)
     return stored != value
 
 
@@ -476,14 +507,20 @@ def _system_in(stored: Any, values: list[Any]) -> bool:
     """System ``$in``: present, comparable to, and equal to some member."""
     if stored is None:
         return False
-    return any(_comparable(stored, v) and stored == v for v in values)
+    return any(_comparable(stored, v) and _eq_aligned(stored, v) for v in values)
 
 
 def _system_nin(stored: Any, values: list[Any]) -> bool:
     """System ``$nin``: include None / wrong-type; exclude only an in-set match."""
     if stored is None:
         return True
-    return not any(_comparable(stored, v) and stored == v for v in values)
+    return not any(_comparable(stored, v) and _eq_aligned(stored, v) for v in values)
+
+
+def _eq_aligned(stored: Any, value: Any) -> bool:
+    """``stored == value`` with a naive/aware datetime pair aligned to UTC first."""
+    stored, value = _align_dt(stored, value)
+    return stored == value
 
 
 def _system_range(stored: Any, value: Any, range_fn: Callable[[Any, Any], bool]) -> bool:
@@ -492,6 +529,7 @@ def _system_range(stored: Any, value: Any, range_fn: Callable[[Any, Any], bool])
         return False
     if not _comparable(stored, value):
         return False
+    stored, value = _align_dt(stored, value)
     return range_fn(stored, value)
 
 

--- a/tests/recall/test_compile_python.py
+++ b/tests/recall/test_compile_python.py
@@ -40,7 +40,7 @@ Python ``None``. ``metadata`` is resolved the same way and defaults to ``{}``.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any
 
@@ -545,6 +545,101 @@ def test_direct_datetime_clause() -> None:
     pred = compile_python(node, _CTX).predicate
     assert pred({"occurred_at": datetime(2026, 6, 1, tzinfo=UTC)}) is True
     assert pred({"occurred_at": datetime(2025, 1, 1, tzinfo=UTC)}) is False
+
+
+# ===========================================================================
+# System date-key tz alignment — naive/aware datetime pairs compare AND order
+# without raising (a naive stored value is read as UTC at the compare boundary).
+#
+# Some backends return tz-NAIVE datetimes for the system date columns (e.g. the
+# embedded sqlite store, whose SQLAlchemy ``DateTime`` column is tz-naive). The
+# §4 type-gate treats datetime-vs-datetime as comparable regardless of tz, so the
+# shared ``_system_eq``/``_ne``/``_in``/``_nin``/``_range`` path must NOT raise
+# ``TypeError: can't compare offset-naive and offset-aware datetimes`` — it
+# normalizes both sides to UTC (Rule 1: never abort the query). A genuinely
+# non-datetime cross-family pair must still stay non-comparable (exclude, no raise).
+# ===========================================================================
+
+
+def _system_clause(op: Op, operand: Any, *, key: str = "occurred_at") -> Any:
+    """Compile a single system date-key leaf clause to its in-memory predicate."""
+    node = FilterNode(op=Op.AND, children=(FilterClause(path=(key,), op=op, operand=operand),))
+    return compile_python(node, _CTX).predicate
+
+
+@pytest.mark.parametrize("key", ["occurred_at", "created_at", "source_timestamp"])
+def test_system_range_naive_stored_vs_aware_operand_orders(key: str) -> None:
+    # naive STORED (sqlite shape) vs aware OPERAND: GTE/LTE order correctly with
+    # the naive value read as UTC — never a TypeError.
+    bound = datetime(2026, 1, 1, tzinfo=UTC)
+    gte = _system_clause(Op.GTE, bound, key=key)
+    assert gte({key: datetime(2026, 6, 1)}) is True  # naive, after bound
+    assert gte({key: datetime(2025, 6, 1)}) is False  # naive, before bound
+    lte = _system_clause(Op.LTE, bound, key=key)
+    assert lte({key: datetime(2025, 6, 1)}) is True
+    assert lte({key: datetime(2026, 6, 1)}) is False
+
+
+def test_system_range_aware_stored_vs_naive_operand_orders() -> None:
+    # Inverse mix: aware STORED vs naive OPERAND also orders without raising.
+    naive_bound = datetime(2026, 1, 1)  # read as UTC
+    gte = _system_clause(Op.GTE, naive_bound)
+    assert gte({"occurred_at": datetime(2026, 6, 1, tzinfo=UTC)}) is True
+    assert gte({"occurred_at": datetime(2025, 6, 1, tzinfo=UTC)}) is False
+
+
+def test_system_range_both_naive_orders() -> None:
+    # Both-naive (no aware side at all) still orders — alignment is a no-op here.
+    gte = _system_clause(Op.GTE, datetime(2026, 1, 1))
+    assert gte({"occurred_at": datetime(2026, 6, 1)}) is True
+    assert gte({"occurred_at": datetime(2025, 6, 1)}) is False
+
+
+def test_system_range_both_aware_orders() -> None:
+    # Both-aware is the original happy path — still correct after the fix.
+    gte = _system_clause(Op.GTE, datetime(2026, 1, 1, tzinfo=UTC))
+    assert gte({"occurred_at": datetime(2026, 6, 1, tzinfo=UTC)}) is True
+    assert gte({"occurred_at": datetime(2025, 6, 1, tzinfo=UTC)}) is False
+
+
+def test_system_eq_naive_stored_matches_same_instant_aware_operand() -> None:
+    # Equality path ($eq / $ne): a naive stored value read as UTC equals an aware
+    # operand denoting the same instant — including an operand in a non-UTC zone
+    # whose instant maps onto the naive-as-UTC value.
+    instant = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    eq = _system_clause(Op.EQ, instant)
+    assert eq({"occurred_at": datetime(2026, 1, 1, 12, 0)}) is True  # naive == same UTC instant
+    assert eq({"occurred_at": datetime(2026, 1, 1, 13, 0)}) is False  # different instant
+    # Operand offset +02:00 → same absolute instant as the naive 12:00 UTC stored.
+    plus_two = datetime(2026, 1, 1, 14, 0, tzinfo=timezone(timedelta(hours=2)))
+    eq_offset = _system_clause(Op.EQ, plus_two)
+    assert eq_offset({"occurred_at": datetime(2026, 1, 1, 12, 0)}) is True
+    ne_offset = _system_clause(Op.NE, plus_two)
+    assert ne_offset({"occurred_at": datetime(2026, 1, 1, 12, 0)}) is False
+
+
+def test_system_in_naive_stored_matches_same_instant_aware_operand() -> None:
+    # Membership path ($in / $nin) aligns each member: a naive stored value matches
+    # an aware member denoting the same instant.
+    members = [datetime(2026, 1, 1, 12, 0, tzinfo=UTC), datetime(2027, 1, 1, tzinfo=UTC)]
+    in_pred = _system_clause(Op.IN, members)
+    assert in_pred({"occurred_at": datetime(2026, 1, 1, 12, 0)}) is True
+    assert in_pred({"occurred_at": datetime(2028, 1, 1)}) is False
+    nin_pred = _system_clause(Op.NIN, members)
+    assert nin_pred({"occurred_at": datetime(2026, 1, 1, 12, 0)}) is False
+
+
+@pytest.mark.parametrize("stored", ["2026-01-01T00:00:00Z", 1735689600])
+def test_system_range_non_datetime_cross_family_excludes_without_raising(stored: Any) -> None:
+    # A datetime OPERAND vs a non-datetime stored value (str / int) is a genuine
+    # cross-family pair: the §4 gate excludes it (Rule 1) and never raises — the
+    # tz alignment is scoped to datetime-vs-datetime only.
+    bound = datetime(2026, 1, 1, tzinfo=UTC)
+    assert _system_clause(Op.GTE, bound)({"occurred_at": stored}) is False
+    assert _system_clause(Op.EQ, bound)({"occurred_at": stored}) is False
+    # Negation polarity ($ne / $nin) INCLUDES a wrong-typed value — also no raise.
+    assert _system_clause(Op.NE, bound)({"occurred_at": stored}) is True
+    assert _system_clause(Op.NIN, [bound])({"occurred_at": stored}) is True
 
 
 # ===========================================================================

--- a/tests/recall/test_filter_chronicle.py
+++ b/tests/recall/test_filter_chronicle.py
@@ -22,13 +22,13 @@ V1's filter is ``source_name == "linear" AND occurred_at >= 2026-04-05 AND
 metadata.tag IN {"urgent", "release"}``. This file reuses V1's shared corpus and
 its exact 5-in-scope / 5-out-of-scope split (each out-of-scope row violating
 EXACTLY ONE predicate, one in-scope row sitting EXACTLY at the date bound). Two
-of V1's three predicate KEYS, however, do not function on the REAL Chronicle
-sqlite_lance recall path, so the three-predicate AND is expressed over the axes
-Chronicle actually carries on the real store — metadata keys — standing in for
-V1's ``source_name`` (a denormalized document key) and ``occurred_at`` (a system
-date key). The in-scope SET is identical; the contract proven here is "a
+of V1's three predicate KEYS, however, do not function the same way on the REAL
+Chronicle sqlite_lance recall path, so the three-predicate AND is expressed over
+the axes Chronicle actually carries on the real store — metadata keys — standing
+in for V1's ``source_name`` (a denormalized document key) and ``occurred_at`` (a
+system date key). The in-scope SET is identical; the contract proven here is "a
 real-store multi-predicate AND narrows to exactly V1's in-scope set". The system
-``occurred_at`` axis is pinned separately by a strict-xfail (below).
+date keys narrow correctly too, pinned separately below.
 
 Why each substitution (verified against this exact sqlite_lance fixture, not
 assumed):
@@ -42,13 +42,13 @@ assumed):
   bug. The source axis therefore rides a metadata key the corpus writes and the
   post-filter reads.
 * ``occurred_at`` (system date key) → ``metadata.when`` ($gte, ``$date``
-  operand). The effective event time IS carried on the record, but the embedded
-  SQLite store returns tz-NAIVE datetimes and the shared system date-key compare
-  currently raises when it puts a naive stored value next to a tz-aware operand.
-  The metadata-date path normalizes both sides to UTC, so a ``$date`` predicate
-  drives the date split cleanly. The system ``occurred_at`` crash is pinned by a
-  strict-xfail test below so the moment the compiler normalizes tz, that test
-  flips to a hard failure and signals it is time to drop the workaround.
+  operand) in the multi-predicate equivalence test. The embedded SQLite store
+  returns tz-NAIVE datetimes; the compiler aligns a naive stored value to UTC at
+  the comparison boundary, so both the system date keys AND the metadata-date
+  path narrow cleanly. The shared equivalence test keeps the metadata-date axis
+  so its three predicate leaves are all metadata leaves (the Scenario 2 telemetry
+  assertion depends on that); the system date keys are pinned by their own
+  narrowing tests below.
 
 The all-metadata filter is also why the unindexed-metadata telemetry assertion
 (Scenario 2) is meaningful here: every in-scope predicate leaf is a metadata
@@ -200,10 +200,12 @@ async def kb(tmp_path: Path) -> AsyncIterator[Khora]:
 #
 # Why all three axes are METADATA keys (not V1's system / doc keys): on the
 # Chronicle sqlite_lance recall DTO the document-projection keys (source_name /
-# source / title / ...) resolve absent, and the SYSTEM occurred_at date compare
-# raises on the embedded store's naive datetimes (pinned by the xfail below). So
-# the source and date axes ride metadata — the only keys this engine both writes
-# and reads on the live post-filter record. The in/out SPLIT is identical to V1's.
+# source / title / ...) resolve absent. The source axis therefore rides a
+# metadata key the engine both writes and reads on the live post-filter record;
+# the date axis rides metadata too so all three predicate leaves are metadata
+# leaves (Scenario 2's telemetry assertion depends on that). The system date
+# keys narrow correctly on their own and are pinned by dedicated tests below.
+# The in/out SPLIT is identical to V1's.
 #
 # Content is DISTINCT per row so each remember produces its own chunk (Chronicle
 # dedupes by content checksum, so identical content would collapse to one chunk);
@@ -245,8 +247,8 @@ _OUT_OF_SCOPE: dict[str, tuple[str | None, str, str | None]] = {
 }
 
 # The live three-predicate recall filter. ``$date`` wraps the date operand so the
-# metadata-date path parses both sides to UTC-aware datetimes (sidestepping the
-# naive-datetime crash a SYSTEM date-key predicate hits on the embedded store).
+# metadata-date path parses both sides to UTC-aware datetimes; keeping all three
+# leaves on metadata is what Scenario 2's unindexed-metadata assertion relies on.
 _RECALL_FILTER = {
     "metadata.channel": "linear",
     "metadata.when": {"$gte": {"$date": _IN_BOUND}},
@@ -354,37 +356,37 @@ async def test_no_filter_returns_all_chunks(kb: Khora) -> None:
 
 
 # ===========================================================================
-# System date-key crash — strict xfail (DO NOT skip).
+# System date-key narrowing — occurred_at / created_at / source_timestamp.
 # ===========================================================================
 #
-# The metadata-date path the green test above rides sidesteps a real defect:
-# filtering on the SYSTEM date key (``occurred_at``) over the embedded store
-# compares a tz-naive stored datetime against the filter's tz-aware operand and
-# raises. This test pins that defect with strict=True so that the instant the
-# compiler learns to normalize tz, the test XPASSes (a hard failure) — the signal
-# to delete this marker AND fold the date axis back onto the system ``occurred_at``
-# key in the green test, matching V1 one-for-one.
+# The embedded SQLite store returns tz-NAIVE datetimes (its SQLAlchemy DateTime
+# column is not timezone-aware), so the system date-key compare lands a naive
+# stored value next to the filter's tz-aware operand. The Python compiler aligns
+# both to UTC at the comparison boundary, so a system date-key predicate narrows
+# the live result instead of raising. These tests pin that on the real store for
+# all three system date keys, via $gte / $lte / range.
+#
+# occurred_at and created_at are POST-FILTER-only on Chronicle, so the $gte / $lte
+# / range trio narrows purely by the post-filter compare — the cleanest exercise
+# of the naive/aware alignment. source_timestamp also PUSHES DOWN into the recency
+# window, whose embedded-store LanceDB pre-filter screens on the ingest-time
+# created_at column; an UPPER bound there clamps any row whose created_at ("now")
+# exceeds the bound, independent of source_timestamp. So source_timestamp's $gte
+# lower bound narrows by the post-filter as expected, while $lte / range carrying
+# an upper bound are asserted only to NOT RAISE (the tz-compare contract) — the
+# pushdown clamp that bounds their exact result set is a separate Chronicle
+# recency characteristic, not the compare under test.
 
 
-@pytest.mark.xfail(
-    strict=True,
-    raises=TypeError,
-    reason=(
-        "system date-key compare on sqlite_lance compares a tz-naive stored datetime "
-        "against a tz-aware operand and raises; the metadata-date path is unaffected. "
-        "Drop this marker when the compiler normalizes tz on the system-key range path."
-    ),
-)
 async def test_system_occurred_at_date_filter_narrows(kb: Khora) -> None:
-    """The system ``occurred_at`` date key SHOULD narrow to the in-range row.
+    """The system ``occurred_at`` date key narrows to the in-range row.
 
     Seeds one in-range and one out-of-range row whose effective event time is set
     via ``source_timestamp`` (the embedded write path leaves the literal
     ``occurred_at`` column null and the engine derives the effective event time
-    from ``source_timestamp``). A system ``occurred_at`` ``$gte`` filter SHOULD
-    return only the in-range row — but currently raises ``TypeError`` on the naive
-    stored datetime, so this test is a strict xfail. The assertion below is the
-    behaviour it WILL pin once the tz defect is fixed.
+    from ``source_timestamp``). A system ``occurred_at`` ``$gte`` filter returns
+    only the in-range row — the naive stored datetime is aligned to UTC before the
+    compare, so it narrows rather than raising ``TypeError``.
     """
     ns = await kb.create_namespace()
     namespace_id: UUID = ns.namespace_id
@@ -420,6 +422,154 @@ async def test_system_occurred_at_date_filter_narrows(kb: Khora) -> None:
 
     returned = {c.content for c in result.chunks}
     assert returned == {in_range}, "system occurred_at filter must narrow to exactly the in-range row"
+
+
+async def test_system_occurred_at_date_filter_lte_and_range(kb: Khora) -> None:
+    """The system ``occurred_at`` date key also narrows via ``$lte`` and a range.
+
+    ``occurred_at`` is post-filter-only (it does not push into the recency
+    window), so the upper-bound and range forms narrow purely by the naive/aware
+    compare. Two recent rows split at an April mid-point: ``$gte`` keeps the later
+    row, ``$lte`` keeps the earlier row, an April-only range keeps neither, and a
+    range that brackets both keeps both — none raising on the naive stored value.
+    """
+    ns = await kb.create_namespace()
+    namespace_id: UUID = ns.namespace_id
+
+    earlier = "occurred at lte probe earlier"
+    later = "occurred at lte probe later"
+    await kb.remember(
+        content=earlier,
+        namespace=namespace_id,
+        title="occ_earlier",
+        source_timestamp=datetime(2026, 3, 1, tzinfo=UTC),
+        entity_types=["PERSON"],
+        relationship_types=["KNOWS"],
+        expertise=_no_event_fact_extraction(),
+    )
+    await kb.remember(
+        content=later,
+        namespace=namespace_id,
+        title="occ_later",
+        source_timestamp=datetime(2026, 5, 1, tzinfo=UTC),
+        entity_types=["PERSON"],
+        relationship_types=["KNOWS"],
+        expertise=_no_event_fact_extraction(),
+    )
+
+    async def _recall(filter_: dict[str, Any]) -> set[str]:
+        result = await kb.recall(
+            "occurred at lte probe",
+            namespace=namespace_id,
+            limit=20,
+            mode=SearchMode.VECTOR,
+            filter=filter_,
+        )
+        return {c.content for c in result.chunks}
+
+    assert await _recall({"occurred_at": {"$gte": "2026-04-01T00:00:00Z"}}) == {later}
+    assert await _recall({"occurred_at": {"$lte": "2026-04-01T00:00:00Z"}}) == {earlier}
+    assert await _recall({"occurred_at": {"$gte": "2026-04-01T00:00:00Z", "$lte": "2026-04-30T00:00:00Z"}}) == set()
+    assert await _recall({"occurred_at": {"$gte": "2026-02-01T00:00:00Z", "$lte": "2026-06-30T00:00:00Z"}}) == {
+        earlier,
+        later,
+    }
+
+
+async def test_system_source_timestamp_date_filter_narrows(kb: Khora) -> None:
+    """The system ``source_timestamp`` date key compares without raising via ``$gte`` / ``$lte`` / range.
+
+    ``source_timestamp`` is the LITERAL column value on the record (not a COALESCE
+    like ``occurred_at``), so it exercises the naive-stored compare on the raw
+    column. Two recent rows (Mar / May 2026) keep both candidates inside the
+    recency window.
+
+    The ``$gte`` LOWER bound narrows by the post-filter compare — exactly the
+    naive/aware alignment under test — keeping only the later row. ``$lte`` / range
+    carry an UPPER bound, which ``source_timestamp`` ALSO pushes into the recency
+    window; that push's embedded-store LanceDB pre-filter screens on the ingest
+    ``created_at`` column ("now"), so an upper bound before "now" clamps the
+    candidate set independent of ``source_timestamp``. The exact upper-bound result
+    is therefore a Chronicle recency characteristic, not the tz compare — so this
+    test asserts ``$lte`` / range only COMPLETE WITHOUT RAISING and stay within the
+    corpus (the contract the tz fix actually owns), while the ``$gte`` lower bound
+    pins the post-filter narrowing.
+    """
+    ns = await kb.create_namespace()
+    namespace_id: UUID = ns.namespace_id
+
+    earlier = "source timestamp probe earlier"
+    later = "source timestamp probe later"
+    corpus = {earlier, later}
+    await kb.remember(
+        content=earlier,
+        namespace=namespace_id,
+        title="st_earlier",
+        source_timestamp=datetime(2026, 3, 1, tzinfo=UTC),
+        entity_types=["PERSON"],
+        relationship_types=["KNOWS"],
+        expertise=_no_event_fact_extraction(),
+    )
+    await kb.remember(
+        content=later,
+        namespace=namespace_id,
+        title="st_later",
+        source_timestamp=datetime(2026, 5, 1, tzinfo=UTC),
+        entity_types=["PERSON"],
+        relationship_types=["KNOWS"],
+        expertise=_no_event_fact_extraction(),
+    )
+
+    async def _recall(filter_: dict[str, Any]) -> set[str]:
+        result = await kb.recall(
+            "source timestamp probe",
+            namespace=namespace_id,
+            limit=20,
+            mode=SearchMode.VECTOR,
+            filter=filter_,
+        )
+        return {c.content for c in result.chunks}
+
+    # $gte lower bound at the April mid-point narrows to the later row (post-filter).
+    assert await _recall({"source_timestamp": {"$gte": "2026-04-01T00:00:00Z"}}) == {later}
+    # $lte / range carry an upper bound — assert they don't raise and stay within
+    # the corpus; their exact set is bounded by the recency pushdown, not the tz fix.
+    assert await _recall({"source_timestamp": {"$lte": "2026-04-01T00:00:00Z"}}) <= corpus
+    assert (
+        await _recall({"source_timestamp": {"$gte": "2026-04-01T00:00:00Z", "$lte": "2026-04-30T00:00:00Z"}}) <= corpus
+    )
+
+
+async def test_system_created_at_date_filter_narrows(kb: Khora) -> None:
+    """The system ``created_at`` date key compares without raising on the naive column.
+
+    ``created_at`` is stamped at ingest (always "now"), so it is the naive-stored
+    column whose value the test does not control. The contract pinned here is that
+    the system date-key compare no longer raises ``TypeError`` and narrows
+    sanely: a ``$gte`` lower bound well in the past keeps every seeded row, a
+    ``$lte`` upper bound well in the past drops them all, and a range bracketing
+    ingest time keeps them — all on the naive stored datetime.
+    """
+    ns = await kb.create_namespace()
+    namespace_id: UUID = ns.namespace_id
+    content_to_label = await _seed(kb, namespace_id)
+    all_labels = set(content_to_label.values())
+
+    async def _recall(filter_: dict[str, Any]) -> set[str]:
+        result = await kb.recall(
+            "alpha bravo charlie",
+            namespace=namespace_id,
+            limit=20,
+            mode=SearchMode.VECTOR,
+            filter=filter_,
+        )
+        return _labels_returned(result, content_to_label)
+
+    # A past lower bound keeps everything; a past upper bound drops everything; a
+    # range from the past to the far future brackets ingest time and keeps all.
+    assert await _recall({"created_at": {"$gte": "2000-01-01T00:00:00Z"}}) == all_labels
+    assert await _recall({"created_at": {"$lte": "2000-01-01T00:00:00Z"}}) == set()
+    assert await _recall({"created_at": {"$gte": "2000-01-01T00:00:00Z", "$lte": "2100-01-01T00:00:00Z"}}) == all_labels
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- System date-key recall filters (`occurred_at` / `created_at` / `source_timestamp`) raised `TypeError: can't compare offset-naive and offset-aware datetimes` instead of narrowing when the stored datetime came back tz-naive (e.g. the embedded SQLite store) and the filter operand was tz-aware. This violated the compiler's contract of excluding incomparable values rather than raising.
- Added `_to_utc` / `_align_dt` helpers and applied them to the **values actually compared** in the shared system-key ops (`_system_eq` / `_system_ne` / `_system_in` / `_system_nin` / `_system_range`), mirroring the existing metadata-date normalization. Naive datetimes are read as UTC; aware datetimes are converted to UTC, so instants compare correctly regardless of the source offset.
- The type gate (`_comparable`) is unchanged — genuinely incomparable cross-family pairs (e.g. `str` vs `datetime`) are still excluded without raising (no behavior change on the previously-working aware/aware path). The fix lives in the shared post-filter, so every backend that can return naive stored datetimes is covered, not just the embedded store.
- Dropped the strict `xfail` that pinned the crash; that test now passes as a plain guard. Added regression coverage across all three system date keys on the real embedded store, plus unit coverage for naive/aware/mixed-offset comparisons and the incomparable-cross-family exclusion rule.

## Known limitation (pre-existing, out of scope)
- On the embedded store, a `source_timestamp` **upper bound** (`$lte` / range) does not narrow: the recency window pre-filters on the ingest-time `created_at` column, so an upper bound before "now" clamps the candidate set. The lower bound (`$gte`) narrows correctly. This is a separate recency-pushdown characteristic, not the datetime-comparison fix here; the regression test scopes `source_timestamp` accordingly and documents it.

## Test plan
- [x] Unit tests pass (`tests/unit/filter`, `tests/recall/test_compile_python.py`)
- [x] Integration tests pass (`tests/recall/test_filter_chronicle.py` on the real embedded sqlite_lance store)
- [x] Cross-backend filter conformance green (python-oracle / chronicle / live postgres)
- [x] `make format` + `make lint` clean
- [ ] Full CI suite green