### PR TITLE
Add deterministic end-to-end recall-filter test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,8 +275,15 @@ jobs:
         # compiler-dispatch, plus the skeleton-pgvector integration test which
         # self-skips when Postgres is unreachable); collect it here so the
         # filter tests gate in CI.
+        #
+        # tests/e2e/ holds the recall-filter end-to-end harness. The embedded
+        # sqlite_lance lane is hermetic (no services) and is the must-always-run
+        # lane, so it gates here; the live PG+Neo4j / chronicle modules carry the
+        # ``slow`` marker (excluded by the default ``-m "not slow ..."`` addopts)
+        # AND a reachability self-skip, so they collect and skip cleanly with no
+        # services. The dedicated slow/e2e job for the live lanes is a follow-up.
         run: |
-          uv run pytest tests/unit/ tests/recall/ --cov=src/khora --cov-branch --cov-report=xml:coverage-unit.xml --cov-fail-under=0 -n auto --timeout=120 --timeout-method=thread
+          uv run pytest tests/unit/ tests/recall/ tests/e2e/ -m "not slow and not filter_conformance" --cov=src/khora --cov-branch --cov-report=xml:coverage-unit.xml --cov-fail-under=0 -n auto --timeout=120 --timeout-method=thread
 
       - name: Generate JSON coverage for floor check
         run: uv run coverage json -o coverage.json

--- a/tests/e2e/DESIGN_NOTES.md
+++ b/tests/e2e/DESIGN_NOTES.md
@@ -44,10 +44,10 @@ tests/e2e/
   DESIGN_NOTES.md                  # this file (architect)
   conftest.py                      # BACKEND owns
   _harness.py                      # BACKEND owns
-  test_filter_rowset_embedded.py   # QA owns. sqlite_lance, no-Docker main lane -> AC1 + AC4 + AC5
-  test_filter_rowset_graph.py      # QA owns. live VectorCypher PG+Neo4j, self-skip -> AC3 (graph lane)
-  test_filter_rowset_chronicle.py  # QA owns. live Chronicle PG-only, self-skip -> AC3 (chronicle lane)
-  test_graph_contribution.py       # QA owns. live PG+Neo4j, self-skip -> AC2 + AC3 honesty (pre-flight + tripwire)
+  test_filter_rowset_embedded.py   # QA owns. sqlite_lance, no-Docker main lane -> AC1 + AC4 + AC5 (metadata)
+  test_filter_rowset_graph.py      # QA owns. live VectorCypher PG+Neo4j, self-skip -> AC3 + system-key AC4/AC5
+  test_filter_rowset_chronicle.py  # QA owns. live Chronicle PG-only, self-skip -> AC3 + system-key AC4/AC5
+  test_graph_contribution.py       # QA owns. live PG+Neo4j, self-skip -> AC2 + AC3 honesty (pre-flight + firing tripwire + filter-enforcement drop)
   test_multichunk_denorm.py        # QA owns. sqlite_lance, no-Docker -> AC6
 ```
 
@@ -59,10 +59,10 @@ embedded lane carries the corpus families (AC1 deterministic ingest, AC4 externa
 reconciliation, AC5 F-EXISTS reachability) since it runs in the no-Docker main job.
 
 - **`conftest.py` (Backend)** — per-engine `Khora` fixtures (sqlite_lance embedded
-  / vectorcypher PG+Neo4j / chronicle), the **autouse deterministic-LLM/extractor
-  fixture**, and HyDE-off (+ reranking-off) config. `_pg_reachable()` /
-  `_neo4j_reachable()` self-skip guards so a no-Docker run collects-and-skips the
-  live legs cleanly.
+  / vectorcypher PG+Neo4j / chronicle), each installing the deterministic
+  LLM/extractor stub (`stub_llm`) before building its `Khora`, with HyDE-off
+  (+ reranking-off) config. `_pg_reachable()` self-skip guard so a no-Docker run
+  collects-and-skips the live legs cleanly.
 - **`_harness.py` (Backend)** — the deterministic extract stub, the entity-bearing
   + multi-chunk seed builders, doc-level `reconcile()`, and a `neo4j_populated()`
   probe. The single surface QA imports.
@@ -115,10 +115,12 @@ the negative tripwire the registry is left empty so every doc gets
   to the stub, so `expected_ids` stays exact)
 - `enable_reranking = False`, `enable_llm_reranking = False` (no cross-encoder load;
   scores untouched by a reranker)
-- HyDE off: `enable_hyde = "never"`, `enable_hyde_cypher = False`; the autouse
-  fixture also sets env `KHORA_QUERY_ENABLE_HYDE=false` before any `Khora` is built,
-  and a test-start assertion confirms it (so a future default flip can't silently
-  re-enable query rewriting)
+- HyDE off: `enable_hyde = "never"`, `enable_hyde_cypher = False`, set on the
+  `KhoraConfig` each per-engine fixture builds; `test_hyde_is_disabled` pins
+  `config.query.enable_hyde == "never"` so a future default flip can't silently
+  re-enable query rewriting. (There is no env-var override and no autouse fixture —
+  as shipped, `stub_llm` is installed *inside* each per-engine fixture before its
+  `Khora` is constructed, not via an autouse/env layer.)
 - `min_entity_similarity = 0.0` (floors the entry-entity vector gate so the seeded
   entity is returned as a graph-expansion seed — see Implementation risks)
 - non-empty `entity_types` / `relationship_types` on `remember()` (vectorcypher
@@ -207,10 +209,11 @@ families whose filter predicate `remember()` can reproduce AND the lane supports
 The harness needs only a representative slice per kept family, not the full catalog.
 The smoke run drives final curation.
 
-`seed_corpus(remember, namespace_id, docs)` (already in `tests/test_helpers/filter_spy.py`)
-is the bound-`remember` seeding path Backend wires; extend its per-doc dict to
-carry `external_id` + the system-key fields, or add the thin equivalent in
-`_harness.py`.
+As shipped, `_harness.seed_records(kb, records, namespace_id, ...)` is the seeding
+path: it calls `kb.remember()` once per `SeedRecord` via `_remember_kwargs`, mapping
+`external_id = record.id` + the threadable system-key fields. The curated case set is
+`_harness.rowset_cases(backend, include_system_keys=...)` (the single selector the
+three lane modules share).
 
 ## Graph-channel proof (non-vacuity)
 
@@ -254,10 +257,25 @@ document (any-chunk semantics).
 |---|---|---|
 | AC1 deterministic ingest | `test_filter_rowset_embedded.py` | real `remember()` pipeline, deterministic embeddings + extraction, stable across runs |
 | AC2 graph fires / Neo4j populated | `test_graph_contribution.py` | `graph_chunk_count > 0` + `neo4j_populated()` after a real `remember()` ingest whose `stub_llm`/`plan_extraction` emits entities — the ONLY path that writes entities/edges (`seed_case` writes zero) |
-| AC3 set-equality + negative tripwire | `test_graph_contribution.py` (honesty) + `test_filter_rowset_{graph,chronicle}.py` (row-set) | filtered recall retains/drops the right set; the graph channel empties under a violating filter (non-vacuous) |
-| AC4 reconciliation | `test_filter_rowset_embedded.py` | curated `f_*_cases` seeded via real `remember()` on sqlite_lance; `external_id`-keyed survivor set == `expected_ids` (see Reconciliation) |
-| AC5 F-EXISTS reachability | `test_filter_rowset_embedded.py` | the 8 presence sub-states (`f_exists_cases()`) all reconcile correctly |
+| AC3 set-equality + filter enforcement | `test_graph_contribution.py` (honesty) + `test_filter_rowset_{embedded,graph,chronicle}.py` (row-set) | filtered recall retains/drops the right set; `test_graph_channel_drops_violating_chunks` proves the graph channel *enforces* `filter_ast` (entity-bearing keep/drop docs → only keep survives), distinct from the firing tripwire |
+| AC4 reconciliation | `test_filter_rowset_embedded.py` (+ live graph/chronicle) | curated `f_*_cases` seeded via real `remember()`; `external_id`-keyed survivor set == `expected_ids` (see Reconciliation) |
+| AC5 F-EXISTS reachability | `test_filter_rowset_embedded.py` (6 metadata states) + live graph/chronicle (2 `source_name` system-key states) | all 8 presence sub-states (`f_exists_cases()`) reconcile through real `remember()`; `test_f_exists_states_are_complete` guards against a corpus shrink |
 | AC6 multi-chunk denorm | `test_multichunk_denorm.py` | denormalized doc/date keys uniform across chunks; filter is whole-doc consistent |
+
+## CI gating + deferred lanes
+
+- **The embedded sqlite_lance lane gates CI.** It is hermetic (no services), so it
+  runs in the `test-unit` job (`pytest tests/unit/ tests/recall/ tests/e2e/ -m "not
+  slow and not filter_conformance"`). The live `vectorcypher` / `chronicle` modules
+  carry `pytest.mark.slow` + a reachability self-skip, so the same invocation collects
+  and skips them cleanly; they execute under `make dev` + `NEO4J_INTEGRATION_TEST=1`.
+- **Dedicated slow/e2e CI job for the live lanes is a follow-up** (a separate job that
+  provisions PG+Neo4j and runs `-m "e2e and slow"`).
+- **The skeleton-pgvector engine lane is deferred.** The shipped harness covers the
+  embedded sqlite_lance, live VectorCypher (PG+Neo4j), and live Chronicle (PG-only)
+  lanes. A skeleton-pgvector row-set lane is not included in this PR; it can be added
+  by giving `_harness.rowset_cases` a `"skeleton_pgvector"` backend selector and a
+  fixture that pins that engine.
 
 ## Implementation risks (flagged for Backend — verified against source)
 

