### PR TITLE
Bound entity extraction so it cannot hang on truncated-output recovery

### DIFF
--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
@@ -16,7 +18,7 @@ from tenacity import (
     wait_exponential,
 )
 
-from khora.config.llm import get_shared_session, llm_call_timeout
+from khora.config.llm import DEFAULT_LLM_TIMEOUT_S, get_shared_session, llm_call_timeout
 from khora.extraction.embedders._request_telemetry import (
     parse_rate_limit_headers,
     set_connector_attributes,
@@ -103,6 +105,19 @@ _MISSING_CREDENTIAL_SIGNALS = (
     "could not resolve auth",
     "authentication",
 )
+
+
+def _is_retryable_extraction_exc(exc: BaseException) -> bool:
+    """Retry predicate for extraction LLM calls (used by ``AsyncRetrying``).
+
+    Never retry cancellation or a timeout: a retried ``CancelledError`` would
+    defeat any surrounding ``asyncio`` deadline (the call is re-attempted instead
+    of unwinding) — exactly how the #1113 hang survived #1059's per-call
+    ``asyncio.wait_for``. Also never retry deterministic auth/credential failures.
+    """
+    if isinstance(exc, (asyncio.CancelledError, TimeoutError)):
+        return False
+    return not _is_nonretryable_auth_error(exc)
 
 
 def _is_nonretryable_auth_error(exc: BaseException) -> bool:
@@ -809,6 +824,67 @@ class LLMEntityExtractor(EntityExtractor):
             retry_wait=config.retry_wait,
         )
 
