### PR TITLE
Denormalize document string keys in the sqlite_lance conformance runner

### DIFF
--- a/src/khora/filter/conformance.py
+++ b/src/khora/filter/conformance.py
@@ -759,27 +759,25 @@ _OP_BACKENDS: frozenset[str] = _INMEM_BACKENDS | _LIVE_BACKENDS
 # The live backends that do NOT carry the seven string document keys
 # (``source_name`` / ``source_url`` / ``external_id`` / ``content_type`` /
 # ``source`` / ``source_type`` / ``title``) on the queryable row, so a predicate that
-# READS a string-key value is empty / divergent there and is pruned: the sqlite_lance
-# runner seeds through the core ``Chunk`` (the string keys live on the Document, not
-# the core chunk, so they land NULL), and the weaviate ``KhoraChunk`` collection
-# schema has no string-key columns at all. The surrealdb and cypher runners seed the
-# seven string keys verbatim onto the queryable row, and the postgres runner now
-# denormalizes them off the parent ``documents`` row onto each chunk (mirroring
-# production), so all three KEEP string-key value cases. (Postgres still prunes a
-# ``source_type`` value leaf when a seed record leaves ``source_type`` unset — see
-# :data:`_SOURCE_TYPE_DEFAULTED_BACKENDS`.)
-_NO_STRING_KEY_BACKENDS: frozenset[str] = frozenset({"sqlite_lance", "weaviate"})
+# READS a string-key value is empty / divergent there and is pruned: the weaviate
+# ``KhoraChunk`` collection schema has no string-key columns at all. The surrealdb and
+# cypher runners seed the seven string keys verbatim onto the queryable row, and the
+# postgres and sqlite_lance runners now denormalize them off the parent ``documents``
+# row onto each chunk (mirroring production), so all four KEEP string-key value cases.
+# (Postgres and sqlite_lance still prune a ``source_type`` value leaf when a seed
+# record leaves ``source_type`` unset — see :data:`_SOURCE_TYPE_DEFAULTED_BACKENDS`.)
+_NO_STRING_KEY_BACKENDS: frozenset[str] = frozenset({"weaviate"})
 
 # The live backends that DEFAULT an unset ``source_type`` to ``"library"``: the
-# postgres runner denormalizes the parent Document's ``source_type`` onto the chunk,
-# and the ``Document`` dataclass defaults ``source_type`` to ``"library"`` (so does
-# ``seed_case`` for a record that leaves it unset). The in-memory oracle, by
-# contrast, sees an unset ``source_type`` as ABSENT, so a ``source_type`` VALUE leaf
-# over a seed with any unset ``source_type`` row diverges (``"library"`` on postgres
-# vs absent in the oracle) and is pruned from postgres. A seed that sets
-# ``source_type`` on every record is unaffected. surrealdb / cypher seed the
-# ``SeedRecord`` verbatim (no Document default), so they are never pruned for this.
-_SOURCE_TYPE_DEFAULTED_BACKENDS: frozenset[str] = frozenset({"postgres"})
+# postgres and sqlite_lance runners denormalize the parent Document's ``source_type``
+# onto the chunk, and the ``Document`` dataclass defaults ``source_type`` to
+# ``"library"`` (so does ``seed_case`` for a record that leaves it unset). The
+# in-memory oracle, by contrast, sees an unset ``source_type`` as ABSENT, so a
+# ``source_type`` VALUE leaf over a seed with any unset ``source_type`` row diverges
+# (``"library"`` on those backends vs absent in the oracle) and is pruned from them. A
+# seed that sets ``source_type`` on every record is unaffected. surrealdb / cypher seed
+# the ``SeedRecord`` verbatim (no Document default), so they are never pruned for this.
+_SOURCE_TYPE_DEFAULTED_BACKENDS: frozenset[str] = frozenset({"postgres", "sqlite_lance"})
 
 # The live backends that STAMP ``created_at`` to ``now()`` on insert when absent
 # (postgres + lance via the skeleton temporal store; weaviate via the same store
@@ -930,15 +928,15 @@ def _backends_for_filter(filter_: dict[str, Any] | RecallFilter, seed: tuple[See
     seed reason — never a silent skip):
 
     * a leaf that READS one of the seven STRING document keys' value (any op except
-      ``$exists``) → drop :data:`_NO_STRING_KEY_BACKENDS` (sqlite_lance / weaviate,
-      whose seed does not carry the string keys). postgres now denormalizes the keys
-      off the parent document, and surrealdb + cypher seed them verbatim, so all
-      three KEEP it; python + chronicle always do;
+      ``$exists``) → drop :data:`_NO_STRING_KEY_BACKENDS` (weaviate, whose seed does
+      not carry the string keys). postgres and sqlite_lance now denormalize the keys
+      off the parent document, and surrealdb + cypher seed them verbatim, so all four
+      KEEP it; python + chronicle always do;
     * a ``source_type`` VALUE leaf over a seed that leaves ``source_type`` unset on
