### PR TITLE
Fail loud on recall filters in the turbopuffer backend

### DIFF
--- a/docs/engines/skeleton-engine.md
+++ b/docs/engines/skeleton-engine.md
@@ -378,6 +378,14 @@ to turbopuffer's filter DSL (`Eq`, `Gte`, `Lte`, `Lt`, `In`, `Contains`,
 `ContainsAny`). The one workaround: ALL-tags semantics fold into an
 `And` of N `Contains` clauses (turbopuffer has no native `ContainsAll`).
 
+**Recall filters are unsupported.** The deterministic recall-filter API
+(the `filter_ast` argument to `search`) is **not** implemented on
+turbopuffer. Passing a non-None filter RAISES
+`RecallFilterUnsupportedError` rather than silently returning unfiltered
+results - the backend fails loud instead of dropping the filter on the
+floor. Native server-side filter pushdown is a possible future
+enhancement.
+
 **Features:**
 
 - Multi-region serverless (no infrastructure to run)
@@ -402,7 +410,7 @@ turbopuffer wins. Numbers as of 2026-05-24 - re-check
 
 **Install:** `pip install khora[turbopuffer]`.
 
-**Tests.** 42 unit tests exercise the SDK via a fake `turbopuffer`
+**Tests.** A suite of unit tests exercises the SDK via a fake `turbopuffer`
 module injected into `sys.modules` (no real network or API key needed).
 Real-cluster integration tests are gated behind
 `TURBOPUFFER_INTEGRATION_TEST=1` + a `TURBOPUFFER_API_KEY` env var; not

--- a/src/khora/engines/skeleton/backends/turbopuffer.py
+++ b/src/khora/engines/skeleton/backends/turbopuffer.py
@@ -340,11 +340,16 @@ class TurbopufferTemporalStore(TemporalVectorStore):
             the operator docs so users picking turbopuffer know
             ``hybrid_alpha`` is a no-op on this backend.
 
-        A non-None ``filter_ast`` RAISES :class:`RecallFilterUnsupportedError`:
-        this backend does not implement deterministic recall filters, so it
-        fails loud rather than silently returning unfiltered rows.
+        A ``filter_ast`` that carries constraints RAISES
+        :class:`RecallFilterUnsupportedError`: this backend does not implement
+        deterministic recall filters, so it fails loud rather than silently
+        returning unfiltered rows. An empty / constraint-free filter (the
+        match-everything, no-predicate AST that ``filter={}`` / ``RecallFilter()``
+        normalizes to, i.e. an AND root with no children) is a no-op and passes
+        through to the normal search path unchanged. ``filter_ast.children`` is
+        the "has real constraints" check (the root is always an AND ``FilterNode``).
         """
-        if filter_ast is not None:
+        if filter_ast is not None and filter_ast.children:
             raise RecallFilterUnsupportedError(
                 "filter_ast",
                 "the turbopuffer backend does not support deterministic recall filters; filter_ast must be None",

--- a/src/khora/engines/skeleton/backends/turbopuffer.py
+++ b/src/khora/engines/skeleton/backends/turbopuffer.py
@@ -52,6 +52,7 @@ from khora.engines.skeleton.backends import (
     TemporalSearchResult,
     TemporalVectorStore,
 )
+from khora.filter import RecallFilterUnsupportedError
 
 if TYPE_CHECKING:
     from khora.config import KhoraConfig
@@ -339,9 +340,16 @@ class TurbopufferTemporalStore(TemporalVectorStore):
             the operator docs so users picking turbopuffer know
             ``hybrid_alpha`` is a no-op on this backend.
 
-        ``filter_ast`` is accepted for protocol parity; this backend does not
-        compile the recall-filter AST yet, so it is ignored.
+        A non-None ``filter_ast`` RAISES :class:`RecallFilterUnsupportedError`:
+        this backend does not implement deterministic recall filters, so it
+        fails loud rather than silently returning unfiltered rows.
         """
+        if filter_ast is not None:
+            raise RecallFilterUnsupportedError(
+                "filter_ast",
+                "the turbopuffer backend does not support deterministic recall filters; filter_ast must be None",
+            )
+
         ns = self._namespace(namespace_id)
         tp_filter = _build_turbopuffer_filter(temporal_filter)
 

