### PR TITLE
Distinguish exact-array and containment operands in filter canonical hash

### DIFF
--- a/src/khora/filter/ast.py
+++ b/src/khora/filter/ast.py
@@ -577,6 +577,15 @@ def canonical_hash(node: FilterNode | FilterClause) -> str:
       sibling predicates does not change the hash (``{a AND b}`` == ``{b AND a}``).
     * **Order is preserved** for a ``$not`` operand, for ``$in``/``$nin`` lists,
       and for ``$eq`` exact-array operands — those are order-significant.
+    * **An ordered-array operand (a tuple: ``$eq`` exact-array, ``$in``/``$nin``)
+      hashes distinctly from a containment-list operand (an explicit ``$eq`` list).**
+      The two are disambiguated by a **structural** ``operand_kind`` field on the
+      clause record — a sibling of ``operand``, not part of the operand value — so
+      an exact-array ``$eq`` and a containment ``$eq`` on the same path do **not**
+      share a hash. The sibling placement makes it **forge-proof**: a user-supplied
+      operand value (which is opaque JSON) cannot mint the distinguishing field
+      because the value is confined under the ``operand`` key. See
+      :func:`_canonicalize` and :func:`_canonicalize_operand`.
     * **Dict operands** (whole-subdocument / whole-blob equality) have their keys
       sorted so semantically equal objects hash equally.
     * Two ASTs that differ only in **semantics** (different op, path, or operand)
@@ -598,12 +607,26 @@ def canonical_hash(node: FilterNode | FilterClause) -> str:
 
 
 def _canonicalize(node: FilterNode | FilterClause) -> Any:
-    """Build the stable, JSON-serializable representation of an AST subtree."""
+    """Build the stable, JSON-serializable representation of an AST subtree.
+
+    A leaf clause records an ``operand_kind`` field **alongside** ``operand`` to
+    disambiguate the two array-shaped operands (an order-significant ``tuple`` —
+    an ``$eq`` exact-array or an ``$in``/``$nin`` list — versus an explicit-``$eq``
+    containment ``list``) that otherwise canonicalize to the same JSON array. This
+    sibling field is **structural**, not part of the operand value: it lives on the
+    clause record, so it is **forge-proof**. A user ``$eq`` operand is arbitrary
+    opaque JSON (a list, a dict, nested), but it is canonicalized under the
+    ``operand`` key only — it can never reach into the clause record to mint its own
+    ``operand_kind`` sibling. (Contrast an in-operand sentinel such as a magic dict
+    key, which a user dict value ``{"<sentinel>": ...}`` could forge.) See
+    :func:`_operand_kind`.
+    """
     if isinstance(node, FilterClause):
         return {
             "k": "clause",
             "path": list(node.path),
             "op": node.op.value,
+            "operand_kind": _operand_kind(node.operand),
             "operand": _canonicalize_operand(node.operand),
         }
     # FilterNode (logical).
@@ -617,11 +640,45 @@ def _canonicalize(node: FilterNode | FilterClause) -> Any:
     return {"k": "node", "op": node.op.value, "children": children}
 
 
+def _operand_kind(operand: Any) -> str:
+    """Return the structural container kind of a leaf operand.
+
+    This is the **forge-proof** discriminator between the two array-shaped operands
+    that would otherwise canonicalize to the same JSON array:
+
+    * ``"tuple"`` — an order-significant array: a ``$eq`` *exact-array* operand (a
+      bare list desugars to this) or an ``$in``/``$nin`` membership list.
+    * ``"list"`` — an explicit-``$eq`` array-containment operand (``{"$eq": [...]}``
+      lowers to a ``list`` via :func:`_lower_scalar_operand`).
+    * ``"scalar"`` — anything else (scalars, dicts, datetimes, ``$date`` literals,
+      ``None``); these never collide with an array, so they share one neutral kind.
+
+    The discriminator is emitted by :func:`_canonicalize` as a clause-record sibling
+    of ``operand`` — *not* inside the operand value — so a user-supplied operand
+    (arbitrary opaque JSON) can never forge it. Only the tuple-vs-list split is
+    load-bearing; ``$in``/``$nin`` tuples are already distinguished from a ``$eq``
+    tuple by the clause-level ``op`` field, so reusing ``"tuple"`` across them is safe.
+    """
+    if isinstance(operand, tuple):
+        return "tuple"
+    if isinstance(operand, list):
+        return "list"
+    return "scalar"
+
+
 def _canonicalize_operand(operand: Any) -> Any:
     """Canonicalize a leaf operand into JSON-serializable form.
 
-    Tuples (``$in``/``$nin`` lists, ``$eq`` exact-arrays) keep their order. Dict
-    operands (subdocument / blob equality) sort their keys recursively so
+    Array-shaped operands (an order-significant ``tuple`` — ``$eq`` exact-array or
+    ``$in``/``$nin`` — and an explicit-``$eq`` containment ``list``) are emitted as
+    plain JSON arrays with element order preserved. They are **not** disambiguated
+    here: the tuple-vs-list distinction is carried by the structural ``operand_kind``
+    sibling on the clause record (see :func:`_canonicalize` / :func:`_operand_kind`),
+    which is forge-proof because it lives outside the operand value. Keeping this
+    function's array encoding plain means a user ``$eq`` value cannot reproduce a
+    distinguishing in-operand sentinel.
+
+    Dict operands (subdocument / blob equality) sort their keys recursively so
     key-order is not significant. :class:`DateLiteral` and :class:`~datetime.datetime`
     are tagged + ISO-encoded so they never collide with a plain string.
     """
