### PR TITLE
Store denormalized document fields on the Weaviate KhoraChunk collection

### DIFF
--- a/src/khora/engines/skeleton/backends/weaviate.py
+++ b/src/khora/engines/skeleton/backends/weaviate.py
@@ -66,6 +66,40 @@ COLLECTION_NAME = "KhoraChunk"
 # survivor set can still reach ``limit`` after the post-filter prunes.
 _FILTER_OVERFETCH = 4
 
+# The seven denormalized document string keys carried on every ``KhoraChunk`` object
+# (the eighth, ``source_timestamp``, is a DATE). Stored as filterable-only TEXT
+# (``index_searchable=False`` keeps them out of BM25 hybrid search) so the post-filter
+# can read them back; they do NOT push down (pushdown stays date-only).
+_DENORM_TEXT_KEYS: tuple[str, ...] = (
+    "source_type",
+    "source_name",
+    "source_url",
+    "external_id",
+    "content_type",
+    "source",
+    "title",
+)
+
+
+def _denorm_properties() -> tuple[Any, ...]:
+    """Build the eight denormalized document properties (single source: create + reconcile).
+
+    Lazily constructed because ``weaviate.classes.config`` is an optional import
+    (the backend module imports fine without ``weaviate-client`` installed). The
+    seven string keys are TEXT with ``index_searchable=False`` — a REQUIRED guard
+    against BM25 hybrid-search pollution — and ``index_filterable=True`` so the
+    post-filter can address them; ``source_timestamp`` is a DATE.
+    """
+    from weaviate.classes.config import DataType, Property
+
+    return (
+        *(
+            Property(name=key, data_type=DataType.TEXT, index_filterable=True, index_searchable=False)
+            for key in _DENORM_TEXT_KEYS
+        ),
+        Property(name="source_timestamp", data_type=DataType.DATE),
+    )
+
 
 @dataclass(frozen=True)
 class WeaviateBackendConfig:
@@ -243,10 +277,19 @@ class WeaviateTemporalStore(TemporalVectorStore):
                     Property(name="tags", data_type=DataType.TEXT_ARRAY),
                     Property(name="confidence", data_type=DataType.NUMBER),
                     Property(name="metadata_json", data_type=DataType.TEXT),  # JSON string
+                    *_denorm_properties(),
                 ],
                 multi_tenancy_config=Configure.multi_tenancy(enabled=True),
             )
             logger.info(f"Created Weaviate collection: {COLLECTION_NAME}")
+        else:
+            # Idempotently reconcile a pre-existing collection: add any denorm property
+            # missing from an older schema (no-op once every denorm key is present).
+            collection = self._client.collections.get(COLLECTION_NAME)
+            existing = {p.name for p in (await collection.config.get()).properties}
+            for prop in _denorm_properties():
+                if prop.name not in existing:
+                    await collection.config.add_property(prop)
 
         self._connected = True
         logger.info(
@@ -427,17 +470,18 @@ class WeaviateTemporalStore(TemporalVectorStore):
            pushed-down date keys in Python is idempotent — this guarantees the
            backend honors the filter and never raises.
 
-        Stale-collection-schema limitation: the eight document-grained system keys
-        (``source_type`` / ``source_name`` / ``source_url`` / ``source_timestamp``
-        / ``external_id`` / ``content_type`` / ``source`` / ``title``) are NOT
-        stored on the ``KhoraChunk`` collection, nor is the structured ``metadata``
-        blob (it is serialized to a single ``metadata_json`` string property). A
-        predicate on any of those post-filters against an absent field, so
-        ``compile_python``'s absent-key semantics apply (a positive op excludes the
-        chunk, a negation includes it). Pushing those down would need a separate
-        collection-projection change and is out of scope here.
+        The eight document-grained system keys (``source_type`` / ``source_name`` /
+        ``source_url`` / ``external_id`` / ``content_type`` / ``source`` / ``title``
+        and ``source_timestamp``) are stored on the ``KhoraChunk`` object as
+        filterable-only properties — the seven strings as ``TEXT`` with
+        ``index_searchable=False`` (kept out of BM25 hybrid search) and
+        ``source_timestamp`` as ``DATE`` — and are enforced by the python post-filter,
+        which reads them back off the returned object. Pushdown stays date-only
+        (``occurred_at`` / ``created_at`` in ``field_mapping``); the structured
+        ``metadata`` blob remains a single ``metadata_json`` string property re-checked
+        by the post-filter.
 
