### PR TITLE
Honor expired relationships in embedded prefer_current graph traversal

### DIFF
--- a/src/khora/storage/backends/sqlite_lance/graph.py
+++ b/src/khora/storage/backends/sqlite_lance/graph.py
@@ -245,6 +245,34 @@ def _relationship_insert_params(rel: Relationship) -> tuple:
     )
 
 
+_RELATIONSHIP_INSERT_SQL = (
+    f"INSERT INTO relationships ({_RELATIONSHIP_COLUMNS}) "  # noqa: S608
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+)
+
+# Re-saving an edge (same ``id``) updates its mutable columns instead of
+# raising on the primary-key conflict. The temporal window (``valid_from`` /
+# ``valid_until``) is the column that matters for ``prefer_current`` recall
+# (#1087): a later ingest can close an edge's validity window, and the CTE
+# traversal filters on ``valid_until``. ``id`` / ``namespace_id`` / endpoints
+# / ``source_document_ids`` / ``source_chunk_ids`` / ``created_at`` are NOT in
+# the SET list — re-saving must never rewrite provenance or the original
+# creation stamp, and the bi-temporal soft-delete columns (``valid_to`` /
+# ``invalidated_at`` / ``invalidated_by``) are likewise left untouched.
+_RELATIONSHIP_UPSERT_SQL = _RELATIONSHIP_INSERT_SQL + (
+    " ON CONFLICT(id) DO UPDATE SET "
+    "relationship_type = excluded.relationship_type, "
+    "description = excluded.description, "
+    "properties = excluded.properties, "
+    "valid_from = excluded.valid_from, "
+    "valid_until = excluded.valid_until, "
+    "confidence = excluded.confidence, "
+    "weight = excluded.weight, "
+    "metadata = excluded.metadata, "
+    "updated_at = excluded.updated_at"
+)
+
+
 # ---------------------------------------------------------------------------
 # Adapter
 # ---------------------------------------------------------------------------
@@ -481,9 +509,7 @@ class SQLiteLanceGraphAdapter(GraphBackendBase):
     # ------------------------------------------------------------------
 
     async def create_relationship(self, relationship: Relationship) -> Relationship:
-        insert_sql = f"INSERT INTO relationships ({_RELATIONSHIP_COLUMNS}) "  # noqa: S608
-        sql = insert_sql + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
-        await self._conn.execute(sql, _relationship_insert_params(relationship))
+        await self._conn.execute(_RELATIONSHIP_UPSERT_SQL, _relationship_insert_params(relationship))
         await self._conn.commit()
         # Reflect the sanitized relationship type back to the caller.
         relationship.relationship_type = sanitize_cypher_label(relationship.relationship_type or "RELATES_TO")
@@ -581,12 +607,10 @@ class SQLiteLanceGraphAdapter(GraphBackendBase):
     ) -> int:
         if not relationships:
             return 0
-        insert_sql = f"INSERT INTO relationships ({_RELATIONSHIP_COLUMNS}) "  # noqa: S608
-        sql = insert_sql + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
         total = 0
         for start in range(0, len(relationships), batch_size):
             chunk = relationships[start : start + batch_size]
-            await self._conn.executemany(sql, [_relationship_insert_params(r) for r in chunk])
+            await self._conn.executemany(_RELATIONSHIP_UPSERT_SQL, [_relationship_insert_params(r) for r in chunk])
             total += len(chunk)
         await self._conn.commit()
         # Mirror the sanitized type back into the caller-provided objects

--- a/tests/integration/matrix/test_vectorcypher_sqlite_lance.py
+++ b/tests/integration/matrix/test_vectorcypher_sqlite_lance.py
@@ -29,17 +29,17 @@ VectorCypher's embedded ``sqlite_lance`` path is wired. Occurred-bounds
 temporal recall (``start_time`` / ``end_time``) now works on the embedded
 path — the filter pushes down to ``khora_chunks.occurred_at`` and the
 retriever skips the unsupported entity-version narrowing with a structured
