### PR TITLE
Gate VectorCypher typed-entity-recent fast path when filter_ast is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 ### Fixed
 
 - **VectorCypher recency channel now fires again on the pgvector stack** — the temporal store now implements `search_recent_chunks` (the channel had been silently dead since the temporal-store rewiring). The pgvector temporal store sorts `khora_chunks` by `COALESCE(occurred_at, source_timestamp, created_at) DESC` (served by a new `ix_khora_chunks_ns_recency` expression index), preserves the embedding so the caller's cosine relevance gate runs, and backends without the capability return the protocol default `[]`. Embedded (`sqlite_lance`) support is tracked in #1182.
+- **VectorCypher typed-entity-recent fast path no longer bypasses the recall filter; filtered recalls route to the full retrieval path.**
 - **Honest filter-pushdown reporting on the skeleton engine** (#1069): `recall(filter=...).engine_info["filter"]["pushed_down"]` was derived from a hardcoded `backend == "pgvector"` check, so it reported `False` on `sqlite_lance` even when the compiler fully pushed the predicate into the SQLite `WHERE` clause. The flag is now derived from what each channel's compiler actually consumed (`pushed_keys`) versus what it re-checked in memory (`post_filtered_keys`), so `pushed_down` is accurate on every backend whose compiler pushes predicates down. A defensive full-predicate re-check (the `sqlite_lance` path) sets `post_filtered=True` without demoting a fully-pushed leaf (NO-DEMOTE).
 
 ### Changed

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -812,7 +812,19 @@ class VectorCypherRetriever:
             force_graph = mode == SearchMode.GRAPH
 
             # Step 3: Vector search for entry points
-            if not force_simple and not force_graph and routing.complexity == QueryComplexity.TYPED_ENTITY_RECENT:
+            if (
+                not force_simple
+                and not force_graph
+                and routing.complexity == QueryComplexity.TYPED_ENTITY_RECENT
+                and filter_ast is None
+            ):
+                # Gate (filter_ast is None): the fast-path Cypher cannot
+                # enforce caller filters — chunk metadata is a serialized
+                # JSON property on the graph node, not queryable columns — so
+                # a filtered recall would silently return unfiltered chunks.
+                # Filtered recalls take the full _vectorcypher_retrieve path
+                # below, which enforces + reports the filter per channel.
+                #
                 # Phase C fast path (#569): a single Cypher query that
                 # finds typed entities (ACTION_ITEM, DECISION, BLOCKER,
                 # RISK) ordered by last MENTIONED_IN chunk timestamp.
@@ -949,6 +961,10 @@ class VectorCypherRetriever:
         2. Joins MENTIONED_IN chunks; computes max(c.occurred_at) per entity.
         3. Returns one evidence chunk per entity (the most recent mention).
         4. Orders by last_mention DESC.
+
+        The dispatch in ``retrieve()`` gates this path on ``filter_ast is
+        None`` — the fast-path Cypher does not enforce caller filters, so
+        filtered recalls take the full ``_vectorcypher_retrieve`` path.
 
         For entity types that carry a ``status`` attribute (ACTION_ITEM,
         COMMITMENT, OPEN_QUESTION), filters out entries whose status is in
@@ -1118,10 +1134,10 @@ class VectorCypherRetriever:
                 metadata={
                     "typed_entity_fast_path": True,
                     "typed_entity_type": entity_type,
-                    # The fast-path Cypher does NOT enforce the caller filter
-                    # (its WHERE is typed-entity/status only), so no channel
-                    # pushed or post-filtered it here — empty plans yield an
-                    # honest all-False report.
+                    # This path is now reachable only when no caller filter is
+                    # present (the dispatch gates it on filter_ast is None), so
+                    # the empty plans dict is the no-filter carrier — there is
+                    # no filter to enforce or report here.
                     "_filter_channel_plans": {},
                 },
             )

--- a/tests/unit/engines/test_typed_entity_recent_retrieve.py
+++ b/tests/unit/engines/test_typed_entity_recent_retrieve.py
@@ -6,9 +6,12 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 from khora.engines.vectorcypher.retriever import (
+    RetrieverConfig,
     VectorCypherResult,
     VectorCypherRetriever,
 )
+from khora.filter import RecallFilter, parse_to_ast
+from khora.query import SearchMode
 from khora.query.router import QueryComplexity, RoutingDecision
 
 