-        Two edge cases worth knowing:
+        One edge case worth knowing:
 
         * **May return fewer than** ``limit``. A predicate Weaviate cannot
           pre-narrow (any ``metadata`` path — metadata is not a queryable property)
@@ -447,12 +491,6 @@ class WeaviateTemporalStore(TemporalVectorStore):
           (never a wrong row, only possibly fewer) and inherent to post-filtering;
           a caller needing exactly ``limit`` under heavy metadata selectivity must
           widen the candidate budget (raise ``limit`` upstream).
-        * **A positive predicate on an unstored key returns ZERO rows.** Because
-          the eight document-grained system keys above are absent on every stored
-          object, a positive predicate such as ``{"source_name": "foo"}``
-          post-filters to an empty result (absent == not-equal under §4); only the
-          negation form (``$ne`` / ``$nin``) admits those rows. Not a silent bug —
-          a direct consequence of the stale-collection-schema limitation.
         """
         from weaviate.classes.query import HybridFusion, MetadataQuery
 
@@ -649,6 +687,14 @@ class WeaviateTemporalStore(TemporalVectorStore):
             tags=props.get("tags") or [],
             confidence=props.get("confidence", 1.0),
             metadata=metadata,
+            source_type=props.get("source_type"),
+            source_name=props.get("source_name"),
+            source_url=props.get("source_url"),
+            external_id=props.get("external_id"),
+            content_type=props.get("content_type"),
+            source=props.get("source"),
+            title=props.get("title"),
+            source_timestamp=_coerce_datetime(props.get("source_timestamp")),
         )
 
     async def health_check(self) -> dict[str, Any]:
@@ -748,6 +794,14 @@ def _chunk_to_properties(chunk: TemporalChunk) -> dict[str, Any]:
         "tags": chunk.tags or [],
         "confidence": chunk.confidence,
         "metadata_json": json.dumps(chunk.metadata or {}),
+        "source_type": chunk.source_type,
+        "source_name": chunk.source_name,
+        "source_url": chunk.source_url,
+        "external_id": chunk.external_id,
+        "content_type": chunk.content_type,
+        "source": chunk.source,
+        "title": chunk.title,
+        "source_timestamp": chunk.source_timestamp.isoformat() if chunk.source_timestamp else None,
     }
 
 

--- a/src/khora/filter/conformance.py
+++ b/src/khora/filter/conformance.py
@@ -756,18 +756,6 @@ _LIVE_BACKENDS: frozenset[str] = _TOTAL_BACKENDS | _SPLIT_BACKENDS
 # Every backend a metadata-only / occurred_at / source_timestamp case can run on.
 _OP_BACKENDS: frozenset[str] = _INMEM_BACKENDS | _LIVE_BACKENDS
 
-# The live backends that do NOT carry the seven string document keys
-# (``source_name`` / ``source_url`` / ``external_id`` / ``content_type`` /
-# ``source`` / ``source_type`` / ``title``) on the queryable row, so a predicate that
-# READS a string-key value is empty / divergent there and is pruned: the weaviate
-# ``KhoraChunk`` collection schema has no string-key columns at all. The surrealdb and
-# cypher runners seed the seven string keys verbatim onto the queryable row, and the
-# postgres and sqlite_lance runners now denormalize them off the parent ``documents``
-# row onto each chunk (mirroring production), so all four KEEP string-key value cases.
-# (Postgres and sqlite_lance still prune a ``source_type`` value leaf when a seed
-# record leaves ``source_type`` unset — see :data:`_SOURCE_TYPE_DEFAULTED_BACKENDS`.)
-_NO_STRING_KEY_BACKENDS: frozenset[str] = frozenset({"weaviate"})
-
 # The live backends that DEFAULT an unset ``source_type`` to ``"library"``: the
 # postgres and sqlite_lance runners denormalize the parent Document's ``source_type``
 # onto the chunk, and the ``Document`` dataclass defaults ``source_type`` to
@@ -892,7 +880,7 @@ def _with_metadata(rec: SeedRecord, metadata: dict[str, Any]) -> SeedRecord:
 # from :data:`SYSTEM_KEYS` (NOT imported from the engines layer, which would be a
 # filter→engines inversion): the store's ``_BACKED_SYSTEM_KEYS`` is the source of
 # truth for the store + the QA drift-gate test, and conformance encodes its surreal
-# capability gap locally — the same way it encodes :data:`_NO_STRING_KEY_BACKENDS`,
+# capability gap locally — the same way it encodes :data:`_SOURCE_TYPE_DEFAULTED_BACKENDS`,
 # :data:`_CREATED_AT_STAMP_BACKENDS`, etc. (kept consistent by the store-side drift
 # test). A predicate on one of these raises ``RecallFilterUnsupportedError`` on the
 # total surreal leg (no post-filter safety net).
@@ -927,16 +915,15 @@ def _backends_for_filter(filter_: dict[str, Any] | RecallFilter, seed: tuple[See
     backends and SUBTRACTING per-backend exclusions (each a documented capability /
     seed reason — never a silent skip):
 
-    * a leaf that READS one of the seven STRING document keys' value (any op except
-      ``$exists``) → drop :data:`_NO_STRING_KEY_BACKENDS` (weaviate, whose seed does
-      not carry the string keys). postgres and sqlite_lance now denormalize the keys
-      off the parent document, and surrealdb + cypher seed them verbatim, so all four
-      KEEP it; python + chronicle always do;
-    * a ``source_type`` VALUE leaf over a seed that leaves ``source_type`` unset on
-      any record → ALSO drop :data:`_SOURCE_TYPE_DEFAULTED_BACKENDS` (postgres +
-      sqlite_lance): the denormalized chunk inherits the Document default ``"library"``
-      while the oracle sees the key absent, so the two diverge. A seed that sets
-      ``source_type`` on every record keeps them;
+    * every live backend now carries the seven string keys on its queryable row
+      (postgres + sqlite_lance denormalized off the parent document, weaviate stored
+      on the ``KhoraChunk`` object, surrealdb + cypher seeded verbatim), so a
+      string-key VALUE leaf prunes nothing by itself. A ``source_type`` VALUE leaf
+      over a seed that leaves ``source_type`` unset on any record → drop
+      :data:`_SOURCE_TYPE_DEFAULTED_BACKENDS` (postgres + sqlite_lance): the
+      denormalized chunk inherits the Document default ``"library"`` while the oracle
+      sees the key absent, so the two diverge. A seed that sets ``source_type`` on
+      every record keeps them;
     * a ``$exists`` on a string document key is **NOT** a prune: ``$exists`` on a
       system key is a CONSTANT (the always-present axiom), value-independent and
       oracle-comparable on every backend — this is what lets the F-EXISTS system-key
@@ -956,18 +943,14 @@ def _backends_for_filter(filter_: dict[str, Any] | RecallFilter, seed: tuple[See
     ``backends`` across the hand-authored families, so widening / pruning is computed,
     never hand-kept.
     """