@@ -629,10 +686,10 @@ def _canonicalize_operand(operand: Any) -> Any:
         return {"$date": operand.value.isoformat()}
     if isinstance(operand, datetime):
         return {"$dt": operand.isoformat()}
-    if isinstance(operand, tuple):
-        # Order-significant — preserve it.
-        return [_canonicalize_operand(item) for item in operand]
-    if isinstance(operand, list):
+    if isinstance(operand, (tuple, list)):
+        # Order-significant array (tuple) or containment list — both plain JSON
+        # arrays, order preserved. The tuple-vs-list distinction is carried by the
+        # structural ``operand_kind`` sibling on the clause record, not here.
         return [_canonicalize_operand(item) for item in operand]
     if isinstance(operand, dict):
         # Order-insensitive object equality — sort keys recursively.

--- a/tests/recall/test_filter_ast.py
+++ b/tests/recall/test_filter_ast.py
@@ -190,8 +190,8 @@ def test_explicit_eq_list_operand_stays_a_plain_list_not_a_tuple() -> None:
     # An EXPLICIT {"$eq": [list]} is array-CONTAINMENT, not the bare-list exact-array
     # sugar. It lowers to a plain ``list`` operand (carried verbatim by
     # ``_lower_scalar_operand``) — distinct from the bare-list form, which lowers to
-    # a ``tuple``. This container-type split is what ``canonical_hash`` tags
-    # differently (``[...]`` vs ``{"$arr": [...]}``).
+    # a ``tuple``. This container-type split is what ``canonical_hash`` records
+    # differently via the structural ``operand_kind`` field on the clause record.
     (clause,) = _clauses(_ast({"metadata.tags": {"$eq": ["a", "b"]}}))
     assert clause.path == ("metadata", "tags")
     assert clause.op == Op.EQ

--- a/tests/recall/test_filter_ast.py
+++ b/tests/recall/test_filter_ast.py
@@ -186,6 +186,20 @@ def test_metadata_explicit_in_stays_in_with_ordered_tuple() -> None:
     assert isinstance(clause.operand, tuple)
 
 
+def test_explicit_eq_list_operand_stays_a_plain_list_not_a_tuple() -> None:
+    # An EXPLICIT {"$eq": [list]} is array-CONTAINMENT, not the bare-list exact-array
+    # sugar. It lowers to a plain ``list`` operand (carried verbatim by
+    # ``_lower_scalar_operand``) — distinct from the bare-list form, which lowers to
+    # a ``tuple``. This container-type split is what ``canonical_hash`` tags
+    # differently (``[...]`` vs ``{"$arr": [...]}``).
+    (clause,) = _clauses(_ast({"metadata.tags": {"$eq": ["a", "b"]}}))
+    assert clause.path == ("metadata", "tags")
+    assert clause.op == Op.EQ
+    assert clause.operand == ["a", "b"]
+    assert isinstance(clause.operand, list)
+    assert not isinstance(clause.operand, tuple)
+
+
 def test_metadata_nin_lowers_to_ordered_tuple() -> None:
     (clause,) = _clauses(_ast({"metadata.k": {"$nin": [1, 2]}}))
     assert clause.op == Op.NIN
@@ -639,6 +653,15 @@ def test_hash_dict_operand_key_order_insensitive() -> None:
     assert a == b
 
 