@@ -266,3 +269,152 @@ class TestTypedEntityRecentRetrieve:
         )
 
         retriever._vectorcypher_retrieve.assert_awaited_once()  # type: ignore[attr-defined]
+
+
+def _ast(spec: dict | None):
+    """Build the canonical recall-filter AST exactly as the public facade does."""
+    if spec is None:
+        return None
+    return parse_to_ast(RecallFilter.model_validate(spec))
+
+
+def _make_dispatch_retriever(complexity: QueryComplexity) -> VectorCypherRetriever:
+    """A retriever wired so ``retrieve()`` runs to the route-dispatch gate.
+
+    Bypasses ``__init__`` and stubs only what ``retrieve()`` touches before the
+    dispatch (``_config``, ``_embedder``, ``_router``). Both downstream paths are
+    spies so the test asserts WHICH one the gate selected:
+
+    * ``_typed_entity_recent_retrieve`` — the #569 fast path.
+    * ``_vectorcypher_retrieve`` — the filtered / fallback path.
+
+    The router is mocked to return ``complexity`` (and ``use_graph``), so the
+    routing decision is fixed regardless of the query text.
+    """
+    retriever = VectorCypherRetriever.__new__(VectorCypherRetriever)
+    retriever._config = RetrieverConfig(  # type: ignore[attr-defined]
+        temporal_recency_floor_enabled=False,
+        temporal_llm_disambiguation_enabled=False,
+    )
+
+    embedder = AsyncMock()
+    embedder.embed = AsyncMock(return_value=[0.0] * 4)
+    embedder.model_name = "test-model"
+    embedder.dimension = 4
+    embedder.cache_stats = {"hits": 0}
+    retriever._embedder = embedder  # type: ignore[attr-defined]
+
+    router = MagicMock()
+    router.route = AsyncMock(
+        return_value=RoutingDecision(
+            complexity=complexity,
+            use_graph=complexity is not QueryComplexity.SIMPLE,
+            graph_depth=1,
+            confidence=0.95,
+            reasoning="test",
+            suggested_entry_limit=10,
+        )
+    )
+    router.compute_adaptive_depth = MagicMock(return_value=1)
+    retriever._router = router  # type: ignore[attr-defined]
+
+    # Both downstream paths are spies returning a benign result.
+    def _result(meta: dict) -> VectorCypherResult:
+        return VectorCypherResult(
+            chunks=[],
+            entities=[],
+            routing_decision=router.route.return_value,
+            metadata=meta,
+        )
+
+    retriever._typed_entity_recent_retrieve = AsyncMock(  # type: ignore[attr-defined]
+        return_value=_result({"typed_entity_fast_path": True})
+    )
+    retriever._vectorcypher_retrieve = AsyncMock(  # type: ignore[attr-defined]
+        return_value=_result({"from_fallback": True})
+    )
+    retriever._simple_retrieve = AsyncMock(  # type: ignore[attr-defined]
+        return_value=_result({"from_simple": True})
+    )
+    return retriever
+
+
+class TestTypedEntityFastPathDispatchGate:
+    """The route-dispatch gate enters the fast path ONLY when ``filter_ast is None``."""
+
+    async def test_filtered_typed_recent_skips_fast_path(self) -> None:
+        """TYPED_ENTITY_RECENT + a non-empty filter -> fast path NOT entered.
+
+        A filtered typed-recent recall falls through to ``_vectorcypher_retrieve``
+        (which enforces + reports the filter per channel); the fast path's Cypher
+        cannot enforce caller filters, so the gate must skip it. The SAME
+        ``filter_ast`` instance is forwarded to ``_vectorcypher_retrieve``, and the
+        result carries no ``typed_entity_fast_path`` marker.
+        """
+        ns = uuid4()
+        ast = _ast({"source_name": "linear", "metadata.tier": "gold"})
+        retriever = _make_dispatch_retriever(QueryComplexity.TYPED_ENTITY_RECENT)
+
+        result = await retriever.retrieve("latest action items", ns, limit=10, filter_ast=ast)
+
+        # Fast path was NOT entered.
+        retriever._typed_entity_recent_retrieve.assert_not_awaited()  # type: ignore[attr-defined]
+        # The filtered path ran and received the SAME filter_ast.
+        retriever._vectorcypher_retrieve.assert_awaited_once()  # type: ignore[attr-defined]
+        assert retriever._vectorcypher_retrieve.await_args.kwargs["filter_ast"] is ast  # type: ignore[attr-defined]
+        assert "typed_entity_fast_path" not in result.metadata
+
+    async def test_unfiltered_typed_recent_takes_fast_path(self) -> None:
+        """TYPED_ENTITY_RECENT + ``filter_ast=None`` -> fast path STILL taken (#569).
+
+        Guards the latency fast path against regression from the gate: with no
+        caller filter the gate condition holds and the fast path runs, stamping
+        ``typed_entity_fast_path=True``.
+        """
+        ns = uuid4()
+        retriever = _make_dispatch_retriever(QueryComplexity.TYPED_ENTITY_RECENT)
+
+        result = await retriever.retrieve("latest action items", ns, limit=10, filter_ast=None)
+
+        retriever._typed_entity_recent_retrieve.assert_awaited_once()  # type: ignore[attr-defined]
+        retriever._vectorcypher_retrieve.assert_not_awaited()  # type: ignore[attr-defined]
+        assert result.metadata["typed_entity_fast_path"] is True
+
+    async def test_simple_mode_unaffected_by_filter(self) -> None:
+        """``mode=VECTOR``/``KEYWORD`` (force_simple) routes to ``_simple_retrieve``.
+
+        The new ``filter_ast is None`` gate condition lives on the TYPED-recent
+        branch only; ``force_simple`` short-circuits ahead of it, so a filtered
+        OR unfiltered VECTOR/KEYWORD recall routes to ``_simple_retrieve`` exactly
+        as before, never the typed fast path.
+        """
+        ns = uuid4()
+        ast = _ast({"source_name": "linear"})
+        for mode in (SearchMode.VECTOR, SearchMode.KEYWORD):
+            for fast in (ast, None):
+                retriever = _make_dispatch_retriever(QueryComplexity.TYPED_ENTITY_RECENT)
+
+                await retriever.retrieve("latest action items", ns, limit=10, mode=mode, filter_ast=fast)
+
+                retriever._simple_retrieve.assert_awaited_once()  # type: ignore[attr-defined]
+                retriever._typed_entity_recent_retrieve.assert_not_awaited()  # type: ignore[attr-defined]
+                retriever._vectorcypher_retrieve.assert_not_awaited()  # type: ignore[attr-defined]
+
+    async def test_graph_mode_unaffected_by_filter(self) -> None:
+        """``mode=GRAPH`` (force_graph) routes to ``_vectorcypher_retrieve`` regardless.
+
+        ``force_graph`` forces the entity-expansion path and is evaluated ahead of
+        the TYPED-recent branch, so a GRAPH recall — filtered or not — bypasses
+        both the fast path and the simple path. The new gate condition does not
+        perturb this branch.
+        """
+        ns = uuid4()
+        ast = _ast({"source_name": "linear"})
+        for fast in (ast, None):
+            retriever = _make_dispatch_retriever(QueryComplexity.TYPED_ENTITY_RECENT)
+
+            await retriever.retrieve("latest action items", ns, limit=10, mode=SearchMode.GRAPH, filter_ast=fast)
+
+            retriever._vectorcypher_retrieve.assert_awaited_once()  # type: ignore[attr-defined]
+            retriever._typed_entity_recent_retrieve.assert_not_awaited()  # type: ignore[attr-defined]
+            retriever._simple_retrieve.assert_not_awaited()  # type: ignore[attr-defined]

