### PR TITLE
Make examples-smoke assert results and cut per-example runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,10 +560,12 @@ jobs:
             # path — without this, the helper package is unreachable
             # because there's no ``examples/__init__.py`` at the root.
             #
-            # 60s budget (was 30s): the crewai example runs through the
-            # full ingest pipeline + LLM stub retries and observed times
-            # around 25-34s on GitHub-hosted runners. 30s was too tight
-            # and produced intermittent flakes (#741 / v0.15.1 release).
+            # 60s budget (was 30s): raised after intermittent flakes
+            # (#741 / v0.15.1 release). Since #1099 the mock LLM returns
+            # valid extraction JSON (no tenacity retry sleeps) and the
+            # fixture disables cross-encoder reranking (no HF Hub model
+            # download inside recall), so examples should sit well under
+            # the budget; 60s is headroom for runner variance.
             if ! PYTHONPATH="${GITHUB_WORKSPACE}" timeout 60s uv run --directory "$ex" python example.py; then
               echo "[examples-smoke] $name: FAILED"
               fail=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ Always run `make format && make test` before committing. CI will reject PRs that
 
 ### Integration examples
 
-Every adapter ships `examples/integrations/<name>/example.py` that runs without external services (sqlite_lance fixture + mock LLM helpers under `examples/_helpers/`). The `python title="example.py"` block in `docs/integrations/<name>.md` must be byte-identical to that file. The `examples-smoke` CI job gates drift via `tools/check_examples_drift.py` and smoke-runs each example under a 30s timeout.
+Every adapter ships `examples/integrations/<name>/example.py` that runs without external services (sqlite_lance fixture + mock LLM helpers under `examples/_helpers/`). The `python title="example.py"` block in `docs/integrations/<name>.md` must be byte-identical to that file. The `examples-smoke` CI job gates drift via `tools/check_examples_drift.py` and smoke-runs each example under a 60s timeout. Examples must assert on their results (not just print) so the smoke run fails on regressions, and the mock LLM's default response is a valid empty extraction payload — a non-JSON default would push every ingest through 3 tenacity retries (~6s of sleeps per document).
 
 ### Coding Principles
 

--- a/docs/integrations/crewai.md
+++ b/docs/integrations/crewai.md
@@ -64,7 +64,16 @@ async def _main() -> None:
             importance=0.6,
         )
 
-        matches = memory.recall("which database did we pick?", limit=3)
+        # Verbatim recall: the mock LLM's hash-derived embeddings only
+        # score an exact text match (cosine 1.0); a paraphrased query
+        # like "which database did we pick?" lands near zero and falls
+        # below the adapter's similarity floor. A real embedder handles
+        # semantic queries.
+        matches = memory.recall("We decided to use PostgreSQL for the user database.", limit=3)
+        assert matches, "expected recall to return at least one match"
+        assert any("PostgreSQL" in match.record.content for match in matches), (
+            "expected the PostgreSQL decision to be recalled"
+        )
         for match in matches:
             print(f"[{match.score:.2f}] {match.record.content}")
 

--- a/docs/integrations/google_adk.md
+++ b/docs/integrations/google_adk.md
@@ -171,6 +171,7 @@ async def main() -> None:
             user_id="example-user-1234",
             query="which database did we pick?",
         )
+        assert response.memories, "expected search_memory to recover the session events"
         print(f"Recovered {len(response.memories)} memory entries:")
         for entry in response.memories:
             text = " ".join(part.text for part in (entry.content.parts or []) if part.text)

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -241,9 +241,8 @@ Lifecycle exercised: ``initialize`` → ``queue_prefetch`` → ``sync_turn``
 ``handle_tool_call("memory_search")`` (blocking dispatch, real result)
 → ``on_pre_compress`` → ``on_session_end`` (drain) → ``shutdown``.
 
