### PR TITLE
Replace recall-filter unindexed_metadata counter with metadata_leaf_count span attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Minor release. The `RecallFilter` foundation from 0.18.5 is now wired end-to-end
 ### Changed
 
 - Denormalized document keys are now projected onto Neo4j chunk nodes (#1024), so document-grained recall filters push down on the graph backend.
+- **Recall-filter metadata-leaf observability moved from a metric counter to a recall-span attribute.** The `khora.recall.filter.unindexed_metadata` counter is removed; the same signal (how many metadata-rooted leaf predicates a filter carries) is now emitted once per recall as the `filter.metadata_leaf_count` attribute on the `khora.recall` span, alongside `filter.canonical_hash`. The per-leaf compile-time fire across the Postgres/SurrealDB/Python compilers is dropped in favor of the single span attribute, which avoids backend-specific double-count concerns and keeps the per-leaf operator breakdown out of an unbounded metric. The `under_filled` and `graph_channel_empty` recall-filter counters are unchanged.
 
 ### Fixed
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -176,8 +176,12 @@ Highlights:
 - **Public metrics**: `khora.memory.{recall,ingest}.duration`,
   `khora.llm.tokens`, `khora.llm.cost_usd`,
   `khora.neo4j.pool.{acquire_duration,timeout,connections.*,utilization}`,
-  `khora.recall.filter.{unindexed_metadata,under_filled,graph_channel_empty}`,
+  `khora.recall.filter.{under_filled,graph_channel_empty}`,
   `khora.chronicle.abstention_signal`, `khora.log.queue.depth`.
+- **Recall filter span attributes** (on `khora.recall`, set only when a
+  `filter=` is present): `filter.canonical_hash` (the AST cache-key digest)
+  and `filter.metadata_leaf_count` (the number of metadata-rooted leaf
+  predicates in the filter).
 - **Khora-contributed resource attribute**:
   `khora.telemetry.contract.version` - bumped alongside contract changes
   so dashboards can filter by schema version independently of khora's

--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -1480,17 +1480,6 @@
       "_comment": "Issue #932. NO namespace_id label - cardinality rule."
     },
     {
-      "name": "khora.recall.filter.unindexed_metadata",
-      "type": "counter",
-      "stability": "public",
-      "unit": "1",
-      "owner": "filter",
-      "labels": [
-        {"name": "op", "values": ["$eq", "$ne", "$gt", "$gte", "$lt", "$lte", "$in", "$nin", "$exists"], "_comment": "The metadata leaf's comparison operator (Op enum wire literal). Logical operators ($and/$or/$not) are nodes, not leaves, so they never appear here. Bounded by the closed Op enum."}
-      ],
-      "description": "Metadata leaves in a deterministic recall filter that compile to an unindexed JSONB column access. Incremented once per metadata leaf at compile time (a filter with N metadata predicates emits N times); compile runs once per recall, so the hybrid vector+bm25 path does not double-count. NO namespace_id label - cardinality rule. The metadata key-path is also unbounded and never a label."
-    },
-    {
       "name": "khora.recall.filter.under_filled",
       "type": "counter",
       "stability": "public",

--- a/src/khora/engines/skeleton/backends/sqlite_lance.py
+++ b/src/khora/engines/skeleton/backends/sqlite_lance.py
@@ -425,12 +425,9 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         filter_ast: FilterNode | None = None,
     ) -> list[TemporalSearchResult]:
         # Build the compile_python post-filter ONCE per recall (it is
-        # alias-independent — it runs on decoded TemporalChunks). compile_python
-        # fires the public ``khora.recall.filter.unindexed_metadata`` counter at
-        # build time, so building it per-pass would double-count it on a hybrid
-        # recall; one build per recall keeps that contract. The compile_lance
+        # alias-independent — it runs on decoded TemporalChunks). The compile_lance
         # pushdown is still compiled per-pass inside each pass (its column
-        # qualifier differs, and it fires zero unindexed_metadata).
+        # qualifier differs).
         post_filter = self._ast_post_filter(filter_ast)
 
         # Vector pass.  Fetch 2× when fusion is requested so RRF has a
@@ -786,9 +783,7 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         there is no AST.
 
         Built ONCE per recall in :meth:`_search_inner` and threaded into both
-        passes: ``compile_python`` fires the public
-        ``khora.recall.filter.unindexed_metadata`` counter at build time, so a
-        per-pass build would double-count it on a hybrid recall.
+        passes.
         """
         if filter_ast is None or not filter_ast.children:
             return lambda _chunk: True

--- a/src/khora/filter/__init__.py
+++ b/src/khora/filter/__init__.py
@@ -32,6 +32,9 @@ from khora.filter.ast import (
     canonical_hash as canonical_hash,
 )
 from khora.filter.ast import (
+    metadata_leaf_count as metadata_leaf_count,
+)
+from khora.filter.ast import (
     parse_to_ast as parse_to_ast,
 )
 from khora.filter.context import (  # noqa: F401

--- a/src/khora/filter/ast.py
+++ b/src/khora/filter/ast.py
@@ -52,6 +52,7 @@ __all__ = [
     "FilterNode",
     "FilterOp",
     "canonical_hash",
+    "metadata_leaf_count",
     "parse_to_ast",
 ]
 
@@ -695,3 +696,19 @@ def _canonicalize_operand(operand: Any) -> Any:
         # Order-insensitive object equality — sort keys recursively.
         return {k: _canonicalize_operand(operand[k]) for k in sorted(operand, key=str)}
     return operand
+
+
+def metadata_leaf_count(node: FilterNode | FilterClause) -> int:
+    """Count the metadata-rooted leaf predicates in an AST subtree.
+
+    ``@internal``. A metadata leaf is a :class:`FilterClause` whose ``path``
+    begins with the ``"metadata"`` root segment (the bare-blob ``("metadata",)``
+    or a folded ``("metadata", ...)`` sub-path); these are the leaves that compile
+    to an unindexed JSONB / object-column access. A system-key leaf (a
+    single-segment path naming a denormalized column) does not count. Recurses
+    through :class:`FilterNode` children (``AND`` / ``OR`` / ``NOT``), which carry
+    no comparison of their own.
+    """
+    if isinstance(node, FilterClause):
+        return 1 if node.path and node.path[0] == "metadata" else 0
+    return sum(metadata_leaf_count(child) for child in node.children)

--- a/src/khora/filter/compilers/lance.py
+++ b/src/khora/filter/compilers/lance.py
@@ -144,10 +144,6 @@ def compile_lance(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[str]:
     functions), plus three cases that cannot match the oracle in SQL even with
     JSON1 (bare-blob ``$eq``, ``object_equal`` dict operands, ``$date`` compares).
 
-    This compiler does **not** emit the ``khora.recall.filter.unindexed_metadata``
-    counter. The always-on ``compile_python`` post-filter (run on the full AST for
-    every sqlite_lance recall) is the canonical once-per-leaf emit site, matching
-    chronicle; firing here too would double-count that public metric.
     """
     consumed: set[str] = set()
     builder = _Builder(ctx=ctx, consumed=consumed)
