### PR TITLE
Keep deprecated recall time bounds on the recency-window axis

### DIFF
--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -2022,19 +2022,23 @@ class Khora:
         from khora.filter import RecallFilter, canonical_hash, parse_to_ast
 
         try:
-            # Resolve the recall filter once, at the facade. Two inputs feed the
-            # single canonical AST: the public ``filter=`` kwarg and the
-            # deprecated ``start_time``/``end_time`` bounds. They are mutually
-            # exclusive. ``temporal_filter`` is still built from the deprecated
-            # bounds so the engines' existing temporal behavior (recency
-            # weighting, version filter) is unchanged. The skeleton engine now
-            # threads ``filter_ast`` through to its temporal store, where the
-            # pgvector backend compiles it to a WHERE predicate (the other
-            # backends accept-and-ignore it). When the deprecated bounds are
-            # used, both ``temporal_filter`` and the folded AST are AND-ed on
-            # the pgvector path, so the folded bounds below mirror
-            # ``temporal_filter``'s boundary semantics exactly to stay
-            # consistent and avoid dropping boundary rows.
+            # Resolve the recall filter once, at the facade. The public
+            # ``filter=`` kwarg and the deprecated ``start_time``/``end_time``
+            # bounds are mutually exclusive but feed DIFFERENT axes on purpose:
+            #
+            #   * ``filter=`` produces a canonical ``filter_ast`` the engines
+            #     compile and post-filter, so an ``occurred_at`` predicate is
+            #     enforced against the EVENT-time axis (no created_at fallback) —
+            #     the documented event-time semantics of the new API.
+            #   * ``start_time``/``end_time`` produce ONLY a ``temporal_filter``
+            #     recency window. They are a window-axis API: every engine narrows
+            #     its channel reads on ``COALESCE(source_timestamp, created_at)``,
+            #     so a chunk recent by ingest time survives even when it carries no
+            #     event-time anchor. Folding these bounds into an ``occurred_at``
+            #     ``filter_ast`` (as an earlier revision did, speculatively) would
+            #     AND an event-time post-filter on top of the window and false-empty
+            #     every anchor-less chunk a plain ``remember()`` produces. They must
+            #     NOT set ``filter_ast``.
             temporal_filter: Any = None
             filter_ast: Any = None
             if filter is not None and (start_time is not None or end_time is not None):
@@ -2055,33 +2059,14 @@ class Khora:
                 norm_end = _normalize_recall_bound(end_time)
                 from khora.engines.skeleton.backends import TemporalFilter as SkeletonTemporalFilter
 
+                # Window-axis only: the recency bounds narrow on
+                # ``COALESCE(source_timestamp, created_at)`` inside each engine.
+                # ``filter_ast`` stays None so no event-time post-filter is AND-ed
+                # on top (see the axis note above).
                 temporal_filter = SkeletonTemporalFilter(
                     occurred_after=norm_start,
                     occurred_before=norm_end,
                 )
-                # Mirror the legacy ``TemporalFilter`` boundary semantics
-                # exactly so the folded AST and the window agree when both
-                # are AND-ed: lower bound inclusive (``occurred_at >=``),
-                # upper bound EXCLUSIVE (``occurred_at <``) — see
-                # ``pgvector._build_filter_conditions``. Using ``$lte`` here
-                # would drop boundary rows once an engine applies both.
-                #
-                # An inverted range (start > end) flows through this same fold
-                # rather than being special-cased: it yields
-                # ``{occurred_at: {$gte: t1, $lt: t2}}``, which is
-                # empty-MATCHING (no row satisfies ``>= t1 AND < t2`` when
-                # t1 > t2), so the recall returns nothing — parity with the
-                # equivalent ``filter=`` predicate rather than an unfiltered
-                # recall. The legacy window is empty-matching for an inverted
-                # pair too, so the two stay consistent.
-                ops: dict[str, Any] = {}
-                if norm_start is not None:
-                    ops["$gte"] = norm_start
-                if norm_end is not None:
-                    ops["$lt"] = norm_end
-                # Route the folded bounds through the same single validation
-                # path as the public filter= kwarg.
-                filter_ast = parse_to_ast(RecallFilter.model_validate({"occurred_at": ops}))
             namespace_id = await self._resolve_namespace(namespace)
 
             # Emit RECALL_REQUESTED before any embedding/retrieval work.

--- a/tests/recall/test_chronicle_filter_composition.py
+++ b/tests/recall/test_chronicle_filter_composition.py
@@ -396,6 +396,42 @@ async def test_created_at_filter_works_against_literal_created_at() -> None:
     assert returned == {in_scope.id}
 
 