--- a/tests/unit/engines/test_vectorcypher_filter_report.py
+++ b/tests/unit/engines/test_vectorcypher_filter_report.py
@@ -794,14 +794,25 @@ class TestGraphFallbackReport:
 
 
 # ---------------------------------------------------------------------------
-# Devil's-advocate scenario C: the typed-entity-recent fast path is HONEST.
+# Devil's-advocate scenario C: a TYPED_ENTITY_RECENT recall WITH a caller filter
+# falls through to the FULL ``_vectorcypher_retrieve`` path and emits a REAL,
+# per-channel report.
 #
-# The fast path's Cypher does NOT enforce the caller filter (a SEPARATE,
-# follow-up-tracked bug). For THIS ticket the report must be honest about that:
-# it must NOT fabricate a channel that enforced the filter. So ``channels`` is
-# empty and the report is all-False even when routed there under a filter. This
-# is explicitly NOT a regression test asserting the fast path returns unfiltered
-# results — that belongs to the follow-up ticket.
+# The dispatch gate (``retrieve()``) enters the #569 fast path ONLY when
+# ``filter_ast is None`` — the fast-path Cypher cannot enforce caller filters
+# (chunk metadata is a serialized JSON property on the graph node, not queryable
+# columns), so a filtered typed-recent recall is routed to
+# ``_vectorcypher_retrieve`` instead, which enforces the filter per channel and
+# folds REAL ``ChannelPlan`` carriers into ``engine_info["filter"]``. Routing
+# TYPED_ENTITY_RECENT through the filtered fallback therefore exercises the same
+# vector/bm25/graph channels as a MODERATE recall — the report is non-empty and
+# validates. (Pre-#1181 this case asserted ``channels={}`` via the fast path; the
+# gate makes that shape STRUCTURALLY UNREACHABLE, so it is flipped here.)
+#
+# The UNFILTERED fast path (``filter_ast=None``) still runs the #569 Cypher and
+# stamps the all-false no-filter carrier (``_filter_channel_plans == {}``), which
+# the engine folds into the constraint-free all-False report with empty
+# ``channels`` — pinned below.
 # ---------------------------------------------------------------------------
 
 
