### PR TITLE
Run hermetic security signature tests in the CI unit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,8 +287,11 @@ jobs:
         # ``slow`` marker (excluded by the default ``-m "not slow ..."`` addopts)
         # AND a reachability self-skip, so they collect and skip cleanly with no
         # services. The dedicated slow/e2e job for the live lanes is a follow-up.
+        #
+        # tests/security/ holds the hermetic cross-namespace IDOR signature gate —
+        # collection-time, ``inspect``-only, no services.
         run: |
-          uv run pytest tests/unit/ tests/recall/ tests/e2e/ -m "not slow and not filter_conformance" --cov=src/khora --cov-branch --cov-report=xml:coverage-unit.xml --cov-fail-under=0 -n auto --timeout=120 --timeout-method=thread
+          uv run pytest tests/unit/ tests/recall/ tests/e2e/ tests/security/ -m "not slow and not filter_conformance" --cov=src/khora --cov-branch --cov-report=xml:coverage-unit.xml --cov-fail-under=0 -n auto --timeout=120 --timeout-method=thread
 
       - name: Generate JSON coverage for floor check
         run: uv run coverage json -o coverage.json

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ test: test-unit test-integration
 # is fully hermetic — no Postgres needed; collect it here so the filter tests gate.
 # The live-pg row-narrowing proof lives in the filter-conformance corpus (its own job).
 test-unit:
-	uv run pytest tests/unit/ tests/recall/ --cov=src/khora --cov-branch --cov-report= --cov-fail-under=0 -n auto
+	uv run pytest tests/unit/ tests/recall/ tests/security/ --cov=src/khora --cov-branch --cov-report= --cov-fail-under=0 -n auto
 
 # Run integration tests serial; appends to .coverage from test-unit and emits the report.
 test-integration:


### PR DESCRIPTION
## Summary
- `tests/security/` holds a single hermetic module that asserts every concrete storage-backend read/write/delete method declares `namespace_id` (the cross-namespace IDOR invariant). It is a collection-time, `inspect`-only signature gate with no database or service dependencies.
- No CI workflow collected it: every pytest invocation used explicit paths (`tests/unit/ tests/recall/ tests/e2e/`, `tests/integration/`) and none referenced `tests/security/`. It only ran under bare local `pytest` via `testpaths`. A new backend method missing `namespace_id` would therefore merge green, defeating the gate's purpose.
- Add `tests/security/` to the unit-test job's "Run unit tests with coverage (parallel)" pytest path list in `.github/workflows/ci.yml`, keeping every other flag unchanged, plus a comment noting it is the hermetic IDOR signature gate (no services).
- Add `tests/security/` to the `Makefile` `test-unit` target so the gate runs locally with the same scope.
- No changes to other workflows or any test source files.

## Test plan
- [x] `uv run pytest tests/security/ --no-cov` collects and passes with no services running (29 passed).
- [x] `git diff` touches only `.github/workflows/ci.yml` and `Makefile`; all other pytest flags byte-identical.
- [ ] CI unit job log shows tests from `tests/security/test_cross_namespace_idor_signatures.py` collected and passing.