-Kept light (3 turns) to fit the 30s CI smoke budget - every
-``sync_turn`` triggers a full extraction pipeline that retries 3× on
-the mock LLM's non-JSON output.
+Kept light (3 turns) to fit the CI smoke budget - every ``sync_turn``
+still runs the full extraction pipeline against the mock LLM.
 """
 
 from __future__ import annotations
@@ -337,10 +336,22 @@ async def main() -> None:
         # 6) Tool dispatch is the blocking path - the LLM is already
         #    waiting on a tool result so we serve real data. The
         #    runtime FIFO ensures the writes drain before recall runs.
+        #    The query repeats turn 1 verbatim (sync_turn embeds
+        #    "USER: ...\n\nASSISTANT: ..."): the mock LLM's hash-derived
+        #    embeddings only score an exact text match (cosine 1.0), and
+        #    a paraphrase would fall below the tool's 0.1 similarity
+        #    floor. A real embedder handles semantic queries.
         result = provider.handle_tool_call(
             "memory_search",
-            {"query": "Phoenix database", "top_k": 3},
+            {
+                "query": (
+                    "USER: Alice picked PostgreSQL for the Phoenix database.\n\n"
+                    "ASSISTANT: Got it - PostgreSQL for Phoenix."
+                ),
+                "top_k": 3,
+            },
         )
+        assert "Phoenix" in result, "expected memory_search to surface the ingested turns"
         print("--- memory_search tool call (blocking dispatch) ---")
         print(result.strip())
 

--- a/docs/integrations/langgraph.md
+++ b/docs/integrations/langgraph.md
@@ -135,9 +135,11 @@ async def main() -> None:
 
         item = await store.aget(("memories",), "note-1")
         assert item is not None
+        assert item.value["text"] == "the sky is blue today"
         print(f"Stored memory: {item.value['text']!r}")
 
         namespaces = await store.alist_namespaces()
+        assert namespaces, "expected the write to register a namespace"
         print(f"Namespaces in store: {namespaces}")
 
 

--- a/docs/integrations/llamaindex.md
+++ b/docs/integrations/llamaindex.md
@@ -84,6 +84,8 @@ async def main() -> None:
         # Verbatim recall: the mock LLM's hash-derived embeddings give
         # an exact match (cosine = 1.0) for the stored text.
         nodes = await retriever.aretrieve(memory_one)
+        assert nodes, "expected verbatim recall to return results"
+        assert any(memory_one in node.node.text for node in nodes), "expected the stored text to be retrieved verbatim"
         for node in nodes:
             text = node.node.text.replace("\n", " ")
             print(f"[{node.score:.2f}] {text}")

--- a/docs/integrations/openai_agents.md
+++ b/docs/integrations/openai_agents.md
@@ -129,8 +129,8 @@ adapter exposes directly: ``KhoraSession`` (SessionABC contract),
 (RunHooks-shaped). Each is what an ``Agent`` would call into.
 
 Kept deliberately small (single ``add_items`` write) so it finishes
-well under the 30s CI smoke budget - every khora write triggers a full
-extraction pipeline that retries 3x on the mock LLM's non-JSON output.
+well under the CI smoke budget - every khora write still runs the full
+extraction pipeline against the mock LLM.
 """
 
 from __future__ import annotations
@@ -162,10 +162,12 @@ async def main() -> None:
 
         # 1) Session - one turn is enough to demonstrate the SessionABC
         #    contract. Every khora write runs full extraction, so we keep
-        #    the example light to fit the 30s CI smoke budget.
+        #    the example light to fit the CI smoke budget.
         session = KhoraSession(kb=kb, namespace=ns_id, session_id="example-conv-1")
         await session.add_items([{"role": "user", "content": "We picked PostgreSQL for the user DB."}])
         items = await session.get_items()
+        assert len(items) == 1, "expected the session to round-trip exactly one item"
+        assert items[-1]["content"] == "We picked PostgreSQL for the user DB."
         print(f"Session has {len(items)} item(s); latest: {items[-1]['content']!r}")
 
         # 2) Recall tool - closes over (kb, namespace, top_k). Construction

--- a/examples/_helpers/khora_fixtures.py
+++ b/examples/_helpers/khora_fixtures.py
@@ -49,6 +49,11 @@ async def embedded_khora(
             embedding_dimension=embedding_dimension,
         )
         config.llm.embedding_dimension = embedding_dimension
