### PR TITLE
Add recall-filter pushdown-spy test suite across VectorCypher channels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,7 +256,7 @@ markers = [
     "embedded: Tests that exercise the SQLite+LanceDB embedded stack (no Docker required)",
     "security: Structural/regression tests for the security surface (IGR-225 IDOR gate, etc.)",
     "filter_conformance: Recall-filter conformance corpus (own CI job; excluded from the main test job)",
-    "filter_enforcement: Recall-filter pushdown/enforcement tests against real backends (runs in the integration job)",
+    "filter_enforcement: Recall-filter pushdown/enforcement/threading tests against real backends (embedded spies run in the main test job; PG+Neo4j variants self-skip without their services)",
 ]
 asyncio_mode = "auto"
 

--- a/tests/integration/matrix/test_filter_enforcement_sqlite_lance.py
+++ b/tests/integration/matrix/test_filter_enforcement_sqlite_lance.py
@@ -1,0 +1,357 @@
+"""Recall-filter pushdown/threading spies on the embedded sqlite_lance stack.
+
+These are the NO-DOCKER critical-path spies for the filter-enforcement
+feature (#1051). They run the real ``Khora(engine="vectorcypher")`` against
+a fully-embedded SQLite+LanceDB coordinator (per-test ``tmp_path``), drive a
+genuine ``kb.recall(..., filter=...)``, and OBSERVE the ``filter_ast`` that
+flows past each channel boundary — asserting it is the SAME canonical AST the
+facade built, via ``canonical_hash`` equality plus a ``len(calls) >= N``
+vacuity guard.
+
+Scope discipline (mirrors the mock-level pushdown suite): we pin the WIRING
+contract — the validated filter reaches the channel unchanged — NOT the row
+set. The end-to-end "the rows are actually narrowed" proof is the
+filter-conformance suite's job. Spying here passes through to the real method,
+so the recall executes its genuine logic; we only read what was threaded.
+
+What enforces vs. only wires on THIS embedded backend (verified against
+source — the no-Docker stack is the point):
+
+* VECTOR channel — ``SQLiteLanceTemporalStore.search`` builds a
+  ``compile_python`` post-filter and a ``compile_lance`` JSON1 pushdown, so the
+  filter is genuinely ENFORCED. The spy asserts the wiring; enforcement is the
+  conformance suite's row-proof.
+* BM25 channel — the embedded ``SQLiteLanceTemporalStore.search_fulltext``
+  accepts ``filter_ast`` for protocol parity but does NOT compile it yet, so
+  the embedded BM25 channel is WIRING-ONLY here (the pgvector sibling enforces;
+  see the PG variant in the qa-graph suite). The spy proves the retriever still
+  THREADS the right filter to that boundary, and a strict-xfail enforcement
+  probe stands as the acceptance test for the day embedded BM25 learns to
+  compile.
+
+No Docker / Postgres / Neo4j — pure in-process aiosqlite + lancedb.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from functools import partial
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+try:  # Module-level import gate matches the sibling sqlite_lance suites.
+    import aiosqlite  # noqa: F401
+    import lancedb  # noqa: F401
+
+    _HAS_EMBEDDED = True
+except ImportError:
+    _HAS_EMBEDDED = False
+
+from khora.config import KhoraConfig
+from khora.config.schema import SQLiteLanceConfig
+from khora.extraction.skills import ExpertiseConfig
+from khora.khora import Khora
+from khora.query import SearchMode
+from khora.query.temporal_detection import TemporalCategory
+from tests.test_helpers.filter_spy import (
+    EMBED_DIM,
+    assert_filter_threaded,
+    plan_extraction,
+    seed_corpus,
+    spy_on,
+    stub_llm,
+)
+
+pytestmark = [
+    pytest.mark.embedded,
+    pytest.mark.integration,
+    pytest.mark.filter_enforcement,
+    pytest.mark.skipif(not _HAS_EMBEDDED, reason="aiosqlite/lancedb not installed"),
+]
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(autouse=True)
+def _patch_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deterministic embedder + content-keyed entity extractor (no API key)."""
+    stub_llm(monkeypatch)
+
+
+@pytest.fixture
+async def kb(tmp_path: Path) -> AsyncIterator[Khora]:
+    """Per-test VectorCypher Khora on a fresh embedded stack.
+
+    Mirrors the sibling sqlite_lance suite: own ``tmp_path`` per test because
+    ``StorageFactory`` caches engine pools by URL.
+    """
+    config = KhoraConfig()
+    config.storage.backend = "sqlite_lance"
+    config.storage.sqlite_lance = SQLiteLanceConfig(
+        db_path=str(tmp_path / "khora.db"),
+        lance_path=str(tmp_path / "khora.lance"),
+        embedding_dimension=EMBED_DIM,
+    )
+    config.llm.embedding_dimension = EMBED_DIM
+    config.storage.embedding_dimension = EMBED_DIM
+    config.neo4j_url = None
+    config.pipelines.chunk_size = 1024
+    config.pipelines.extract_entities = True
+    config.pipelines.selective_extraction = False
+
+    kb = Khora(config, engine="vectorcypher", run_migrations=True)
+    await kb.connect()
+    try:
+        yield kb
+    finally:
+        try:
+            await kb.disconnect()
+        except Exception:
+            pass
+
+
+@pytest.fixture
+async def namespace_id(kb: Khora) -> UUID:
+    ns = await kb.create_namespace()
+    return ns.namespace_id
+
+
+def _expertise() -> ExpertiseConfig:
+    return ExpertiseConfig(name="vc-filter-enforcement-embedded")
+
+
+def _remember(kb: Khora) -> Any:
+    """Bind the per-test remember wiring for ``seed_corpus``."""
+    return partial(
+        kb.remember,
+        title="",
+        entity_types=["PERSON", "CONCEPT", "EVENT", "ORG"],
+        relationship_types=["KNOWS", "RELATES_TO", "MENTIONS"],
+        expertise=_expertise(),
+    )
+
+
+def _retriever(kb: Khora) -> Any:
+    """The live VectorCypherRetriever instance (built at connect)."""
+    return kb._engine._get_retriever()  # type: ignore[union-attr]
+
+
+# A representative system-key filter that compiles cleanly on every backend:
+# a typed source column plus a date range. Both keys are projected onto the
+# Chunk row, so the vector channel pushes them down.
+_FILTER = {
+    "source_name": "linear",
+    "occurred_at": {"$gte": "2026-01-01"},
+}
+
+
+async def _seed(kb: Khora, namespace_id: UUID) -> None:
+    """Seed an entity-bearing corpus shared across the path spies."""
+    plan_extraction(
+        "Falcon",
+        entities=[("Falcon", "EVENT"), ("SpaceX", "ORG")],
+        relationships=[("SpaceX", "Falcon", "RELATES_TO")],
+    )
+    await seed_corpus(
+        _remember(kb),
+        namespace_id,
+        [
+            "Falcon launch coordinated by SpaceX in early 2026.",
+            "Falcon recovery operations reported by SpaceX teams.",
+            "Falcon mission telemetry archived after the SpaceX review.",
+        ],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Path 1 — VECTOR channel (_vector_search_chunks -> temporal store search)
+# --------------------------------------------------------------------------- #
+
+
+async def test_vector_channel_threads_filter(kb: Khora, namespace_id: UUID, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The vector chunk channel receives the facade's exact filter AST.
+
+    ENFORCES on embedded (compile_lance + compile_python). Here we pin the
+    wiring: ``_vector_search_chunks`` is called and every call carries a
+    ``filter_ast`` whose canonical_hash matches the facade-built AST.
+    """
+    await _seed(kb, namespace_id)
+    records = spy_on(monkeypatch, _retriever(kb), "_vector_search_chunks")
+
+    await kb.recall("Falcon launch", namespace=namespace_id, limit=10, filter=_FILTER)
+
+    assert_filter_threaded(records, _FILTER, min_calls=1)
+
+
+# --------------------------------------------------------------------------- #
+# Path 2 — BM25 channel (_bm25_search_chunks -> temporal store search_fulltext)
+# --------------------------------------------------------------------------- #
+
+
+async def test_bm25_channel_threads_filter(kb: Khora, namespace_id: UUID, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The BM25 channel receives the facade's exact filter AST.
+
+    WIRING-ONLY on embedded: ``SQLiteLanceTemporalStore.search_fulltext``
+    accepts ``filter_ast`` for protocol parity but does not compile it yet, so
+    this asserts the retriever still THREADS the correct filter to that
+    boundary. (Enforcement is tracked separately — see the strict-xfail probe
+    below.)
+
+    DIFFERENTIAL gate-fire check (avoids a vacuous wiring spy on a dead
+    channel): the BM25 channel is default-off in ``RetrieverConfig``. We first
+    confirm that with the flag OFF the channel does NOT fire (control), then
+    enable it and confirm it fires AND threads the filter. So the spy is proven
+    to be observing a genuinely-active channel, not silently passing because
+    ``_bm25_search_chunks`` was never reached.
+    """
+    await _seed(kb, namespace_id)
+    retriever = _retriever(kb)
+
+    # Control: flag OFF -> channel does not fire.
+    retriever._config.enable_bm25_channel = False
+    off_records = spy_on(monkeypatch, retriever, "_bm25_search_chunks")
+    await kb.recall("Falcon launch", namespace=namespace_id, limit=10, filter=_FILTER)
+    assert not off_records, (
+        f"BM25 channel fired with enable_bm25_channel=False ({len(off_records)} call(s)); "
+        f"the flag is not the gate, so the wiring assertion below would not prove the channel is live."
+    )
+
+    # Flag ON -> channel fires AND threads the facade filter.
+    retriever._config.enable_bm25_channel = True
+    on_records = spy_on(monkeypatch, retriever, "_bm25_search_chunks")
+    await kb.recall("Falcon launch", namespace=namespace_id, limit=10, filter=_FILTER)
+    assert_filter_threaded(on_records, _FILTER, min_calls=1)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Embedded SQLiteLanceTemporalStore.search_fulltext accepts filter_ast for "
+        "protocol parity but does not compile it yet, so the embedded BM25 channel "
+        "does not enforce the recall filter. This is the acceptance test for when "
+        "it learns to compile (mirrors the pgvector sibling). See #1051."
+    ),
+)
+async def test_bm25_channel_enforces_filter_embedded(kb: Khora, namespace_id: UUID) -> None:
+    """A filter that excludes every chunk must yield an empty BM25-only recall.
+
+    Until embedded BM25 compiles the filter, a contradiction filter still
+    returns rows through the BM25 channel — so this xfails. The day enforcement
+    lands, it asserts cleanly and the xfail is removed.
+    """
+    await _seed(kb, namespace_id)
+    retriever = _retriever(kb)
+    retriever._config.enable_bm25_channel = True
+
+    # A source_name that matches NOTHING in the seed corpus.
+    contradiction = {"source_name": "no-such-source-xyzzy"}
+    result = await kb.recall(
+        "Falcon launch",
+        namespace=namespace_id,
+        limit=10,
+        mode=SearchMode.KEYWORD,
+        filter=contradiction,
+    )
+    assert result.chunks == [], f"filter-excluded chunks leaked through embedded BM25: {len(result.chunks)}"
+
+
+# --------------------------------------------------------------------------- #
+# Path 6 — EXPLICIT-synthesis decision (engine.py date-key gate)
+# --------------------------------------------------------------------------- #
+
+
+async def test_date_filter_synthesizes_explicit_signal(
+    kb: Khora, namespace_id: UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A date-key caller filter drives an EXPLICIT (source="api") temporal signal.
+
+    The engine gates EXPLICIT synthesis on ``filter_constrains_date_key`` — a
+    date predicate makes the recall an explicit temporal intent. We capture the
+    ``temporal_signal`` the retriever receives and assert the category, plus the
+    threaded filter hash (same facade AST).
+    """
+    await _seed(kb, namespace_id)
+    records = spy_on(monkeypatch, _retriever(kb), "retrieve")
+
+    # occurred_at predicate -> date key -> EXPLICIT.
+    await kb.recall("Falcon launch", namespace=namespace_id, limit=10, filter={"occurred_at": {"$gte": "2026-01-01"}})
+
+    assert_filter_threaded(records, {"occurred_at": {"$gte": "2026-01-01"}}, min_calls=1)
+    signal = records[0].kwargs["temporal_signal"]
+    assert signal is not None and signal.category == TemporalCategory.EXPLICIT, (
+        f"date-key filter must synthesize EXPLICIT, got {getattr(signal, 'category', None)}"
+    )
+    assert signal.source == "api", f"EXPLICIT from a caller filter must be source='api', got {signal.source!r}"
+
+
+async def test_non_date_filter_does_not_synthesize_explicit(
+    kb: Khora, namespace_id: UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pure-metadata caller filter must NOT trigger EXPLICIT synthesis.
+
+    DIFFERENTIAL (avoids a vacuous negative): the SAME non-temporal query
+    ``"Falcon launch"`` is run twice against the SAME stack — once with a DATE
+    filter (positive control: MUST synthesize EXPLICIT) and once with a
+    non-date filter (MUST NOT). If the date-key gate were dead (always or never
+    EXPLICIT), one of the two halves fails. So a passing test proves the
+    EXPLICIT decision is driven by the date key, not an incidental constant.
+    """
+    await _seed(kb, namespace_id)
+    retriever = _retriever(kb)
+
+    # Positive control: a date-key filter on this exact query DOES go EXPLICIT.
+    pos_records = spy_on(monkeypatch, retriever, "retrieve")
+    await kb.recall("Falcon launch", namespace=namespace_id, limit=10, filter={"occurred_at": {"$gte": "2026-01-01"}})
+    pos_signal = pos_records[0].kwargs["temporal_signal"]
+    assert pos_signal is not None and pos_signal.category == TemporalCategory.EXPLICIT, (
+        "positive control failed: a date-key filter must synthesize EXPLICIT on this query, "
+        f"got {getattr(pos_signal, 'category', None)} — the gate is not firing, so the "
+        "negative half below would be vacuous."
+    )
+
+    # Negative case: same query, non-date filter -> must NOT go EXPLICIT.
+    neg_records = spy_on(monkeypatch, retriever, "retrieve")
+    await kb.recall("Falcon launch", namespace=namespace_id, limit=10, filter={"source_name": "linear"})
+    assert_filter_threaded(neg_records, {"source_name": "linear"}, min_calls=1)
+    neg_signal = neg_records[0].kwargs["temporal_signal"]
+    assert neg_signal is None or neg_signal.category != TemporalCategory.EXPLICIT, (
+        f"non-date filter must NOT synthesize EXPLICIT, got {getattr(neg_signal, 'category', None)}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Path 5 — restrictive-fallback guard, embedded fail-fast contract.
+#
+# The restrictive-filter unfiltered re-run (retriever.py:1479) only fires when a
+# point-in-time ``temporal_filter`` (occurred bounds) reached the retriever. The
+# embedded sqlite_lance backend lacks bi-temporal version columns, so it FAILS
+# FAST on any point-in-time temporal query *before* retrieval (retriever.py:601)
+# rather than silently returning current-state rows. That fail-fast makes the
+# re-run path itself unreachable embedded — so the re-run-guard enforcement
+# (filter_ast suppresses the unfiltered re-run) is proven on the PG+Neo4j stack
+# (qa-graph), where point-in-time is honored. Here we pin the embedded promise
+# the fail-fast actually makes: a point-in-time query raises cleanly and never
+# degrades into an unfiltered current-state recall.
+# --------------------------------------------------------------------------- #
+
+
+async def test_embedded_point_in_time_fails_fast(kb: Khora, namespace_id: UUID) -> None:
+    """A point-in-time temporal query raises NotImplementedError on embedded.
+
+    This is the embedded backstop behind path 5: the embedded stack cannot honor
+    occurred-bounds temporal queries, so it refuses them rather than returning
+    unfiltered current-state rows (which would silently violate any concurrent
+    recall filter). The clean raise is the contract; this guards it against a
+    regression that would let those queries through unfiltered.
+    """
+    await _seed(kb, namespace_id)
+
+    # "last week" resolves to an occurred-bounds temporal_filter -> point-in-time.
+    with pytest.raises(NotImplementedError, match="sqlite_lance"):
+        await kb.recall("Falcon launch last week", namespace=namespace_id, limit=10)

--- a/tests/integration/matrix/test_vectorcypher_sqlite_lance.py
+++ b/tests/integration/matrix/test_vectorcypher_sqlite_lance.py
@@ -402,7 +402,15 @@ async def test_vc_two_hop_traversal(kb: Khora, namespace_id: UUID) -> None:
 
 @pytest.mark.xfail(
     strict=True,
-    reason="VectorCypher embedded path doesn't push temporal filter to LanceDB query",
+    reason=(
+        "VectorCypher embedded path does not support point-in-time temporal recall: "
+        "an occurred-bounds temporal_filter (here from start_time) trips the "
+        "sqlite_lance fail-fast at retriever.py:601 (NotImplementedError), so the "
+        "recall raises before any LanceDB-level temporal narrowing. Verified by "
+        "running both ways (xfail kept: --runxfail FAILS with that NotImplementedError, "
+        "not a clean filtered result). Keep until the embedded backend honors "
+        "point-in-time temporal queries; this is the acceptance test for that work."
+    ),
 )
 async def test_vc_temporal_filter(kb: Khora, namespace_id: UUID) -> None:
     """Two docs at different ``occurred_at``; recall with ``last 7 days`` filter

--- a/tests/integration/test_filter_pushdown_graph.py
+++ b/tests/integration/test_filter_pushdown_graph.py
@@ -313,9 +313,9 @@ async def test_graph_overfetch_post_filter_threads_filter(
 @_SKIP
 @pytest.mark.asyncio
 async def test_session_fanout_threads_filter(kb: Khora, namespace_id: UUID, monkeypatch: pytest.MonkeyPatch) -> None:
-    """When entry entities span >= 2 sessions, every per-session search threads the filter.
+    """When entry entities span >= 2 channels, every per-channel search threads the filter.
 
-    Vacuity N is DYNAMIC: one ``_vector_search_chunks`` per fanned-out session +
+    Vacuity N is DYNAMIC: one ``_vector_search_chunks`` per fanned-out channel +
     one unscoped fallback. We assert ``>= 2`` (fan-out requires >= 2 channels)
     and that every capture matches — not a hardcoded exact count.
     """
@@ -323,19 +323,20 @@ async def test_session_fanout_threads_filter(kb: Khora, namespace_id: UUID, monk
         "Ada Lovelace",
         entities=[("Ada Lovelace", "PERSON")],
     )
-    # Two docs in TWO DISTINCT sessions naming the same entity, so the entry
-    # entity spans >= 2 sessions and the fan-out activates. seed_corpus does not
-    # thread session_id, so seed directly with remember(session_id=...) (#620).
-    from uuid import uuid4
-
-    for content in ("Ada Lovelace published her notes.", "Ada Lovelace presented again later."):
-        await kb.remember(
-            content=content,
-            namespace=namespace_id,
-            entity_types=["PERSON"],
-            relationship_types=[],
-            session_id=uuid4(),
-        )
+    # Two docs in TWO DISTINCT channels naming the same entity, so the entry
+    # entity is MENTIONED_IN chunks spanning >= 2 distinct ``c.channel`` values
+    # and the session-aware fan-out activates. ``get_entity_channels`` reads the
+    # Chunk ``channel`` column, which is derived from document ``metadata["channel"]``
+    # (engine.py: ``doc_metadata.get("channel")``) — NOT session_id — so the
+    # discriminator to seed is the channel, set via per-doc metadata.
+    await seed_corpus(
+        lambda **kw: kb.remember(entity_types=["PERSON"], relationship_types=[], **kw),
+        namespace_id,
+        [
+            {"content": "Ada Lovelace published her notes.", "metadata": {"channel": "chan-a"}},
+            {"content": "Ada Lovelace presented again later.", "metadata": {"channel": "chan-b"}},
+        ],
+    )
 
     retriever = _retriever(kb)
     await _assert_entry_entities_present(retriever, "Ada Lovelace", namespace_id)

--- a/tests/integration/test_filter_pushdown_graph.py
+++ b/tests/integration/test_filter_pushdown_graph.py
@@ -69,7 +69,6 @@ from khora import Khora
 from khora.config import KhoraConfig
 from khora.query import SearchMode
 from tests.test_helpers.filter_spy import (
-    EMBED_DIM,
     assert_filter_threaded,
     plan_extraction,
     seed_corpus,
@@ -78,6 +77,11 @@ from tests.test_helpers.filter_spy import (
 )
 
 pytestmark = [pytest.mark.integration, pytest.mark.filter_enforcement]
+
+# The Postgres pgvector column is fixed at 1536 (KhoraConfig rejects any other
+# dimension on the PG backend), so the live-DB suite sizes its deterministic
+# vectors at 1536 rather than the small embedded ``EMBED_DIM``.
+_PG_EMBED_DIM = 1536
 
 
 # --------------------------------------------------------------------------- #
@@ -111,7 +115,8 @@ _SKIP = pytest.mark.skipif(
 async def kb(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[Khora]:
     # Deterministic extractor + embedder so the same content seeds the same
     # entities + vectors as the embedded suite (shared via filter_spy.stub_llm).
-    stub_llm(monkeypatch)
+    # Sized at 1536 because the Postgres pgvector column requires it.
+    stub_llm(monkeypatch, dim=_PG_EMBED_DIM)
 
     database_url = os.environ.get(
         "KHORA_DATABASE_URL",
@@ -121,8 +126,8 @@ async def kb(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[Khora]:
     config = KhoraConfig(database_url=database_url, neo4j_url=neo4j_url)
     config.storage.neo4j_user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
     config.storage.neo4j_password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
-    config.llm.embedding_dimension = EMBED_DIM
-    config.storage.embedding_dimension = EMBED_DIM
+    config.llm.embedding_dimension = _PG_EMBED_DIM
+    config.storage.embedding_dimension = _PG_EMBED_DIM
     config.pipeline.extract_entities = True
     config.pipeline.selective_extraction = False
 

--- a/tests/integration/test_filter_pushdown_graph.py
+++ b/tests/integration/test_filter_pushdown_graph.py
@@ -1,0 +1,484 @@
+"""Filter-pushdown spies — VectorCypher paths that need the live graph stack.
+
+White-box spies proving the recall filter reaches every graph-side channel
+UNCHANGED (same ``canonical_hash`` at each pushdown boundary). These paths only
+fire on the full PG+Neo4j VectorCypher config. Two reasons they cannot run on the
+embedded ``sqlite_lance`` stack: (a) session fan-out and CHANGE version-history are
+Neo4j-gated (``_dual_nodes`` / ``_neo4j_driver`` are ``None`` there); and (b) on the
+embedded stack with the deterministic test embedder, entity-vector similarity falls
+below the entity-similarity floor (``min_entity_similarity=0.3``), so entry-entity
+search returns 0 and every graph path short-circuits to ``_simple_retrieve`` before
+its channel can fire. The live stack lowers the floor in the fixture so real
+entry entities surface (see ``_retriever``). The embedded counterparts (vector /
+BM25 / recency / restrictive-fallback / EXPLICIT synthesis) live in the no-Docker
+module owned by qa-embedded.
+
+Paths covered here:
+
+* (3) Cypher channel — the caller filter is compiled to a ``c.<key>`` predicate
+  via ``compile_cypher`` at the graph chunk-fetch boundary.
+* (4) session fan-out — when entry entities span >= 2 sessions, the per-session
+  ``_vector_search_chunks`` calls + the unscoped fallback each carry the filter.
+* (5) restrictive-fallback re-run guard — under a caller filter, the unfiltered
+  re-run that normally fires on sparse temporal results is SUPPRESSED (it drops
+  the filter); reachable only on PG (embedded fails fast on point-in-time).
+* (7) CHANGE decomposition — a CHANGE query with version history runs a second
+  ``_vector_search_chunks`` over the decomposed current-state sub-query, which
+  carries the filter.
+* (8) graph over-fetch + metadata post-filter — a residual (metadata) predicate
+  widens the graph fetch and is applied as an in-memory post-filter; the filter
+  threads to ``_fetch_chunks_from_entities``.
+
+Spy contract (shared with the embedded suite via ``tests.test_helpers.filter_spy``):
+``len(captures) >= N`` vacuity guard + every capture's ``canonical_hash`` equals
+the facade-built expected hash. NEVER an exact count — several channels compile
+the same filter at more than one site (``compile_cypher`` fires from both the
+over-fetch probe and ``dual_nodes`` chunk fetch; ``compile_python`` from both the
+graph and recency post-filters), so an exact-count assertion is a vacuity trap.
+Each ``>= N`` spy is paired with a CONTROL recall under the inverse condition
+(no filter, or a mode that skips the channel) proving the spied call COULD fire
+but did NOT — so the positive assertion cannot pass vacuously. NO result/ranking
+inspection.
+
+Self-skip: the whole module is gated on ``NEO4J_INTEGRATION_TEST`` + Postgres
+reachability, so a no-Docker ``make test`` collects-and-skips it cleanly. Run it
+with THIS repo's live stack — note ``make dev`` exposes Neo4j Bolt on 7688 and
+Postgres on 5434 with the Neo4j password ``pleaseletmein`` (see ``compose.yaml``),
+so the env overrides below are required (the defaults match the CI service ports
+7687 / ``password``, not the local ``make dev`` ports)::
+
+    make dev
+    NEO4J_INTEGRATION_TEST=1 KHORA_PG_REQUIRED=1 \\
+        KHORA_DATABASE_URL=postgresql+asyncpg://khora:khora@localhost:5434/khora \\
+        KHORA_NEO4J_URL=bolt://localhost:7688 \\
+        KHORA_NEO4J_PASSWORD=pleaseletmein \\
+        uv run pytest tests/integration/test_filter_pushdown_graph.py
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from collections.abc import AsyncIterator
+from urllib.parse import urlparse
+from uuid import UUID
+
+import pytest
+
+from khora import Khora
+from khora.config import KhoraConfig
+from khora.query import SearchMode
+from tests.test_helpers.filter_spy import (
+    EMBED_DIM,
+    assert_filter_threaded,
+    plan_extraction,
+    seed_corpus,
+    spy_on,
+    stub_llm,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.filter_enforcement]
+
+
+# --------------------------------------------------------------------------- #
+# Self-skip guards — mirror the existing tests/integration skip pattern so the
+# default no-Docker run collects-and-skips cleanly.
+# --------------------------------------------------------------------------- #
+
+
+def _pg_reachable() -> bool:
+    url = os.environ.get("KHORA_DATABASE_URL", "postgresql://khora:khora@localhost:5434/khora")
+    parsed = urlparse(url.replace("+asyncpg", ""))
+    try:
+        with socket.create_connection((parsed.hostname or "localhost", parsed.port or 5432), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+_SKIP = pytest.mark.skipif(
+    not os.environ.get("NEO4J_INTEGRATION_TEST") or not _pg_reachable(),
+    reason="set NEO4J_INTEGRATION_TEST=1 and run `make dev` (PG+Neo4j) to exercise the graph-side filter spies",
+)
+
+
+# --------------------------------------------------------------------------- #
+# Live PG+Neo4j kb fixture (mirrors tests/integration/test_*_integration.py).
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+async def kb(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[Khora]:
+    # Deterministic extractor + embedder so the same content seeds the same
+    # entities + vectors as the embedded suite (shared via filter_spy.stub_llm).
+    stub_llm(monkeypatch)
+
+    database_url = os.environ.get(
+        "KHORA_DATABASE_URL",
+        "postgresql+asyncpg://khora:khora@localhost:5434/khora",
+    )
+    neo4j_url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+    config = KhoraConfig(database_url=database_url, neo4j_url=neo4j_url)
+    config.storage.neo4j_user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+    config.storage.neo4j_password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+    config.llm.embedding_dimension = EMBED_DIM
+    config.storage.embedding_dimension = EMBED_DIM
+    config.pipeline.extract_entities = True
+    config.pipeline.selective_extraction = False
+
+    instance = Khora(config, run_migrations=False)
+    await instance.connect()
+    try:
+        yield instance
+    finally:
+        await instance.disconnect()
+
+
+@pytest.fixture
+async def namespace_id(kb: Khora) -> UUID:
+    ns = await kb.create_namespace()
+    return ns.namespace_id
+
+
+def _retriever(kb: Khora):
+    """Reach the live VectorCypher retriever the engine drives, floor lowered.
+
+    The shared seed uses a deterministic HASH embedder (``fake_embedding``): its
+    vectors carry no semantic meaning, so a query↔entity cosine similarity sits
+    well below the default ``min_entity_similarity=0.3`` floor (retriever.py:270)
+    and ``_vector_search_entities`` would return 0 entry entities — short-circuiting
+    every graph path to ``_simple_retrieve`` and making these spies pass vacuously.
+    Lowering the floor to 0.0 lets the deterministic-embedder entities clear it so
+    ``entry_entities > 0`` on the live pgvector stack. This is a test-fixture knob,
+    not a product change.
+    """
+    retriever = kb._engine._retriever  # type: ignore[union-attr,attr-defined]
+    retriever._config.min_entity_similarity = 0.0
+    return retriever
+
+
+async def _assert_entry_entities_present(retriever, query: str, namespace_id: UUID) -> None:
+    """Sanity gate: prove the seed yields entry entities on the live stack.
+
+    Every graph path lives PAST the ``if not entry_entities: return
+    _simple_retrieve(...)`` early-exit in ``_vectorcypher_retrieve`` (retriever.py:1149).
+    If entity vector search returns 0, the recall short-circuits and the graph
+    spies pass VACUOUSLY. Asserting > 0 here (with the floor lowered) closes that
+    hole before any channel assertion.
+    """
+    embedding = await retriever._embedder.embed(query)
+    entry = await retriever._vector_search_entities(embedding, namespace_id, limit=10)
+    assert entry, (
+        "entry_entities == 0 on the live stack even with min_entity_similarity=0.0 — "
+        "the seed did not surface; graph spies would pass vacuously. Escalate (seed problem)."
+    )
+
+
+# Filters: a pushable system-key leaf (consumed by compile_cypher → path 3) and a
+# residual metadata SUB-PATH leaf (unpushable to Cypher → over-fetch + in-memory
+# post-filter → path 8). The dotted form yields path ('metadata', 'tier') — a
+# genuine sub-path the Cypher compiler defers, vs whole-blob ('metadata',) equality.
+_SYSTEM_FILTER = {"source_type": {"$eq": "slack"}}
+_METADATA_FILTER = {"metadata.tier": {"$eq": "gold"}}
+
+
+# --------------------------------------------------------------------------- #
+# (3) Cypher channel — caller filter reaches compile_cypher unchanged.
+# --------------------------------------------------------------------------- #
+
+
+@_SKIP
+@pytest.mark.asyncio
+async def test_cypher_channel_threads_filter(kb: Khora, namespace_id: UUID, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A pushable system-key filter reaches ``compile_cypher`` with its hash intact.
+
+    ``compile_cypher`` fires from BOTH the over-fetch probe and the dual_nodes
+    chunk fetch, so we assert ``>= 1`` and that EVERY capture matches — never an
+    exact count.
+    """
+    plan_extraction(
+        "Ada Lovelace",
+        entities=[("Ada Lovelace", "PERSON"), ("Analytical Engine", "CONCEPT")],
+        relationships=[("Ada Lovelace", "Analytical Engine", "WORKED_ON")],
+    )
+    await seed_corpus(
+        lambda **kw: kb.remember(entity_types=["PERSON", "CONCEPT"], relationship_types=["WORKED_ON"], **kw),
+        namespace_id,
+        ["Ada Lovelace wrote the first algorithm for the Analytical Engine."],
+    )
+
+    retriever = _retriever(kb)
+    await _assert_entry_entities_present(retriever, "Ada Lovelace", namespace_id)
+
+    # compile_cypher is a SYNC module-level function imported function-locally in
+    # both call sites; spy the SOURCE module so both sites are captured.
+    import khora.filter.compilers.cypher as cypher_mod
+
+    captures = spy_on(monkeypatch, cypher_mod, "compile_cypher")
+
+    await kb.recall("Ada Lovelace", namespace=namespace_id, filter=_SYSTEM_FILTER)
+    assert_filter_threaded(captures, _SYSTEM_FILTER, min_calls=1)
+
+    # CONTROL: a no-filter recall must NOT compile any filter at this boundary —
+    # proves the spied call is driven by the caller filter, not always-on.
+    control = spy_on(monkeypatch, cypher_mod, "compile_cypher")
+    await kb.recall("Ada Lovelace", namespace=namespace_id)
+    assert control == [], "control: compile_cypher must not run with no caller filter"
+
+
+# --------------------------------------------------------------------------- #
+# (8) graph over-fetch + metadata post-filter.
+# --------------------------------------------------------------------------- #
+
+
+@_SKIP
+@pytest.mark.asyncio
+async def test_graph_overfetch_post_filter_threads_filter(
+    kb: Khora, namespace_id: UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A residual metadata filter widens the graph fetch and threads to the post-filter.
+
+    The metadata predicate cannot push to Cypher, so the engine over-fetches and
+    applies an in-memory ``compile_python`` post-filter. We assert the filter
+    reaches ``_fetch_chunks_from_entities`` (graph fetch) unchanged; ``>= 1`` +
+    all-match (compile_python also fires from the recency post-filter site).
+    """
+    import khora.filter.compilers.cypher as cypher_mod
+    import khora.filter.compilers.python as python_mod
+
+    plan_extraction(
+        "Ada Lovelace",
+        entities=[("Ada Lovelace", "PERSON"), ("Analytical Engine", "CONCEPT")],
+        relationships=[("Ada Lovelace", "Analytical Engine", "WORKED_ON")],
+    )
+    # The seeded chunk CARRIES metadata {"tier": "gold"} so the residual metadata
+    # predicate post-filters something real and graph_chunks are non-empty.
+    await seed_corpus(
+        lambda **kw: kb.remember(entity_types=["PERSON", "CONCEPT"], relationship_types=["WORKED_ON"], **kw),
+        namespace_id,
+        [
+            {
+                "content": "Ada Lovelace wrote the first algorithm for the Analytical Engine.",
+                "metadata": {"tier": "gold"},
+            }
+        ],
+    )
+
+    retriever = _retriever(kb)
+    await _assert_entry_entities_present(retriever, "Ada Lovelace", namespace_id)
+
+    # 8a: the over-fetch residual probe + dual_nodes fetch both compile the filter
+    # to Cypher; 8b: the in-memory post-filter compiles it to Python. Both must
+    # receive the UNCHANGED full AST. Spy the graph fetch (filter threading) AND
+    # the compile_python post-filter (the metadata backstop).
+    fetch_caps = spy_on(monkeypatch, retriever, "_fetch_chunks_from_entities")
+    cypher_caps = spy_on(monkeypatch, cypher_mod, "compile_cypher")
+    python_caps = spy_on(monkeypatch, python_mod, "compile_python")
+
+    await kb.recall("Ada Lovelace", namespace=namespace_id, filter=_METADATA_FILTER)
+
+    # The graph fetch carries the filter; the Cypher probe + Python post-filter
+    # both receive the same unchanged AST. ``>= 1`` + ALL-match (each compiler
+    # also fires at a second site — path-3 cypher fetch / recency post-filter —
+    # so an exact count is a vacuity trap).
+    assert_filter_threaded(fetch_caps, _METADATA_FILTER, min_calls=1)
+    assert_filter_threaded(cypher_caps, _METADATA_FILTER, min_calls=1)
+    assert_filter_threaded(python_caps, _METADATA_FILTER, min_calls=1)
+
+    # CONTROL: no-filter recall — the graph fetch still runs, but with no
+    # filter_ast, so a capture with no FilterNode proves the spy observes the
+    # boundary and the positive case is driven by the caller filter.
+    control = spy_on(monkeypatch, retriever, "_fetch_chunks_from_entities")
+    await kb.recall("Ada Lovelace", namespace=namespace_id)
+    assert control, "control precondition: the graph fetch must run on a no-filter recall too"
+    assert all(c.canonical_hash is None for c in control), "control: no-filter recall must carry no filter_ast"
+
+
+# --------------------------------------------------------------------------- #
+# (4) session fan-out — per-session searches each carry the filter.
+# --------------------------------------------------------------------------- #
+
+
+@_SKIP
+@pytest.mark.asyncio
+async def test_session_fanout_threads_filter(kb: Khora, namespace_id: UUID, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When entry entities span >= 2 sessions, every per-session search threads the filter.
+
+    Vacuity N is DYNAMIC: one ``_vector_search_chunks`` per fanned-out session +
+    one unscoped fallback. We assert ``>= 2`` (fan-out requires >= 2 channels)
+    and that every capture matches — not a hardcoded exact count.
+    """
+    plan_extraction(
+        "Ada Lovelace",
+        entities=[("Ada Lovelace", "PERSON")],
+    )
+    # Two docs in TWO DISTINCT sessions naming the same entity, so the entry
+    # entity spans >= 2 sessions and the fan-out activates. seed_corpus does not
+    # thread session_id, so seed directly with remember(session_id=...) (#620).
+    from uuid import uuid4
+
+    for content in ("Ada Lovelace published her notes.", "Ada Lovelace presented again later."):
+        await kb.remember(
+            content=content,
+            namespace=namespace_id,
+            entity_types=["PERSON"],
+            relationship_types=[],
+            session_id=uuid4(),
+        )
+
+    retriever = _retriever(kb)
+    await _assert_entry_entities_present(retriever, "Ada Lovelace", namespace_id)
+    captures = spy_on(monkeypatch, retriever, "_vector_search_chunks")
+
+    # A temporal query is required for session-aware fan-out to engage.
+    await kb.recall("what did Ada Lovelace do recently", namespace=namespace_id, filter=_SYSTEM_FILTER)
+    assert_filter_threaded(captures, _SYSTEM_FILTER, min_calls=2)
+
+    # CONTROL: mode=VECTOR skips the graph entry-entity path that drives fan-out,
+    # so the per-session fan-out does not engage — proves the >= 2 above is the
+    # fan-out firing, not an unconditional channel.
+    control = spy_on(monkeypatch, retriever, "_vector_search_chunks")
+    await kb.recall(
+        "what did Ada Lovelace do recently",
+        namespace=namespace_id,
+        filter=_SYSTEM_FILTER,
+        mode=SearchMode.VECTOR,
+    )
+    assert len(control) < 2, "control: mode=VECTOR must not fan out per-session searches"
+
+
+# --------------------------------------------------------------------------- #
+# (7) CHANGE decomposition — the current-state sub-query carries the filter.
+# --------------------------------------------------------------------------- #
+
+
+@_SKIP
+@pytest.mark.asyncio
+async def test_change_decomposition_threads_filter(
+    kb: Khora, namespace_id: UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A CHANGE query with version history runs a 2nd vector search that carries the filter.
+
+    SUPERSEDES version history is written automatically by ``upsert_entities_batch``
+    when an existing entity's attributes change across ingests: two ``remember()``
+    calls naming the SAME entity with a CHANGED description close the old version
+    (``version_valid_to``) and create the ``[:SUPERSEDES]`` edge, so
+    ``_fetch_version_history`` returns rows. With a CHANGE-classified query, the
+    decomposition fires a 2nd ``_vector_search_chunks`` for the current-state
+    sub-query — so N >= 2 (original + decomposed), every capture matching.
+    """
+
+    # Same entity, CHANGED attrs across two ingests → SUPERSEDES edge in Neo4j.
+    def rem(**kw):
+        return kb.remember(entity_types=["ORG"], relationship_types=[], **kw)
+
+    plan_extraction("Acme Corp", entities=[("Acme Corp", "ORG")])
+    await seed_corpus(rem, namespace_id, ["Acme Corp is a hardware company."])
+    plan_extraction("Acme Corp", entities=[("Acme Corp", "ORG")])
+    await seed_corpus(rem, namespace_id, ["Acme Corp is now a cloud software company."])
+
+    retriever = _retriever(kb)
+    await _assert_entry_entities_present(retriever, "Acme Corp", namespace_id)
+
+    # Sanity: the SUPERSEDES seed must produce version history, else the CHANGE
+    # decomposition never fires and the >= 2 assertion is vacuous.
+    entry = await retriever._vector_search_entities(
+        await retriever._embedder.embed("Acme Corp"), namespace_id, limit=10
+    )
+    version_history = await retriever._fetch_version_history([e[0] for e in entry], namespace_id)
+    assert version_history, "SUPERSEDES seed produced no version history — CHANGE decomp would not fire"
+
+    captures = spy_on(monkeypatch, retriever, "_vector_search_chunks")
+    # "how has Acme Corp changed" → CHANGE category; _decompose_change_query
+    # rewrites it, triggering the second vector search.
+    await kb.recall("how has Acme Corp changed", namespace=namespace_id, filter=_SYSTEM_FILTER)
+    assert_filter_threaded(captures, _SYSTEM_FILTER, min_calls=2)
+
+    # CONTROL: a non-CHANGE query must not run the decomposition sub-search, so
+    # the capture count is strictly lower — proves the extra sub-search above is
+    # the CHANGE decomposition, not the always-on primary vector channel.
+    control = spy_on(monkeypatch, retriever, "_vector_search_chunks")
+    await kb.recall("who is Acme Corp", namespace=namespace_id, filter=_SYSTEM_FILTER)
+    assert len(control) < len(captures), "control: non-CHANGE query must not add a decomposition sub-search"
+
+
+# --------------------------------------------------------------------------- #
+# (5) restrictive-fallback re-run guard — SUPPRESSED under a caller filter.
+# --------------------------------------------------------------------------- #
+
+
+def _is_unfiltered_rerun(record: object) -> bool:
+    """Whether a ``_vector_search_chunks`` capture is the unfiltered re-run.
+
+    The restrictive-fallback re-run is the only ``_vector_search_chunks`` call
+    issued with BOTH ``temporal_filter=None`` AND no ``filter_ast`` — it drops
+    both, which is precisely why it must not fire under a caller filter (it would
+    smuggle filter-violating chunks into RRF). The primary vector channel always
+    carries the caller filter, so this predicate isolates the re-run.
+    """
+    kwargs = record.kwargs  # type: ignore[attr-defined]
+    return kwargs.get("temporal_filter") is None and record.canonical_hash is None  # type: ignore[attr-defined]
+
+
+@_SKIP
+@pytest.mark.asyncio
+async def test_restrictive_fallback_rerun_suppressed_under_filter(
+    kb: Khora, namespace_id: UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A caller filter SUPPRESSES the unfiltered restrictive-fallback re-run.
+
+    When a temporal filter yields sparse results, the engine normally re-runs the
+    vector channel WITHOUT the temporal filter (and without ``filter_ast``). That
+    re-run is gated ``and filter_ast is None`` (retriever ``_vectorcypher_retrieve``):
+    under a caller filter it must NOT fire, because re-searching unfiltered would
+    leak filter-violating chunks. This is a NEGATIVE (suppression) assertion, so
+    it is paired with a DIFFERENTIAL control proving the re-run IS reachable when
+    no caller filter is present — otherwise "no re-run fired" is vacuously true.
+
+    PG-specific: the embedded sqlite_lance stack fails fast on point-in-time
+    queries, so the re-run path is only reachable on the live PG+Neo4j stack —
+    which is why this spy lives here, not in the embedded suite.
+
+    IMPORTANT — arming the fallback. The re-run is gated on a populated
+    ``temporal_filter`` (retriever ``_vectorcypher_retrieve``). The public
+    ``filter=`` kwarg does NOT populate ``temporal_filter`` — a date predicate
+    there stays in ``filter_ast`` and leaves ``temporal_filter`` None (see
+    ``khora.recall``), so the fallback never arms. The engine populates
+    ``temporal_filter`` by SYNTHESIS from a RECENCY signal. So the trigger is a
+    recency QUERY (``"... recently"``), not a date filter; the seed is a single
+    old chunk so the synthesized recency window is sparse. The caller filter
+    (the thing whose presence must suppress the re-run) comes from ``filter=``,
+    which is orthogonal to the synthesized ``temporal_filter`` — both can be set,
+    unlike ``filter=`` vs the deprecated ``start_time/end_time`` (mutually
+    exclusive).
+    """
+    plan_extraction("Ada Lovelace", entities=[("Ada Lovelace", "PERSON")])
+    # One OLD chunk: a synthesized recency window then has < limit//2 in range,
+    # arming the restrictive-fallback.
+    await seed_corpus(
+        lambda **kw: kb.remember(entity_types=["PERSON"], relationship_types=[], **kw),
+        namespace_id,
+        ["Ada Lovelace published her notes long ago."],
+    )
+
+    retriever = _retriever(kb)
+    await _assert_entry_entities_present(retriever, "Ada Lovelace", namespace_id)
+
+    # POSITIVE: a recency query SYNTHESIZES temporal_filter; with a caller filter
+    # present, the unfiltered re-run must be SUPPRESSED (gate `filter_ast is None`).
+    captures = spy_on(monkeypatch, retriever, "_vector_search_chunks")
+    await kb.recall("what did Ada Lovelace do recently", namespace=namespace_id, filter=_SYSTEM_FILTER)
+    assert not any(_is_unfiltered_rerun(c) for c in captures), (
+        "restrictive-fallback re-run fired under a caller filter — it drops the "
+        "filter and would leak filter-violating chunks (gate is `filter_ast is None`)"
+    )
+
+    # CONTROL: same recency query, NO caller filter → the re-run IS reachable, so
+    # at least one unfiltered re-run capture appears. This proves the positive
+    # assertion above is the guard working, not the path being dead.
+    control = spy_on(monkeypatch, retriever, "_vector_search_chunks")
+    await kb.recall("what did Ada Lovelace do recently", namespace=namespace_id)
+    assert any(_is_unfiltered_rerun(c) for c in control), (
+        "control: with no caller filter, the restrictive-fallback re-run MUST be "
+        "reachable on the live PG stack — else the suppression test is vacuous"
+    )

--- a/tests/integration/test_filter_pushdown_graph.py
+++ b/tests/integration/test_filter_pushdown_graph.py
@@ -170,9 +170,15 @@ async def _assert_entry_entities_present(retriever, query: str, namespace_id: UU
     If entity vector search returns 0, the recall short-circuits and the graph
     spies pass VACUOUSLY. Asserting > 0 here (with the floor lowered) closes that
     hole before any channel assertion.
+
+    ``recall()`` resolves the public namespace_id to the active row-level id
+    before searching entity vectors (entities are keyed by the row id), so we
+    resolve here too — passing the public id straight to
+    ``_vector_search_entities`` matches nothing and fails this gate spuriously.
     """
+    resolved = await retriever._storage.resolve_namespace(namespace_id)
     embedding = await retriever._embedder.embed(query)
-    entry = await retriever._vector_search_entities(embedding, namespace_id, limit=10)
+    entry = await retriever._vector_search_entities(embedding, resolved, limit=10)
     assert entry, (
         "entry_entities == 0 on the live stack even with min_entity_similarity=0.0 — "
         "the seed did not surface; graph spies would pass vacuously. Escalate (seed problem)."
@@ -386,11 +392,11 @@ async def test_change_decomposition_threads_filter(
     await _assert_entry_entities_present(retriever, "Acme Corp", namespace_id)
 
     # Sanity: the SUPERSEDES seed must produce version history, else the CHANGE
-    # decomposition never fires and the >= 2 assertion is vacuous.
-    entry = await retriever._vector_search_entities(
-        await retriever._embedder.embed("Acme Corp"), namespace_id, limit=10
-    )
-    version_history = await retriever._fetch_version_history([e[0] for e in entry], namespace_id)
+    # decomposition never fires and the >= 2 assertion is vacuous. Resolve the
+    # public namespace_id to the row id (entities/version history are keyed by it).
+    resolved = await retriever._storage.resolve_namespace(namespace_id)
+    entry = await retriever._vector_search_entities(await retriever._embedder.embed("Acme Corp"), resolved, limit=10)
+    version_history = await retriever._fetch_version_history([e[0] for e in entry], resolved)
     assert version_history, "SUPERSEDES seed produced no version history — CHANGE decomp would not fire"
 
     captures = spy_on(monkeypatch, retriever, "_vector_search_chunks")

--- a/tests/recall/test_canonical_hash_stability.py
+++ b/tests/recall/test_canonical_hash_stability.py
@@ -1,0 +1,111 @@
+"""Stability contract for the recall-filter canonical hash.
+
+The filter-pushdown spies prove a path threaded the filter by comparing
+``canonical_hash`` of the captured ``filter_ast`` against the hash of an
+expected AST rebuilt from the public filter document. That comparison is
+only sound if the hash is STABLE under semantically-irrelevant variation
+and SENSITIVE to semantically-relevant variation. This module pins both
+directions so a regression in ``canonical_hash`` (which would silently
+weaken or break every spy) is caught here first.
+
+No database, no I/O — pure AST hashing. Mirrors the equality/inequality
+families ``canonical_hash`` documents (``src/khora/filter/ast.py``):
+
+* commutative ``$and`` / ``$or`` siblings sort -> reorder is invisible,
+* dict-operand keys sort -> object key-order is invisible,
+* ``$in`` / ``$nin`` list order is significant -> reorder is visible,
+* a different op / path / operand hashes differently.
+
+It also covers the shared helper's :func:`expected_hash` oracle, since
+that is the exact function the spies trust.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from khora.filter import RecallFilter, canonical_hash, parse_to_ast
+from tests.test_helpers.filter_spy import expected_hash
+
+pytestmark = [pytest.mark.unit, pytest.mark.filter_enforcement]
+
+
+def _h(doc: dict) -> str:
+    """Hash a public filter document the way the facade does."""
+    return canonical_hash(parse_to_ast(RecallFilter.model_validate(doc)))
+
+
+# --------------------------------------------------------------------------- #
+# Stable: semantically-equal constructions hash equally.
+# --------------------------------------------------------------------------- #
+
+
+def test_and_sibling_reorder_same_hash() -> None:
+    """Reordering top-level ($and) predicates does not change the hash."""
+    a = _h({"source_name": "linear", "occurred_at": {"$gte": "2026-04-05"}})
+    b = _h({"occurred_at": {"$gte": "2026-04-05"}, "source_name": "linear"})
+    assert a == b
+
+
+def test_or_sibling_reorder_same_hash() -> None:
+    """Reordering $or branches does not change the hash (commutative)."""
+    a = _h({"$or": [{"source_name": "linear"}, {"source_name": "slack"}]})
+    b = _h({"$or": [{"source_name": "slack"}, {"source_name": "linear"}]})
+    assert a == b
+
+
+def test_dict_operand_key_reorder_same_hash() -> None:
+    """Whole-object equality operands sort keys: key-order is invisible."""
+    a = _h({"metadata": {"$eq": {"a": 1, "b": 2}}})
+    b = _h({"metadata": {"$eq": {"b": 2, "a": 1}}})
+    assert a == b
+
+
+def test_recallfilter_instance_and_dict_agree() -> None:
+    """A RecallFilter instance and the equivalent dict hash identically.
+
+    The facade uses the instance as-is but validates a dict via
+    ``model_validate``; both must land on the same AST and hash.
+    """
+    doc = {"source_name": "linear", "occurred_at": {"$gte": "2026-04-05"}}
+    from_dict = expected_hash(doc)
+    from_instance = expected_hash(RecallFilter.model_validate(doc))
+    assert from_dict == from_instance
+
+
+def test_expected_hash_matches_facade_construction() -> None:
+    """The helper oracle equals the literal facade build sequence."""
+    doc = {"source_name": {"$in": ["linear", "slack"]}}
+    assert expected_hash(doc) == _h(doc)
+
+
+# --------------------------------------------------------------------------- #
+# Sensitive: different semantics hash differently.
+# --------------------------------------------------------------------------- #
+
+
+def test_different_value_differs() -> None:
+    assert _h({"source_name": "linear"}) != _h({"source_name": "slack"})
+
+
+def test_different_operator_differs() -> None:
+    assert _h({"occurred_at": {"$gte": "2026-04-05"}}) != _h({"occurred_at": {"$gt": "2026-04-05"}})
+
+
+def test_different_path_differs() -> None:
+    assert _h({"source_name": "linear"}) != _h({"source_type": "linear"})
+
+
+def test_in_list_order_is_significant() -> None:
+    """$in membership lists are order-significant: reorder MUST differ.
+
+    This is the one case that is intentionally NOT commutative — guards
+    against a future "sort everything" change that would over-normalise.
+    """
+    assert _h({"source_name": {"$in": ["a", "b"]}}) != _h({"source_name": {"$in": ["b", "a"]}})
+
+
+def test_and_vs_or_differs() -> None:
+    """Same leaves under $and vs $or are different semantics, different hash."""
+    leaves = [{"source_name": "linear"}, {"source_type": "ticket"}]
+    assert _h({"$and": leaves}) != _h({"$or": leaves})

--- a/tests/recall/test_filter_enforcement_audit_gate.py
+++ b/tests/recall/test_filter_enforcement_audit_gate.py
@@ -1,0 +1,234 @@
+"""Audit gate: every VectorCypher channel call must carry the recall filter.
+
+The filter-enforcement feature (#1051) threads the caller ``filter_ast``
+through every adaptive sub-search so no channel silently drops or mis-applies
+it. This meta-test is the structural backstop for that contract: it statically
+walks ``src/khora/engines/vectorcypher`` and asserts that every CALL to a
+filter-aware channel method passes ``filter_ast=``. Any call that omits it is a
+site where a filter-violating chunk could reach RRF fusion — so the omission set
+must equal a small, explicitly-justified allowlist. A NEW unguarded call fails
+this gate until it is either fixed (thread the filter) or consciously added to
+the allowlist with a reason.
+
+Modelled on the ``SYSTEM_KEYS`` coverage meta-test in
+``src/khora/filter/conformance.py``: enumerate the surface from source, diff
+against a declared set, fail on drift. No database, no imports of the engine —
+pure ``ast`` over the source files, so it runs in the main ``test`` job with no
+infrastructure.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.filter_enforcement]
+
+# The retriever module is the surface the filter is threaded through.
+_RETRIEVER = Path(__file__).resolve().parents[2] / "src" / "khora" / "engines" / "vectorcypher" / "retriever.py"
+
+# Channel / sub-search methods that ACCEPT a ``filter_ast`` parameter. Every
+# call to one of these is expected to pass ``filter_ast=`` — that is the
+# thread-through contract. Derived from "every method in retriever.py whose
+# signature declares a filter_ast parameter" (see test_param_set_is_current).
+_FILTER_AWARE_METHODS = frozenset(
+    {
+        "retrieve",
+        "_typed_entity_recent_retrieve",
+        "_vectorcypher_retrieve",
+        "_simple_retrieve",
+        "_fetch_chunks_from_entities",
+        "_vector_search_chunks",
+        "_recency_channel_chunks",
+        "_bm25_search_chunks",
+    }
+)
+
+# Calls that deliberately OMIT ``filter_ast`` — each MUST carry a justification
+# below. Keyed by the call's line number is brittle across edits, so we key by
+# (called_method, enclosing_function) which is stable under line drift.
+#
+# (method_called, enclosing_function): reason
+_ALLOWLISTED_OMISSIONS: dict[tuple[str, str], str] = {
+    (
+        "_vector_search_chunks",
+        "_vectorcypher_retrieve",
+    ): (
+        "Restrictive-filter unfiltered re-run: re-searches with temporal_filter=None "
+        "and intentionally drops the caller filter. GUARDED by an explicit `filter_ast "
+        "is None` precondition on the enclosing `if`, so it is unreachable whenever a "
+        "caller filter is present — it cannot smuggle filter-violating chunks into RRF. "
+        "Covered behaviorally by the PG restrictive-fallback spy (qa-graph) and the "
+        "embedded point-in-time fail-fast test."
+    ),
+    (
+        "_simple_retrieve",
+        "_vector_only_fallback",
+    ): (
+        "KNOWN GAP (reported to team-lead): the Neo4j-transient graph-failure "
+        "degradation path calls _simple_retrieve without threading filter_ast, so a "
+        "filtered recall that hits a transient graph error degrades to vector-only "
+        "WITHOUT the filter. Reachable only on the PG+Neo4j stack (embedded has no "
+        "Neo4j to fail). Allowlisted so the gate stays green while the gap is "
+        "triaged; REMOVE this entry once _vector_only_fallback forwards filter_ast."
+    ),
+}
+
+# Storage-layer boundaries that RECEIVE filter_ast (the retriever threads it
+# correctly — wiring verified by the spies) but do NOT compile/enforce it yet.
+# These are NOT retriever call-site omissions, so they live here as tracked
+# "wiring-done, enforcement-pending" boundaries rather than in the omission
+# allowlist. Pillar-2 (the filter REACHES the channel) is satisfied; Pillar-4
+# (the channel ENFORCES it) is tracked for follow-up. Each is keyed by
+# "module::method" with a reason.
+_ENFORCEMENT_PENDING_BOUNDARIES: dict[str, str] = {
+    "khora.engines.skeleton.backends.sqlite_lance::search_fulltext": (
+        "Embedded SQLiteLanceTemporalStore.search_fulltext accepts filter_ast for "
+        "protocol parity but does not compile it yet — the BM25 channel is wiring-only "
+        "on the embedded stack. The retriever DOES thread the correct filter to it "
+        "(verified by the embedded path-2 spy + its strict-xfail enforcement probe); "
+        "enforcement is tracked for a follow-up engine ticket. The pgvector sibling "
+        "already enforces. REMOVE once embedded search_fulltext compiles filter_ast."
+    ),
+}
+
+
+def _retriever_tree() -> ast.Module:
+    return ast.parse(_RETRIEVER.read_text())
+
+
+def _enclosing_function(tree: ast.Module, target: ast.Call) -> str | None:
+    """Return the name of the function lexically enclosing ``target``."""
+    best: str | None = None
+    best_lineno = -1
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+            if node.lineno <= target.lineno <= (node.end_lineno or node.lineno):
+                if node.lineno > best_lineno:
+                    best, best_lineno = node.name, node.lineno
+    return best
+
+
+def _channel_calls(tree: ast.Module) -> list[tuple[ast.Call, str, str | None]]:
+    """Every ``self.<filter_aware_method>(...)`` call with its enclosing func."""
+    out: list[tuple[ast.Call, str, str | None]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            method = node.func.attr
+            if method in _FILTER_AWARE_METHODS:
+                out.append((node, method, _enclosing_function(tree, node)))
+    return out
+
+
+def test_param_set_is_current() -> None:
+    """The declared filter-aware method set matches the source signatures.
+
+    Keeps ``_FILTER_AWARE_METHODS`` honest: if someone adds a method with a
+    ``filter_ast`` parameter (a new channel) and forgets to register it here,
+    this fails — so the channel-call audit below can't silently miss it.
+    """
+    tree = _retriever_tree()
+    declared_in_source: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+            params = [a.arg for a in node.args.args] + [a.arg for a in node.args.kwonlyargs]
+            if "filter_ast" in params:
+                declared_in_source.add(node.name)
+    assert declared_in_source == set(_FILTER_AWARE_METHODS), (
+        "filter-aware method set drifted from source.\n"
+        f"  in source but not declared here: {declared_in_source - set(_FILTER_AWARE_METHODS)}\n"
+        f"  declared here but not in source: {set(_FILTER_AWARE_METHODS) - declared_in_source}\n"
+        "Update _FILTER_AWARE_METHODS (a new channel must be threaded + audited)."
+    )
+
+
+def test_every_channel_call_threads_filter() -> None:
+    """No channel call omits ``filter_ast`` except the justified allowlist.
+
+    This is the gate: if a channel is invoked without the filter, a
+    filter-violating chunk could reach fusion. Drift in EITHER direction fails —
+    a new unguarded call (must be threaded or justified) OR a stale allowlist
+    entry whose call now threads the filter (the omission was fixed; remove it).
+    """
+    tree = _retriever_tree()
+    observed_omissions: dict[tuple[str, str | None], int] = {}
+    for call, method, enclosing in _channel_calls(tree):
+        threads = any(kw.arg == "filter_ast" for kw in call.keywords)
+        if not threads:
+            observed_omissions[(method, enclosing)] = call.lineno
+
+    observed_keys = set(observed_omissions)
+    allowlisted_keys = set(_ALLOWLISTED_OMISSIONS)
+
+    new_unguarded = observed_keys - allowlisted_keys
+    assert not new_unguarded, (
+        "NEW channel call(s) omit filter_ast — a filter-violating chunk could reach RRF.\n"
+        + "\n".join(
+            f"  {_RETRIEVER.name}:{observed_omissions[k]}  self.{k[0]}(...) inside {k[1]}()"
+            for k in sorted(new_unguarded)
+        )
+        + "\nThread filter_ast into the call, or add it to _ALLOWLISTED_OMISSIONS with a reason."
+    )
+
+    stale_allowlist = allowlisted_keys - observed_keys
+    assert not stale_allowlist, (
+        "Stale allowlist entries — these calls now thread filter_ast (gap fixed?).\n"
+        + "\n".join(f"  self.{k[0]}(...) inside {k[1]}()" for k in sorted(stale_allowlist))
+        + "\nRemove them from _ALLOWLISTED_OMISSIONS."
+    )
+
+
+def test_allowlist_entries_have_reasons() -> None:
+    """Every allowlisted omission carries a non-empty justification."""
+    for key, reason in _ALLOWLISTED_OMISSIONS.items():
+        assert reason and reason.strip(), f"allowlist entry {key} has no justification"
+
+
+def test_enforcement_pending_boundaries_have_reasons() -> None:
+    """Every wiring-done/enforcement-pending boundary carries a reason."""
+    for key, reason in _ENFORCEMENT_PENDING_BOUNDARIES.items():
+        assert reason and reason.strip(), f"enforcement-pending boundary {key} has no reason"
+
+
+def test_embedded_search_fulltext_still_ignores_filter_ast() -> None:
+    """Pins the documented embedded BM25 enforcement gap to source.
+
+    The path-2 embedded spy is WIRING-ONLY precisely because
+    ``SQLiteLanceTemporalStore.search_fulltext`` accepts ``filter_ast`` but does
+    not compile it. If someone wires real enforcement, this fails — prompting
+    removal of the enforcement-pending boundary entry AND the strict-xfail on
+    the embedded path-2 enforcement probe. Keyed off the source so the doc note
+    can't silently drift from reality.
+    """
+    backend = (
+        Path(__file__).resolve().parents[2] / "src" / "khora" / "engines" / "skeleton" / "backends" / "sqlite_lance.py"
+    )
+    tree = ast.parse(backend.read_text())
+    fn = next(
+        (
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, (ast.AsyncFunctionDef, ast.FunctionDef)) and n.name == "search_fulltext"
+        ),
+        None,
+    )
+    assert fn is not None, "search_fulltext not found in sqlite_lance temporal store"
+    # It declares filter_ast (wiring present) ...
+    params = [a.arg for a in fn.args.args] + [a.arg for a in fn.args.kwonlyargs]
+    assert "filter_ast" in params, "search_fulltext no longer declares filter_ast — wiring changed"
+    # ... but its body must NOT pass filter_ast into the inner _bm25_search
+    # (that's how it would enforce). If it starts doing so, enforcement landed.
+    passes_to_bm25 = any(
+        isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Attribute)
+        and call.func.attr == "_bm25_search"
+        and any(kw.arg == "filter_ast" for kw in call.keywords)
+        for call in ast.walk(fn)
+    )
+    assert not passes_to_bm25, (
+        "Embedded search_fulltext now forwards filter_ast to _bm25_search — enforcement "
+        "may have landed. Remove the enforcement-pending boundary entry and re-evaluate "
+        "the strict-xfail on the embedded path-2 enforcement probe."
+    )

--- a/tests/recall/test_filter_spy_helper.py
+++ b/tests/recall/test_filter_spy_helper.py
@@ -1,0 +1,163 @@
+"""Self-tests for the shared filter-spy helper.
+
+The embedded and live-DB enforcement spies trust ``assert_filter_threaded`` and
+``spy_on`` to FAIL when a filter is dropped, mutated, or never threaded. If the
+helper's own assertion were vacuous, every spy that depends on it would go green
+for the wrong reason. These tests pin the helper's non-vacuity directly — no
+database, no engine — so the guarantee is committed, not ad-hoc.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from khora.filter import RecallFilter, parse_to_ast
+from tests.test_helpers.filter_spy import (
+    FilterCallRecord,
+    assert_filter_threaded,
+    expected_hash,
+    seed_corpus,
+    spy_on,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.filter_enforcement]
+
+_FILTER = {"source_name": "linear", "occurred_at": {"$gte": "2026-01-01"}}
+
+
+def _record_for(doc: dict) -> FilterCallRecord:
+    """A record whose positional arg is the AST for ``doc``."""
+    return FilterCallRecord(args=(parse_to_ast(RecallFilter.model_validate(doc)),), kwargs={})
+
+
+def test_correct_filter_passes() -> None:
+    assert_filter_threaded([_record_for(_FILTER)], _FILTER, min_calls=1)
+
+
+def test_filter_in_kwarg_is_captured() -> None:
+    """filter_ast passed as a kwarg (the channel-method shape) is captured."""
+    ast = parse_to_ast(RecallFilter.model_validate(_FILTER))
+    rec = FilterCallRecord(args=(), kwargs={"filter_ast": ast})
+    assert_filter_threaded([rec], _FILTER, min_calls=1)
+
+
+def test_vacuity_guard_fails_on_zero_calls() -> None:
+    """An empty record list FAILS — the channel was never exercised."""
+    with pytest.raises(AssertionError, match="vacuity guard"):
+        assert_filter_threaded([], _FILTER, min_calls=1)
+
+
+def test_vacuity_guard_respects_min_calls() -> None:
+    """Fewer calls than the floor FAILS even if each one is correct."""
+    with pytest.raises(AssertionError, match="vacuity guard"):
+        assert_filter_threaded([_record_for(_FILTER)], _FILTER, min_calls=2)
+
+
+def test_dropped_filter_fails() -> None:
+    """A call that carried NO filter_ast FAILS (the filter was dropped)."""
+    rec = FilterCallRecord(args=(), kwargs={})
+    with pytest.raises(AssertionError, match="NO filter_ast"):
+        assert_filter_threaded([rec], _FILTER, min_calls=1)
+
+
+def test_wrong_filter_fails() -> None:
+    """A call carrying a different filter FAILS on canonical_hash mismatch."""
+    with pytest.raises(AssertionError, match="canonical_hash"):
+        assert_filter_threaded([_record_for({"source_name": "slack"})], _FILTER, min_calls=1)
+
+
+def test_one_good_one_bad_fails() -> None:
+    """If ANY call diverges, the assertion FAILS — not a majority vote."""
+    records = [_record_for(_FILTER), _record_for({"source_name": "slack"})]
+    with pytest.raises(AssertionError):
+        assert_filter_threaded(records, _FILTER, min_calls=1)
+
+
+def test_expected_hash_accepts_instance_and_dict() -> None:
+    inst = RecallFilter.model_validate(_FILTER)
+    assert expected_hash(_FILTER) == expected_hash(inst)
+
+
+async def test_spy_on_passes_through_and_records() -> None:
+    """spy_on records each call AND returns the real method's result."""
+
+    class _Chan:
+        async def search(self, *, filter_ast=None):  # noqa: ANN001, ANN202
+            return ("ran", filter_ast)
+
+    chan = _Chan()
+    mp = pytest.MonkeyPatch()
+    try:
+        records = spy_on(mp, chan, "search")
+        ast = parse_to_ast(RecallFilter.model_validate(_FILTER))
+        out = await chan.search(filter_ast=ast)
+        # Pass-through: the real method still ran and returned its value.
+        assert out == ("ran", ast)
+        # Recorded: one call, captured with the right hash.
+        assert_filter_threaded(records, _FILTER, min_calls=1)
+    finally:
+        mp.undo()
+
+
+def test_spy_on_records_sync_target() -> None:
+    """spy_on works on a SYNC module-level function (the compile_cypher shape).
+
+    qa-graph's path-3/8 spy point is the sync ``compile_cypher(ast, ctx)``; the
+    filter is the FIRST POSITIONAL arg, not a kwarg. The sync wrapper must record
+    it (via FilterCallRecord's positional-FilterNode fallback) AND pass through
+    without awaiting a non-coroutine.
+    """
+    import types
+
+    mod = types.ModuleType("fake_compiler_mod")
+
+    def compile_like(ast, ctx):  # noqa: ANN001, ANN202 — mimics compile_cypher(ast, ctx)
+        return ("compiled", ast, ctx)
+
+    mod.compile_like = compile_like  # type: ignore[attr-defined]
+
+    mp = pytest.MonkeyPatch()
+    try:
+        records = spy_on(mp, mod, "compile_like")
+        ast = parse_to_ast(RecallFilter.model_validate(_FILTER))
+        out = mod.compile_like(ast, {"node": "Chunk"})  # type: ignore[attr-defined]
+        # Pass-through: sync call returns the real value (not a coroutine).
+        assert out == ("compiled", ast, {"node": "Chunk"})
+        # Recorded with the positional AST resolved to the right hash.
+        assert_filter_threaded(records, _FILTER, min_calls=1)
+    finally:
+        mp.undo()
+
+
+async def test_seed_corpus_threads_per_doc_metadata() -> None:
+    """seed_corpus passes per-doc metadata/title to remember; plain strings don't.
+
+    Path 8's residual-metadata predicate needs a plantable metadata key on the
+    seeded chunk. A dict doc must thread ``metadata=`` (and ``title=``) to
+    remember; a plain-string doc must call remember with neither, so the two
+    shapes coexist.
+    """
+    calls: list[dict] = []
+
+    async def fake_remember(**kwargs):  # noqa: ANN003, ANN202
+        calls.append(kwargs)
+
+    ns = uuid4()
+    await seed_corpus(
+        fake_remember,
+        ns,
+        [
+            "plain string doc",
+            {"content": "eng doc", "metadata": {"channel": "eng"}, "title": "T"},
+        ],
+    )
+
+    assert calls[0] == {"content": "plain string doc", "namespace": ns}
+    assert calls[1] == {
+        "content": "eng doc",
+        "namespace": ns,
+        "metadata": {"channel": "eng"},
+        "title": "T",
+    }

--- a/tests/test_helpers/filter_spy.py
+++ b/tests/test_helpers/filter_spy.py
@@ -1,0 +1,315 @@
+"""Shared spy helpers for the recall-filter pushdown/threading suites.
+
+Both the embedded (``sqlite_lance``, no Docker) and the live-DB (PG+Neo4j)
+filter-enforcement spy modules import from here so the *contract* they
+assert is identical across backends:
+
+* the canonical filter AST is rebuilt EXACTLY as the facade builds it
+  (``RecallFilter.model_validate`` then ``parse_to_ast`` — see
+  ``khora.recall`` in ``src/khora/khora.py``), and
+* a path is proven to thread the filter by capturing the live
+  ``filter_ast`` it received and comparing :func:`canonical_hash` against
+  that expected AST.
+
+What this helper deliberately does NOT do: inspect result rows, scores,
+or ranking. The spies pin the WIRING contract (the validated AST reaches
+each channel unchanged); the end-to-end row-set proof is the
+filter-conformance suite's job. Keeping the two concerns apart is what
+lets the no-Docker embedded spies run in the main ``test`` job.
+
+The deterministic extractor + embedder + seed helpers are lifted from the
+existing ``sqlite_lance`` integration suite so embedded and live-DB spies
+share ONE entity-bearing seed (same content -> same entities -> same
+vectors), making cross-backend comparisons apples-to-apples.
+
+Not shipped as part of the khora package.
+"""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import inspect
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
+
+from khora.extraction.extractors.base import (
+    ExtractedEntity,
+    ExtractedRelationship,
+    ExtractionResult,
+)
+from khora.filter import RecallFilter, canonical_hash, parse_to_ast
+from khora.filter.ast import FilterNode
+
+__all__ = [
+    "EMBED_DIM",
+    "FilterCallRecord",
+    "assert_filter_threaded",
+    "expected_hash",
+    "fake_embedding",
+    "plan_extraction",
+    "seed_corpus",
+    "spy_on",
+    "stub_llm",
+]
+
+# Embedded LanceDB default; the live-DB suites override their own dimension
+# at the kb-fixture level and never import this constant for sizing.
+EMBED_DIM = 32
+
+
+# --------------------------------------------------------------------------- #
+# Expected-AST oracle.
+# --------------------------------------------------------------------------- #
+
+
+def expected_hash(filter: dict[str, Any] | RecallFilter) -> str:
+    """Return the canonical hash a correctly-threaded path must carry.
+
+    Rebuilds the AST the SAME way the facade does — ``RecallFilter`` instance
+    used as-is, dict validated via ``model_validate`` — then hashes it. This is
+    the oracle the spies compare every captured ``filter_ast`` against.
+    """
+    recall_filter = filter if isinstance(filter, RecallFilter) else RecallFilter.model_validate(filter)
+    return canonical_hash(parse_to_ast(recall_filter))
+
+
+# --------------------------------------------------------------------------- #
+# Call capture.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class FilterCallRecord:
+    """One captured call to a spied method.
+
+    ``filter_ast`` is pulled from the call's ``filter_ast`` kwarg when present,
+    else from the first positional arg that is a :class:`FilterNode` (covers
+    free-function spy points like ``compile_cypher(ast, ctx)`` that take the AST
+    positionally). ``canonical_hash`` is computed once at capture time so the
+    assertion helper is a pure comparison.
+    """
+
+    args: tuple[Any, ...]
+    kwargs: dict[str, Any]
+    filter_ast: FilterNode | None = field(default=None)
+    canonical_hash: str | None = field(default=None)
+
+    def __post_init__(self) -> None:
+        ast = self.kwargs.get("filter_ast")
+        if ast is None:
+            ast = next((a for a in self.args if isinstance(a, FilterNode)), None)
+        self.filter_ast = ast
+        self.canonical_hash = canonical_hash(ast) if isinstance(ast, FilterNode) else None
+
+
+def spy_on(
+    monkeypatch: Any,
+    target: Any,
+    method_name: str,
+) -> list[FilterCallRecord]:
+    """Wrap ``target.method_name`` so every call is recorded, then passed through.
+
+    Returns a live list that grows by one :class:`FilterCallRecord` per call.
+    The real method still runs (and its result is returned to the caller
+    unchanged), so the spy is non-invasive: the recall under test executes its
+    genuine logic and we only OBSERVE what ``filter_ast`` flowed past this
+    boundary.
+
+    Handles BOTH async and SYNC targets: bound async retriever methods
+    (``_vector_search_chunks`` etc.) AND module-level sync compilers
+    (``compile_cypher`` / ``compile_postgres`` — pass the module as ``target``,
+    e.g. ``spy_on(monkeypatch, khora.filter.compilers.cypher, "compile_cypher")``).
+    The sync/async branch is selected off the wrapped callable so the wrapper
+    matches the original's call convention (awaiting a sync function raises).
+
+    Use with the real ``monkeypatch`` fixture so the patch is undone at test
+    teardown.
+    """
+    original = getattr(target, method_name)
+    records: list[FilterCallRecord] = []
+
+    if inspect.iscoroutinefunction(original):
+
+        @functools.wraps(original)
+        async def _async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            records.append(FilterCallRecord(args=args, kwargs=dict(kwargs)))
+            return await original(*args, **kwargs)
+
+        monkeypatch.setattr(target, method_name, _async_wrapper)
+    else:
+
+        @functools.wraps(original)
+        def _sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            records.append(FilterCallRecord(args=args, kwargs=dict(kwargs)))
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(target, method_name, _sync_wrapper)
+    return records
+
+
+def assert_filter_threaded(
+    records: list[FilterCallRecord],
+    expected: dict[str, Any] | RecallFilter,
+    *,
+    min_calls: int = 1,
+) -> None:
+    """Assert a path threaded the expected recall filter, with a vacuity guard.
+
+    Two-part contract, both required:
+
+    1. **Vacuity guard** — ``len(records) >= min_calls``. A path that silently
+       stopped issuing the call (so nothing was ever captured) must FAIL rather
+       than pass an empty all-of over zero records. This is what keeps a spy
+       from going green when the channel it watches was never exercised.
+    2. **Canonical-hash equality** — every captured ``filter_ast`` hashes to
+       ``expected_hash(expected)``. Comparing the hash (not object identity or
+       the dict) means equivalent-but-reordered ASTs still match and a dropped
+       or mutated predicate is caught.
+
+    No result/ranking inspection — by design.
+    """
+    want = expected_hash(expected)
+    assert len(records) >= min_calls, (
+        f"vacuity guard: expected >= {min_calls} spied call(s) carrying the filter, "
+        f"got {len(records)} — the path under test was never exercised, so the "
+        f"thread-through is unproven (not green)."
+    )
+    for i, rec in enumerate(records):
+        assert rec.canonical_hash is not None, (
+            f"call #{i} reached the channel with NO filter_ast (got args={rec.args!r} "
+            f"kwargs={rec.kwargs!r}); the filter was dropped before this boundary."
+        )
+        assert rec.canonical_hash == want, (
+            f"call #{i} carried a filter whose canonical_hash {rec.canonical_hash} "
+            f"!= expected {want}; the threaded AST diverged from what the facade built."
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic extractor + embedder + seed.
+# --------------------------------------------------------------------------- #
+
+
+def fake_embedding(text: str, dim: int = EMBED_DIM) -> list[float]:
+    """Deterministic L2-normalised vector for ``text``.
+
+    SHA-256 the text, expand to ``dim`` floats, normalise. Same text -> same
+    vector; different text -> different vector. Suitable for deterministic
+    top-k ordering, NOT for semantic similarity. Shared by embedded and
+    live-DB spies so identical content seeds identical vectors on both.
+    """
+    seed = hashlib.sha256(text.encode("utf-8")).digest()
+    raw = [(seed[i % len(seed)] - 128) / 128.0 for i in range(dim)]
+    norm = sum(x * x for x in raw) ** 0.5 or 1.0
+    return [x / norm for x in raw]
+
+
+# Content-keyed registry: a document whose text CONTAINS a registered marker
+# yields that marker's ExtractionResult. Module-global so ``stub_llm`` can
+# reset it per module; tests stage entries via ``plan_extraction``.
+_EXTRACTION_REGISTRY: dict[str, ExtractionResult] = {}
+
+
+def plan_extraction(
+    marker: str,
+    entities: list[tuple[str, str]],
+    relationships: list[tuple[str, str, str]] | None = None,
+) -> None:
+    """Stage a deterministic ``ExtractionResult`` for docs containing ``marker``.
+
+    ``entities`` are ``(name, entity_type)`` pairs; ``relationships`` are
+    ``(source, target, relationship_type)`` triples. This is the hook the graph
+    channels need: seed specific entity pairs + a typed edge so the Cypher /
+    over-fetch paths actually traverse.
+    """
+    _EXTRACTION_REGISTRY[marker] = ExtractionResult(
+        entities=[ExtractedEntity(name=n, entity_type=t, confidence=0.99) for n, t in entities],
+        relationships=[
+            ExtractedRelationship(
+                source_entity=s,
+                target_entity=t,
+                relationship_type=rt,
+                confidence=0.99,
+            )
+            for s, t, rt in (relationships or [])
+        ],
+    )
+
+
+def stub_llm(monkeypatch: Any) -> None:
+    """Patch the embedder + entity extractor to the deterministic registry.
+
+    No ``OPENAI_API_KEY`` / network needed. Call once per test module (e.g. via
+    an autouse fixture). Resets the extraction registry so stale markers from a
+    prior module never leak. Embedding and extraction are patched at the class
+    method level so every engine code path picks them up.
+    """
+    _EXTRACTION_REGISTRY.clear()
+
+    async def _embed_batch(self: Any, texts: list[str]) -> list[list[float]]:
+        return [fake_embedding(t) for t in texts]
+
+    async def _embed(self: Any, text: str) -> list[float]:
+        return fake_embedding(text)
+
+    async def _extract_multi(self: Any, texts: list[str], **_kwargs: Any) -> list[ExtractionResult]:
+        out: list[ExtractionResult] = []
+        for t in texts:
+            matched = next(
+                (result for marker, result in _EXTRACTION_REGISTRY.items() if marker in t),
+                None,
+            )
+            out.append(matched if matched is not None else ExtractionResult())
+        return out
+
+    monkeypatch.setattr(
+        "khora.extraction.embedders.litellm.LiteLLMEmbedder.embed_batch",
+        _embed_batch,
+    )
+    monkeypatch.setattr(
+        "khora.extraction.embedders.litellm.LiteLLMEmbedder.embed",
+        _embed,
+    )
+    monkeypatch.setattr(
+        "khora.extraction.extractors.llm.LLMEntityExtractor.extract_multi",
+        _extract_multi,
+    )
+
+
+async def seed_corpus(
+    remember: Callable[..., Awaitable[Any]],
+    namespace_id: UUID,
+    docs: list[str | dict[str, Any]],
+) -> None:
+    """Seed an entity-bearing corpus via the caller's ``remember`` API.
+
+    ``remember`` is a partial / bound callable that already pins the kb +
+    per-test ``entity_types`` / ``expertise`` wiring — embedded and live-DB
+    fixtures differ there, so each owns its own. We only drive content +
+    namespace (+ optional metadata/title) so the SAME documents (and therefore
+    the same registered entities) seed both backends. Read-only after seed;
+    namespace-partitioned by the caller.
+
+    Each doc is either:
+
+    * a plain ``str`` → seeded as ``remember(content=doc, namespace=...)``; or
+    * a ``dict`` ``{"content": str, "metadata": {...}?, "title": str?}`` → the
+      ``metadata`` is threaded to ``remember(metadata=...)`` so a graph-channel
+      residual-metadata predicate (e.g. ``{"metadata": {"channel": {"$eq":
+      "eng"}}}``) has a plantable key to post-filter on. The bound ``remember``
+      MUST NOT pre-bind ``metadata`` when dict docs are used, or the per-doc
+      value collides with the partial.
+    """
+    for doc in docs:
+        if isinstance(doc, str):
+            await remember(content=doc, namespace=namespace_id)
+            continue
+        kwargs: dict[str, Any] = {"content": doc["content"], "namespace": namespace_id}
+        if doc.get("metadata") is not None:
+            kwargs["metadata"] = doc["metadata"]
+        if doc.get("title") is not None:
+            kwargs["title"] = doc["title"]
+        await remember(**kwargs)

--- a/tests/test_helpers/filter_spy.py
+++ b/tests/test_helpers/filter_spy.py
@@ -239,21 +239,26 @@ def plan_extraction(
     )
 
 
-def stub_llm(monkeypatch: Any) -> None:
+def stub_llm(monkeypatch: Any, dim: int = EMBED_DIM) -> None:
     """Patch the embedder + entity extractor to the deterministic registry.
 
     No ``OPENAI_API_KEY`` / network needed. Call once per test module (e.g. via
     an autouse fixture). Resets the extraction registry so stale markers from a
     prior module never leak. Embedding and extraction are patched at the class
     method level so every engine code path picks them up.
+
+    ``dim`` sizes the deterministic vectors. The embedded LanceDB suites use the
+    default (small) ``EMBED_DIM``; the live-DB suites pass ``dim=1536`` because
+    the Postgres pgvector column is fixed at 1536 (see ``KhoraConfig`` validation:
+    "Postgres backend currently supports only embedding_dimension=1536").
     """
     _EXTRACTION_REGISTRY.clear()
 
     async def _embed_batch(self: Any, texts: list[str]) -> list[list[float]]:
-        return [fake_embedding(t) for t in texts]
+        return [fake_embedding(t, dim) for t in texts]
 
     async def _embed(self: Any, text: str) -> list[float]:
-        return fake_embedding(text)
+        return fake_embedding(text, dim)
 
     async def _extract_multi(self: Any, texts: list[str], **_kwargs: Any) -> list[ExtractionResult]:
         out: list[ExtractionResult] = []

--- a/tests/unit/engines/vectorcypher/test_filter_pushdown_partial_failure.py
+++ b/tests/unit/engines/vectorcypher/test_filter_pushdown_partial_failure.py
@@ -1,0 +1,274 @@
+"""Filter-pushdown spy — VectorCypher partial-failure path (path 9).
+
+White-box spy proving the recall filter's behavior at the graph-channel
+*partial-failure* boundary: when the Postgres (vector-channel) compile
+succeeds but the Cypher (graph-channel) compile cannot express a predicate,
+the resulting ``RecallFilterUnsupportedError`` must SURFACE — it must NOT be
+swallowed by ``_vector_only_fallback``. Letting it fall back to a vector-only
+search would silently drop the filter on the graph channel and leak
+filter-violating chunks into the result, which is exactly the failure this
+guards against.
+
+Why this is a *differential* test (three arms):
+
+  A "the fallback was not called" assertion is vacuously true if the spy
+  could never observe the call in the first place. So this module asserts
+  the arms against the SAME spied method:
+
+  * Arm A (transient, positive control): ``compile_cypher`` raises
+    ``ServiceUnavailable`` (a ``_NEO4J_TRANSIENT_ERRORS`` member) → the outer
+    ``except`` in ``retrieve()`` catches it and ``_vector_only_fallback`` IS
+    called. This proves the spy can actually observe the fallback firing, so
+    Arm B's ``count == 0`` is a real signal, not a dead assertion.
+
+  * Arm B (filter-unsupported): ``compile_cypher`` raises
+    ``RecallFilterUnsupportedError`` (a ``KhoraError``, NOT a member of the
+    retriever's ``_NEO4J_TRANSIENT_ERRORS`` tuple) → the error PROPAGATES out
+    of ``retrieve()`` and ``_vector_only_fallback`` is NEVER called. This is
+    the filter-pushdown contract working correctly: a filter the graph channel
+    cannot honor fails loud rather than degrading to an unfiltered search.
+
+  * Arm C (KNOWN GAP, documented not fixed): on the Arm-A transient path, the
+    ``_vector_only_fallback`` re-run does NOT thread ``filter_ast`` — its
+    signature has no such parameter and the ``_simple_retrieve`` it calls is
+    not handed one — so the transient-graph-error fallback returns UNFILTERED
+    results. This is a potential filter leak. The test below pins the CURRENT
+    behavior (no filter reaches the fallback) so the gap is visible and a later
+    fix has a failing-then-passing anchor; it is intentionally NOT fixed here
+    (engine change is out of scope for this test ticket).
+
+The spy point is the ``compile_cypher`` over-fetch probe at the top of
+``_vectorcypher_retrieve`` (it is the first filter-touching code on that path
+and is gated only on ``filter_ast is not None``), reached from ``retrieve()``
+via ``mode=GRAPH`` (forces the VectorCypher branch deterministically, no
+routing heuristics). Storage/embedder/router are mocked, so this runs with no
+Postgres or Neo4j — it is pure control-flow over the retriever, not a
+data-path test, and carries no service skip.
+
+This module asserts ONLY filter error-propagation / fallback control-flow —
+never result sets or ranking (that is a separate pillar).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from neo4j.exceptions import ServiceUnavailable
+
+from khora.engines.vectorcypher.retriever import (
+    RetrieverConfig,
+    VectorCypherResult,
+    VectorCypherRetriever,
+)
+from khora.engines.vectorcypher.router import QueryComplexity, RoutingDecision
+from khora.filter import FilterNode, RecallFilter, RecallFilterUnsupportedError, parse_to_ast
+from khora.query import SearchMode
+
+pytestmark = pytest.mark.filter_enforcement
+
+
+def _make_retriever() -> VectorCypherRetriever:
+    """A retriever with mocked I/O — no Postgres / Neo4j, no real driver."""
+    return VectorCypherRetriever(
+        vector_store=AsyncMock(),
+        neo4j_driver=AsyncMock(),
+        embedder=AsyncMock(),
+        config=RetrieverConfig(),
+        storage=AsyncMock(),
+    )
+
+
+def _graph_routing() -> RoutingDecision:
+    """A routing decision that sends ``retrieve()`` down the VectorCypher branch.
+
+    ``mode=GRAPH`` already forces ``force_graph`` in ``retrieve()``; this only
+    supplies the fields the branch reads (entry limit / depth) so the over-fetch
+    probe is reached deterministically without depending on the real router's
+    complexity heuristics.
+    """
+    return RoutingDecision(
+        complexity=QueryComplexity.COMPLEX,
+        use_graph=True,
+        graph_depth=2,
+        confidence=1.0,
+        reasoning="forced graph branch for the partial-failure spy",
+    )
+
+
+def _wire(retriever: VectorCypherRetriever) -> list[object]:
+    """Stub router + embedder; spy ``_vector_only_fallback`` via a call log.
+
+    What stays REAL: the test calls the genuine ``retrieve()`` and the genuine
+    ``_vectorcypher_retrieve``, so the actual outer ``try/except`` and the actual
+    "fall back to vector-only?" DECISION execute unchanged. Only three leaves are
+    stubbed, none of which is the partial-failure logic itself:
+
+    * ``_router.route`` / ``_embedder.embed`` — so the call reaches the graph
+      branch without a real model / router (``mode=GRAPH`` forces the branch;
+      this just satisfies its inputs).
+    * ``_vector_only_fallback`` — replaced with a passthrough spy. Its REAL body
+      runs ``_simple_retrieve`` over the full storage stack, which is irrelevant
+      to the contract under test (does the real dispatch CALL it, and with what
+      filter?). The spy captures the EXACT args the real dispatch passes, so
+      Arm C's "no filter_ast reached the fallback" reads the true boundary.
+
+    Returns the live call-log list (one entry per real-dispatch invocation).
+    """
+    retriever._router.route = AsyncMock(return_value=_graph_routing())  # type: ignore[method-assign]
+    retriever._embedder.embed = AsyncMock(return_value=[0.1, 0.2, 0.3, 0.4])  # type: ignore[attr-defined]
+
+    calls: list[object] = []
+
+    async def _spied_fallback(*args: object, **kwargs: object) -> VectorCypherResult:
+        calls.append((args, kwargs))
+        return VectorCypherResult(chunks=[], entities=[], routing_decision=_graph_routing(), metadata={})
+
+    retriever._vector_only_fallback = _spied_fallback  # type: ignore[method-assign]
+    return calls
+
+
+# A residual-metadata filter: ``metadata.*`` is unpushable to Cypher, so this is
+# the shape that drives the graph channel's compile in real use. The value is
+# irrelevant here — the compile is monkeypatched to raise — but using a
+# realistic filter keeps the test honest about what reaches the boundary.
+_FILTER = RecallFilter.model_validate({"metadata": {"channel": {"$eq": "eng"}}})
+
+
+def _has_filter_node(call: tuple[tuple[object, ...], dict[str, object]]) -> bool:
+    """Whether a captured ``_vector_only_fallback`` call carried a filter AST.
+
+    Checks the ``filter_ast`` kwarg and every positional arg for a
+    :class:`FilterNode`. ``_vector_only_fallback`` has no ``filter_ast``
+    parameter today, so this is expected to be ``False`` — that is the gap
+    Arm C documents.
+    """
+    args, kwargs = call
+    if isinstance(kwargs.get("filter_ast"), FilterNode):
+        return True
+    return any(isinstance(a, FilterNode) for a in args)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_transient_neo4j_error_does_trigger_vector_only_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Arm A (positive control): a transient Neo4j error DOES hit the fallback.
+
+    Proves the spy can observe ``_vector_only_fallback`` firing — so Arm B's
+    ``count == 0`` is a meaningful signal, not a dead assertion. Raising the
+    transient error from the same ``compile_cypher`` probe keeps the arms
+    differing in exactly one variable: the exception type.
+    """
+    retriever = _make_retriever()
+    fallback_calls = _wire(retriever)
+
+    def _raise_transient(ast: object, ctx: object) -> object:
+        raise ServiceUnavailable("neo4j unreachable")
+
+    # Patch the SOURCE module, not the retriever module: ``compile_cypher`` is
+    # imported FUNCTION-LOCALLY inside ``_vectorcypher_retrieve``, so it is not a
+    # ``retriever`` module attribute. A ``setattr`` on the retriever module would
+    # silently no-op and this test would pass vacuously. Do NOT "simplify" the
+    # target back to ``khora.engines.vectorcypher.retriever.compile_cypher``.
+    monkeypatch.setattr("khora.filter.compilers.cypher.compile_cypher", _raise_transient)
+
+    # The transient error is caught by the outer ``except _NEO4J_TRANSIENT_ERRORS``
+    # in ``retrieve()`` and routed to the fallback — so ``retrieve()`` returns.
+    result = await retriever.retrieve(
+        query="anything",
+        namespace_id=uuid4(),
+        mode=SearchMode.GRAPH,
+        filter_ast=parse_to_ast(_FILTER),
+    )
+
+    # Proof we went through the REAL retrieve() dispatch (not a shortcut into the
+    # fallback): the genuine routing + embedding steps ran before the branch.
+    retriever._router.route.assert_awaited()  # type: ignore[attr-defined]
+    retriever._embedder.embed.assert_awaited()  # type: ignore[attr-defined]
+    assert len(fallback_calls) >= 1, "a transient Neo4j error MUST route to _vector_only_fallback"
+    assert result is not None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_filter_unsupported_surfaces_and_skips_vector_only_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Arm B: a graph-channel filter-unsupported error propagates; no fallback.
+
+    ``RecallFilterUnsupportedError`` is not in ``_NEO4J_TRANSIENT_ERRORS``, so
+    the outer ``except`` in ``retrieve()`` does not catch it and
+    ``_vector_only_fallback`` is never reached — the filter fails loud instead
+    of degrading to an unfiltered search.
+    """
+    retriever = _make_retriever()
+    fallback_calls = _wire(retriever)
+
+    def _raise_unsupported(ast: object, ctx: object) -> object:
+        raise RecallFilterUnsupportedError("metadata.channel", "metadata predicates are not pushed down to Cypher")
+
+    # Same source-module target as Arm A (see that test for the rationale).
+    monkeypatch.setattr("khora.filter.compilers.cypher.compile_cypher", _raise_unsupported)
+
+    with pytest.raises(RecallFilterUnsupportedError):
+        await retriever.retrieve(
+            query="anything",
+            namespace_id=uuid4(),
+            mode=SearchMode.GRAPH,
+            filter_ast=parse_to_ast(_FILTER),
+        )
+
+    assert fallback_calls == [], "_vector_only_fallback must NOT be called on a filter-unsupported error"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_transient_fallback_drops_filter_KNOWN_GAP(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Arm C: DOCUMENTS a known filter leak on the transient-error fallback path.
+
+    KNOWN GAP: transient-graph-error vector-only fallback does not thread
+    ``filter_ast`` → unfiltered results; tracked separately for follow-up.
+
+    On Arm A's transient path, ``retrieve()`` routes to ``_vector_only_fallback``,
+    which has NO ``filter_ast`` parameter and calls ``_simple_retrieve`` without
+    one. So the caller's recall filter is silently dropped on this degradation
+    path and the fallback returns unfiltered results — a potential filter leak.
+
+    This test pins the CURRENT behavior (no filter AST reaches the fallback) so
+    the gap is visible and a future fix has a failing-then-passing anchor. It is
+    intentionally NOT fixed here: changing ``_vector_only_fallback`` to thread the
+    filter is an engine change, out of scope for this test ticket. The audit gate
+    allowlists ``_vector_only_fallback`` for the SAME reason.
+    """
+    retriever = _make_retriever()
+    fallback_calls = _wire(retriever)
+
+    def _raise_transient(ast: object, ctx: object) -> object:
+        raise ServiceUnavailable("neo4j unreachable")
+
+    # Same source-module target as Arm A (see that test for the rationale).
+    monkeypatch.setattr("khora.filter.compilers.cypher.compile_cypher", _raise_transient)
+
+    await retriever.retrieve(
+        query="anything",
+        namespace_id=uuid4(),
+        mode=SearchMode.GRAPH,
+        filter_ast=parse_to_ast(_FILTER),
+    )
+
+    assert len(fallback_calls) >= 1, "precondition: the transient error must reach the fallback"
+    # The gap: NOT ONE captured fallback call carries the filter AST. When the
+    # engine is fixed to thread filter_ast into _vector_only_fallback, this
+    # assertion flips and this test should be updated to assert the filter IS
+    # carried (canonical_hash equality) instead.
+    assert not any(_has_filter_node(c) for c in fallback_calls), (
+        "KNOWN GAP changed: _vector_only_fallback now receives a filter AST — "
+        "the transient-fallback filter leak may be fixed; update this test to "
+        "assert the filter is threaded (canonical_hash equality) and remove the "
+        "audit-gate allowlist entry for _vector_only_fallback."
+    )


### PR DESCRIPTION
## Summary

White-box "pushdown-spy" tests proving the recall filter reaches every VectorCypher channel and adaptive sub-search **unchanged**: each pushdown boundary is asserted to receive a filter whose `canonical_hash` matches the caller's (a dropped filter is absent; a mutated one mismatches), with a `len(calls) >= N` vacuity guard and a differential control recall, and **no result/ranking inspection** (that is a separate concern).

- **Embedded (sqlite+LanceDB), runs without Docker:** vector channel, BM25 wiring, EXPLICIT date-synthesis (both arms), plus a point-in-time fail-fast backstop.
- **Graph (PG+Neo4j), self-skips without the live stack:** Cypher channel, session fan-out, restrictive-fallback re-run guard, CHANGE decomposition, and graph over-fetch + metadata post-filter. Each is gated on `NEO4J_INTEGRATION_TEST` + Postgres reachability, consistent with the existing Neo4j-backed integration tests; the live-run command is documented in the module docstring.
- **Partial-failure (mock-level, runs in the unit job):** the filter is preserved when a compile error surfaces (no silent vector-only fallback), and the transient-fallback filter drop is captured by a known-gap test that flips to a positive assertion once the underlying issue is fixed.
- **`canonical_hash` stability unit** and a **`temporal_filter`/`filter_ast` audit gate** that fails if a new call site drops the filter (proven non-vacuous via a mutation harness).
- Shared spy helper (sync/async capture + deterministic seed corpus) and a new `filter_enforcement` pytest marker.
- Corrects the embedded temporal-filter xfail reason to its real cause (the point-in-time `NotImplementedError` gate), keeping it `strict`.

This is a **test-only** change (no engine source modified). The investigation surfaced two pre-existing latent filter gaps, both tracked separately and documented in-suite with known-gap/xfail tests: the embedded BM25 channel accepts but does not yet compile the filter, and the transient-graph-error vector-only fallback drops the filter.

## Test plan

- [x] `pytest -m filter_enforcement` passes without Docker — 34 passed, 29 skipped (graph spies self-skip cleanly), 1 xfailed; no failures/errors
- [x] New unit/recall files pass in isolation (29 passed); embedded spies pass
- [x] `make lint` clean; `make format` clean
- [ ] Graph-config spies pass against a live PG+Neo4j stack (`make dev`) — not runnable in CI without Neo4j; self-skip there
- [ ] CI green