### PR TITLE
Correct conformance created_at docs: stamp-then-strip mechanism and forward-protection rationale

### DIFF
--- a/src/khora/filter/conformance.py
+++ b/src/khora/filter/conformance.py
@@ -775,10 +775,13 @@ _SOURCE_TYPE_DEFAULTED_BACKENDS: frozenset[str] = frozenset({"postgres"})
 # (postgres + lance via the skeleton temporal store; weaviate via the same store
 # path), so an "absent" row cannot stay NULL there — its ``now()`` value satisfies a
 # lower-bound op and breaks the by-construction ``expected_ids``. A ``created_at``
-# predicate is pruned from these. The surrealdb (explicit ``option<datetime>`` insert,
-# no default) and cypher (omitted property when absent) runners keep an absent
-# ``created_at`` NULL, so they KEEP ``created_at`` cases. ``occurred_at`` /
-# ``source_timestamp`` are user-supplied and stay NULL everywhere — never pruned.
+# predicate is pruned from these. The surrealdb and cypher runners KEEP ``created_at``
+# cases, but for different reasons: surrealdb leaves an absent ``created_at`` NULL
+# natively (explicit ``option<datetime>`` insert, no default), while the cypher
+# production writer ALSO stamps ``now()`` and the conformance seeder strips it back to
+# NULL post-write (``_strip_stamped_created_at`` in ``_conformance_neo4j.py``).
+# ``occurred_at`` / ``source_timestamp`` are user-supplied and stay NULL everywhere —
+# never pruned.
 _CREATED_AT_STAMP_BACKENDS: frozenset[str] = frozenset({"postgres", "sqlite_lance", "weaviate"})
 
 # The live backends whose runner seeds through ``seed_case`` — i.e. it writes one
