### PR TITLE
Persist and read occurred_at on the SurrealDB chunk path

### DIFF
--- a/src/khora/storage/backends/surrealdb/schema.py
+++ b/src/khora/storage/backends/surrealdb/schema.py
@@ -104,6 +104,8 @@ DEFINE FIELD IF NOT EXISTS metadata_ ON chunk FLEXIBLE TYPE option<object>;
 DEFINE FIELD IF NOT EXISTS chunker_info ON chunk FLEXIBLE TYPE object DEFAULT {};
 DEFINE FIELD IF NOT EXISTS created_at ON chunk TYPE datetime DEFAULT time::now();
 DEFINE FIELD IF NOT EXISTS source_timestamp ON chunk TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS occurred_at ON chunk TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS last_accessed_at ON chunk TYPE option<datetime>;
 DEFINE FIELD IF NOT EXISTS session_id ON chunk TYPE option<string>;
 DEFINE INDEX IF NOT EXISTS idx_chunk_namespace ON chunk FIELDS namespace;
 DEFINE INDEX IF NOT EXISTS idx_chunk_document ON chunk FIELDS document;

--- a/src/khora/storage/backends/surrealdb/vector.py
+++ b/src/khora/storage/backends/surrealdb/vector.py
@@ -131,6 +131,8 @@ class SurrealDBVectorAdapter:
             "chunker_info = $chunker_info, "
             "created_at = $created_at, "
             "source_timestamp = $source_timestamp, "
+            "occurred_at = $occurred_at, "
+            "last_accessed_at = $last_accessed_at, "
             "session_id = $session_id"
         )
         bindings = self._chunk_to_bindings(chunk)
@@ -160,6 +162,8 @@ class SurrealDBVectorAdapter:
                     "chunker_info": chunk.chunker_info or {},
                     "created_at": chunk.created_at,
                     "source_timestamp": chunk.source_timestamp,
+                    "occurred_at": chunk.occurred_at,
+                    "last_accessed_at": chunk.last_accessed_at,
                     "session_id": str(chunk.session_id) if chunk.session_id else None,
                 }
             )
@@ -799,6 +803,8 @@ class SurrealDBVectorAdapter:
             "chunker_info": chunk.chunker_info or {},
             "created_at": chunk.created_at,
             "source_timestamp": chunk.source_timestamp,
+            "occurred_at": chunk.occurred_at,
+            "last_accessed_at": chunk.last_accessed_at,
             "session_id": str(chunk.session_id) if chunk.session_id else None,
         }
 
@@ -840,6 +846,8 @@ class SurrealDBVectorAdapter:
             embedding_model=row.get("embedding_model", ""),
             created_at=_parse_dt(row.get("created_at")) or datetime.now(UTC),
             source_timestamp=_parse_dt(row.get("source_timestamp")),
+            occurred_at=_parse_dt(row.get("occurred_at")),
+            last_accessed_at=_parse_dt(row.get("last_accessed_at")),
             session_id=_parse_uuid(row.get("session_id")) if row.get("session_id") else None,
         )
 