+def test_hash_whole_blob_metadata_dict_key_order_insensitive() -> None:
+    # The bare ``metadata`` WHOLE-BLOB $eq operand (a different lowering path than a
+    # ``metadata.<sub>`` subdocument) also sorts its keys, so the wire dict-key order
+    # on the blob does not change the hash.
+    a = canonical_hash(_ast({"metadata": {"a": 1, "b": 2}}))
+    b = canonical_hash(_ast({"metadata": {"b": 2, "a": 1}}))
+    assert a == b
+
+
 def test_hash_differs_on_operand_semantics() -> None:
     a = canonical_hash(_ast({"source_name": "a"}))
     b = canonical_hash(_ast({"source_name": "b"}))
@@ -700,6 +723,34 @@ def test_hash_distinguishes_eq_list_operand_from_in_same_path() -> None:
     eq_hash = canonical_hash(_ast({"source_name": ["a", "b"]}))
     in_hash = canonical_hash(_ast({"source_name": {"$in": ["a", "b"]}}))
     assert eq_hash != in_hash
+
+
+def test_bare_list_and_explicit_eq_list_hash_differently() -> None:
+    # Headline: a bare list ``{path: [a, b]}`` is $eq EXACT-ARRAY (tuple operand),
+    # while an explicit ``{path: {"$eq": [a, b]}}`` is array-CONTAINMENT (list
+    # operand). SAME path, SAME op ($eq), SAME elements/order — only the operand's
+    # container kind differs, and the two carry different row-set semantics, so they
+    # must hash DIFFERENTLY. The canonical clause record carries a structural
+    # ``operand_kind`` field (tuple vs list) that breaks the collision.
+    bare_hash = canonical_hash(_ast({"metadata.tags": ["a", "b"]}))
+    explicit_eq_hash = canonical_hash(_ast({"metadata.tags": {"$eq": ["a", "b"]}}))
+    assert bare_hash != explicit_eq_hash
+
+
+def test_bare_list_does_not_collide_with_dict_operand_mimicking_the_tag() -> None:
+    # The tuple-vs-list distinction is a STRUCTURAL clause field (operand_kind), not
+    # an in-operand sentinel, so it is forge-proof. A user $eq operand is arbitrary
+    # opaque JSON and is canonicalized only under the "operand" key — it can never
+    # mint the clause-level discriminator. So a bare list (tuple, exact-array
+    # equality) must NOT collide with an explicit $eq whose operand is a dict, even
+    # one that mimics an internal marker. These are semantically different (exact
+    # ARRAY equality vs exact DICT equality); an in-operand sentinel would have
+    # collided them.
+    tuple_hash = canonical_hash(_ast({"metadata.tags": ["a", "b"]}))
+    arr_dict_hash = canonical_hash(_ast({"metadata.tags": {"$eq": {"$arr": ["a", "b"]}}}))
+    forge_dict_hash = canonical_hash(_ast({"metadata.tags": {"$eq": {"operand_kind": "tuple"}}}))
+    assert tuple_hash != arr_dict_hash
+    assert tuple_hash != forge_dict_hash
 
 
 # --- AC3: order preservation for non-commutative shapes ------------------- #


### PR DESCRIPTION
## Summary
- A bare-list operand (`$eq` exact-array equality, lowered to a tuple) and an explicit `{"$eq": [list]}` operand (array containment, lowered to a list) canonicalized to the same JSON array, so they collided on `canonical_hash` even though they compile to different row sets. A recall-filter cache keyed on the hash could mis-serve one form's result for the other — a latent cache-correctness hazard.
- The fix records the operand's container kind as a **structural field on the clause's canonical representation** (a sibling of the operand value), so the two forms hash differently. Because the marker lives on the clause record and not inside the operand value, no user-supplied operand (arbitrary opaque JSON carried under the operand key) can forge it.
- Hash-only change: lowering, the operand types carried on the AST, and compiler row-set semantics are untouched. The canonicalization is `@internal` (not part of the public surface); the only effect is that in-memory cache keys for array-shaped operands change.
- Adds regression tests for the exact-array vs containment distinction and for the forge-proof property (a dict operand that mimics the internal marker does not collide).

## Test plan
- [x] Unit tests pass — full `tests/unit/` + `tests/recall/` suite green (8492 passed, 46 skipped) run serially
- [x] Filter AST suite (`tests/recall/test_filter_ast.py`) passes, including new regression tests
- [x] Conformance corpus unaffected (row-set driven, not hash driven) — passes
- [x] `ruff format` / `ruff check` clean
- [ ] Integration tests run in CI (require Docker; not available in the local dev environment)