+@pytest.mark.asyncio
+async def test_unanchored_chunk_survives_recency_window_with_no_filter_ast() -> None:
+    # POSITIVE engine-level guard for the deprecated start_time/end_time path:
+    # those bounds now build ONLY a recency-window temporal_filter (no filter_ast),
+    # so NO event-time post-filter runs. The SAME anchor-less chunk that
+    # test_occurred_at_filter_excludes_unanchored_chunk_no_created_at_fallback proves
+    # an occurred_at filter EXCLUDES must SURVIVE here — the regression was the
+    # facade folding the bounds into an occurred_at filter_ast and false-emptying
+    # this chunk (the shape a plain remember() with no timestamp produces). The
+    # window narrows on COALESCE(source_timestamp, created_at), so a chunk recent by
+    # ingest time belongs in it even with no event-time anchor.
+    from khora.engines.skeleton.backends import TemporalFilter as SkeletonTemporalFilter
+
+    unanchored = _chunk(
+        "alpha unanchored",
+        occurred_at=None,
+        source_timestamp=None,
+        created_at=datetime(2026, 6, 1, tzinfo=UTC),  # recent by ingest time
+    )
+    engine = _engine_with_semantic([(unanchored, 0.9)])
+    result = await engine.recall(
+        "alpha",
+        uuid4(),
+        limit=10,
+        mode=SearchMode.VECTOR,
+        # Exactly what the deprecated start_time= bound now forwards: a window, no AST.
+        temporal_filter=SkeletonTemporalFilter(occurred_after=datetime(2026, 1, 1, tzinfo=UTC)),
+        filter_ast=None,
+    )
+
+    assert unanchored.id in {c.id for c in result.chunks}, (
+        "an anchor-less chunk must SURVIVE a recency-window-only recall (no filter_ast); "
+        "folding the deprecated bounds into an occurred_at filter would false-empty it"
+    )
+
+
 # ===========================================================================
 # (3) unindexed_metadata counter increments on the post-filter path.
 # ===========================================================================

--- a/tests/unit/test_khora.py
+++ b/tests/unit/test_khora.py
@@ -631,9 +631,14 @@ class TestRecall:
 class TestRecallTemporalBounds:
     """Tests for the deprecated start_time/end_time bounds on recall().
 
-    The deprecated bounds now fold to a canonical filter AST (passed to the
-    engine as ``filter_ast``) while still building the legacy ``temporal_filter``
-    window for the engines that already consume it.
+    The deprecated bounds are a recency-WINDOW API: they build ONLY the legacy
+    ``temporal_filter`` window (the engines narrow their channel reads on
+    ``COALESCE(source_timestamp, created_at)``) and DO NOT fold an ``occurred_at``
+    ``filter_ast``. Folding one would AND an event-time post-filter — with no
+    created_at fallback — on top of the window and false-empty every chunk that
+    carries no event-time anchor (the shape a plain ``remember()`` produces). The
+    event-time semantics belong to the public ``filter={"occurred_at": {...}}``
+    kwarg, not to these window bounds.
     """
 
     # Shared helper: make a minimal RecallResult mock return value
@@ -648,30 +653,10 @@ class TestRecallTemporalBounds:
             relationships=[],
         )
 
-    @staticmethod
-    def _occurred_at_clauses(filter_ast: object) -> list[object]:
-        """Collect every ``occurred_at`` leaf clause from a folded filter AST."""
-        from khora.filter import FilterClause, FilterNode
-
-        if filter_ast is None:
-            return []
-        out: list[object] = []
-        stack: list[object] = [filter_ast]
-        while stack:
-            node = stack.pop()
-            if isinstance(node, FilterClause):
-                if node.path == ("occurred_at",):
-                    out.append(node)
-            elif isinstance(node, FilterNode):
-                stack.extend(node.children)
-        return out
-
     @pytest.mark.asyncio
-    async def test_start_time_only_folds_to_gte(self) -> None:
-        """start_time only → temporal_filter window + a single $gte occurred_at clause."""
+    async def test_start_time_only_forwards_window_no_filter_ast(self) -> None:
+        """start_time only → temporal_filter lower-bound window, no folded filter_ast."""
         from datetime import UTC, datetime
-
-        from khora.filter import Op
 
         kb = _make_kb(connected=True)
         ns_id = uuid4()
@@ -688,21 +673,13 @@ class TestRecallTemporalBounds:
         assert temporal_filter.occurred_after == start
         assert temporal_filter.occurred_before is None
 
-        clauses = self._occurred_at_clauses(call_kwargs.kwargs.get("filter_ast"))
-        assert [c.op for c in clauses] == [Op.GTE]  # type: ignore[attr-defined]
-        assert clauses[0].operand == start  # type: ignore[attr-defined]
+        # No event-time post-filter is folded on top of the window.
+        assert call_kwargs.kwargs.get("filter_ast") is None
 
     @pytest.mark.asyncio
-    async def test_end_time_only_folds_to_lt(self) -> None:
-        """end_time only → temporal_filter window + a single $lt occurred_at clause.
-
-        The upper bound is EXCLUSIVE to mirror the legacy ``TemporalFilter``
-        window (``occurred_at < occurred_before``), so the folded AST and the
-        window agree at the boundary.
-        """
+    async def test_end_time_only_forwards_window_no_filter_ast(self) -> None:
+        """end_time only → temporal_filter upper-bound window, no folded filter_ast."""
         from datetime import UTC, datetime