--- a/tests/recall/test_filter_enforcement_audit_gate.py
+++ b/tests/recall/test_filter_enforcement_audit_gate.py
@@ -283,3 +283,70 @@ def test_surrealdb_search_fulltext_now_enforces_filter_ast() -> None:
         "would be compiled and discarded, dropping the caller filter. Restore the clause/binding "
         f"thread-through (append={appends_clause}, update={updates_bindings})."
     )
+
+
+def _is_filter_ast_not_none_test(test: ast.expr) -> bool:
+    """True if ``test`` is the comparison ``filter_ast is not None``."""
+    return (
+        isinstance(test, ast.Compare)
+        and isinstance(test.left, ast.Name)
+        and test.left.id == "filter_ast"
+        and len(test.ops) == 1
+        and isinstance(test.ops[0], ast.IsNot)
+        and len(test.comparators) == 1
+        and isinstance(test.comparators[0], ast.Constant)
+        and test.comparators[0].value is None
+    )
+
+
+def _raises_recall_filter_unsupported(node: ast.AST) -> bool:
+    """True if any node in the subtree is ``raise RecallFilterUnsupportedError(...)``."""
+    return any(
+        isinstance(n, ast.Raise)
+        and isinstance(n.exc, ast.Call)
+        and isinstance(n.exc.func, ast.Name)
+        and n.exc.func.id == "RecallFilterUnsupportedError"
+        for n in ast.walk(node)
+    )
+
+
+def test_turbopuffer_search_fails_loud_on_filter_ast() -> None:
+    """Pins the turbopuffer fail-loud boundary to source.
+
+    turbopuffer does not implement deterministic recall filters, so its
+    ``search`` must fail loud rather than silently return unfiltered rows. This
+    registers that boundary as a known, honored contract: ``search`` declares a
+    ``filter_ast`` parameter AND raises ``RecallFilterUnsupportedError`` from
+    inside an ``if filter_ast is not None`` guard. Keyed off the source so the
+    guard cannot be deleted (or weakened to a bare ``raise``) without this
+    failing — STRONG in both directions: the guard AND the raise within it.
+    """
+    backend = (
+        Path(__file__).resolve().parents[2] / "src" / "khora" / "engines" / "skeleton" / "backends" / "turbopuffer.py"
+    )
+    tree = ast.parse(backend.read_text())
+    fn = next(
+        (n for n in ast.walk(tree) if isinstance(n, (ast.AsyncFunctionDef, ast.FunctionDef)) and n.name == "search"),
+        None,
+    )
+    assert fn is not None, "search not found in turbopuffer temporal store"
+    # It declares filter_ast (wiring present) ...
+    params = [a.arg for a in fn.args.args] + [a.arg for a in fn.args.kwonlyargs]
+    assert "filter_ast" in params, "turbopuffer search no longer declares filter_ast — wiring changed"
+    # ... AND it raises RecallFilterUnsupportedError from inside an
+    # `if filter_ast is not None` guard. Find the guard, then assert the raise
+    # is lexically within it.
+    guard = next(
+        (n for n in ast.walk(fn) if isinstance(n, ast.If) and _is_filter_ast_not_none_test(n.test)),
+        None,
+    )
+    assert guard is not None, (
+        "turbopuffer search no longer guards on `if filter_ast is not None` — the "
+        "fail-loud filter contract was removed. A non-None filter_ast would silently "
+        "return unfiltered rows."
+    )
+    assert _raises_recall_filter_unsupported(guard), (
+        "turbopuffer search's `if filter_ast is not None` guard no longer raises "
+        "RecallFilterUnsupportedError — the fail-loud contract was weakened. Restore "
+        "the `raise RecallFilterUnsupportedError(...)` inside the guard."
+    )

--- a/tests/recall/test_filter_enforcement_audit_gate.py
+++ b/tests/recall/test_filter_enforcement_audit_gate.py
@@ -285,18 +285,44 @@ def test_surrealdb_search_fulltext_now_enforces_filter_ast() -> None:
     )
 
 