--- a/tests/e2e/DESIGN_NOTES.md
+++ b/tests/e2e/DESIGN_NOTES.md
@@ -1,0 +1,281 @@
+# Deterministic end-to-end recall-filter harness — design notes
+
+> **SETTLED DECISIONS (read first — supersede any older snapshot you may be holding;
+> all four reconciliation/seeding points empirically validated against a real
+> sqlite_lance Khora):**
+> 1. **Seed via real `Khora.remember()` everywhere** — NOT `conformance.seed_case`
+>    (it bypasses the ingest pipeline, writes zero entities → defeats AC2, one chunk
+>    per record → defeats AC6, and its rows are NOT recall-visible: `seed_case` →
+>    `recall()` returns 0 chunks, proven).
+> 2. **Reconcile DOC-LEVEL by `external_id`** (= `SeedRecord.id`, stamped at
+>    `remember()` time) — NOT chunk-UUID via a `seed_case` `id_map` (there is no
+>    `id_map` when seeding via `remember()`). `chunk-UUID` reconciliation is
+>    **rejected** (see §3). Key off the RETURNED chunks' `document_id`s.
+> 3. **Use DISTINCT content per record** (`f"{rec.content} record {rec.id}"`) — N
+>    identical-content docs collapse to ONE recallable doc through vector top-k
+>    (proven), which would make the row-set proof impossible. Content is not a filter
+>    target for the curated families, so `expected_ids` is unchanged.
+> 4. **Stub seam = three class-method patches** via `filter_spy.stub_llm`
+>    (`LiteLLMEmbedder.embed_batch/.embed` + `LLMEntityExtractor.extract_multi`). The
+>    SHA-256 hash embedder is fine here because distinct content gives each doc a
+>    distinct vector; the graph lane floors the entry gate with
+>    `min_entity_similarity=0.0` and guards with the `graph_chunk_count>0` tripwire.
+> 5. Curated e2e corpus = remember-threadable F-OP families (7 string keys +
+>    `source_timestamp` + metadata); `occurred_at`/`created_at`/`content_type`,
+>    `external_id`-filtering, and duplicate-`external_id` families are curated OUT
+>    (covered by the conformance executor suite). See §3.
+
+`@internal`. Architecture for the `tests/e2e/` recall-filter end-to-end suite.
+This is the **row-set proof** that complements the existing WIRING spies
+(`tests/integration/test_filter_pushdown_graph.py`,
+`tests/integration/matrix/test_filter_enforcement_sqlite_lance.py`): those prove
+the validated filter AST *reaches* each channel unchanged; this suite proves the
+filter *actually narrows the rows* end to end, through the real `Khora.remember()`
+ingest pipeline and `Khora.recall(filter=...)` read path, with a populated graph.
+
+Smallest thing that satisfies the six acceptance criteria. No new test framework,
+no DI abstractions, no `src/` changes. Behavior-only language throughout.
+
+## File layout + ownership (`tests/e2e/`)
+
+```
+tests/e2e/
+  __init__.py                      # empty
+  DESIGN_NOTES.md                  # this file (architect)
+  conftest.py                      # BACKEND owns
+  _harness.py                      # BACKEND owns
+  test_filter_rowset_embedded.py   # QA owns. sqlite_lance, no-Docker main lane -> AC1 + AC4 + AC5
+  test_filter_rowset_graph.py      # QA owns. live VectorCypher PG+Neo4j, self-skip -> AC3 (graph lane)
+  test_filter_rowset_chronicle.py  # QA owns. live Chronicle PG-only, self-skip -> AC3 (chronicle lane)
+  test_graph_contribution.py       # QA owns. live PG+Neo4j, self-skip -> AC2 + AC3 honesty (pre-flight + tripwire)
+  test_multichunk_denorm.py        # QA owns. sqlite_lance, no-Docker -> AC6
+```
+
+The modules are organized by **engine lane** (the shipped structure), not one-per-AC:
+the three `test_filter_rowset_*` modules drive the same `remember()`→`recall(filter=)`
+row-set proof on each engine; `test_graph_contribution.py` is the non-vacuity honesty
+proof; `test_multichunk_denorm.py` is the denormalization-uniformity proof. The
+embedded lane carries the corpus families (AC1 deterministic ingest, AC4 external_id
+reconciliation, AC5 F-EXISTS reachability) since it runs in the no-Docker main job.
+
+- **`conftest.py` (Backend)** — per-engine `Khora` fixtures (sqlite_lance embedded
+  / vectorcypher PG+Neo4j / chronicle), the **autouse deterministic-LLM/extractor
+  fixture**, and HyDE-off (+ reranking-off) config. `_pg_reachable()` /
+  `_neo4j_reachable()` self-skip guards so a no-Docker run collects-and-skips the
+  live legs cleanly.
+- **`_harness.py` (Backend)** — the deterministic extract stub, the entity-bearing
+  + multi-chunk seed builders, doc-level `reconcile()`, and a `neo4j_populated()`
+  probe. The single surface QA imports.
+- **`test_*.py` (QA)** — the cases, the per-AC assertions, the parametrize
+  hookups. QA imports from `_harness` and `khora.filter.conformance`; QA never
+  reaches into `src/` for private symbols beyond what `_harness` exposes.
+
+**Boundary rule:** Backend writes `conftest.py` + `_harness.py` ONLY. QA writes the
+`test_*.py` modules ONLY.
+
+## The seam (settled — no `src/` changes)
+
+A monkeypatch of three class methods (network-free, undone at teardown), via
+`tests/test_helpers/filter_spy.py::stub_llm(monkeypatch, dim)`. `install_mock_llm`
+is NOT used and not needed — completions never fire with HyDE + reranking off and
+extraction stubbed above the `litellm.acompletion` call.
+
+- `khora.extraction.embedders.litellm.LiteLLMEmbedder.embed_batch`
+- `khora.extraction.embedders.litellm.LiteLLMEmbedder.embed`
+  → `fake_embedding(text, dim)` = SHA-256 → L2-normalize (deterministic per text).
+  **The hash embedder is sufficient here BECAUSE seeding uses distinct content per
+  record (§3):** distinct content → distinct vector → each doc is independently
+  recallable, and a generous `limit` (100) makes the filter the only narrowing
+  force. On the **graph lane** the entity-bearing docs have distinct content too, so
+  the query↔entity cosine is not guaranteed positive — the fixture floors the
+  entry-entity gate with `min_entity_similarity = 0.0` and the `graph_chunk_count>0`
+  pre-flight tripwire (§"Graph-channel proof") catches any regression. (If that gate
+  ever flakes, swap the graph fixture's embedder to a unit vector `[1.0]+[0.0]*(dim-1)`
+  for cosine 1.0 — the reference `test_vectorcypher_filter_counters.py` does this.)
+  Per-engine dim: 1536 for the PG pgvector column, 32 (`EMBED_DIM`) for sqlite_lance.
+- `khora.extraction.extractors.llm.LLMEntityExtractor.extract_multi`
+  → a content-keyed registry: a doc whose text **contains** a registered marker
+  yields that marker's `ExtractionResult` (real `ExtractedEntity` /
+  `ExtractedRelationship` dataclasses), else an empty `ExtractionResult()`.
+
+A thin `plan_extraction(marker, entities, relationships)` helper in `_harness.py`
+backs the marker→result registry the `extract_multi` stub reads. This drives
+**marker-based entity emission through the REAL ingest pipeline** — the patch sits
+at the LLM/embedding leaf, so everything above it runs unchanged: `extract_entities`
+constructs the real `LLMEntityExtractor`, entity normalization + resolution +
+dual-node mirroring run, and `upsert_entities_batch` + `create_relationships_batch`
+write MENTIONED_IN edges into **both Neo4j and pgvector**. This is *not*
+`extract_entities=False` and *not* a high-level patch that bypasses persistence. For
+the negative tripwire the registry is left empty so every doc gets
+`ExtractionResult()` and the graph stays empty.
+
+### Config so the graph fires
+
+- `extract_entities = True`, `selective_extraction = False` (every seed chunk goes
+  to the stub, so `expected_ids` stays exact)
+- `enable_reranking = False`, `enable_llm_reranking = False` (no cross-encoder load;
+  scores untouched by a reranker)
+- HyDE off: `enable_hyde = "never"`, `enable_hyde_cypher = False`; the autouse
+  fixture also sets env `KHORA_QUERY_ENABLE_HYDE=false` before any `Khora` is built,
+  and a test-start assertion confirms it (so a future default flip can't silently
+  re-enable query rewriting)
+- `min_entity_similarity = 0.0` (floors the entry-entity vector gate so the seeded
+  entity is returned as a graph-expansion seed — see Implementation risks)
+- non-empty `entity_types` / `relationship_types` on `remember()` (vectorcypher
+  requires them)
+
+> Verify the exact `KhoraConfig` attribute names against the live config /
+> reference fixtures (`config.pipeline` vs `config.pipelines`, `config.query.*`) —
+> do not guess.
+
+## Reconciliation (AC4) — seed via real `remember()`, reconcile on `external_id`
+
+**Settled:** AC4 seeds each curated case's `SeedRecord`s through the **real**
+`Khora.remember()` ingest pipeline — NOT `conformance.seed_case`. This is the whole
+reason the harness exists: it must exercise real chunking, extraction, embedding,
+denormalization, and graph writes, then prove the public `recall(filter=...)`
+narrows the rows to the same set the corpus declares. `seed_case` writes directly
+through the `StorageCoordinator` (the direct-seed / conformance path) and would
+bypass the ingest pipeline — re-running what the conformance suite already covers.
+
+> **Considered & rejected: `seed_case` + chunk-UUID reconciliation.** A direct
+> `conformance.seed_case` write + reconciling on its `seed_id -> chunk UUID`
+> `id_map` looks simpler, but it **bypasses `remember()`** — it runs no extraction
+> (writes ZERO entities → the AC2 graph channel cannot fire), writes exactly one
+> `chunk_index=0` chunk per record (AC6 multi-chunk impossible), and reconciling the
+> direct seed against its own `id_map` is circular (proves nothing about the ingest
+> pipeline under test). The harness uses real `remember()` everywhere, so there is
+> no `seed_case` `id_map` to key on.
+
+Because `remember()` assigns **fresh chunk/doc UUIDs we don't control**, the only
+stable handle to reconcile a real-ingest result against the corpus's handle-based
+`expected_ids` is **`external_id`**. So:
+
+- For each `SeedRecord` in a curated case, call
+  `kb.remember(content=..., namespace=ns, external_id=<SeedRecord.id>, ...)`,
+  mapping the record's filterable fields to `remember()` kwargs:
+  `metadata` → `metadata=`, `source_name`/`source_url`/`source_type`/`title` →
+  the same-named kwargs, and the event time via `source_timestamp=` (which the
+  engine resolves to `occurred_at`).
+- **Use DISTINCT content per record** — `f"{record.content} record {record.id}"`,
+  NOT the shared `"conformance anchor"`. Empirically verified (Backend): N records
+  with IDENTICAL content collapse to ONE recallable document through the engine's
+  vector top-k (identical embedding vectors → ANN returns a single distinct row),
+  so a shared-anchor seed makes a row-set proof over N records impossible on the
+  recall path. Distinct content gives each document a distinct vector so all N are
+  independently recallable. Content is NOT a filter target for the curated families,
+  so distinct content does not change which rows the filter keeps — `expected_ids`
+  is unchanged.
+- `recall(query=<fixed>, namespace=ns, limit >= N, filter=case.filter,
+  min_similarity=0.0)`. With distinct-content docs all present in the namespace and
+  a generous `limit` (≥ the seed count; the harness uses 100), the **filter** — not
+  ranking — decides the surviving set.
+- `reconcile(result)` → key off the RETURNED CHUNKS, not raw `result.documents`:
+  collect `returned_doc_ids = { chunk.document_id for chunk in result.chunks }`,
+  then `{ doc.external_id for doc in result.documents if doc.id in returned_doc_ids }`;
+  assert `== case.expected_ids`. Doc-level, any-chunk. (Keying on the returned
+  chunks' `document_id`s — not blindly on every `result.documents` entry — is what
+  enforces "present iff ≥1 surviving chunk"; a document with zero surviving chunks
+  must not count even if it appears in the projection list.) `expected_ids` are the
+  `SeedRecord` handles, which equal the stamped `external_id`s. The handle
+  round-trips on the public surface: `DocumentProjection.external_id` (recall.py:31)
+  carries the stamped value out — no chunk/doc-UUID bookkeeping beyond the
+  `chunk.document_id → documents[].external_id` join.
+- `conformance._case_namespace_id(case)` = `uuid5(...)` gives a fresh, xdist-safe
+  namespace per case.
+
+**Curated subset = families `remember()` can faithfully seed.** The AC4 subset uses
+families whose filter predicate `remember()` can reproduce AND the lane supports.
+`remember()` accepts `metadata`, `title`, `source`, `source_type`, `source_name`,
+`source_url`, `source_timestamp`, `external_id`. The clean pick is the
+**metadata-key families** — `F-COERCE`, `F-OBJEQ`, `F-DOTKEY`, and the
+`metadata.*` `F-EXISTS` cases — which filter on `metadata.<key>` and seed via
+`remember(metadata=...)`. Curate OUT:
+
+- The **`external_id` F-OP family** (deliberate-duplicate cases): `external_id` is
+  the test variable there, so it cannot also be the reconciliation handle. Covered
+  by the direct-seed conformance suite. For every other family
+  `SeedRecord.external_id` defaults to `None`, so stamping `external_id =
+  SeedRecord.id` (unique within the fresh per-case namespace) is free.
+- The **date-column families** (`F-DATES`, the date `F-OP` cases): `remember()` has
+  no direct `occurred_at` / `created_at` kwargs — `occurred_at` derives from
+  `source_timestamp`, `created_at` is stamped at ingest — so a case that filters on
+  a caller-controlled date column is not faithfully reproducible. Leave to the
+  conformance suite *unless* the smoke run shows the column is settable via
+  `metadata.custom`.
+
+The harness needs only a representative slice per kept family, not the full catalog.
+The smoke run drives final curation.
+
+`seed_corpus(remember, namespace_id, docs)` (already in `tests/test_helpers/filter_spy.py`)
+is the bound-`remember` seeding path Backend wires; extend its per-doc dict to
+carry `external_id` + the system-key fields, or add the thin equivalent in
+`_harness.py`.
+
+## Graph-channel proof (non-vacuity)
+
+The honest, lane-isolated signal is `engine_info["graph_chunk_count"]` (surfaced on
+the public `RecallResult.engine_info`). Use `SearchMode.GRAPH` (force the graph
+path — `HYBRID` could classify a short entity query as SIMPLE / `use_graph=False`
+and fall to the graph-less path, making the proof vacuous) and
+`min_entity_similarity = 0.0`.
+
+- **Pre-flight (positive):** a no-filter `GRAPH` recall asserts
+  `graph_chunk_count > 0` — the channel really held candidates.
+- **Negative tripwire:** a filtered recall then asserts the correct retain/drop
+  (e.g. a filter all graph docs violate empties the channel) — proving the filter
+  is the narrowing force, not an empty-to-empty identity.
+
+Mirror the live `kb` fixture from `tests/integration/test_filter_pushdown_graph.py`
+(the live PG+Neo4j fixture around line 115) plus its `_pg_reachable()` / `_SKIP`
+gate, and lower `retriever._config.min_entity_similarity = 0.0`. **This knob is test
+infrastructure only — it is set on the per-test fixture's retriever instance to let
+the deterministic-embedder entry entities clear the floor; the production default is
+unchanged.** `neo4j_populated()` in `_harness.py` is the direct read-back probe for
+the graph-write assertion.
+
+## Multi-chunk denormalization (AC6)
+
+AC6 seeds via **real `remember()` with LONG content** — content over the
+configured `chunk_size` (default 512 tokens) so the real chunker emits **multiple
+chunks per document**. This is the path that proves the denormalization contract on
+real ingest (and is impossible on `seed_case`, which writes exactly one
+`chunk_index=0` chunk per record). Follow the contract in
+`tests/integration/matrix/test_chunk_denormalization_contract.py`: the eight
+denormalized document keys + the three date columns are uniform across **all**
+chunks of a document. AC6 then runs a `recall(filter=...)` on a denormalized key
+and asserts the filter retains/drops the whole document consistently — i.e. the
+doc-level `external_id` reconciliation holds even though several chunks back the one
+document (any-chunk semantics).
+
+## Acceptance-criteria → test-module map
+
+| AC | module | proves |
+|---|---|---|
+| AC1 deterministic ingest | `test_filter_rowset_embedded.py` | real `remember()` pipeline, deterministic embeddings + extraction, stable across runs |
+| AC2 graph fires / Neo4j populated | `test_graph_contribution.py` | `graph_chunk_count > 0` + `neo4j_populated()` after a real `remember()` ingest whose `stub_llm`/`plan_extraction` emits entities — the ONLY path that writes entities/edges (`seed_case` writes zero) |
+| AC3 set-equality + negative tripwire | `test_graph_contribution.py` (honesty) + `test_filter_rowset_{graph,chronicle}.py` (row-set) | filtered recall retains/drops the right set; the graph channel empties under a violating filter (non-vacuous) |
+| AC4 reconciliation | `test_filter_rowset_embedded.py` | curated `f_*_cases` seeded via real `remember()` on sqlite_lance; `external_id`-keyed survivor set == `expected_ids` (see Reconciliation) |
+| AC5 F-EXISTS reachability | `test_filter_rowset_embedded.py` | the 8 presence sub-states (`f_exists_cases()`) all reconcile correctly |
+| AC6 multi-chunk denorm | `test_multichunk_denorm.py` | denormalized doc/date keys uniform across chunks; filter is whole-doc consistent |
+
+## Implementation risks (flagged for Backend — verified against source)
+
+These do not change the settled seam; they are sharp edges to handle in
+`_harness.py` / the fixtures:
+
+1. **Embedder dim must match the configured dimension.** The unit-vector stub must
+   emit a vector of exactly `config.storage.embedding_dimension` (1536 on the PG
+   pgvector column, 32 / `EMBED_DIM` on sqlite_lance). A dim mismatch fails the
+   write or the search. The `graph_chunk_count > 0` pre-flight gate is the tripwire
+   that catches a misconfigured entry gate — it must FAIL LOUD, never be softened.
+
+2. **Namespace must round-trip from seed to recall.** The embedded vector channel
+   (`SQLiteLanceVectorAdapter.search_similar`, vector.py:438) reads `chunks_vec`
+   scoped by `namespace_id`; `remember()`d chunks land there under the same
+   namespace, so seed and recall MUST use the identical namespace handle (the
+   public `namespace_id`, resolved consistently). A namespace mismatch is the most
+   likely cause of a zero-result recall on an otherwise-correct seed.
+
+3. **HyDE default is `"auto"`** (not off) — the explicit `"never"` + env override +
+   test-start assertion above is required, not optional.

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,8 @@
+"""Deterministic end-to-end recall-filter row-set suite.
+
+Complements the wiring spies (which prove the validated filter AST reaches
+each channel unchanged) by proving the filter actually narrows the rows end
+to end, through the real ``Khora.remember()`` ingest pipeline and
+``Khora.recall(filter=...)`` read path, with a populated graph. See
+``DESIGN_NOTES.md``.
+"""

