### PR TITLE
Stub entity extraction in chronicle recall-filter tests

### DIFF
--- a/tests/recall/test_filter_chronicle.py
+++ b/tests/recall/test_filter_chronicle.py
@@ -78,6 +78,7 @@ except ImportError:
 
 from khora.config import KhoraConfig
 from khora.config.schema import SQLiteLanceConfig
+from khora.extraction.extractors.base import ExtractionResult
 from khora.extraction.skills import ExpertiseConfig
 from khora.extraction.skills.base import EventExtractionConfig, FactExtractionConfig
 from khora.filter import telemetry as filter_telemetry
@@ -130,6 +131,38 @@ def _patch_embedder(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "khora.extraction.embedders.litellm.LiteLLMEmbedder.embed",
         _stub_embed,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entity-extraction stub — no OPENAI_API_KEY required.
+# ---------------------------------------------------------------------------
+#
+# Every ``remember`` here passes ``entity_types=["PERSON"]`` /
+# ``relationship_types=["KNOWS"]``, so the ingest pipeline's ``extract_entities``
+# task calls ``LLMEntityExtractor.extract_multi`` — a LIVE LiteLLM call. Without
+# an API key each call retries with exponential backoff before degrading to zero
+# entities, which is slow and network-dependent. No test in this file asserts on
+# extracted entities (the corpus filters only on source_name / occurred_at /
+# metadata.tag), so stubbing the extractor to return empty results keeps these
+# tests hermetic and fast while leaving the filter-narrowing contract untouched.
+#
+# ``extract_multi`` is the method the pipeline calls; the consumer zips its result
+# one-to-one with the input chunks, so the stub returns exactly one empty
+# ``ExtractionResult`` per text. (Events/facts extraction is already disabled via
+# ``_no_event_fact_extraction()``, so the entity extractor is the only live LLM
+# extractor left to stub.)
+
+
+async def _stub_extract_multi(self: Any, texts: list[str], *args: Any, **kwargs: Any) -> list[ExtractionResult]:
+    return [ExtractionResult() for _ in texts]
+
+
+@pytest.fixture(autouse=True)
+def _patch_entity_extractor(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "khora.extraction.extractors.llm.LLMEntityExtractor.extract_multi",
+        _stub_extract_multi,
     )
 
 


### PR DESCRIPTION
## Summary
- The Chronicle recall-filter integration tests (`tests/recall/test_filter_chronicle.py`) passed `entity_types=["PERSON"]` / `relationship_types=["KNOWS"]` to every `remember()` call, which fired **live** LiteLLM entity extraction. With no API key configured, each call retried with exponential backoff before degrading to zero entities — roughly 6s per `remember()`, ~9.5 minutes across the file.
- No test in the file asserts on extracted entities (the corpus narrows only on `source_name`, `occurred_at`, and `metadata.tag`). This adds an autouse fixture that stubs `LLMEntityExtractor.extract_multi` to return one empty `ExtractionResult` per chunk, mirroring the existing embedder stub (`_patch_embedder`).
- This removes the only remaining live-LLM path in the file — event/fact extraction was already disabled via the per-test expertise config — so the suite is now fully hermetic. The 7 `remember()` call sites are unchanged, preserving the realistic call shape; only the extractor is intercepted.
- Net effect: file runtime drops from ~585s to ~8s with no change to any filter-narrowing assertion.

## Test plan
- [x] `env -u OPENAI_API_KEY uv run pytest tests/recall/test_filter_chronicle.py -p no:cacheprovider --no-cov -q` → **12 passed in ~7s** (was ~585s), `OPENAI_API_KEY` unset to prove no live LLM call occurs
- [x] `make format` clean, `make lint` exit 0 (no new diagnostics in the changed file)
- [ ] CI `test-unit` job green

Fixes #1101