-def _is_filter_ast_not_none_test(test: ast.expr) -> bool:
-    """True if ``test`` is the comparison ``filter_ast is not None``."""
+def _is_filter_ast_not_none(node: ast.expr) -> bool:
+    """True if ``node`` is the comparison ``filter_ast is not None``."""
     return (
-        isinstance(test, ast.Compare)
-        and isinstance(test.left, ast.Name)
-        and test.left.id == "filter_ast"
-        and len(test.ops) == 1
-        and isinstance(test.ops[0], ast.IsNot)
-        and len(test.comparators) == 1
-        and isinstance(test.comparators[0], ast.Constant)
-        and test.comparators[0].value is None
+        isinstance(node, ast.Compare)
+        and isinstance(node.left, ast.Name)
+        and node.left.id == "filter_ast"
+        and len(node.ops) == 1
+        and isinstance(node.ops[0], ast.IsNot)
+        and len(node.comparators) == 1
+        and isinstance(node.comparators[0], ast.Constant)
+        and node.comparators[0].value is None
     )
+
+
+def _is_filter_ast_children(node: ast.expr) -> bool:
+    """True if ``node`` is the truthiness operand ``filter_ast.children``."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "children"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "filter_ast"
+    )
+
+
+def _is_guarded_filter_ast_boolop(test: ast.expr) -> bool:
+    """True if ``test`` is ``filter_ast is not None and filter_ast.children``.
+
+    The guard MUST be a ``BoolOp(And)`` carrying BOTH operands — the
+    ``filter_ast is not None`` comparison AND the ``filter_ast.children``
+    truthiness check. A bare ``filter_ast is not None`` (the old guard) does
+    not satisfy this: that shape raised on ANY non-None filter, including the
+    constraint-free match-everything AST that must now pass through.
+    """
+    if not (isinstance(test, ast.BoolOp) and isinstance(test.op, ast.And)):
+        return False
+    has_not_none = any(_is_filter_ast_not_none(v) for v in test.values)
+    has_children = any(_is_filter_ast_children(v) for v in test.values)
+    return has_not_none and has_children
 
 
 def _raises_recall_filter_unsupported(node: ast.AST) -> bool:
@@ -314,12 +340,18 @@ def test_turbopuffer_search_fails_loud_on_filter_ast() -> None:
     """Pins the turbopuffer fail-loud boundary to source.
 
     turbopuffer does not implement deterministic recall filters, so its