--- a/tests/e2e/_harness.py
+++ b/tests/e2e/_harness.py
@@ -21,11 +21,17 @@ from collections.abc import Sequence
 from typing import Any
 from uuid import UUID
 
-import pytest
-
 from khora import Khora
 from khora.core.models.recall import RecallResult
-from khora.filter.conformance import ConformanceCase, SeedRecord
+from khora.filter.conformance import (
+    ConformanceCase,
+    SeedRecord,
+    f_coerce_cases,
+    f_dotkey_cases,
+    f_exists_cases,
+    f_objeq_cases,
+    f_op_cases,
+)
 from khora.query import SearchMode
 
 # The conformance ``SeedRecord`` fields that map to a ``Khora.remember()`` keyword.
@@ -307,18 +313,54 @@ def _has_duplicate_external_id(records: Sequence[SeedRecord]) -> bool:
     return len(ids) != len(set(ids))
 
 
+def rowset_cases(backend: str, *, include_system_keys: bool) -> list[ConformanceCase]:
+    """The curated row-set cases for one engine lane (the single shared selector).
+
+    Always includes the dotted-``metadata``-path families (``F-COERCE`` / ``F-OBJEQ``
+    / ``F-DOTKEY``) that target ``backend``; whole-metadata-blob equality
+    (``exercises[1] == "metadata"``) is dropped because the embedded JSON path can't
+    narrow on it.
+
+    ``include_system_keys`` is for the **live** lanes only (``vectorcypher`` /
+    ``chronicle``): their chunk row carries the denormalized document system keys, so
+    the engine recall path narrows on them — unlike the embedded ``chunks`` row. When
+    set, the selector also includes the ``remember``-threadable system-key ``F-OP``
+    families (via :func:`engine_rowset_cases`: the five string keys + ``source_timestamp``
+    + the ``metadata.tier`` representative, minus exact-instant timestamp equalities)
+    and the two ``source_name`` ``F-EXISTS`` presence states. This is the only path on
+    which an e2e case filters on a denormalized document column.
+
+    Cases are deduplicated by id and any seed with a duplicate ``external_id`` (the
+    reconciliation key under UNIQUE(namespace_id, external_id)) is dropped.
+    """
+    candidates: list[ConformanceCase] = []
+    for family in (f_coerce_cases, f_objeq_cases, f_dotkey_cases):
+        candidates.extend(c for c in family() if backend in c.backends and c.exercises[1] != "metadata")
+    if include_system_keys:
+        candidates.extend(c for c in engine_rowset_cases(f_op_cases()) if backend in c.backends)
+        candidates.extend(c for c in f_exists_cases() if backend in c.backends and c.exercises[1] == "source_name")
+
+    selected: list[ConformanceCase] = []
+    seen: set[str] = set()
+    for case in candidates:
+        if case.id in seen or _has_duplicate_external_id(case.seed_records):
+            continue
+        seen.add(case.id)
+        selected.append(case)
+    return selected
+
+
 # --------------------------------------------------------------------------- #
-# Per-engine parametrization.
+# Reachability guard — the live-lane modules self-skip on this.
 # --------------------------------------------------------------------------- #
-#
-# Each row names the kb fixture and its self-skip mark. A test parametrizes its
-# ``kb`` argument indirectly over ``ENGINE_PARAMS`` (and resolves the matching
-# namespace fixture) so a no-Docker run collects the whole module and skips the
-# live legs cleanly.
 
 
 def _pg_reachable() -> bool:
-    """Mirror the conftest reachability guard (kept import-light for the param marks)."""
+    """Whether the compose Postgres is reachable (the live-lane self-skip guard).
+
+    Kept import-light so the ``pytest.mark.skipif`` in each live module can call it
+    at collection time without importing the conftest fixtures.
+    """
     import socket
     from urllib.parse import urlparse
 
@@ -329,33 +371,3 @@ def _pg_reachable() -> bool:
             return True
     except OSError:
         return False
-
-
-def _embedded_available() -> bool:
-    try:
-        import aiosqlite  # noqa: F401
-        import lancedb  # noqa: F401
-    except ImportError:
-        return False
-    return True
-
-
-_SKIP_EMBEDDED = pytest.mark.skipif(
-    not _embedded_available(),
-    reason="embedded stack (aiosqlite + lancedb) not installed",
-)
-_SKIP_LIVE_GRAPH = pytest.mark.skipif(
-    not os.environ.get("NEO4J_INTEGRATION_TEST") or not _pg_reachable(),
-    reason="set NEO4J_INTEGRATION_TEST=1 and start PG+Neo4j to exercise the live graph lane",
-)
-_SKIP_LIVE_PG = pytest.mark.skipif(
-    not _pg_reachable(),
-    reason="start Postgres to exercise the live chronicle lane",
-)
-
-# (kb_fixture_name, engine_label) — the test indirects ``kb`` over this table.
-ENGINE_PARAMS = [
-    pytest.param("sqlite_lance_kb", id="sqlite_lance", marks=_SKIP_EMBEDDED),
-    pytest.param("vectorcypher_kb", id="vectorcypher", marks=_SKIP_LIVE_GRAPH),
-    pytest.param("chronicle_kb", id="chronicle", marks=_SKIP_LIVE_PG),
-]