@@ -336,12 +332,6 @@ class _Builder:
                 # JSON1 (bare-blob $eq, object_equal dict operand, $date compare).
                 # Already reported as unsupported inside the metadata compiler.
                 return self._unsupported(clause, "metadata predicate is not pushed down to SQLite")
-            # NB: deliberately does NOT fire ``record_unindexed_metadata`` here.
-            # The always-on ``compile_python`` post-filter (which sqlite_lance runs
-            # on the full AST for every recall) is the canonical once-per-leaf
-            # emit site, matching chronicle; firing here too would double-count
-            # the public ``khora.recall.filter.unindexed_metadata`` metric on every
-            # metadata recall. Do not re-add.
         else:
             return self._unsupported(clause, "path is neither a system key nor a metadata path")
         self._consumed.add(_path_str(path))

--- a/src/khora/filter/compilers/postgres.py
+++ b/src/khora/filter/compilers/postgres.py
@@ -59,7 +59,6 @@ from khora.filter.ast import (
     canonical_hash,
 )
 from khora.filter.model import SYSTEM_KEYS, Op
-from khora.filter.telemetry import record_unindexed_metadata
 
 __all__ = ["compile_postgres"]
 
@@ -179,13 +178,6 @@ class _Builder:
             expr = self._compile_system_clause(clause)
         elif path and path[0] == "metadata":
             expr = self._compile_metadata_clause(clause)
-            # A metadata leaf compiles to an unindexed JSONB column access.
-            # Emit once per metadata leaf (a filter with N metadata predicates
-            # emits N times) — each leaf is a separate unindexed-column access.
-            # compile_postgres runs once per recall (the compiled predicate is
-            # reused across the vector + bm25 channels), so this does not
-            # double-count on the hybrid path.
-            record_unindexed_metadata(op=clause.op.value)
         else:
             return self._unsupported(clause, "path is neither a system key nor a metadata path")
         self._consumed.add(_path_str(path))

--- a/src/khora/filter/compilers/python.py
+++ b/src/khora/filter/compilers/python.py
@@ -71,7 +71,6 @@ from khora.filter.ast import (
     canonical_hash,
 )
 from khora.filter.model import SYSTEM_KEYS, Op
-from khora.filter.telemetry import record_unindexed_metadata
 
 __all__ = ["compile_python"]
 