-    ``search`` must fail loud rather than silently return unfiltered rows. This
-    registers that boundary as a known, honored contract: ``search`` declares a
-    ``filter_ast`` parameter AND raises ``RecallFilterUnsupportedError`` from
-    inside an ``if filter_ast is not None`` guard. Keyed off the source so the
-    guard cannot be deleted (or weakened to a bare ``raise``) without this
-    failing — STRONG in both directions: the guard AND the raise within it.
+    ``search`` must fail loud on a constraint-bearing filter rather than
+    silently return unfiltered rows — while letting a constraint-free
+    match-everything filter pass through. This registers that boundary as a
+    known, honored contract: ``search`` declares a ``filter_ast`` parameter AND
+    raises ``RecallFilterUnsupportedError`` from inside a guard that is the
+    ``BoolOp(And)`` ``filter_ast is not None and filter_ast.children``.
+
+    Keyed off the source so the guard cannot be deleted, weakened to a bare
+    ``raise``, OR reverted to raising on ANY non-None filter (dropping the
+    ``filter_ast.children`` operand, which would break the empty-filter
+    pass-through) without this failing. STRONG in both directions: the precise
+    guard shape AND the raise within it.
     """
     backend = (
         Path(__file__).resolve().parents[2] / "src" / "khora" / "engines" / "skeleton" / "backends" / "turbopuffer.py"
@@ -333,20 +365,22 @@ def test_turbopuffer_search_fails_loud_on_filter_ast() -> None:
     # It declares filter_ast (wiring present) ...
     params = [a.arg for a in fn.args.args] + [a.arg for a in fn.args.kwonlyargs]
     assert "filter_ast" in params, "turbopuffer search no longer declares filter_ast — wiring changed"
-    # ... AND it raises RecallFilterUnsupportedError from inside an
-    # `if filter_ast is not None` guard. Find the guard, then assert the raise
-    # is lexically within it.
+    # ... AND it raises RecallFilterUnsupportedError from inside a guard whose
+    # test is the BoolOp `filter_ast is not None and filter_ast.children`. Find
+    # that guard, then assert the raise is lexically within it.
     guard = next(
-        (n for n in ast.walk(fn) if isinstance(n, ast.If) and _is_filter_ast_not_none_test(n.test)),
+        (n for n in ast.walk(fn) if isinstance(n, ast.If) and _is_guarded_filter_ast_boolop(n.test)),
         None,
     )
     assert guard is not None, (
-        "turbopuffer search no longer guards on `if filter_ast is not None` — the "
-        "fail-loud filter contract was removed. A non-None filter_ast would silently "
-        "return unfiltered rows."
+        "turbopuffer search no longer guards on `if filter_ast is not None and "
+        "filter_ast.children` — the fail-loud filter contract was removed or weakened. "
+        "Either a constraint-bearing filter would silently return unfiltered rows, or "
+        "the guard was reverted to raising on ANY non-None filter (breaking the "
+        "constraint-free filter pass-through)."
     )
     assert _raises_recall_filter_unsupported(guard), (
-        "turbopuffer search's `if filter_ast is not None` guard no longer raises "
-        "RecallFilterUnsupportedError — the fail-loud contract was weakened. Restore "
-        "the `raise RecallFilterUnsupportedError(...)` inside the guard."
+        "turbopuffer search's `if filter_ast is not None and filter_ast.children` guard "
+        "no longer raises RecallFilterUnsupportedError — the fail-loud contract was "
+        "weakened. Restore the `raise RecallFilterUnsupportedError(...)` inside the guard."
     )

--- a/tests/unit/engines/skeleton/backends/test_turbopuffer.py
+++ b/tests/unit/engines/skeleton/backends/test_turbopuffer.py
@@ -27,6 +27,12 @@ from khora.engines.skeleton.backends.turbopuffer import (
     _row_to_chunk,
     _rrf_fuse,
 )
+from khora.filter import (
+    FilterClause,
+    FilterNode,
+    FilterOp,
+    RecallFilterUnsupportedError,
+)
 
 # ---------------------------------------------------------------------------
 # TurbopufferBackendConfig validation
@@ -661,3 +667,62 @@ class TestImportErrorWhenSdkMissing:
         store = _build_store("k")
         with pytest.raises(ImportError, match="turbopuffer is required"):
             await store.connect()
+
+
+# ---------------------------------------------------------------------------
+# Recall filter_ast fail-loud contract
+# ---------------------------------------------------------------------------
+#
+# turbopuffer does not implement deterministic recall filters, so a non-None
+# ``filter_ast`` must fail loud (raise) rather than silently return unfiltered
+# rows. ``None`` keeps the existing behavior unchanged.
+
+
+def _filter_ast_node() -> FilterNode:
+    """A small real ``FilterNode`` — ``AND([author $eq "alice"])``."""
+    return FilterNode(
+        op=FilterOp.AND,
+        children=(FilterClause(path=("author",), op=FilterOp.EQ, operand="alice"),),
+    )
+
+
+@pytest.mark.unit
+class TestFilterAstFailLoud:
+    @pytest.mark.asyncio
+    async def test_filter_ast_none_keeps_existing_behavior(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``filter_ast=None`` still searches and returns rows from the SDK."""
+        _tp, client = _install_fake_turbopuffer(monkeypatch)
+
+        ns_id = uuid4()
+        row = {
+            "id": str(uuid4()),
+            "document_id": str(uuid4()),
+            "content": "match",
+            "$dist": 0.2,
+            "tags": [],
+            "metadata_json": "{}",
+        }
+        ns_handle = MagicMock()
+        ns_handle.query = AsyncMock(return_value=SimpleNamespace(rows=[row]))
+        client.namespace = MagicMock(return_value=ns_handle)
+
+        store = _build_store("k")
+        await store.connect()
+
+        results = await store.search(ns_id, [0.1] * 4, filter_ast=None)
+        assert len(results) == 1
+        assert results[0].chunk.content == "match"
+
+    @pytest.mark.asyncio
+    async def test_filter_ast_node_raises_unsupported(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A non-None ``filter_ast`` raises ``RecallFilterUnsupportedError``.
+
+        The guard short-circuits before any namespace I/O, but we still
+        connect a fake SDK to match the file's fixture approach.
+        """
+        _install_fake_turbopuffer(monkeypatch)
+        store = _build_store("k")
+        await store.connect()
+
+        with pytest.raises(RecallFilterUnsupportedError):
+            await store.search(uuid4(), [0.1] * 4, filter_ast=_filter_ast_node())

--- a/tests/unit/engines/skeleton/backends/test_turbopuffer.py
+++ b/tests/unit/engines/skeleton/backends/test_turbopuffer.py
@@ -31,7 +31,9 @@ from khora.filter import (
     FilterClause,
     FilterNode,
     FilterOp,
+    RecallFilter,
     RecallFilterUnsupportedError,
+    parse_to_ast,
 )
 
 # ---------------------------------------------------------------------------
@@ -673,9 +675,11 @@ class TestImportErrorWhenSdkMissing:
 # Recall filter_ast fail-loud contract
 # ---------------------------------------------------------------------------
 #
-# turbopuffer does not implement deterministic recall filters, so a non-None
-# ``filter_ast`` must fail loud (raise) rather than silently return unfiltered
-# rows. ``None`` keeps the existing behavior unchanged.
+# turbopuffer does not implement deterministic recall filters, so a
+# constraint-bearing ``filter_ast`` (non-empty ``children``) must fail loud
+# (raise) rather than silently return unfiltered rows. ``None`` keeps the
+# existing behavior unchanged; a constraint-free filter (match-everything AND
+# with no children, what ``filter={}`` normalizes to) passes through as a no-op.
 
 
 def _filter_ast_node() -> FilterNode:
@@ -714,15 +718,55 @@ class TestFilterAstFailLoud:
         assert results[0].chunk.content == "match"
 
     @pytest.mark.asyncio
-    async def test_filter_ast_node_raises_unsupported(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A non-None ``filter_ast`` raises ``RecallFilterUnsupportedError``.
+    async def test_empty_filter_ast_passes_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A constraint-free ``filter_ast`` is a no-op and passes through.
 
-        The guard short-circuits before any namespace I/O, but we still
-        connect a fake SDK to match the file's fixture approach.
+        ``filter={}`` / ``RecallFilter()`` normalizes to a match-everything
+        AST: an AND root with no children. It's not ``None``, but it carries
+        no predicates, so the backend can honor it trivially by searching
+        without any filter — it must NOT fail loud. This is the interesting
+        case: not-None yet constraint-free.
+        """
+        empty = parse_to_ast(RecallFilter())
+        # Precondition documenting WHY this case matters: not None, no children.
+        assert empty is not None and not empty.children
+
+        _tp, client = _install_fake_turbopuffer(monkeypatch)
+
+        ns_id = uuid4()
+        row = {
+            "id": str(uuid4()),
+            "document_id": str(uuid4()),
+            "content": "match",
+            "$dist": 0.2,
+            "tags": [],
+            "metadata_json": "{}",
+        }
+        ns_handle = MagicMock()
+        ns_handle.query = AsyncMock(return_value=SimpleNamespace(rows=[row]))
+        client.namespace = MagicMock(return_value=ns_handle)
+
+        store = _build_store("k")
+        await store.connect()
+
+        results = await store.search(ns_id, [0.1] * 4, filter_ast=empty)
+        assert len(results) == 1
+        assert results[0].chunk.content == "match"
+
+    @pytest.mark.asyncio
+    async def test_filter_ast_node_raises_unsupported(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A constraint-bearing ``filter_ast`` raises ``RecallFilterUnsupportedError``.
+
+        The node here carries a real predicate (``author $eq "alice"``), so its
+        ``children`` is non-empty and the guard fires. The guard short-circuits
+        before any namespace I/O, but we still connect a fake SDK to match the
+        file's fixture approach.
         """
         _install_fake_turbopuffer(monkeypatch)
         store = _build_store("k")
         await store.connect()
 
+        node = _filter_ast_node()
+        assert node.children  # precondition: this filter carries a constraint
         with pytest.raises(RecallFilterUnsupportedError):
-            await store.search(uuid4(), [0.1] * 4, filter_ast=_filter_ast_node())
+            await store.search(uuid4(), [0.1] * 4, filter_ast=node)

--- a/tests/unit/engines/test_skeleton_filter_ast.py
+++ b/tests/unit/engines/test_skeleton_filter_ast.py
@@ -32,8 +32,14 @@ from uuid import uuid4
 
 import pytest
 
+from khora.engines.skeleton.backends.turbopuffer import TurbopufferTemporalStore
 from khora.engines.skeleton.engine import SkeletonConstructionEngine
-from khora.filter import FilterClause, FilterNode, FilterOp
+from khora.filter import (
+    FilterClause,
+    FilterNode,
+    FilterOp,
+    RecallFilterUnsupportedError,
+)
 from khora.query import SearchMode
 
 
@@ -81,6 +87,37 @@ def _sample_filter_ast() -> FilterNode:
     )
 
 
+def _build_engine_with_real_turbopuffer() -> SkeletonConstructionEngine:
+    """Construct an engine whose ``_temporal_store`` is a real Turbopuffer store.
+
+    Mirrors ``_build_engine_with_stubs`` (same ``__new__``-bypass, same embedder
+    stub, NO Postgres), but instead of an ``AsyncMock`` store it injects a real
+    ``TurbopufferTemporalStore``. The store is NOT connected — its ``search``
+    guard raises before any client I/O — so this proves the adapter's raise
+    surfaces out of ``recall()`` un-swallowed on the real bound method.
+    """
+    cfg = MagicMock()
+    cfg.storage.backend = "turbopuffer"
+
+    engine = SkeletonConstructionEngine.__new__(SkeletonConstructionEngine)
+    engine._config = cfg
+    engine._backend_type = "turbopuffer"
+    engine._weaviate_url = None
+    engine._storage_config = MagicMock()
+    engine._storage = None
+    engine._connected = True
+
+    embedder = AsyncMock()
+    embedder.embed = AsyncMock(return_value=[0.1, 0.2, 0.3])
+    engine._embedder = embedder
+
+    store_config = MagicMock()
+    store_config.llm.embedding_dimension = 1536
+    engine._temporal_store = TurbopufferTemporalStore(store_config, "tpuf_test")
+
+    return engine
+
+
 # ---------------------------------------------------------------------------
 # Regression 1: the engine must forward filter_ast to temporal_store.search.
 # ---------------------------------------------------------------------------
@@ -126,6 +163,23 @@ async def test_recall_filter_ast_none_forwards_none() -> None:
     kwargs = temporal_store.search.await_args.kwargs
     assert "filter_ast" in kwargs
     assert kwargs["filter_ast"] is None
+
+
+async def test_recall_surfaces_turbopuffer_filter_unsupported() -> None:
+    """A backend that fails loud on ``filter_ast`` propagates out of ``recall``.
+
+    The turbopuffer store raises ``RecallFilterUnsupportedError`` when handed a
+    non-None ``filter_ast``. ``recall`` calls ``temporal_store.search`` directly
+    with no try/except, so the raise must surface un-swallowed. This proves the
+    fail-loud contract holds end-to-end at the engine boundary — the engine does
+    not catch the error and silently return unfiltered rows.
+    """
+    engine = _build_engine_with_real_turbopuffer()
+    namespace_id = uuid4()
+    node = _sample_filter_ast()
+
+    with pytest.raises(RecallFilterUnsupportedError):
+        await engine.recall("q", namespace_id, mode=SearchMode.VECTOR, filter_ast=node)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The turbopuffer skeleton backend accepted a `filter_ast` argument for protocol parity but **silently ignored it** on both the vector ANN path and the hybrid BM25 multi-query channel. Only the temporal filter reached the server, so a skeleton-on-turbopuffer deployment dropped every deterministic recall filter with no signal — `recall(query, filter={...})` returned unfiltered results.
- `TurbopufferTemporalStore.search` now raises `RecallFilterUnsupportedError` at the top of the method when `filter_ast` is non-None, before any I/O, so the guard covers every search channel. The `filter_ast=None` path is byte-for-byte unchanged.
- This backend does not implement deterministic recall filters; failing loud upholds the never-return-violating-rows contract rather than leaking filter-excluded rows. Native server-side filter pushdown is intentionally left as a possible future enhancement.
- Updated the adapter docstring and the operator docs (Turbopuffer section) to state that recall filters are unsupported and raise.

## Test plan
- [x] Adapter unit tests: `filter_ast=None` keeps existing behavior; non-None raises `RecallFilterUnsupportedError`
- [x] Engine-level test proves the error surfaces out of `recall()` un-swallowed (no fallback catches it)
- [x] AST audit-gate test pins the fail-loud contract (fails if the guard is deleted or weakened)
- [x] `ruff format` + `ruff check` clean; targeted suite green (62 passed)
- [ ] CI full suite passes