-
-        from khora.filter import Op
 
         kb = _make_kb(connected=True)
         ns_id = uuid4()
@@ -719,16 +696,12 @@ class TestRecallTemporalBounds:
         assert temporal_filter.occurred_before == end
         assert temporal_filter.occurred_after is None
 
-        clauses = self._occurred_at_clauses(call_kwargs.kwargs.get("filter_ast"))
-        assert [c.op for c in clauses] == [Op.LT]  # type: ignore[attr-defined]
-        assert clauses[0].operand == end  # type: ignore[attr-defined]
+        assert call_kwargs.kwargs.get("filter_ast") is None
 
     @pytest.mark.asyncio
-    async def test_both_bounds_fold_to_gte_and_lt(self) -> None:
-        """Both bounds (start < end) → $gte (inclusive) and $lt (exclusive) clauses."""
+    async def test_both_bounds_forward_window_no_filter_ast(self) -> None:
+        """Both bounds (start < end) → a bounded temporal_filter window, no filter_ast."""
         from datetime import UTC, datetime
-
-        from khora.filter import Op
 
         kb = _make_kb(connected=True)
         ns_id = uuid4()
@@ -746,22 +719,18 @@ class TestRecallTemporalBounds:
         assert temporal_filter.occurred_after == start
         assert temporal_filter.occurred_before == end
 
-        clauses = self._occurred_at_clauses(call_kwargs.kwargs.get("filter_ast"))
-        ops = {c.op for c in clauses}  # type: ignore[attr-defined]
-        assert ops == {Op.GTE, Op.LT}
+        assert call_kwargs.kwargs.get("filter_ast") is None
 
     @pytest.mark.asyncio
-    async def test_equal_bounds_fold_to_gte_and_lt(self) -> None:
-        """start == end → both $gte and $lt clauses (equal is not inverted).
+    async def test_equal_bounds_forward_degenerate_window_no_filter_ast(self) -> None:
+        """start == end → a degenerate (empty-matching) window, still no filter_ast.
 
-        Equal bounds yield a degenerate empty range (``occurred_at >= bound AND
-        occurred_at < bound``) — but that is exactly what the legacy
-        ``TemporalFilter`` window also yields, so the folded AST stays consistent
-        with the window rather than disagreeing at the boundary.
+        Equal bounds give ``occurred_after == occurred_before``; the engine's window
+        (``COALESCE(...) >= bound AND COALESCE(...) <= bound``) admits only the exact
+        instant, mirroring the legacy ``TemporalFilter`` behavior. No filter_ast is
+        folded.
         """
         from datetime import UTC, datetime
-
-        from khora.filter import Op
 
         kb = _make_kb(connected=True)
         ns_id = uuid4()
@@ -778,27 +747,19 @@ class TestRecallTemporalBounds:
         assert temporal_filter.occurred_after == bound
         assert temporal_filter.occurred_before == bound
 
-        clauses = self._occurred_at_clauses(call_kwargs.kwargs.get("filter_ast"))
-        ops = {c.op for c in clauses}  # type: ignore[attr-defined]
-        assert ops == {Op.GTE, Op.LT}
+        assert call_kwargs.kwargs.get("filter_ast") is None
 
     @pytest.mark.asyncio
-    async def test_inverted_range_folds_to_empty_matching_filter(self) -> None:
-        """start > end → a real, empty-MATCHING filter (not an unfiltered recall).
+    async def test_inverted_range_forwards_empty_matching_window_no_filter_ast(self) -> None:
+        """start > end → an empty-MATCHING window (not an unfiltered recall), no filter_ast.
 
-        An inverted range flows through the same fold as any other bounds rather
-        than being special-cased away. It yields ``occurred_at >= t1 AND
-        occurred_at < t2`` with t1 > t2 — a predicate nothing can satisfy — so
-        the recall returns zero rows, giving parity with the equivalent
-        ``filter={'occurred_at': {...}}``. The legacy window is built from the
-        same (inverted, empty-matching) bounds, so the two stay consistent.
-
-        This is a unit assertion on the synthesized ``filter_ast`` shape; the
-        zero-row recall behavior follows from the empty-matching predicate.
+        An inverted range flows through to the window unchanged: ``occurred_after = t1``
+        and ``occurred_before = t2`` with t1 > t2. The engine's window
+        (``COALESCE(...) >= t1 AND COALESCE(...) <= t2``) is unsatisfiable, so the
+        recall returns zero rows — the same empty result the legacy window always
+        produced for an inverted pair. No filter_ast is folded.
         """
         from datetime import UTC, datetime
-
-        from khora.filter import Op
 
         kb = _make_kb(connected=True)
         ns_id = uuid4()
@@ -812,20 +773,14 @@ class TestRecallTemporalBounds:
 
         call_kwargs = kb._engine.recall.call_args
 