-    string_keys = set(_DOC_STRING_KEYS)
     excluded: set[str] = set()
     for clause in iter_leaf_clauses(_resolve_ast(filter_)):
         root = clause.path[0] if clause.path else ""
-        if root in string_keys and clause.op is not Op.EXISTS:
-            # A value-reading predicate on a string column the seed may not carry.
-            excluded |= _NO_STRING_KEY_BACKENDS
+        if root == "source_type" and clause.op is not Op.EXISTS and any(rec.source_type is None for rec in seed):
             # A ``source_type`` value leaf diverges on postgres / sqlite_lance when any
             # seed record left ``source_type`` unset: the denormalized chunk inherits
             # the Document default ``"library"`` while the oracle treats it as absent.
-            if root == "source_type" and any(rec.source_type is None for rec in seed):
-                excluded |= _SOURCE_TYPE_DEFAULTED_BACKENDS
+            excluded |= _SOURCE_TYPE_DEFAULTED_BACKENDS
         elif root == "created_at":
             # A store that stamps created_at on insert can't keep the absent row NULL.
             excluded |= _CREATED_AT_STAMP_BACKENDS
@@ -1007,9 +990,9 @@ def _seed_has_duplicate_external_id(seed: tuple[SeedRecord, ...]) -> bool:
 # postgres and sqlite_lance too. Every other string key is nullable (unset ⇒ NULL on
 # the stores that carry it, ``None`` in the oracle — consistent), so it carries the
 # ``-5`` NULL row that F1 (Mongo-faithful negation) keeps under ``$ne``/``$nin``. A
-# string-key VALUE case now runs on every backend whose runner carries the string keys
-# (postgres + sqlite_lance + surrealdb + cypher, plus python + chronicle); only
-# weaviate prunes it; the per-case set is computed by :func:`_backends_for_filter`.
+# string-key VALUE case now runs on every backend; surrealdb asserts the fail-loud
+# ``RecallFilterUnsupportedError`` via ``expect_unsupported`` rather than comparing
+# rows; the per-case set is computed by :func:`_backends_for_filter`.
 _NON_NULL_STRING_KEY = "source_type"
 
 
