### PR TITLE
Make sqlite_lance vector-channel temporal upper bound inclusive

### DIFF
--- a/src/khora/storage/backends/sqlite_lance/vector.py
+++ b/src/khora/storage/backends/sqlite_lance/vector.py
@@ -481,9 +481,14 @@ class SQLiteLanceVectorAdapter:
         # truth for chunk metadata and tracks ``source_timestamp`` (LanceDB
         # only stores ``created_at``), so we re-apply the bounds here using
         # ``COALESCE(source_timestamp, created_at)`` — matches the pgvector
-        # backend's column-precedence rule (PR #470). Half-open
-        # interval ``>= start AND < end`` to match the Chronicle pushdown
-        # contract.
+        # backend's column-precedence rule (PR #470). The upper bound is
+        # INCLUSIVE (``<=``) to honor the superset-safe pushdown contract: the
+        # pushed candidate set must be a superset of the post-filtered set and
+        # never false-exclude, so the bound instant itself stays inside the
+        # window. Strictness (``$lt`` vs ``$lte``) is deliberately NOT carried
+        # into the pushed bound — ``compile_python`` re-checks exact strictness
+        # post-filter. This also matches pgvector, SurrealDB, and this
+        # backend's own BM25 channel.
         # Defense-in-depth (IDOR family): also enforce namespace_id on the SQLite
         # side rather than trusting LanceDB's filter alone. If LanceDB's
         # where-clause regressed, the SQLite filter would still keep cross-
@@ -497,7 +502,7 @@ class SQLiteLanceVectorAdapter:
             sql_parts.append("AND COALESCE(source_timestamp, created_at) >= ?")
             params.append(_dt_to_str(created_after))
         if created_before is not None:
-            sql_parts.append("AND COALESCE(source_timestamp, created_at) < ?")
+            sql_parts.append("AND COALESCE(source_timestamp, created_at) <= ?")
             params.append(_dt_to_str(created_before))
         cur = await self._sqlite.execute(" ".join(sql_parts), params)
         rows = await cur.fetchall()

--- a/tests/integration/test_chronicle_filter_embedded.py
+++ b/tests/integration/test_chronicle_filter_embedded.py
@@ -74,6 +74,10 @@ _SHARED_EMBEDDING = fake_embedding(_QUERY_TEXT, dim=EMBED_DIM)
 _IN_RANGE = datetime(2026, 6, 1, tzinfo=UTC)
 _OUT_OF_RANGE = datetime(2020, 1, 1, tzinfo=UTC)
 _FILTER_LB = "2026-01-01T00:00:00Z"
+# An upper-bound filter whose instant equals a chunk's source_timestamp exactly.
+# 2026-06-01T00:00:00Z is the ISO form of _IN_RANGE, so a chunk seeded with
+# source_timestamp == _IN_RANGE sits on the boundary of a $lte filter at this value.
+_FILTER_UB_AT_BOUND = "2026-06-01T00:00:00Z"
 
 
 def _filter_ast(wire: dict) -> Any:
@@ -193,6 +197,48 @@ async def test_source_timestamp_pushdown_narrows_against_real_window(tmp_path: P
 
         returned = await _recall_ids(_engine_over(coord), ns.id, {"source_timestamp": {"$gte": _FILTER_LB}})
         assert returned == {in_range_id}
+    finally:
+        await coord.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_source_timestamp_upper_bound_is_inclusive_at_boundary(tmp_path: Path) -> None:
+    # A chunk whose effective source_timestamp equals the upper-bound instant EXACTLY
+    # must survive a source_timestamp $lte <that instant> filter. The bound pushes into
+    # the SQLite-side recency window COALESCE(source_timestamp, created_at), whose upper
+    # comparison must be inclusive (<=): the boundary instant stays inside the window.
+    # SearchMode.VECTOR routes the whole seed set through the vector channel only (BM25
+    # is gated on HYBRID/ALL), so this can pass solely via the vector path.
+    #
+    # created_at is seeded well before the bound so the coarse LanceDB pre-filter (which
+    # filters on the LanceDB-side created_at, not source_timestamp) lets both rows
+    # through; the inclusive SQLite COALESCE(source_timestamp, created_at) refinement is
+    # then the only thing deciding the boundary case (source_timestamp is non-null, so
+    # COALESCE resolves to it, not created_at).
+    coord = await build_sqlite_lance_coordinator(tmp_path)
+    try:
+        ns = await coord.create_namespace(MemoryNamespace())
+        chunks = await _seed(
+            coord,
+            ns.id,
+            [
+                # source_timestamp == the filter's upper-bound instant exactly.
+                {"content": "on the boundary", "source_timestamp": _IN_RANGE, "created_at": _OUT_OF_RANGE},
+                # strictly after the bound → excluded by the inclusive upper bound.
+                {
+                    "content": "after the boundary",
+                    "source_timestamp": datetime(2026, 6, 2, tzinfo=UTC),
+                    "created_at": _OUT_OF_RANGE,
+                },
+            ],
+        )
+        on_bound_id = chunks[0].id
+
+        returned = await _recall_ids(_engine_over(coord), ns.id, {"source_timestamp": {"$lte": _FILTER_UB_AT_BOUND}})
+        assert returned == {on_bound_id}, (
+            "a chunk whose source_timestamp equals the $lte bound instant exactly must be "
+            "returned — the recency-window upper bound is inclusive"
+        )
     finally:
         await coord.disconnect()
 


### PR DESCRIPTION
## Summary
- The SQLite-side recency-window refinement in the `sqlite_lance` **vector** channel used a half-open `<` on the `COALESCE(source_timestamp, created_at)` upper bound, while pgvector, SurrealDB (vector + BM25), and this backend's own BM25 channel all use an inclusive `<=`.
- The half-open form **false-excluded** a chunk whose effective timestamp equals the bound instant exactly: the row was dropped pre-filter, and the Python post-filter can only remove rows, never restore them — a cross-backend determinism break and an intra-backend split with the BM25 channel.
- Standardized on inclusive `<=` so the pushed candidate set stays a safe **superset** of the post-filtered set (the bound instant stays in the window; `$lt` vs `$lte` strictness is re-checked by the Python post-filter, not carried into the pushed bound).
- Replaced the misleading comment that claimed a non-existent "half-open contract" with the accurate inclusive / superset-safe pushdown rationale.
- Added a vector-channel regression test that seeds a chunk on the exact upper-bound instant and asserts an inclusive `$lte` filter returns it (stash-verified: fails with `<`, passes with `<=`).

All four chunk-search temporal pushdown sites now use `>=` lower / `<=` upper; lower bounds were left untouched.

## Test plan
- [x] New regression test `test_source_timestamp_upper_bound_is_inclusive_at_boundary` passes via the vector channel (semantic-only routing) and fails when the one-character fix is reverted
- [x] Embedded / hermetic suites green locally (`chronicle_filter_embedded`: 6 passed; `sqlite_lance` vector unit: 157 passed; recall-filter suite: 453 passed)
- [x] `ruff format` / `ruff check` / type check clean
- [ ] Full integration suite + combined coverage gate (Postgres/Neo4j) — runs in CI