### PR TITLE
Add fail-loud tripwires for container-free e2e CI lanes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,25 +71,33 @@ jobs:
             select: tests/e2e/test_filter_rowset_graph.py tests/e2e/test_graph_contribution.py
             postgres: true
             neo4j: true
-          # Embedded vectorcypher engine — sqlite_lance, no service.
+          # Embedded vectorcypher engine — sqlite_lance, no service. `embedded`
+          # flips the conftest tripwire on so a missing aiosqlite/lancedb fails
+          # RED instead of skipping green.
           - backend: vc_embedded
             select: tests/e2e/ -k vc_embedded
+            embedded: true
           # Pgvector skeleton — live Postgres only.
           - backend: skeleton_pgvector
             select: tests/e2e/ -k skeleton_pgvector
             postgres: true
-          # SurrealDB skeleton — embedded (memory://), no service.
+          # SurrealDB skeleton — embedded (memory://), no service. `surreal`
+          # flips the conftest tripwire on so a missing surrealdb SDK fails RED
+          # instead of skipping green.
           - backend: skeleton_surrealdb
             select: tests/e2e/ -k skeleton_surrealdb
+            surreal: true
           # Weaviate skeleton — vectors in live Weaviate, documents in live
           # Postgres (so this leg provisions BOTH stores).
           - backend: skeleton_weaviate
             select: tests/e2e/ -k skeleton_weaviate
             postgres: true
             weaviate: true
-          # SQLite + LanceDB skeleton — embedded, no service.
+          # SQLite + LanceDB skeleton — embedded, no service. `embedded` flips
+          # the conftest tripwire on (same as vc_embedded).
           - backend: skeleton_sqlite_lance
             select: tests/e2e/ -k skeleton_sqlite_lance
+            embedded: true
           # Chronicle engine — PG-only (no graph backend).
           - backend: chronicle
             select: tests/e2e/ -k chronicle
@@ -295,6 +303,11 @@ jobs:
           WEAVIATE_URL: ${{ matrix.weaviate && 'http://localhost:8080' || '' }}
           WEAVIATE_GRPC_PORT: ${{ matrix.weaviate && '50051' || '' }}
           KHORA_E2E_WEAVIATE_REQUIRED: ${{ matrix.weaviate && '1' || '' }}
+          # The container-free legs have no store to provision, but a missing
+          # optional dep would skip them green; these flags make the conftest
+          # tripwire abort RED if the embedded stack / SurrealDB SDK is absent.
+          KHORA_E2E_EMBEDDED_REQUIRED: ${{ matrix.embedded && '1' || '' }}
+          KHORA_E2E_SURREAL_REQUIRED: ${{ matrix.surreal && '1' || '' }}
         run: |
           uv run pytest \
             ${{ matrix.select }} \

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -27,6 +27,7 @@ from pydantic import SecretStr
 
 from khora import Khora
 from khora.config.schema import KhoraConfig, SQLiteLanceConfig, SurrealDBConfig
+from tests.e2e import _harness
 from tests.test_helpers.filter_spy import EMBED_DIM, stub_llm
 
 pytestmark = pytest.mark.e2e