@@ -1137,12 +1120,11 @@ def _string_op_cases(key: str) -> list[ConformanceCase]:
     # "connection"). The two reasons converge on the same survivor set, so the
     # expected_ids stay consistent across every backend that carries the string key.
     # ``backends`` is computed per-case (:func:`_backends_for_filter`): a value-reading
-    # string predicate drops the live legs that do not carry the string keys
-    # (weaviate) and keeps postgres + sqlite_lance (both denormalized off the parent
-    # document) + surrealdb + cypher plus python + chronicle. A ``source_type`` value
-    # leaf would additionally drop postgres / sqlite_lance if any seed row left it
-    # unset, but this seed populates all five rows, so both stay. An ``$exists`` (a
-    # constant on a system key) stays on all.
+    # string predicate prunes no backend (postgres + sqlite_lance denormalize off the
+    # parent document, weaviate stores the keys on the object, surrealdb + cypher seed
+    # verbatim). A ``source_type`` value leaf would additionally drop postgres /
+    # sqlite_lance if any seed row left it unset, but this seed populates all five rows,
+    # so both stay. An ``$exists`` (a constant on a system key) stays on all.
     def case(suffix: str, predicate: Any, expected: frozenset[str], op_tag: str) -> ConformanceCase:
         filter_ = {key: predicate}
         backends = _backends_for_filter(filter_, seed)
@@ -1210,11 +1192,9 @@ def f_op_cases() -> list[ConformanceCase]:
     ``-5`` row that F1 (Mongo-faithful negation) keeps under ``$ne`` / ``$nin``,
     while the one non-null key (``source_type``) is seeded fully populated so its
     ``expected_ids`` stay consistent across every backend that carries the key. A
-    string-key VALUE case runs on the backends whose runner carries the string keys
-    (postgres + sqlite_lance — both denormalized off the parent document — plus
-    surrealdb + cypher + python + chronicle); only weaviate prunes it. A string-key
-    ``$exists`` (a constant on a system key) runs on all (see
-    :func:`_backends_for_filter`).
+    string-key VALUE case runs on every backend (weaviate now stores the eight
+    denormalized document fields). A string-key ``$exists`` (a constant on a system
+    key) runs on all (see :func:`_backends_for_filter`).
     Every case tags the system key it exercises in ``exercises`` so the coverage
     meta-test can assert the union covers :data:`SYSTEM_KEYS`. ``expected_ids`` is
     computed by construction from each case's known seed (the runner confirms,

--- a/tests/integration/matrix/_conformance_weaviate.py
+++ b/tests/integration/matrix/_conformance_weaviate.py
@@ -52,10 +52,11 @@ from khora.engines.skeleton.backends import TemporalChunk
 from khora.engines.skeleton.backends.weaviate import (
     WeaviateBackendConfig,
     WeaviateTemporalStore,
+    _coerce_datetime,
 )
 from khora.filter import CompiledFilter
 from khora.filter.ast import FilterNode
-from khora.filter.conformance import ConformanceCase, SeedRecord, WeaviateExecutor
+from khora.filter.conformance import _DOC_STRING_KEYS, ConformanceCase, SeedRecord, WeaviateExecutor
 
 # One fixed tenant for the whole conformance corpus. Chunk ids are globally unique
 # (a fresh ``uuid4`` per seed record), so scoping a read by chunk id inside this one
@@ -105,7 +106,9 @@ def _to_chunk(record: SeedRecord, namespace_id: UUID, chunk_id: UUID) -> Tempora
 
     Carries the fields the weaviate property surface exposes: the three date keys
     (the store stores ``occurred_at`` / ``created_at`` as ISO strings; the compiler
-    declares only those two pushable) and the ``metadata`` blob (serialized to the
+    declares only those two pushable), the seven denormalized document string keys
+    (``source_type`` … ``title``, stored as filterable-only TEXT properties the
+    post-filter reads back), and the ``metadata`` blob (serialized to the
     ``metadata_json`` text property the post-filter decodes). A document id is
     minted per chunk; it is irrelevant to the filter. ``source_timestamp`` rides on
     the chunk so the post-filter (which re-checks the full AST) sees it.
@@ -120,6 +123,13 @@ def _to_chunk(record: SeedRecord, namespace_id: UUID, chunk_id: UUID) -> Tempora
         created_at=record.created_at,
         source_timestamp=record.source_timestamp,
         metadata=dict(record.metadata or {}),
+        source_type=record.source_type,
+        source_name=record.source_name,
+        source_url=record.source_url,
+        external_id=record.external_id,
+        content_type=record.content_type,
+        source=record.source,
+        title=record.title,
     )
 
 