@@ -810,8 +821,9 @@ def _typed_entity_retriever(ns_id: UUID, rows: list[dict[str, Any]]) -> VectorCy
 
     The router returns ``TYPED_ENTITY_RECENT``; ``_dual_nodes._session()`` yields
     a session whose ``execute_read`` returns ``rows`` so the REAL fast path runs
-    (and stamps its honest empty ``_filter_channel_plans``) rather than falling
-    back to ``_vectorcypher_retrieve``.
+    (and stamps its no-filter ``_filter_channel_plans == {}`` carrier) rather than
+    falling back to ``_vectorcypher_retrieve``. Used by the UNFILTERED case; the
+    FILTERED case routes through the fully-wired ``_make_retriever`` channels.
     """
     vector_store = AsyncMock()
     embedder = AsyncMock()
@@ -853,15 +865,58 @@ def _typed_entity_retriever(ns_id: UUID, rows: list[dict[str, Any]]) -> VectorCy
 
 
 class TestTypedEntityFastPathHonesty:
-    """The typed-entity fast path emits an honest all-False report under a filter."""
+    """Typed-recent reports: REAL report when filtered, no-filter carrier when not."""
 
-    async def test_fast_path_reports_no_enforcing_channel(self) -> None:
-        """Routed to the fast path under a filter -> ``channels={}``, all-False.
+    async def test_filtered_typed_recent_emits_real_report(self) -> None:
+        """TYPED_ENTITY_RECENT routed WITH a filter -> non-empty, valid report.
 
-        The fast-path Cypher does not enforce the caller filter; the report is
-        honest about that by recording NO channel (rather than fabricating one
-        that "pushed" the filter). This pins the report's honesty, NOT the
-        fast-path filtering behaviour (a separate follow-up ticket).
+        The dispatch gate skips the #569 fast path under a filter and routes to
+        ``_vectorcypher_retrieve``, which enforces the filter per channel. So the
+        report is the FULL vector/bm25/graph disposition — non-empty ``channels``
+        that pass ``FilterPushdownReport.model_validate`` — exactly the fallback
+        coverage the devil's-advocate flagged: a typed-recent query WITH a caller
+        filter exercised end-to-end through the enforcing path, not asserted via a
+        mock-only ``channels={}`` claim.
+        """
+        ns_id = uuid4()
+        # Fully-wired channels (vector + bm25 + graph) but routed TYPED_ENTITY_RECENT
+        # so the gate's filter fall-through is the path actually under test.
+        retriever = _make_retriever(ns_id, enable_bm25=True, graph_chunks=[_graph_chunk(ns_id, tier="gold")])
+        retriever._router.route = AsyncMock(
+            return_value=RoutingDecision(
+                complexity=QueryComplexity.TYPED_ENTITY_RECENT,
+                use_graph=True,
+                graph_depth=2,
+                confidence=0.9,
+                reasoning="typed_entity_recent",
+            )
+        )
+        engine = _build_engine(retriever)
+
+        # "latest action items" would route to the fast path with no filter; under
+        # a filter the gate falls through to the enforcing ``_vectorcypher_retrieve``.
+        report = await _recall_filter_report(engine, ns_id, query="latest action items")
+
+        # A REAL per-channel report (the fallback path ran end-to-end).
+        assert report["channels"], "filtered typed-recent must emit a non-empty per-channel report"
+        assert set(report["channels"]) == {"vector", "bm25", "graph"}
+        assert report["channels"]["graph"] == {
+            "pushed_keys": ["source_name"],
+            "post_filtered_keys": ["metadata.tier"],
+        }
+        assert report["pushed_keys"] == ["source_name"]
+        assert report["post_filtered_keys"] == ["metadata.tier"]
+        assert report["post_filtered"] is True
+        # ``_recall_filter_report`` already model_validate'd it; re-assert explicitly.
+        FilterPushdownReport.model_validate(report)
+
+    async def test_unfiltered_fast_path_carries_no_filter_marker(self) -> None:
+        """TYPED_ENTITY_RECENT routed WITHOUT a filter -> all-False, empty channels.
+
+        With no caller filter the gate runs the #569 fast path, which stamps the
+        all-false no-filter carrier (``_filter_channel_plans == {}``). The engine
+        folds that into the constraint-free all-False report whose ``channels``
+        reflect no caller filter (empty map).
         """
         ns_id = uuid4()
         eid, cid, did = uuid4(), uuid4(), uuid4()
