### PR TITLE
Implement search_recent_chunks on the pgvector temporal store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 
 ### Fixed
 
+- **VectorCypher recency channel now fires again on the pgvector stack** — the temporal store now implements `search_recent_chunks` (the channel had been silently dead since the temporal-store rewiring). The pgvector temporal store sorts `khora_chunks` by `COALESCE(occurred_at, source_timestamp, created_at) DESC` (served by a new `ix_khora_chunks_ns_recency` expression index), preserves the embedding so the caller's cosine relevance gate runs, and backends without the capability return the protocol default `[]`. Embedded (`sqlite_lance`) support is tracked in #1182.
 - **Honest filter-pushdown reporting on the skeleton engine** (#1069): `recall(filter=...).engine_info["filter"]["pushed_down"]` was derived from a hardcoded `backend == "pgvector"` check, so it reported `False` on `sqlite_lance` even when the compiler fully pushed the predicate into the SQLite `WHERE` clause. The flag is now derived from what each channel's compiler actually consumed (`pushed_keys`) versus what it re-checked in memory (`post_filtered_keys`), so `pushed_down` is accurate on every backend whose compiler pushes predicates down. A defensive full-predicate re-check (the `sqlite_lance` path) sets `post_filtered=True` without demoting a fully-pushed leaf (NO-DEMOTE).
 
 ### Changed

--- a/src/khora/engines/skeleton/backends/__init__.py
+++ b/src/khora/engines/skeleton/backends/__init__.py
@@ -236,6 +236,32 @@ class TemporalVectorStore(Protocol):
         """
         return []
 
+    # Optional capability — backends that store ingested chunk content in
+    # their own table override this to expose a pure-recency channel for the
+    # VectorCypher recency path. Default returns an empty list so backends
+    # without a recency-capable table contribute nothing to the channel.
+    async def search_recent_chunks(
+        self,
+        namespace_id: UUID,
+        limit: int,
+        *,
+        created_after: datetime | None = None,
+    ) -> list[tuple[Chunk, float | None]]:
+        """Return the ``limit`` most-recent chunks in the namespace.
+
+        Pure recency sort with no semantic gate — the caller (the
+        VectorCypher recency channel) applies the cosine relevance floor.
+        The recency axis is ``COALESCE(occurred_at, source_timestamp,
+        created_at)`` (event-time → producer-time → ingest-time), narrowed
+        from above by the optional ``created_after`` bound on the same axis.
+
+        Returns ``(chunk, None)`` tuples; the ``None`` signals "no cosine
+        score available" so the caller branches on it. The default empty
+        list means the backend does not support the recency channel
+        (sqlite_lance support tracked in GitHub issue #1182).
+        """
+        return []
+
 
 def temporal_chunk_to_chunk(tc: TemporalChunk) -> Chunk:
     """Adapt a ``TemporalChunk`` (skeleton storage) to a public ``Chunk``.

--- a/src/khora/engines/skeleton/backends/pgvector.py
+++ b/src/khora/engines/skeleton/backends/pgvector.py
@@ -178,6 +178,17 @@ class PgVectorTemporalStore(TemporalVectorStore):
                 """)
             )
 
+            # B-tree expression index serving the recency channel's
+            # ORDER BY COALESCE(...) DESC LIMIT. The COALESCE expression is
+            # byte-identical to ``search_recent_chunks`` so Postgres serves
+            # the sort from the index.
+            await conn.execute(
+                text("""
+                CREATE INDEX IF NOT EXISTS ix_khora_chunks_ns_recency
+                ON khora_chunks (namespace_id, (COALESCE(occurred_at, source_timestamp, created_at)) DESC)
+                """)
+            )
+
             # Create HNSW index on embedding
             await conn.execute(
                 text(f"""
@@ -648,6 +659,49 @@ class PgVectorTemporalStore(TemporalVectorStore):
         async with self._get_session() as session:
             results = await self._bm25_search(session, query_text, conditions, limit)
         return [(temporal_chunk_to_chunk(r.chunk), float(r.bm25_score or 0.0)) for r in results]
+
+    async def search_recent_chunks(
+        self,
+        namespace_id: UUID,
+        limit: int,
+        *,
+        created_after: datetime | None = None,
+    ) -> list[tuple[Chunk, float | None]]:
+        """Return the ``limit`` most-recent chunks in ``namespace_id``.
+
+        Pure recency sort with no semantic gate — the caller (the
+        VectorCypher recency channel) applies the cosine relevance floor.
+        The recency axis is the 3-way ``COALESCE(occurred_at,
+        source_timestamp, created_at)`` (event-time → producer-time →
+        ingest-time), narrowed from above by the optional ``created_after``
+        bound on the SAME axis. The expression is byte-identical to the
+        ``ix_khora_chunks_ns_recency`` index expression so Postgres can serve
+        the ``ORDER BY ... DESC LIMIT`` from the index.
+
+        Selects the FULL row (not the embedding-excluding ``_retrieval_cols``
+        path) so ``embedding`` survives onto the returned ``Chunk`` — the
+        recency channel drops embedding-less chunks before the cosine gate.
+
+        Returns ``(chunk, None)`` tuples; the ``None`` signals "no cosine
+        score available" for the caller's RRF branch.
+        """
+        async with self._get_session() as session:
+            temporal_col = func.coalesce(
+                khora_chunks_table.c.occurred_at,
+                khora_chunks_table.c.source_timestamp,
+                khora_chunks_table.c.created_at,
+            )
+            stmt = (
+                select(khora_chunks_table)
+                .where(khora_chunks_table.c.namespace_id == namespace_id)
+                .order_by(temporal_col.desc())
+                .limit(limit)
+            )
+            if created_after is not None:
+                stmt = stmt.where(temporal_col >= created_after)
+            result = await session.execute(stmt)
+            rows = result.fetchall()
+        return [(temporal_chunk_to_chunk(self._row_to_chunk(r)), None) for r in rows]
 
     async def _bm25_search(
         self,

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -1676,19 +1676,20 @@ class VectorCypherRetriever:
             # irrelevant-but-fresh chunks muscling in (Devil's-Advocate
             # follow-up: decouple channel filter from synthesized floor).
             #
-            # The recency channel reads the relational chunks table, which
-            # cannot push down a khora_chunks-compiled predicate, so the caller
-            # filter is enforced as an in-memory post-filter inside
+            # The recency channel reads the temporal store's chunk table
+            # (``khora_chunks`` on pgvector). Pushdown of a khora_chunks-compiled
+            # predicate is NOT implemented for this recency SQL, so the caller
+            # filter is enforced as a full-AST in-memory post-filter inside
             # _recency_channel_chunks. Quality trade-off (accepted): under a
             # restrictive caller filter the recency channel post-filters in
             # memory and may return fewer rows, slightly under-recalling the
             # "current state" intent on a tightly date-filtered namespace.
             # The recency channel records its own ChannelPlan internally — and
             # only when it actually produced post-filtered chunks on the real
-            # execution path. On every wired temporal store its SQL source
-            # (``search_recent_chunks``) is absent, so it early-returns [] and
-            # records nothing: the channel honestly never appears in the report
-            # rather than being credited with a disposition it never reached.
+            # execution path. Backends WITHOUT the capability (e.g. SurrealDB)
+            # return the protocol default [] from ``search_recent_chunks``, so
+            # the channel honestly never appears in the report rather than being
+            # credited with a disposition it never reached.
             recent_chunks = await self._recency_channel_chunks(
                 query_embedding=query_embedding,
                 namespace_id=namespace_id,
@@ -3481,26 +3482,28 @@ class VectorCypherRetriever:
     ) -> list[tuple[UUID, float, Chunk]]:
         """Issue #567 A3 — pure-recency candidate pool.
 
-        Pulls the N most-recent chunks in the namespace via the
-        ``search_recent_chunks`` SQL (uses the ``ix_chunks_ns_temporal``
-        index from migration 017), then computes per-chunk cosine
-        similarity against ``query_embedding`` and drops anything below
+        Pulls the N most-recent chunks in the namespace via the temporal
+        store's ``search_recent_chunks`` (on pgvector this reads the
+        ``khora_chunks`` table, served by the ``ix_khora_chunks_ns_recency``
+        index), then computes per-chunk cosine similarity against
+        ``query_embedding`` and drops anything below
         ``temporal_query_relevance_floor``. Pool augmentation only — the
         caller merges results into the existing vector pool.
 
-        ``filter_ast``: the caller recall-filter AST. This channel reads the
-        relational chunks table, which cannot push down a khora_chunks-compiled
-        predicate, so the filter is enforced as a full-AST in-memory post-filter
-        — no filter-violating chunk reaches RRF. (Trade-off: under a restrictive
+        ``filter_ast``: the caller recall-filter AST. Pushdown of a
+        khora_chunks-compiled predicate is not implemented for this recency
+        SQL, so the filter is enforced as a full-AST in-memory post-filter —
+        no filter-violating chunk reaches RRF. (Trade-off: under a restrictive
         caller filter this may return fewer rows; see the call site.)
 
         ``filter_channel_plans``: when provided, the honest recency ChannelPlan
         is recorded here — but ONLY on the real execution path, after the channel
         has actually post-filtered surviving chunks under a filter. The channel
         pushes nothing (pure recency sort) and re-checks every leaf in memory, so
-        the plan post-filters every leaf. The early-returns above (no SQL source,
-        no rows, no embeddings) record nothing, so a channel that never produced
-        a post-filtered result is never credited with a disposition.
+        the plan post-filters every leaf. The early-returns above (backend
+        without the capability, no rows, no embeddings) record nothing, so a
+        channel that never produced a post-filtered result is never credited
+        with a disposition.
 
         Returns ``list[tuple[chunk_id, score, Chunk]]`` matching the
         shape of ``_vector_search_chunks`` so RRF can fuse it directly.
@@ -3575,9 +3578,10 @@ class VectorCypherRetriever:
                             },
                             chunker_info=getattr(chunk, "chunker_info", None) or {},
                             created_at=getattr(chunk, "created_at", None) or getattr(chunk, "occurred_at", None),
-                            # Recency channel reads the main chunks table, which
-                            # carries the producer time but no chunk event-time;
-                            # the projection falls back to source_timestamp.
+                            # The temporal store carries the chunk event-time
+                            # (occurred_at, surfaced into metadata above) and the
+                            # producer time (source_timestamp); the projection
+                            # uses event-time first, then producer time.
                             source_timestamp=getattr(chunk, "source_timestamp", None),
                         ),
                     )

--- a/tests/integration/test_vectorcypher_recency_channel_pg.py
+++ b/tests/integration/test_vectorcypher_recency_channel_pg.py
@@ -486,8 +486,16 @@ async def test_recency_channel_records_plan_end_to_end(kb_vc: Khora) -> None:
     assert channels["recency"]["post_filtered_keys"] == ["metadata.tag"]
     assert channels["recency"]["pushed_keys"] == []
 
-    # Every returned chunk must satisfy the filter (tag == "urgent").
+    # Every returned chunk must satisfy the filter (tag == "urgent"). The tag
+    # is carried on the chunk's parent document (``DocumentProjection.metadata``),
+    # reached via ``RecallChunk.document_id`` into ``result.documents`` — the
+    # response projection does not duplicate metadata onto each chunk.
     assert result.chunks, "expected at least the urgent chunk to survive the filter"
+    docs_by_id = {doc.id: doc for doc in result.documents}
     for chunk in result.chunks:
-        tag = (chunk.metadata or {}).get("tag")
+        doc = docs_by_id.get(chunk.document_id)
+        assert doc is not None, (
+            f"chunk {chunk.id} references document {chunk.document_id} missing from result.documents"
+        )
+        tag = (doc.metadata or {}).get("tag")
         assert tag == "urgent", f"filter-violating chunk leaked through: tag={tag!r}"

--- a/tests/integration/test_vectorcypher_recency_channel_pg.py
+++ b/tests/integration/test_vectorcypher_recency_channel_pg.py
@@ -1,0 +1,493 @@
+"""Live-PG proof for the VectorCypher recency channel (GitHub issue #1182).
+
+Two layers of coverage:
+
+(a) STORE-LEVEL — ``PgVectorTemporalStore.search_recent_chunks`` against live
+    Postgres. Proves the recency SQL orders on the 3-way
+    ``COALESCE(occurred_at, source_timestamp, created_at) DESC`` axis, honors
+    ``limit`` and the ``created_after`` floor, isolates by namespace, and — the
+    LOAD-BEARING regression guard — selects the embedding column so every
+    returned ``Chunk`` carries a non-None ``.embedding`` (the recency channel
+    drops embedding-less chunks before the cosine gate, so a missing embedding
+    column would silently empty the channel).
+
+(b) CHANNEL-LEVEL — a full ``Khora(engine="vectorcypher")`` recall with
+    ``temporal_recency_channel_enabled=True`` and a RECENCY-classified query
+    under a caller filter. Asserts ``engine_info["filter"]`` records the
+    ``"recency"`` channel (post-filtering all filter leaves) and that every
+    returned chunk satisfies the filter. The recency ChannelPlan is recorded
+    ONLY when post-filtered recency candidates SURVIVE, so a green assertion
+    proves the channel fired end-to-end (never vacuous).
+
+    PATH CHOSEN: the full ``Khora.recall()`` path. ``VectorCypherEngine.connect``
+    verifies Neo4j connectivity for the PG backend, so the recency channel only
+    runs inside ``_vectorcypher_retrieve`` — which needs a graph-seeded entry
+    entity. Hence (b) gates on BOTH Postgres AND Neo4j reachability; (a) needs
+    only Postgres. ``mode=SearchMode.GRAPH`` forces ``_vectorcypher_retrieve``
+    deterministically (HYBRID would let the router classify a short query as
+    SIMPLE and fall to the recency-less ``_simple_retrieve``).
+
+How to run locally::
+
+    make dev   # postgres (5434) + neo4j (bolt 7688) via docker compose
+    NEO4J_INTEGRATION_TEST=1 KHORA_NEO4J_URL=bolt://localhost:7688 \\
+        uv run pytest tests/integration/test_vectorcypher_recency_channel_pg.py \\
+        -v -m integration --no-cov
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import socket
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.parse import urlparse
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from khora.config import KhoraConfig
+from khora.db.session import run_migrations
+from khora.engines.skeleton.backends import TemporalChunk
+from khora.engines.skeleton.backends.pgvector import PgVectorTemporalStore
+from khora.extraction.extractors.base import ExtractedEntity, ExtractionResult
+from khora.khora import Khora
+from khora.query import SearchMode
+
+EMBED_DIM = 1536  # matches the khora_chunks.embedding Vector(1536) column
+
+DATABASE_URL = os.environ.get(
+    "KHORA_DATABASE_URL",
+    "postgresql+asyncpg://khora:khora@localhost:5434/khora",
+)
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
+
+
+# ---------------------------------------------------------------------------
+# Reachability gates (mirrors tests/integration/matrix/test_skeleton_pg.py)
+# ---------------------------------------------------------------------------
+
+
+def _pg_reachable() -> bool:
+    parsed = urlparse(DATABASE_URL.replace("+asyncpg", ""))
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _pg_reachable(),
+        reason="PostgreSQL not reachable (run `make dev` first)",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Deterministic keyword embedder stub (mirrors test_skeleton_pg.py).
+#
+# Each keyword maps to a fixed slot in the 1536-dim vector; chunks containing a
+# keyword get a unit component there, so cosine similarity reflects keyword
+# overlap. The query embedding shares the freshest chunk's keyword, so the
+# fresh chunk clears ``temporal_query_relevance_floor`` in the cosine gate.
+# ---------------------------------------------------------------------------
+_KEYWORD_SLOTS: dict[str, int] = {
+    "falcon": 0,
+    "launch": 1,
+    "rocket": 2,
+    "recent": 3,
+    "old": 4,
+    "alpha": 5,
+    "bravo": 6,
+    "charlie": 7,
+}
+
+
+def _embed_for(text_in: str) -> list[float]:
+    """Deterministic 1536-dim unit vector derived from ``text_in``."""
+    vec = [0.0] * EMBED_DIM
+    vec[EMBED_DIM - 1] = 0.01  # baseline so empty inputs aren't zero vectors
+    lower = text_in.lower()
+    for kw, slot in _KEYWORD_SLOTS.items():
+        if kw in lower:
+            vec[slot] = 1.0
+    norm = math.sqrt(sum(v * v for v in vec)) or 1.0
+    return [v / norm for v in vec]
+
+
+async def _stub_embed_batch(self: Any, texts: list[str]) -> list[list[float]]:
+    return [_embed_for(t) for t in texts]
+
+
+async def _stub_embed(self: Any, text_in: str) -> list[float]:
+    return _embed_for(text_in)
+
+
+# ---------------------------------------------------------------------------
+# Migrations-once fixture (mirrors test_skeleton_pg.py). Needed for the
+# channel-level test (full Khora wires the alembic-managed core schema); the
+# PgVectorTemporalStore creates its own ``khora_chunks`` table imperatively on
+# connect(), so the store-level test does not depend on this.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+async def _migrations_once() -> None:
+    eng = create_async_engine(DATABASE_URL)
+    try:
+        async with eng.begin() as conn:
+            r = await conn.execute(
+                text("SELECT typname FROM pg_type WHERE typnamespace = 'public'::regnamespace AND typtype = 'e'")
+            )
+            for (typname,) in r.fetchall():
+                await conn.execute(text(f"DROP TYPE IF EXISTS public.{typname} CASCADE"))
+            await conn.execute(text("DROP SCHEMA public CASCADE"))
+            await conn.execute(text("CREATE SCHEMA public"))
+            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+            await conn.execute(
+                text(
+                    "CREATE TABLE khora_alembic_version ("
+                    "  version_num VARCHAR(64) NOT NULL,"
+                    "  CONSTRAINT khora_alembic_version_pkc PRIMARY KEY (version_num)"
+                    ")"
+                )
+            )
+    finally:
+        await eng.dispose()
+
+    result = await run_migrations(DATABASE_URL)
+    assert result.success, f"Migrations failed: {result.error}"
+
+
+# ===========================================================================
+# (a) STORE-LEVEL — PgVectorTemporalStore.search_recent_chunks on live PG
+# ===========================================================================
+
+
+@pytest.fixture
+async def store() -> AsyncIterator[PgVectorTemporalStore]:
+    """A connected PgVectorTemporalStore.
+
+    ``connect()`` runs ``metadata.create_all`` for ``khora_chunks`` plus the
+    recency / HNSW / GIN indexes, so this fixture does NOT need the alembic
+    chain — the temporal store owns its table.
+    """
+    config = KhoraConfig(database_url=DATABASE_URL)
+    config.llm.embedding_dimension = EMBED_DIM
+    config.storage.embedding_dimension = EMBED_DIM
+    config.storage.postgresql_url = DATABASE_URL
+    store = PgVectorTemporalStore(config)
+    await store.connect()
+    try:
+        yield store
+    finally:
+        await store.disconnect()
+
+
+def _temporal_chunk(
+    *,
+    namespace_id: UUID,
+    content: str,
+    occurred_at: datetime | None = None,
+    source_timestamp: datetime | None = None,
+    created_at: datetime | None = None,
+) -> TemporalChunk:
+    return TemporalChunk(
+        id=uuid4(),
+        namespace_id=namespace_id,
+        document_id=uuid4(),
+        content=content,
+        embedding=_embed_for(content),
+        occurred_at=occurred_at,
+        source_timestamp=source_timestamp,
+        created_at=created_at,
+    )
+
+
+async def test_store_search_recent_chunks_recency_order_and_embedding(
+    store: PgVectorTemporalStore,
+) -> None:
+    """Recency-ordered on the COALESCE axis; every Chunk carries an embedding."""
+    ns = uuid4()
+    now = datetime.now(UTC)
+
+    # Three chunks exercising each leg of COALESCE(occurred_at, source_timestamp,
+    # created_at): the recent one uses occurred_at, the middle uses
+    # source_timestamp (occurred_at NULL), the old one falls back to created_at.
+    recent = _temporal_chunk(namespace_id=ns, content="recent falcon launch", occurred_at=now - timedelta(days=1))
+    middle = _temporal_chunk(
+        namespace_id=ns,
+        content="middle falcon note",
+        occurred_at=None,
+        source_timestamp=now - timedelta(days=10),
+    )
+    old = _temporal_chunk(
+        namespace_id=ns,
+        content="old falcon archive",
+        occurred_at=None,
+        source_timestamp=None,
+        created_at=now - timedelta(days=30),
+    )
+    await store.create_chunks_batch([old, middle, recent])
+
+    results = await store.search_recent_chunks(ns, limit=10)
+
+    # Recency-ordered: recent before middle before old, on the COALESCE axis.
+    returned_ids = [chunk.id for chunk, _sim in results]
+    assert returned_ids == [recent.id, middle.id, old.id], (
+        f"recency order violated on the COALESCE axis: {returned_ids}"
+    )
+    # Every tuple carries the None similarity sentinel.
+    assert all(sim is None for _chunk, sim in results)
+    # LOAD-BEARING: the embedding column was selected, so .embedding survives.
+    for chunk, _sim in results:
+        assert chunk.embedding is not None, f"chunk {chunk.id} returned with embedding=None"
+        assert len(chunk.embedding) == EMBED_DIM
+
+
+async def test_store_search_recent_chunks_honors_limit(store: PgVectorTemporalStore) -> None:
+    """``limit`` caps the returned rows to the most-recent N."""
+    ns = uuid4()
+    now = datetime.now(UTC)
+    chunks = [
+        _temporal_chunk(namespace_id=ns, content=f"falcon entry {i}", occurred_at=now - timedelta(days=i))
+        for i in range(5)
+    ]
+    await store.create_chunks_batch(chunks)
+
+    results = await store.search_recent_chunks(ns, limit=2)
+
+    assert len(results) == 2
+    # The two most-recent (smallest day offset) come back first.
+    assert [c.id for c, _ in results] == [chunks[0].id, chunks[1].id]
+
+
+async def test_store_search_recent_chunks_created_after_excludes_old(
+    store: PgVectorTemporalStore,
+) -> None:
+    """``created_after`` narrows on the same COALESCE axis, excluding old rows."""
+    ns = uuid4()
+    now = datetime.now(UTC)
+    recent = _temporal_chunk(namespace_id=ns, content="recent falcon", occurred_at=now - timedelta(days=2))
+    old = _temporal_chunk(namespace_id=ns, content="old falcon", occurred_at=now - timedelta(days=40))
+    await store.create_chunks_batch([recent, old])
+
+    cutoff = now - timedelta(days=7)
+    results = await store.search_recent_chunks(ns, limit=10, created_after=cutoff)
+
+    returned_ids = {c.id for c, _ in results}
+    assert recent.id in returned_ids
+    assert old.id not in returned_ids, "created_after floor did not exclude the 40-day-old chunk"
+
+
+async def test_store_search_recent_chunks_namespace_isolation(store: PgVectorTemporalStore) -> None:
+    """Chunks in a second namespace never appear in the first namespace's results."""
+    ns_a = uuid4()
+    ns_b = uuid4()
+    now = datetime.now(UTC)
+
+    a_chunks = [
+        _temporal_chunk(namespace_id=ns_a, content=f"falcon alpha {i}", occurred_at=now - timedelta(hours=i))
+        for i in range(3)
+    ]
+    b_chunks = [
+        _temporal_chunk(namespace_id=ns_b, content=f"falcon bravo {i}", occurred_at=now - timedelta(hours=i))
+        for i in range(3)
+    ]
+    await store.create_chunks_batch(a_chunks + b_chunks)
+
+    results_a = await store.search_recent_chunks(ns_a, limit=50)
+    returned_a_ids = {c.id for c, _ in results_a}
+    b_ids = {c.id for c in b_chunks}
+
+    assert returned_a_ids == {c.id for c in a_chunks}, "namespace A results are not exactly A's chunks"
+    assert not (returned_a_ids & b_ids), "namespace B chunks leaked into namespace A results"
+
+
+# ===========================================================================
+# (b) CHANNEL-LEVEL — full Khora.recall() proves the recency channel fires
+#                     end-to-end and records its ChannelPlan under a filter.
+# ===========================================================================
+
+
+def _neo4j_url() -> str:
+    return os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7688")
+
+
+def _neo4j_reachable() -> bool:
+    parsed = urlparse(_neo4j_url())
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 7687
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+_GRAPH_ENTITY_NAME = "Falcon"
+_GRAPH_MARKER = "graphdoc"
+
+
+async def _stub_extract_multi_with_entity(self: Any, texts: list[str], **_kwargs: Any) -> list[ExtractionResult]:
+    """Emit the shared entity for marker-carrying docs (real MENTIONED_IN edges)."""
+    out: list[ExtractionResult] = []
+    for text_in in texts:
+        if _GRAPH_MARKER in text_in:
+            out.append(
+                ExtractionResult(
+                    entities=[ExtractedEntity(name=_GRAPH_ENTITY_NAME, entity_type="PERSON", confidence=0.99)]
+                )
+            )
+        else:
+            out.append(ExtractionResult())
+    return out
+
+
+@pytest.fixture
+def _patch_llm_channel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub embedder + extractor for the channel-level test (no external LLM)."""
+    monkeypatch.setattr(
+        "khora.extraction.embedders.litellm.LiteLLMEmbedder.embed_batch",
+        _stub_embed_batch,
+    )
+    monkeypatch.setattr(
+        "khora.extraction.embedders.litellm.LiteLLMEmbedder.embed",
+        _stub_embed,
+    )
+    monkeypatch.setattr(
+        "khora.extraction.extractors.llm.LLMEntityExtractor.extract_multi",
+        _stub_extract_multi_with_entity,
+    )
+
+
+@pytest.fixture
+async def kb_vc(_migrations_once: None, _patch_llm_channel: None) -> AsyncIterator[Khora]:
+    """Connected VectorCypher Khora (live PG + Neo4j) with the recency channel ON."""
+    config = KhoraConfig(database_url=DATABASE_URL, neo4j_url=_neo4j_url())
+    config.storage.neo4j_user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+    config.storage.neo4j_password = os.environ.get("KHORA_NEO4J_PASSWORD", "pleaseletmein")
+    config.llm.embedding_dimension = EMBED_DIM
+    config.storage.embedding_dimension = EMBED_DIM
+    config.storage.postgresql_url = DATABASE_URL
+    config.pipeline.extract_entities = True
+    config.pipeline.selective_extraction = False
+    config.query.enable_reranking = False
+    config.query.enable_llm_reranking = False
+    config.query.min_entity_similarity = 0.0
+    # The feature under test. Floor synthesis stays OFF (default) so the recency
+    # channel runs with temporal_filter=None and is not vetoed.
+    config.query.temporal_recency_channel_enabled = True
+    config.query.temporal_query_relevance_floor = 0.30
+    config.pipelines.chunk_size = 1024  # single-chunk docs keep the test deterministic
+
+    instance = Khora(config, engine="vectorcypher", run_migrations=False)
+    await instance.connect()
+    try:
+        yield instance
+    finally:
+        try:
+            await instance.disconnect()
+        except Exception:
+            pass
+
+
+@pytest.mark.skipif(
+    not _neo4j_reachable() or not os.environ.get("NEO4J_INTEGRATION_TEST"),
+    reason="set NEO4J_INTEGRATION_TEST=1 and run `make dev` (needs Neo4j for the full vectorcypher path)",
+)
+async def test_recency_channel_records_plan_end_to_end(kb_vc: Khora) -> None:
+    """A RECENCY recall under a caller filter records the ``"recency"`` channel
+    in ``engine_info["filter"]`` and every returned chunk satisfies the filter.
+
+    Non-vacuous by construction: the recency ChannelPlan is recorded ONLY when
+    post-filtered recency candidates SURVIVE. The freshest doc carries the
+    filter-matching ``tag="urgent"``; older docs carry ``tag="noise"``. All docs
+    mention the shared entity (real MENTIONED_IN edges) and share the query's
+    ``falcon`` keyword (cosine 1.0, clearing the relevance floor), so the
+    recency channel post-filters the urgent doc through and gates it in RRF.
+    """
+    ns = await kb_vc.create_namespace()
+    namespace_id: UUID = ns.namespace_id
+
+    # Older "noise" docs — relevant + recent enough to enter the recency channel,
+    # but excluded by the filter (proves the post-filter is real).
+    for i in range(3):
+        await kb_vc.remember(
+            content=f"{_GRAPH_ENTITY_NAME} {_GRAPH_MARKER} old launch note {i}: alpha bravo charlie.",
+            namespace=namespace_id,
+            title=f"noise-doc-{i}",
+            metadata={"tag": "noise"},
+            entity_types=["PERSON"],
+            relationship_types=[],
+        )
+    # The freshest, filter-matching doc.
+    r_fresh = await kb_vc.remember(
+        content=f"{_GRAPH_ENTITY_NAME} {_GRAPH_MARKER} recent launch update: alpha bravo charlie.",
+        namespace=namespace_id,
+        title="urgent-doc",
+        metadata={"tag": "urgent"},
+        entity_types=["PERSON"],
+        relationship_types=[],
+    )
+
+    # Backdate occurred_at on the temporal store table so the freshest doc is
+    # unambiguously the newest on the recency axis (single-doc remember does not
+    # stamp occurred_at; mirror the skeleton-pg pattern via direct SQL).
+    eng = create_async_engine(DATABASE_URL)
+    try:
+        async with eng.begin() as conn:
+            await conn.execute(
+                text("UPDATE khora_chunks SET occurred_at = NOW() - INTERVAL '20 days' WHERE namespace_id = :ns"),
+                {"ns": str(namespace_id)},
+            )
+            await conn.execute(
+                text(
+                    "UPDATE khora_chunks SET occurred_at = NOW() - INTERVAL '1 day' "
+                    "WHERE namespace_id = :ns AND document_id = :doc"
+                ),
+                {"ns": str(namespace_id), "doc": str(r_fresh.document_id)},
+            )
+    finally:
+        await eng.dispose()
+
+    # mode=GRAPH forces _vectorcypher_retrieve (where the recency channel lives);
+    # the RECENCY-classified query drives the recency path; the caller filter
+    # restricts to the urgent doc.
+    result = await kb_vc.recall(
+        "latest falcon launch update",
+        namespace=namespace_id,
+        limit=20,
+        mode=SearchMode.GRAPH,
+        filter={"metadata.tag": {"$in": ["urgent"]}},
+    )
+
+    filter_report = result.engine_info["filter"]
+    channels = filter_report["channels"]
+    assert "recency" in channels, (
+        "the recency channel did not record a ChannelPlan — it never produced "
+        f"surviving post-filtered candidates; channels={list(channels)}, "
+        f"engine_info.filter={filter_report}"
+    )
+    # The recency channel pushes nothing (pure recency sort) and re-checks every
+    # leaf in memory, so post_filtered_keys == all filter leaves.
+    assert channels["recency"]["post_filtered_keys"] == ["metadata.tag"]
+    assert channels["recency"]["pushed_keys"] == []
+
+    # Every returned chunk must satisfy the filter (tag == "urgent").
+    assert result.chunks, "expected at least the urgent chunk to survive the filter"
+    for chunk in result.chunks:
+        tag = (chunk.metadata or {}).get("tag")
+        assert tag == "urgent", f"filter-violating chunk leaked through: tag={tag!r}"

--- a/tests/unit/engines/test_recency_channel.py
+++ b/tests/unit/engines/test_recency_channel.py
@@ -8,13 +8,16 @@ today-dated. This test pins the gate.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
 from khora.core.models import Chunk
+from khora.engines.skeleton.backends import TemporalVectorStore
 from khora.engines.vectorcypher.retriever import RetrieverConfig, VectorCypherRetriever
+from khora.filter import FilterNode, RecallFilter, parse_to_ast
 
 
 def _make_chunk(content: str, occurred_at: datetime | None, embedding: list[float]) -> Chunk:
@@ -148,3 +151,77 @@ async def test_chunks_without_embeddings_skipped(retriever_with_mocked_store) ->
         temporal_filter=None,
     )
     assert result == []
+
+
+class _ProtocolDefaultStore(TemporalVectorStore):
+    """A concrete TemporalVectorStore that relies on the Protocol's DEFAULT
+    ``search_recent_chunks`` (which returns ``[]``).
+
+    Unlike SurrealDB or pgvector this store does NOT override the recency
+    method — it inherits the no-op default. The only abstract members it
+    implements are the bare minimum to instantiate; none are exercised by
+    the recency channel under test, so they raise if mis-called.
+    """
+
+    async def connect(self) -> None:  # pragma: no cover - not exercised
+        raise NotImplementedError
+
+    async def disconnect(self) -> None:  # pragma: no cover - not exercised
+        raise NotImplementedError
+
+    async def create_chunk(self, chunk: Any) -> Any:  # pragma: no cover
+        raise NotImplementedError
+
+    async def create_chunks_batch(self, chunks: Any) -> Any:  # pragma: no cover
+        raise NotImplementedError
+
+    async def get_chunk(self, chunk_id: UUID, namespace_id: UUID) -> Any:  # pragma: no cover
+        raise NotImplementedError
+
+    async def delete_chunk(self, chunk_id: UUID, namespace_id: UUID) -> bool:  # pragma: no cover
+        raise NotImplementedError
+
+    async def delete_chunks_by_document(self, document_id: UUID, namespace_id: UUID) -> int:  # pragma: no cover
+        raise NotImplementedError
+
+    async def search(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover
+        raise NotImplementedError
+
+    async def health_check(self) -> dict[str, Any]:  # pragma: no cover
+        raise NotImplementedError
+
+
+def _filter_ast() -> FilterNode:
+    """A real recall-filter AST so the plan-recording branch is reachable."""
+    return parse_to_ast(RecallFilter.model_validate({"metadata.tier": "gold"}))
+
+
+@pytest.mark.asyncio
+async def test_protocol_default_store_returns_empty_and_records_no_plan() -> None:
+    """A real ``TemporalVectorStore`` that inherits the Protocol DEFAULT
+    ``search_recent_chunks`` (returns ``[]``) contributes nothing: the
+    channel returns ``[]`` and records NO ChannelPlan, even when a caller
+    filter is present (the early-return on empty SQL rows precedes the
+    plan-recording site). A channel that never produced post-filtered
+    chunks must never be credited with a disposition in the report."""
+    cfg = RetrieverConfig(
+        temporal_recency_channel_enabled=True,
+        temporal_query_relevance_floor=0.30,
+    )
+    retriever = VectorCypherRetriever.__new__(VectorCypherRetriever)
+    retriever._config = cfg
+    retriever._vector_store = _ProtocolDefaultStore()
+
+    filter_channel_plans: dict[str, Any] = {}
+    result = await retriever._recency_channel_chunks(
+        query_embedding=[1.0, 0.0, 0.0],
+        namespace_id=uuid4(),
+        temporal_filter=None,
+        filter_ast=_filter_ast(),
+        filter_channel_plans=filter_channel_plans,
+    )
+
+    assert result == []
+    # The recency channel honestly never appears in the report.
+    assert "recency" not in filter_channel_plans
+    assert filter_channel_plans == {}


### PR DESCRIPTION
## Summary
- The VectorCypher recency channel was dead on every stack. The channel calls `search_recent_chunks` on the wired temporal store, but no temporal-store backend implemented it (it existed only on the storage-layer pgvector backend, which is never the temporal store), so the channel always early-returned `[]` and its config knobs were no-ops. The channel is default-OFF, so this changes no default behavior.
- Add `search_recent_chunks` as a non-abstract optional-capability method on the `TemporalVectorStore` protocol (default body `return []`), mirroring the existing `search_fulltext` pattern. Backends without a recency-capable table contribute nothing and never appear in the filter report.
- Implement it on the pgvector temporal store: a pure recency sort over `COALESCE(occurred_at, source_timestamp, created_at)` (event-time → producer-time → ingest-time), with an optional `created_after` lower bound on the same axis and a `limit`. The query selects the full row so embeddings survive onto the returned chunks — the channel drops embedding-less chunks before the cosine gate, so losing the embedding would silently re-kill the channel.
- Add a matching B-tree expression index `ix_khora_chunks_ns_recency (namespace_id, (COALESCE(occurred_at, source_timestamp, created_at)) DESC)`, created idempotently on connect, whose expression is byte-identical to the `ORDER BY` so Postgres serves the sort from the index.
- Rewrite stale comments at the call site and in the channel docstring that claimed the channel read the relational chunks table and that the method was absent on every wired store. No control-flow change — the capability guard, embedding-drop guard, in-memory post-filter, and channel-plan recording are untouched.
- Embedded (sqlite_lance) support is deferred and tracked in #1182.

## Test plan
- [x] Unit tests pass (recency-channel suite extended with a protocol-default-store case: a real protocol implementer relying on the default `[]` yields no channel plan)
- [ ] Integration tests pass (new pgvector suite: store-level recency ordering on the COALESCE axis, embeddings populated on returned chunks, `limit`/`created_after` honored, namespace isolation; plus end-to-end recall asserting the recency channel appears in the filter report with all caller-filter leaves post-filtered) — run in CI against provisioned Postgres/Neo4j
- [x] `ruff check` + `ruff format` clean; full local unit run shows no regressions vs. base (pre-existing failures are confined to optional-extra backends not installed in this combo)