@@ -900,7 +903,9 @@ def _backends_for_filter(filter_: dict[str, Any] | RecallFilter, seed: tuple[See
       shapes execute in both the pushed-down and post-filtered modes;
     * a leaf reading ``created_at`` → drop :data:`_CREATED_AT_STAMP_BACKENDS`
       (postgres / sqlite_lance / weaviate stamp ``now()`` on insert). surrealdb +
-      cypher KEEP it (they leave an absent ``created_at`` NULL); ``occurred_at`` /
+      cypher KEEP it: surrealdb leaves an absent ``created_at`` NULL natively, and
+      the cypher seeder strips the writer's stamped ``now()`` back to NULL post-write
+      (``_strip_stamped_created_at`` in ``_conformance_neo4j.py``); ``occurred_at`` /
       ``source_timestamp`` are never pruned;
     * a surreal-only quirk (unsafe segment / metadata ``$date`` / present-null the
       filter distinguishes) → drop **surrealdb** only (:func:`_surreal_excluded`);

--- a/tests/integration/matrix/_conformance_neo4j.py
+++ b/tests/integration/matrix/_conformance_neo4j.py
@@ -27,11 +27,16 @@ store for the postgres leg) so both legs feed their production writer the same c
 One corpus-fidelity adjustment: ``create_chunk_nodes_batch`` stamps an absent
 ``created_at`` to ``now()`` (the production default), but the conformance corpus
 keeps ``created_at`` cases on the cypher leg *because* cypher is expected to leave an
-absent ``created_at`` NULL (an absent row that gets a ``now()`` value would satisfy a
-lower-bound pushdown and break the by-construction ``expected_ids``). So after the
-batch write, the seeder ``REMOVE``s ``created_at`` from exactly the nodes whose
-``SeedRecord`` left it ``None``, restoring the missing-property semantics the compiler
-relies on. ``occurred_at`` / ``source_timestamp`` are user-supplied and the production
+absent ``created_at`` NULL. So after the batch write, the seeder ``REMOVE``s
+``created_at`` from exactly the nodes whose ``SeedRecord`` left it ``None``, restoring
+the missing-property semantics the compiler relies on. The strip is forward-protection
+against false EXCLUSION, not against over-inclusion: the ``compile_python`` post-filter
+already rescues a stamped ``now()`` that over-includes on a lower-bound op (a post-filter
+can only narrow the Cypher candidate set), so no current case false-fails without the
+strip. But a ``$not``-wrapped or null-operand ``created_at`` predicate would false-
+EXCLUDE the absent row in the Cypher prefilter, and a post-filter cannot re-add an
+excluded row — so the strip is what keeps that exclusion class correct as the corpus
+grows. ``occurred_at`` / ``source_timestamp`` are user-supplied and the production
 writer already leaves them absent when ``None``, so they need no fixup.
 
 Seed/read split (write-once, read-many), mirroring the live-Postgres leg. The graph
@@ -176,7 +181,10 @@ async def build_seed_map() -> dict[str, dict[str, str]]:
     The production writer stamps an absent ``created_at`` to ``now()``; the corpus
     expects cypher to leave it NULL (see module docstring), so after the batch write
     every node whose ``SeedRecord`` left ``created_at`` ``None`` has the property
-    removed, restoring the missing-value semantics the compiler relies on.
+    removed, restoring the missing-value semantics the compiler relies on. This is
+    forward-protection against false EXCLUSION in the Cypher prefilter (a post-filter
+    can only narrow, never re-add an excluded row), not against the over-inclusion the
+    post-filter already rescues.
     """
     driver = _connect()
     seed_map: dict[str, dict[str, str]] = {}
@@ -207,10 +215,15 @@ async def _strip_stamped_created_at(driver: Any, database: str, chunk_ids: Seque
 
     ``create_chunk_nodes_batch`` defaults an absent ``created_at`` to ``now()`` (the
     production behavior). The conformance corpus keeps ``created_at`` cases on the
-    cypher leg precisely because cypher is expected to leave an absent ``created_at``
-    NULL, so a ``now()`` value would satisfy a lower-bound pushdown and break the
-    by-construction ``expected_ids``. Re-establish the missing-property semantics by
-    removing the stamped value on exactly those nodes.
+    cypher leg because cypher is expected to leave an absent ``created_at`` NULL.
+    Re-establish the missing-property semantics by removing the stamped value on
+    exactly those nodes. The payoff is forward-protection against false EXCLUSION: a
+    ``$not``-wrapped or null-operand ``created_at`` predicate would drop the absent row
+    in the Cypher prefilter, and the ``compile_python`` post-filter can only narrow the
+    candidate set — it cannot re-add an excluded row. (Over-inclusion from a stamped
+    ``now()`` on a lower-bound op is already rescued by that post-filter, so the strip
+    is not needed for any current case — it guards the exclusion class as the corpus
+    grows.)
     """
     if not chunk_ids:
         return


### PR DESCRIPTION
## Summary
- Reword the cypher-leg `created_at` classification comments in `src/khora/filter/conformance.py` so they attribute the leg keeping an absent `created_at` NULL to the conformance seeder's **post-write strip**, not to the writer omitting the property. The production graph writer now stamps an absent `created_at` to `now()`, and the seeder removes it post-write — the older "omitted property when absent" wording was stale for the cypher leg. surrealdb's genuinely-native no-default behavior is kept described accurately and clearly separated from cypher's stamp-then-strip.
- Reword the strip-rationale docstrings in `tests/integration/matrix/_conformance_neo4j.py` (module docstring, `build_seed_map`, `_strip_stamped_created_at`) to state the strip's real purpose: **forward-protection against false EXCLUSION**. A future `$not`-wrapped or null-operand `created_at` predicate would drop the absent row in the Cypher prefilter, and the full-AST post-filter can only narrow the candidate set — it cannot re-add an excluded row. The previous lower-bound over-inclusion rationale is inaccurate here: that over-inclusion is already rescued today by the narrowing post-filter, so the strip is not load-bearing for any current case.
- Comment/docstring only — no logic, identifiers, or set membership changed.

## Test plan
- [x] `make lint` green (ruff check + ruff format --check clean across the repo; ty typecheck reports no new errors)
- [x] Both edited files parse (AST) cleanly
- [x] Diff verified comment/docstring-only — every changed line is inside a comment or docstring token; executable code byte-identical to base
- [ ] CI: unit + integration + recall-filter conformance legs green
