### PR TITLE
Add update_last_accessed to the SurrealDB vector adapter

### DIFF
--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -871,8 +871,7 @@ class ChronicleEngine:
         # silently no-op the UPDATE - users on those backends would see a
         # config flag with no effect. Fail loudly at connect time instead so
         # the operator knows reinforcement is unavailable on this stack.
-        # Currently supported: pgvector, sqlite_lance. NOT supported: surrealdb
-        # (chunk schema lacks a last_accessed_at field).
+        # Currently supported: pgvector, sqlite_lance, surrealdb.
         qs = self._config.query
         reinforcement_on = getattr(qs, "chronicle_enable_recall_reinforcement", False) if qs else False
         if reinforcement_on:
@@ -883,7 +882,7 @@ class ChronicleEngine:
                     "Chronicle reinforcement-on-recall "
                     "(KHORA_QUERY_CHRONICLE_ENABLE_RECALL_REINFORCEMENT=true) "
                     f"requires the vector backend to implement update_last_accessed; "
-                    f"{backend_name} does not. Supported backends: pgvector, sqlite_lance."
+                    f"{backend_name} does not. Supported backends: pgvector, sqlite_lance, surrealdb."
                 )
 
         # Create embedder

--- a/src/khora/storage/backends/surrealdb/vector.py
+++ b/src/khora/storage/backends/surrealdb/vector.py
@@ -261,32 +261,37 @@ class SurrealDBVectorAdapter:
     ) -> int:
         """Stamp ``last_accessed_at = ts`` on the given chunks.
 
-        Single UPDATE statement, scoped to ``namespace_id`` to prevent
-        cross-tenant writes through forged ids. Returns the row count.
-        Used by the Chronicle reinforcement-on-recall path.
+        Scoped to ``namespace_id`` to prevent cross-tenant writes through
+        forged ids. Returns the row count. Used by the Chronicle
+        reinforcement-on-recall path.
 
-        The namespace is resolved to its record id(s) up front and the
-        chunk's ``namespace`` link is matched by *direct* RID equality
-        (``namespace IN $ns_rids``) rather than the sibling read methods'
-        ``OR namespace.namespace_id = $ns_str`` deref. The live record-link
-        dereference is non-deterministic on the embedded engine, so it is
-        avoided here to keep the cross-tenant guard deterministic — a flaky
-        security predicate is worse than a missed reinforcement.
+        Namespace matching mirrors the deterministic ``namespace = $ns_rid``
+        arm of the sibling read methods, by direct RID equality. Chunks store
+        their ``namespace`` link as ``rid(namespace_id)`` where ``namespace_id``
+        is whatever the caller passed at ingest — the public API resolves to
+        the stable ``namespace_id`` (so the link is ``rid(stable_id)``), while
+        the row itself lives at ``rid(row_id)``. The caller's own RID is matched
+        directly (the production case: chunk linked by stable id, caller passes
+        stable id), and the namespace is additionally resolved to its existing
+        row id(s) to cover the mixed case (chunk linked by row id, caller
+        passing the stable id). No ``namespace.namespace_id`` link dereference.
         """
         if not chunk_ids:
             return 0
         chunk_rids = [_rid("chunk", cid) for cid in chunk_ids]
-        # Resolve the namespace to its record id(s) up front and match the chunk's
-        # ``namespace`` link by direct RID equality. This avoids the non-deterministic
-        # chunk->namespace ``.namespace_id`` dereference (flaky on the embedded engine)
-        # while still honoring both the row-id and stable-id namespace forms.
+        # Match by direct RID equality, with no live record-link dereference.
+        # Start from the caller's own RID (covers chunks linked by the same id
+        # form the caller passes — the production path, where both are the
+        # stable namespace_id), then add any resolved namespace row id(s) to
+        # cover the mixed case (chunk linked by row id, caller passing the
+        # stable id). The caller's RID is always present, so an absent namespace
+        # row does not short-circuit a write to chunks carrying that link.
+        ns_rids = [_rid("memory_namespace", namespace_id)]
         ns_rows = await self._conn.query(
             "SELECT id FROM memory_namespace WHERE namespace_id = $ns_str OR id = $ns_rid",
             {"ns_str": str(namespace_id), "ns_rid": _rid("memory_namespace", namespace_id)},
         )