@@ -880,8 +935,8 @@ class TestTypedEntityFastPathHonesty:
         retriever = _typed_entity_retriever(ns_id, rows)
         engine = _build_engine(retriever)
 
-        # "latest action items" routes to the typed-entity fast path.
-        report = await _recall_filter_report(engine, ns_id, query="latest action items")
+        # "latest action items" + no filter routes to the typed-entity fast path.
+        report = await _recall_filter_report(engine, ns_id, query="latest action items", spec=None)
 
         assert report == {
             "pushed_down": False,


### PR DESCRIPTION
## Summary

- The typed-entity-recent fast path (`_typed_entity_recent_retrieve`) runs a single typed-entity/status-only Cypher query and builds result chunks straight from the rows. It received the caller's filter but never applied it, so a recall carrying a metadata or document filter was silently returned **unfiltered**.
- The fast-path Cypher cannot enforce caller filters: chunk metadata is stored as a serialized JSON property on the graph node (not queryable as distinct columns), and the path hydrates chunks with `occurred_at` only.
- Fix: gate the fast path in the dispatch on `filter_ast is None`. Unfiltered typed-entity-recent recalls keep the single-Cypher fast path (recency-ordered, unchanged). Filtered recalls fall through to the full `_vectorcypher_retrieve` path, which enforces the filter on every channel (vector, BM25, graph) and emits the canonical per-channel filter-pushdown report.
- The fast path's `filter_ast` parameter and its internal fallback threading are left intact so the static filter-enforcement audit gate stays satisfied.
- Correctness-over-latency tradeoff: a filtered typed-entity-recent recall loses the single-Cypher recency optimization. This combination is rare; a follow-up could push system-key leaves into the fast-path Cypher to recover it.

## Test plan

- [x] Unit suite passes locally (`make test-unit`: 8845 passed, 35 skipped), including:
  - [x] Filtered typed-entity-recent recall skips the fast path and forwards the same filter to the full path (no `typed_entity_fast_path` marker on the result).
  - [x] Unfiltered typed-entity-recent recall still takes the fast path (latency regression guard).
  - [x] `mode=VECTOR/KEYWORD/GRAPH` dispatch unaffected by the new condition.
  - [x] Filter-report suite: a filtered typed-entity-recent recall emits a real non-empty per-channel report (validates against the report model); the unfiltered fast path carries the all-false no-filter report.
  - [x] Filter-enforcement audit gate passes (filter threading intact).
- [x] Lint/format clean (`make format`, `make lint`).
- [ ] Integration tests — validated in CI (Docker is not available in the authoring sandbox).

## Related issues

- #1181 — canonical filter-pushdown report in VectorCypher `engine_info["filter"]` (foundation for this gate).
- #569 — original typed-entity-recent fast path.