-        # The folded AST is a real empty-matching predicate, NOT None.
-        clauses = self._occurred_at_clauses(call_kwargs.kwargs.get("filter_ast"))
-        by_op = {c.op: c.operand for c in clauses}  # type: ignore[attr-defined]
-        assert set(by_op) == {Op.GTE, Op.LT}
-        assert by_op[Op.GTE] == start  # lower bound t1
-        assert by_op[Op.LT] == end  # upper bound t2 (< t1 → no row matches)
-
-        # The legacy window is built from the same inverted bounds (also
-        # empty-matching), so it agrees with the folded AST instead of being
-        # nulled out.
+        # The inverted bounds reach the window verbatim (empty-matching there).
         temporal_filter = call_kwargs.kwargs.get("temporal_filter")
         assert temporal_filter is not None
         assert temporal_filter.occurred_after == start
         assert temporal_filter.occurred_before == end
+
+        # No event-time post-filter is folded on top.
+        assert call_kwargs.kwargs.get("filter_ast") is None
 
     @pytest.mark.asyncio
     async def test_mixed_timezone_normalizes_to_utc(self) -> None:

--- a/tests/unit/test_recall_deprecated_bounds_shim.py
+++ b/tests/unit/test_recall_deprecated_bounds_shim.py
@@ -1,0 +1,134 @@
+"""The deprecated ``start_time``/``end_time`` recall bounds are a WINDOW axis.
+
+``Khora.recall(start_time=..., end_time=...)`` is the legacy recency-window API:
+each engine narrows its channel reads on ``COALESCE(source_timestamp, created_at)``,
+so a chunk that is recent by ingest time survives the window even when it carries
+no event-time anchor (``source_timestamp`` / ``occurred_at`` both ``None`` — the
+shape a plain ``remember(content=...)`` produces).
+
+These tests pin the facade-level translation in ``Khora.recall``: the deprecated
+bounds forward ONLY a ``temporal_filter`` recency window and DO NOT fold an
+``occurred_at`` ``filter_ast``. Folding one would AND an event-time post-filter
+(``record.occurred_at = COALESCE(occurred_at, source_timestamp)``, no created_at
+fallback) on top of the window and false-empty every anchor-less chunk — the
+regression these guards prevent. The public ``filter={"occurred_at": {...}}``
+kwarg, by contrast, intentionally DOES produce a ``filter_ast`` and keeps its
+documented event-time semantics; the final test pins that the two paths stay
+distinct.
+
+Hermetic: the engine is a capture stub, so no database, embedder, or LLM is
+touched — the assertion is purely on what the facade hands to ``engine.recall``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from khora.core.models.recall import RecallResult
+from khora.khora import Khora
+from khora.query import SearchMode
+
+pytestmark = pytest.mark.unit
+
+
+def _capture_engine(captured: dict[str, Any]) -> Any:
+    """A minimal engine stub whose ``recall`` records its kwargs and returns empty."""
+    ns = uuid4()
+
+    async def _recall(query: str, namespace_id: Any, **kwargs: Any) -> RecallResult:
+        captured.update(kwargs)
+        return RecallResult(
+            query=query,
+            namespace_id=namespace_id,
+            documents=[],
+            chunks=[],
+            entities=[],
+            relationships=[],
+            engine_info={"engine": "chronicle"},
+        )
+
+    engine = AsyncMock()
+    engine.recall = _recall
+    engine._ns = ns
+    return engine
+
+
+def _facade(captured: dict[str, Any]) -> Khora:
+    """A Khora wired only enough to drive ``recall``'s filter-resolution shim.
+
+    Built via ``__new__`` so no config / connection is needed; the engine is the
+    capture stub and the recall method's collaborators (namespace resolve, hook
+    dispatch, document upgrade) are no-op stubs.
+    """
+    kb = Khora.__new__(Khora)
+    kb._engine_name = "chronicle"
+    engine = _capture_engine(captured)
+    kb._get_engine = lambda: engine  # type: ignore[method-assign]
+    kb._resolve_namespace = AsyncMock(return_value=uuid4())  # type: ignore[method-assign]
+    kb._dispatch_hook = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+    async def _passthrough(result: RecallResult, namespace_id: Any) -> RecallResult:
+        return result
+
+    kb._upgrade_recall_documents = _passthrough  # type: ignore[method-assign]
+    return kb
+
+
+@pytest.mark.asyncio
+async def test_deprecated_start_time_forwards_window_not_occurred_at_filter() -> None:
+    captured: dict[str, Any] = {}
+    kb = _facade(captured)
+
+    start = datetime(2026, 6, 1, tzinfo=UTC)
+    with pytest.warns(DeprecationWarning):
+        await kb.recall("alpha", namespace=uuid4(), mode=SearchMode.VECTOR, start_time=start)
+
+    # The window is forwarded on the temporal axis.
+    tf = captured["temporal_filter"]
+    assert tf is not None, "start_time must forward a recency-window temporal_filter"
+    assert tf.occurred_after == start
+
+    # No event-time post-filter is folded on top — that is the false-empty guard.
+    assert captured["filter_ast"] is None, (
+        "the deprecated window bounds must NOT fold an occurred_at filter_ast; "
+        "doing so AND-s an event-time post-filter with no created_at fallback and "
+        "false-empties anchor-less chunks"
+    )
+
+
+@pytest.mark.asyncio
+async def test_deprecated_end_time_forwards_window_not_occurred_at_filter() -> None:
+    captured: dict[str, Any] = {}
+    kb = _facade(captured)
+
+    end = datetime(2026, 6, 1, tzinfo=UTC)
+    with pytest.warns(DeprecationWarning):
+        await kb.recall("alpha", namespace=uuid4(), mode=SearchMode.VECTOR, end_time=end)
+
+    tf = captured["temporal_filter"]
+    assert tf is not None
+    assert tf.occurred_before == end
+    assert captured["filter_ast"] is None
+
+
+@pytest.mark.asyncio
+async def test_public_occurred_at_filter_still_forwards_filter_ast() -> None:
+    # Contrast: the NEW public API keeps its documented event-time semantics —
+    # an occurred_at filter DOES produce a filter_ast (and no temporal_filter).
+    captured: dict[str, Any] = {}
+    kb = _facade(captured)
+
+    await kb.recall(
+        "alpha",
+        namespace=uuid4(),
+        mode=SearchMode.VECTOR,
+        filter={"occurred_at": {"$gte": "2026-01-01T00:00:00Z"}},
+    )
+
+    assert captured["filter_ast"] is not None, "filter={'occurred_at': ...} must still forward a filter_ast"
+    assert captured["temporal_filter"] is None

--- a/tests/unit/test_recall_deprecated_bounds_window_axis.py
+++ b/tests/unit/test_recall_deprecated_bounds_window_axis.py
@@ -1,0 +1,357 @@
+"""Complementary edge cases for the deprecated ``start_time``/``end_time`` axis.
+
+Sibling to ``test_recall_deprecated_bounds_shim.py`` (which pins the core
+facade translation: the deprecated bounds forward a ``temporal_filter`` window and
+NOT an ``occurred_at`` ``filter_ast``). This file widens that guard along the
+boundary shapes the window-axis API has to get right, and adds the BEHAVIORAL
+contrast the shim ultimately protects:
+
+1. **Window-forwarding edge shapes** — start-only, end-only, both, and an inverted
+   pair all forward a recency-window ``temporal_filter`` and keep ``filter_ast``
+   ``None``. A naive (tz-less) bound is coerced to UTC on the window. These pin the
+   facade translation across every one/both/none combination of the two bounds.
+
+2. **The event-time vs window-axis divergence, end to end through the engine** — an
+   anchor-less chunk (``occurred_at`` AND ``source_timestamp`` both ``None`` — the
+   shape a plain ``remember(content=...)`` with no timestamp produces) SURVIVES a
+   ``start_time`` recency window but is EXCLUDED by an equivalent ``occurred_at``
+   filter. The window path runs no event-time post-filter (``filter_ast`` is
+   ``None``), so the chunk passes through; the ``occurred_at`` filter compiles a
+   post-filter whose record ``occurred_at`` is ``COALESCE(occurred_at,
+   source_timestamp)`` — ``None`` for an unanchored chunk — so the positive
+   predicate drops it. Folding the deprecated bounds into an ``occurred_at`` filter
+   (the regression) would collapse the first path into the second and false-empty
+   the chunk.
+
+Hermetic: the facade tests use a capture-stub engine (same pattern as the sibling
+file); the behavioral test drives the real ``ChronicleEngine`` over a mocked
+storage + embedder (same pattern as ``test_chronicle_filter_composition.py``).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from khora.config import KhoraConfig
+from khora.config.schema import QuerySettings
+from khora.core.models import Chunk
+from khora.core.models.recall import RecallResult
+from khora.engines.chronicle.engine import ChronicleEngine
+from khora.khora import Khora
+from khora.query import SearchMode
+
+pytestmark = pytest.mark.unit
+
+
+# ===========================================================================
+# (1) Facade window-forwarding edge shapes — capture-stub engine.
+# ===========================================================================
+#
+# Same minimal capture harness as the sibling file: the engine records the
+# kwargs the facade hands it and returns empty, so the assertion is purely on the
+# facade's start_time/end_time → (temporal_filter, filter_ast) translation.
+
+
+def _capture_engine(captured: dict[str, Any]) -> Any:
+    async def _recall(query: str, namespace_id: Any, **kwargs: Any) -> RecallResult:
+        captured.update(kwargs)
+        return RecallResult(
+            query=query,
+            namespace_id=namespace_id,
+            documents=[],
+            chunks=[],
+            entities=[],
+            relationships=[],
+            engine_info={"engine": "chronicle"},
+        )
+
+    engine = AsyncMock()
+    engine.recall = _recall
+    return engine
+
+
+def _facade(captured: dict[str, Any]) -> Khora:
+    kb = Khora.__new__(Khora)
+    kb._engine_name = "chronicle"
+    engine = _capture_engine(captured)
+    kb._get_engine = lambda: engine  # type: ignore[method-assign]
+    kb._resolve_namespace = AsyncMock(return_value=uuid4())  # type: ignore[method-assign]
+    kb._dispatch_hook = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+    async def _passthrough(result: RecallResult, namespace_id: Any) -> RecallResult:
+        return result
+
+    kb._upgrade_recall_documents = _passthrough  # type: ignore[method-assign]
+    return kb
+
+
+_START = datetime(2026, 4, 1, tzinfo=UTC)
+_END = datetime(2026, 6, 1, tzinfo=UTC)
+
+
+async def _recall_bounds(*, start: datetime | None = None, end: datetime | None = None) -> dict[str, Any]:
+    """Drive the facade with the given deprecated bounds, return captured kwargs."""
+    captured: dict[str, Any] = {}
+    kb = _facade(captured)
+    with pytest.warns(DeprecationWarning):
+        await kb.recall("alpha", namespace=uuid4(), mode=SearchMode.VECTOR, start_time=start, end_time=end)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_both_bounds_forward_window_no_filter_ast() -> None:
+    captured = await _recall_bounds(start=_START, end=_END)
+    tf = captured["temporal_filter"]
+    assert tf is not None
+    assert tf.occurred_after == _START
+    assert tf.occurred_before == _END
+    assert captured["filter_ast"] is None, "a both-bounds window must not fold an occurred_at filter_ast"
+
+
+@pytest.mark.asyncio
+async def test_start_only_leaves_upper_bound_open() -> None:
+    captured = await _recall_bounds(start=_START)
+    tf = captured["temporal_filter"]
+    assert tf.occurred_after == _START
+    assert tf.occurred_before is None, "start_time only must leave the window's upper bound open"
+    assert captured["filter_ast"] is None
+
+
+@pytest.mark.asyncio
+async def test_end_only_leaves_lower_bound_open() -> None:
+    captured = await _recall_bounds(end=_END)
+    tf = captured["temporal_filter"]
+    assert tf.occurred_before == _END
+    assert tf.occurred_after is None, "end_time only must leave the window's lower bound open"
+    assert captured["filter_ast"] is None
+
+
+@pytest.mark.asyncio
+async def test_inverted_range_forwards_verbatim_no_special_casing() -> None:
+    # An inverted pair (start later than end) is forwarded verbatim to the window —
+    # the facade does not special-case it into an empty filter_ast. The engine's
+    # recency window decides the (empty) outcome; the facade contract is just "no
+    # occurred_at fold".
+    captured = await _recall_bounds(start=_END, end=_START)
+    tf = captured["temporal_filter"]
+    assert tf.occurred_after == _END
+    assert tf.occurred_before == _START
+    assert captured["filter_ast"] is None
+
+
+@pytest.mark.asyncio
+async def test_naive_bound_is_coerced_to_utc_on_window() -> None:
+    # A tz-naive bound is normalized to tz-aware UTC before it reaches the window,
+    # so a downstream tz-aware compare never raises.
+    naive = datetime(2026, 4, 1)  # noqa: DTZ001 — intentionally naive for the coercion test
+    captured = await _recall_bounds(start=naive)
+    tf = captured["temporal_filter"]
+    assert tf.occurred_after.tzinfo is not None, "naive start_time must be coerced to tz-aware"
+    assert tf.occurred_after == naive.replace(tzinfo=UTC)
+    assert tf.occurred_after.utcoffset() == UTC.utcoffset(None), "the coerced bound must carry a zero (UTC) offset"
+    assert captured["filter_ast"] is None
+
+
+# ===========================================================================
+# (2) Event-time vs window-axis divergence — through the FACADE, real engine.
+# ===========================================================================
+#
+# The behavioral heart of the contract, driven end to end through
+# ``Khora.recall`` so it exercises the facade translation under test (NOT the
+# engine kwargs directly): the same anchor-less chunk passes a deprecated
+# ``start_time`` window but is dropped by the equivalent public ``occurred_at``
+# filter. On pre-fix code the ``start_time`` path folded an ``occurred_at``
+# ``filter_ast`` and the chunk was false-emptied, so this guard bites the
+# regression while also documenting the user-visible behavior the two APIs must
+# keep distinct.
+
+
+def _anchorless_chunk() -> Chunk:
+    """A chunk with NO event-time anchor — occurred_at AND source_timestamp None.
+
+    This is the shape a plain ``remember(content=...)`` with no timestamp produces.
+    ``created_at`` is recent so it would sit inside any sane recency window.
+    """
+    return Chunk(
+        id=uuid4(),
+        namespace_id=uuid4(),
+        document_id=uuid4(),
+        content="alpha anchorless",
+        created_at=datetime(2026, 6, 1, tzinfo=UTC),
+        metadata={},
+        occurred_at=None,
+        source_timestamp=None,
+    )
+
+
+def _real_engine(results: list[tuple[Chunk, float]]) -> ChronicleEngine:
+    """A connected ChronicleEngine whose semantic channel returns ``results``.
+
+    Reranking is OFF (it only reorders, never adds/drops a row) to keep the test
+    hermetic and fast. The mocked storage ignores the recency-window
+    ``created_after`` / ``created_before`` kwargs, so the WINDOW path's narrowing
+    is NOT what this test measures — it measures that the window path runs no
+    event-time post-filter at all, while the occurred_at path does.
+    """
+    engine = ChronicleEngine(KhoraConfig(query=QuerySettings(enable_reranking=False)))
+    storage = MagicMock()
+    storage.search_fulltext_chunks = AsyncMock(return_value=[])
+    storage.search_similar_chunks = AsyncMock(return_value=results)
+    storage.search_similar_entities = AsyncMock(return_value=[])
+    engine._storage = storage
+
+    embedder = MagicMock()
+    embedder.embed = AsyncMock(return_value=[0.1] * 1536)
+    engine._embedder = embedder
+    engine._connected = True
+    return engine
+
+
+def _facade_with_engine(engine: ChronicleEngine) -> Khora:
+    """A Khora wired to drive ``recall`` end to end into ``engine``.
+
+    Same ``__new__`` construction as the capture harness, but the engine is the
+    REAL ChronicleEngine (over mocked storage) so the facade's start_time/filter
+    translation flows all the way through the post-filter.
+    """
+    kb = Khora.__new__(Khora)
+    kb._engine_name = "chronicle"
+    kb._get_engine = lambda: engine  # type: ignore[method-assign]
+    kb._resolve_namespace = AsyncMock(return_value=uuid4())  # type: ignore[method-assign]
+    kb._dispatch_hook = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+    async def _passthrough(result: RecallResult, namespace_id: Any) -> RecallResult:
+        return result
+
+    kb._upgrade_recall_documents = _passthrough  # type: ignore[method-assign]
+    return kb
+
+
+@pytest.mark.asyncio
+async def test_anchorless_chunk_survives_window_but_excluded_by_occurred_at_filter() -> None:
+    # WINDOW axis (deprecated start_time): the facade forwards a temporal_filter
+    # window and NO filter_ast, so no event-time post-filter runs → the anchor-less
+    # chunk survives.
+    chunk_window = _anchorless_chunk()
+    kb_window = _facade_with_engine(_real_engine([(chunk_window, 0.9)]))
+    with pytest.warns(DeprecationWarning):
+        window_result = await kb_window.recall(
+            "alpha",
+            namespace=uuid4(),
+            limit=10,
+            mode=SearchMode.VECTOR,
+            start_time=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+    assert chunk_window.id in {c.id for c in window_result.chunks}, (
+        "an anchor-less chunk recent by ingest time must SURVIVE the deprecated "
+        "start_time recency window (the facade folds NO event-time post-filter)"
+    )
+
+    # EVENT-TIME axis (public filter={'occurred_at': ...}): the facade forwards a
+    # filter_ast → the post-filter record's occurred_at = COALESCE(occurred_at,
+    # source_timestamp) is None for an unanchored chunk → the positive $gte drops it.
+    chunk_filter = _anchorless_chunk()
+    kb_filter = _facade_with_engine(_real_engine([(chunk_filter, 0.9)]))
+    filter_result = await kb_filter.recall(
+        "alpha",
+        namespace=uuid4(),
+        limit=10,
+        mode=SearchMode.VECTOR,
+        filter={"occurred_at": {"$gte": "2026-01-01T00:00:00Z"}},
+    )
+    assert filter_result.chunks == [], (
+        "the equivalent occurred_at filter EXCLUDES the same anchor-less chunk "
+        "(no created_at fallback) — proving the two axes diverge. Folding the "
+        "deprecated bounds into this filter (the regression) would false-empty the "
+        "window path too."
+    )
+
+
+# ===========================================================================
+# (3) Boundary inclusivity on the PUBLIC occurred_at filter path.
+# ===========================================================================
+#
+# The deprecated bounds no longer emit any range AST after the fix, so the
+# ``$gte``-inclusive / ``$lt``-exclusive boundary semantics now live ONLY on the
+# public ``filter={"occurred_at": {...}}`` path. These pin the exact-instant
+# behavior a row sitting EXACTLY on the bound must get: the lower bound includes
+# it (``$gte``), the upper bound EXCLUDES it (``$lt``) while the inclusive upper
+# (``$lte``) keeps it — the ``$lte`` vs ``$lt`` contrast is what makes the
+# exclusivity load-bearing rather than a one-second rounding accident. Driven
+# end to end through ``Khora.recall(filter=...)`` like the section above.
+
+# The exact instant a boundary row sits on; the filter operand is the SAME instant.
+_BOUND_INSTANT = datetime(2026, 6, 1, tzinfo=UTC)
+_BOUND_ISO = "2026-06-01T00:00:00Z"
+
+
+def _chunk_at(instant: datetime) -> Chunk:
+    """A chunk whose effective event time is exactly ``instant``.
+
+    ``occurred_at`` is left ``None`` (the legacy pgvector DTO shape) so the record's
+    effective event time resolves via ``COALESCE(occurred_at, source_timestamp)`` =
+    ``source_timestamp`` — exercising the same recovery path the shim protects.
+    """
+    return Chunk(
+        id=uuid4(),
+        namespace_id=uuid4(),
+        document_id=uuid4(),
+        content="alpha boundary",
+        created_at=instant,
+        metadata={},
+        occurred_at=None,
+        source_timestamp=instant,
+    )
+
+
+@pytest.mark.asyncio
+async def test_occurred_at_gte_is_inclusive_at_the_exact_bound() -> None:
+    # A row whose event time equals the bound SURVIVES a $gte (inclusive lower).
+    at_bound = _chunk_at(_BOUND_INSTANT)
+    kb = _facade_with_engine(_real_engine([(at_bound, 0.9)]))
+    result = await kb.recall(
+        "alpha",
+        namespace=uuid4(),
+        limit=10,
+        mode=SearchMode.VECTOR,
+        filter={"occurred_at": {"$gte": _BOUND_ISO}},
+    )
+    assert at_bound.id in {c.id for c in result.chunks}, (
+        "occurred_at $gte must be INCLUSIVE at the exact bound — a row on the lower edge survives"
+    )
+
+
+@pytest.mark.asyncio
+async def test_occurred_at_lt_is_exclusive_at_the_exact_bound_unlike_lte() -> None:
+    # A row whose event time equals the bound is DROPPED by $lt (exclusive upper)
+    # but KEPT by $lte (inclusive upper). The contrast pins the exclusivity rather
+    # than an off-by-a-second artifact.
+    dropped = _chunk_at(_BOUND_INSTANT)
+    kb_lt = _facade_with_engine(_real_engine([(dropped, 0.9)]))
+    lt_result = await kb_lt.recall(
+        "alpha",
+        namespace=uuid4(),
+        limit=10,
+        mode=SearchMode.VECTOR,
+        filter={"occurred_at": {"$lt": _BOUND_ISO}},
+    )
+    assert lt_result.chunks == [], "occurred_at $lt must EXCLUDE a row sitting exactly on the upper bound"
+
+    kept = _chunk_at(_BOUND_INSTANT)
+    kb_lte = _facade_with_engine(_real_engine([(kept, 0.9)]))
+    lte_result = await kb_lte.recall(
+        "alpha",
+        namespace=uuid4(),
+        limit=10,
+        mode=SearchMode.VECTOR,
+        filter={"occurred_at": {"$lte": _BOUND_ISO}},
+    )
+    assert kept.id in {c.id for c in lte_result.chunks}, (
+        "occurred_at $lte must KEEP the same boundary row — the $lt/$lte contrast is "
+        "what makes the $lt exclusivity meaningful"
+    )


### PR DESCRIPTION
## Summary
- The deprecated `start_time`/`end_time` recall bounds previously folded into an `occurred_at` event-time filter **in addition** to the recency-window `temporal_filter`. On the Chronicle engine, chunks ingested without an explicit timestamp carry no `occurred_at` or `source_timestamp` anchor, so the AND-ed event-time post-filter dropped them even when they were recent by ingest time — a false-empty of in-scope results.
- These bounds now forward **only** the recency-window `temporal_filter` (`COALESCE(source_timestamp, created_at)`). The change is purely subtractive in the facade shim.
- The public `filter={"occurred_at": ...}` API is unchanged and keeps its documented event-time semantics (no `created_at` fallback) — the two paths now correctly diverge: the window axis includes anchor-less recent chunks, the event-time axis excludes them.
- Skeleton/pgvector is unaffected: it applies `temporal_filter` independently of `filter_ast`, and its lake always populates `occurred_at`, so it never had the false-empty.

## Test plan
- [x] Unit: facade shim (deprecated bounds → window only, `filter_ast` None), window-axis edge cases (start-only / end-only / inverted / naive→UTC), and the rewritten temporal-bounds suite
- [x] Engine-level guard: an anchor-less chunk (no `occurred_at`/`source_timestamp`, recent `created_at`) survives the deprecated-bounds window path on Chronicle, alongside its event-time-filter exclusion contrast
- [x] Public-filter boundary semantics: `$gte` inclusive / `$lt` exclusive, proven non-vacuous via operator-flip controls
- [x] Embedded sqlite_lance integration leg green (occurred_at-derived-from-source_timestamp path; no conflation)
- [x] Regression guards proven non-vacuous (fail on pre-fix code, pass after)
- [ ] Full integration matrix (live PostgreSQL / Neo4j) — runs in CI