@@ -241,6 +251,33 @@ def reachable() -> bool:
         return False
 
 
+def _object_to_record(obj: Any) -> dict[str, Any]:
+    """Rebuild the ``_record_mapping``-shaped dict the post-filter reads from a read-back object.
+
+    Mirrors the harness's ``_record_mapping``: ``occurred_at`` coalesces to
+    ``source_timestamp`` (the corpus's ``expected_ids`` assume that fold), the literal
+    ``created_at`` / ``source_timestamp`` columns ride through, ``metadata`` decodes
+    from the ``metadata_json`` text property, and each populated denormalized string
+    key is read straight off the object surface. Re-applying the coalesce here is
+    required because the weaviate seeder bypasses the engine, so the read-back record
+    must reproduce the shape ``_record_mapping`` would have produced.
+    """
+    props = obj.properties
+    occurred_at = _coerce_datetime(props.get("occurred_at"))
+    source_timestamp = _coerce_datetime(props.get("source_timestamp"))
+    mapping: dict[str, Any] = {
+        "occurred_at": occurred_at if occurred_at is not None else source_timestamp,
+        "created_at": _coerce_datetime(props.get("created_at")),
+        "source_timestamp": source_timestamp,
+        "metadata": json.loads(props["metadata_json"]) if props.get("metadata_json") else {},
+    }
+    for key in _DOC_STRING_KEYS:
+        value = props.get(key)
+        if value is not None:
+            mapping[key] = value
+    return mapping
+
+
 async def run_live(
     id_map: Mapping[str, UUID],
     compiled: CompiledFilter[Any],
@@ -260,13 +297,17 @@ async def run_live(
     over-returns (it pushes only monotone-narrowing date predicates and defers
     negations / ``$exists`` / ``source_timestamp`` / all metadata).
 
-    Read-only: no seeding here. ``records`` carries the ``(seed_id, mapping)`` pairs
-    ``post_filter`` reads; they are keyed back to the surviving objects by chunk id.
-    Returns the ``SeedRecord`` ids whose object survived prefilter and post-filter.
+    Read-only: no seeding here. The ``records`` parameter is part of the shared
+    :class:`LiveRunner` signature but is intentionally unused on this leg: the
+    post-filter now evaluates the read-back OBJECT surface (rebuilt by
+    :func:`_object_to_record`) rather than the harness's in-memory mapping, so the leg
+    verifies the store actually round-trips every filtered field (the eight
+    denormalized document keys included), not just that the in-memory record would
+    have matched. Returns the ``SeedRecord`` ids whose object survived prefilter and
+    post-filter.
     """
     from weaviate.classes.query import Filter
 
-    record_map = dict(records)
     chunk_to_seed = {chunk_id: seed_id for seed_id, chunk_id in id_map.items()}
 
     # Scope to exactly this case's chunk ids; AND the superset prefilter when present.
@@ -287,7 +328,7 @@ async def run_live(
         seed_id = chunk_to_seed.get(chunk_id)
         if seed_id is None:
             continue
-        if post_filter(record_map[seed_id]):
+        if post_filter(_object_to_record(obj)):
             survivors.add(seed_id)
     return frozenset(survivors)
 

--- a/tests/unit/engines/skeleton/backends/test_weaviate_async.py
+++ b/tests/unit/engines/skeleton/backends/test_weaviate_async.py
@@ -19,12 +19,15 @@ from pydantic import SecretStr
 
 from khora.engines.skeleton.backends import TemporalChunk
 from khora.engines.skeleton.backends.weaviate import (
+    _DENORM_TEXT_KEYS,
     _FILTER_OVERFETCH,
     COLLECTION_NAME,
     WeaviateBackendConfig,
     WeaviateTemporalStore,
+    _chunk_to_properties,
     _coerce_backend_config,
     _coerce_datetime,
+    _denorm_properties,
     _extract_vector,
     _parse_host_port,
 )
@@ -149,6 +152,37 @@ class TestHelpers:
 # WeaviateTemporalStore.connect routing (local / cloud / custom)
 # ---------------------------------------------------------------------------
 
+# The collection's pre-denorm column names, in schema order. The denorm names
+# (``_DENORM_TEXT_KEYS`` + ``source_timestamp``) are appended to make the
+# reconcile-no-op schema.
+_BASE_PROPERTY_NAMES: tuple[str, ...] = (
+    "content",
+    "document_id",
+    "namespace_id",
+    "occurred_at",
+    "created_at",
+    "source_system",
+    "author",
+    "channel",
+    "tags",
+    "confidence",
+    "metadata_json",
+)
+
+
+def _reconcile_noop_collection() -> MagicMock:
+    """A collection handle whose schema already carries every denorm property.
+
+    ``connect()``'s reconcile branch reads ``config.get().properties`` and only adds
+    a missing denorm prop, so a handle reporting the full schema makes reconcile a
+    no-op — what every connect-path test that doesn't exercise reconcile expects.
+    """
+    collection = MagicMock(name="CollectionAsync")
+    full = [*_BASE_PROPERTY_NAMES, *_DENORM_TEXT_KEYS, "source_timestamp"]
+    collection.config.get = AsyncMock(return_value=SimpleNamespace(properties=[SimpleNamespace(name=n) for n in full]))
+    collection.config.add_property = AsyncMock()
+    return collection
+
 
 def _install_fake_weaviate(monkeypatch: pytest.MonkeyPatch) -> tuple[MagicMock, MagicMock]:
     """Inject a fake ``weaviate`` module into ``sys.modules``.
@@ -170,7 +204,10 @@ def _install_fake_weaviate(monkeypatch: pytest.MonkeyPatch) -> tuple[MagicMock, 
     client.collections = MagicMock()
     client.collections.exists = AsyncMock(return_value=True)  # skip create branch
     client.collections.create = AsyncMock()
-    client.collections.get = MagicMock(return_value=MagicMock(name="CollectionAsync"))
+    # The default existing-collection handle reports a schema that ALREADY carries
+    # every denorm property, so connect()'s reconcile branch is a no-op for the
+    # tests that don't exercise it (they override collections.get when they do).
+    client.collections.get = MagicMock(return_value=_reconcile_noop_collection())
 
     fake_weaviate.use_async_with_local = MagicMock(return_value=client)
     fake_weaviate.use_async_with_custom = MagicMock(return_value=client)
@@ -200,8 +237,8 @@ def _install_fake_weaviate(monkeypatch: pytest.MonkeyPatch) -> tuple[MagicMock, 
         TEXT_ARRAY = "TEXT_ARRAY"
         NUMBER = "NUMBER"
 
-    def _Property(*, name: str, data_type: str) -> Any:
-        return SimpleNamespace(name=name, data_type=data_type)
+    def _Property(*, name: str, data_type: str, **kwargs: Any) -> Any:
+        return SimpleNamespace(name=name, data_type=data_type, **kwargs)
 
     class _Auth:
         @staticmethod
@@ -331,7 +368,7 @@ class TestTenantCache:
     async def test_tenants_created_once_per_namespace(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _weaviate, client = _install_fake_weaviate(monkeypatch)
 
-        collection = MagicMock(name="CollectionAsync")
+        collection = _reconcile_noop_collection()
         collection.tenants.create = AsyncMock()
         collection.with_tenant = MagicMock(return_value=MagicMock(name="TenantScopedCollection"))
         client.collections.get = MagicMock(return_value=collection)
@@ -398,7 +435,7 @@ class TestCRUD:
     async def test_create_chunk_awaits_insert(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _weaviate, client = _install_fake_weaviate(monkeypatch)
 
-        collection = MagicMock(name="CollectionAsync")
+        collection = _reconcile_noop_collection()
         collection.tenants.create = AsyncMock()
         tenant_scoped = MagicMock(name="TenantScopedCollection")
         tenant_scoped.data.insert = AsyncMock()
@@ -429,7 +466,7 @@ class TestCRUD:
     async def test_create_chunks_batch_fans_out(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _weaviate, client = _install_fake_weaviate(monkeypatch)
 
-        collection = MagicMock(name="CollectionAsync")
+        collection = _reconcile_noop_collection()
         collection.tenants.create = AsyncMock()
         tenant_scoped = MagicMock(name="TenantScopedCollection")
         tenant_scoped.data.insert = AsyncMock()
@@ -460,7 +497,7 @@ class TestCRUD:
     async def test_delete_chunk_awaits_delete(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _weaviate, client = _install_fake_weaviate(monkeypatch)
 
-        collection = MagicMock(name="CollectionAsync")
+        collection = _reconcile_noop_collection()
         collection.tenants.create = AsyncMock()
         tenant_scoped = MagicMock(name="TenantScopedCollection")
         tenant_scoped.data.delete_by_id = AsyncMock()
@@ -611,7 +648,7 @@ async def _store_with_query(
     _weaviate, client = _install_fake_weaviate(monkeypatch)
     _install_query_filter(monkeypatch)
 
-    collection = MagicMock(name="CollectionAsync")
+    collection = _reconcile_noop_collection()
     collection.tenants.create = AsyncMock()
     tenant_scoped = MagicMock(name="TenantScopedCollection")
     tenant_scoped.query.near_vector = AsyncMock(return_value=SimpleNamespace(objects=objects))
@@ -783,3 +820,168 @@ class TestSearchFilterAstWiring:
         # Exactly the 2 matching rows survive (< limit=3), in returned order.
         assert [str(r.chunk.id) for r in results] == match_ids
         assert all(r.chunk.metadata.get("tag") == "rare" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Denormalized document fields: write/read round-trip + reconcile
+# ---------------------------------------------------------------------------
+
+
+def _readback_object(props: dict[str, Any], chunk_id: UUID) -> SimpleNamespace:
+    """A fake read-back object whose ``.properties`` is exactly what the store wrote."""
+    return SimpleNamespace(uuid=str(chunk_id), properties=props, vector=None)
+
+
+@pytest.mark.unit
+class TestDenormFieldsRoundTrip:
+    @pytest.mark.asyncio
+    async def test_populated_fields_round_trip(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # _chunk_to_properties → readback object → _object_to_chunk preserves all
+        # eight denormalized document fields.
+        _install_fake_weaviate(monkeypatch)
+        store = _build_store("http://localhost:8090")
+
+        ns_id = uuid4()
+        ts = datetime(2026, 4, 1, 9, 30, tzinfo=UTC)
+        chunk = TemporalChunk(
+            id=uuid4(),
+            namespace_id=ns_id,
+            document_id=uuid4(),
+            content="hello",
+            embedding=[0.1] * 1536,
+            source_type="slack",
+            source_name="general",
+            source_url="https://example.com/x",
+            external_id="ext-42",
+            content_type="text/plain",
+            source="slack-export",
+            title="A title",
+            source_timestamp=ts,
+        )
+
+        props = _chunk_to_properties(chunk)
+        # The seven strings ride verbatim; source_timestamp serializes to ISO.
+        assert props["source_type"] == "slack"
+        assert props["title"] == "A title"
+        assert props["source_timestamp"] == ts.isoformat()
+
+        back = store._object_to_chunk(_readback_object(props, chunk.id), ns_id)
+        assert back.source_type == "slack"
+        assert back.source_name == "general"
+        assert back.source_url == "https://example.com/x"
+        assert back.external_id == "ext-42"
+        assert back.content_type == "text/plain"
+        assert back.source == "slack-export"
+        assert back.title == "A title"
+        assert back.source_timestamp == ts
+
+    @pytest.mark.asyncio
+    async def test_absent_fields_round_trip_to_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A chunk with no denorm string keys and no source_timestamp round-trips
+        # back to None for each — no crash on absent / None properties.
+        _install_fake_weaviate(monkeypatch)
+        store = _build_store("http://localhost:8090")
+
+        ns_id = uuid4()
+        chunk = TemporalChunk(
+            id=uuid4(),
+            namespace_id=ns_id,
+            document_id=uuid4(),
+            content="hello",
+            embedding=[0.1] * 1536,
+        )
+
+        props = _chunk_to_properties(chunk)
+        assert props["source_timestamp"] is None
+        assert props["source_type"] is None
+
+        # Drop the keys entirely (simulate an older row that never carried them) to
+        # also exercise the absent-property read path.
+        for key in (*_DENORM_TEXT_KEYS, "source_timestamp"):
+            props.pop(key, None)
+
+        back = store._object_to_chunk(_readback_object(props, chunk.id), ns_id)
+        for key in _DENORM_TEXT_KEYS:
+            assert getattr(back, key) is None
+        assert back.source_timestamp is None
+
+
+@pytest.mark.unit
+class TestDenormFieldsReconciliation:
+    @pytest.mark.asyncio
+    async def test_connect_adds_missing_denorm_properties(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # connect() against a pre-existing collection whose schema predates the denorm
+        # properties adds each missing one exactly once, with the exact definitions —
+        # and the seven TEXT props carry index_searchable=False.
+        _weaviate, client = _install_fake_weaviate(monkeypatch)
+        client.collections.exists = AsyncMock(return_value=True)
+
+        # The OLD property set (no denorm props): only the pre-denorm columns.
+        old_props = [
+            SimpleNamespace(name=name)
+            for name in (
+                "content",
+                "document_id",
+                "namespace_id",
+                "occurred_at",
+                "created_at",
+                "source_system",
+                "author",
+                "channel",
+                "tags",
+                "confidence",
+                "metadata_json",
+            )
+        ]
+        collection = MagicMock(name="CollectionAsync")
+        collection.config.get = AsyncMock(return_value=SimpleNamespace(properties=old_props))
+        collection.config.add_property = AsyncMock()
+        client.collections.get = MagicMock(return_value=collection)
+
+        store = _build_store("http://localhost:8090")
+        await store.connect()
+
+        expected = _denorm_properties()
+        assert collection.config.add_property.await_count == len(expected)
+        added = [call.args[0] for call in collection.config.add_property.await_args_list]
+        assert [p.name for p in added] == [p.name for p in expected]
+        # The seven TEXT props keep BM25 out (index_searchable=False); the DATE prop
+        # (source_timestamp) is not a TEXT prop and carries no such flag.
+        text_added = [p for p in added if p.data_type == "TEXT"]
+        assert {p.name for p in text_added} == set(_DENORM_TEXT_KEYS)
+        assert all(p.index_searchable is False for p in text_added)
+        assert all(p.index_filterable is True for p in text_added)
+        # The DATE prop (source_timestamp) is typed DATE, not TEXT.
+        date_added = [p for p in added if p.name == "source_timestamp"]
+        assert [p.data_type for p in date_added] == ["DATE"]
+
+    @pytest.mark.asyncio
+    async def test_connect_is_noop_when_denorm_properties_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A second connect() where every denorm property already exists adds nothing.
+        _weaviate, client = _install_fake_weaviate(monkeypatch)
+        client.collections.exists = AsyncMock(return_value=True)
+
+        existing_names = [
+            "content",
+            "document_id",
+            "namespace_id",
+            "occurred_at",
+            "created_at",
+            "source_system",
+            "author",
+            "channel",
+            "tags",
+            "confidence",
+            "metadata_json",
+            *(p.name for p in _denorm_properties()),
+        ]
+        full_props = [SimpleNamespace(name=name) for name in existing_names]
+        collection = MagicMock(name="CollectionAsync")
+        collection.config.get = AsyncMock(return_value=SimpleNamespace(properties=full_props))
+        collection.config.add_property = AsyncMock()
+        client.collections.get = MagicMock(return_value=collection)
+
+        store = _build_store("http://localhost:8090")
+        await store.connect()
+
+        collection.config.add_property.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Persist the eight denormalized document fields (`source_type`, `source_name`, `source_url`, `external_id`, `content_type`, `source`, `title`, `source_timestamp`) on the `KhoraChunk` collection. Previously these were never stored, so recall filters over them were silently wrong — a positive predicate matched **zero rows** and a negation was a no-op, even though the projection displayed the values hydrated from the relational row.
- The seven string keys are stored as **filterable-only** `TEXT` properties (`index_filterable=True`, `index_searchable=False` so provenance strings don't pollute BM25 hybrid-search scoring); `source_timestamp` is a `DATE`. They are defined once in a lazily-built property tuple (import-safe — `weaviate-client` is an optional dependency) shared by both collection creation and an **idempotent schema-reconciliation** path that adds any missing property to a pre-existing collection.
- `_chunk_to_properties` now writes the eight fields and `_object_to_chunk` reads them back, so the post-filter (the correctness safety net) can address them. Server-side pushdown stays date-only.
- **Conformance fidelity fix:** the filter-conformance weaviate leg now evaluates the post-filter against the **read-back object surface** rather than the declared seed mapping, so the leg verifies the store actually round-trips every filtered field (it previously stayed green even when the store dropped a field at write/readback). The obsolete string-key prune is removed now that the keys are carried on every backend.

## Test plan
- [x] Unit tests pass — `tests/unit/engines/skeleton/backends/test_weaviate_async.py` (47 passed; adds round-trip + idempotent-reconciliation coverage, asserting `index_searchable=False` on the TEXT properties)
- [x] Filter-conformance python leg passes — `KHORA_CONFORMANCE_BACKEND=python … -m filter_conformance` (208 passed)
- [x] Conformance unit guards pass — harness / catalog / system-keys-coverage (no changes; identical pre-existing env-only failures with the optional extra absent)
- [x] `ruff check` + `ruff format --check` clean on the changed files
- [ ] CI runs the weaviate Docker leg with a fresh container (exercises the new create path + the new properties end-to-end)

**Conformance case-count delta (weaviate leg):** 122 → 189 (**+67**). The added cases are string-key VALUE predicates that previously pruned the weaviate leg and now run against it — green only because the keys are seeded, stored, and read back correctly.