+        # Cross-encoder reranking downloads BAAI/bge-reranker-v2-m3 from
+        # HF Hub on first recall (~25s unauthenticated in CI, rate-limit
+        # prone). The examples demonstrate adapter wiring, not ranking
+        # quality — skip it.
+        config.query.enable_reranking = False
 
         kb = Khora(config, engine=engine, run_migrations=True)
         await kb.connect()

--- a/examples/_helpers/mock_llm.py
+++ b/examples/_helpers/mock_llm.py
@@ -4,8 +4,11 @@ Patches ``litellm.acompletion`` and ``litellm.aembedding`` so the
 examples-smoke job does not need an OpenAI key. Embeddings are
 hash-derived (SHA1 → numpy seed → L2-normalised float vector) so the
 same text always produces the same embedding across runs. Completions
-cycle through a configurable response list (default ``["stub
-response"]``).
+cycle through a configurable response list. The default response is a
+valid empty extraction payload (``{"entities": [], "relationships":
+[]}``) so khora's extraction pipeline succeeds on the first attempt —
+a non-JSON default would send every ingest through 3 tenacity retries
+with ~6s of backoff sleeps and an ERROR log per document.
 
 Usage in an ``example.py``::
 
@@ -25,6 +28,11 @@ import sys
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
+
+# Parses as a flat-format extraction response: zero entities, zero
+# relationships, no retries. Harmless for non-extraction call sites
+# (HyDE, routing), which only need *some* completion text.
+DEFAULT_RESPONSE = '{"entities": [], "relationships": []}'
 
 
 def _hash_to_unit_vector(text: str, dim: int) -> list[float]:
@@ -115,7 +123,7 @@ class MockLLM:
     """Cycles through stub completions and produces hashed embeddings."""
 
     def __init__(self, responses: Sequence[str] | None = None, dim: int = 1536) -> None:
-        self._responses: list[str] = list(responses) if responses else ["stub response"]
+        self._responses: list[str] = list(responses) if responses else [DEFAULT_RESPONSE]
         if not self._responses:
             raise ValueError("MockLLM requires at least one response")
         self._dim = dim
@@ -177,8 +185,8 @@ def install_mock_llm(
         monkeypatch: pytest ``MonkeyPatch`` fixture. If provided, patches
             are scoped to the test. If ``None``, patches are applied
             globally (suitable for ``example.py`` scripts).
-        responses: completion strings to cycle through. Default ``["stub
-            response"]``.
+        responses: completion strings to cycle through. Default
+            ``[DEFAULT_RESPONSE]`` (a valid empty extraction payload).
         dim: embedding dimension. Default 1536 (matches text-embedding-3-small).
 
     Returns:
@@ -198,17 +206,23 @@ def install_mock_llm(
         monkeypatch.setattr(litellm, "completion", mock.completion)
         monkeypatch.setattr(litellm, "embedding", mock.embedding)
     else:
+        originals = {
+            sym: getattr(litellm, sym, None) for sym in ("acompletion", "aembedding", "completion", "embedding")
+        }
         litellm.acompletion = mock.acompletion  # type: ignore[assignment]
         litellm.aembedding = mock.aembedding  # type: ignore[assignment]
         litellm.completion = mock.completion  # type: ignore[assignment]
         litellm.embedding = mock.embedding  # type: ignore[assignment]
-        # Some khora call sites import these as module-level symbols; refresh.
+        # Refresh held references: any module that did ``from litellm
+        # import completion`` (CrewAI's analyze step does) keeps the
+        # original function object, so patching the litellm module alone
+        # is not enough. Replace by identity across all loaded modules.
         for module_name in list(sys.modules):
             module = sys.modules[module_name]
-            if module is None or not module_name.startswith(("khora.", "litellm")):
+            if module is None:
                 continue
-            for sym in ("acompletion", "aembedding", "completion", "embedding"):
-                if getattr(module, sym, None) is not None and module_name.startswith("litellm"):
+            for sym, original in originals.items():
+                if original is not None and getattr(module, sym, None) is original:
                     setattr(module, sym, getattr(mock, sym))
 
     return mock

--- a/examples/integrations/crewai/example.py
+++ b/examples/integrations/crewai/example.py
@@ -34,7 +34,16 @@ async def _main() -> None:
             importance=0.6,
         )
 
-        matches = memory.recall("which database did we pick?", limit=3)
+        # Verbatim recall: the mock LLM's hash-derived embeddings only
+        # score an exact text match (cosine 1.0); a paraphrased query
+        # like "which database did we pick?" lands near zero and falls
+        # below the adapter's similarity floor. A real embedder handles
+        # semantic queries.
+        matches = memory.recall("We decided to use PostgreSQL for the user database.", limit=3)
+        assert matches, "expected recall to return at least one match"
+        assert any("PostgreSQL" in match.record.content for match in matches), (
+            "expected the PostgreSQL decision to be recalled"
+        )
         for match in matches:
             print(f"[{match.score:.2f}] {match.record.content}")
 

--- a/examples/integrations/google_adk/example.py
+++ b/examples/integrations/google_adk/example.py
@@ -75,6 +75,7 @@ async def main() -> None:
             user_id="example-user-1234",
             query="which database did we pick?",
         )
+        assert response.memories, "expected search_memory to recover the session events"
         print(f"Recovered {len(response.memories)} memory entries:")
         for entry in response.memories:
             text = " ".join(part.text for part in (entry.content.parts or []) if part.text)

--- a/examples/integrations/hermes/example.py
+++ b/examples/integrations/hermes/example.py
@@ -17,9 +17,8 @@ Lifecycle exercised: ``initialize`` → ``queue_prefetch`` → ``sync_turn``
 ``handle_tool_call("memory_search")`` (blocking dispatch, real result)
 → ``on_pre_compress`` → ``on_session_end`` (drain) → ``shutdown``.
 
-Kept light (3 turns) to fit the 30s CI smoke budget - every
-``sync_turn`` triggers a full extraction pipeline that retries 3× on
-the mock LLM's non-JSON output.
+Kept light (3 turns) to fit the CI smoke budget - every ``sync_turn``
+still runs the full extraction pipeline against the mock LLM.
 """
 
 from __future__ import annotations
@@ -113,10 +112,22 @@ async def main() -> None:
         # 6) Tool dispatch is the blocking path - the LLM is already
         #    waiting on a tool result so we serve real data. The
         #    runtime FIFO ensures the writes drain before recall runs.
+        #    The query repeats turn 1 verbatim (sync_turn embeds
+        #    "USER: ...\n\nASSISTANT: ..."): the mock LLM's hash-derived
+        #    embeddings only score an exact text match (cosine 1.0), and
+        #    a paraphrase would fall below the tool's 0.1 similarity
+        #    floor. A real embedder handles semantic queries.
         result = provider.handle_tool_call(
             "memory_search",
-            {"query": "Phoenix database", "top_k": 3},
+            {
+                "query": (
+                    "USER: Alice picked PostgreSQL for the Phoenix database.\n\n"
+                    "ASSISTANT: Got it - PostgreSQL for Phoenix."
+                ),
+                "top_k": 3,
+            },
         )
+        assert "Phoenix" in result, "expected memory_search to surface the ingested turns"
         print("--- memory_search tool call (blocking dispatch) ---")
         print(result.strip())
 

--- a/examples/integrations/langgraph/example.py
+++ b/examples/integrations/langgraph/example.py
@@ -49,9 +49,11 @@ async def main() -> None:
 
         item = await store.aget(("memories",), "note-1")
         assert item is not None
+        assert item.value["text"] == "the sky is blue today"
         print(f"Stored memory: {item.value['text']!r}")
 
         namespaces = await store.alist_namespaces()
+        assert namespaces, "expected the write to register a namespace"
         print(f"Namespaces in store: {namespaces}")
 
 

--- a/examples/integrations/llamaindex/example.py
+++ b/examples/integrations/llamaindex/example.py
@@ -50,6 +50,8 @@ async def main() -> None:
         # Verbatim recall: the mock LLM's hash-derived embeddings give
         # an exact match (cosine = 1.0) for the stored text.
         nodes = await retriever.aretrieve(memory_one)
+        assert nodes, "expected verbatim recall to return results"
+        assert any(memory_one in node.node.text for node in nodes), "expected the stored text to be retrieved verbatim"
         for node in nodes:
             text = node.node.text.replace("\n", " ")
             print(f"[{node.score:.2f}] {text}")

--- a/examples/integrations/openai_agents/example.py
+++ b/examples/integrations/openai_agents/example.py
@@ -12,8 +12,8 @@ adapter exposes directly: ``KhoraSession`` (SessionABC contract),
 (RunHooks-shaped). Each is what an ``Agent`` would call into.
 
 Kept deliberately small (single ``add_items`` write) so it finishes
-well under the 30s CI smoke budget - every khora write triggers a full
-extraction pipeline that retries 3x on the mock LLM's non-JSON output.
+well under the CI smoke budget - every khora write still runs the full
+extraction pipeline against the mock LLM.
 """
 
 from __future__ import annotations
@@ -45,10 +45,12 @@ async def main() -> None:
 
         # 1) Session - one turn is enough to demonstrate the SessionABC
         #    contract. Every khora write runs full extraction, so we keep
-        #    the example light to fit the 30s CI smoke budget.
+        #    the example light to fit the CI smoke budget.
         session = KhoraSession(kb=kb, namespace=ns_id, session_id="example-conv-1")
         await session.add_items([{"role": "user", "content": "We picked PostgreSQL for the user DB."}])
         items = await session.get_items()
+        assert len(items) == 1, "expected the session to round-trip exactly one item"
+        assert items[-1]["content"] == "We picked PostgreSQL for the user DB."
         print(f"Session has {len(items)} item(s); latest: {items[-1]['content']!r}")
 
         # 2) Recall tool - closes over (kb, namespace, top_k). Construction


### PR DESCRIPTION
## Summary
- Fixes #1099. Review of the examples-smoke job found the examples assert nothing, every ingest burns ~6s in extraction retry sleeps against the mock LLM's non-JSON default, and the first `recall()` downloads the cross-encoder reranker from HF Hub (~26s, unauthenticated → rate-limit prone). Together these put google_adk at ~51s of the 60s budget and caused the #1083 timeout flake at 60.08s.
- `examples/_helpers/mock_llm.py`: default completion is now a valid empty extraction payload (`{"entities": [], "relationships": []}`) so extraction succeeds first-attempt — no tenacity backoff sleeps, no `JSON parse error` / `Multi-extraction failed` log noise. The module-refresh loop now re-patches held references by identity across all loaded modules (the previous `khora.` prefix branch was dead code and non-litellm modules were never covered).
- `examples/_helpers/khora_fixtures.py`: `embedded_khora` disables cross-encoder reranking — the examples demonstrate adapter wiring, not ranking quality, and the HF Hub download was both the bulk of the wall time and a network flake source.
- Every example now asserts on its results instead of just printing. This immediately exposed that the crewai example's recall has returned zero matches in every CI run: hash-derived mock embeddings score near-zero (often negative) for paraphrased queries, and the adapter's 0.0 similarity floor drops them. crewai and hermes now recall verbatim text (cosine 1.0), the pattern the llamaindex example already documented; hermes additionally has a 0.1 floor on `memory_search`.
- `docs/integrations/*.md` snippets re-synced byte-identical (drift gate green), stale 30s-budget comments in `ci.yml` and `CLAUDE.md` refreshed.

Observed locally: google_adk ~51s → ~20s, crewai ~24s → ~5s, all six examples pass with assertions enabled.

## Test plan
- `uv run python tools/check_examples_drift.py` — 6 snippets byte-identical.
- All six examples run green locally via the CI smoke invocation (`PYTHONPATH=$REPO uv run --directory examples/integrations/<name> python example.py`), each well under the 60s budget.
- `uv run pytest tests/integration/integrations/ tests/unit/tools/test_examples_helpers.py` — 10 passed, 2 skipped (env-gated combos).
- `ruff check` / `ruff format --check` clean on changed files.