### PR TITLE
Enforce recall filter in SurrealDB BM25 full-text search

### DIFF
--- a/src/khora/engines/skeleton/backends/surrealdb.py
+++ b/src/khora/engines/skeleton/backends/surrealdb.py
@@ -503,8 +503,9 @@ class SurrealDBTemporalStore(TemporalVectorStore):
         ``Chunk`` adaptation. Falls back to ``[]`` on backends without
         a BM25 index configured (``optimize_storage()`` not yet run).
 
-        ``filter_ast`` is accepted for protocol parity; this backend does not
-        compile the recall-filter AST yet, so it is ignored.
+        ``filter_ast`` is the deterministic recall-filter AST. When provided it
+        is compiled to a SurrealQL ``WHERE`` predicate and AND-ed into the BM25
+        query alongside the namespace + temporal-bound clauses.
         """
         if not query_text or not query_text.strip():
             return []
@@ -515,6 +516,27 @@ class SurrealDBTemporalStore(TemporalVectorStore):
                 created_before=created_before,
             )
         filter_clauses, filter_bindings = self._build_filter_clauses(namespace_id, temporal_filter)
+
+        # Deterministic recall-filter AST: compile to a SurrealQL predicate and
+        # AND it into the shared clauses (mirrors the vector path in
+        # ``_search_inner``). ``field_mapping`` maps the ``metadata`` root to the
+        # physical ``metadata_`` column; ``on_unsupported="raise"`` because the
+        # skeleton engine has no post-filter path.
+        if filter_ast is not None:
+            from khora.filter import CompileContext
+            from khora.filter.compilers.surrealdb import compile_surrealdb
+
+            compiled = compile_surrealdb(
+                filter_ast,
+                CompileContext(
+                    backend_target="temporal_chunk",
+                    field_mapping={"metadata": "metadata_"},
+                    on_unsupported="raise",
+                ),
+            )
+            filter_clauses.append(compiled.predicate)
+            filter_bindings.update(compiled.params)
+
         results = await self._bm25_search(filter_clauses, filter_bindings, query_text, limit)
         return [(temporal_chunk_to_chunk(r.chunk), float(r.bm25_score or 0.0)) for r in results]
 

--- a/tests/integration/matrix/test_filter_enforcement_surrealdb.py
+++ b/tests/integration/matrix/test_filter_enforcement_surrealdb.py
@@ -1,0 +1,202 @@
+"""BM25 filter-enforcement proof on the embedded Skeleton + SurrealDB stack.
+
+The SurrealDB sibling of the embedded sqlite_lance BM25 enforcement test
+(``test_filter_enforcement_sqlite_lance.py::test_bm25_channel_enforces_filter_embedded``).
+It drives a real ``Khora(engine="skeleton")`` against an in-process ``memory://``
+SurrealDB store to seed a BM25-searchable corpus, then exercises the public BM25
+entry point (``SurrealDBTemporalStore.search_fulltext``) directly, proving a
+contradiction recall filter excludes every chunk through the keyword channel.
+
+Why drive ``search_fulltext`` directly rather than ``recall(mode=KEYWORD)`` (as
+the sqlite_lance sibling does)? On this backend the two BM25 surfaces differ:
+``recall(mode=KEYWORD)`` routes through ``search`` -> ``_search_inner`` (which has
+long compiled ``filter_ast`` into its pure-BM25 ``WHERE``), while
+``search_fulltext`` is the separate public BM25 lookup the BM25 recall channel
+calls. ``search_fulltext`` is the surface that now compiles ``filter_ast`` and
+ANDs the predicate into its BM25 ``WHERE`` (mirroring the vector path); a test
+that only went through ``_search_inner`` would not exercise that enforcement.
+
+A POSITIVE CONTROL (an unfiltered ``search_fulltext`` over the SAME corpus
+returns NON-EMPTY results) proves the corpus is genuinely BM25-searchable, so the
+zero in the enforcement assertion means "the filter excluded them", not "BM25
+found nothing anyway".
+
+The BM25 full-text index is defined after seeding (the keyword channel falls back
+to ``[]`` without it). The store's ``ensure_search_indexes()`` bundles a
+dimension-pinned HNSW build the small test embedding dimension cannot satisfy, so
+only the BM25 index is defined here — the keyword path never uses HNSW.
+
+Embedded ``memory://`` runs in-process — no server, no Docker. The module
+self-skips when the optional ``surrealdb`` SDK is absent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from functools import partial
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+pytest.importorskip("surrealdb")
+
+from khora.config import KhoraConfig  # noqa: E402
+from khora.config.schema import SurrealDBConfig  # noqa: E402
+from khora.engines.skeleton.backends.surrealdb import SurrealDBTemporalStore  # noqa: E402
+from khora.extraction.skills import ExpertiseConfig  # noqa: E402
+from khora.filter import RecallFilter, parse_to_ast  # noqa: E402
+from khora.khora import Khora  # noqa: E402
+from tests.test_helpers.filter_spy import EMBED_DIM, seed_corpus, stub_llm  # noqa: E402
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.filter_enforcement,
+]
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(autouse=True)
+def _patch_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deterministic embedder + entity extractor (no API key / network)."""
+    stub_llm(monkeypatch, dim=EMBED_DIM)
+
+
+@pytest.fixture
+async def kb() -> AsyncIterator[Khora]:
+    """Per-test Skeleton Khora on a fresh in-process SurrealDB store.
+
+    ``mode="memory"`` runs SurrealDB in-process (no container, no on-disk file);
+    each test gets its own database. Schema initialises declaratively on
+    ``connect()`` (no Alembic), so ``run_migrations`` is a no-op here.
+    """
+    config = KhoraConfig()
+    config.storage.backend = "surrealdb"
+    config.storage.surrealdb = SurrealDBConfig(mode="memory", embedding_dimension=EMBED_DIM)
+    config.llm.embedding_dimension = EMBED_DIM
+    config.storage.embedding_dimension = EMBED_DIM
+    config.pipelines.extract_entities = False
+
+    kb = Khora(config, engine="skeleton")
+    await kb.connect()
+    try:
+        yield kb
+    finally:
+        try:
+            await kb.disconnect()
+        except Exception:
+            pass
+
+
+@pytest.fixture
+async def namespace_id(kb: Khora) -> UUID:
+    ns = await kb.create_namespace()
+    return ns.namespace_id
+
+
+def _store(kb: Khora) -> SurrealDBTemporalStore:
+    """The live SurrealDB temporal store backing the skeleton engine."""
+    store = kb._engine._get_temporal_store()  # type: ignore[union-attr]
+    assert isinstance(store, SurrealDBTemporalStore)
+    return store
+
+
+def _remember(kb: Khora) -> Any:
+    """Bind the per-test remember wiring for ``seed_corpus``."""
+    return partial(
+        kb.remember,
+        title="",
+        entity_types=[],
+        relationship_types=[],
+        expertise=ExpertiseConfig(name="skeleton-surrealdb-filter-enforcement"),
+    )
+
+
+# Every row shares the token "Falcon" (so a "Falcon" BM25 query returns the full
+# set) and carries metadata.visibility == "public" (the discrimination key).
+_CORPUS = [
+    {"content": "Falcon launch coordinated by SpaceX in early 2026.", "metadata": {"visibility": "public"}},
+    {"content": "Falcon recovery operations reported by SpaceX teams.", "metadata": {"visibility": "public"}},
+    {"content": "Falcon mission telemetry archived after the SpaceX review.", "metadata": {"visibility": "public"}},
+]
+_SEED_ROW_COUNT = len(_CORPUS)
+
+
+async def _seed(kb: Khora, namespace_id: UUID) -> None:
+    """Seed a BM25-searchable corpus and define the BM25 full-text index.
+
+    The skeleton SurrealDB keyword channel returns ``[]`` without a BM25 index,
+    so the BM25 full-text index is defined after seeding. Only the BM25 index is
+    defined here (the keyword path brute-forces vectors and never uses HNSW); the
+    analyzer + index DDL mirrors ``_TEMPORAL_CHUNK_SEARCH_INDEXES``.
+    """
+    await seed_corpus(_remember(kb), namespace_id, _CORPUS)
+    await _store(kb)._conn.execute(
+        "DEFINE INDEX IF NOT EXISTS idx_tc_content_ft ON temporal_chunk "
+        "FIELDS content SEARCH ANALYZER khora_fulltext BM25;"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# BM25 enforcement — a contradiction filter yields an empty keyword lookup, a
+# matching filter retains every row (value discrimination).
+# --------------------------------------------------------------------------- #
+
+
+async def test_bm25_channel_enforces_filter_embedded_surrealdb(kb: Khora, namespace_id: UUID) -> None:
+    """The BM25 channel narrows by metadata VALUE, not all-or-nothing.
+
+    The skeleton SurrealDB ``search_fulltext`` now compiles ``filter_ast`` and
+    ANDs it into the BM25 ``WHERE``. Mirrors the sqlite_lance sibling's
+    enforcement contract; see the module docstring for why this drives
+    ``search_fulltext`` directly rather than ``recall(mode=KEYWORD)`` on this
+    backend.
+
+    The filters are DOTTED metadata predicates on ``metadata.visibility`` — every
+    seeded row carries ``visibility == "public"``, so the predicate descends the
+    real FLEXIBLE ``metadata_`` column. A dotted metadata key is chosen
+    deliberately over a bare system key (e.g. ``source_name``): a bare key that is
+    not a column on the ``temporal_chunk`` schema would exclude every row by
+    NONE-comparison regardless of value, which cannot distinguish "the filter
+    discriminates by value" from "the compiled clause nukes everything".
+
+    Three checks pin value-equivalent semantics:
+
+    * UNFILTERED control — proves the corpus is genuinely BM25-searchable, so the
+      contradiction zero below is not vacuous.
+    * MATCHING filter (``visibility == "public"``) — RETAINS every row; proves a
+      filter is not blanket-excluding.
+    * CONTRADICTION filter (``visibility == "confidential"``) — excludes every
+      row; the enforcement assertion. Together with the matching case this proves
+      the channel narrows by value, not "any filter empties the result".
+
+    The query is the bare token ``"Falcon"`` (present in all three seeded chunks)
+    so the BM25 result set is the full corpus and the row counts above reconcile
+    exactly.
+    """
+    await _seed(kb, namespace_id)
+    store = _store(kb)
+
+    # Unfiltered control: BM25 finds the whole corpus.
+    baseline = await store.search_fulltext(namespace_id, "Falcon", limit=10)
+    assert len(baseline) == _SEED_ROW_COUNT, (
+        f"unfiltered control: expected the full BM25 corpus ({_SEED_ROW_COUNT} rows), got {len(baseline)} — "
+        "the corpus is not fully BM25-searchable, so the discrimination/enforcement assertions below would be vacuous"
+    )
+
+    # Discrimination positive: a MATCHING metadata value RETAINS every row.
+    match_ast = parse_to_ast(RecallFilter.model_validate({"metadata.visibility": "public"}))
+    matched = await store.search_fulltext(namespace_id, "Falcon", limit=10, filter_ast=match_ast)
+    assert len(matched) == _SEED_ROW_COUNT, (
+        f"matching filter (visibility=public) must RETAIN every seeded row ({_SEED_ROW_COUNT}), got {len(matched)} — "
+        "if a matching filter drops rows the contradiction zero would be a blanket-exclude, not value discrimination"
+    )
+
+    # Enforcement: a metadata value NO seeded row carries excludes every row.
+    contradiction_ast = parse_to_ast(RecallFilter.model_validate({"metadata.visibility": "confidential"}))
+    filtered = await store.search_fulltext(namespace_id, "Falcon", limit=10, filter_ast=contradiction_ast)
+    assert filtered == [], f"filter-excluded chunks leaked through embedded SurrealDB BM25: {len(filtered)}"

--- a/tests/recall/test_filter_enforcement_audit_gate.py
+++ b/tests/recall/test_filter_enforcement_audit_gate.py
@@ -212,3 +212,74 @@ def test_embedded_search_fulltext_now_enforces_filter_ast() -> None:
         "BM25 channel would drop the caller filter. Restore the `filter_ast=filter_ast` "
         "forward so the embedded BM25 channel enforces the recall filter."
     )
+
+
+def test_surrealdb_search_fulltext_now_enforces_filter_ast() -> None:
+    """Pins embedded SurrealDB BM25 filter enforcement to source.
+
+    ``SurrealDBTemporalStore.search_fulltext`` declares ``filter_ast`` AND
+    threads it into the BM25 ``WHERE`` it builds. Unlike the sqlite_lance sibling
+    (which forwards ``filter_ast=`` into ``_bm25_search``), this backend's
+    ``_bm25_search`` takes pre-built clauses, so enforcement happens upstream:
+    ``search_fulltext`` compiles the AST via ``compile_surrealdb`` and mutates the
+    ``filter_clauses`` / ``filter_bindings`` it then passes to ``_bm25_search``.
+    If someone regresses any link in that thread, this fails — the SurrealDB BM25
+    channel would silently drop the caller filter again. Keyed off the source so
+    the doc note can't silently drift from reality.
+    """
+    backend = (
+        Path(__file__).resolve().parents[2] / "src" / "khora" / "engines" / "skeleton" / "backends" / "surrealdb.py"
+    )
+    tree = ast.parse(backend.read_text())
+    fn = next(
+        (
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, (ast.AsyncFunctionDef, ast.FunctionDef)) and n.name == "search_fulltext"
+        ),
+        None,
+    )
+    assert fn is not None, "search_fulltext not found in surrealdb temporal store"
+    # It declares filter_ast (wiring present) ...
+    params = [a.arg for a in fn.args.args] + [a.arg for a in fn.args.kwonlyargs]
+    assert "filter_ast" in params, "search_fulltext no longer declares filter_ast — wiring changed"
+    # ... AND its body compiles the AST via compile_surrealdb ...
+    compiles_ast = any(
+        isinstance(call, ast.Call)
+        and (
+            (isinstance(call.func, ast.Name) and call.func.id == "compile_surrealdb")
+            or (isinstance(call.func, ast.Attribute) and call.func.attr == "compile_surrealdb")
+        )
+        for call in ast.walk(fn)
+    )
+    assert compiles_ast, (
+        "SurrealDB search_fulltext no longer compiles filter_ast via compile_surrealdb — the "
+        "BM25 channel would drop the caller filter. Restore the compile + clause-threading so "
+        "the SurrealDB BM25 channel enforces the recall filter."
+    )
+    # ... AND threads the compiled predicate + params into the clauses/bindings it
+    # later hands to _bm25_search (the actual enforcement link). We require BOTH a
+    # `filter_clauses.append(...)` and a `filter_bindings.update(...)` so a regress
+    # that compiles but never wires the result into the WHERE fails here.
+    appends_clause = any(
+        isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Attribute)
+        and call.func.attr == "append"
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id == "filter_clauses"
+        for call in ast.walk(fn)
+    )
+    updates_bindings = any(
+        isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Attribute)
+        and call.func.attr == "update"
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id == "filter_bindings"
+        for call in ast.walk(fn)
+    )
+    assert appends_clause and updates_bindings, (
+        "SurrealDB search_fulltext compiles filter_ast but no longer threads the result into the "
+        "BM25 WHERE (filter_clauses.append(...) / filter_bindings.update(...)) — the predicate "
+        "would be compiled and discarded, dropping the caller filter. Restore the clause/binding "
+        f"thread-through (append={appends_clause}, update={updates_bindings})."
+    )


### PR DESCRIPTION
## Summary
- The SurrealDB temporal store's `search_fulltext` (the BM25 keyword channel) accepted a deterministic recall-filter AST but ignored it — it built its `WHERE` from namespace + temporal bounds only. As a result, the BM25 arm could return filter-excluded chunks into RRF fusion, so a filtered recall leaked rows the caller asked to exclude.
- Compile the filter AST to a SurrealQL `WHERE` predicate and AND it into the BM25 query, mirroring the vector channel's existing pushdown exactly (same compiler, `metadata` → `metadata_` mapping, raise-on-unsupported). When no filter is supplied, behavior is byte-identical to before.
- Update the method docstring, which previously stated the filter was ignored.

## Tests
- New embedded-SurrealDB (in-process `memory://`, no Docker) enforcement test that drives the public BM25 lookup directly with a three-way proof: an unfiltered control returns the full corpus, a *matching* metadata filter retains every row, and a *contradiction* metadata filter excludes every row. Stash-verified to fail without the source change (rows leak) and pass with it.
- New source-pinned audit-gate guard asserting `search_fulltext` declares the filter parameter, compiles it, and threads the compiled predicate/bindings into the BM25 `WHERE` — so a future regression that drops the thread-through fails the unit suite.

## Test plan
- [x] Unit tests pass (filter, recall, surrealdb backend, audit gate)
- [x] New embedded-SurrealDB BM25 enforcement test passes (stash-verified teeth)
- [ ] CI: full matrix + SurrealDB conformance leg