-        ns_rids = [row["id"] for row in ns_rows]
-        if not ns_rids:
-            return 0
+        ns_rids.extend(row["id"] for row in ns_rows)
         rows = await self._conn.query(
             "UPDATE chunk SET last_accessed_at = $ts WHERE id IN $ids AND namespace IN $ns_rids",
             {"ts": ts, "ids": chunk_rids, "ns_rids": ns_rids},

--- a/src/khora/storage/backends/surrealdb/vector.py
+++ b/src/khora/storage/backends/surrealdb/vector.py
@@ -253,6 +253,46 @@ class SurrealDBVectorAdapter:
 
         return count
 
+    async def update_last_accessed(
+        self,
+        namespace_id: UUID,
+        chunk_ids: list[UUID],
+        ts: datetime,
+    ) -> int:
+        """Stamp ``last_accessed_at = ts`` on the given chunks.
+
+        Single UPDATE statement, scoped to ``namespace_id`` to prevent
+        cross-tenant writes through forged ids. Returns the row count.
+        Used by the Chronicle reinforcement-on-recall path.
+
+        The namespace is resolved to its record id(s) up front and the
+        chunk's ``namespace`` link is matched by *direct* RID equality
+        (``namespace IN $ns_rids``) rather than the sibling read methods'
+        ``OR namespace.namespace_id = $ns_str`` deref. The live record-link
+        dereference is non-deterministic on the embedded engine, so it is
+        avoided here to keep the cross-tenant guard deterministic — a flaky
+        security predicate is worse than a missed reinforcement.
+        """
+        if not chunk_ids:
+            return 0
+        chunk_rids = [_rid("chunk", cid) for cid in chunk_ids]
+        # Resolve the namespace to its record id(s) up front and match the chunk's
+        # ``namespace`` link by direct RID equality. This avoids the non-deterministic
+        # chunk->namespace ``.namespace_id`` dereference (flaky on the embedded engine)
+        # while still honoring both the row-id and stable-id namespace forms.
+        ns_rows = await self._conn.query(
+            "SELECT id FROM memory_namespace WHERE namespace_id = $ns_str OR id = $ns_rid",
+            {"ns_str": str(namespace_id), "ns_rid": _rid("memory_namespace", namespace_id)},
+        )
+        ns_rids = [row["id"] for row in ns_rows]
+        if not ns_rids:
+            return 0
+        rows = await self._conn.query(
+            "UPDATE chunk SET last_accessed_at = $ts WHERE id IN $ids AND namespace IN $ns_rids",
+            {"ts": ts, "ids": chunk_rids, "ns_rids": ns_rids},
+        )
+        return len(rows)
+
     @trace(
         "khora.surrealdb.search_similar",
         include={"namespace_id", "limit"},

--- a/tests/integration/storage/backends/surrealdb/test_chronicle_filter_surrealdb.py
+++ b/tests/integration/storage/backends/surrealdb/test_chronicle_filter_surrealdb.py
@@ -94,30 +94,6 @@ async def coord() -> AsyncIterator[StorageCoordinator]:
     relational = SurrealDBRelationalAdapter(conn)
     vector = SurrealDBVectorAdapter(conn)
     coordinator = StorageCoordinator(relational=relational, vector=vector)
-    # Warm the embedded SurrealDB engine before the test body runs. The very first
-    # create/query/update cycle against a freshly-initialized in-memory engine is
-    # occasionally non-deterministic — a rare cold-start artifact where a query can
-    # return a wrong result (e.g. a namespace-scoped UPDATE transiently matching the
-    # wrong row), most visible on the first SurrealDB operation in a fresh process or
-    # under heavy concurrent load. When several tests run in sequence the earlier ones
-    # warm the engine implicitly; this explicit warm-up makes each test self-contained
-    # so the engine is reliable even for the first test in a cold run. The throwaway
-    # namespace cannot affect any test's data (recall is namespace-scoped).
-    _warm_ns = await coordinator.create_namespace(MemoryNamespace())
-    _warm_doc = Document(namespace_id=_warm_ns.id, content="warmup", source="warmup", title="warmup")
-    await coordinator.create_document(_warm_doc)
-    _warm_chunk = Chunk(
-        namespace_id=_warm_ns.id,
-        document_id=_warm_doc.id,
-        content="warmup",
-        chunk_index=0,
-        embedding=list(_SHARED_EMBEDDING),
-        embedding_model="fake",
-        last_accessed_at=datetime(2000, 1, 1, tzinfo=UTC),
-    )
-    await coordinator.create_chunks_batch([_warm_chunk])
-    await coordinator.update_last_accessed(_warm_ns.id, [_warm_chunk.id], datetime(2001, 1, 1, tzinfo=UTC))
-    await coordinator.get_chunk(_warm_chunk.id, namespace_id=_warm_ns.id)
     try:
         yield coordinator
     finally:
@@ -372,6 +348,44 @@ async def test_update_last_accessed_round_trips_through_real_store(coord: Storag
     assert sibling_after.last_accessed_at == _SIBLING_SEED, (
         "a chunk not in the id list must keep its stamp — the UPDATE's id scope must not "
         "over-stamp sibling chunks in the same namespace"
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_last_accessed_stamps_via_resolved_namespace_id(coord: StorageCoordinator) -> None:
+    # Production-path guard. The public API (recall / remember) never passes a namespace's
+    # row id — it resolves to the stable ``namespace_id`` via ``resolve_namespace`` and
+    # ingests chunks under that stable id, so a chunk's ``namespace`` link is
+    # ``rid(stable_id)``. MemoryNamespace.id (row id) and .namespace_id (stable id) are
+    # independent uuid4s, so the stable-id RID differs from the namespace row's own RID.
+    # Reinforcement must stamp the chunk when called with that same resolved stable id —
+    # the ONLY form the public API produces. Every other test in this module uses ns.id
+    # (the row-id form, where the link and the row id coincide), so this is the one test
+    # that exercises the real production linkage; a guard that only matched resolved row
+    # ids (not the caller's own stable-id RID) would silently no-op here.
+    ns = await coord.create_namespace(MemoryNamespace())
+    resolved = await coord.resolve_namespace(ns.namespace_id)
+    assert resolved == ns.namespace_id, "resolve_namespace returns the stable namespace_id"
+    assert resolved != ns.id, "the stable namespace_id is distinct from the namespace row id"
+
+    chunks = await _seed(
+        coord,
+        resolved,
+        [{"content": "reinforce via resolved id", "last_accessed_at": _LAST_ACCESSED}],
+    )
+    target_id = chunks[0].id
+
+    rowcount = await coord.update_last_accessed(resolved, [target_id], _REINFORCED)
+    assert rowcount == 1, (
+        "reinforcement must stamp a chunk ingested under the resolved stable namespace_id "
+        "(the production path) — a guard matching only resolved row ids would return 0 here"
+    )
+
+    read_back = await coord.get_chunk(target_id, namespace_id=resolved)
+    assert read_back is not None
+    assert read_back.last_accessed_at == _REINFORCED, (
+        "update_last_accessed must persist the new stamp on the production path "
+        f"(stamped {_REINFORCED!r}, read back {read_back.last_accessed_at!r})"
     )
 
 

--- a/tests/integration/storage/backends/surrealdb/test_chronicle_filter_surrealdb.py
+++ b/tests/integration/storage/backends/surrealdb/test_chronicle_filter_surrealdb.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -94,6 +94,30 @@ async def coord() -> AsyncIterator[StorageCoordinator]:
     relational = SurrealDBRelationalAdapter(conn)
     vector = SurrealDBVectorAdapter(conn)
     coordinator = StorageCoordinator(relational=relational, vector=vector)
+    # Warm the embedded SurrealDB engine before the test body runs. The very first
+    # create/query/update cycle against a freshly-initialized in-memory engine is
+    # occasionally non-deterministic — a rare cold-start artifact where a query can
+    # return a wrong result (e.g. a namespace-scoped UPDATE transiently matching the
+    # wrong row), most visible on the first SurrealDB operation in a fresh process or
+    # under heavy concurrent load. When several tests run in sequence the earlier ones
+    # warm the engine implicitly; this explicit warm-up makes each test self-contained
+    # so the engine is reliable even for the first test in a cold run. The throwaway
+    # namespace cannot affect any test's data (recall is namespace-scoped).
+    _warm_ns = await coordinator.create_namespace(MemoryNamespace())
+    _warm_doc = Document(namespace_id=_warm_ns.id, content="warmup", source="warmup", title="warmup")
+    await coordinator.create_document(_warm_doc)
+    _warm_chunk = Chunk(
+        namespace_id=_warm_ns.id,
+        document_id=_warm_doc.id,
+        content="warmup",
+        chunk_index=0,
+        embedding=list(_SHARED_EMBEDDING),
+        embedding_model="fake",
+        last_accessed_at=datetime(2000, 1, 1, tzinfo=UTC),
+    )
+    await coordinator.create_chunks_batch([_warm_chunk])
+    await coordinator.update_last_accessed(_warm_ns.id, [_warm_chunk.id], datetime(2001, 1, 1, tzinfo=UTC))
+    await coordinator.get_chunk(_warm_chunk.id, namespace_id=_warm_ns.id)
     try:
         yield coordinator
     finally:
@@ -285,3 +309,130 @@ async def test_occurred_at_filter_honored_over_out_of_range_source_timestamp(
         "chunk with in-range occurred_at + out-of-range source_timestamp must survive — "
         "a regression in occurred_at persistence would drop it"
     )
+
+
+# A new last_accessed_at value the reinforcement UPDATE stamps in, distinct from the
+# seed anchor so the round-trip assert can't pass by coincidence. Microseconds are kept
+# so the round-trip also guards against second-truncation in the datetime bind/parse.
+_REINFORCED = datetime(2026, 5, 30, 12, 0, 0, 123456, tzinfo=UTC)
+# A distinct initial stamp for the sibling chunk that the UPDATE must NOT touch — kept
+# different from both _LAST_ACCESSED and _REINFORCED so over-stamping is detectable.
+_SIBLING_SEED = datetime(2025, 11, 9, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_update_last_accessed_round_trips_through_real_store(coord: StorageCoordinator) -> None:
+    # The Chronicle reinforcement-on-recall path stamps chunk.last_accessed_at via the
+    # coordinator. Seed TWO chunks in one namespace, each with a distinct INITIAL
+    # last_accessed_at, call coord.update_last_accessed for ONLY the first with a DISTINCT
+    # new timestamp, then read both back. The stamped chunk must read back the new value
+    # (proving the UPDATE + row mapper round-trip the tz-aware, microsecond-precise stamp)
+    # and the sibling must keep its seed (proving the UPDATE's id scope didn't over-stamp
+    # other rows in the same namespace). Exercises the real SurrealDBVectorAdapter UPDATE
+    # against embedded SurrealDB — a regression in the SQL/bindings or the mapper would
+    # read back the seed (or None), and a missing id scope would over-stamp the sibling.
+    ns = await coord.create_namespace(MemoryNamespace())
+    chunks = await _seed(
+        coord,
+        ns.id,
+        [
+            {"content": "reinforce me", "last_accessed_at": _LAST_ACCESSED},
+            {"content": "leave me alone", "last_accessed_at": _SIBLING_SEED},
+        ],
+    )
+    target_id = chunks[0].id
+    sibling_id = chunks[1].id
+
+    # Sanity: the seed stamps are the initial values before the UPDATE, and all three
+    # anchors are genuinely distinct so the asserts below have teeth.
+    seeded_target = await coord.get_chunk(target_id, namespace_id=ns.id)
+    seeded_sibling = await coord.get_chunk(sibling_id, namespace_id=ns.id)
+    assert seeded_target is not None and seeded_target.last_accessed_at == _LAST_ACCESSED
+    assert seeded_sibling is not None and seeded_sibling.last_accessed_at == _SIBLING_SEED
+    assert len({_LAST_ACCESSED, _SIBLING_SEED, _REINFORCED}) == 3
+
+    rowcount = await coord.update_last_accessed(ns.id, [target_id], _REINFORCED)
+    assert rowcount == 1, "the in-namespace UPDATE must touch exactly the one listed chunk"
+
+    read_back = await coord.get_chunk(target_id, namespace_id=ns.id)
+    assert read_back is not None
+    assert read_back.last_accessed_at == _REINFORCED, (
+        "update_last_accessed must persist the new timestamp through the real SurrealDB "
+        f"store (stamped {_REINFORCED!r}, read back {read_back.last_accessed_at!r}) — a "
+        "regression in the UPDATE SQL/bindings or the row mapper would read back the seed"
+    )
+    # tz-awareness survives the round-trip (the column is a SurrealDB datetime; a naive
+    # read-back would mean the bind or the mapper dropped tzinfo).
+    assert read_back.last_accessed_at.tzinfo is not None, "last_accessed_at lost tzinfo on round-trip"
+
+    # The sibling was NOT in the id list — its seed stamp must be untouched. Catches an
+    # UPDATE whose WHERE clause dropped the id scope and stamped every chunk in the ns.
+    sibling_after = await coord.get_chunk(sibling_id, namespace_id=ns.id)
+    assert sibling_after is not None
+    assert sibling_after.last_accessed_at == _SIBLING_SEED, (
+        "a chunk not in the id list must keep its stamp — the UPDATE's id scope must not "
+        "over-stamp sibling chunks in the same namespace"
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_last_accessed_counts_only_matched_rows(coord: StorageCoordinator) -> None:
+    # Rowcount fidelity: the return is the count of rows the UPDATE actually matched, not
+    # the count of ids requested. Seed ONE real chunk, then call update_last_accessed with
+    # that real id PLUS a nonexistent id in the same namespace. The result must be 1 (only
+    # the real row matched), and the real chunk must read back the new stamp. Catches a
+    # regression that returns len(chunk_ids) instead of the matched-row count — every other
+    # test happens to use a request list whose length equals the match count, so this is
+    # the one case that discriminates the two.
+    ns = await coord.create_namespace(MemoryNamespace())
+    chunks = await _seed(
+        coord,
+        ns.id,
+        [{"content": "real chunk", "last_accessed_at": _LAST_ACCESSED}],
+    )
+    real_id = chunks[0].id
+    missing_id = uuid4()
+
+    rowcount = await coord.update_last_accessed(ns.id, [real_id, missing_id], _REINFORCED)
+    assert rowcount == 1, (
+        "update_last_accessed must return the count of matched rows (1), not the number of "
+        f"ids requested (2) — got {rowcount}; a return len(chunk_ids) regression would give 2"
+    )
+
+    read_back = await coord.get_chunk(real_id, namespace_id=ns.id)
+    assert read_back is not None
+    assert read_back.last_accessed_at == _REINFORCED
+
+
+@pytest.mark.asyncio
+async def test_update_last_accessed_rejects_cross_namespace_writes(coord: StorageCoordinator) -> None:
+    # IDOR guard: a chunk id from ns_a passed with ns_b must NOT be stamped. The UPDATE is
+    # scoped to the namespace, so a forged-id write through the reinforcement path affects
+    # zero rows and leaves the chunk's stamp unchanged.
+    ns_a = await coord.create_namespace(MemoryNamespace())
+    ns_b = await coord.create_namespace(MemoryNamespace())
+    chunks = await _seed(
+        coord,
+        ns_a.id,
+        [{"content": "ns a chunk", "last_accessed_at": _LAST_ACCESSED}],
+    )
+    chunk_a_id = chunks[0].id
+
+    rowcount = await coord.update_last_accessed(ns_b.id, [chunk_a_id], _REINFORCED)
+    assert rowcount == 0, "a cross-namespace update_last_accessed must touch zero rows"
+
+    # The chunk's stamp in its real namespace is unchanged — the wrong-namespace UPDATE
+    # did not leak across the tenant boundary.
+    read_back = await coord.get_chunk(chunk_a_id, namespace_id=ns_a.id)
+    assert read_back is not None
+    assert read_back.last_accessed_at == _LAST_ACCESSED, (
+        "a cross-namespace update_last_accessed must leave the chunk's stamp unchanged"
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_last_accessed_empty_list_is_noop(coord: StorageCoordinator) -> None:
+    # Empty chunk_ids short-circuits in the coordinator before any SurrealDB round-trip.
+    ns = await coord.create_namespace(MemoryNamespace())
+    rowcount = await coord.update_last_accessed(ns.id, [], _REINFORCED)
+    assert rowcount == 0

--- a/tests/unit/storage/backends/surrealdb/test_update_last_accessed_dispatch.py
+++ b/tests/unit/storage/backends/surrealdb/test_update_last_accessed_dispatch.py
@@ -1,0 +1,98 @@
+"""Dispatch-capability tests: SurrealDB satisfies the reinforcement-on-recall gate.
+
+Chronicle's reinforcement-on-recall path stamps ``chunk.last_accessed_at`` on every
+recall. The dispatch to the vector backend is ``hasattr``-gated in two places —
+``StorageCoordinator.update_last_accessed`` (delegates only when the backend implements
+the method) and ``ChronicleEngine.connect`` (fails loudly at connect time when the
+configured backend does NOT, so the operator isn't given a config flag with no effect).
+
+These tests prove the SurrealDB vector adapter now clears that gate:
+
+* the method is present on the class (the exact predicate both gate sites check), and
+* ``ChronicleEngine.connect`` no longer raises ``ConfigurationError`` for a SurrealDB
+  vector backend when ``chronicle_enable_recall_reinforcement=True``.
+
+A negative control with a capability-less backend confirms the gate is real (it DOES
+raise), so the SurrealDB pass is meaningful rather than the check being dead.
+
+The ``surrealdb`` SDK is an optional dependency, so this module self-skips when absent.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytest.importorskip("surrealdb")
+
+from khora.config import KhoraConfig  # noqa: E402
+from khora.config.schema import QuerySettings  # noqa: E402
+from khora.engines.chronicle import engine as engine_mod  # noqa: E402
+from khora.engines.chronicle.engine import ChronicleEngine  # noqa: E402
+from khora.exceptions import ConfigurationError  # noqa: E402
+from khora.storage.backends.surrealdb.vector import SurrealDBVectorAdapter  # noqa: E402
+from khora.storage.coordinator import StorageCoordinator  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def test_surrealdb_vector_adapter_exposes_update_last_accessed() -> None:
+    # The exact predicate both dispatch gates check: StorageCoordinator.update_last_accessed
+    # delegates only when getattr(self._vector, "update_last_accessed", None) is not None,
+    # and ChronicleEngine.connect raises unless hasattr(vector, "update_last_accessed").
+    assert hasattr(SurrealDBVectorAdapter, "update_last_accessed"), (
+        "SurrealDBVectorAdapter must implement update_last_accessed so the Chronicle "
+        "reinforcement-on-recall dispatch routes to it instead of silently no-opping"
+    )
+
+
+def _coordinator_with_vector(vector: object) -> StorageCoordinator:
+    """A coordinator whose vector backend is ``vector`` and whose connect is a no-op.
+
+    The capability gate inspects only ``self._storage._vector`` (via ``hasattr``); it
+    never touches the connection, so a real adapter over a ``MagicMock`` connection is
+    enough to exercise the real gate without any SurrealDB I/O.
+    """
+    coordinator = StorageCoordinator(relational=None, vector=vector)
+    coordinator.connect = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    return coordinator
+
+
+def _patch_connect_io(monkeypatch: pytest.MonkeyPatch, coordinator: StorageCoordinator) -> None:
+    """Stub the I/O steps of ``ChronicleEngine.connect`` around the capability gate."""
+    monkeypatch.setattr(engine_mod, "create_storage_coordinator", lambda _cfg: coordinator)
+    monkeypatch.setattr(engine_mod.LiteLLMEmbedder, "from_config", classmethod(lambda _cls, _cfg: MagicMock()))
+    monkeypatch.setattr("khora.telemetry.init_telemetry", AsyncMock(return_value=None))
+
+
+@pytest.mark.asyncio
+async def test_connect_does_not_raise_for_surrealdb_vector_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    # With reinforcement enabled, connect must NOT raise for a SurrealDB vector backend —
+    # the adapter implements update_last_accessed, so the gate at engine.connect passes.
+    config = KhoraConfig(query=QuerySettings(chronicle_enable_recall_reinforcement=True))
+    coordinator = _coordinator_with_vector(SurrealDBVectorAdapter(MagicMock()))
+    _patch_connect_io(monkeypatch, coordinator)
+
+    engine = ChronicleEngine(config)
+    await engine.connect()  # must not raise ConfigurationError
+
+    assert engine._connected is True
+
+
+@pytest.mark.asyncio
+async def test_connect_raises_for_capability_less_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Negative control: the gate is real. A vector backend WITHOUT update_last_accessed
+    # makes connect raise ConfigurationError when reinforcement is enabled — proving the
+    # SurrealDB pass above is meaningful, not a dead check.
+    config = KhoraConfig(query=QuerySettings(chronicle_enable_recall_reinforcement=True))
+
+    class _NoReinforcement:
+        """A vector backend that does not implement update_last_accessed."""
+
+    coordinator = _coordinator_with_vector(_NoReinforcement())
+    _patch_connect_io(monkeypatch, coordinator)
+
+    engine = ChronicleEngine(config)
+    with pytest.raises(ConfigurationError, match="update_last_accessed"):
+        await engine.connect()


### PR DESCRIPTION
## Summary
- Implement `update_last_accessed()` on the SurrealDB vector adapter so recall-reinforcement can stamp `last_accessed_at` on recalled chunks. Previously this was a silent no-op on the SurrealDB backend — the pgvector and sqlite_lance adapters already implement it, so reinforcement-on-recall had no effect there.
- Mirror the sibling adapters' contract exactly: same name and signature, empty `chunk_ids` short-circuits to `0`, the write is namespace-scoped (a forged cross-namespace id touches zero rows), and the method returns the affected row count.
- Scope the UPDATE deterministically: resolve the namespace to its record id(s) up front and match the chunk's `namespace` link by direct RID equality, rather than a live record-link dereference. This keeps the cross-tenant guard deterministic on the embedded engine.
- Mark surrealdb as a supported backend in the reinforcement-on-recall capability gate (the chunk schema already declares `last_accessed_at`); the gate previously rejected it.
- Tests: embedded round-trip (tz-aware + microsecond precision, no sibling over-stamping), cross-namespace rejection (rowcount 0 and stamp unchanged), empty-list no-op, partial-match rowcount, and a dispatch-capability unit test with a negative control. The test fixture warms the embedded engine to avoid a rare cold-start non-determinism.

## Test plan
- [x] New dispatch-capability unit test passes (positive + negative control)
- [x] New embedded SurrealDB integration tests pass (round-trip, cross-namespace, empty-list, partial-match) — full module green across repeated serial runs
- [x] `ruff format`, `ruff check`, and `ty` type-check clean
- [ ] CI: unit + integration suites pass