+    @asynccontextmanager
+    async def _acquire_slot(self) -> AsyncIterator[None]:
+        """Acquire the shared concurrency semaphore under a wall-clock deadline.
+
+        ``self._semaphore`` is shared process-wide across concurrent documents (one
+        ``shared_extractor``). ``asyncio.Semaphore.acquire()`` has no timeout, so a
+        permit held by a wedged call could otherwise park every other extraction
+        coroutine forever — the per-call ``asyncio.wait_for`` only bounds the
+        network call *inside* the slot, never the acquire itself. See #1113.
+        """
+        deadline = llm_call_timeout(self._timeout) or DEFAULT_LLM_TIMEOUT_S
+        await asyncio.wait_for(self._semaphore.acquire(), deadline)
+        try:
+            yield
+        finally:
+            self._semaphore.release()
+
+    def _batch_deadline(self, batch_size: int) -> float:
+        """Aggregate wall-clock BACKSTOP (seconds) for processing one batch.
+
+        Coarse backstop, NOT a tight bound — the primary per-call deadline is
+        enforced by ``_bounded_acompletion``. Sized generously so it does not fire
+        during legitimate work: the dominant cost is the single-doc fallback (up to
+        ``batch_size`` sequential ``self.extract()`` calls, each retrying up to
+        ``max_retries`` times), so a degraded-but-progressing backend is not killed
+        mid-fallback (which would discard its completed work). See #1113.
+        """
+        per_call = llm_call_timeout(self._timeout) or DEFAULT_LLM_TIMEOUT_S
+        return per_call * (batch_size + 1) * max(1, self._max_retries)
+
+    @staticmethod
+    def _abandon_task(task: asyncio.Task[Any]) -> None:
+        """Detach a timed-out litellm task so its eventual outcome is retrieved
+        (silences 'Task exception was never retrieved'). The task is never awaited:
+        an uncancellable call must not be allowed to block the caller's teardown."""
+
+        def _drain(t: asyncio.Task[Any]) -> None:
+            if not t.cancelled():
+                t.exception()
+
+        task.add_done_callback(_drain)
+
+    async def _bounded_acompletion(self, coro: Any, deadline: float | None) -> Any:
+        """Await a ``litellm.acompletion`` coroutine under a hard wall-clock deadline.
+
+        ``asyncio.wait_for``/``asyncio.timeout`` cannot free a coroutine stuck in an
+        await that ignores cancellation (e.g. a half-open socket whose teardown
+        blocks), and the surrounding tenacity loop must not retry that cancellation.
+        Run the call as a *shielded* task; on the deadline, cancel it best-effort and
+        ABANDON it — never await its teardown — so the caller always regains control
+        within ``deadline``. Behaves like ``asyncio.wait_for(coro, deadline)``
+        otherwise. See #1113.
+        """
+        task: asyncio.Task[Any] = asyncio.ensure_future(coro)
+        try:
+            return await asyncio.wait_for(asyncio.shield(task), deadline or DEFAULT_LLM_TIMEOUT_S)
+        except (TimeoutError, asyncio.CancelledError):
+            task.cancel()
+            self._abandon_task(task)
+            raise
+
     async def extract(
         self,
         text: str,
@@ -854,7 +930,7 @@ class LLMEntityExtractor(EntityExtractor):
 
         try:
             async for attempt in AsyncRetrying(
-                retry=retry_if_exception(lambda e: not _is_nonretryable_auth_error(e)),
+                retry=retry_if_exception(_is_retryable_extraction_exc),
                 stop=stop_after_attempt(self._max_retries) | stop_after_delay(180),
                 wait=wait_exponential(multiplier=self._retry_wait, min=self._retry_wait, max=10),
                 before_sleep=lambda retry_state: logger.warning(
@@ -874,7 +950,7 @@ class LLMEntityExtractor(EntityExtractor):
                 reraise=True,
             ):
                 with attempt:
-                    async with self._semaphore:
+                    async with self._acquire_slot():
                         import time as _time
 
                         from khora.telemetry import get_collector, trace_span
@@ -886,7 +962,7 @@ class LLMEntityExtractor(EntityExtractor):
 
                         with trace_span("khora.extraction.llm_call", model=self._model, call_type="single") as llm_span:
                             set_connector_attributes(llm_span, get_shared_session())
-                            response = await asyncio.wait_for(
+                            response = await self._bounded_acompletion(
                                 litellm.acompletion(
                                     model=self._model,
                                     messages=[
@@ -970,7 +1046,10 @@ class LLMEntityExtractor(EntityExtractor):
                     return result
         except Exception as e:
             logger.error(f"Extraction failed after {self._max_retries} attempts: {e}")
-            return ExtractionResult(metadata={"error": str(e)})
+            # `str(e) or type(e).__name__`: a bare TimeoutError has an empty str(),
+            # which is falsy and would defeat the fail-loud/breaker/fallback checks
+            # that test `metadata.get("error")` for truthiness (#1113).
+            return ExtractionResult(metadata={"error": str(e) or type(e).__name__})
 
     @staticmethod
     def _should_run_second_pass(result: ExtractionResult) -> bool:
@@ -1028,7 +1107,7 @@ class LLMEntityExtractor(EntityExtractor):
         )
 
         try:
-            async with self._semaphore:
+            async with self._acquire_slot():
                 import time as _time
 
                 from khora.telemetry import get_collector, trace_span
@@ -1038,7 +1117,7 @@ class LLMEntityExtractor(EntityExtractor):
                     "khora.extraction.llm_call", model=self._model, call_type="relationship_second_pass"
                 ) as llm_span:
                     set_connector_attributes(llm_span, get_shared_session())
-                    response = await asyncio.wait_for(
+                    response = await self._bounded_acompletion(
                         litellm.acompletion(
                             model=self._model,
                             messages=[
@@ -1583,7 +1662,7 @@ class LLMEntityExtractor(EntityExtractor):
         # _consecutive_batch_failures is an instance attribute so it persists across
         # extract_batch invocations, making the circuit breaker actually reachable.
 
-        async def _run_batch(batch: list[str]) -> list[ExtractionResult]:
+        async def _run_batch_inner(batch: list[str]) -> list[ExtractionResult]:
             # Circuit breaker tripped — go straight to single-doc extraction
             if self._consecutive_batch_failures >= self._BATCH_FAILURE_THRESHOLD and len(batch) > 1:
                 logger.warning(
@@ -1675,6 +1754,29 @@ class LLMEntityExtractor(EntityExtractor):
                 results = [self._filter_by_confidence(r, expertise) for r in results]
             return results
 
+        async def _run_batch(batch: list[str]) -> list[ExtractionResult]:
+            # #1113: coarse aggregate backstop over the whole batch (bisection
+            # gather + floor + fallback + slot acquire). The per-call
+            # _bounded_acompletion is the primary bound; this catches anything that
+            # escapes it. On expiry, fail the batch and continue.
+            budget = self._batch_deadline(len(batch))
+            breaker_before = self._consecutive_batch_failures
+            try:
+                async with asyncio.timeout(budget):
+                    return await _run_batch_inner(batch)
+            except TimeoutError:
+                logger.error(
+                    "Batch extraction exceeded wall-clock budget ({:.0f}s) for {} texts "
+                    "(#1113 guard); marking batch failed and continuing",
+                    budget,
+                    len(batch),
+                )
+                # Count this timed-out batch as exactly ONE consecutive failure, even
+                # if _run_batch_inner already incremented before the deadline fired —
+                # double-counting would trip the breaker after a single batch.
+                self._consecutive_batch_failures = breaker_before + 1
+                return [ExtractionResult(metadata={"error": "extraction_timeout"}) for _ in batch]
+
         # Process batches in waves: concurrent within each wave, circuit breaker
         # checked between waves.  This restores most of the throughput of the
         # original asyncio.gather() while letting the breaker trip before the
@@ -1695,7 +1797,11 @@ class LLMEntityExtractor(EntityExtractor):
                 all_results.extend(results)
 
         error_count = sum(1 for r in all_results if r.metadata.get("error"))
-        logger.debug(
+        # Fail loud: surface failed/timed-out documents at WARNING so a degraded
+        # run is visible (and countable) rather than silently producing empty
+        # extraction — see #1113 (behaviour: mark + log + count, continue).
+        _log = logger.warning if error_count else logger.debug
+        _log(
             "Extraction complete: {} results ({} errors) from {} texts in {} batches",
             len(all_results),
             error_count,
@@ -1778,7 +1884,7 @@ Return ONLY valid JSON, no other text."""
 
         try:
             async for attempt in AsyncRetrying(
-                retry=retry_if_exception(lambda e: not _is_nonretryable_auth_error(e)),
+                retry=retry_if_exception(_is_retryable_extraction_exc),
                 stop=stop_after_attempt(self._max_retries) | stop_after_delay(180),
                 wait=wait_exponential(multiplier=self._retry_wait, min=self._retry_wait, max=10),
                 before_sleep=lambda retry_state: logger.warning(
@@ -1798,7 +1904,7 @@ Return ONLY valid JSON, no other text."""
                 reraise=True,
             ):
                 with attempt:
-                    async with self._semaphore:
+                    async with self._acquire_slot():
                         import time as _time
 
                         from khora.telemetry import get_collector, trace_span
@@ -1811,7 +1917,7 @@ Return ONLY valid JSON, no other text."""
                             batch_size=len(texts),
                         ) as llm_span:
                             set_connector_attributes(llm_span, get_shared_session())
-                            response = await asyncio.wait_for(
+                            response = await self._bounded_acompletion(
                                 litellm.acompletion(
                                     model=self._model,
                                     messages=[
@@ -1945,7 +2051,9 @@ Return ONLY valid JSON, no other text."""
                     return results
         except Exception as e:
             logger.error(f"Multi-extraction failed after {self._max_retries} attempts: {e}")
-            return [ExtractionResult(metadata={"error": str(e)}) for _ in texts]
+            # str(e) or type name — a bare TimeoutError's empty str() is falsy and
+            # would be ignored by the truthiness-based error checks (#1113).
+            return [ExtractionResult(metadata={"error": str(e) or type(e).__name__}) for _ in texts]
 
     def _compute_entity_confidence(self, entity_data: dict[str, Any]) -> float:
         """Compute confidence score for an entity based on extraction quality heuristics.

--- a/tests/unit/test_extraction_hang_guards.py
+++ b/tests/unit/test_extraction_hang_guards.py
@@ -1,0 +1,166 @@
+"""Regression guards for the #1113 extraction hang.
+
+The per-call ``asyncio.wait_for`` added in #1059 bounds only ``litellm.acompletion``;
+it does NOT cover the bisection ``asyncio.gather`` fan-out or the shared-semaphore
+acquire, so a wedged child or a starved permit could still hang the run forever.
+These tests pin the new aggregate-deadline / bounded-acquire guards.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from khora.config.llm import llm_call_timeout
+from khora.extraction.extractors.base import ExtractionResult
+from khora.extraction.extractors.llm import (
+    LLMEntityExtractor,
+    _is_retryable_extraction_exc,
+)
+
+
+def test_retry_predicate_never_retries_cancellation_or_timeout() -> None:
+    """tenacity must NOT retry cancellation/timeout — retrying a CancelledError
+    would defeat any surrounding asyncio deadline and reintroduce the hang."""
+    assert _is_retryable_extraction_exc(asyncio.CancelledError()) is False
+    assert _is_retryable_extraction_exc(TimeoutError()) is False  # == asyncio.TimeoutError in 3.11+
+    # A generic transient error is still retryable.
+    assert _is_retryable_extraction_exc(ValueError("transient")) is True
+
+
+def test_batch_deadline_is_finite_and_scales_with_depth() -> None:
+    ext = LLMEntityExtractor(model="test-model", timeout=60)
+    d1 = ext._batch_deadline(1)
+    d4 = ext._batch_deadline(4)
+    d8 = ext._batch_deadline(8)
+    assert 0 < d1 < d4 < d8 < float("inf")
+
+
+def test_extraction_guards_finite_even_with_nonpositive_timeout() -> None:
+    """``llm_call_timeout`` returns None for a non-positive timeout (a latent
+    footgun in the shared helper), but the extraction guards defend locally with
+    ``or DEFAULT_LLM_TIMEOUT_S`` so the aggregate ceiling is never disabled."""
+    assert llm_call_timeout(0) is None  # shared-helper footgun (out of scope here)
+    ext = LLMEntityExtractor(model="test-model")
+    ext._timeout = 0
+    assert 0 < ext._batch_deadline(4) < float("inf")  # guard stays finite anyway
+
+
+@pytest.mark.asyncio
+async def test_acquire_slot_times_out_when_starved(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A held permit must not let a sibling park forever on ``acquire()``."""
+    monkeypatch.setattr("khora.config.llm._LLM_DEADLINE_GRACE_S", 0.0)
+    ext = LLMEntityExtractor(model="test-model", max_concurrent=1)
+    ext._timeout = 0.1  # acquire deadline ~= llm_call_timeout(0.1) = 0.1s
+    await ext._semaphore.acquire()  # exhaust the only permit
+    try:
+        t0 = time.monotonic()
+        with pytest.raises(asyncio.TimeoutError):
+            async with ext._acquire_slot():
+                pass
+        assert time.monotonic() - t0 < 2.0  # bounded — did not park forever
+    finally:
+        ext._semaphore.release()
+
+
+@pytest.mark.asyncio
+async def test_extract_batch_aggregate_deadline_fires(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the inner multi-batch call stalls, the per-batch aggregate deadline must
+    fire, mark the batch failed, and return — never hang (#1113)."""
+    monkeypatch.setattr("khora.config.llm._LLM_DEADLINE_GRACE_S", 0.0)
+    ext = LLMEntityExtractor(model="test-model", timeout=1)
+    ext._timeout = 0.2  # small per-batch budget
+
+    async def _stall(*_args: object, **_kwargs: object) -> list:
+        await asyncio.sleep(60)
+        return []
+
+    monkeypatch.setattr(ext, "_extract_multi_batch", _stall)
+
+    # Must exceed the tier1 regex threshold (20 chars) so they route to the LLM path.
+    texts = [
+        "Alice met Bob in Paris last summer to discuss the company merger deal.",
+        "The Acme Corporation acquired Globex in a landmark technology transaction.",
+    ]
+    t0 = time.monotonic()
+    # Outer wait_for is a test safety net; the guard should fire long before it.
+    results = await asyncio.wait_for(ext.extract_batch(texts), timeout=10)
+    elapsed = time.monotonic() - t0
+
+    assert elapsed < 8.0, f"extract_batch did not return promptly ({elapsed:.1f}s)"
+    assert len(results) == len(texts)
+    assert any(r.metadata.get("error") == "extraction_timeout" for r in results)
+
+
+@pytest.mark.asyncio
+async def test_extract_batch_survives_uncancellable_acompletion(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The real #1113 shape: the underlying litellm call IGNORES the deadline's
+    cancellation (half-open socket). `_bounded_acompletion` must still return control
+    to the caller within the deadline by abandoning the task, and tenacity must not
+    turn the resulting cancel into a retry — so extract_batch returns, never hangs.
+    """
+    import litellm
+
+    monkeypatch.setattr("khora.config.llm._LLM_DEADLINE_GRACE_S", 0.0)
+    ext = LLMEntityExtractor(model="test-model", timeout=1)
+    ext._timeout = 0.2  # per-call deadline ~0.2s
+
+    async def _swallows_deadline_cancel(*_a: object, **_k: object) -> None:
+        # Models an await whose cancellation teardown does not return promptly.
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            await asyncio.sleep(0.05)  # ignore the deadline's cancel, finish shortly
+            return None  # caller has already abandoned us; value is irrelevant
+
+    monkeypatch.setattr(litellm, "acompletion", _swallows_deadline_cancel)
+
+    texts = [
+        "Alice met Bob in Paris last summer to discuss the company merger deal.",
+        "The Acme Corporation acquired Globex in a landmark technology transaction.",
+    ]
+    t0 = time.monotonic()
+    results = await asyncio.wait_for(
+        ext.extract_batch(texts, entity_types=["PERSON", "ORGANIZATION"]),
+        timeout=10,
+    )
+    elapsed = time.monotonic() - t0
+
+    assert elapsed < 8.0, f"extract_batch hung on an uncancellable call ({elapsed:.1f}s)"
+    assert len(results) == len(texts)
+    # Failed extraction, not a hang — every doc is marked with a TRUTHY error so
+    # the fail-loud summary, circuit breaker, and fallback all see it (not the
+    # silently-empty {'error': ''} that round 2 caught). And no entities leaked.
+    assert all(not r.entities for r in results)
+    assert all(r.metadata.get("error") for r in results), "timed-out docs must carry a truthy error"
+    await asyncio.sleep(0.1)  # let the abandoned task finish before loop teardown
+
+
+@pytest.mark.asyncio
+async def test_timeout_during_fallback_increments_breaker_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the aggregate batch budget fires DURING the single-doc fallback, the
+    circuit breaker must move by exactly ONE for the batch — not twice (the inner
+    all-failed branch + the outer timeout handler). #1113."""
+    monkeypatch.setattr("khora.config.llm._LLM_DEADLINE_GRACE_S", 0.0)
+    ext = LLMEntityExtractor(model="test-model", timeout=1, max_retries=1)
+    ext._timeout = 0.3  # budget = per_call*(batch+1)*max_retries = 0.3*3*1 = 0.9s
+
+    async def _all_error(batch: list[str], *_a: object, **_k: object) -> list[ExtractionResult]:
+        # All-failed (truthy error) → inner branch bumps the breaker + runs fallback.
+        return [ExtractionResult(metadata={"error": "boom"}) for _ in batch]
+
+    async def _slow_extract(*_a: object, **_k: object) -> ExtractionResult:
+        await asyncio.sleep(60)  # stall the fallback so the aggregate budget fires
+        return ExtractionResult()
+
+    monkeypatch.setattr(ext, "_extract_multi_batch", _all_error)
+    monkeypatch.setattr(ext, "extract", _slow_extract)
+
+    before = ext._consecutive_batch_failures
+    texts = ["a" * 24, "b" * 24]  # > tier1 threshold → LLM path
+    results = await asyncio.wait_for(ext.extract_batch(texts), timeout=10)
+
+    assert len(results) == len(texts)
+    assert ext._consecutive_batch_failures == before + 1, "breaker must increment exactly once per batch"


### PR DESCRIPTION
## Summary

Fixes #1113. Follow-up to #1059. That PR wrapped every `litellm.acompletion` in `asyncio.wait_for`, but extraction could **still hang indefinitely** in the truncation→bisection path (process alive, zero progress). The deadline was **mis-scoped, not missing**:

- `asyncio.wait_for` bounds only the network call — not the bisection `asyncio.gather(...)` fan-out, nor the shared `asyncio.Semaphore` **acquire** (`async with self._semaphore:` is entered *outside* the `wait_for`; `Semaphore.acquire()` has no timeout). One wedged permit-holder, across a single extractor shared by many concurrent documents, parks every sibling on `acquire()`.
- The calls run inside a tenacity `AsyncRetrying` loop whose predicate matched `CancelledError`, so a deadline's cancellation was *retried* instead of propagating.
- The aiohttp transport builds its per-request `ClientTimeout` with no `total` (only `sock_read`), so a half-open socket is never cancelled at the transport layer — and `asyncio.wait_for` / `asyncio.timeout` cannot free a coroutine stuck in an await that ignores cancellation.

## Changes

- Exclude `CancelledError` / `TimeoutError` from the extraction retry predicate so a deadline propagates instead of being retried.
- `_bounded_acompletion`: run each `litellm.acompletion` as a shielded task and abandon it on the per-call deadline — bounds even an await that ignores cancellation.
- `_acquire_slot`: bound the shared-semaphore acquire under a wall-clock deadline.
- A coarse aggregate per-batch backstop with idempotent failure accounting.
- A timed-out document is marked failed (truthy, countable error), logged + counted, and the run continues instead of producing silently-empty output.

## Test plan

`tests/unit/test_extraction_hang_guards.py`: the retry predicate never retries cancellation/timeout; `extract_batch` returns within budget when `litellm.acompletion` swallows cancellation (the real hang shape); the semaphore acquire times out when starved; the aggregate budget fires on a stalled inner call; the breaker increments exactly once per timed-out batch. Locally these + `test_extraction_llm.py` + `test_llm_call_timeout.py` pass; `ruff` clean. Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)