-degradation rather than failing. Two tests remain ``xfail`` for known
-backend gaps (each xfail carries an explanatory string):
+degradation rather than failing. ``prefer_current`` now honors expired edges
+on the embedded CTE path (#1087) — see ``test_vc_prefer_current_via_cte``.
+One test remains ``xfail`` for a known backend gap (the xfail carries an
+explanatory string):
 
 * ``test_vc_two_hop_traversal`` — multi-hop CTE traversal correctness
   on the SQL-emulated graph.
-* ``test_vc_prefer_current_via_cte`` — ``prefer_current`` honoring on
-  CTE traversal.
 
-The remaining xfails track concrete behavioural gaps, not a wiring
-issue. They are written end-to-end so that when the underlying paths
-land, the same tests serve as the acceptance suite without rewriting.
+The remaining xfail tracks a concrete behavioural gap, not a wiring
+issue. It is written end-to-end so that when the underlying path
+lands, the same test serves as the acceptance suite without rewriting.
 """
 
 from __future__ import annotations
@@ -634,66 +634,90 @@ async def test_vc_cooccurrence_carries_source_document_ids(kb: Khora, namespace_
         )
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "VectorCypher embedded prefer_current does not honor expired edges via the "
-        "SQLite CTE traversal: an edge whose valid_to is in the past is still walked, "
-        "so content reachable only through it leaks into the recall result. Tracked in "
-        "#1087; this is the acceptance test for that bi-temporal-invalidation work."
-    ),
-    raises=Exception,
-)
 async def test_vc_prefer_current_via_cte(kb: Khora, namespace_id: UUID) -> None:
-    """3-hop A→B→C with B's outgoing edge expired; ``prefer_current=True`` must
-    NOT return C's content.
+    """A 1-hop edge whose validity window has closed is skipped when
+    ``prefer_current`` is active (#1087).
 
-    This tests Graphiti-style bi-temporal invalidation pushed through the
-    SQLite-CTE traversal. R2 is the fix that makes
-    ``prefer_current`` honor expired/invalidated edges in the CTE. Until
-    that lands, the CTE happily walks expired edges, so this test is
-    expected to fail until the VC embedded path is wired.
+    Mechanism: re-saving the ``Pierre→polonium`` edge with ``valid_until`` in
+    the past UPSERTs the stored row — the fix, since
+    ``create_relationships_batch`` was INSERT-only and the re-save previously
+    collided on the primary key instead of closing the window. The recursive
+    CTE traversal then drops the edge wherever ``prefer_current`` requires
+    ``valid_until > now``.
 
-    The chain: B→C edge has ``valid_to`` in the past → with
-    ``prefer_current=True`` it must be skipped → C ("polonium") is
-    unreachable from A ("Marie") via 2-hop traversal. We assert
-    ``"polonium"`` is NOT in the recall context.
+    The scenario is deliberately **1-hop** — anchor on Pierre and expire the
+    single edge out of Pierre — so the result isolates the expiry from the
+    orthogonal multi-hop traversal gap (``test_vc_two_hop_traversal``).
+
+    The traversal is asserted at the coordinator path ``recall`` drives
+    (``get_neighborhoods_batch`` — the ``prefer_current`` sink) rather than on
+    ``kb.recall``'s chunks DELIBERATELY: the embedded stack uses fake
+    content-hash embeddings, so the vector channel surfaces the polonium chunk
+    independently of the graph edge and would mask the edge filter at the
+    recall layer. One layer down, ``prefer_current`` is the only thing acting,
+    so the signal is deterministic. Three cases prove the filter is the cause:
+
+    * BEFORE expiry, ``prefer_current=True`` → polonium present (the live edge
+      is returned even under ``prefer_current`` — not a vacuous always-empty).
+    * AFTER expiry, ``prefer_current=True`` → polonium gone (the closed window
+      is filtered — the fix).
+    * AFTER expiry, ``prefer_current=False`` → polonium present (the row still
+      exists; its absence above is caused by ``prefer_current`` + expiry).
+
+    We also confirm the front door: a "currently"-phrased query classifies as
+    STATE_QUERY, the temporal category that switches ``prefer_current`` on
+    (it is not a public ``recall`` kwarg).
     """
     _plan_extraction(
-        "Marie",
-        entities=[("Marie", "PERSON"), ("Pierre", "PERSON")],
-        relationships=[("Marie", "Pierre", "KNOWS")],
+        "Pierre worked",
+        entities=[("Pierre", "PERSON")],
     )
     _plan_extraction(
-        "Pierre",
+        "polonium",
         entities=[("Pierre", "PERSON"), ("polonium", "CONCEPT")],
         relationships=[("Pierre", "polonium", "STUDIES")],
     )
 
-    await _remember(kb, namespace_id=namespace_id, content="Marie collaborated with Pierre.")
+    await _remember(kb, namespace_id=namespace_id, content="Pierre worked at the institute.")
     await _remember(kb, namespace_id=namespace_id, content="Pierre researched polonium extensively.")
 
-    # Manually expire the Pierre→polonium edge in the embedded graph.
     coord = kb._engine._storage  # type: ignore[union-attr]
     row_ns_id = await coord.resolve_namespace(namespace_id)
+
     rels = await coord.graph.list_relationships(row_ns_id, limit=100)
-    target_rel = next(
-        (r for r in rels if r.relationship_type == "STUDIES"),
-        None,
-    )
+    target_rel = next((r for r in rels if r.relationship_type == "STUDIES"), None)
     assert target_rel is not None, f"expected STUDIES relationship, got {rels!r}"
-    # Expire the edge by setting valid_to in the past. The exact field
-    # name lives on Relationship; CTE traversal R2 reads it for filtering.
-    target_rel.valid_to = datetime.now(UTC) - timedelta(days=1)
-    await coord.graph.create_relationships_batch(row_ns_id, [target_rel])
+    pierre_id = target_rel.source_entity_id  # Pierre→polonium
 
-    result = await kb.recall(
-        "Marie",
-        namespace=namespace_id,
-        limit=10,
-        graph_depth=2,
-        prefer_current=True,
+    # The "currently"-phrased query classifies as STATE_QUERY, the category
+    # that carries prefer_current=True — the only way recall turns it on.
+    result = await kb.recall("What is Pierre currently studying?", namespace=namespace_id, limit=10)
+    assert result.engine_info.get("temporal_category") == "state_query", (
+        f"temporal query did not trigger the prefer_current category: {result.engine_info.get('temporal_category')!r}"
     )
 
-    text_blob = " ".join(c.content for c in result.chunks).lower()
-    assert "polonium" not in text_blob, "expired edge leaked through prefer_current=True (R2 fix not in main)"
+    # BEFORE expiry, prefer_current=True still returns polonium: the live edge
+    # is walked under prefer_current, so a later empty result is the filter
+    # acting, not prefer_current trivially returning nothing.
+    nb_live = await coord.get_neighborhoods_batch([pierre_id], namespace_id=row_ns_id, depth=1, prefer_current=True)
+    live_names = {e.name for e in nb_live[pierre_id]["entities"]}
+    assert "polonium" in live_names, f"live edge dropped under prefer_current before any expiry: {live_names}"
+
+    # Expire the single Pierre→polonium edge by re-saving it with valid_until
+    # in the past. This exercises the UPSERT (pre-fix the re-save collided on
+    # the primary key instead of closing the window).
+    target_rel.valid_until = datetime.now(UTC) - timedelta(days=1)
+    await coord.graph.create_relationships_batch([target_rel])
+
+    # prefer_current=True now filters the closed-window edge → polonium gone.
+    nb_current = await coord.get_neighborhoods_batch([pierre_id], namespace_id=row_ns_id, depth=1, prefer_current=True)
+    current_names = {e.name for e in nb_current[pierre_id]["entities"]}
+    assert "polonium" not in current_names, f"expired edge leaked through prefer_current=True: {current_names}"
+
+    # And without prefer_current the expired edge is still walked — proving the
+    # absence above is caused by prefer_current + expiry, not the edge vanishing.
+    nb_default = await coord.get_neighborhoods_batch([pierre_id], namespace_id=row_ns_id, depth=1, prefer_current=False)
+    default_names = {e.name for e in nb_default[pierre_id]["entities"]}
+    assert "polonium" in default_names, (
+        f"polonium unreachable even without prefer_current after expiry — control is vacuous: {default_names}"
+    )

--- a/tests/unit/storage/backends/sqlite_lance/test_graph.py
+++ b/tests/unit/storage/backends/sqlite_lance/test_graph.py
@@ -417,6 +417,73 @@ class TestRelationships:
         assert fetched is not None
         assert fetched.relationship_type == "RELATES_TO"
 
+    async def test_resave_updates_valid_until_without_pk_conflict(self, adapter: SQLiteLanceGraphAdapter):
+        """Re-saving an edge with the same ``id`` closes its validity window (#1087).
+
+        ``create_relationships_batch`` is UPSERT: re-saving an existing edge
+        with a new ``valid_until`` updates the stored row instead of raising
+        on the primary-key conflict. Without this, a later ingest that expires
+        an edge could never narrow ``prefer_current`` recall on the embedded
+        path.
+        """
+        ns = uuid4()
+        a = _make_entity(ns, name="A")
+        b = _make_entity(ns, name="B")
+        await adapter.create_entity(a)
+        await adapter.create_entity(b)
+
+        rel = _make_relationship(ns, a.id, b.id, rel_type="STUDIES")
+        await adapter.create_relationships_batch([rel])
+        assert await adapter.count_relationships(ns) == 1
+
+        expired = datetime.now(UTC) - timedelta(days=1)
+        rel.valid_until = expired
+        # Re-save the same id — pre-fix this raised IntegrityError (UNIQUE).
+        count = await adapter.create_relationships_batch([rel])
+        assert count == 1
+        # No duplicate row inserted.
+        assert await adapter.count_relationships(ns) == 1
+
+        fetched = await adapter.get_relationship(rel.id, namespace_id=ns)
+        assert fetched is not None
+        assert fetched.valid_until is not None
+        assert fetched.valid_until.replace(tzinfo=UTC) <= datetime.now(UTC)
+
+    async def test_resave_preserves_provenance_and_created_at(self, adapter: SQLiteLanceGraphAdapter):
+        """UPSERT must not clobber provenance or the original ``created_at``.
+
+        ``source_document_ids`` / ``source_chunk_ids`` / ``created_at`` are
+        deliberately absent from the ON CONFLICT SET list, so a later re-save
+        that carries empty provenance leaves the originally-recorded sources
+        and creation stamp intact.
+        """
+        ns = uuid4()
+        a = _make_entity(ns, name="A")
+        b = _make_entity(ns, name="B")
+        await adapter.create_entity(a)
+        await adapter.create_entity(b)
+
+        doc_id = uuid4()
+        chunk_id = uuid4()
+        created = datetime(2020, 1, 1, tzinfo=UTC)
+        rel = _make_relationship(ns, a.id, b.id, rel_type="STUDIES")
+        rel.source_document_ids = [doc_id]
+        rel.source_chunk_ids = [chunk_id]
+        rel.created_at = created
+        await adapter.create_relationships_batch([rel])
+
+        # Re-save the same id with empty provenance and a newer created_at.
+        resave = _make_relationship(ns, a.id, b.id, rel_type="STUDIES")
+        resave.id = rel.id
+        resave.valid_until = datetime.now(UTC) - timedelta(days=1)
+        await adapter.create_relationships_batch([resave])
+
+        fetched = await adapter.get_relationship(rel.id, namespace_id=ns)
+        assert fetched is not None
+        assert fetched.source_document_ids == [doc_id], "provenance was clobbered by the UPSERT"
+        assert fetched.source_chunk_ids == [chunk_id], "chunk provenance was clobbered by the UPSERT"
+        assert fetched.created_at.replace(tzinfo=UTC) == created, "created_at was overwritten by the UPSERT"
+
 
 # ---------------------------------------------------------------------------
 # Traversal — recursive CTEs


### PR DESCRIPTION
## Summary
- The embedded (SQLite + LanceDB) graph backend's `create_relationship` / `create_relationships_batch` were INSERT-only, so re-saving an edge to close its validity window raised on the primary-key conflict and the expiry was never persisted. The recursive-CTE traversal already filtered `valid_until` under `prefer_current`, but no closed window could ever reach it — so expired-edge content leaked into recall.
- Give both writers UPSERT semantics (`INSERT ... ON CONFLICT(id) DO UPDATE`) over the mutable/temporal columns only (`relationship_type`, `description`, `properties`, `valid_from`, `valid_until`, `confidence`, `weight`, `metadata`, `updated_at`). `id`, `namespace_id`, edge endpoints, `source_document_ids`/`source_chunk_ids` provenance and `created_at` are deliberately left out of the SET list, as are the reserved bi-temporal soft-delete columns. Result: an edge whose validity window has closed is excluded from `prefer_current` traversal.
- Rewrite the embedded acceptance test to assert the edge-filter effect deterministically at the coordinator traversal layer (`get_neighborhoods_batch`) with a 1-hop expiry and a positive control. On the embedded mock the content-hash vector channel surfaces the chunk independently of the graph edge, so a recall-text assertion can't isolate the filter; the test documents this and asserts one layer down where `prefer_current` is the only signal. It also asserts the front-door wiring (`prefer_current` is derived from the temporal query category, not a public kwarg).
- Adds two unit regression tests: re-save updates `valid_until` without a PK conflict / duplicate row, and re-save preserves provenance + `created_at`.

## Test plan
- [x] Unit: `tests/unit/storage/backends/sqlite_lance/test_graph.py` — 49 passed (incl. 2 new UPSERT regression tests)
- [x] Embedded integration: `tests/integration/matrix/test_vectorcypher_sqlite_lance.py` — 13 passed, 1 xfailed (the unrelated 2-hop gap stays xfail); the rewritten `test_vc_prefer_current_via_cte` now passes with its xfail removed
- [x] Mutation-checked non-vacuousness: removing only the expiry line makes the test fail (`expired edge leaked through prefer_current=True`)
- [x] `ruff format` / `ruff check` / `ty check` clean
- [ ] Full Docker-backed integration matrix (Postgres/Neo4j) — gated by CI

Fixes #1087