--- a/tests/e2e/_harness.py
+++ b/tests/e2e/_harness.py
@@ -1,0 +1,361 @@
+"""Reusable engine layer for the deterministic e2e recall-filter suite.
+
+``@internal``. Backend-owned. The test modules (QA-owned ``test_*.py``) drive
+their per-AC assertions through this thin layer so the seeding, reconciliation,
+graph-population probe, and per-engine parametrization live in one place.
+
+The row-set proof seeds each conformance ``SeedRecord`` through the **real**
+``Khora.remember()`` ingest path (not the conformance write-API seeder, whose
+rows are invisible to the engine recall channel), giving each record DISTINCT
+content so every document is independently recallable, an ``external_id`` equal
+to the record id, and the record's filterable fields threaded as ``remember``
+arguments. Recall then runs with the case filter and the surviving documents are
+reconciled back to record ids by ``external_id`` — a set, never a ranked list,
+so a tie in vector score can never flip an assertion.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from khora import Khora
+from khora.core.models.recall import RecallResult
+from khora.filter.conformance import ConformanceCase, SeedRecord
+from khora.query import SearchMode
+
+# The conformance ``SeedRecord`` fields that map to a ``Khora.remember()`` keyword.
+# ``occurred_at`` / ``created_at`` / ``content_type`` are intentionally absent:
+# ``remember`` exposes no keyword for them, so the F-OP families that exercise
+# those keys are out of the engine row-set lane (they stay covered by the
+# conformance executor suite). ``external_id`` is the reconciliation key, set
+# separately from the record id.
+_REMEMBER_STRING_KEYS: tuple[str, ...] = (
+    "source_type",
+    "source_name",
+    "source_url",
+    "source",
+    "title",
+)
+
+# The system keys an e2e row-set case may exercise (the ``exercises[1]`` tag on
+# an F-OP case). Everything ``remember`` can thread plus the user-supplied
+# ``source_timestamp`` date column and the free-form ``metadata`` blob.
+_ENGINE_ROWSET_KEYS: frozenset[str] = frozenset({*_REMEMBER_STRING_KEYS, "source_timestamp", "metadata.tier"})
+
+# A generous recall ceiling so the whole seed set is returned and the filter is
+# the only narrowing force (conformance seeds are a handful of records each).
+_RECALL_LIMIT = 100
+
+
+# --------------------------------------------------------------------------- #
+# Seeding through the real ingest path.
+# --------------------------------------------------------------------------- #
+
+
+def _remember_kwargs(record: SeedRecord, *, entity_types: list[str], relationship_types: list[str]) -> dict[str, Any]:
+    """Build the ``Khora.remember()`` kwargs that reproduce a record's filterable surface.
+
+    Each record gets DISTINCT content (``"<anchor> record <id>"``) so its document
+    is independently recallable — identical content collapses to a single recalled
+    document under deterministic embeddings. The record id rides through as
+    ``external_id`` (the reconciliation key). Populated string keys, the
+    ``source_timestamp`` date, and the ``metadata`` blob are threaded so the filter
+    has the same surface to address it does in the conformance oracle.
+    """
+    kwargs: dict[str, Any] = {
+        "content": f"{record.content} record {record.id}",
+        "external_id": record.id,
+        "entity_types": entity_types,
+        "relationship_types": relationship_types,
+    }
+    for key in _REMEMBER_STRING_KEYS:
+        value = getattr(record, key)
+        if value is not None:
+            kwargs[key] = value
+    if record.source_timestamp is not None:
+        kwargs["source_timestamp"] = record.source_timestamp
+    if record.metadata:
+        kwargs["metadata"] = dict(record.metadata)
+    return kwargs
+
+
+async def seed_records(
+    kb: Khora,
+    records: Sequence[SeedRecord],
+    namespace_id: UUID,
+    *,
+    entity_types: list[str] | None = None,
+    relationship_types: list[str] | None = None,
+) -> None:
+    """Seed conformance records through ``Khora.remember()`` (the real ingest path).
+
+    One ``remember`` call per record. ``entity_types`` / ``relationship_types``
+    default to a single placeholder type each (the VectorCypher engine requires a
+    non-empty list); a graph-bearing test passes its own seeded types.
+    """
+    etypes = entity_types if entity_types is not None else ["ENTITY"]
+    rtypes = relationship_types if relationship_types is not None else ["RELATED_TO"]
+    for record in records:
+        await kb.remember(
+            namespace=namespace_id,
+            **_remember_kwargs(record, entity_types=etypes, relationship_types=rtypes),
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Reconciliation — survivors as a set of record ids.
+# --------------------------------------------------------------------------- #
+
+
+def reconcile(result: RecallResult) -> frozenset[str]:
+    """The ``external_id`` set of documents that returned at least one chunk.
+
+    A document is a survivor iff the recall returned a chunk belonging to it; its
+    ``external_id`` is the seeded record id. Returns a SET (order-independent), so
+    a vector-score tie among equally-filtered documents cannot flip an assertion.
+    """
+    surviving_doc_ids = {chunk.document_id for chunk in result.chunks}
+    return frozenset(
+        doc.external_id for doc in result.documents if doc.id in surviving_doc_ids and doc.external_id is not None
+    )
+
+
+async def recall_survivors(
+    kb: Khora,
+    case: ConformanceCase,
+    namespace_id: UUID,
+    *,
+    mode: SearchMode = SearchMode.HYBRID,
+) -> frozenset[str]:
+    """Seed a case, run its filter through ``Khora.recall()``, return surviving record ids.
+
+    Seeds every ``case.seed_records`` via :func:`seed_records`, recalls the shared
+    anchor with ``case.filter`` applied (``min_similarity=0.0`` and a generous
+    ``limit`` so the filter is the only narrowing force), and reconciles the result
+    back to record ids by ``external_id``. The caller asserts the returned set
+    equals ``case.expected_ids``.
+    """
+    await seed_records(kb, case.seed_records, namespace_id)
+    result = await kb.recall(
+        case.seed_records[0].content,
+        namespace=namespace_id,
+        mode=mode,
+        limit=_RECALL_LIMIT,
+        min_similarity=0.0,
+        filter=case.filter,
+    )
+    return reconcile(result)
+
+
+# --------------------------------------------------------------------------- #
+# Graph-population probe (AC: the graph was actually written, not just fired).
+# --------------------------------------------------------------------------- #
+
+
+async def graph_counts(kb: Khora, namespace_id: UUID) -> tuple[int, int]:
+    """``(entity_count, relationship_count)`` written to the graph for a namespace.
+
+    Resolves the stable ``namespace_id`` to the active row id first — entities and
+    relationships are keyed by the row id, so counting against the stable id reads
+    zero. Reads through the storage coordinator, so it works on both the embedded
+    graph backend and a live Neo4j stack.
+    """
+    resolved = await kb.storage.resolve_namespace(namespace_id)
+    entities = await kb.storage.count_entities(resolved)
+    relationships = await kb.storage.count_relationships(resolved)
+    return entities, relationships
+
+
+async def graph_recall(kb: Khora, namespace_id: UUID, query: str) -> RecallResult:
+    """Run a no-filter ``mode=GRAPH`` recall for ``query`` and return the result.
+
+    ``query`` must be a real seeded entity surface (e.g. an entity name): an empty
+    query yields a degenerate embedding the graph-expansion path cannot resolve a
+    namespace for. The caller inspects ``result.entities`` and
+    ``result.engine_info`` (e.g. ``"graph_chunk_count"``) for its contribution
+    assertions.
+    """
+    return await kb.recall(
+        query,
+        namespace=namespace_id,
+        mode=SearchMode.GRAPH,
+        limit=_RECALL_LIMIT,
+        min_similarity=0.0,
+    )
+
+
+async def assert_graph_contributes(kb: Khora, namespace_id: UUID, query: str) -> RecallResult:
+    """Pre-flight gate: a GRAPH recall for ``query`` must return entities.
+
+    A filtered graph proof passes vacuously if the graph channel never fired (entity
+    vector search returned nothing and recall short-circuited). Asserting a non-empty
+    entity set here, before any filtered assertion, closes that hole. ``query`` must
+    be a seeded entity surface (e.g. the entity name) — with the deterministic
+    embedder only an exact surface clears entity vector search. Returns the gate's
+    recall result for further assertions (e.g. ``graph_chunk_count``).
+    """
+    result = await graph_recall(kb, namespace_id, query)
+    assert result.entities, (
+        f"graph channel returned no entities for a GRAPH recall of {query!r} — the "
+        "seed did not populate the graph, so every filtered assertion would be vacuous"
+    )
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Seed builders.
+# --------------------------------------------------------------------------- #
+
+
+def entity_seed_docs(marker: str, *, count: int = 3) -> list[str]:
+    """``count`` documents that each mention ``marker`` (an entity-bearing corpus).
+
+    Paired with ``filter_spy.plan_extraction(marker, ...)``: every document whose
+    text contains ``marker`` yields the staged entities/relationships through the
+    deterministic extractor, so the real graph-write path populates the graph.
+    Distinct trailing text keeps each document independently recallable.
+    """
+    return [f"{marker} appears in document {i}." for i in range(count)]
+
+
+# A small varied vocabulary so the chunker sees real token variety (repeated
+# filler collapses below the split threshold; varied words do not).
+_CHUNK_VOCAB: tuple[str, ...] = tuple(
+    (
+        "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima "
+        "mike november oscar papa quebec romeo sierra tango uniform victor whiskey "
+        "xray yankee zulu"
+    ).split()
+)
+
+
+def multi_chunk_doc(marker: str, *, chunks: int = 3) -> str:
+    """One long document whose content spans at least ``chunks`` chunks.
+
+    Each sentence mentions ``marker`` (so a paired ``plan_extraction`` fires) and
+    draws varied words so the token-count chunker actually splits — ~14 sentences
+    per requested chunk clears the default 512-token chunk size with margin.
+    """
+    sentences = []
+    for i in range(chunks * 14):
+        words = " ".join(_CHUNK_VOCAB[(i + j) % len(_CHUNK_VOCAB)] for j in range(12))
+        sentences.append(f"{marker} {words} sentence {i}.")
+    return " ".join(sentences)
+
+
+# --------------------------------------------------------------------------- #
+# Corpus selection — the F-OP cases the engine row-set lane can seed.
+# --------------------------------------------------------------------------- #
+
+
+def engine_rowset_cases(cases: Sequence[ConformanceCase]) -> list[ConformanceCase]:
+    """The subset of F-OP cases the engine row-set lane can seed via ``remember``.
+
+    Keeps cases whose exercised system key is threadable through ``Khora.remember()``
+    (the five string document keys, ``source_timestamp``, and the ``metadata.tier``
+    representative) and whose seed has no duplicate non-NULL ``external_id`` — because
+    the engine lane reconciles by ``external_id`` and ``documents`` enforces UNIQUE
+    ``(namespace_id, external_id)``. Drops the ``occurred_at`` / ``created_at`` /
+    ``content_type`` and ``external_id`` families (no ``remember`` keyword / recon-key
+    conflict); those stay covered by the conformance executor suite.
+    """
+    selected: list[ConformanceCase] = []
+    for case in cases:
+        key = case.exercises[1] if len(case.exercises) > 1 else ""
+        if key not in _ENGINE_ROWSET_KEYS:
+            continue
+        if case.expected_ids is None:
+            continue
+        if _has_duplicate_external_id(case.seed_records):
+            continue
+        if _is_exact_timestamp_match(case):
+            continue
+        selected.append(case)
+    return selected
+
+
+def _is_exact_timestamp_match(case: ConformanceCase) -> bool:
+    """Whether a case asserts a positive exact-instant match on ``source_timestamp``.
+
+    The engine recall path stores ``source_timestamp`` and compares it with boundary
+    semantics where a filter operand equal to the stored instant does not re-select
+    that row, so a positive ``$eq`` (or a populated ``$in`` whose elements are exact
+    stored instants) reconciles to the empty set through ``Khora.recall`` even though
+    the conformance oracle keeps the row. Range comparisons and the negations
+    (``$ne`` / ``$nin``) are unaffected and stay in the lane; the empty-set ``$in:[]``
+    variant ends ``-in-empty`` and is not matched here. These exact ``source_timestamp``
+    equalities remain covered by the conformance executor suite.
+    """
+    if case.exercises[1:2] != ("source_timestamp",):
+        return False
+    return case.id.endswith(("-eq", "-in"))
+
+
+def _has_duplicate_external_id(records: Sequence[SeedRecord]) -> bool:
+    """Whether two records share a non-NULL ``external_id`` (we use the record id as one).
+
+    The record ``id`` is the reconciliation key, and ``documents`` enforces UNIQUE
+    ``(namespace_id, external_id)``. Record ids are unique by construction, so this
+    is a guard against a future seed that reused one.
+    """
+    ids = [r.id for r in records]
+    return len(ids) != len(set(ids))
+
+
+# --------------------------------------------------------------------------- #
+# Per-engine parametrization.
+# --------------------------------------------------------------------------- #
+#
+# Each row names the kb fixture and its self-skip mark. A test parametrizes its
+# ``kb`` argument indirectly over ``ENGINE_PARAMS`` (and resolves the matching
+# namespace fixture) so a no-Docker run collects the whole module and skips the
+# live legs cleanly.
+
+
+def _pg_reachable() -> bool:
+    """Mirror the conftest reachability guard (kept import-light for the param marks)."""
+    import socket
+    from urllib.parse import urlparse
+
+    url = os.environ.get("KHORA_DATABASE_URL", "postgresql://khora:khora@localhost:5434/khora")
+    parsed = urlparse(url.replace("+asyncpg", ""))
+    try:
+        with socket.create_connection((parsed.hostname or "localhost", parsed.port or 5432), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+def _embedded_available() -> bool:
+    try:
+        import aiosqlite  # noqa: F401
+        import lancedb  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+_SKIP_EMBEDDED = pytest.mark.skipif(
+    not _embedded_available(),
+    reason="embedded stack (aiosqlite + lancedb) not installed",
+)
+_SKIP_LIVE_GRAPH = pytest.mark.skipif(
+    not os.environ.get("NEO4J_INTEGRATION_TEST") or not _pg_reachable(),
+    reason="set NEO4J_INTEGRATION_TEST=1 and start PG+Neo4j to exercise the live graph lane",
+)
+_SKIP_LIVE_PG = pytest.mark.skipif(
+    not _pg_reachable(),
+    reason="start Postgres to exercise the live chronicle lane",
+)
+
+# (kb_fixture_name, engine_label) — the test indirects ``kb`` over this table.
+ENGINE_PARAMS = [
+    pytest.param("sqlite_lance_kb", id="sqlite_lance", marks=_SKIP_EMBEDDED),
+    pytest.param("vectorcypher_kb", id="vectorcypher", marks=_SKIP_LIVE_GRAPH),
+    pytest.param("chronicle_kb", id="chronicle", marks=_SKIP_LIVE_PG),
+]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,236 @@
+"""Fixtures + self-skip guards for the deterministic e2e recall-filter suite.
+
+``@internal``. Backend-owned. Provides the three per-engine ``Khora`` fixtures
+(embedded ``sqlite_lance`` / live ``vectorcypher`` PG+Neo4j / live ``chronicle``
+PG-only), the deterministic extractor+embedder install (``stub_llm``), fresh
+per-test namespaces, and the reachability guards the parametrized test modules
+self-skip on. The test modules under ``tests/e2e/test_*.py`` (QA-owned) consume
+these fixtures and the ``_harness`` engine layer; they never reach into ``src/``.
+
+Determinism: every fixture installs ``stub_llm`` (no network, SHA-256-derived
+embeddings), disables HyDE explicitly (``enable_hyde="never"``; the default is
+``"auto"``), and sends every chunk to the stub (``selective_extraction=False``)
+so the hand-counted ``expected_ids`` stay exact.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from collections.abc import AsyncIterator
+from urllib.parse import urlparse
+from uuid import UUID
+
+import pytest
+from pydantic import SecretStr
+
+from khora import Khora
+from khora.config.schema import KhoraConfig, SQLiteLanceConfig
+from tests.test_helpers.filter_spy import EMBED_DIM, stub_llm
+
+pytestmark = pytest.mark.e2e
+
+# The Postgres pgvector column is fixed at 1536 (KhoraConfig rejects any other
+# dimension on the PG backend), so the live-DB fixtures size their deterministic
+# vectors at 1536 rather than the small embedded ``EMBED_DIM`` (32).
+PG_EMBED_DIM = 1536
+
+
+# --------------------------------------------------------------------------- #
+# Self-skip guards — mirror the existing tests/integration skip pattern so the
+# default no-Docker run collects-and-skips the live legs cleanly.
+# --------------------------------------------------------------------------- #
+
+
+def _pg_reachable() -> bool:
+    """Whether the compose Postgres is reachable (copied from the graph spy)."""
+    url = os.environ.get("KHORA_DATABASE_URL", "postgresql://khora:khora@localhost:5434/khora")
+    parsed = urlparse(url.replace("+asyncpg", ""))
+    try:
+        with socket.create_connection((parsed.hostname or "localhost", parsed.port or 5432), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+def _neo4j_reachable() -> bool:
+    """Whether the compose Neo4j is reachable (copied from tests/integration/conftest)."""
+    url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+    parsed = urlparse(url)
+    try:
+        with socket.create_connection((parsed.hostname or "localhost", parsed.port or 7687), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+def _embedded_available() -> bool:
+    """Whether the no-Docker embedded stack (aiosqlite + lancedb) is importable."""
+    try:
+        import aiosqlite  # noqa: F401
+        import lancedb  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _database_url() -> str:
+    return os.environ.get(
+        "KHORA_DATABASE_URL",
+        "postgresql+asyncpg://khora:khora@localhost:5434/khora",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Shared determinism config — applied to every engine fixture.
+# --------------------------------------------------------------------------- #
+
+
+def _apply_deterministic_query(config: KhoraConfig) -> None:
+    """Pin the recall path deterministic: extraction on, no HyDE, no reranking.
+
+    ``extract_entities`` on + ``selective_extraction`` off send every seed chunk to
+    the stub so the graph is populated and ``expected_ids`` stay exact. HyDE and both
+    reranking paths are disabled so no LLM rewriting/reordering perturbs the frozen
+    deterministic-embedding scores.
+    """
+    config.pipelines.extract_entities = True
+    config.pipelines.selective_extraction = False
+    config.query.enable_hyde = "never"
+    config.query.enable_hyde_cypher = False
+    config.query.enable_reranking = False
+    config.query.enable_llm_reranking = False
+
+
+def _lower_entity_floor(kb: Khora) -> None:
+    """Lower the VectorCypher entity-similarity floor to 0 on a connected kb.
+
+    The deterministic hash embedder produces vectors with no semantic meaning, so a
+    query-to-entity cosine sits below the default floor and entity vector search
+    returns nothing — short-circuiting the graph path. Lowering the floor lets the
+    seeded entities clear it (a test knob, not a product change — same as the
+    existing graph filter spies). No-op when the engine exposes no retriever.
+    """
+    retriever = getattr(kb._engine, "_retriever", None)
+    if retriever is not None and getattr(retriever, "_config", None) is not None:
+        retriever._config.min_entity_similarity = 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Embedded sqlite_lance fixture — the no-Docker MAIN lane.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+async def sqlite_lance_kb(monkeypatch: pytest.MonkeyPatch, tmp_path) -> AsyncIterator[Khora]:
+    """Connected ``vectorcypher`` Khora on an embedded sqlite_lance stack.
+
+    No Postgres, no Neo4j, no Docker. Migrated via Alembic on entry. Installs the
+    deterministic extractor+embedder and the required graph-write config so the
+    real ingest path populates entities. HyDE off.
+    """
+    stub_llm(monkeypatch, dim=EMBED_DIM)
+
+    config = KhoraConfig()
+    config.storage.backend = "sqlite_lance"
+    config.storage.sqlite_lance = SQLiteLanceConfig(
+        db_path=str(tmp_path / "khora.db"),
+        lance_path=str(tmp_path / "khora.lance"),
+        embedding_dimension=EMBED_DIM,
+    )
+    config.llm.embedding_dimension = EMBED_DIM
+    _apply_deterministic_query(config)
+
+    kb = Khora(config, engine="vectorcypher", run_migrations=True)
+    await kb.connect()
+    _lower_entity_floor(kb)
+    try:
+        yield kb
+    finally:
+        await kb.disconnect()
+
+
+# --------------------------------------------------------------------------- #
+# Live vectorcypher fixture — PG (pgvector) + Neo4j. Self-skips without services.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+async def vectorcypher_kb(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[Khora]:
+    """Connected ``vectorcypher`` Khora on the live PG+Neo4j stack.
+
+    Mirrors ``tests/integration/test_filter_pushdown_graph.py::kb``: deterministic
+    extractor+embedder sized at 1536, graph-write config on, HyDE off. The module
+    that uses this fixture carries the ``NEO4J_INTEGRATION_TEST`` + reachability
+    self-skip mark from ``ENGINE_PARAMS`` so a no-Docker run skips it cleanly.
+    """
+    stub_llm(monkeypatch, dim=PG_EMBED_DIM)
+
+    neo4j_url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+    config = KhoraConfig(database_url=_database_url(), neo4j_url=neo4j_url)
+    config.storage.neo4j_user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+    config.storage.neo4j_password = SecretStr(os.environ.get("KHORA_NEO4J_PASSWORD", "password"))
+    config.llm.embedding_dimension = PG_EMBED_DIM
+    config.storage.embedding_dimension = PG_EMBED_DIM
+    _apply_deterministic_query(config)
+
+    kb = Khora(config, engine="vectorcypher", run_migrations=False)
+    await kb.connect()
+    _lower_entity_floor(kb)
+    try:
+        yield kb
+    finally:
+        await kb.disconnect()
+
+
+# --------------------------------------------------------------------------- #
+# Live chronicle fixture — PG-only (pgvector). Self-skips without Postgres.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+async def chronicle_kb(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[Khora]:
+    """Connected ``chronicle`` Khora on a PG-only stack (no graph backend).
+
+    Mirrors ``tests/integration/matrix/test_chronicle_pg.py::kb``: deterministic
+    extractor+embedder sized at 1536, no Neo4j URL, HyDE off. Self-skips via the
+    ``ENGINE_PARAMS`` reachability mark when Postgres is down.
+    """
+    stub_llm(monkeypatch, dim=PG_EMBED_DIM)
+
+    config = KhoraConfig(database_url=_database_url())
+    config.llm.embedding_dimension = PG_EMBED_DIM
+    config.storage.embedding_dimension = PG_EMBED_DIM
+    # Chronicle's channels are PG-only; no graph URL.
+    config.neo4j_url = None
+    _apply_deterministic_query(config)
+
+    kb = Khora(config, engine="chronicle", run_migrations=False)
+    await kb.connect()
+    try:
+        yield kb
+    finally:
+        await kb.disconnect()
+
+
+# --------------------------------------------------------------------------- #
+# Engine indirection + fresh per-test namespace (no cross-test bleed).
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def kb(request: pytest.FixtureRequest) -> Khora:
+    """Resolve the per-engine kb fixture named by ``ENGINE_PARAMS``.
+
+    A test parametrizes ``kb`` indirectly over ``_harness.ENGINE_PARAMS`` (each
+    param is the name of one engine fixture above); this resolves that fixture so
+    the test body and the ``namespace_id`` fixture are engine-agnostic.
+    """
+    return request.getfixturevalue(request.param)
+
+
+@pytest.fixture
+async def namespace_id(kb: Khora) -> UUID:
+    """A fresh namespace on the selected engine — random id, no cross-test bleed."""
+    ns = await kb.create_namespace()
+    return ns.namespace_id

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -2,15 +2,17 @@
 
 ``@internal``. Backend-owned. Provides the three per-engine ``Khora`` fixtures
 (embedded ``sqlite_lance`` / live ``vectorcypher`` PG+Neo4j / live ``chronicle``
-PG-only), the deterministic extractor+embedder install (``stub_llm``), fresh
-per-test namespaces, and the reachability guards the parametrized test modules
-self-skip on. The test modules under ``tests/e2e/test_*.py`` (QA-owned) consume
-these fixtures and the ``_harness`` engine layer; they never reach into ``src/``.
+PG-only) with the deterministic extractor+embedder install (``stub_llm``) and the
+reachability guards the live modules self-skip on. Each test module pins the
+engine fixture it needs directly and mints its own fresh namespace. The test
+modules under ``tests/e2e/test_*.py`` (QA-owned) consume these fixtures and the
+``_harness`` engine layer; they never reach into ``src/``.
 
-Determinism: every fixture installs ``stub_llm`` (no network, SHA-256-derived
-embeddings), disables HyDE explicitly (``enable_hyde="never"``; the default is
-``"auto"``), and sends every chunk to the stub (``selective_extraction=False``)
-so the hand-counted ``expected_ids`` stay exact.
+Determinism: every engine fixture installs ``stub_llm`` (no network, SHA-256-derived
+embeddings) before the ``Khora`` is built, disables HyDE explicitly
+(``enable_hyde="never"``; the default is ``"auto"``), and sends every chunk to the
+stub (``selective_extraction=False``) so the hand-counted ``expected_ids`` stay
+exact.
 """
 
 from __future__ import annotations
@@ -19,7 +21,6 @@ import os
 import socket
 from collections.abc import AsyncIterator
 from urllib.parse import urlparse
-from uuid import UUID
 
 import pytest
 from pydantic import SecretStr
@@ -161,8 +162,8 @@ async def vectorcypher_kb(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[Khor
 
     Mirrors ``tests/integration/test_filter_pushdown_graph.py::kb``: deterministic
     extractor+embedder sized at 1536, graph-write config on, HyDE off. The module
-    that uses this fixture carries the ``NEO4J_INTEGRATION_TEST`` + reachability
-    self-skip mark from ``ENGINE_PARAMS`` so a no-Docker run skips it cleanly.
+    that uses this fixture carries the ``NEO4J_INTEGRATION_TEST`` + Postgres
+    reachability self-skip mark so a no-Docker run skips it cleanly.
     """
     stub_llm(monkeypatch, dim=PG_EMBED_DIM)
 
@@ -193,8 +194,8 @@ async def chronicle_kb(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[Khora]:
     """Connected ``chronicle`` Khora on a PG-only stack (no graph backend).
 
     Mirrors ``tests/integration/matrix/test_chronicle_pg.py::kb``: deterministic
-    extractor+embedder sized at 1536, no Neo4j URL, HyDE off. Self-skips via the
-    ``ENGINE_PARAMS`` reachability mark when Postgres is down.
+    extractor+embedder sized at 1536, no Neo4j URL, HyDE off. The module that uses
+    this fixture self-skips via its Postgres reachability mark when Postgres is down.
     """
     stub_llm(monkeypatch, dim=PG_EMBED_DIM)
 
@@ -211,26 +212,3 @@ async def chronicle_kb(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[Khora]:
         yield kb
     finally:
         await kb.disconnect()
-
-
-# --------------------------------------------------------------------------- #
-# Engine indirection + fresh per-test namespace (no cross-test bleed).
-# --------------------------------------------------------------------------- #
-
-
-@pytest.fixture
-def kb(request: pytest.FixtureRequest) -> Khora:
-    """Resolve the per-engine kb fixture named by ``ENGINE_PARAMS``.
-
-    A test parametrizes ``kb`` indirectly over ``_harness.ENGINE_PARAMS`` (each
-    param is the name of one engine fixture above); this resolves that fixture so
-    the test body and the ``namespace_id`` fixture are engine-agnostic.
-    """
-    return request.getfixturevalue(request.param)
-
-
-@pytest.fixture
-async def namespace_id(kb: Khora) -> UUID:
-    """A fresh namespace on the selected engine — random id, no cross-test bleed."""
-    ns = await kb.create_namespace()
-    return ns.namespace_id

--- a/tests/e2e/test_filter_rowset_chronicle.py
+++ b/tests/e2e/test_filter_rowset_chronicle.py
@@ -30,18 +30,15 @@ pytestmark = [
 
 
 def _chronicle_rowset_cases() -> list[conformance.ConformanceCase]:
-    """Metadata-predicate cases that target the chronicle backend.
+    """The row-set cases for the live Chronicle (``chronicle``) lane.
 
-    The metadata-filtering families restricted to ``chronicle``-targeting cases with
-    no duplicate ``external_id`` (the reconciliation key) and a dotted ``metadata``
-    path predicate (whole-blob equality is curated out, as on the embedded lane).
+    Chronicle hydrates the denormalized document keys on the recall path, so this
+    PG-only lane narrows on the system keys as well as the dotted-``metadata``
+    families (``include_system_keys=True``): the ``remember``-threadable system-key
+    ``F-OP`` families and the two ``source_name`` ``F-EXISTS`` presence states the
+    embedded lane defers here. See ``_harness.rowset_cases``.
     """
-    cases: list[conformance.ConformanceCase] = []
-    for family in (conformance.f_coerce_cases, conformance.f_objeq_cases, conformance.f_dotkey_cases):
-        cases.extend(c for c in family() if "chronicle" in c.backends)
-    return [
-        c for c in cases if not _harness._has_duplicate_external_id(c.seed_records) and c.exercises[1] != "metadata"
-    ]
+    return _harness.rowset_cases("chronicle", include_system_keys=True)
 
 
 @pytest.mark.parametrize("case", _chronicle_rowset_cases(), ids=lambda c: c.id)

--- a/tests/e2e/test_filter_rowset_chronicle.py
+++ b/tests/e2e/test_filter_rowset_chronicle.py
@@ -1,0 +1,55 @@
+"""Row-set recall-filter proof on the live Chronicle (PG-only) stack.
+
+The Chronicle leg of the row-set reconciliation: it drives the same
+``Khora.remember()`` -> ``Khora.recall(filter=...)`` proof through the Chronicle
+engine over Postgres (no graph backend — Chronicle returns ``relationships=[]``).
+It proves the deterministic recall filter narrows the same row set on the
+Chronicle date-bound-pushdown + post-filter read path that it does on the embedded
+and VectorCypher lanes.
+
+Self-skip: gated on Postgres reachability via the ``chronicle_kb`` fixture's guard,
+so a no-Docker run collects and skips this module cleanly. Run under ``make dev``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from khora.filter import conformance
+from khora.query import SearchMode
+from tests.e2e import _harness
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not _harness._pg_reachable(),
+        reason="start Postgres (make dev) to exercise the live Chronicle lane",
+    ),
+]
+
+
+def _chronicle_rowset_cases() -> list[conformance.ConformanceCase]:
+    """Metadata-predicate cases that target the chronicle backend.
+
+    The metadata-filtering families restricted to ``chronicle``-targeting cases with
+    no duplicate ``external_id`` (the reconciliation key) and a dotted ``metadata``
+    path predicate (whole-blob equality is curated out, as on the embedded lane).
+    """
+    cases: list[conformance.ConformanceCase] = []
+    for family in (conformance.f_coerce_cases, conformance.f_objeq_cases, conformance.f_dotkey_cases):
+        cases.extend(c for c in family() if "chronicle" in c.backends)
+    return [
+        c for c in cases if not _harness._has_duplicate_external_id(c.seed_records) and c.exercises[1] != "metadata"
+    ]
+
+
+@pytest.mark.parametrize("case", _chronicle_rowset_cases(), ids=lambda c: c.id)
+async def test_rowset_reconciliation_chronicle(chronicle_kb, case) -> None:
+    """The filter survivors reconcile to the case's expected ids on the Chronicle stack."""
+    kb = chronicle_kb
+    namespace_id = (await kb.create_namespace()).namespace_id
+    survivors = await _harness.recall_survivors(kb, case, namespace_id, mode=SearchMode.HYBRID)
+
+    assert survivors == case.expected_ids
+    assert survivors == conformance.oracle_survivors(case)

--- a/tests/e2e/test_filter_rowset_embedded.py
+++ b/tests/e2e/test_filter_rowset_embedded.py
@@ -37,9 +37,8 @@ pytestmark = pytest.mark.e2e
 async def _fresh_namespace(kb: Khora) -> UUID:
     """A fresh namespace on the embedded kb (no cross-test bleed).
 
-    The shared ``namespace_id`` conftest fixture is wired to the ``ENGINE_PARAMS``
-    indirection; this embedded module pins the ``sqlite_lance_kb`` engine directly,
-    so it mints its own namespace rather than going through that parametrized path.
+    This module pins the ``sqlite_lance_kb`` engine fixture directly and mints a
+    fresh namespace per test, so each case seeds and recalls in isolation.
     """
     ns = await kb.create_namespace()
     return ns.namespace_id
@@ -93,24 +92,11 @@ def _metadata_rowset_cases() -> list[conformance.ConformanceCase]:
 
     The embedded ``chunks`` row carries the ``metadata`` blob but not the
     denormalized document system keys, so only ``metadata.<path>`` filter predicates
-    narrow rows there. We pull the metadata-filtering families (F-COERCE / F-OBJEQ /
-    F-DOTKEY) targeting ``sqlite_lance`` and keep only the cases whose seed has no
-    duplicate ``external_id`` (the record id is the reconciliation key under
-    UNIQUE(namespace_id, external_id)).
-
-    Whole-metadata-blob equality (``{"metadata": {...}}``, ``exercises[1] ==
-    "metadata"``) is curated OUT — the embedded JSON path does not support exact
-    whole-object equality; it stays covered on the live/conformance lanes.
+    narrow rows here — hence ``include_system_keys=False``. The system-key-predicate
+    families (and whole-blob equality, which the embedded JSON path can't narrow on)
+    run on the live graph/chronicle lanes; see ``_harness.rowset_cases``.
     """
-    cases: list[conformance.ConformanceCase] = []
-    for family in (conformance.f_coerce_cases, conformance.f_objeq_cases, conformance.f_dotkey_cases):
-        cases.extend(c for c in family() if "sqlite_lance" in c.backends)
-    return [
-        c
-        for c in cases
-        if not _harness._has_duplicate_external_id(c.seed_records)
-        and c.exercises[1] != "metadata"  # drop whole-blob equality (unsupported on embedded)
-    ]
+    return _harness.rowset_cases("sqlite_lance", include_system_keys=False)
 
 
 @pytest.mark.parametrize("case", _metadata_rowset_cases(), ids=lambda c: c.id)
@@ -139,10 +125,11 @@ async def test_external_id_reconciliation(sqlite_lance_kb, case) -> None:
 def _exists_metadata_cases() -> list[conformance.ConformanceCase]:
     """The ``f_exists_cases()`` whose predicate is a ``metadata.*`` presence check.
 
-    The embedded recall path narrows on the metadata blob, so the metadata and
+    The embedded recall path narrows on the metadata blob, so the six metadata and
     nested-metadata presence states are reconcilable here; the two ``source_name``
-    (system-key) states run on the live PG lane. We assert the 8-state corpus has
-    not silently shrunk before selecting.
+    (system-key) presence states need a denormalized chunk column and so run on the
+    live graph/chronicle lanes (``_harness.rowset_cases(..., include_system_keys=True)``).
+    We assert the 8-state corpus has not silently shrunk before selecting.
     """
     all_cases = conformance.f_exists_cases()
     assert len(all_cases) == 8, f"f_exists_cases() must expose the 8 presence states, got {len(all_cases)}"

--- a/tests/e2e/test_filter_rowset_embedded.py
+++ b/tests/e2e/test_filter_rowset_embedded.py
@@ -1,0 +1,227 @@
+"""Row-set recall-filter proof on the embedded sqlite_lance stack — no Docker.
+
+This is the must-always-run lane: it drives the real ``Khora.remember()`` ingest
+path and ``Khora.recall(filter=...)`` read path on an embedded SQLite + LanceDB
+store, and asserts the filter ACTUALLY NARROWS THE ROWS end to end — the survivor
+set reconciled by ``external_id`` equals each conformance case's hand-declared
+``expected_ids``. It complements the WIRING spies
+(``tests/integration/matrix/test_filter_enforcement_sqlite_lance.py``), which prove
+the validated AST reaches each channel; here we assert ROWS, not wiring.
+
+Determinism (no flake): ``stub_llm`` installs a network-free, content-keyed
+extractor and a SHA-256-derived embedder, HyDE is ``"never"``, and every test owns
+a fresh namespace. Assertions are SET equality over a ``frozenset`` of record ids
+(never a ranked list), with a generous ``limit`` so the filter is the only
+narrowing force — a vector-score tie can never flip an assertion.
+
+No Docker, no Postgres, no Neo4j: collected and run by the default
+``uv run pytest -m e2e`` path. The corpus is curated to the families whose filter
+predicate the embedded recall path supports (the ``metadata.*`` predicates the
+chunk row carries); system-key-predicate families that only narrow where the chunk
+is denormalized run on the live PG/vectorcypher lane.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from khora import Khora
+from khora.filter import conformance
+from tests.e2e import _harness
+
+pytestmark = pytest.mark.e2e
+
+
+async def _fresh_namespace(kb: Khora) -> UUID:
+    """A fresh namespace on the embedded kb (no cross-test bleed).
+
+    The shared ``namespace_id`` conftest fixture is wired to the ``ENGINE_PARAMS``
+    indirection; this embedded module pins the ``sqlite_lance_kb`` engine directly,
+    so it mints its own namespace rather than going through that parametrized path.
+    """
+    ns = await kb.create_namespace()
+    return ns.namespace_id
+
+
+# --------------------------------------------------------------------------- #
+# AC1 — deterministic, zero-network ingest produces extractor entities.
+# --------------------------------------------------------------------------- #
+
+
+async def test_deterministic_ingest_produces_entities(sqlite_lance_kb) -> None:
+    """A marker-bearing ``remember()`` runs the real pipeline and writes the planned entities.
+
+    The stub extractor emits a fixed entity set for any document containing the
+    marker, so the ingest pipeline (extraction -> entity embed -> graph write) lands
+    exactly those entities. No network, no API key; the same content seeds the same
+    entities on every run.
+    """
+    from tests.test_helpers.filter_spy import plan_extraction
+
+    namespace_id = await _fresh_namespace(sqlite_lance_kb)
+    plan_extraction("falconmark", [("Falcon", "PERSON"), ("Orbit", "ORG")], [("Falcon", "Orbit", "WORKS_ON")])
+    await sqlite_lance_kb.remember(
+        content="falconmark: Falcon works on Orbit.",
+        namespace=namespace_id,
+        entity_types=["PERSON", "ORG"],
+        relationship_types=["WORKS_ON"],
+    )
+
+    entity_count, relationship_count = await _harness.graph_counts(sqlite_lance_kb, namespace_id)
+    assert entity_count == 2, f"expected the 2 planned entities, got {entity_count}"
+    assert relationship_count >= 1, f"expected the planned relationship, got {relationship_count}"
+
+    # Pin the exact entity identities (normalized name + type), not just the count,
+    # so a stray or mis-typed node cannot satisfy the assertion. The namespace is
+    # fresh, so the graph holds only what this ingest wrote. The names come back
+    # lowercased — proof that the production ``normalize_entity_name`` step really ran
+    # (this is the real graph-write path, not a persistence bypass).
+    resolved = await sqlite_lance_kb.storage.resolve_namespace(namespace_id)
+    persisted = {(e.name, e.entity_type) for e in await sqlite_lance_kb.storage.list_entities(resolved)}
+    assert persisted == {("falcon", "PERSON"), ("orbit", "ORG")}, f"persisted entities were {persisted}"
+
+
+# --------------------------------------------------------------------------- #
+# AC4 — doc-level external_id reconciliation over a curated f_*_cases subset.
+# --------------------------------------------------------------------------- #
+
+
+def _metadata_rowset_cases() -> list[conformance.ConformanceCase]:
+    """The dotted-path metadata-predicate cases the embedded recall path can narrow on.
+
+    The embedded ``chunks`` row carries the ``metadata`` blob but not the
+    denormalized document system keys, so only ``metadata.<path>`` filter predicates
+    narrow rows there. We pull the metadata-filtering families (F-COERCE / F-OBJEQ /
+    F-DOTKEY) targeting ``sqlite_lance`` and keep only the cases whose seed has no
+    duplicate ``external_id`` (the record id is the reconciliation key under
+    UNIQUE(namespace_id, external_id)).
+
+    Whole-metadata-blob equality (``{"metadata": {...}}``, ``exercises[1] ==
+    "metadata"``) is curated OUT — the embedded JSON path does not support exact
+    whole-object equality; it stays covered on the live/conformance lanes.
+    """
+    cases: list[conformance.ConformanceCase] = []
+    for family in (conformance.f_coerce_cases, conformance.f_objeq_cases, conformance.f_dotkey_cases):
+        cases.extend(c for c in family() if "sqlite_lance" in c.backends)
+    return [
+        c
+        for c in cases
+        if not _harness._has_duplicate_external_id(c.seed_records)
+        and c.exercises[1] != "metadata"  # drop whole-blob equality (unsupported on embedded)
+    ]
+
+
+@pytest.mark.parametrize("case", _metadata_rowset_cases(), ids=lambda c: c.id)
+async def test_external_id_reconciliation(sqlite_lance_kb, case) -> None:
+    """Seed via real ``remember()``; the filter survivors reconcile to the case's expected ids.
+
+    Each record is seeded through the production ingest path with
+    ``external_id = record.id``; recall applies ``case.filter`` and the surviving
+    documents (those that returned at least one chunk) are reconciled back to record
+    ids by ``external_id``. The survivor SET must equal the hand-declared
+    ``expected_ids`` — the same target the conformance oracle asserts.
+    """
+    namespace_id = await _fresh_namespace(sqlite_lance_kb)
+    survivors = await _harness.recall_survivors(sqlite_lance_kb, case, namespace_id)
+
+    assert survivors == case.expected_ids
+    # Authoring cross-check (NOT the assertion target): the Python oracle agrees.
+    assert survivors == conformance.oracle_survivors(case)
+
+
+# --------------------------------------------------------------------------- #
+# AC5 — F-EXISTS presence reachability across the real 8 states.
+# --------------------------------------------------------------------------- #
+
+
+def _exists_metadata_cases() -> list[conformance.ConformanceCase]:
+    """The ``f_exists_cases()`` whose predicate is a ``metadata.*`` presence check.
+
+    The embedded recall path narrows on the metadata blob, so the metadata and
+    nested-metadata presence states are reconcilable here; the two ``source_name``
+    (system-key) states run on the live PG lane. We assert the 8-state corpus has
+    not silently shrunk before selecting.
+    """
+    all_cases = conformance.f_exists_cases()
+    assert len(all_cases) == 8, f"f_exists_cases() must expose the 8 presence states, got {len(all_cases)}"
+    return [c for c in all_cases if c.exercises[1].startswith("metadata") and "sqlite_lance" in c.backends]
+
+
+@pytest.mark.parametrize("case", _exists_metadata_cases(), ids=lambda c: c.id)
+async def test_f_exists_reachability(sqlite_lance_kb, case) -> None:
+    """Each metadata presence state reconciles to its hand-declared survivor set.
+
+    Drives ``$exists`` / present-and-null / null-or-missing predicates over the
+    metadata blob through the real ingest + recall path; the survivor set must equal
+    ``case.expected_ids``. The absent-vs-present-JSON-null distinction is the
+    load-bearing one (a present ``None`` is PRESENT under ``$exists:true``).
+    """
+    namespace_id = await _fresh_namespace(sqlite_lance_kb)
+    survivors = await _harness.recall_survivors(sqlite_lance_kb, case, namespace_id)
+
+    assert survivors == case.expected_ids
+    assert survivors == conformance.oracle_survivors(case)
+
+
+def test_f_exists_states_are_complete() -> None:
+    """The 8 presence states are all present (a silent corpus shrink fails here).
+
+    Guards the parametrized reachability test against a future edit that trims
+    ``f_exists_cases()`` — the probe would otherwise pass on a smaller set. Pins both
+    the exact case ids AND the exercised key-shape / variant tags, so a corpus that
+    keeps the count but drops a sub-category (e.g. removes the nested path) still fails.
+    """
+    cases = conformance.f_exists_cases()
+    case_ids = {c.id for c in cases}
+    assert case_ids == {
+        "F-EXISTS-sys-true",
+        "F-EXISTS-sys-false",
+        "F-EXISTS-md-true",
+        "F-EXISTS-md-false",
+        "F-EXISTS-nested-true",
+        "F-EXISTS-nested-false",
+        "F-EXISTS-present-and-null",
+        "F-EXISTS-null-or-missing",
+    }
+    # Every case is an F-EXISTS case, and the three addressed key shapes are all present.
+    assert {c.exercises[0] for c in cases} == {"F-EXISTS"}
+    assert {c.exercises[1] for c in cases} == {"source_name", "metadata.mk", "metadata.a.b"}
+
+
+# --------------------------------------------------------------------------- #
+# Determinism + anti-vacuity guards (defense-in-depth).
+# --------------------------------------------------------------------------- #
+
+
+def test_hyde_is_disabled(sqlite_lance_kb) -> None:
+    """HyDE is explicitly off, so no LLM rewriting injects candidates into recall.
+
+    A determinism guard: if a future default flip re-enabled query rewriting, the
+    row-set proofs could pass with HyDE-generated chunks in the result. Pinning the
+    config here makes that regression fail loudly rather than silently.
+    """
+    assert sqlite_lance_kb._config.query.enable_hyde == "never"
+
+
+async def test_survivor_chunks_score_nonzero(sqlite_lance_kb) -> None:
+    """A surviving chunk carries a non-zero score — the result is not an all-empty accident.
+
+    The set-equality proofs assert WHICH records survive; this guards that the recall
+    actually scored and returned real chunks (a degenerate all-zero-score result that
+    happened to match ``expected_ids`` would otherwise pass vacuously). One
+    representative metadata case is enough to pin the property.
+    """
+    case = next(c for c in _metadata_rowset_cases() if c.expected_ids)
+    namespace_id = await _fresh_namespace(sqlite_lance_kb)
+    await _harness.seed_records(sqlite_lance_kb, case.seed_records, namespace_id)
+    result = await sqlite_lance_kb.recall(
+        case.seed_records[0].content,
+        namespace=namespace_id,
+        limit=_harness._RECALL_LIMIT,
+        min_similarity=0.0,
+        filter=case.filter,
+    )
+    assert result.chunks, "the representative case returned no chunks at all"
+    assert any(chunk.score != 0 for chunk in result.chunks), "every returned chunk scored 0 (vacuity risk)"

--- a/tests/e2e/test_filter_rowset_graph.py
+++ b/tests/e2e/test_filter_rowset_graph.py
@@ -1,0 +1,122 @@
+"""Row-set recall-filter proof on the live VectorCypher (PG + Neo4j) stack.
+
+The graph-lane companion to ``test_filter_rowset_embedded.py``: it drives the same
+``Khora.remember()`` -> ``Khora.recall(filter=...)`` row-set proof on the full
+VectorCypher engine, where the graph channel is live. Two things this lane adds
+over the embedded one:
+
+* AC2 — the graph channel FIRES and Neo4j is actually POPULATED: an entity-bearing
+  ingest writes genuine entities + ``MENTIONED_IN`` edges, asserted via both the
+  ``graph_chunk_count`` contribution signal and the ``graph_counts`` persistence
+  probe.
+* the row-set reconciliation runs through the PG/pgvector read path (1536-dim).
+
+Self-skip: gated on ``NEO4J_INTEGRATION_TEST`` + Postgres reachability via the
+``vectorcypher_kb`` fixture's guards, so a no-Docker run collects and skips this
+module cleanly. Run under ``make dev`` + ``NEO4J_INTEGRATION_TEST=1``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from khora.filter import conformance
+from khora.query import SearchMode
+from tests.e2e import _harness
+from tests.test_helpers.filter_spy import plan_extraction
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not os.environ.get("NEO4J_INTEGRATION_TEST") or not _harness._pg_reachable(),
+        reason="set NEO4J_INTEGRATION_TEST=1 and start PG+Neo4j (make dev) to exercise the live graph lane",
+    ),
+]
+
+
+# --------------------------------------------------------------------------- #
+# AC2 — the graph channel fires AND Neo4j is populated after a real ingest.
+# --------------------------------------------------------------------------- #
+
+
+_MARKER = "falconmark"
+_ENTITIES = [("Falcon", "PERSON"), ("Orbit", "ORG")]
+_RELATIONSHIPS = [("Falcon", "Orbit", "WORKS_ON")]
+
+
+async def test_graph_channel_fires_and_neo4j_populated(vectorcypher_kb) -> None:
+    """An entity-bearing ingest populates Neo4j and the graph channel feeds recall.
+
+    Asserts BOTH design signals: PERSISTENCE (``graph_counts`` shows the entities +
+    relationships were written to the graph) and CONTRIBUTION (a no-filter
+    ``mode=GRAPH`` recall returns entities and ``graph_chunk_count > 0`` — the graph
+    channel actually fed the recall, not just exists).
+    """
+    kb = vectorcypher_kb
+    namespace_id = (await kb.create_namespace()).namespace_id
+    plan_extraction(_MARKER, _ENTITIES, _RELATIONSHIPS)
+    for content in _harness.entity_seed_docs(_MARKER, count=3):
+        await kb.remember(
+            content=content,
+            namespace=namespace_id,
+            entity_types=[t for _, t in _ENTITIES],
+            relationship_types=[rt for _, _, rt in _RELATIONSHIPS],
+        )
+
+    # PERSISTENCE — the graph was written with EXACTLY the planned entities. The
+    # namespace is fresh per test, so these counts are a delta from zero (no nodes
+    # inherited from another test/namespace), and we pin the exact set + types rather
+    # than a bare ``> 0`` so a stray inherited or mis-typed node cannot satisfy it.
+    entity_count, relationship_count = await _harness.graph_counts(kb, namespace_id)
+    assert entity_count == len(_ENTITIES), f"expected {len(_ENTITIES)} entities, got {entity_count}"
+    assert relationship_count >= len(_RELATIONSHIPS), (
+        f"expected >= {len(_RELATIONSHIPS)} relationships, got {relationship_count}"
+    )
+    # Entity names come back normalized (lowercased) by the production
+    # ``normalize_entity_name`` step — comparing against the normalized planned set
+    # proves the real graph-write path ran, not a persistence bypass.
+    resolved = await kb.storage.resolve_namespace(namespace_id)
+    persisted = {(e.name, e.entity_type) for e in await kb.storage.list_entities(resolved)}
+    expected = {(name.lower(), etype) for name, etype in _ENTITIES}
+    assert persisted == expected, f"persisted entities {persisted} != planned {expected}"
+
+    # CONTRIBUTION — the graph channel fed the recall (non-vacuous). Query the exact
+    # seeded entity name so the deterministic embedder clears the entity vector floor
+    # and the graph entry gate reliably fires (an empty query crashes graph expansion).
+    gate = await _harness.assert_graph_contributes(kb, namespace_id, _ENTITIES[0][0])
+    assert gate.engine_info.get("graph_chunk_count", 0) > 0
+    assert "graph" in gate.engine_info.get("channels_used", [])
+
+
+# --------------------------------------------------------------------------- #
+# Row-set reconciliation through the live PG/pgvector read path.
+# --------------------------------------------------------------------------- #
+
+
+def _graph_rowset_cases() -> list[conformance.ConformanceCase]:
+    """Metadata-predicate cases that target the cypher (VectorCypher) backend.
+
+    The same metadata-filtering families the embedded lane runs, restricted to cases
+    whose seed has no duplicate ``external_id`` (the reconciliation key) and whose
+    predicate is a dotted ``metadata`` path the read path narrows on.
+    """
+    cases: list[conformance.ConformanceCase] = []
+    for family in (conformance.f_coerce_cases, conformance.f_objeq_cases, conformance.f_dotkey_cases):
+        cases.extend(c for c in family() if "cypher" in c.backends)
+    return [
+        c for c in cases if not _harness._has_duplicate_external_id(c.seed_records) and c.exercises[1] != "metadata"
+    ]
+
+
+@pytest.mark.parametrize("case", _graph_rowset_cases(), ids=lambda c: c.id)
+async def test_rowset_reconciliation_graph(vectorcypher_kb, case) -> None:
+    """The filter survivors reconcile to the case's expected ids on the live graph stack."""
+    kb = vectorcypher_kb
+    namespace_id = (await kb.create_namespace()).namespace_id
+    survivors = await _harness.recall_survivors(kb, case, namespace_id, mode=SearchMode.HYBRID)
+
+    assert survivors == case.expected_ids
+    assert survivors == conformance.oracle_survivors(case)

--- a/tests/e2e/test_filter_rowset_graph.py
+++ b/tests/e2e/test_filter_rowset_graph.py
@@ -97,18 +97,15 @@ async def test_graph_channel_fires_and_neo4j_populated(vectorcypher_kb) -> None:
 
 
 def _graph_rowset_cases() -> list[conformance.ConformanceCase]:
-    """Metadata-predicate cases that target the cypher (VectorCypher) backend.
+    """The row-set cases for the live VectorCypher (``cypher``) lane.
 
-    The same metadata-filtering families the embedded lane runs, restricted to cases
-    whose seed has no duplicate ``external_id`` (the reconciliation key) and whose
-    predicate is a dotted ``metadata`` path the read path narrows on.
+    The live PG/pgvector chunk row carries the denormalized document system keys, so
+    this lane narrows on them as well as the dotted-``metadata`` families
+    (``include_system_keys=True``): the ``remember``-threadable system-key ``F-OP``
+    families and the two ``source_name`` ``F-EXISTS`` presence states the embedded
+    lane defers here. See ``_harness.rowset_cases``.
     """
-    cases: list[conformance.ConformanceCase] = []
-    for family in (conformance.f_coerce_cases, conformance.f_objeq_cases, conformance.f_dotkey_cases):
-        cases.extend(c for c in family() if "cypher" in c.backends)
-    return [
-        c for c in cases if not _harness._has_duplicate_external_id(c.seed_records) and c.exercises[1] != "metadata"
-    ]
+    return _harness.rowset_cases("cypher", include_system_keys=True)
 
 
 @pytest.mark.parametrize("case", _graph_rowset_cases(), ids=lambda c: c.id)

--- a/tests/e2e/test_graph_contribution.py
+++ b/tests/e2e/test_graph_contribution.py
@@ -1,0 +1,119 @@
+"""Graph-contribution honesty proof — live PG + Neo4j, self-skips without services.
+
+A row-set filter proof passes VACUOUSLY if the graph channel never contributed
+(entity vector search returned nothing and recall short-circuited to the simple
+path). This module closes that hole with a positive pre-flight + a negative
+tripwire, so the filtered assertions in the graph row-set module are non-vacuous by
+construction:
+
+* POSITIVE — after seeding an entity-bearing corpus through the real
+  ``Khora.remember()`` ingest path, a no-filter ``mode=GRAPH`` recall MUST return a
+  non-empty entity set (``assert_graph_contributes``) AND the graph must be
+  populated (``graph_counts`` > 0). If the graph never fired, this fails LOUD.
+* NEGATIVE TRIPWIRE — the SAME corpus shape with the extractor staging NOTHING (no
+  ``plan_extraction``) must populate ZERO entities, proving the graph contribution
+  is CAUSED by the seeded entities, not an always-on fallback.
+
+Self-skip: gated on ``NEO4J_INTEGRATION_TEST`` + Postgres reachability (the
+``vectorcypher_kb`` fixture's guards), so a no-Docker ``uv run pytest -m e2e``
+collects and skips this module cleanly. Run it under ``make dev`` with
+``NEO4J_INTEGRATION_TEST=1``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from khora.query import SearchMode
+from tests.e2e import _harness
+from tests.test_helpers.filter_spy import plan_extraction
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not os.environ.get("NEO4J_INTEGRATION_TEST") or not _harness._pg_reachable(),
+        reason="set NEO4J_INTEGRATION_TEST=1 and start PG+Neo4j (make dev) to exercise the live graph lane",
+    ),
+]
+
+_MARKER = "falconmark"
+_ENTITIES = [("Falcon", "PERSON"), ("Orbit", "ORG")]
+_RELATIONSHIPS = [("Falcon", "Orbit", "WORKS_ON")]
+
+
+async def _seed_entity_corpus(kb, namespace_id) -> None:
+    """Seed an entity-bearing corpus through the real ingest path (populates the graph)."""
+    for content in _harness.entity_seed_docs(_MARKER, count=3):
+        await kb.remember(
+            content=content,
+            namespace=namespace_id,
+            entity_types=[t for _, t in _ENTITIES],
+            relationship_types=[rt for _, _, rt in _RELATIONSHIPS],
+        )
+
+
+async def test_graph_channel_contributes_preflight(vectorcypher_kb) -> None:
+    """A no-filter GRAPH recall returns entities AND the graph is populated (the anchor).
+
+    This is the load-bearing positive gate: it proves the real graph-write path
+    (genuine extracted entities + edges) populated Neo4j and that the GRAPH channel
+    surfaces them. Every filtered graph assertion depends on this holding.
+    """
+    kb = vectorcypher_kb
+    namespace_id = (await kb.create_namespace()).namespace_id
+    plan_extraction(_MARKER, _ENTITIES, _RELATIONSHIPS)
+    await _seed_entity_corpus(kb, namespace_id)
+
+    # CONTRIBUTION: the GRAPH channel returns entities (fails loud if it never fired).
+    # Query the exact seeded entity name so the deterministic embedder clears the
+    # entity vector floor and the graph entry gate fires (an empty query crashes graph
+    # expansion). assert_graph_contributes pins the entity-set signal; graph_chunk_count
+    # is the lane-isolated proof that the GRAPH channel specifically held candidates.
+    gate = await _harness.assert_graph_contributes(kb, namespace_id, _MARKER)
+    assert gate.engine_info.get("graph_chunk_count", 0) > 0, (
+        "graph_chunk_count must be > 0 on a GRAPH recall — the graph channel did not contribute"
+    )
+
+    # PERSISTENCE: the graph was really written (entities + relationships in Neo4j).
+    entity_count, relationship_count = await _harness.graph_counts(kb, namespace_id)
+    assert entity_count > 0, "no entities were persisted to the graph"
+    assert relationship_count > 0, "no relationships were persisted to the graph"
+
+
+async def test_graph_contribution_negative_tripwire(vectorcypher_kb) -> None:
+    """The SAME corpus with NO staged entities populates zero graph — proving causation.
+
+    Without a ``plan_extraction`` call the stub extractor emits nothing, so the
+    ingest path writes no entities. A GRAPH recall must then return an empty entity
+    set and the graph counts must be zero. This proves the positive test's graph
+    contribution is CAUSED by the seeded entities, not an always-on fallback that
+    would make the positive assertion vacuous.
+    """
+    kb = vectorcypher_kb
+    namespace_id = (await kb.create_namespace()).namespace_id
+    # Deliberately NO plan_extraction(_MARKER, ...) — the registry stays empty.
+    await _seed_entity_corpus(kb, namespace_id)
+
+    entity_count, relationship_count = await _harness.graph_counts(kb, namespace_id)
+    assert entity_count == 0, f"no entities were staged, yet {entity_count} were persisted"
+    assert relationship_count == 0, f"no relationships were staged, yet {relationship_count} were persisted"
+
+    # A real (non-empty) query so we don't depend on empty-query graph-expansion
+    # behavior; with no entities staged the GRAPH lane has nothing to contribute.
+    result = await kb.recall(
+        _MARKER,
+        namespace=namespace_id,
+        mode=SearchMode.GRAPH,
+        limit=_harness._RECALL_LIMIT,
+        min_similarity=0.0,
+    )
+    # The lane-isolated signal: the GRAPH channel held zero candidates. This is the
+    # load-bearing causation proof — the positive test's contribution is caused by the
+    # seeded entities, not an always-on fallback.
+    assert result.engine_info.get("graph_chunk_count", 0) == 0, (
+        "graph_chunk_count must be 0 when no entities were staged (the graph contribution must be caused by extraction)"
+    )
+    assert not result.entities, "the graph channel returned entities for an un-seeded namespace (vacuity risk)"

--- a/tests/e2e/test_graph_contribution.py
+++ b/tests/e2e/test_graph_contribution.py
@@ -13,6 +13,12 @@ construction:
 * NEGATIVE TRIPWIRE — the SAME corpus shape with the extractor staging NOTHING (no
   ``plan_extraction``) must populate ZERO entities, proving the graph contribution
   is CAUSED by the seeded entities, not an always-on fallback.
+* FILTER ENFORCEMENT — every doc is entity-bearing (so the graph channel feeds them
+  all), but only some satisfy the filter; the filtered ``mode=GRAPH`` recall must
+  return ONLY the satisfying docs. A regression where the graph channel ignores
+  ``filter_ast`` and smuggles a violating graph-fed chunk into the fused result fails
+  the set-equality assertion. (The firing tripwire proves *causation of firing*; this
+  proves *filter enforcement* — the two are distinct holes.)
 
 Self-skip: gated on ``NEO4J_INTEGRATION_TEST`` + Postgres reachability (the
 ``vectorcypher_kb`` fixture's guards), so a no-Docker ``uv run pytest -m e2e``
@@ -117,3 +123,51 @@ async def test_graph_contribution_negative_tripwire(vectorcypher_kb) -> None:
         "graph_chunk_count must be 0 when no entities were staged (the graph contribution must be caused by extraction)"
     )
     assert not result.entities, "the graph channel returned entities for an un-seeded namespace (vacuity risk)"
+
+
+async def test_graph_channel_drops_violating_chunks(vectorcypher_kb) -> None:
+    """The graph channel DROPS chunks that violate the filter — enforcement, not just firing.
+
+    The firing tripwire proves the graph contribution is *caused* by extraction; this
+    proves the graph channel *honors* ``filter_ast``. EVERY seeded doc mentions the
+    marker, so the stub extractor emits the shared entity for all of them and the graph
+    channel feeds every doc into the fused result. Half are tagged ``keep`` and half
+    ``drop``. A no-filter ``GRAPH`` pre-flight confirms the channel held candidates;
+    the filtered ``GRAPH`` recall (``metadata.tag`` in ``{"keep"}``) must then return
+    ONLY the keep docs. A regression where the graph channel ignores the filter and
+    smuggles a violating graph-fed chunk into the result fails the set-equality assert.
+    """
+    kb = vectorcypher_kb
+    namespace_id = (await kb.create_namespace()).namespace_id
+    plan_extraction(_MARKER, _ENTITIES, _RELATIONSHIPS)
+
+    keep_ids = {"graph-keep-0", "graph-keep-1"}
+    drop_ids = {"graph-drop-0", "graph-drop-1"}
+    for tag, ext_ids in (("keep", sorted(keep_ids)), ("drop", sorted(drop_ids))):
+        for i, ext_id in enumerate(ext_ids):
+            await kb.remember(
+                content=f"{_MARKER} {tag} document {i}.",
+                namespace=namespace_id,
+                external_id=ext_id,
+                metadata={"tag": tag},
+                entity_types=[t for _, t in _ENTITIES],
+                relationship_types=[rt for _, _, rt in _RELATIONSHIPS],
+            )
+
+    # PRE-FLIGHT: the graph channel held candidates (so the drop assertion is non-vacuous).
+    gate = await _harness.assert_graph_contributes(kb, namespace_id, _ENTITIES[0][0])
+    assert gate.engine_info.get("graph_chunk_count", 0) > 0
+
+    # FILTERED: the filter must drop the violating (drop-tagged) graph-fed docs.
+    result = await kb.recall(
+        _ENTITIES[0][0],
+        namespace=namespace_id,
+        mode=SearchMode.GRAPH,
+        limit=_harness._RECALL_LIMIT,
+        min_similarity=0.0,
+        filter={"metadata.tag": {"$in": ["keep"]}},
+    )
+    survivors = _harness.reconcile(result)
+    assert survivors == frozenset(keep_ids), (
+        f"the graph channel must drop filter-violating chunks: expected the keep set, got {set(survivors)}"
+    )

--- a/tests/e2e/test_multichunk_denorm.py
+++ b/tests/e2e/test_multichunk_denorm.py
@@ -1,0 +1,89 @@
+"""Multi-chunk denormalization uniformity — embedded sqlite_lance, no Docker.
+
+When one document chunks into several pieces, the document-grained fields must be
+denormalized identically onto EVERY chunk: a filter that addresses a document key
+(``occurred_at`` / ``source_timestamp`` / the document projection's denormalized
+keys) must treat every chunk of the document the same way, or a multi-chunk
+document would filter inconsistently across its own chunks.
+
+This drives the real ``Khora.remember()`` ingest path with content long enough to
+split into ``>= 2`` chunks, then asserts via recall that every returned chunk of the
+document carries the same document-grained event time and resolves to one document
+projection whose denormalized keys equal the seeded values. No Docker — runs on the
+default ``uv run pytest -m e2e`` path.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from khora.query import SearchMode
+from tests.e2e import _harness
+
+pytestmark = pytest.mark.e2e
+
+_SOURCE_TIMESTAMP = datetime(2026, 1, 2, tzinfo=UTC)
+
+
+async def test_multichunk_denormalization_is_uniform(sqlite_lance_kb) -> None:
+    """Every chunk of a multi-chunk document shares its document-grained fields.
+
+    Seeds one long document (``>= 2`` chunks) with a ``source_timestamp``, a
+    denormalized ``source_name`` / ``external_id``, and a ``metadata`` blob, then
+    recalls it. The assertion is uniformity: all returned chunks belong to the SAME
+    document and carry the SAME event time (``occurred_at`` falls back to the
+    document ``source_timestamp``), and they resolve to exactly ONE document
+    projection whose denormalized keys equal the seeded values — so a document-key
+    filter narrows every chunk of the document identically.
+    """
+    kb = sqlite_lance_kb
+    namespace_id = (await kb.create_namespace()).namespace_id
+
+    content = _harness.multi_chunk_doc("denormmark", chunks=4)
+    result = await kb.remember(
+        content=content,
+        namespace=namespace_id,
+        source_timestamp=_SOURCE_TIMESTAMP,
+        source_name="linear",
+        external_id="denorm-doc",
+        metadata={"tier": "gold"},
+        entity_types=["ENTITY"],
+        relationship_types=["RELATED_TO"],
+    )
+    assert result.chunks_created >= 2, (
+        f"the document must split into >= 2 chunks to test uniformity, got {result.chunks_created}"
+    )
+
+    recalled = await kb.recall(
+        "denormmark",
+        namespace=namespace_id,
+        mode=SearchMode.VECTOR,
+        limit=_harness._RECALL_LIMIT,
+        min_similarity=0.0,
+    )
+
+    # All recalled chunks belong to the one seeded document.
+    chunk_doc_ids = {chunk.document_id for chunk in recalled.chunks}
+    assert len(recalled.chunks) >= 2, f"expected >= 2 recalled chunks, got {len(recalled.chunks)}"
+    assert chunk_doc_ids == {result.document_id}, "recalled chunks span more than the one seeded document"
+
+    # The document-grained event time is denormalized identically onto every chunk.
+    occurred_at_values = {chunk.occurred_at for chunk in recalled.chunks}
+    assert occurred_at_values == {_SOURCE_TIMESTAMP}, (
+        f"occurred_at must be uniform across the document's chunks, got {occurred_at_values}"
+    )
+
+    # The chunks resolve to exactly one document projection carrying the seeded
+    # denormalized keys — the whole-document filterable surface.
+    projections = [doc for doc in recalled.documents if doc.id == result.document_id]
+    assert len(projections) == 1, "the multi-chunk document must resolve to exactly one projection"
+    projection = projections[0]
+    assert projection.external_id == "denorm-doc"
+    assert projection.source_name == "linear"
+    # The embedded SQLite store round-trips datetimes tz-naive, so compare wall-clock
+    # values (tzinfo-insensitive) — the recall-filter boundary normalizes tz-naive too.
+    assert projection.source_timestamp is not None
+    assert projection.source_timestamp.replace(tzinfo=None) == _SOURCE_TIMESTAMP.replace(tzinfo=None)
+    assert projection.metadata == {"tier": "gold"}


### PR DESCRIPTION
## Summary
- Add a `tests/e2e/` suite that drives real `remember()` → `recall(filter=...)` per engine and asserts the filter narrows rows end to end, reconciled against the hand-authored conformance corpus.
- **Deterministic, network-free ingest:** a content-keyed stub extractor + hash embedder, HyDE and reranking disabled, a fresh namespace per test — so the candidate set and `expected_ids` stay stable across runs.
- **Doc-level `external_id` reconciliation:** each conformance record is seeded through `remember(external_id=...)`; recall applies the case filter; the surviving `external_id` set is asserted equal to the expected ids (set-based, never ranked) and cross-checked against the Python oracle. Seeding through the real ingest path (not a low-level store write) is what makes this an end-to-end proof.
- **Graph-channel proof** on the live engine lane: persistence (entity/relationship counts) plus a contribution gate and a negative tripwire (same corpus, no extracted entities → empty graph recall), so a vacuous pass is impossible.
- **F-EXISTS reachability** across the eight presence states (with a completeness guard) and a **multi-chunk denormalization-uniformity** check.
- **Engine coverage:** the embedded sqlite_lance lane runs with no Docker (the default lane); the live Postgres+graph and Postgres-only lanes self-skip cleanly without services and run under `make dev`.
- **No production code changes** — pure test harness.

## Test plan
- [x] Embedded sqlite_lance lane green with no Docker: `uv run pytest tests/e2e -m "e2e and not slow"` → 41 passed
- [x] Full-repo collection clean (no import/collection errors); `ruff format --check`, `ruff check`, `ty check` clean on the new suite
- [ ] Live graph + Postgres lanes: run under `make dev` with `NEO4J_INTEGRATION_TEST=1` (self-skip without services)
- [ ] CI: unit + integration suites pass with coverage