--- a/tests/integration/storage/backends/surrealdb/test_chronicle_filter_surrealdb.py
+++ b/tests/integration/storage/backends/surrealdb/test_chronicle_filter_surrealdb.py
@@ -1,0 +1,287 @@
+"""End-to-end occurred_at persistence + recall-filter tests on the SurrealDB chunk path.
+
+The SurrealDB ``chunk`` table carries a distinct ``occurred_at`` ``option<datetime>``
+field (the real-world event time the chunk's content refers to, separate from both
+``created_at`` ingestion time and ``source_timestamp``). These tests drive that field
+through the production ``SurrealDBVectorAdapter`` write/read path against an embedded,
+in-memory SurrealDB (``mode="memory"``) — no storage mocks, no Docker, no external
+service — and prove two halves of the contract:
+
+* **Round-trip** — a chunk written with an ``occurred_at`` distinct from both
+  ``created_at`` and ``source_timestamp`` reads back with that exact value. This fails
+  loudly if the write path drops ``occurred_at`` (it would read back ``None``) or the
+  SCHEMAFULL ``chunk`` table strips the field.
+* **Recall-filter regression guard** — a chunk whose ``occurred_at`` is in range but
+  whose ``source_timestamp`` is out of range is honored by an ``occurred_at`` recall
+  filter. The effective event time is ``COALESCE(occurred_at, source_timestamp)``; if
+  the write path dropped ``occurred_at`` (read back as ``None``), that COALESCE would
+  collapse to the out-of-range ``source_timestamp`` and the chunk would be (wrongly)
+  filtered out. So this proves ``occurred_at`` is genuinely persisted, not silently
+  recovered from ``source_timestamp``.
+
+The SurrealDB sibling of ``tests/integration/test_chronicle_filter_embedded.py`` (the
+sqlite_lance sibling) and ``tests/integration/test_chronicle_filter_pgvector.py`` (the
+PG/pgvector sibling): same engine, same filter AST, same recall path — only the storage
+backend differs. Seeding goes through the coordinator's own write API
+(``create_chunks_batch``) with deterministic fake embeddings; all seed chunks share one
+embedding so the vector channel returns the whole seed set and the filter is the only
+narrowing force. ``SurrealDBVectorAdapter.search_similar`` scores with
+``vector::dot(embedding, $query_embedding)`` (brute-force cosine; SurrealDB ``<|K|>``
+KNN is unreliable embedded), so identical unit vectors all score 1.0.
+
+The ``surrealdb`` SDK is an optional dependency, so this module self-skips when it is
+absent (``pytest.importorskip``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+pytest.importorskip("surrealdb")
+
+from khora.config import KhoraConfig  # noqa: E402
+from khora.config.schema import QuerySettings  # noqa: E402
+from khora.core.models import Chunk, Document, MemoryNamespace  # noqa: E402
+from khora.engines.chronicle.engine import ChronicleEngine  # noqa: E402
+from khora.filter import RecallFilter  # noqa: E402
+from khora.filter.ast import parse_to_ast  # noqa: E402
+from khora.query import SearchMode  # noqa: E402
+from khora.storage.backends.surrealdb.connection import SurrealDBConnection  # noqa: E402
+from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter  # noqa: E402
+from khora.storage.backends.surrealdb.vector import SurrealDBVectorAdapter  # noqa: E402
+from khora.storage.coordinator import StorageCoordinator  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+# A small embedding dimension is fine — the SurrealDB ``embedding`` field is
+# ``option<array<float>>`` with no fixed width and ``search_similar`` brute-forces the
+# dot product. One shared unit vector so every seed chunk scores 1.0 and the vector
+# channel returns the whole seed set, leaving the filter as the only narrowing force.
+EMBED_DIM = 8
+_QUERY_TEXT = "shared retrieval anchor"
+_SHARED_EMBEDDING = [1.0] + [0.0] * (EMBED_DIM - 1)
+
+# Tz-AWARE bounds (the column is a SurrealDB ``datetime``). The filter literal is the
+# same instant in ISO-8601 Z form so the post-filter compares tz-aware to tz-aware.
+_IN_RANGE = datetime(2026, 6, 1, tzinfo=UTC)
+_OUT_OF_RANGE = datetime(2020, 1, 1, tzinfo=UTC)
+_FILTER_LB = "2026-01-01T00:00:00Z"
+# A fourth distinct anchor for the last_accessed_at round-trip (the implementation
+# folded last_accessed_at in alongside occurred_at); kept different from every other
+# seeded timestamp so the round-trip assert can't pass by coincidence.
+_LAST_ACCESSED = datetime(2026, 2, 14, tzinfo=UTC)
+
+
+@pytest.fixture
+async def coord() -> AsyncIterator[StorageCoordinator]:
+    """A connected coordinator over an embedded SurrealDB unified backend.
+
+    Both the relational and vector adapters share one in-memory ``SurrealDBConnection``
+    (the unified backend): ``create_namespace`` / ``create_document`` live on the
+    relational adapter; ``create_chunks_batch`` / ``get_chunk`` / the recall
+    ``search_*`` channels live on the vector adapter. Sharing one connection keeps both
+    writes landing in the same database the recall path later reads. The connection's
+    auto schema-init runs the full khora SCHEMAFULL schema (which already declares
+    ``occurred_at`` on ``chunk``).
+    """
+    conn = SurrealDBConnection(mode="memory", namespace="khora_test", database="occurredat")
+    await conn.connect()
+    relational = SurrealDBRelationalAdapter(conn)
+    vector = SurrealDBVectorAdapter(conn)
+    coordinator = StorageCoordinator(relational=relational, vector=vector)
+    try:
+        yield coordinator
+    finally:
+        await conn.disconnect()
+
+
+class _FakeEmbedder:
+    async def embed(self, _text: str) -> list[float]:
+        return list(_SHARED_EMBEDDING)
+
+
+def _engine_over(coordinator: StorageCoordinator) -> ChronicleEngine:
+    """A ChronicleEngine bound to the embedded SurrealDB coordinator.
+
+    Reranking is disabled (it would lazily pull a cross-encoder on first recall); it
+    only reorders candidates, never adds/drops a row, so the filter contract is
+    unaffected. The fake embedder returns the shared query embedding so the vector
+    channel retrieves the whole seed set.
+    """
+    engine = ChronicleEngine(KhoraConfig(query=QuerySettings(enable_reranking=False)))
+    engine._storage = coordinator
+    engine._embedder = _FakeEmbedder()
+    engine._connected = True
+    return engine
+
+
+def _filter_ast(wire: dict) -> Any:
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+async def _seed(
+    coordinator: StorageCoordinator,
+    namespace_id: UUID,
+    specs: list[dict[str, Any]],
+) -> list[Chunk]:
+    """Insert one document + one chunk per spec via the real coordinator write API.
+
+    Each ``spec`` carries ``content`` plus any of ``source_timestamp`` / ``occurred_at``
+    / ``last_accessed_at`` / ``created_at``. All chunks share ``_SHARED_EMBEDDING`` so
+    the vector channel returns them all.
+    """
+    chunks: list[Chunk] = []
+    for spec in specs:
+        doc = Document(
+            namespace_id=namespace_id,
+            content=spec["content"],
+            source="test",
+            title=spec["content"][:32],
+        )
+        await coordinator.create_document(doc)
+        chunk_kwargs: dict[str, Any] = {
+            "namespace_id": namespace_id,
+            "document_id": doc.id,
+            "content": spec["content"],
+            "chunk_index": 0,
+            "embedding": list(_SHARED_EMBEDDING),
+            "embedding_model": "fake",
+            "metadata": spec.get("metadata", {}),
+        }
+        for date_key in ("source_timestamp", "occurred_at", "last_accessed_at", "created_at"):
+            if date_key in spec:
+                chunk_kwargs[date_key] = spec[date_key]
+        chunks.append(Chunk(**chunk_kwargs))
+    await coordinator.create_chunks_batch(chunks)
+    return chunks
+
+
+async def _recall_ids(engine: ChronicleEngine, namespace_id: UUID, wire: dict) -> set[UUID]:
+    result = await engine.recall(
+        _QUERY_TEXT,
+        namespace_id,
+        limit=50,
+        mode=SearchMode.VECTOR,
+        filter_ast=_filter_ast(wire),
+    )
+    return {c.id for c in result.chunks}
+
+
+@pytest.mark.asyncio
+async def test_occurred_at_round_trips_through_real_store(coord: StorageCoordinator) -> None:
+    # Direct write→read round-trip of the distinct occurred_at field through the real
+    # SurrealDB vector adapter (no filter, no engine). A chunk seeded with an
+    # occurred_at that differs from BOTH created_at and source_timestamp must read back
+    # with that exact occurred_at — proving the write path persists it and the read path
+    # restores it, rather than the batch insert dropping it or the SCHEMAFULL table
+    # silently stripping it. last_accessed_at (folded in by the same implementation) is
+    # round-tripped alongside, seeded distinct from every other anchor.
+    ns = await coord.create_namespace(MemoryNamespace())
+    created_at = datetime(2025, 3, 15, tzinfo=UTC)
+    chunks = await _seed(
+        coord,
+        ns.id,
+        [
+            {
+                "content": "distinct occurred_at",
+                "occurred_at": _IN_RANGE,
+                "source_timestamp": _OUT_OF_RANGE,
+                "last_accessed_at": _LAST_ACCESSED,
+                "created_at": created_at,
+            },
+        ],
+    )
+    written = chunks[0]
+    # Sanity: all four anchors are genuinely distinct before the round-trip.
+    assert written.occurred_at == _IN_RANGE
+    assert written.source_timestamp == _OUT_OF_RANGE
+    assert written.last_accessed_at == _LAST_ACCESSED
+    assert written.created_at == created_at
+    assert (
+        len(
+            {
+                written.occurred_at,
+                written.source_timestamp,
+                written.last_accessed_at,
+                written.created_at,
+            }
+        )
+        == 4
+    )
+
+    read_back = await coord.get_chunk(written.id, namespace_id=ns.id)
+    assert read_back is not None
+    assert read_back.occurred_at == _IN_RANGE, (
+        "occurred_at must round-trip through the real SurrealDB store unchanged "
+        f"(wrote {written.occurred_at!r}, read back {read_back.occurred_at!r}) — a "
+        "regression in the batch write path or the row mapper would read back None"
+    )
+    # last_accessed_at must round-trip too (folded into the same write/read wiring).
+    assert read_back.last_accessed_at == _LAST_ACCESSED, (
+        "last_accessed_at must round-trip through the real SurrealDB store unchanged "
+        f"(wrote {written.last_accessed_at!r}, read back {read_back.last_accessed_at!r})"
+    )
+    # The other anchors stay distinct — occurred_at is not derived from any of them.
+    assert read_back.source_timestamp == _OUT_OF_RANGE
+    assert read_back.occurred_at != read_back.source_timestamp
+    assert read_back.occurred_at != read_back.created_at
+    assert read_back.occurred_at != read_back.last_accessed_at
+
+
+@pytest.mark.asyncio
+async def test_occurred_at_filter_honored_over_out_of_range_source_timestamp(
+    coord: StorageCoordinator,
+) -> None:
+    # Recall-filter regression guard. The effective event time is
+    # COALESCE(occurred_at, source_timestamp). Seed a chunk whose occurred_at is in
+    # range but whose source_timestamp is out of range: an occurred_at recall filter
+    # must HONOR it, because the in-range occurred_at — not the out-of-range
+    # source_timestamp — is the effective event time.
+    #
+    # This is the guard for the persist-occurred_at fix: if the write path dropped
+    # occurred_at (read back as None), the effective event time would fall back to the
+    # out-of-range source_timestamp and this chunk would be (wrongly) dropped. That it
+    # survives proves occurred_at is genuinely persisted, not silently recovered via
+    # COALESCE(occurred_at, source_timestamp).
+    #
+    # A second chunk with NO occurred_at but an in-range source_timestamp confirms the
+    # fallback still recovers (no false-empty); a third chunk with neither anchor in
+    # range is the negative case.
+    ns = await coord.create_namespace(MemoryNamespace())
+    chunks = await _seed(
+        coord,
+        ns.id,
+        [
+            # occurred_at in range, source_timestamp out of range → survives ONLY if
+            # occurred_at round-trips. This is the regression guard.
+            {"content": "occurred honored", "occurred_at": _IN_RANGE, "source_timestamp": _OUT_OF_RANGE},
+            # no occurred_at, source_timestamp in range → COALESCE recovers via
+            # source_timestamp → survives (proves no false-empty when occurred_at unset).
+            {"content": "fallback recover", "source_timestamp": _IN_RANGE},
+            # neither anchor in range → dropped.
+            {"content": "no anchor in range", "source_timestamp": _OUT_OF_RANGE},
+        ],
+    )
+    honored_id = chunks[0].id
+    fallback_id = chunks[1].id
+
+    returned = await _recall_ids(_engine_over(coord), ns.id, {"occurred_at": {"$gte": _FILTER_LB}})
+
+    assert returned == {honored_id, fallback_id}, (
+        "occurred_at filter must (1) honor a persisted in-range occurred_at even when "
+        "source_timestamp is out of range, and (2) recover event time from "
+        "source_timestamp when occurred_at is unset (no false-empty); rows whose "
+        "effective event time is out of range are dropped"
+    )
+    # Explicit regression guard: the honored chunk would be dropped if the write path
+    # failed to round-trip occurred_at (its effective event time would fall back to the
+    # out-of-range source_timestamp). Assert it survives on its own merits.
+    assert honored_id in returned, (
+        "chunk with in-range occurred_at + out-of-range source_timestamp must survive — "
+        "a regression in occurred_at persistence would drop it"
+    )


### PR DESCRIPTION
## Summary
- The SurrealDB `chunk` table is schemafull, and `occurred_at` / `last_accessed_at` were never declared via `DEFINE FIELD` — SurrealDB silently strips undeclared fields, so even a code-side write would no-op at the DB layer. Both fields are now declared as `option<datetime>`, alongside the existing `source_timestamp`.
- Wire both fields through the four chunk sites in the SurrealDB vector adapter (`create_chunk` SET clause, `create_chunks_batch` record dict, `_chunk_to_bindings`, `_row_to_chunk`), mirroring the existing `source_timestamp` handling. Previously a distinct `occurred_at` written through this backend read back NULL and the effective event time silently fell back to `source_timestamp` via `COALESCE(occurred_at, source_timestamp)` — benign for recall, but a distinct event time could not be honored. This closes the last backend gap; the sqlite_lance and pgvector siblings were fixed in #1054 and #1062.
- The temporal WHERE clauses in the adapter intentionally keep `(source_timestamp ?? created_at)`: recall filters on `occurred_at` are post-filter-only by design (only the `source_timestamp` axis pushes down), matching the other backends.
- Add an embedded SurrealDB (in-memory, no external service) integration test module mirroring the sqlite_lance/pgvector siblings: a distinct `occurred_at` (and `last_accessed_at`) round-trips through the real store, and an `occurred_at` recall filter is honored for a chunk whose `source_timestamp` is out of range — proving genuine persistence rather than COALESCE recovery.

## Test plan
- [x] `make test` green locally: 8577 unit + 378 integration passed, coverage 84% (gate 77%). Postgres/Neo4j-gated tests self-skip locally and run in CI.
- [x] New tests verified as genuine regression guards: with the adapter fix stashed, both fail (round-trip reads back NULL; the in-range-`occurred_at` chunk is wrongly dropped).
- [x] `make format` clean, `make lint` exits 0. Production diff is +10 lines.