### PR TITLE
Fail loud on recall filters over unbacked SurrealDB system keys

### DIFF
--- a/docs/engines/skeleton-engine.md
+++ b/docs/engines/skeleton-engine.md
@@ -493,6 +493,21 @@ results = await engine.recall(query, namespace_id=ns_id, mode=SearchMode.HYBRID)
 # Use VectorCypher engine for graph-based queries
 ```
 
+### Deterministic recall filters
+
+The deterministic recall-filter API (the `filter_ast` argument to the backend
+`search`) is supported on the SurrealDB backend, but only over the system keys the
+`temporal_chunk` table backs with a real column: the two datetime keys
+`occurred_at` and `created_at`, plus any `metadata.<path>`. The other eight system
+keys (`source_name`, `source_type`, `source_url`, `source_timestamp`,
+`external_id`, `content_type`, `source`, `title`) are denormalized document fields
+that are **not** columns on `temporal_chunk`. A filter on one of them RAISES
+`RecallFilterUnsupportedError` rather than silently returning nothing: on the
+SCHEMAFULL table the missing field reads as absent, and because SurrealQL's
+absent-compare is total-false (`NONE = x` → `false`) the predicate would drop every
+row. Failing loud surfaces the unsupported key instead of returning a quietly empty
+result set.
+
 ## Configuration
 
 ### Via KhoraConfig

--- a/src/khora/engines/skeleton/backends/surrealdb.py
+++ b/src/khora/engines/skeleton/backends/surrealdb.py
@@ -34,6 +34,7 @@ from khora.telemetry import trace, trace_span
 if TYPE_CHECKING:
     from khora.config import KhoraConfig
     from khora.config.schema import SurrealDBConfig
+    from khora.filter import CompileContext
     from khora.filter.ast import FilterNode
 
 
@@ -111,6 +112,41 @@ _LEGACY_RANGE_OPS: dict[str, Op] = {
 # ``(metadata_.<path> = $b)`` (no type-gate), preserving the equality semantics
 # callers depend on while no longer interpolating an unvalidated user key.
 _LEGACY_OPS: dict[str, Op] = {"eq": Op.EQ, **_LEGACY_RANGE_OPS}
+
+# The system keys this table backs with a real column — the single source of truth.
+# Of the ten ``SYSTEM_KEYS`` only these two are columns on ``temporal_chunk``
+# (``DEFINE FIELD occurred_at`` / ``created_at`` in ``_TEMPORAL_CHUNK_SCHEMA``); the
+# other eight denormalized document keys are not. The deterministic recall-filter
+# compiler reads the declared+pushable system keys off the compile context's
+# ``field_mapping`` (the same dual interpretation ``compile_weaviate`` uses), so a
+# filter on a system key absent here raises ``RecallFilterUnsupportedError`` rather
+# than emitting a predicate that silently drops every row (SurrealQL's absent-compare
+# is total-false). The conformance harness imports this set so its expectation never
+# drifts from the schema.
+_BACKED_SYSTEM_KEYS: frozenset[str] = frozenset({"occurred_at", "created_at"})
+
+
+def _filter_compile_context() -> CompileContext:
+    """Build the deterministic-filter :class:`CompileContext` for this backend.
+
+    The single source of truth for the SurrealDB store's recall-filter compile
+    context, shared by the vector (``_search_inner``) and BM25 (``search_fulltext``)
+    paths. ``field_mapping`` declares the two backed system keys (identity-mapped to
+    their bare columns) plus the ``metadata`` root remap to the physical
+    ``metadata_`` column; its key set is the compiler's declared+pushable whitelist,
+    so a filter on any other system key fails loud. ``on_unsupported="raise"`` because
+    the skeleton engine has no post-filter path — partial pushdown ("split") is never
+    consumed here. Imported lazily so the filter machinery stays off the no-filter
+    hot path.
+    """
+    from khora.filter import CompileContext
+
+    field_mapping = {key: key for key in _BACKED_SYSTEM_KEYS} | {"metadata": "metadata_"}
+    return CompileContext(
+        backend_target="temporal_chunk",
+        field_mapping=field_mapping,
+        on_unsupported="raise",
+    )
 
 
 class SurrealDBTemporalStore(TemporalVectorStore):
@@ -375,24 +411,17 @@ class SurrealDBTemporalStore(TemporalVectorStore):
         filter_clauses, filter_bindings = self._build_filter_clauses(namespace_id, temporal_filter)
 
         # Deterministic recall-filter AST: compile to a SurrealQL predicate and
-        # AND it into the shared clauses. ``field_mapping`` maps the ``metadata``
-        # root to the physical ``metadata_`` column so a metadata path descends
-        # natively; system keys map identity (the table stores them as bare
-        # columns). The compiler runs in on_unsupported="raise" mode — the
-        # skeleton engine has no post-filter path, so partial pushdown ("split")
-        # is never consumed here.
+        # AND it into the shared clauses via the shared compile context
+        # (:func:`_filter_compile_context`). Its ``field_mapping`` declares the two
+        # backed system keys (``occurred_at`` / ``created_at``) plus the ``metadata``
+        # → ``metadata_`` remap; the other eight system keys are not columns, so a
+        # filter on one raises ``RecallFilterUnsupportedError`` (on_unsupported=
+        # "raise" — the skeleton engine has no post-filter path) rather than emitting
+        # a predicate that silently matches nothing.
         if filter_ast is not None:
-            from khora.filter import CompileContext
             from khora.filter.compilers.surrealdb import compile_surrealdb
 
-            compiled = compile_surrealdb(
-                filter_ast,
-                CompileContext(
-                    backend_target="temporal_chunk",
-                    field_mapping={"metadata": "metadata_"},
-                    on_unsupported="raise",
-                ),
-            )
+            compiled = compile_surrealdb(filter_ast, _filter_compile_context())
             filter_clauses.append(compiled.predicate)
             filter_bindings.update(compiled.params)
 
@@ -519,21 +548,15 @@ class SurrealDBTemporalStore(TemporalVectorStore):
 
         # Deterministic recall-filter AST: compile to a SurrealQL predicate and
         # AND it into the shared clauses (mirrors the vector path in
-        # ``_search_inner``). ``field_mapping`` maps the ``metadata`` root to the
-        # physical ``metadata_`` column; ``on_unsupported="raise"`` because the
-        # skeleton engine has no post-filter path.
+        # ``_search_inner``) via the shared compile context
+        # (:func:`_filter_compile_context`) — the same declared backed-system-keys +
+        # ``metadata_`` field_mapping, ``on_unsupported="raise"``. A filter on a
+        # system key this table does not back with a column raises
+        # ``RecallFilterUnsupportedError`` here.
         if filter_ast is not None:
-            from khora.filter import CompileContext
             from khora.filter.compilers.surrealdb import compile_surrealdb
 
-            compiled = compile_surrealdb(
-                filter_ast,
-                CompileContext(
-                    backend_target="temporal_chunk",
-                    field_mapping={"metadata": "metadata_"},
-                    on_unsupported="raise",
-                ),
-            )
+            compiled = compile_surrealdb(filter_ast, _filter_compile_context())
             filter_clauses.append(compiled.predicate)
             filter_bindings.update(compiled.params)
 

--- a/src/khora/filter/compilers/surrealdb.py
+++ b/src/khora/filter/compilers/surrealdb.py
@@ -27,10 +27,24 @@ is already a property of SurrealQL's NONE-boolean algebra.
 **NONE vs NULL are distinct.** ``NONE`` is an absent path; ``NULL`` is an
 explicit JSON null value. A ``{k: null}`` match resolves to ``(p = NULL OR p IS
 NONE)``. On a METADATA path, ``$exists: true`` is ``(p IS NOT NONE)`` and
-``$exists: false`` is ``(p IS NONE)`` (real presence). On a SYSTEM key, ``$exists``
-is instead a CONSTANT (``true`` / ``false``) — a system key is treated as
-always-present (the oracle's axiom), so a presence test would diverge whenever the
-column is genuinely unset (an unwritten denormalized doc key reads NONE).
+``$exists: false`` is ``(p IS NONE)`` (real presence). On a *declared* SYSTEM key,
+``$exists`` is instead a CONSTANT (``true`` / ``false``) — a system key is treated
+as always-present (the oracle's axiom), so a presence test would diverge whenever
+the column is genuinely unset (an unwritten denormalized doc key reads NONE).
+
+**Only declared system keys are backed.** A backend declares the system keys it
+backs with a real column via ``ctx.field_mapping`` — its key set is the
+declared+pushable whitelist (the same dual interpretation
+:func:`~khora.filter.compilers.weaviate.compile_weaviate` uses). The live recall
+path declares only ``occurred_at`` / ``created_at`` (the two datetime columns on
+the ``temporal_chunk`` table); the other eight denormalized document system keys
+are NOT columns. A clause on an undeclared system key — every operator, ``$exists``
+included — is routed to :meth:`~_Builder._unsupported`: on the SCHEMAFULL table the
+missing field reads NONE, and SurrealQL's total-false absent-compare (``NONE = x`` →
+``false``) would silently drop every row, so the compiler fails loud
+(``on_unsupported="raise"`` raises :class:`RecallFilterUnsupportedError`; ``"split"``
+emits a non-constraining ``"true"`` and leaves it unconsumed for a post-filter)
+instead of emitting a predicate that quietly matches nothing.
 
 **Metadata equality / membership is array-aware.** A scalar ``$eq`` operand
 matches **both** a scalar field equal to it **and** an array field that contains
@@ -168,6 +182,13 @@ class _Builder:
         self._alias = ctx.table_alias
         self.params: dict[str, Any] = {}
         self._counter = 0
+        # The declared keys = the ``field_mapping`` key set (mirrors
+        # ``compile_weaviate._Builder._declared``). A SYSTEM key absent from it is
+        # undeclared — the backend does not back it with a column, so the
+        # system-key branch of :meth:`compile_clause` routes it to ``_unsupported``.
+        # The ``metadata`` root is keyed separately, so the metadata branch never
+        # consults this set.
+        self._declared: dict[str, str] = dict(ctx.field_mapping or {})
 
     # ----- bind allocation ------------------------------------------------ #
 
@@ -237,6 +258,20 @@ class _Builder:
         """Dispatch a leaf on key-kind (system key vs metadata path)."""
         path = clause.path
         if len(path) == 1 and path[0] in SYSTEM_KEYS:
+            # A system key the backend does not declare in ``field_mapping`` is not
+            # backed by a column on this table (only ``occurred_at`` / ``created_at``
+            # are; the other eight denormalized document keys are not). The compiler
+            # cannot express it — on the SCHEMAFULL table the missing field reads
+            # NONE, and SurrealQL's total-false absent-compare would silently drop
+            # every row — so route it through ``_unsupported`` (every operator,
+            # ``$exists`` included). Returning BEFORE the ``_consumed`` add below
+            # leaves it unconsumed in ``"split"`` mode for a post-filter; in
+            # ``"raise"`` mode ``_unsupported`` raises here. Mirrors
+            # ``compile_weaviate.compile_clause``'s declared-property gate.
+            if path[0] not in self._declared:
+                return self._unsupported(
+                    clause, f"the surrealdb backend does not back system key {path[0]!r} with a column"
+                )
             expr = self._compile_system_clause(clause)
         elif path and path[0] == "metadata":
             expr = self._compile_metadata_clause(clause)

--- a/src/khora/filter/conformance.py
+++ b/src/khora/filter/conformance.py
@@ -69,7 +69,7 @@ from khora.filter.compilers.weaviate import compile_weaviate
 # is the one production CompileContext builder; ``run_chronicle_filter`` is the
 # Chronicle date-bound-pushdown + full-AST post-filter applied to in-memory records.
 from khora.filter.execute import build_compile_context, iter_leaf_clauses, run_chronicle_filter
-from khora.filter.model import Op
+from khora.filter.model import SYSTEM_KEYS, Op
 from khora.storage.coordinator import StorageCoordinator
 
 __all__ = [
@@ -428,10 +428,13 @@ class SurrealExecutor:
     row-set. The compiler is driven with ``on_unsupported="raise"`` (a clause it
     cannot express surfaces as :class:`RecallFilterUnsupportedError`, matched against
     ``expect_unsupported``), against the production context the skeleton SurrealDB
-    backend uses (``temporal_chunk`` target, ``metadata`` → ``metadata_`` mapping).
-    A ``compile_python`` post-filter is still built and passed through so every live
-    runner shares one :class:`LiveRunner` signature; the surrealdb runner may ignore
-    it (the total ``WHERE`` is the source of truth).
+    backend uses (``temporal_chunk`` target; the two backed system keys
+    ``occurred_at`` / ``created_at`` declared in ``field_mapping`` plus the
+    ``metadata`` → ``metadata_`` remap). A filter on any other system key — the eight
+    unbacked denormalized document keys — therefore raises here, mirroring
+    production. A ``compile_python`` post-filter is still built and passed through so
+    every live runner shares one :class:`LiveRunner` signature; the surrealdb runner
+    may ignore it (the total ``WHERE`` is the source of truth).
     """
 
     def __init__(self, runner: LiveRunner) -> None:
@@ -442,9 +445,16 @@ class SurrealExecutor:
         filter_ast: FilterNode,
         records: Sequence[tuple[str, Mapping[str, Any]]],
     ) -> frozenset[str]:
+        # Declare the two backed system keys (``occurred_at`` / ``created_at``)
+        # alongside the ``metadata`` → ``metadata_`` remap, exactly as the skeleton
+        # SurrealDB store's ``_filter_compile_context`` does (the backed set is its
+        # ``_BACKED_SYSTEM_KEYS`` source of truth, schema-guarded by the drift test).
+        # The compiler reads this key set as the declared+pushable whitelist, so a
+        # filter on any other system key surfaces as ``RecallFilterUnsupportedError``
+        # — the production-faithful fail-loud behavior.
         ctx = build_compile_context(
             "temporal_chunk",
-            field_mapping={"metadata": "metadata_"},
+            field_mapping={"occurred_at": "occurred_at", "created_at": "created_at", "metadata": "metadata_"},
             on_unsupported="raise",
         )
         compiled = compile_surrealdb(filter_ast, ctx)
@@ -879,6 +889,38 @@ def _with_metadata(rec: SeedRecord, metadata: dict[str, Any]) -> SeedRecord:
     return replace(rec, metadata=metadata)
 
 
+# The system keys the skeleton SurrealDB ``temporal_chunk`` table does NOT back with
+# a real column — every system key except the two datetime columns. Computed locally
+# from :data:`SYSTEM_KEYS` (NOT imported from the engines layer, which would be a
+# filter→engines inversion): the store's ``_BACKED_SYSTEM_KEYS`` is the source of
+# truth for the store + the QA drift-gate test, and conformance encodes its surreal
+# capability gap locally — the same way it encodes :data:`_NO_STRING_KEY_BACKENDS`,
+# :data:`_CREATED_AT_STAMP_BACKENDS`, etc. (kept consistent by the store-side drift
+# test). A predicate on one of these raises ``RecallFilterUnsupportedError`` on the
+# total surreal leg (no post-filter safety net).
+_UNBACKED_SYSTEM_KEYS: frozenset[str] = SYSTEM_KEYS - frozenset({"occurred_at", "created_at"})
+
+
+def _surreal_unsupported(filter_: dict[str, Any] | RecallFilter) -> frozenset[str]:
+    """``{"surrealdb"}`` iff any leaf reads an unbacked system key, else ``frozenset()``.
+
+    ``@internal``. The surrealdb recall-filter compiler declares only the two backed
+    datetime system keys; a predicate on any other system key raises
+    ``RecallFilterUnsupportedError`` (every operator, ``$exists`` included — the gate
+    precedes operator dispatch). This is operator-agnostic: it keys on the leaf
+    ``path[0]`` alone, so an ``$exists`` / ``$eq`` / range on an unbacked key all
+    flag. The result is unioned into a case's ``expect_unsupported`` so the surreal
+    leg STAYS in ``backends`` and asserts the raise (rather than being silently
+    skipped). ``metadata.*`` leaves never flag — their ``path[0]`` is ``"metadata"``,
+    not a system key — so a pure-metadata case (handled by :func:`_surreal_excluded`)
+    is untouched.
+    """
+    for clause in iter_leaf_clauses(_resolve_ast(filter_)):
+        if clause.path and clause.path[0] in _UNBACKED_SYSTEM_KEYS:
+            return frozenset({"surrealdb"})
+    return frozenset()
+
+
 def _backends_for_filter(filter_: dict[str, Any] | RecallFilter, seed: tuple[SeedRecord, ...]) -> frozenset[str]:
     """Compute the backend set a case can run on, from the leaves its filter touches.
 
@@ -1044,12 +1086,14 @@ def _date_op_cases(key: str) -> list[ConformanceCase]:
     # ``$lt`` / ``$lte`` date cases.
     def case(suffix: str, predicate: dict[str, Any], expected: frozenset[str], op_tag: str) -> ConformanceCase:
         filter_ = {key: predicate}
+        backends = _backends_for_filter(filter_, seed)
         return ConformanceCase(
             id=f"F-OP-{key}-{suffix}",
             filter=filter_,
             seed_records=seed,
             expected_ids=expected,
-            backends=_backends_for_filter(filter_, seed),
+            backends=backends,
+            expect_unsupported=_surreal_unsupported(filter_) & backends,
             exercises=("F-OP", key, op_tag),
         )
 
@@ -1103,12 +1147,14 @@ def _string_op_cases(key: str) -> list[ConformanceCase]:
     # system key) stays on all.
     def case(suffix: str, predicate: Any, expected: frozenset[str], op_tag: str) -> ConformanceCase:
         filter_ = {key: predicate}
+        backends = _backends_for_filter(filter_, seed)
         return ConformanceCase(
             id=f"F-OP-{key}-{suffix}",
             filter=filter_,
             seed_records=seed,
             expected_ids=expected,
-            backends=_backends_for_filter(filter_, seed),
+            backends=backends,
+            expect_unsupported=_surreal_unsupported(filter_) & backends,
             exercises=("F-OP", key, op_tag),
         )
 
@@ -1140,12 +1186,14 @@ def _metadata_op_case() -> ConformanceCase:
         SeedRecord(id="meta-absent"),
     )
     filter_ = {"metadata.tier": "gold"}
+    backends = _backends_for_filter(filter_, seed)
     return ConformanceCase(
         id="F-OP-metadata-tier-eq",
         filter=filter_,
         seed_records=seed,
         expected_ids=frozenset({"meta-gold"}),
-        backends=_backends_for_filter(filter_, seed),
+        backends=backends,
+        expect_unsupported=_surreal_unsupported(filter_) & backends,
         exercises=("F-OP", "metadata.tier", "$eq"),
     )
 
@@ -1213,14 +1261,19 @@ def _case(
     chronicle, the total-exact postgres + surrealdb, and the split cypher +
     weaviate + sqlite_lance whose post-filter lands on the oracle); a case touching
     a string document key or ``created_at`` is pruned with the documented
-    capability/seed reason. No family is silently skipped.
+    capability/seed reason. No family is silently skipped. A leaf on an unbacked
+    surreal system key keeps surrealdb in ``backends`` and unions it into
+    ``expect_unsupported`` (:func:`_surreal_unsupported`) so the surreal leg asserts
+    the raise rather than being skipped.
     """
+    backends = _backends_for_filter(filter_, seed)
     return ConformanceCase(
         id=cid,
         filter=filter_,
         seed_records=seed,
         expected_ids=expected,
-        backends=_backends_for_filter(filter_, seed),
+        backends=backends,
+        expect_unsupported=_surreal_unsupported(filter_) & backends,
         exercises=exercises,
     )
 

--- a/tests/integration/engines/skeleton/test_surrealdb_store_filter_channels.py
+++ b/tests/integration/engines/skeleton/test_surrealdb_store_filter_channels.py
@@ -1,0 +1,237 @@
+"""Store-level recall-filter contract on BOTH read channels — embedded SurrealDB.
+
+The compiler-level tests (``tests/unit/filter/test_compile_surrealdb.py``) and the
+predicate row-set tests (``tests/integration/filter/test_compile_surrealdb_embedded.py``)
+prove the SurrealDB compiler raises on an unbacked system key and pushes a backed
+one. This module proves the SAME contract holds at the STORE seam — through
+:class:`~khora.engines.skeleton.backends.surrealdb.SurrealDBTemporalStore`'s two
+public read channels:
+
+* the **vector** channel — ``store.search(..., hybrid_alpha=1.0, filter_ast=…)``
+  (the ``SearchMode.VECTOR`` route compiles ``filter_ast`` in ``on_unsupported="raise"``
+  mode before the cosine scan);
+* the **BM25** channel — ``store.search_fulltext(..., filter_ast=…)`` (the
+  ``SearchMode.KEYWORD`` route, same raise-mode compile before the full-text scan).
+
+Both channels compile the filter through the live recall context, so an unbacked
+system key (one of the eight denormalized document keys the ``temporal_chunk`` table
+does not back with a column) must FAIL LOUD on EITHER channel rather than silently
+returning a wrong row-set, and a backed predicate (``occurred_at`` range,
+``metadata.<key>``) must still narrow correctly on EITHER channel.
+
+Embedded ``memory://`` runs in-process — no server, no Docker. The module self-skips
+when the embedded SurrealDB SDK is unavailable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+
+pytest.importorskip("surrealdb")
+
+from khora.config import KhoraConfig  # noqa: E402
+from khora.engines.skeleton.backends import TemporalChunk  # noqa: E402
+from khora.engines.skeleton.backends.surrealdb import _BACKED_SYSTEM_KEYS, SurrealDBTemporalStore  # noqa: E402
+from khora.filter import RecallFilter  # noqa: E402
+from khora.filter.ast import FilterNode, parse_to_ast  # noqa: E402
+from khora.filter.context import RecallFilterUnsupportedError  # noqa: E402
+from khora.filter.model import SYSTEM_KEYS  # noqa: E402
+from khora.storage.backends.surrealdb.connection import SurrealDBConnection  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+# Embedding width matches the HNSW index the store's schema defines (DIMENSION 1536).
+_DIM = 1536
+_EMBED = [0.1] * _DIM
+
+# The eight unbacked system keys = SYSTEM_KEYS minus the store's declared backed set.
+# Derived from the source of truth so the corpus tracks any change to the backed set.
+_UNBACKED_KEYS = tuple(sorted(SYSTEM_KEYS - _BACKED_SYSTEM_KEYS))
+_DATE_TYPED_UNBACKED = "source_timestamp"
+_STRING_UNBACKED_KEYS = tuple(k for k in _UNBACKED_KEYS if k != _DATE_TYPED_UNBACKED)
+# Substring the backend gate raises with (the message also names the offending key).
+_GATE_REASON = "does not back"
+
+
+def _unbacked_wire(key: str, *, exists: bool = False) -> dict:
+    """A valid wire filter over an unbacked key, respecting its operand type.
+
+    ``source_timestamp`` is datetime-typed (DateOps) — it takes a date operand and
+    forbids ``$exists``; the seven string keys take a string and accept ``$exists``.
+    """
+    if exists:
+        return {key: {"$exists": True}}
+    if key == _DATE_TYPED_UNBACKED:
+        return {key: "2026-01-01T00:00:00Z"}
+    return {key: "v"}
+
+
+# Two seed rows: a recent, gold-tier chunk and an ancient, silver-tier one. Both
+# share the BM25 token "pagerduty" so the full-text channel returns both before the
+# filter narrows. ``content`` is the row's stable label.
+_NS = uuid4()
+_DOC = uuid4()
+_RECENT = datetime(2026, 6, 1, tzinfo=UTC)
+_ANCIENT = datetime(2020, 1, 1, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _reset_surrealdb_schema_init_lock() -> None:
+    """Reset the module-level schema-init lock per test (loop-local, see issue #718)."""
+    from khora.storage.backends.surrealdb import connection as _conn_mod
+
+    _conn_mod._schema_init_lock = asyncio.Lock()
+
+
+def _ast(wire: dict) -> FilterNode:
+    """Validate a wire-form filter and lower it to the canonical AST."""
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+@pytest.fixture
+async def store() -> AsyncIterator[tuple[SurrealDBTemporalStore, UUID]]:
+    """An embedded SurrealDB store seeded with the two chunks + BM25 index built.
+
+    Yields ``(store, namespace_id)``. ``ensure_search_indexes()`` builds the BM25
+    full-text index so the ``search_fulltext`` channel actually runs (without it the
+    BM25 path degrades to ``[]`` on "no suitable index").
+    """
+    conn = SurrealDBConnection(mode="memory")
+    await conn.connect()
+    store = SurrealDBTemporalStore(KhoraConfig(), connection=conn)
+    await store.connect()
+    await store.ensure_search_indexes()
+    try:
+        await store.create_chunks_batch(
+            [
+                TemporalChunk(
+                    id=uuid4(),
+                    namespace_id=_NS,
+                    document_id=_DOC,
+                    content="recent pagerduty alert",
+                    embedding=_EMBED,
+                    occurred_at=_RECENT,
+                    metadata={"tier": "gold"},
+                ),
+                TemporalChunk(
+                    id=uuid4(),
+                    namespace_id=_NS,
+                    document_id=_DOC,
+                    content="ancient pagerduty alert",
+                    embedding=_EMBED,
+                    occurred_at=_ANCIENT,
+                    metadata={"tier": "silver"},
+                ),
+            ]
+        )
+        yield store, _NS
+    finally:
+        await conn.disconnect()
+
+
+async def _vector_contents(store: SurrealDBTemporalStore, ns: UUID, filter_ast: FilterNode) -> list[str]:
+    """Run the vector channel (pure-vector) with ``filter_ast``; return sorted contents."""
+    results = await store.search(ns, _EMBED, hybrid_alpha=1.0, filter_ast=filter_ast)
+    return sorted(r.chunk.content for r in results)
+
+
+async def _bm25_contents(store: SurrealDBTemporalStore, ns: UUID, filter_ast: FilterNode) -> list[str]:
+    """Run the BM25 channel (search_fulltext) with ``filter_ast``; return sorted contents."""
+    results = await store.search_fulltext(ns, "pagerduty", filter_ast=filter_ast)
+    return sorted(chunk.content for chunk, _score in results)
+
+
+# ===========================================================================
+# (1) Unbacked system keys FAIL LOUD on BOTH channels — every key.
+# ===========================================================================
+
+
+@pytest.mark.parametrize("key", _UNBACKED_KEYS)
+async def test_unbacked_key_raises_on_vector_channel(store: tuple[SurrealDBTemporalStore, UUID], key: str) -> None:
+    # The vector channel compiles ``filter_ast`` in raise mode before the cosine
+    # scan, so an unbacked system key raises rather than returning a wrong row-set.
+    st, ns = store
+    with pytest.raises(RecallFilterUnsupportedError, match=_GATE_REASON) as exc:
+        await st.search(ns, _EMBED, hybrid_alpha=1.0, filter_ast=_ast(_unbacked_wire(key)))
+    # Load-bearing invariant: the gate named the RIGHT key (robust to re-wording).
+    assert key in str(exc.value)
+
+
+@pytest.mark.parametrize("key", _UNBACKED_KEYS)
+async def test_unbacked_key_raises_on_bm25_channel(store: tuple[SurrealDBTemporalStore, UUID], key: str) -> None:
+    # The BM25 channel (search_fulltext / SearchMode.KEYWORD) compiles in the same
+    # raise mode, so the identical fail-loud contract holds there.
+    st, ns = store
+    with pytest.raises(RecallFilterUnsupportedError, match=_GATE_REASON) as exc:
+        await st.search_fulltext(ns, "pagerduty", filter_ast=_ast(_unbacked_wire(key)))
+    assert key in str(exc.value)
+
+
+@pytest.mark.parametrize("key", _STRING_UNBACKED_KEYS)
+async def test_unbacked_string_key_exists_raises_on_both_channels(
+    store: tuple[SurrealDBTemporalStore, UUID], key: str
+) -> None:
+    # The gate fires for EVERY operator, $exists included: on a backed key $exists is
+    # a constant, but on an unbacked (non-column) key it raises on both channels.
+    # (source_timestamp is datetime-typed and DateOps forbids $exists upstream, so the
+    # $exists probe is the seven string keys.)
+    st, ns = store
+    ast = _ast(_unbacked_wire(key, exists=True))
+    with pytest.raises(RecallFilterUnsupportedError, match=_GATE_REASON) as exc_vec:
+        await st.search(ns, _EMBED, hybrid_alpha=1.0, filter_ast=ast)
+    assert key in str(exc_vec.value)
+    with pytest.raises(RecallFilterUnsupportedError, match=_GATE_REASON) as exc_bm25:
+        await st.search_fulltext(ns, "pagerduty", filter_ast=ast)
+    assert key in str(exc_bm25.value)
+
+
+async def test_unbacked_key_ne_raises_on_both_channels(store: tuple[SurrealDBTemporalStore, UUID]) -> None:
+    # The rejection is op-independent: a $ne over an unbacked key raises on both
+    # channels too (pre-fix it silently kept every row).
+    st, ns = store
+    ast = _ast({"source_name": {"$ne": "x"}})
+    with pytest.raises(RecallFilterUnsupportedError, match=_GATE_REASON) as exc_vec:
+        await st.search(ns, _EMBED, hybrid_alpha=1.0, filter_ast=ast)
+    assert "source_name" in str(exc_vec.value)
+    with pytest.raises(RecallFilterUnsupportedError, match=_GATE_REASON) as exc_bm25:
+        await st.search_fulltext(ns, "pagerduty", filter_ast=ast)
+    assert "source_name" in str(exc_bm25.value)
+
+
+# ===========================================================================
+# (2) Positive controls — a backed predicate still narrows on BOTH channels.
+# ===========================================================================
+
+
+async def test_occurred_at_range_narrows_on_both_channels(store: tuple[SurrealDBTemporalStore, UUID]) -> None:
+    # occurred_at is a backed datetime column, so a range filter pushes down and
+    # keeps only the recent row on both the vector and the BM25 channel.
+    st, ns = store
+    ast = _ast({"occurred_at": {"$gte": "2026-01-01T00:00:00Z"}})
+    assert await _vector_contents(st, ns, ast) == ["recent pagerduty alert"]
+    assert await _bm25_contents(st, ns, ast) == ["recent pagerduty alert"]
+
+
+async def test_metadata_filter_narrows_on_both_channels(store: tuple[SurrealDBTemporalStore, UUID]) -> None:
+    # A metadata.<key> filter descends into the FLEXIBLE metadata_ column and keeps
+    # only the gold-tier row on both channels — the backed-predicate counterpart to
+    # the unbacked fail-loud cases above.
+    st, ns = store
+    ast = _ast({"metadata.tier": "gold"})
+    assert await _vector_contents(st, ns, ast) == ["recent pagerduty alert"]
+    assert await _bm25_contents(st, ns, ast) == ["recent pagerduty alert"]
+
+
+async def test_no_filter_returns_both_rows_on_both_channels(store: tuple[SurrealDBTemporalStore, UUID]) -> None:
+    # Control for the controls: with no filter both channels see both rows, so the
+    # narrowing above is a real cut, not an empty corpus.
+    st, ns = store
+    vector = sorted(r.chunk.content for r in await st.search(ns, _EMBED, hybrid_alpha=1.0))
+    bm25 = sorted(chunk.content for chunk, _ in await st.search_fulltext(ns, "pagerduty"))
+    assert vector == ["ancient pagerduty alert", "recent pagerduty alert"]
+    assert bm25 == ["ancient pagerduty alert", "recent pagerduty alert"]

--- a/tests/integration/filter/test_compile_surrealdb_embedded.py
+++ b/tests/integration/filter/test_compile_surrealdb_embedded.py
@@ -34,16 +34,20 @@ from khora.filter import RecallFilter  # noqa: E402
 from khora.filter.ast import parse_to_ast  # noqa: E402
 from khora.filter.compilers.python import compile_python  # noqa: E402
 from khora.filter.compilers.surrealdb import compile_surrealdb  # noqa: E402
-from khora.filter.context import CompileContext  # noqa: E402
+from khora.filter.context import CompileContext, RecallFilterUnsupportedError  # noqa: E402
 from khora.storage.backends.surrealdb._helpers import _rid  # noqa: E402
 from khora.storage.backends.surrealdb.connection import SurrealDBConnection  # noqa: E402
 
 pytestmark = pytest.mark.integration
 
 
-# The live recall path's context: ``metadata`` root → physical ``metadata_``
-# column; system keys map identity (bare columns on the table).
-_CTX = CompileContext(backend_target="temporal_chunk", field_mapping={"metadata": "metadata_"})
+# The live recall path's context: the two BACKED system keys (occurred_at /
+# created_at) map to their bare columns, the ``metadata`` root → physical
+# ``metadata_`` column. The eight unbacked keys are absent from the mapping (rejected).
+_CTX = CompileContext(
+    backend_target="temporal_chunk",
+    field_mapping={"occurred_at": "occurred_at", "created_at": "created_at", "metadata": "metadata_"},
+)
 
 # A trimmed temporal_chunk shape — only the columns these row-set assertions
 # touch. Keeping it minimal (no namespace/document record links, no HNSW index)
@@ -53,8 +57,7 @@ _CTX = CompileContext(backend_target="temporal_chunk", field_mapping={"metadata"
 _SCHEMA = """
 DEFINE TABLE IF NOT EXISTS temporal_chunk SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS content ON temporal_chunk TYPE string;
-DEFINE FIELD IF NOT EXISTS source_name ON temporal_chunk TYPE option<string>;
-DEFINE FIELD IF NOT EXISTS source_url ON temporal_chunk TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS occurred_at ON temporal_chunk TYPE option<datetime>;
 DEFINE FIELD IF NOT EXISTS metadata_ ON temporal_chunk FLEXIBLE TYPE option<object>;
 """
 
@@ -183,22 +186,36 @@ async def test_not_over_range_keeps_absent_and_null_excludes_match(conn: Surreal
 
 
 # ===========================================================================
-# (4) An always-absent system key: $eq drops all rows / $ne keeps all rows.
+# (4) An unbacked system key FAILS LOUD — it never reaches the database.
 # ===========================================================================
+#
+# ``source_url`` (one of the eight denormalized document keys) is NOT a column on
+# the ``temporal_chunk`` table. Pre-fix the compiler emitted a bare ``source_url``
+# field ref, which read NONE at query time and — via SurrealQL's total-false
+# absent-compare — silently dropped every row (an $eq) or kept every row (a $ne),
+# quietly returning a WRONG row-set instead of the intended filter. The compiler now
+# refuses to emit that predicate: ``compile_surrealdb`` raises
+# ``RecallFilterUnsupportedError`` BEFORE any query runs, so the row-set bug is
+# impossible. These assert the raise on the same live compile path the row-set tests
+# use (no SELECT is ever issued).
 
 
-async def test_always_absent_system_key_eq_drops_all(conn: SurrealDBConnection) -> None:
-    # ``source_url`` is never written on these rows, so it reads NONE. A bare
-    # ``=`` compare against an absent column is a total false → no rows.
-    assert await _matching_content(conn, {"source_url": "anything"}) == []
+async def test_unbacked_system_key_eq_raises(conn: SurrealDBConnection) -> None:
+    # The $eq form raised — the predicate that pre-fix silently dropped every row.
+    ast = parse_to_ast(RecallFilter.model_validate({"source_url": "anything"}))
+    with pytest.raises(RecallFilterUnsupportedError, match="does not back") as exc:
+        compile_surrealdb(ast, _CTX)
+    # Load-bearing invariant: the gate named the offending key (robust to re-wording).
+    assert "source_url" in str(exc.value)
 
 
-async def test_always_absent_system_key_ne_keeps_all(conn: SurrealDBConnection) -> None:
-    # Polarity (Rule 2): ``!=`` against an absent column is total TRUE, so $ne on
-    # an always-absent key keeps every row — no null guard needed.
-    assert await _matching_content(conn, {"source_url": {"$ne": "anything"}}) == sorted(
-        ["absent", "null", "ten", "three", "mismatch", "deep"]
-    )
+async def test_unbacked_system_key_ne_raises(conn: SurrealDBConnection) -> None:
+    # The $ne form raised too — the predicate that pre-fix silently kept every row.
+    # The rejection is op-independent: an unbacked column is never queryable.
+    ast = parse_to_ast(RecallFilter.model_validate({"source_url": {"$ne": "anything"}}))
+    with pytest.raises(RecallFilterUnsupportedError, match="does not back") as exc:
+        compile_surrealdb(ast, _CTX)
+    assert "source_url" in str(exc.value)
 
 
 # ===========================================================================

--- a/tests/unit/filter/test_compile_surrealdb.py
+++ b/tests/unit/filter/test_compile_surrealdb.py
@@ -14,10 +14,22 @@ expression), the SurrealDB compiler returns a plain string with ``$name`` placeh
 and carries the values out-of-band in ``params``. So the assertions match against the
 string directly and check ``params`` for the bound values.
 
+**Backed vs unbacked system keys.** Only two of the ten :data:`SYSTEM_KEYS`
+(``occurred_at`` / ``created_at`` — the store's
+:data:`~khora.engines.skeleton.backends.surrealdb._BACKED_SYSTEM_KEYS`) are real
+columns on the SCHEMAFULL ``temporal_chunk`` table; the other eight denormalized
+document keys are not. The live recall context only maps the backed keys (plus the
+``metadata`` root), so the compiler FAILS LOUD (``RecallFilterUnsupportedError`` in
+``"raise"`` mode) on any predicate over an unbacked key, for **every** operator
+(``$exists`` included) — emitting a predicate against a non-existent column would
+read NONE and SurrealQL's total-false absent-compare would silently drop every row.
+So the system-key *emission* contract below is pinned on the two BACKED date keys,
+and the eight unbacked keys are pinned to RAISE.
+
 The contract these tests lock (§4), and the one deliberate divergence from Cypher:
 
 * Every operator ``$eq``/``$ne``/``$gt``/``$gte``/``$lt``/``$lte``/``$in``/``$nin``/``$exists``.
-* System key (typed column) emission; the empty AST → match-everything (``true``).
+* System key (typed column) emission on a BACKED key; the empty AST → match-everything (``true``).
 * A *nested* metadata path descends natively (``metadata.a.b.c`` → ``metadata_.a.b.c``),
   never collapsed/mangled into a single token.
 * The four field-match rules, as SurrealQL expresses them via its NONE-boolean algebra
@@ -46,11 +58,12 @@ from datetime import UTC, datetime
 
 import pytest
 
+from khora.engines.skeleton.backends.surrealdb import _BACKED_SYSTEM_KEYS
 from khora.filter import RecallFilter
 from khora.filter.ast import FilterClause, FilterNode, canonical_hash, parse_to_ast
 from khora.filter.compilers.surrealdb import compile_surrealdb
-from khora.filter.context import CompileContext
-from khora.filter.model import Op
+from khora.filter.context import CompileContext, RecallFilterUnsupportedError
+from khora.filter.model import SYSTEM_KEYS, Op
 
 # Hard import (NOT importorskip): the compiler is pure-Python string emission with
 # no SurrealDB SDK dependency, so an import failure here must be a LOUD test error,
@@ -63,9 +76,17 @@ pytestmark = pytest.mark.unit
 # Helpers.
 # ---------------------------------------------------------------------------
 
-# The live recall path's context: the ``metadata`` root maps to the physical
-# ``metadata_`` column; system keys map identity (bare columns on the table).
-_CTX = CompileContext(backend_target="temporal_chunk", field_mapping={"metadata": "metadata_"})
+# The live recall path's context: the two BACKED system keys (occurred_at /
+# created_at) map to their bare columns and the ``metadata`` root maps to the
+# physical ``metadata_`` column. The eight unbacked keys are ABSENT from the mapping,
+# so the compiler treats them as undeclared and rejects any predicate over them.
+_CTX = CompileContext(
+    backend_target="temporal_chunk",
+    field_mapping={"occurred_at": "occurred_at", "created_at": "created_at", "metadata": "metadata_"},
+)
+
+# A backed datetime operand reused across the system-key emission tests.
+_DT = "2026-01-01T00:00:00Z"
 
 
 def _ast(wire: dict) -> FilterNode:
@@ -110,37 +131,41 @@ def test_empty_filter_binds_nothing() -> None:
 
 
 # ===========================================================================
-# Scalar operators on a SYSTEM (typed column) key.
+# Scalar operators on a BACKED SYSTEM (typed column) key.
 # ===========================================================================
+#
+# The two backed system keys (occurred_at / created_at) are real datetime columns
+# on the SCHEMAFULL table, so they push down. A datetime column binds a real
+# :class:`~datetime.datetime` (the SDK encodes it as a SurrealQL datetime).
 
 
 def test_system_eq_is_bare_property_equals() -> None:
-    compiled = compile_surrealdb(_ast({"source_name": "linear"}), _CTX)
+    compiled = compile_surrealdb(_ast({"occurred_at": _DT}), _CTX)
     sql = _norm(compiled.predicate)
     # $eq is a total boolean in SurrealQL: a plain ``=`` compare (no coalesce — an
     # absent column compares false, and a wrapping $not flips it). The operand is
     # bound, not inlined. The system key is a bare physical column, not metadata.
-    assert "(source_name = $f_0)" in sql
+    assert "(occurred_at = $f_0)" in sql
     assert "coalesce" not in sql
     assert "metadata" not in sql
-    assert compiled.params == {"f_0": "linear"}
+    assert isinstance(compiled.params["f_0"], datetime)
 
 
 def test_system_eq_with_ops_form() -> None:
-    compiled = compile_surrealdb(_ast({"source_type": {"$eq": "slack"}}), _CTX)
-    assert "(source_type = $f_0)" in _norm(compiled.predicate)
-    assert compiled.params == {"f_0": "slack"}
+    compiled = compile_surrealdb(_ast({"created_at": {"$eq": _DT}}), _CTX)
+    assert "(created_at = $f_0)" in _norm(compiled.predicate)
+    assert isinstance(compiled.params["f_0"], datetime)
 
 
 def test_system_ne_is_bare_not_equals() -> None:
     # Rule 2 (polarity): ``!=`` against an absent column already returns true in
     # SurrealQL, so $ne admits absent rows without an extra ``OR IS NONE`` — no
     # null guard needed (the divergence from Cypher's ``IS NULL OR ...``).
-    compiled = compile_surrealdb(_ast({"source_name": {"$ne": "linear"}}), _CTX)
+    compiled = compile_surrealdb(_ast({"occurred_at": {"$ne": _DT}}), _CTX)
     sql = _norm(compiled.predicate)
-    assert "(source_name != $f_0)" in sql
+    assert "(occurred_at != $f_0)" in sql
     assert "is none" not in sql
-    assert compiled.params == {"f_0": "linear"}
+    assert isinstance(compiled.params["f_0"], datetime)
 
 
 def test_system_gt_is_property_compare() -> None:
@@ -177,69 +202,128 @@ def test_system_date_range_operators(wire_op: str, surql_op: str) -> None:
 
 
 # ===========================================================================
-# All ten system keys lower to a bare field ref (incl. the 8 always-absent ones).
+# The 8 UNBACKED system keys FAIL LOUD — every operator raises.
 # ===========================================================================
 #
 # Eight of the ten system keys (source_timestamp / source_type / source_name /
-# source_url / external_id / content_type / source / title) are not written onto
-# the temporal_chunk table, so they read NONE at query time — but the compiler
-# still emits a bare field ref for each (an undefined-field ref does not error in
-# SurrealQL). The two date keys (occurred_at / created_at) are real columns. This
-# pins that EVERY system key pushes down to a ``<key> = $bind`` compare and lands
-# in consumed_keys, independent of whether the column is physically present.
-_ALWAYS_ABSENT_SYSTEM_KEYS = (
-    "source_type",
-    "source_name",
-    "source_url",
-    "external_id",
-    "content_type",
-    "source",
-    "title",
+# source_url / external_id / content_type / source / title) are NOT columns on the
+# temporal_chunk table — they are absent from the store's _BACKED_SYSTEM_KEYS and
+# from the live recall context's field_mapping. A predicate over one would reference
+# a field the table does not define, reading NONE; SurrealQL's total-false
+# absent-compare (``NONE = x`` → ``false``) would then SILENTLY DROP EVERY ROW
+# instead of filtering. So the compiler refuses to emit such a predicate and, under
+# the live recall path's ``on_unsupported="raise"`` mode, raises
+# ``RecallFilterUnsupportedError`` for EVERY operator (``$exists`` included). This is
+# the inverse of the pre-fix contract, which emitted a bare field ref that quietly
+# matched nothing.
+#
+# The unbacked set is derived from the store's source-of-truth _BACKED_SYSTEM_KEYS,
+# so this corpus tracks any change to the backed set automatically (the schema-drift
+# gate in ``test_surrealdb_backed_keys_drift.py`` pins the backed set to the schema).
+_UNBACKED_KEYS = tuple(sorted(SYSTEM_KEYS - _BACKED_SYSTEM_KEYS))
+
+# The unbacked key whose type forbids ``$exists`` upstream (DateOps datetime key).
+_DATE_TYPED_UNBACKED = "source_timestamp"
+# The seven string-typed unbacked keys, on which ``$exists`` is a valid wire form
+# that must reach (and trip) the backend gate.
+_STRING_UNBACKED_KEYS = tuple(k for k in _UNBACKED_KEYS if k != _DATE_TYPED_UNBACKED)
+
+# Every operator form a wire filter can put on a STRING unbacked key — incl. both
+# $exists polarities. All must trip the backend gate (the leaf dispatch raises before
+# any operator-specific lowering, $exists constant included).
+_STRING_OP_FORMS = (
+    {"$eq": "v"},
+    {"$ne": "v"},
+    {"$in": ["a", "b"]},
+    {"$nin": ["a", "b"]},
+    {"$exists": True},
+    {"$exists": False},
 )
 
+# The operator forms a DATE unbacked key (source_timestamp) accepts upstream — DateOps
+# has no ``$exists`` and rejects a non-datetime operand, so probe with date operands.
+_DATE_OP_FORMS = (
+    {"$eq": "2026-01-01T00:00:00Z"},
+    {"$ne": "2026-01-01T00:00:00Z"},
+    {"$in": ["2026-01-01T00:00:00Z"]},
+    {"$nin": ["2026-01-01T00:00:00Z"]},
+    {"$gt": "2026-01-01T00:00:00Z"},
+)
 
-@pytest.mark.parametrize("key", _ALWAYS_ABSENT_SYSTEM_KEYS)
-def test_always_absent_string_key_emits_bare_field_ref(key: str) -> None:
-    compiled = compile_surrealdb(_ast({key: "v"}), _CTX)
-    sql = _norm(compiled.predicate)
-    assert f"({key} = $f_0)" in sql
-    assert compiled.params == {"f_0": "v"}
-    assert key in compiled.consumed_keys
-    # A system key is a bare column ref, never a serialized-metadata lookup.
-    assert "metadata" not in sql
+# The reason fragment the backend gate raises with (asserted as a substring, not the
+# whole string — the message also names the offending key).
+_GATE_REASON = "does not back"
 
 
-def test_source_timestamp_emits_bare_field_ref() -> None:
-    # source_timestamp is the one always-absent datetime-typed system key. It
-    # pushes down as a bare ``=`` compare and binds a real datetime (system-column
-    # binding), completing the 8-key always-absent set with the string keys above.
-    compiled = compile_surrealdb(_ast({"source_timestamp": "2026-02-03T00:00:00Z"}), _CTX)
-    sql = _norm(compiled.predicate)
-    assert "(source_timestamp = $f_0)" in sql
-    assert isinstance(compiled.params["f_0"], datetime)
-    assert "source_timestamp" in compiled.consumed_keys
+def test_unbacked_keys_are_the_eight_remaining_system_keys() -> None:
+    # The corpus covers exactly the eight denormalized document keys (SYSTEM_KEYS minus
+    # the two backed date columns). A change to the backed set is caught here and in
+    # the schema-drift gate.
+    assert set(_UNBACKED_KEYS) == set(SYSTEM_KEYS) - {"occurred_at", "created_at"}
+    assert len(_UNBACKED_KEYS) == 8
+
+
+@pytest.mark.parametrize("key", _STRING_UNBACKED_KEYS)
+@pytest.mark.parametrize("op_form", _STRING_OP_FORMS, ids=lambda f: next(iter(f)) + "_" + str(next(iter(f.values()))))
+def test_unbacked_string_key_every_operator_raises(key: str, op_form: dict) -> None:
+    # EVERY operator over a string unbacked key raises — $eq/$ne/$in/$nin AND both
+    # $exists polarities. The $exists case is the subtle one: on a backed key it is a
+    # constant, but on an unbacked (non-column) key even a constant would be
+    # meaningless, so the gate rejects it too (it never reaches the constant
+    # short-circuit). The error names the key and carries the "does not back" reason.
+    with pytest.raises(RecallFilterUnsupportedError, match=_GATE_REASON) as exc:
+        compile_surrealdb(_ast({key: op_form}), _CTX)
+    assert exc.value.path == key
+    assert key in str(exc.value)
+
+
+@pytest.mark.parametrize("op_form", _DATE_OP_FORMS, ids=lambda f: next(iter(f)))
+def test_unbacked_source_timestamp_every_valid_operator_raises(op_form: dict) -> None:
+    # source_timestamp is the one unbacked DATETIME-typed system key. DateOps has no
+    # $exists, so its testable operator surface is $eq/$ne/$in/$nin/range with date
+    # operands — every one trips the backend gate the same way (it is not a column on
+    # the temporal_chunk table). The error names the key and carries the reason.
+    with pytest.raises(RecallFilterUnsupportedError, match=_GATE_REASON) as exc:
+        compile_surrealdb(_ast({_DATE_TYPED_UNBACKED: op_form}), _CTX)
+    assert exc.value.path == _DATE_TYPED_UNBACKED
+    assert _DATE_TYPED_UNBACKED in str(exc.value)
+
+
+def test_unbacked_key_not_in_consumed_keys_on_split() -> None:
+    # In ``"split"`` mode the unbacked leaf is NOT consumed (it is left for a
+    # post-filter) and emits a non-constraining ``"true"`` — the same _unsupported
+    # path, just non-raising. This pins that the raise is mode-gated, not a hard crash.
+    ctx = CompileContext(
+        backend_target="temporal_chunk",
+        field_mapping={"occurred_at": "occurred_at", "created_at": "created_at", "metadata": "metadata_"},
+        on_unsupported="split",
+    )
+    compiled = compile_surrealdb(_ast({"source_name": "linear"}), ctx)
+    assert "source_name" not in compiled.consumed_keys
+    assert _norm(compiled.predicate) in ("true", "(true)")
 
 
 # ===========================================================================
-# $in / $nin on a SYSTEM key → INSIDE / !(INSIDE) membership.
+# $in / $nin on a BACKED system key → INSIDE / !(INSIDE) membership.
 # ===========================================================================
 
 
 def test_system_in_is_inside_list() -> None:
-    compiled = compile_surrealdb(_ast({"source_name": {"$in": ["a", "b", "c"]}}), _CTX)
-    assert "(source_name inside $f_0)" in _norm(compiled.predicate)
-    assert compiled.params == {"f_0": ["a", "b", "c"]}
+    compiled = compile_surrealdb(_ast({"occurred_at": {"$in": [_DT, "2026-02-01T00:00:00Z"]}}), _CTX)
+    assert "(occurred_at inside $f_0)" in _norm(compiled.predicate)
+    assert isinstance(compiled.params["f_0"], list)
+    assert all(isinstance(v, datetime) for v in compiled.params["f_0"])
 
 
 def test_system_nin_is_negated_inside() -> None:
     # Rule 2 (polarity): $nin is the negated INSIDE. An absent column is not INSIDE
     # the set, so the negation is true — absent rows are admitted, total without an
     # extra null guard (the divergence from Cypher's ``IS NULL OR NOT ... IN``).
-    compiled = compile_surrealdb(_ast({"source_type": {"$nin": ["spam", "junk"]}}), _CTX)
+    compiled = compile_surrealdb(_ast({"created_at": {"$nin": [_DT]}}), _CTX)
     sql = _norm(compiled.predicate)
-    assert "!(source_type inside $f_0)" in sql
+    assert "!(created_at inside $f_0)" in sql
     assert "is none" not in sql
-    assert compiled.params == {"f_0": ["spam", "junk"]}
+    assert isinstance(compiled.params["f_0"], list)
 
 
 def test_system_empty_in_is_constant_false() -> None:
@@ -247,7 +331,7 @@ def test_system_empty_in_is_constant_false() -> None:
     # membership over ∅ matches nothing. The compiler emits the constant explicitly
     # (the single-clause filter normalizes to AND([leaf]), rendering as the wrapped
     # "(false)") and binds nothing.
-    compiled = compile_surrealdb(_ast({"source_name": {"$in": []}}), _CTX)
+    compiled = compile_surrealdb(_ast({"occurred_at": {"$in": []}}), _CTX)
     assert _norm(compiled.predicate) == "(false)"
     assert compiled.params == {}
 
@@ -255,78 +339,37 @@ def test_system_empty_in_is_constant_false() -> None:
 def test_system_empty_nin_is_constant_true() -> None:
     # An empty $nin operand list matches everything (negation over ∅) — the polarity
     # mirror of the empty-$in case. Emitted as the wrapped constant "(true)".
-    compiled = compile_surrealdb(_ast({"source_name": {"$nin": []}}), _CTX)
+    compiled = compile_surrealdb(_ast({"occurred_at": {"$nin": []}}), _CTX)
     assert _norm(compiled.predicate) == "(true)"
     assert compiled.params == {}
 
 
 # ===========================================================================
-# Rule 3 — bare-list (exact-array) operand vs scalar SYSTEM column.
+# Rule 4 — null operand on a BACKED system key resolves to (= NULL OR IS NONE).
 # ===========================================================================
-
-
-def test_system_eq_array_operand_binds_as_list() -> None:
-    # A bare list on a scalar system key lowers to $eq EXACT-ARRAY. The compiler
-    # binds the operand as a SurrealQL list and emits the same plain ``=`` compare;
-    # a scalar column never equals a list, so it yields false at query time — no
-    # special-cased constant, the list binds like any other operand. (The AST
-    # carries a tuple; it is bound as a driver list, not a tuple.)
-    compiled = compile_surrealdb(_ast({"source_name": ["a", "b"]}), _CTX)
-    sql = _norm(compiled.predicate)
-    assert "(source_name = $f_0)" in sql
-    assert "inside" not in sql  # exact-array $eq, NOT membership
-    assert compiled.params == {"f_0": ["a", "b"]}
-
-
-def test_system_in_is_membership_not_exact_array() -> None:
-    # $in on a system key is membership (INSIDE), NOT exact-array — distinct from
-    # the bare-list $eq case above.
-    compiled = compile_surrealdb(_ast({"occurred_at": {"$in": ["2026-01-01T00:00:00Z"]}}), _CTX)
-    sql = _norm(compiled.predicate)
-    assert "(occurred_at inside $f_0)" in sql
-    assert "!=" not in sql
-
-
-# ===========================================================================
-# Rule 4 — $exists on a system key is a CONSTANT (the always-present axiom); a
-# null operand resolves to (= NULL OR IS NONE).
-# ===========================================================================
-
-
-def test_system_exists_true_is_constant_true() -> None:
-    # A system key is treated as ALWAYS PRESENT (the oracle's axiom), so $exists:true
-    # is a CONSTANT ``true`` — NOT a presence test (``IS NOT NONE``), which would
-    # exclude rows where an unwritten denormalized doc key reads NONE. Matches
-    # compile_python / compile_postgres / compile_lance. Binds nothing.
-    compiled = compile_surrealdb(_ast({"source_name": {"$exists": True}}), _CTX)
-    sql = _norm(compiled.predicate)
-    assert "true" in sql
-    assert "is not none" not in sql and "is none" not in sql
-    assert compiled.params == {}
-
-
-def test_system_exists_false_is_constant_false() -> None:
-    compiled = compile_surrealdb(_ast({"source_name": {"$exists": False}}), _CTX)
-    sql = _norm(compiled.predicate)
-    assert "false" in sql
-    assert "is none" not in sql
-    assert compiled.params == {}
+#
+# Note: ``$exists`` and the bare-list (exact-array) ``$eq`` semantics that the old
+# string-keyed exemplars pinned are not expressible on the two backed keys (both are
+# datetime-typed, and DateOps forbids ``$exists`` / a list operand). Those forms are
+# only reachable via the unbacked path, where they RAISE — so they are covered by
+# the inversion tests above, and on the metadata path (which keeps its own $exists /
+# bare-list cases) below.
 
 
 def test_system_null_operand_is_null_or_none() -> None:
     # An explicit null is an active null-or-missing match. NONE (absent path) and
     # NULL (explicit json null) are distinct in SurrealQL, so the match covers both.
-    compiled = compile_surrealdb(_ast({"source_name": None}), _CTX)
+    compiled = compile_surrealdb(_ast({"occurred_at": None}), _CTX)
     sql = _norm(compiled.predicate)
-    assert "(source_name = null or source_name is none)" in sql
+    assert "(occurred_at = null or occurred_at is none)" in sql
     assert compiled.params == {}
 
 
 def test_system_ne_null_is_present_and_not_null() -> None:
     # $ne null → present (IS NOT NONE) and not explicit-null (!= NULL).
-    compiled = compile_surrealdb(_ast({"source_name": {"$ne": None}}), _CTX)
+    compiled = compile_surrealdb(_ast({"occurred_at": {"$ne": None}}), _CTX)
     sql = _norm(compiled.predicate)
-    assert "(source_name is not none and source_name != null)" in sql
+    assert "(occurred_at is not none and occurred_at != null)" in sql
     assert compiled.params == {}
 
 
@@ -336,13 +379,13 @@ def test_system_ne_null_is_present_and_not_null() -> None:
 
 
 def test_system_date_binds_real_datetime() -> None:
-    # A system date key takes a plain ISO string (the `$date` typed literal is a
-    # metadata-only form). It compiles to a plain ``=`` compare; the operand binds
+    # A backed system date key takes a plain ISO string (the `$date` typed literal is
+    # a metadata-only form). It compiles to a plain ``=`` compare; the operand binds
     # as a real, UTC-normalized datetime (the SDK encodes it as a SurrealQL
     # datetime — NOT an .isoformat() string, unlike Cypher and unlike the metadata
     # path).
-    compiled = compile_surrealdb(_ast({"source_timestamp": "2026-02-03T00:00:00Z"}), _CTX)
-    assert "(source_timestamp = $f_0)" in _norm(compiled.predicate)
+    compiled = compile_surrealdb(_ast({"created_at": "2026-02-03T00:00:00Z"}), _CTX)
+    assert "(created_at = $f_0)" in _norm(compiled.predicate)
     bound = compiled.params["f_0"]
     assert isinstance(bound, datetime)
     assert bound == datetime(2026, 2, 3, tzinfo=UTC)
@@ -572,25 +615,25 @@ def test_metadata_empty_nin_is_constant_true() -> None:
 
 
 # ===========================================================================
-# Logical composition — AND / OR / NOT + totality.
+# Logical composition — AND / OR / NOT + totality (over BACKED keys).
 # ===========================================================================
 
 
 def test_and_node_joins_with_and() -> None:
-    # Two sibling keys compose with " AND ". Child order is normalized (the system
-    # keys lower in a fixed order), not authored order — so do NOT assert order,
-    # only that both leaves and the AND join are present.
-    sql = _surql_norm(_ast({"source_name": "linear", "source_type": "slack"}))
+    # Two sibling backed keys compose with " AND ". Child order is normalized (the
+    # system keys lower in a fixed order), not authored order — so do NOT assert
+    # order, only that both leaves and the AND join are present.
+    sql = _surql_norm(_ast({"occurred_at": _DT, "created_at": "2026-02-01T00:00:00Z"}))
     assert " and " in sql
-    assert "source_name = $" in sql
-    assert "source_type = $" in sql
+    assert "occurred_at = $" in sql
+    assert "created_at = $" in sql
 
 
 def test_or_node_joins_with_or() -> None:
-    sql = _surql_norm(_ast({"$or": [{"source_name": "linear"}, {"source_type": "slack"}]}))
+    sql = _surql_norm(_ast({"$or": [{"occurred_at": _DT}, {"created_at": "2026-02-01T00:00:00Z"}]}))
     assert " or " in sql
-    assert "source_name = $" in sql
-    assert "source_type = $" in sql
+    assert "occurred_at = $" in sql
+    assert "created_at = $" in sql
 
 
 def test_not_node_negates_with_bang_and_plain_child() -> None:
@@ -599,9 +642,9 @@ def test_not_node_negates_with_bang_and_plain_child() -> None:
     # the inner leaf is the PLAIN (un-coalesced) ``=`` compare, and the ``!(...)``
     # flips an absent/null row IN correctly (Rule 2) without any coalesce wrapper.
     # We assert the bang-negation SHAPE and that the inner leaf carries NO coalesce.
-    sql = _surql_norm(_ast({"$not": {"source_name": "linear"}}))
+    sql = _surql_norm(_ast({"$not": {"occurred_at": _DT}}))
     assert sql.startswith("!(")
-    assert "(source_name = $f_0)" in sql
+    assert "(occurred_at = $f_0)" in sql
     assert "coalesce" not in sql
 
 
@@ -619,8 +662,8 @@ def test_nested_and_or_structure() -> None:
     sql = _surql_norm(
         _ast(
             {
-                "source_name": "linear",
-                "$or": [{"source_type": "slack"}, {"content_type": "text/plain"}],
+                "occurred_at": _DT,
+                "$or": [{"created_at": "2026-02-01T00:00:00Z"}, {"metadata.tier": "gold"}],
             }
         )
     )
@@ -634,14 +677,16 @@ def test_composition_binds_are_distinct_per_clause() -> None:
     compiled = compile_surrealdb(
         _ast(
             {
-                "source_name": "linear",
-                "$or": [{"source_type": "slack"}, {"content_type": "text/plain"}],
+                "occurred_at": _DT,
+                "$or": [{"created_at": "2026-02-01T00:00:00Z"}, {"metadata.tier": "gold"}],
             }
         ),
         _CTX,
     )
     assert set(compiled.params) == {"f_0", "f_1", "f_2"}
-    assert set(compiled.params.values()) == {"linear", "slack", "text/plain"}
+    # Two datetime binds + one string bind ("gold").
+    assert "gold" in compiled.params.values()
+    assert sum(isinstance(v, datetime) for v in compiled.params.values()) == 2
 
 
 # ===========================================================================
@@ -650,25 +695,25 @@ def test_composition_binds_are_distinct_per_clause() -> None:
 
 
 def test_compiled_filter_carries_canonical_hash() -> None:
-    node = _ast({"source_name": "linear"})
+    node = _ast({"occurred_at": _DT})
     compiled = compile_surrealdb(node, _CTX)
     assert compiled.canonical_hash == canonical_hash(node)
 
 
 def test_compiled_filter_consumed_keys_is_frozenset() -> None:
-    compiled = compile_surrealdb(_ast({"source_name": "linear"}), _CTX)
+    compiled = compile_surrealdb(_ast({"occurred_at": _DT}), _CTX)
     assert isinstance(compiled.consumed_keys, frozenset)
-    assert "source_name" in compiled.consumed_keys
+    assert "occurred_at" in compiled.consumed_keys
 
 
 def test_consumed_keys_collects_every_leaf() -> None:
     # A mixed system + nested-metadata filter consumes the dotted metadata key
-    # (its full dot-path string) alongside the system key.
+    # (its full dot-path string) alongside the backed system key.
     compiled = compile_surrealdb(
-        _ast({"source_name": "linear", "metadata.labels.tier": "gold"}),
+        _ast({"occurred_at": _DT, "metadata.labels.tier": "gold"}),
         _CTX,
     )
-    assert compiled.consumed_keys == frozenset({"source_name", "metadata.labels.tier"})
+    assert compiled.consumed_keys == frozenset({"occurred_at", "metadata.labels.tier"})
 
 
 def test_empty_filter_consumes_nothing() -> None:
@@ -702,19 +747,24 @@ def test_field_mapping_default_metadata_root_unremapped() -> None:
 
 
 def test_field_mapping_remaps_system_key_name() -> None:
-    # A system-key remap renames the bare column ref (e.g. the legacy schema's
-    # ``source_system`` column behind the ``source`` logical key).
+    # A backed system-key remap renames the bare column ref (e.g. a schema whose
+    # event-time column is named ``event_time`` behind the ``occurred_at`` logical
+    # key). The remap is a context choice; the key is still queryable (backed).
     ctx = CompileContext(
         backend_target="temporal_chunk",
-        field_mapping={"source": "source_system"},
+        field_mapping={"occurred_at": "event_time", "metadata": "metadata_"},
     )
-    assert "(source_system = $f_0)" in _surql_norm(_ast({"source": "slack"}), ctx)
+    assert "(event_time = $f_0)" in _surql_norm(_ast({"occurred_at": _DT}), ctx)
 
 
 def test_param_namespace_prefixes_bind_names() -> None:
     # param_namespace prefixes every bind name so compiled params cannot collide
     # with the engine's own query parameters.
-    ctx = CompileContext(backend_target="temporal_chunk", param_namespace="p")
-    compiled = compile_surrealdb(_ast({"source_name": "linear"}), ctx)
+    ctx = CompileContext(
+        backend_target="temporal_chunk",
+        param_namespace="p",
+        field_mapping={"occurred_at": "occurred_at", "created_at": "created_at", "metadata": "metadata_"},
+    )
+    compiled = compile_surrealdb(_ast({"occurred_at": _DT}), ctx)
     assert "$p_0" in compiled.predicate
-    assert compiled.params == {"p_0": "linear"}
+    assert isinstance(compiled.params["p_0"], datetime)

--- a/tests/unit/filter/test_conformance_harness.py
+++ b/tests/unit/filter/test_conformance_harness.py
@@ -284,13 +284,16 @@ def test_postgres_executor_invokes_real_compiler() -> None:
 # assert_case's expect_unsupported branch (harness control flow).
 # --------------------------------------------------------------------------- #
 #
-# The validator and the python/postgres compilers share one expressiveness
-# envelope by design, so no VALIDATED wire filter naturally diverges between them
-# (the catalog's F-UNSUP family carves out the real unsupported clauses end to end).
-# To exercise the harness's own unsupported handling here, in process, a synthetic
-# executor raises RecallFilterUnsupportedError and assert_case is checked to (a)
-# accept it when the backend is declared unsupported and (b) NOT swallow it
-# otherwise.
+# The validator and the python/postgres compilers share one expressiveness envelope
+# by design, so no VALIDATED wire filter diverges between THOSE two. A real
+# backend-specific divergence does now exist on the surreal leg: the SurrealDB
+# compiler raises RecallFilterUnsupportedError on a predicate over one of the eight
+# unbacked system keys (the catalog's F-UNSUP surreal-unbacked cases carry it end to
+# end via expect_unsupported={"surrealdb"}). The synthetic check below is the
+# in-process unit for the harness's OWN unsupported control flow, independent of any
+# real backend: a synthetic executor raises RecallFilterUnsupportedError and
+# assert_case is checked to (a) accept it when the backend is declared unsupported
+# and (b) NOT swallow it otherwise.
 
 
 class _RaisingExecutor:
@@ -480,31 +483,27 @@ def test_f_exists_covers_eight_shapes_in_two_modes() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# System-key $exists is a CONSTANT on EVERY string-emitting backend (cross-
-# backend determinism — the always-present axiom).
+# System-key $exists is a CONSTANT on the column-projecting string-emitting
+# backends (cross-backend determinism — the always-present axiom).
 # --------------------------------------------------------------------------- #
 #
 # The oracle treats a system key as always-present, so $exists:true is a constant
 # TRUE (all rows) and $exists:false a constant FALSE (no rows). postgres / lance
-# already emit a constant; cypher and surrealdb were FIXED to do the same (they
-# previously emitted a `IS NOT NULL` / `IS NOT NONE` presence test that diverged on
-# an unset system column). Pin the constant on every string-emitting compiler so a
-# regression to a presence test on ANY backend fails loudly. (postgres emits a
-# SQLAlchemy ``true()``/``false()`` object and weaviate defers $exists to the
-# post-filter — both are checked in their own compiler suites; here we pin the
-# three string-emitting compilers where the regression risk lives.)
+# already emit a constant; cypher was FIXED to do the same (it previously emitted an
+# `IS NOT NULL` presence test that diverged on an unset system column). Pin the
+# constant on these string-emitting compilers so a regression to a presence test
+# fails loudly. (postgres emits a SQLAlchemy ``true()``/``false()`` object and
+# weaviate defers $exists to the post-filter — both are checked in their own
+# compiler suites; here we pin the string-emitting compilers where the regression
+# risk lives.) surrealdb is the deliberate exception: the eight unbacked system keys
+# are NOT columns on its ``temporal_chunk`` table, so it RAISES on an unbacked-key
+# $exists (a constant would be meaningless on a non-existent column) — its divergence
+# is asserted directly below, not as a constant.
 
 
 @pytest.mark.parametrize(
     ("label", "compiler", "ctx", "true_token", "false_token"),
     [
-        (
-            "surrealdb",
-            "compile_surrealdb",
-            {"backend_target": "temporal_chunk", "field_mapping": {"metadata": "metadata_"}},
-            "true",
-            "false",
-        ),
         ("cypher", "compile_cypher", {"backend_target": "Chunk", "table_alias": "c"}, "true", "false"),
         # SQLite has no boolean literal — the constant is the integer 1 / 0.
         ("sqlite_lance", "compile_lance", {"backend_target": "khora_chunks"}, "1", "0"),
@@ -536,3 +535,25 @@ def test_system_exists_is_constant_not_presence_test(
     # is caught here.
     assert true_token in true_pred and "is not null" not in true_pred and "is not none" not in true_pred, true_pred
     assert false_token in false_pred and "is null" not in false_pred and "is none" not in false_pred, false_pred
+
+
+@pytest.mark.parametrize("exists", [True, False])
+def test_surrealdb_unbacked_system_key_exists_raises_not_constant(exists: bool) -> None:
+    # The surrealdb counterpart to the cross-backend constant axiom above: an
+    # unbacked system key ($exists on ``source_name``, which is not a column on the
+    # ``temporal_chunk`` table) does NOT collapse to a constant — it RAISES, because
+    # a constant over a non-existent column would be meaningless. This is the
+    # backend's deliberate divergence from the always-present axiom.
+    from khora.filter import RecallFilter
+    from khora.filter.compilers.surrealdb import compile_surrealdb
+    from khora.filter.context import CompileContext, RecallFilterUnsupportedError
+
+    ctx = CompileContext(
+        backend_target="temporal_chunk",
+        field_mapping={"occurred_at": "occurred_at", "created_at": "created_at", "metadata": "metadata_"},
+    )
+    ast = parse_to_ast(RecallFilter.model_validate({"source_name": {"$exists": exists}}))
+    with pytest.raises(RecallFilterUnsupportedError, match="does not back") as exc:
+        compile_surrealdb(ast, ctx)
+    # Load-bearing invariant alongside the intent substring: the gate named the key.
+    assert "source_name" in str(exc.value)

--- a/tests/unit/filter/test_surrealdb_backed_keys_drift.py
+++ b/tests/unit/filter/test_surrealdb_backed_keys_drift.py
@@ -1,0 +1,87 @@
+"""Drift gate: the surrealdb backed-key set tracks the temporal_chunk schema — ``@internal``.
+
+The SurrealDB recall path can only push a predicate over a system key the
+``temporal_chunk`` table actually backs with a real column. The store declares that
+queryable set as :data:`~khora.engines.skeleton.backends.surrealdb._BACKED_SYSTEM_KEYS`
+(``{"occurred_at", "created_at"}``) and the compiler refuses (raising) any predicate
+over a system key outside it.
+
+That declared set is hand-maintained, but its SOURCE OF TRUTH is the schema: the only
+:data:`SYSTEM_KEYS` members that are real columns on the SCHEMAFULL ``temporal_chunk``
+table. This test parses the schema DDL the store actually runs and asserts the two
+stay in lock-step, so a future schema edit (adding a system-key column, or dropping
+``occurred_at``) that is not mirrored into ``_BACKED_SYSTEM_KEYS`` — or vice versa —
+fails LOUDLY here instead of silently letting an unbacked predicate through
+(drop-every-row bug) or rejecting a now-backed key.
+
+Note: ``source_system`` / ``author`` / ``channel`` / ``tags`` are columns on the
+table but are NOT :data:`SYSTEM_KEYS`, so the ``SYSTEM_KEYS ∩ columns`` intersection
+naturally excludes them — the gate is about the filterable system-key surface, not
+every physical column.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from khora.engines.skeleton.backends.surrealdb import _BACKED_SYSTEM_KEYS, _TEMPORAL_CHUNK_SCHEMA
+from khora.filter.model import SYSTEM_KEYS
+
+pytestmark = pytest.mark.unit
+
+# Every ``DEFINE FIELD IF NOT EXISTS <name> ON temporal_chunk`` column name in the
+# schema DDL the store runs on ``connect()``.
+_SCHEMA_FIELD_RE = re.compile(r"DEFINE FIELD IF NOT EXISTS (\w+) ON temporal_chunk")
+
+
+def _schema_columns() -> frozenset[str]:
+    """The set of column names defined on the temporal_chunk table by the store DDL."""
+    return frozenset(_SCHEMA_FIELD_RE.findall(_TEMPORAL_CHUNK_SCHEMA))
+
+
+def test_backed_system_keys_are_exactly_occurred_at_and_created_at() -> None:
+    # The declared backed (queryable) system-key set is exactly the two datetime
+    # columns. A regression that adds/drops a key is caught here.
+    assert _BACKED_SYSTEM_KEYS == frozenset({"occurred_at", "created_at"})
+
+
+def test_backed_system_keys_match_schema_columns() -> None:
+    # The drift gate: the declared backed system-key set MUST equal the SYSTEM_KEYS
+    # members that are actually columns on the temporal_chunk table. If a schema
+    # migration adds (or removes) a system-key column without updating
+    # _BACKED_SYSTEM_KEYS — or _BACKED_SYSTEM_KEYS drifts from the schema — these two
+    # sets diverge and this assertion fails, naming the offending keys.
+    schema_backed = SYSTEM_KEYS & _schema_columns()
+    assert _BACKED_SYSTEM_KEYS == schema_backed, (
+        f"surrealdb backed system keys {sorted(_BACKED_SYSTEM_KEYS)} drifted from temporal_chunk schema "
+        f"columns {sorted(schema_backed)} — update _BACKED_SYSTEM_KEYS to match the schema"
+    )
+
+
+def test_backed_set_is_a_subset_of_system_keys() -> None:
+    # The backed set only ever names real SYSTEM_KEYS members — a typo or a stray
+    # non-system column (e.g. ``source_system``) would not be a filterable key.
+    assert _BACKED_SYSTEM_KEYS <= SYSTEM_KEYS
+
+
+def test_unbacked_keys_are_the_eight_remaining_system_keys() -> None:
+    # The complement within SYSTEM_KEYS is the eight denormalized document keys the
+    # gate rejects — pin it so a key silently migrating between backed/unbacked is
+    # caught. (Guards the partition: backed ∪ unbacked == SYSTEM_KEYS, disjoint.)
+    unbacked = SYSTEM_KEYS - _BACKED_SYSTEM_KEYS
+    assert unbacked == frozenset(
+        {
+            "source_type",
+            "source_name",
+            "source_url",
+            "source_timestamp",
+            "external_id",
+            "content_type",
+            "source",
+            "title",
+        }
+    )
+    assert _BACKED_SYSTEM_KEYS | unbacked == SYSTEM_KEYS
+    assert _BACKED_SYSTEM_KEYS & unbacked == frozenset()


### PR DESCRIPTION
## Summary
- The SurrealDB skeleton store's `temporal_chunk` table backs only two of the denormalized document system keys with real columns (`occurred_at`, `created_at`). A recall filter on any of the other eight (`source_name`, `source_type`, `source_url`, `source_timestamp`, `external_id`, `content_type`, `source`, `title`) previously compiled to a predicate over a field the SCHEMAFULL table reads as `NONE` — total-false for every row — so recall **silently returned nothing** (and negations could leak excluded rows) instead of erroring.
- Gate the SurrealQL filter compiler's system-key pushdown on the declared `field_mapping` whitelist (mirroring the Weaviate compiler): a system key absent from the declared mapping is routed to `on_unsupported`. The store compiles in raise mode on both the vector and BM25 channels, so it now raises `RecallFilterUnsupportedError` for **any** operator (including `$exists`) on an unbacked key — fail loud, no silent wrong results.
- The store declares exactly the backed keys (`occurred_at`, `created_at`, plus the `metadata → metadata_` mapping) through one shared compile-context helper used at both compile sites. `occurred_at`/`created_at` and `metadata.*` filters are unaffected.
- Register the eight keys as expected-unsupported on the filter-conformance corpus's SurrealDB leg (asserting the raise, not silently skipping), add a drift gate pinning the declared key set to the table schema, and add store-level tests covering both channels plus positive controls.
- No schema columns added; no other backends' compilers touched.

## Test plan
- [x] Unit lane passes (`make test-unit`: 8728 passed, 35 skipped)
- [x] Filter compiler corpus + drift gate + conformance harness unit tests pass
- [x] SurrealDB conformance leg green (`-m filter_conformance`, embedded: 189 passed)
- [x] Store-level both-channel tests pass (vector + BM25 raise on the 8 keys; `occurred_at` range + `metadata.*` positive controls)
- [x] `make lint` + `make format` clean