@@ -379,8 +380,18 @@ async def skeleton_weaviate_kb(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator
 #   KHORA_E2E_WEAVIATE_REQUIRED=1  -> Weaviate must be reachable (skeleton_weaviate
 #                                     leg).
 #
-# The devops e2e workflow sets these on the matching container legs only; the
-# default no-Docker job leaves them unset so the per-fixture self-skip still wins.
+# The container-free legs have no service to socket-probe, but a missing optional
+# dependency would silently skip them green just the same. The same fail-loud
+# contract applies — the "store" is the importable embedded stack:
+#
+#   KHORA_E2E_EMBEDDED_REQUIRED=1  -> the embedded sqlite_lance stack (aiosqlite +
+#                                     lancedb) must import (vc_embedded,
+#                                     skeleton_sqlite_lance legs).
+#   KHORA_E2E_SURREAL_REQUIRED=1   -> the embedded SurrealDB SDK must import
+#                                     (skeleton_surrealdb leg).
+#
+# The devops e2e workflow sets these on the matching legs only; the default
+# no-Docker job leaves them unset so the per-fixture self-skip still wins.
 # --------------------------------------------------------------------------- #
 
 
@@ -406,5 +417,19 @@ def pytest_configure(config: pytest.Config) -> None:
         pytest.exit(
             f"KHORA_E2E_WEAVIATE_REQUIRED=1 but Weaviate is unreachable at {weaviate_url}. "
             "The e2e CI leg provisions Weaviate; a skip here would hide real failures.",
+            returncode=1,
+        )
+
+    if os.environ.get("KHORA_E2E_EMBEDDED_REQUIRED") == "1" and not _harness._embedded_available():
+        pytest.exit(
+            "KHORA_E2E_EMBEDDED_REQUIRED=1 but the embedded stack (aiosqlite + lancedb) is not "
+            "importable. The e2e CI leg installs it; a skip here would hide real failures.",
+            returncode=1,
+        )
+
+    if os.environ.get("KHORA_E2E_SURREAL_REQUIRED") == "1" and not _harness._surreal_embedded_available():
+        pytest.exit(
+            "KHORA_E2E_SURREAL_REQUIRED=1 but the embedded SurrealDB SDK is not importable. "
+            "The e2e CI leg installs it; a skip here would hide real failures.",
             returncode=1,
         )

--- a/tests/unit/filter/test_e2e_required_tripwires.py
+++ b/tests/unit/filter/test_e2e_required_tripwires.py
@@ -1,0 +1,102 @@
+"""Negative-verification: the e2e ``*_REQUIRED`` tripwires have teeth.
+
+``tests/e2e/conftest.py::pytest_configure`` converts a silent green skip into a
+hard red exit on the container-free legs: when ``KHORA_E2E_EMBEDDED_REQUIRED=1``
+(the embedded ``sqlite_lance`` stack) or ``KHORA_E2E_SURREAL_REQUIRED=1`` (the
+embedded SurrealDB SDK) is set but the matching ``_harness`` probe reports the
+backend unavailable, it calls ``pytest.exit(..., returncode=1)`` — which raises
+``_pytest.outcomes.Exit``. A tripwire that never fires is worse than none, so
+this hermetic test (no DB, no network) proves each one actually aborts when its
+probe says the backend is missing, and stays quiet when the probe says it is
+present.
+
+Each test monkeypatches the relevant probe on the shared ``_harness`` module
+object that ``conftest`` references (``_harness._embedded_available()`` /
+``_harness._surreal_embedded_available()``) and deletes the other four
+``KHORA_E2E_*_REQUIRED`` flags so a real local Postgres/Neo4j/Weaviate — or a
+stray sibling flag — cannot perturb the assertion. ``monkeypatch`` auto-restores
+both the env vars and the patched attributes after each test.
+
+No DB, no infra — runs in the fast unit suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+from _pytest.outcomes import Exit
+
+import tests.e2e._harness as _harness
+from tests.e2e import conftest
+
+pytestmark = [pytest.mark.unit]
+
+# Every ``KHORA_E2E_*_REQUIRED`` flag ``pytest_configure`` consults. Each test
+# sets exactly one and clears the rest so an ambient env value cannot change the
+# branch that fires.
+_ALL_REQUIRED_FLAGS = (
+    "KHORA_E2E_PG_REQUIRED",
+    "KHORA_E2E_NEO4J_REQUIRED",
+    "KHORA_E2E_WEAVIATE_REQUIRED",
+    "KHORA_E2E_EMBEDDED_REQUIRED",
+    "KHORA_E2E_SURREAL_REQUIRED",
+)
+
+
+def _isolate_required_flags(monkeypatch: pytest.MonkeyPatch, keep: str) -> None:
+    """Clear every ``*_REQUIRED`` flag except ``keep``, which is set to ``"1"``.
+
+    Deleting the others (``raising=False`` — they are usually unset) stops a real
+    local Postgres/etc. or a sibling flag left in the environment from tripping a
+    different branch of ``pytest_configure`` and masking the assertion.
+    """
+    for flag in _ALL_REQUIRED_FLAGS:
+        monkeypatch.delenv(flag, raising=False)
+    monkeypatch.setenv(keep, "1")
+
+
+def test_embedded_required_aborts_when_probe_false(
+    monkeypatch: pytest.MonkeyPatch, pytestconfig: pytest.Config
+) -> None:
+    """``KHORA_E2E_EMBEDDED_REQUIRED=1`` + embedded probe False → ``pytest.exit``.
+
+    The container-free embedded ``sqlite_lance`` lane must fail RED, not skip
+    green, when the embedded stack is unavailable in a leg that requires it.
+    """
+    _isolate_required_flags(monkeypatch, keep="KHORA_E2E_EMBEDDED_REQUIRED")
+    monkeypatch.setattr(_harness, "_embedded_available", lambda: False)
+
+    with pytest.raises(Exit):
+        conftest.pytest_configure(pytestconfig)
+
+
+def test_surreal_required_aborts_when_probe_false(monkeypatch: pytest.MonkeyPatch, pytestconfig: pytest.Config) -> None:
+    """``KHORA_E2E_SURREAL_REQUIRED=1`` + surreal probe False → ``pytest.exit``.
+
+    Symmetric to the embedded case: the in-process SurrealDB lane must abort the
+    session when the optional ``surrealdb`` SDK is missing in a leg that requires it.
+    """
+    _isolate_required_flags(monkeypatch, keep="KHORA_E2E_SURREAL_REQUIRED")
+    monkeypatch.setattr(_harness, "_surreal_embedded_available", lambda: False)
+
+    with pytest.raises(Exit):
+        conftest.pytest_configure(pytestconfig)
+
+
+def test_embedded_required_passes_when_probe_true(monkeypatch: pytest.MonkeyPatch, pytestconfig: pytest.Config) -> None:
+    """``KHORA_E2E_EMBEDDED_REQUIRED=1`` + embedded probe True → no abort.
+
+    The tripwire is conditional, not unconditional: when the required backend IS
+    available, ``pytest_configure`` must return cleanly so the leg runs.
+    """
+    _isolate_required_flags(monkeypatch, keep="KHORA_E2E_EMBEDDED_REQUIRED")
+    monkeypatch.setattr(_harness, "_embedded_available", lambda: True)
+
+    conftest.pytest_configure(pytestconfig)
+
+
+def test_surreal_required_passes_when_probe_true(monkeypatch: pytest.MonkeyPatch, pytestconfig: pytest.Config) -> None:
+    """``KHORA_E2E_SURREAL_REQUIRED=1`` + surreal probe True → no abort."""
+    _isolate_required_flags(monkeypatch, keep="KHORA_E2E_SURREAL_REQUIRED")
+    monkeypatch.setattr(_harness, "_surreal_embedded_available", lambda: True)
+
+    conftest.pytest_configure(pytestconfig)

--- a/tests/unit/filter/test_verification_coverage_gate.py
+++ b/tests/unit/filter/test_verification_coverage_gate.py
@@ -636,6 +636,11 @@ def _backends_from_signal(text: str) -> set[str]:
         out.add("weaviate")
     if "_PG_REACHABLE" in up or "KHORA_PG_REQUIRED" in up or "KHORA_E2E_PG_REQUIRED" in up:
         out.add("postgres")
+    # The container-free lanes (embedded sqlite_lance / in-process SurrealDB) gate
+    # on these "required" flags too; both imply the embedded sentinel, which every
+    # leg provides — so a module gated on them is covered by any leg.
+    if "KHORA_E2E_EMBEDDED_REQUIRED" in up or "KHORA_E2E_SURREAL_REQUIRED" in up:
+        out.add(_EMBEDDED)
     return out
 
 
@@ -981,6 +986,9 @@ def test_e2e_env_flags_infer_backends() -> None:
     assert _backends_from_signal("KHORA_E2E_NEO4J_REQUIRED") == {"neo4j"}
     assert _backends_from_signal("KHORA_E2E_WEAVIATE_REQUIRED") == {"weaviate"}
     assert _backends_from_signal("KHORA_E2E_PG_REQUIRED KHORA_E2E_NEO4J_REQUIRED") == {"postgres", "neo4j"}
+    # The container-free lanes' required flags both map to the embedded sentinel.
+    assert _backends_from_signal("KHORA_E2E_EMBEDDED_REQUIRED") == {_EMBEDDED}
+    assert _backends_from_signal("KHORA_E2E_SURREAL_REQUIRED") == {_EMBEDDED}
 
 
 def test_tracking_ref_accepts_long_issue_numbers() -> None:


### PR DESCRIPTION
## Summary
- The three container-free e2e matrix lanes (embedded sqlite_lance and in-process SurrealDB) skip every test and stay **green** if their optional dependencies ever stop installing, masking real failures. The container-backed lanes are already protected by skip→fail tripwires (`*_REQUIRED` env flags checked in `pytest_configure`); the container-free lanes had no equivalent.
- Add `KHORA_E2E_EMBEDDED_REQUIRED` / `KHORA_E2E_SURREAL_REQUIRED` flags, wired per-leg in the e2e workflow matrix, that make the e2e `pytest_configure` abort the session (exit 1) when the flag is set but the embedded stack (`aiosqlite` + `lancedb`) or the SurrealDB SDK is not importable — mirroring the existing Postgres/Neo4j/Weaviate tripwires.
- Teach the verification-coverage meta-gate to recognize both new flags (both map to the embedded sentinel, which every leg provides).
- Add a hermetic regression test proving the tripwires fire on dependency drift and stay quiet when the deps are present.

Behavior is unchanged when the embedded extras are installed (CI reality): the flags only convert an all-skip into a loud failure.

## Test plan
- [x] Unit + recall suite passes locally (`make test-unit`: 8631 passed, 35 skipped)
- [x] New negative-verification test asserts `pytest_configure` aborts when the import probe is `False` and returns quietly when `True`
- [x] Verification-coverage gate still green (the new test is a pure-unit module; no false orphan)
- [ ] Integration + 7-lane e2e matrix pass in CI (require Docker; exercised by the CI workflows)