@@ -117,10 +116,6 @@ def compile_python(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[Calla
     express: ``"raise"`` raises :class:`RecallFilterUnsupportedError`; ``"split"``
     drops the clause from ``consumed_keys`` and treats it as match-all so it does
     not narrow the record set.
-
-    The ``khora.recall.filter.unindexed_metadata`` counter fires once per metadata
-    leaf **at compile time** (during this AST walk), mirroring
-    :func:`compile_postgres` — never inside the returned per-record callable.
     """
     consumed: set[str] = set()
     builder = _Builder(ctx=ctx, consumed=consumed)
@@ -185,11 +180,6 @@ class _Builder:
             fn = self._compile_system_clause(clause)
         elif path and path[0] == "metadata":
             fn = self._compile_metadata_clause(clause)
-            # A metadata leaf reads an unindexed blob. Emit once per metadata
-            # leaf at compile time (a filter with N metadata predicates emits N
-            # times) — matching compile_postgres. NOT inside ``fn`` (that would
-            # fire per record).
-            record_unindexed_metadata(op=clause.op.value)
         else:
             return self._unsupported(clause, "path is neither a system key nor a metadata path")
         self._consumed.add(_path_str(path))

--- a/src/khora/filter/compilers/surrealdb.py
+++ b/src/khora/filter/compilers/surrealdb.py
@@ -93,7 +93,6 @@ from khora.filter.ast import (
 )
 from khora.filter.context import CompileError
 from khora.filter.model import SYSTEM_KEYS, Op
-from khora.filter.telemetry import record_unindexed_metadata
 
 __all__ = ["compile_surrealdb"]
 
@@ -241,10 +240,6 @@ class _Builder:
             expr = self._compile_system_clause(clause)
         elif path and path[0] == "metadata":
             expr = self._compile_metadata_clause(clause)
-            # A metadata leaf reads the FLEXIBLE ``object`` column (no index).
-            # Emit once per metadata leaf (a filter with N metadata predicates
-            # emits N times) — mirrors compile_postgres / compile_python.
-            record_unindexed_metadata(op=clause.op.value)
         else:
             return self._unsupported(clause, "path is neither a system key nor a metadata path")
         self._consumed.add(_path_str(path))

--- a/src/khora/filter/telemetry.py
+++ b/src/khora/filter/telemetry.py
@@ -1,6 +1,6 @@
 """OTel counters for the deterministic recall filter — ``@internal``.
 
-Three service-level counters that surface how the deterministic recall
+Two service-level counters that surface how the deterministic recall
 filter behaves at compile/recall time. They complement the per-recall
 ``filter.*`` span attributes (on ``khora.recall``) with aggregate signals
 SREs can alert on without subscribing to sampled spans.
@@ -11,9 +11,7 @@ a double-checked lock so a cold import never builds an instrument, and so the
 no-op meter (no real ``MeterProvider`` installed) stays free to call.
 
 Cardinality discipline (matching the rest of khora's metrics): ``namespace_id``
-is **never** an attribute here — it lives on span attributes only. The single
-bounded label exposed is ``op`` (the metadata leaf's comparison operator, a
-member of the closed :class:`~khora.filter.model.Op` enum).
+is **never** an attribute here — it lives on span attributes only.
 """
 
 from __future__ import annotations
@@ -24,25 +22,8 @@ from typing import Any
 from khora.telemetry.metrics import metric_counter
 
 _lock = threading.Lock()
-_unindexed_metadata_counter: Any | None = None
 _under_filled_counter: Any | None = None
 _graph_channel_empty_counter: Any | None = None
-
-
-def _get_unindexed_metadata_counter() -> Any:
-    global _unindexed_metadata_counter
-    if _unindexed_metadata_counter is None:
-        with _lock:
-            if _unindexed_metadata_counter is None:
-                _unindexed_metadata_counter = metric_counter(
-                    "khora.recall.filter.unindexed_metadata",
-                    unit="1",
-                    description=(
-                        "Metadata leaves in a deterministic recall filter that compile to an "
-                        "unindexed JSONB column access. Split by op (the leaf's comparison operator)."
-                    ),
-                )
-    return _unindexed_metadata_counter
 
 
 def _get_under_filled_counter() -> Any:
@@ -72,18 +53,6 @@ def _get_graph_channel_empty_counter() -> Any:
                     ),
                 )
     return _graph_channel_empty_counter
-
-
-def record_unindexed_metadata(*, op: str) -> None:
-    """Record one metadata leaf that compiled to an unindexed JSONB access.
-
-    Fired once per metadata leaf, so a filter with N metadata predicates emits
-    N observations (each leaf is a distinct unindexed-column access). ``op`` is
-    the leaf's comparison operator wire literal (an :class:`~khora.filter.model.Op`
-    value, e.g. ``"$eq"``) — the only attribute, and bounded by that closed enum.
-    Never pass ``namespace_id`` or a metadata key-path (both unbounded).
-    """
-    _get_unindexed_metadata_counter().add(1, attributes={"op": op})
 
 
 def record_under_filled() -> None:

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -2019,7 +2019,7 @@ class Khora:
         _t0 = _time.perf_counter()
         _status = "success"
         _recall_id = uuid4()
-        from khora.filter import RecallFilter, canonical_hash, parse_to_ast
+        from khora.filter import RecallFilter, canonical_hash, metadata_leaf_count, parse_to_ast
 
         try:
             # Resolve the recall filter once, at the facade. The public
@@ -2098,6 +2098,7 @@ class Khora:
                 # the common no-filter recall does not carry a meaningless attribute.
                 if filter_ast is not None:
                     _recall_span.set_attribute("filter.canonical_hash", canonical_hash(filter_ast))
+                    _recall_span.set_attribute("filter.metadata_leaf_count", metadata_leaf_count(filter_ast))
                 result = await self._get_engine().recall(
                     query,
                     namespace_id,

--- a/tests/recall/test_chronicle_filter_composition.py
+++ b/tests/recall/test_chronicle_filter_composition.py
@@ -11,12 +11,9 @@ compiled halves of a recall filter at ``recall()`` time —
 2. **The metadata predicate post-filters chunk candidates.** The
    :func:`compile_python` predicate is applied to the fused candidates so an
    out-of-scope chunk is dropped before top-k.
-3. **``khora.recall.filter.unindexed_metadata`` increments on the post-filter
-   path.** ``compile_python`` emits the counter per metadata leaf at compile time
-   (mirroring ``compile_postgres``), so a metadata-bearing filter recall fires it.
 
 The window-intersection assertions exercise the pure ``_intersect_*`` helpers
-directly (deterministic, no infra). The post-filter / telemetry assertions drive
+directly (deterministic, no infra). The post-filter assertions drive
 ``ChronicleEngine.recall()`` over a mocked storage + embedder (the established
 unit pattern from ``tests/unit/engines/test_chronicle_abstention_signals.py``):
 the semantic channel returns a known in-scope / out-of-scope chunk mix and the
@@ -38,7 +35,6 @@ from khora.core.models import Chunk
 from khora.core.models.document import DocumentSource
 from khora.engines.chronicle import engine as chronicle_engine
 from khora.engines.chronicle.engine import ChronicleEngine
-from khora.filter import telemetry as filter_telemetry
 from khora.query import SearchMode
 
 pytestmark = pytest.mark.unit
@@ -430,97 +426,6 @@ async def test_unanchored_chunk_survives_recency_window_with_no_filter_ast() -> 
         "an anchor-less chunk must SURVIVE a recency-window-only recall (no filter_ast); "
         "folding the deprecated bounds into an occurred_at filter would false-empty it"
     )
-
-
-# ===========================================================================
-# (3) unindexed_metadata counter increments on the post-filter path.
-# ===========================================================================
-
-
-class _RecordingCounter:
-    """Captures ``.add(value, attributes=...)`` calls for assertions."""
-
-    def __init__(self) -> None:
-        self.adds: list[tuple[float, dict[str, Any]]] = []
-
-    def add(self, value: float, attributes: Any = None) -> None:
-        self.adds.append((value, dict(attributes or {})))
-
-
-@pytest.fixture
-def recording_counters(monkeypatch: pytest.MonkeyPatch) -> dict[str, _RecordingCounter]:
-    """Replace the filter-telemetry counter singletons with recording fakes.
-
-    Same monkeypatch-the-singleton hook the existing recall-filter telemetry tests
-    use (tests/unit/filter/test_filter_telemetry.py): pre-seeding each module
-    global makes ``record_unindexed_metadata`` land on the fake.
-    """
-    counters = {
-        "unindexed_metadata": _RecordingCounter(),
-        "under_filled": _RecordingCounter(),
-        "graph_channel_empty": _RecordingCounter(),
-    }
-    monkeypatch.setattr(filter_telemetry, "_unindexed_metadata_counter", counters["unindexed_metadata"])
-    monkeypatch.setattr(filter_telemetry, "_under_filled_counter", counters["under_filled"])
-    monkeypatch.setattr(filter_telemetry, "_graph_channel_empty_counter", counters["graph_channel_empty"])
-    return counters
-
-
-@pytest.mark.asyncio
-async def test_unindexed_metadata_fires_on_post_filter_recall(
-    recording_counters: dict[str, _RecordingCounter],
-) -> None:
-    # A metadata-bearing filter recall fires the unindexed_metadata counter (the
-    # post-filter compiles the metadata leaf to a Python predicate). Assert >= 1
-    # observation carrying the leaf's op — robust whether emission is per-compile
-    # or (hypothetically) per-evaluation.
-    chunks = [_chunk("alpha", metadata={"tier": "gold"})]
-    engine = _engine_with_semantic([(chunks[0], 0.9)])
-
-    await engine.recall(
-        "alpha",
-        uuid4(),
-        limit=10,
-        mode=SearchMode.VECTOR,
-        filter_ast=_filter_ast({"metadata.tier": "gold"}),
-    )
-
-    adds = recording_counters["unindexed_metadata"].adds
-    assert len(adds) >= 1, "a metadata-bearing filter recall must fire unindexed_metadata"
-    assert any(a[1].get("op") == "$eq" for a in adds)
-
-
-@pytest.mark.asyncio
-async def test_unindexed_metadata_silent_for_system_key_only_recall(
-    recording_counters: dict[str, _RecordingCounter],
-) -> None:
-    # A system-key-only filter (occurred_at date bound) does not touch metadata, so
-    # the unindexed_metadata counter stays quiet on the post-filter path.
-    chunks = [_chunk("alpha", metadata={"tier": "gold"})]
-    engine = _engine_with_semantic([(chunks[0], 0.9)])
-
-    await engine.recall(
-        "alpha",
-        uuid4(),
-        limit=10,
-        mode=SearchMode.VECTOR,
-        filter_ast=_filter_ast({"occurred_at": {"$gte": "2020-01-01T00:00:00Z"}}),
-    )
-
-    assert recording_counters["unindexed_metadata"].adds == []
-
-
-@pytest.mark.asyncio
-async def test_no_filter_recall_does_not_fire_unindexed_metadata(
-    recording_counters: dict[str, _RecordingCounter],
-) -> None:
-    # No filter → no compile → no counter.
-    chunks = [_chunk("alpha", metadata={"tier": "gold"})]
-    engine = _engine_with_semantic([(chunks[0], 0.9)])
-
-    await engine.recall("alpha", uuid4(), limit=10, mode=SearchMode.VECTOR)
-
-    assert recording_counters["unindexed_metadata"].adds == []
 
 
 # ===========================================================================

--- a/tests/recall/test_compile_python.py
+++ b/tests/recall/test_compile_python.py
@@ -661,18 +661,13 @@ def test_compiled_filter_carries_canonical_hash() -> None:
 
 
 # ===========================================================================
-# unindexed_metadata telemetry — emitted PER METADATA LEAF at COMPILE time.
+# Filter-telemetry counters stay quiet on the in-memory compile path.
 # ===========================================================================
 #
-# Contract (confirmed against the binding precedent, tests/unit/filter/
-# test_filter_telemetry.py): the in-memory post-filter compiler emits
-# ``record_unindexed_metadata(op=...)`` ONCE PER METADATA LEAF while building the
-# predicate (the AST walk), mirroring ``compile_postgres`` at postgres.py:187 —
-# NOT inside the returned callable, and NOT per candidate record. So the count is
-# stable regardless of how many records the predicate is later evaluated against,
-# and a system-key-only filter emits nothing. The fixture monkeypatches the same
-# three module-level singletons in ``khora.filter.telemetry`` the postgres
-# telemetry tests use.
+# The two V1-only counters (``under_filled`` / ``graph_channel_empty``) are
+# pre-declared but have no ``.add()`` call site on the compile path here, so they
+# stay quiet. The fixture monkeypatches the same module-level singletons in
+# ``khora.filter.telemetry`` the postgres telemetry tests use.
 
 
 class _RecordingCounter:
@@ -687,78 +682,21 @@ class _RecordingCounter:
 
 @pytest.fixture
 def recording_counters(monkeypatch: pytest.MonkeyPatch) -> dict[str, _RecordingCounter]:
-    """Replace the three filter-telemetry counter singletons with recording fakes.
+    """Replace the filter-telemetry counter singletons with recording fakes.
 
     The ``_get_*`` helpers return the singleton if already set, so pre-seeding each
-    module global makes ``record_unindexed_metadata`` (and any ``.add()`` site)
-    land on the fake. Identical shape to test_filter_telemetry.py::recording_counters.
+    module global makes any ``.add()`` site land on the fake. Identical shape to
+    test_filter_telemetry.py::recording_counters.
     """
     from khora.filter import telemetry as filter_telemetry
 
     counters = {
-        "unindexed_metadata": _RecordingCounter(),
         "under_filled": _RecordingCounter(),
         "graph_channel_empty": _RecordingCounter(),
     }
-    monkeypatch.setattr(filter_telemetry, "_unindexed_metadata_counter", counters["unindexed_metadata"])
     monkeypatch.setattr(filter_telemetry, "_under_filled_counter", counters["under_filled"])
     monkeypatch.setattr(filter_telemetry, "_graph_channel_empty_counter", counters["graph_channel_empty"])
     return counters
-
-
-def test_unindexed_metadata_fires_once_per_metadata_leaf_at_compile(
-    recording_counters: dict[str, _RecordingCounter],
-) -> None:
-    # Compiling (not evaluating) a single metadata predicate emits exactly one
-    # observation, with the leaf's op as the bounded attribute.
-    compile_python(_ast({"metadata.tier": "gold"}), _CTX)
-
-    adds = recording_counters["unindexed_metadata"].adds
-    assert len(adds) == 1
-    assert adds[0] == (1, {"op": "$eq"})
-
-
-def test_unindexed_metadata_counts_each_metadata_leaf(
-    recording_counters: dict[str, _RecordingCounter],
-) -> None:
-    # N metadata leaves → N observations; a sibling system key does NOT add.
-    wire = {
-        "source_name": "linear",  # system key — no emit
-        "metadata.tier": "gold",  # $eq metadata leaf
-        "metadata.score": {"$gt": 5},  # $gt metadata leaf
-    }
-    compile_python(_ast(wire), _CTX)
-
-    adds = recording_counters["unindexed_metadata"].adds
-    assert len(adds) == 2
-    assert sorted(a[1]["op"] for a in adds) == ["$eq", "$gt"]
-    assert all(a[0] == 1 for a in adds)
-
-
-def test_unindexed_metadata_silent_for_system_key_only(
-    recording_counters: dict[str, _RecordingCounter],
-) -> None:
-    # A system-key-only filter post-filters typed columns — no JSONB/metadata access.
-    compile_python(_ast({"source_name": "linear"}), _CTX)
-    assert recording_counters["unindexed_metadata"].adds == []
-
-
-def test_unindexed_metadata_not_emitted_per_record_evaluation(
-    recording_counters: dict[str, _RecordingCounter],
-) -> None:
-    # The load-bearing contract: emission is at COMPILE time, not per evaluation.
-    # Build the predicate once, then call it on several records — the count must
-    # NOT grow (emission happened during the compile AST walk, not in the callable).
-    pred = compile_python(_ast({"metadata.tier": "gold"}), _CTX).predicate
-    baseline = len(recording_counters["unindexed_metadata"].adds)
-    assert baseline == 1
-
-    for tier in ("gold", "silver", "bronze", "gold", "gold"):
-        pred({"metadata": {"tier": tier}})
-
-    assert len(recording_counters["unindexed_metadata"].adds) == baseline, (
-        "the counter must not fire per candidate record — emission is compile-time only"
-    )
 
 
 def test_v1_only_counters_stay_quiet_on_compile(

--- a/tests/recall/test_filter_chronicle.py
+++ b/tests/recall/test_filter_chronicle.py
@@ -44,8 +44,7 @@ sqlite_lance fixture, not assumed):
   datetimes; the compiler aligns a naive stored value to UTC at the comparison
   boundary, so the system date key narrows cleanly rather than raising.
 * ``metadata.tag`` ($in {"urgent", "release"}) — the one free-form metadata
-  leaf, and the leaf Scenario 2's unindexed-metadata telemetry assertion now
-  exercises via its own dedicated metadata filter.
+  leaf.
 
 ENVIRONMENT: needs the ``sqlite_lance`` extra (``pip install khora[sqlite_lance]``
 → aiosqlite + lancedb). No Docker / Postgres / Neo4j. The module self-skips when
@@ -80,7 +79,6 @@ from khora.config import KhoraConfig
 from khora.config.schema import SQLiteLanceConfig
 from khora.extraction.skills import ExpertiseConfig
 from khora.extraction.skills.base import EventExtractionConfig, FactExtractionConfig
-from khora.filter import telemetry as filter_telemetry
 from khora.khora import Khora
 from khora.query import SearchMode
 from tests.test_helpers.diagnostics import assert_no_silent_degradation
@@ -264,8 +262,7 @@ def _parse_when(when: str) -> datetime:
 # coerces it to a UTC-aware datetime; the ``{"$date": ...}`` typed literal is an
 # AST-level form the dict API does not accept on a system date key), matching the
 # existing system-``occurred_at`` tests below. ``source_name`` and ``occurred_at``
-# are SYSTEM keys (no unindexed_metadata fire); ``metadata.tag`` is the one
-# metadata leaf.
+# are SYSTEM keys; ``metadata.tag`` is the one metadata leaf.
 _RECALL_FILTER = {
     "source_name": "linear",
     "occurred_at": {"$gte": _IN_BOUND},
@@ -752,117 +749,3 @@ async def test_system_created_at_date_filter_narrows(kb: Khora) -> None:
     assert await _recall({"created_at": {"$gte": "2000-01-01T00:00:00Z"}}) == all_labels
     assert await _recall({"created_at": {"$lte": "2000-01-01T00:00:00Z"}}) == set()
     assert await _recall({"created_at": {"$gte": "2000-01-01T00:00:00Z", "$lte": "2100-01-01T00:00:00Z"}}) == all_labels
-
-
-# ===========================================================================
-# Scenario 2 — post-filter increments unindexed_metadata, with negative controls.
-# ===========================================================================
-#
-# ``compile_python`` emits ``khora.recall.filter.unindexed_metadata`` once per
-# metadata leaf at compile time, so a metadata-bearing filter recall fires it.
-# The positive test uses a DEDICATED metadata filter ({"metadata.tag": "urgent"},
-# a $eq metadata leaf) rather than the shared _RECALL_FILTER: after the system-key
-# rewrite _RECALL_FILTER's only metadata leaf is metadata.tag with $in (its
-# source_name / occurred_at leaves are SYSTEM keys that do NOT fire the counter),
-# so a dedicated $eq filter keeps the $eq coverage and the intent explicit. The
-# two negative controls rule out the counter firing for the wrong reason: a
-# non-metadata filter (no metadata leaf) and a no-filter recall must both leave
-# it silent.
-
-
-class _RecordingCounter:
-    """Captures ``.add(value, attributes=...)`` calls for assertions."""
-
-    def __init__(self) -> None:
-        self.adds: list[tuple[float, dict[str, Any]]] = []
-
-    def add(self, value: float, attributes: Any = None) -> None:
-        self.adds.append((value, dict(attributes or {})))
-
-
-@pytest.fixture
-def recording_counter(monkeypatch: pytest.MonkeyPatch) -> _RecordingCounter:
-    """Replace the unindexed-metadata counter singleton with a recording fake.
-
-    Same monkeypatch-the-singleton hook the existing recall-filter telemetry
-    tests use: pre-seeding the module global makes ``record_unindexed_metadata``
-    land on the fake (the lazy getter returns the already-set value).
-    """
-    counter = _RecordingCounter()
-    monkeypatch.setattr(filter_telemetry, "_unindexed_metadata_counter", counter)
-    return counter
-
-
-async def test_metadata_filter_fires_unindexed_metadata(kb: Khora, recording_counter: _RecordingCounter) -> None:
-    """A metadata-bearing filter recall fires ``unindexed_metadata`` on the live
-    post-filter path, carrying the leaf's comparison op.
-
-    Uses a dedicated ``{"metadata.tag": "urgent"}`` filter — a single ``$eq``
-    metadata leaf — so the counter observes at least one add carrying that real
-    leaf op. (The shared ``_RECALL_FILTER`` now carries ``source_name`` /
-    ``occurred_at`` as SYSTEM keys, which do NOT fire the counter, leaving only a
-    ``$in`` metadata leaf; the dedicated filter keeps the ``$eq`` coverage.)
-    ``>= 1`` is robust whether emission is per-compile or (hypothetically)
-    per-evaluation.
-    """
-    ns = await kb.create_namespace()
-    namespace_id: UUID = ns.namespace_id
-    await _seed(kb, namespace_id)
-
-    await kb.recall(
-        "alpha bravo charlie",
-        namespace=namespace_id,
-        limit=20,
-        mode=SearchMode.VECTOR,
-        filter={"metadata.tag": "urgent"},
-    )
-
-    adds = recording_counter.adds
-    assert len(adds) >= 1, "a metadata-bearing filter recall must fire unindexed_metadata"
-    assert any(a[1].get("op") == "$eq" for a in adds), f"expected a $eq leaf op among the observations; got {adds}"
-
-
-async def test_non_metadata_filter_silent_for_unindexed_metadata(
-    kb: Khora, recording_counter: _RecordingCounter
-) -> None:
-    """Negative control: a non-metadata filter does not touch metadata, so the
-    unindexed_metadata counter stays silent.
-
-    ``{"source": {"$ne": "no-such-source"}}`` is a document-projection (SYSTEM)
-    key with no metadata leaf and no datetime compare. The corpus never seeds
-    ``source`` (only ``source_name``), so it resolves to no real value on any row
-    and ``$ne "no-such-source"`` matches every row regardless — the recall does
-    not narrow and, crucially, does not crash. What matters here is that NO
-    metadata leaf compiles, so the counter must not fire. This pins that Scenario
-    2's positive signal comes from the metadata leaf, not from the mere presence
-    of a filter.
-    """
-    ns = await kb.create_namespace()
-    namespace_id: UUID = ns.namespace_id
-    await _seed(kb, namespace_id)
-
-    await kb.recall(
-        "alpha bravo charlie",
-        namespace=namespace_id,
-        limit=20,
-        mode=SearchMode.VECTOR,
-        filter={"source": {"$ne": "no-such-source"}},
-    )
-
-    assert recording_counter.adds == [], "a non-metadata filter must leave unindexed_metadata silent"
-
-
-async def test_no_filter_recall_silent_for_unindexed_metadata(kb: Khora, recording_counter: _RecordingCounter) -> None:
-    """Negative control: no filter → no compile → no counter."""
-    ns = await kb.create_namespace()
-    namespace_id: UUID = ns.namespace_id
-    await _seed(kb, namespace_id)
-
-    await kb.recall(
-        "alpha bravo charlie",
-        namespace=namespace_id,
-        limit=20,
-        mode=SearchMode.VECTOR,
-    )
-
-    assert recording_counter.adds == [], "a no-filter recall must leave unindexed_metadata silent"

--- a/tests/unit/filter/test_filter_telemetry.py
+++ b/tests/unit/filter/test_filter_telemetry.py
@@ -1,18 +1,17 @@
 """Unit tests for the deterministic recall-filter telemetry — ``@internal``.
 
-Covers the three OTel counters in :mod:`khora.filter.telemetry` and the
-``filter.canonical_hash`` attribute set on the ``khora.recall`` span:
+Covers the two OTel counters in :mod:`khora.filter.telemetry` and the
+``filter.canonical_hash`` / ``filter.metadata_leaf_count`` attributes set on the
+``khora.recall`` span:
 
-1. All three counters are constructible via their ``_get_*`` helpers (and
-   memoized — a second call returns the same instrument).
-2. ``khora.recall.filter.unindexed_metadata`` fires once per metadata leaf when
-   :func:`compile_postgres` lowers a metadata predicate, and does **not** fire
-   for a system-key-only filter.
-3. The two V1-only counters (``under_filled`` / ``graph_channel_empty``) are
+1. Both counters are constructible via their ``_get_*`` helpers (and memoized —
+   a second call returns the same instrument).
+2. The two V1-only counters (``under_filled`` / ``graph_channel_empty``) are
    pre-declared but have no ``.add()`` call site yet, so they stay quiet on the
    compile + recall paths exercised here.
-4. ``filter.canonical_hash`` is present on the ``khora.recall`` span exactly when
-   a ``filter=`` is supplied, and absent on an unfiltered recall.
+3. ``filter.canonical_hash`` and ``filter.metadata_leaf_count`` are present on
+   the ``khora.recall`` span exactly when a ``filter=`` is supplied, and absent
+   on an unfiltered recall.
 
 Hermetic — no Docker / DB. The counter tests monkeypatch the module-level
 singletons in ``khora.filter.telemetry`` with recording fakes (mirroring
@@ -34,7 +33,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from khora.filter import RecallFilter, canonical_hash
+from khora.filter import RecallFilter, canonical_hash, metadata_leaf_count
 from khora.filter import telemetry as filter_telemetry
 from khora.filter.ast import parse_to_ast
 from khora.filter.compilers.postgres import compile_postgres
@@ -68,49 +67,43 @@ def _ast(wire: dict) -> Any:
 
 @pytest.fixture
 def recording_counters(monkeypatch: pytest.MonkeyPatch) -> dict[str, _RecordingCounter]:
-    """Replace the three module-level counter singletons with recording fakes.
+    """Replace the two module-level counter singletons with recording fakes.
 
     The ``_get_*`` helpers return the singleton if already set, so pre-seeding
     each module global makes ``record_*`` / any ``.add()`` site land on the fake.
     """
     counters = {
-        "unindexed_metadata": _RecordingCounter(),
         "under_filled": _RecordingCounter(),
         "graph_channel_empty": _RecordingCounter(),
     }
-    monkeypatch.setattr(filter_telemetry, "_unindexed_metadata_counter", counters["unindexed_metadata"])
     monkeypatch.setattr(filter_telemetry, "_under_filled_counter", counters["under_filled"])
     monkeypatch.setattr(filter_telemetry, "_graph_channel_empty_counter", counters["graph_channel_empty"])
     return counters
 
 
 # ===========================================================================
-# (1) All three counters are constructible via their _get_* helpers.
+# (1) Both counters are constructible via their _get_* helpers.
 # ===========================================================================
 
 
 @pytest.fixture
 def _reset_counter_singletons() -> Any:
-    """Null out the three singletons so the _get_* helpers build fresh ones."""
+    """Null out the two singletons so the _get_* helpers build fresh ones."""
     saved = (
-        filter_telemetry._unindexed_metadata_counter,
         filter_telemetry._under_filled_counter,
         filter_telemetry._graph_channel_empty_counter,
     )
-    filter_telemetry._unindexed_metadata_counter = None
     filter_telemetry._under_filled_counter = None
     filter_telemetry._graph_channel_empty_counter = None
     yield
     (
-        filter_telemetry._unindexed_metadata_counter,
         filter_telemetry._under_filled_counter,
         filter_telemetry._graph_channel_empty_counter,
     ) = saved
 
 
-def test_all_three_counter_helpers_construct(_reset_counter_singletons: Any) -> None:
+def test_both_counter_helpers_construct(_reset_counter_singletons: Any) -> None:
     """Each ``_get_*`` helper returns a non-None instrument (no real provider needed)."""
-    assert filter_telemetry._get_unindexed_metadata_counter() is not None
     assert filter_telemetry._get_under_filled_counter() is not None
     assert filter_telemetry._get_graph_channel_empty_counter() is not None
 
@@ -118,7 +111,6 @@ def test_all_three_counter_helpers_construct(_reset_counter_singletons: Any) -> 
 def test_counter_helpers_are_memoized(_reset_counter_singletons: Any) -> None:
     """A second call returns the same instrument (lazy double-checked singleton)."""
     for getter in (
-        filter_telemetry._get_unindexed_metadata_counter,
         filter_telemetry._get_under_filled_counter,
         filter_telemetry._get_graph_channel_empty_counter,
     ):
@@ -127,79 +119,14 @@ def test_counter_helpers_are_memoized(_reset_counter_singletons: Any) -> None:
 
 
 # ===========================================================================
-# (2) unindexed_metadata fires for metadata leaves, not system-key-only.
-# ===========================================================================
-
-
-def test_unindexed_metadata_fires_on_metadata_predicate(
-    recording_counters: dict[str, _RecordingCounter],
-) -> None:
-    """Compiling a single metadata predicate emits exactly one observation."""
-    compile_postgres(_ast({"metadata.tier": "gold"}), _CTX)
-
-    adds = recording_counters["unindexed_metadata"].adds
-    assert len(adds) == 1
-    value, attrs = adds[0]
-    assert value == 1
-    assert attrs == {"op": "$eq"}
-
-
-def test_unindexed_metadata_silent_for_system_key_only(
-    recording_counters: dict[str, _RecordingCounter],
-) -> None:
-    """A system-key-only filter compiles to a typed column — no JSONB access."""
-    compile_postgres(_ast({"source_name": "linear"}), _CTX)
-
-    assert recording_counters["unindexed_metadata"].adds == []
-
-
-def test_unindexed_metadata_fires_once_per_metadata_leaf(
-    recording_counters: dict[str, _RecordingCounter],
-) -> None:
-    """N metadata predicates → N observations; a sibling system key does not add."""
-    wire = {
-        "source_name": "linear",  # system key — no emit
-        "metadata.tier": "gold",  # $eq metadata leaf
-        "metadata.score": {"$gt": 5},  # $gt metadata leaf
-    }
-    compile_postgres(_ast(wire), _CTX)
-
-    adds = recording_counters["unindexed_metadata"].adds
-    assert len(adds) == 2
-    ops = sorted(a[1]["op"] for a in adds)
-    assert ops == ["$eq", "$gt"]
-    assert all(a[0] == 1 for a in adds)
-
-
-def test_unindexed_metadata_op_attribute_tracks_operator(
-    recording_counters: dict[str, _RecordingCounter],
-) -> None:
-    """The ``op`` attribute is the metadata leaf's comparison-operator wire literal."""
-    compile_postgres(_ast({"metadata.tags": {"$in": ["a", "b"]}}), _CTX)
-
-    adds = recording_counters["unindexed_metadata"].adds
-    assert len(adds) == 1
-    assert adds[0][1] == {"op": "$in"}
-
-
-def test_record_unindexed_metadata_helper_adds_one(
-    recording_counters: dict[str, _RecordingCounter],
-) -> None:
-    """The public ``record_unindexed_metadata`` helper adds 1 with the op label."""
-    filter_telemetry.record_unindexed_metadata(op="$lte")
-
-    assert recording_counters["unindexed_metadata"].adds == [(1, {"op": "$lte"})]
-
-
-# ===========================================================================
-# (3) under_filled + graph_channel_empty stay quiet on V1 paths.
+# (2) under_filled + graph_channel_empty stay quiet on V1 paths.
 # ===========================================================================
 
 
 def test_v1_counters_quiet_on_metadata_compile(
     recording_counters: dict[str, _RecordingCounter],
 ) -> None:
-    """Compiling a metadata predicate touches only unindexed_metadata."""
+    """Compiling a metadata predicate fires neither V1 counter."""
     compile_postgres(_ast({"metadata.tier": "gold"}), _CTX)
 
     assert recording_counters["under_filled"].adds == []
@@ -209,16 +136,15 @@ def test_v1_counters_quiet_on_metadata_compile(
 def test_v1_counters_quiet_on_system_key_compile(
     recording_counters: dict[str, _RecordingCounter],
 ) -> None:
-    """A system-key-only compile emits none of the three counters."""
+    """A system-key-only compile emits neither V1 counter."""
     compile_postgres(_ast({"source_name": "linear"}), _CTX)
 
-    assert recording_counters["unindexed_metadata"].adds == []
     assert recording_counters["under_filled"].adds == []
     assert recording_counters["graph_channel_empty"].adds == []
 
 
 # ===========================================================================
-# (4) filter.canonical_hash on the khora.recall span.
+# (3) filter.canonical_hash + filter.metadata_leaf_count on the khora.recall span.
 # ===========================================================================
 #
 # Drive the real ``Khora.recall`` facade over a mocked engine so the actual
@@ -345,3 +271,44 @@ async def test_recall_span_omits_canonical_hash_without_filter(span_exporter: An
 
     span = _recall_span(span_exporter)
     assert "filter.canonical_hash" not in span.attributes
+
+
+@pytest.mark.asyncio
+async def test_recall_span_has_metadata_leaf_count_when_filter_given(span_exporter: Any) -> None:
+    """A ``filter=`` recall tags the span with the AST's metadata-leaf count."""
+    ns_id = uuid4()
+    kb = _make_kb(ns_id)
+    # Two metadata leaves plus a system key (which does not count).
+    wire = {"source_name": "linear", "metadata.tier": "gold", "metadata.score": {"$gt": 5}}
+
+    await kb.recall("q", namespace=ns_id, filter=wire)
+
+    span = _recall_span(span_exporter)
+    expected = metadata_leaf_count(parse_to_ast(RecallFilter.model_validate(wire)))
+    assert expected == 2
+    assert span.attributes.get("filter.metadata_leaf_count") == expected
+
+
+@pytest.mark.asyncio
+async def test_recall_span_metadata_leaf_count_zero_for_system_key_only(span_exporter: Any) -> None:
+    """A system-key-only ``filter=`` recall tags the span with a zero leaf count."""
+    ns_id = uuid4()
+    kb = _make_kb(ns_id)
+    wire = {"source_name": "linear"}
+
+    await kb.recall("q", namespace=ns_id, filter=wire)
+
+    span = _recall_span(span_exporter)
+    assert span.attributes.get("filter.metadata_leaf_count") == 0
+
+
+@pytest.mark.asyncio
+async def test_recall_span_omits_metadata_leaf_count_without_filter(span_exporter: Any) -> None:
+    """An unfiltered recall does not carry the ``filter.metadata_leaf_count`` attribute."""
+    ns_id = uuid4()
+    kb = _make_kb(ns_id)
+
+    await kb.recall("q", namespace=ns_id)
+
+    span = _recall_span(span_exporter)
+    assert "filter.metadata_leaf_count" not in span.attributes

--- a/tests/unit/filter/test_metadata_leaf_count.py
+++ b/tests/unit/filter/test_metadata_leaf_count.py
@@ -1,0 +1,65 @@
+"""Unit tests for :func:`khora.filter.metadata_leaf_count` — ``@internal``.
+
+``metadata_leaf_count`` counts the metadata-rooted leaf predicates in a filter
+AST (the leaves that compile to an unindexed JSONB / object-column access). A
+system-key leaf — a single-segment path naming a denormalized column — does not
+count. The count is surfaced as the ``filter.metadata_leaf_count`` attribute on
+the ``khora.recall`` span.
+
+Pure AST counting — no Docker / DB. ASTs are built the way the facade does, by
+validating a wire-form filter and lowering it (mirrors
+``tests/recall/test_canonical_hash_stability.py``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from khora.filter import RecallFilter, metadata_leaf_count, parse_to_ast
+
+pytestmark = pytest.mark.unit
+
+
+def _count(doc: dict) -> int:
+    """Count metadata leaves of a public filter document the way the facade does."""
+    return metadata_leaf_count(parse_to_ast(RecallFilter.model_validate(doc)))
+
+
+def test_system_key_only_counts_zero() -> None:
+    """A system-key-only filter has no metadata leaves."""
+    assert _count({"source_type": "x"}) == 0
+
+
+def test_empty_filter_counts_zero() -> None:
+    """An empty (match-everything) filter has no metadata leaves."""
+    assert _count({}) == 0
+
+
+def test_dot_path_predicates_each_count() -> None:
+    """Each folded ``metadata.<path>`` predicate is one leaf."""
+    assert _count({"metadata.a": 1, "metadata.b": 2}) == 2
+
+
+def test_bare_metadata_blob_counts_one() -> None:
+    """A bare ``metadata`` dict is a single whole-blob leaf."""
+    assert _count({"metadata": {"a": 1, "b": 2}}) == 1
+
+
+def test_system_and_metadata_mix_counts_only_metadata() -> None:
+    """A sibling system key does not inflate the metadata-leaf count."""
+    assert _count({"source_name": "linear", "metadata.tier": "gold"}) == 1
+
+
+def test_or_branches_count_their_metadata_leaves() -> None:
+    """Logical ``$or`` nesting counts the metadata leaves in each branch."""
+    assert _count({"$or": [{"metadata.a": 1}, {"metadata.b": 2}]}) == 2
+
+
+def test_not_counts_its_inner_metadata_leaf() -> None:
+    """A ``$not`` over a metadata predicate counts its inner leaf."""
+    assert _count({"$not": {"metadata.a": 1}}) == 1
+
+
+def test_in_metadata_leaf_counts_one() -> None:
+    """An ``$in`` metadata predicate is a single leaf."""
+    assert _count({"metadata.tags": {"$in": ["a", "b"]}}) == 1


### PR DESCRIPTION
## Summary
- Remove the experimental `khora.recall.filter.unindexed_metadata` OTel counter. It fired once per metadata leaf per compile pass, so multi-channel engines that compile each retrieval channel independently (vector / bm25 / graph / recency) over-counted by an engine- and routing-dependent multiplier; and its "unindexed" semantic could not be kept truthful because filter indexes ship via `CREATE INDEX CONCURRENTLY` outside the migration chain.
- Add a pure `metadata_leaf_count()` helper in the filter AST layer (counts metadata-rooted leaf predicates in the validated filter AST) and set `filter.metadata_leaf_count` once per recall on the `khora.recall` span, alongside `filter.canonical_hash`. This is demand-side and exact by construction — index-independent and emitted once per recall.
- Drop the three compile-time fire sites (Postgres / SurrealDB / Python compilers) plus their imports, and clean stale references in the Lance compiler and the embedded sqlite_lance backend comments.
- Update the telemetry contract JSON and observability docs. The `under_filled` and `graph_channel_empty` recall-filter counters are unchanged.

## Test plan
- [x] Unit tests pass (`tests/unit/filter`, `tests/unit/telemetry`) — includes new `metadata_leaf_count` coverage and recall-span attribute tests
- [x] Recall filter suite passes (`tests/recall`)
- [x] Telemetry contract drift gate green (`tests/unit/telemetry/test_contract.py`)
- [ ] CI full matrix (unit + integration + e2e across engine configs)