-      any record → ALSO drop :data:`_SOURCE_TYPE_DEFAULTED_BACKENDS` (postgres): the
-      denormalized chunk inherits the Document default ``"library"`` while the oracle
-      sees the key absent, so the two diverge. A seed that sets ``source_type`` on
-      every record keeps postgres;
+      any record → ALSO drop :data:`_SOURCE_TYPE_DEFAULTED_BACKENDS` (postgres +
+      sqlite_lance): the denormalized chunk inherits the Document default ``"library"``
+      while the oracle sees the key absent, so the two diverge. A seed that sets
+      ``source_type`` on every record keeps them;
     * a ``$exists`` on a string document key is **NOT** a prune: ``$exists`` on a
       system key is a CONSTANT (the always-present axiom), value-independent and
       oracle-comparable on every backend — this is what lets the F-EXISTS system-key
@@ -965,9 +963,9 @@ def _backends_for_filter(filter_: dict[str, Any] | RecallFilter, seed: tuple[See
         if root in string_keys and clause.op is not Op.EXISTS:
             # A value-reading predicate on a string column the seed may not carry.
             excluded |= _NO_STRING_KEY_BACKENDS
-            # A ``source_type`` value leaf diverges on postgres when any seed record
-            # left ``source_type`` unset: the denormalized chunk inherits the
-            # Document default ``"library"`` while the oracle treats it as absent.
+            # A ``source_type`` value leaf diverges on postgres / sqlite_lance when any
+            # seed record left ``source_type`` unset: the denormalized chunk inherits
+            # the Document default ``"library"`` while the oracle treats it as absent.
             if root == "source_type" and any(rec.source_type is None for rec in seed):
                 excluded |= _SOURCE_TYPE_DEFAULTED_BACKENDS
         elif root == "created_at":
@@ -1000,18 +998,18 @@ def _seed_has_duplicate_external_id(seed: tuple[SeedRecord, ...]) -> bool:
 
 
 # The one non-null string system key — the ``Document`` dataclass defaults
-# ``source_type`` to ``"library"``, which the postgres runner denormalizes onto the
-# chunk, so a ``-5`` row with the key unset would be ``"library"`` on that backend
-# but ``None`` in the in-memory oracle. To keep ``expected_ids`` backend-consistent
-# that key is seeded with five populated rows (no NULL row); with every record
-# populated, the seed-aware postgres prune (:func:`_backends_for_filter`) does not
-# fire, so ``source_type`` VALUE cases run on postgres too. Every other string key is
-# nullable (unset ⇒ NULL on the stores that carry it, ``None`` in the oracle —
-# consistent), so it carries the ``-5`` NULL row that F1 (Mongo-faithful negation)
-# keeps under ``$ne``/``$nin``. A string-key VALUE case now runs on every backend
-# whose runner carries the string keys (postgres + surrealdb + cypher, plus python +
-# chronicle); only sqlite_lance / weaviate prune it; the per-case set is computed by
-# :func:`_backends_for_filter`.
+# ``source_type`` to ``"library"``, which the postgres and sqlite_lance runners
+# denormalize onto the chunk, so a ``-5`` row with the key unset would be ``"library"``
+# on those backends but ``None`` in the in-memory oracle. To keep ``expected_ids``
+# backend-consistent that key is seeded with five populated rows (no NULL row); with
+# every record populated, the seed-aware ``source_type`` prune
+# (:func:`_backends_for_filter`) does not fire, so ``source_type`` VALUE cases run on
+# postgres and sqlite_lance too. Every other string key is nullable (unset ⇒ NULL on
+# the stores that carry it, ``None`` in the oracle — consistent), so it carries the
+# ``-5`` NULL row that F1 (Mongo-faithful negation) keeps under ``$ne``/``$nin``. A
+# string-key VALUE case now runs on every backend whose runner carries the string keys
+# (postgres + sqlite_lance + surrealdb + cypher, plus python + chronicle); only
+# weaviate prunes it; the per-case set is computed by :func:`_backends_for_filter`.
 _NON_NULL_STRING_KEY = "source_type"
 
 
@@ -1140,11 +1138,11 @@ def _string_op_cases(key: str) -> list[ConformanceCase]:
     # expected_ids stay consistent across every backend that carries the string key.
     # ``backends`` is computed per-case (:func:`_backends_for_filter`): a value-reading
     # string predicate drops the live legs that do not carry the string keys
-    # (sqlite_lance / weaviate) and keeps postgres (denormalized off the parent
+    # (weaviate) and keeps postgres + sqlite_lance (both denormalized off the parent
     # document) + surrealdb + cypher plus python + chronicle. A ``source_type`` value
-    # leaf would additionally drop postgres if any seed row left it unset, but this
-    # seed populates all five rows, so postgres stays. An ``$exists`` (a constant on a
-    # system key) stays on all.
+    # leaf would additionally drop postgres / sqlite_lance if any seed row left it
+    # unset, but this seed populates all five rows, so both stay. An ``$exists`` (a
+    # constant on a system key) stays on all.
     def case(suffix: str, predicate: Any, expected: frozenset[str], op_tag: str) -> ConformanceCase:
         filter_ = {key: predicate}
         backends = _backends_for_filter(filter_, seed)
@@ -1213,8 +1211,8 @@ def f_op_cases() -> list[ConformanceCase]:
     while the one non-null key (``source_type``) is seeded fully populated so its
     ``expected_ids`` stay consistent across every backend that carries the key. A
     string-key VALUE case runs on the backends whose runner carries the string keys
-    (postgres — denormalized off the parent document — plus surrealdb + cypher +
-    python + chronicle); only sqlite_lance / weaviate prune it. A string-key
+    (postgres + sqlite_lance — both denormalized off the parent document — plus
+    surrealdb + cypher + python + chronicle); only weaviate prunes it. A string-key
     ``$exists`` (a constant on a system key) runs on all (see
     :func:`_backends_for_filter`).
     Every case tags the system key it exercises in ``exercises`` so the coverage

--- a/tests/integration/matrix/_conformance_lance.py
+++ b/tests/integration/matrix/_conformance_lance.py
@@ -59,7 +59,7 @@ from khora.engines.skeleton.backends import TemporalChunk
 from khora.engines.skeleton.backends.sqlite_lance import SQLiteLanceTemporalStore
 from khora.filter import CompiledFilter
 from khora.filter.ast import FilterNode
-from khora.filter.conformance import ConformanceCase, LanceExecutor, seed_case
+from khora.filter.conformance import _DOC_STRING_KEYS, ConformanceCase, LanceExecutor, seed_case
 from khora.storage.backends.sqlite_lance import SQLiteLanceRelationalAdapter
 from khora.storage.backends.sqlite_lance._helpers import uuid_to_text
 from khora.storage.backends.sqlite_lance.connection import (
@@ -105,15 +105,23 @@ def lance_conformance_cases() -> list[ConformanceCase]:
     return [c for c in cases if "sqlite_lance" in c.backends]
 
 
-def _to_temporal_chunk(chunk: Chunk) -> TemporalChunk:
+def _to_temporal_chunk(chunk: Chunk, doc_keys: Mapping[str, Any]) -> TemporalChunk:
     """Adapt a core ``Chunk`` (what ``seed_case`` builds) to the ``TemporalChunk``
-    the skeleton ``khora_chunks`` store writes.
+    the skeleton ``khora_chunks`` store writes, stamping the parent document's
+    denormalized string keys.
 
     ``SQLiteLanceTemporalStore.create_chunks_batch`` reads ``TemporalChunk``-only
     columns (``source_system`` / ``author`` / ``channel`` / the denormalized document
     keys). ``seed_case`` sets only the fields both models share — ids, content, the
     three date keys (occurred_at / created_at / source_timestamp), and metadata — so
-    copy those and let the skeleton-only columns default to ``None``.
+    copy those. The seven string document keys
+    (``source_type`` / ``source_name`` / ``source_url`` / ``external_id`` /
+    ``content_type`` / ``source`` / ``title``) live on the parent ``Document``, not
+    the core ``Chunk``; ``doc_keys`` carries them off that document so the chunk row
+    is queryable on them, mirroring the production denormalization the
+    ``SQLiteLanceTemporalStore`` write path performs (the same move the postgres twin
+    ``_conformance_pg.py`` makes). The remaining skeleton-only columns default to
+    ``None``.
 
     ``embedding`` is dropped (``None``): filter conformance never touches the vector
     channel, and a ``None`` embedding makes the store skip the LanceDB write entirely
@@ -130,6 +138,7 @@ def _to_temporal_chunk(chunk: Chunk) -> TemporalChunk:
         source_timestamp=chunk.source_timestamp,
         metadata=dict(chunk.metadata or {}),
         chunker_info=dict(chunk.chunker_info or {}),
+        **doc_keys,
     )
 
 
@@ -139,11 +148,37 @@ class _CoreChunkTemporalStore(SQLiteLanceTemporalStore):
     The conformance seeder writes through the coordinator with core ``Chunk``
     instances, but the skeleton store's batch insert reads ``TemporalChunk``-only
     attributes. Convert at this boundary so the harness stays storage-agnostic and the
-    production store is untouched.
+    production store is untouched. The parent document's seven string keys are
+    denormalized onto each chunk (one batched SELECT on the shared SQLite file), so the
+    sqlite_lance leg carries them on the queryable row exactly as production does —
+    mirroring the postgres twin's ``_CoreChunkTemporalStore`` in ``_conformance_pg.py``.
     """
 
     async def create_chunks_batch(self, chunks: list[Chunk]) -> list[TemporalChunk]:  # type: ignore[override]
-        return await super().create_chunks_batch([_to_temporal_chunk(c) for c in chunks])
+        doc_keys_by_id = await self._fetch_document_keys({c.document_id for c in chunks})
+        temporal = [_to_temporal_chunk(c, doc_keys_by_id.get(c.document_id, {})) for c in chunks]
+        return await super().create_chunks_batch(temporal)
+
+    async def _fetch_document_keys(self, document_ids: set[UUID]) -> dict[UUID, dict[str, Any]]:
+        """Read the seven string keys off each parent document (one batched query).
+
+        Mirrors production denormalization: the keys live on ``documents`` and are
+        copied onto the chunk row. The documents were written by ``seed_case`` through
+        the relational adapter's SQLAlchemy engine immediately before — onto the same
+        physical SQLite file this raw-aiosqlite handle reads, in the shared
+        hex-no-dashes UUID encoding (``uuid_to_text``) — so the rows are present and
+        the ``id IN (...)`` bind matches. This is the sqlite_lance counterpart to the
+        postgres twin's ``_fetch_document_keys`` in ``_conformance_pg.py``.
+        """
+        if not document_ids:
+            return {}
+        placeholders = ",".join("?" for _ in document_ids)
+        columns = ", ".join(("id", *_DOC_STRING_KEYS))
+        sql = f"SELECT {columns} FROM documents WHERE id IN ({placeholders})"  # noqa: S608 - ids bind positionally
+        ids = [uuid_to_text(did) for did in document_ids]
+        cur = await self._sqlite.execute(sql, ids)
+        rows = await cur.fetchall()
+        return {UUID(row["id"]): {key: row[key] for key in _DOC_STRING_KEYS} for row in rows}
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- The recall-filter conformance corpus pruned every case that reads the *value* of one of the seven string document keys (`source_type`, `source_name`, `source_url`, `external_id`, `content_type`, `source`, `title`) off the `sqlite_lance` leg. The pruning existed because the conformance seeder builds chunk rows from the core `Chunk` model, which carries no string keys (they live on `Document`), so the denormalized chunk columns landed `NULL` and diverged from the python oracle.
- This was a seeder gap, not a backend gap: production `sqlite_lance` copies those keys onto each chunk row (the compiled predicate targets the denormalized chunk columns, no documents join). The conformance runner now mirrors production — and the existing postgres conformance runner — by fetching the seven keys off the parent `documents` row in one batched query and stamping them onto each `TemporalChunk` before insert.
- `_NO_STRING_KEY_BACKENDS` now contains only `weaviate` (whose collection schema genuinely lacks the columns). `sqlite_lance` joins `_SOURCE_TYPE_DEFAULTED_BACKENDS`: an unset `source_type` denormalizes to the `Document` default `"library"` while the oracle sees the key absent, so a `source_type` value leaf over a seed with an unset row is still pruned for that specific reason.
- Test-runner only: no production code changes. The override lives entirely in the conformance runner subclass.

Collect-count on the `sqlite_lance` leg rises from **122 → 187** (+65 string-key value cases now exercised).

## Test plan
- [x] `sqlite_lance` filter-conformance leg green — 187 passed (was 122 collected before)
- [x] `python` oracle filter-conformance leg unaffected — 208 passed
- [x] Filter unit guards green — 698 passed (`test_conformance_harness`, `test_conformance_catalog`, `test_system_keys_coverage`)
- [x] `make format` and `make lint` clean
- [ ] Full CI matrix (including docker integration/e2e legs) green