### PR TITLE
Drop absent-created_at seeds from filter-conformance corpus

### DIFF
--- a/src/khora/filter/conformance.py
+++ b/src/khora/filter/conformance.py
@@ -758,19 +758,6 @@ _LIVE_BACKENDS: frozenset[str] = _TOTAL_BACKENDS | _SPLIT_BACKENDS
 # Every backend a metadata-only / occurred_at / source_timestamp case can run on.
 _OP_BACKENDS: frozenset[str] = _INMEM_BACKENDS | _LIVE_BACKENDS
 
-# The live backends that STAMP ``created_at`` to ``now()`` on insert when absent
-# (postgres + lance via the skeleton temporal store; weaviate via the same store
-# path), so an "absent" row cannot stay NULL there — its ``now()`` value satisfies a
-# lower-bound op and breaks the by-construction ``expected_ids``. A ``created_at``
-# predicate is pruned from these. The surrealdb and cypher runners KEEP ``created_at``
-# cases, but for different reasons: surrealdb leaves an absent ``created_at`` NULL
-# natively (explicit ``option<datetime>`` insert, no default), while the cypher
-# production writer ALSO stamps ``now()`` and the conformance seeder strips it back to
-# NULL post-write (``_strip_stamped_created_at`` in ``_conformance_neo4j.py``).
-# ``occurred_at`` / ``source_timestamp`` are user-supplied and stay NULL everywhere —
-# never pruned.
-_CREATED_AT_STAMP_BACKENDS: frozenset[str] = frozenset({"postgres", "sqlite_lance", "weaviate"})
-
 # The live backends whose runner seeds through ``seed_case`` — i.e. it writes one
 # ``Document`` per record into the relational ``documents`` table (which enforces
 # UNIQUE ``(namespace_id, external_id)``). A case whose seed has a duplicate non-NULL
@@ -871,10 +858,9 @@ def _with_metadata(rec: SeedRecord, metadata: dict[str, Any]) -> SeedRecord:
 # from :data:`SYSTEM_KEYS` (NOT imported from the engines layer, which would be a
 # filter→engines inversion): the store's ``_BACKED_SYSTEM_KEYS`` is the source of
 # truth for the store + the QA drift-gate test, and conformance encodes its surreal
-# capability gap locally — the same way it encodes :data:`_CREATED_AT_STAMP_BACKENDS`,
-# :data:`_SEED_CASE_BACKENDS`, etc. (kept consistent by the store-side drift
-# test). A predicate on one of these raises ``RecallFilterUnsupportedError`` on the
-# total surreal leg (no post-filter safety net).
+# capability gap locally — the same way it encodes :data:`_SEED_CASE_BACKENDS`, etc.
+# (kept consistent by the store-side drift test). A predicate on one of these raises
+# ``RecallFilterUnsupportedError`` on the total surreal leg (no post-filter safety net).
 _UNBACKED_SYSTEM_KEYS: frozenset[str] = SYSTEM_KEYS - frozenset({"occurred_at", "created_at"})
 
 
@@ -917,12 +903,11 @@ def _backends_for_filter(filter_: dict[str, Any] | RecallFilter, seed: tuple[See
       system key is a CONSTANT (the always-present axiom), value-independent and
       oracle-comparable on every backend — this is what lets the F-EXISTS system-key
       shapes execute in both the pushed-down and post-filtered modes;
-    * a leaf reading ``created_at`` → drop :data:`_CREATED_AT_STAMP_BACKENDS`
-      (postgres / sqlite_lance / weaviate stamp ``now()`` on insert). surrealdb +
-      cypher KEEP it: surrealdb leaves an absent ``created_at`` NULL natively, and
-      the cypher seeder strips the writer's stamped ``now()`` back to NULL post-write
-      (``_strip_stamped_created_at`` in ``_conformance_neo4j.py``); ``occurred_at`` /
-      ``source_timestamp`` are never pruned;
+    * a leaf reading ``created_at`` over a seed that leaves it unset on ANY record →
+      RAISE at construction: ``created_at`` is always-present in production (NOT NULL
+      column + default + writer stamping), so an unset-``created_at`` seed models an
+      unreachable state — every record must stamp a concrete date. ``occurred_at`` /
+      ``source_timestamp`` stay nullable and are never pruned;
     * a surreal-only quirk (unsafe segment / metadata ``$date`` / present-null the
       filter distinguishes) → drop **surrealdb** only (:func:`_surreal_excluded`);
     * a metadata-only / ``occurred_at`` / ``source_timestamp`` case → all backends.
@@ -935,9 +920,15 @@ def _backends_for_filter(filter_: dict[str, Any] | RecallFilter, seed: tuple[See
     excluded: set[str] = set()
     for clause in iter_leaf_clauses(_resolve_ast(filter_)):
         root = clause.path[0] if clause.path else ""
-        if root == "created_at":
-            # A store that stamps created_at on insert can't keep the absent row NULL.
-            excluded |= _CREATED_AT_STAMP_BACKENDS
+        if root == "created_at" and any(rec.created_at is None for rec in seed):
+            # created_at is always-present in production (NOT NULL + default_factory +
+            # writer stamping): a seed that leaves it unset models an unreachable state
+            # and would silently diverge on the stamping legs.
+            raise ValueError(
+                f"filter reads created_at but seed record(s) leave it unset "
+                f"({sorted(r.id for r in seed if r.created_at is None)}): "
+                "stamp a concrete date on every record"
+            )
     if _seed_has_duplicate_external_id(seed):
         # The ``documents`` table has a UNIQUE ``(namespace_id, external_id)``
         # constraint, so a seed with two records sharing an ``external_id`` cannot be
@@ -978,21 +969,25 @@ _NON_NULL_STRING_KEY = "source_type"
 
 
 def _date_field_seed(key: str) -> tuple[SeedRecord, ...]:
-    """Five records for a date-key F-OP case: two ties, a mid, a miss, and a NULL row.
+    """Five records for a date-key F-OP case: two ties, a mid, a miss, and a fifth row.
 
     The date is stamped on ``key`` (one of the three date columns). ``-3``/``-4``
     are tied at the hit instant (so ``$eq`` keeps a pair), ``-2`` sits at the mid
     instant (in range of the lower bound, exercising boundary inclusion), ``-1`` is
-    the out-of-range miss, and ``-5`` carries no date at all — the NULL row F1
-    keeps under ``$ne``/``$nin``. All share the default content so they share an
-    embedding.
+    the out-of-range miss. The ``-5`` row is per-key: ``occurred_at`` /
+    ``source_timestamp`` are genuinely nullable, so their ``-5`` carries no date at
+    all — the NULL row F1 negation coverage lives there; ``created_at`` is
+    always-present (NOT NULL + default + writer stamping), so its ``-5`` sits at
+    the miss instant ``_DATE_MISS`` rather than NULL. All share the default content
+    so they share an embedding.
     """
+    fifth = SeedRecord(id=f"{key}-5", **{key: _DATE_MISS}) if key == "created_at" else SeedRecord(id=f"{key}-5")
     return (
         SeedRecord(id=f"{key}-1", **{key: _DATE_MISS}),
         SeedRecord(id=f"{key}-2", **{key: _DATE_MID}),
         SeedRecord(id=f"{key}-3", **{key: _DATE_HIT}),
         SeedRecord(id=f"{key}-4", **{key: _DATE_HIT}),
-        SeedRecord(id=f"{key}-5"),
+        fifth,
     )
 
 
@@ -1020,11 +1015,19 @@ def _date_op_cases(key: str) -> list[ConformanceCase]:
 
     ``expected_ids`` is computed by construction from the known five-record seed
     (``-1`` miss @ 2020-01-01, ``-2`` mid @ 2026-03-15, ``-3``/``-4`` tied @
-    2026-06-01, ``-5`` NULL). The bound is 2026-01-01, so ``$gt``/``$gte`` keep the
-    mid + the tied pair, the upper-bound ops keep only the miss, ``$eq`` against the
-    hit instant keeps the tied pair, and ``$lte`` against the hit keeps everything
-    dated. Negations follow F1: ``$ne``/``$nin``/``$nin:[]`` over the nullable date
-    column **include the NULL ``-5`` row**; ``$in:[]`` keeps nothing.
+    2026-06-01). The ``-5`` row is per-key: ``occurred_at`` / ``source_timestamp``
+    keep the NULL ``-5`` row (genuinely nullable; F1 negation coverage lives there),
+    while ``created_at`` is always-present (NOT NULL + default + writer stamping), so
+    its ``-5`` sits at the miss instant ``_DATE_MISS`` (2020-01-01). The bound is
+    2026-01-01, so
+    ``$gt``/``$gte`` keep the mid + the tied pair, the upper-bound ops keep the miss
+    (plus, for ``created_at``, the at-miss ``-5``), ``$eq`` against the hit instant
+    keeps the tied pair, and ``$lte`` against the hit keeps everything dated.
+    Negations follow F1: over a **nullable** date column (``occurred_at`` /
+    ``source_timestamp``) ``$ne``/``$nin``/``$nin:[]`` **include the NULL ``-5``
+    row**; over ``created_at`` the ``-5`` row keeps by VALUE-mismatch (it is dated at
+    the miss instant, not NULL) wherever the predicate excludes the hit. ``$in:[]``
+    keeps nothing.
 
     Date keys deliberately have **no** ``$exists`` case: ``DateOps`` carries no
     ``$exists`` field, so ``$exists`` on a date key is a *validation* failure (not
@@ -1039,11 +1042,11 @@ def _date_op_cases(key: str) -> list[ConformanceCase]:
     hit_iso = _DATE_HIT.isoformat().replace("+00:00", "Z")
 
     # ``backends`` is computed per-case from the filter + seed
-    # (:func:`_backends_for_filter`): a ``created_at`` predicate drops the live legs
-    # that stamp ``now()`` on insert (postgres / sqlite_lance / weaviate) while
-    # keeping surrealdb / cypher (which leave an absent ``created_at`` NULL);
-    # ``occurred_at`` / ``source_timestamp`` are user-supplied and stay on every
-    # backend. The surrealdb NONE<date asymmetry on lower-bound ops is handled in
+    # (:func:`_backends_for_filter`): a date predicate now imposes NO exclusions —
+    # every date key (``occurred_at`` / ``created_at`` / ``source_timestamp``) is
+    # oracle-comparable on every backend (``created_at`` is always-present — NOT NULL
+    # + default + writer stamping — so the live legs' ``now()`` stamping is unreachable
+    # on these seeds). The surrealdb NONE<date asymmetry on lower-bound ops is handled in
     # ``compile_surrealdb`` (a guarded ``IS NOT NONE``), so surreal keeps the
     # ``$lt`` / ``$lte`` date cases.
     def case(suffix: str, predicate: dict[str, Any], expected: frozenset[str], op_tag: str) -> ConformanceCase:
@@ -1059,15 +1062,27 @@ def _date_op_cases(key: str) -> list[ConformanceCase]:
             exercises=("F-OP", key, op_tag),
         )
 
+    # created_at is always-present (NOT NULL + default + writer stamping): its -5 row
+    # sits at the miss instant instead of NULL, so the lower-bound ops and the $in
+    # listing the miss keep it.
+    miss5 = frozenset({r5}) if key == "created_at" else frozenset()
     return [
         case("gt", {"$gt": bound}, frozenset({r2, r3, r4}), "$gt"),
         case("gte", {"$gte": bound}, frozenset({r2, r3, r4}), "$gte"),
-        case("lt", {"$lt": bound}, frozenset({r1}), "$lt"),
-        case("lte", {"$lte": bound}, frozenset({r1}), "$lte"),
+        case("lt", {"$lt": bound}, frozenset({r1}) | miss5, "$lt"),
+        case("lte", {"$lte": bound}, frozenset({r1}) | miss5, "$lte"),
         case("eq", {"$eq": hit_iso}, frozenset({r3, r4}), "$eq"),
-        # F1: $ne over a nullable date column includes the NULL -5 row.
+        # F1: $ne over a nullable date column (occurred_at / source_timestamp)
+        # includes the NULL -5 row. For created_at the -5 row is dated at the miss
+        # instant, so it is kept by VALUE-mismatch (it is not the hit) rather than by
+        # NULL-inclusion — either way r5 survives $ne against the hit.
         case("ne", {"$ne": hit_iso}, frozenset({r1, r2, r5}), "$ne"),
-        case("in", {"$in": [hit_iso, _DATE_MISS.isoformat().replace("+00:00", "Z")]}, frozenset({r1, r3, r4}), "$in"),
+        case(
+            "in",
+            {"$in": [hit_iso, _DATE_MISS.isoformat().replace("+00:00", "Z")]},
+            frozenset({r1, r3, r4}) | miss5,
+            "$in",
+        ),
         case("in-empty", {"$in": []}, frozenset(), "$in"),
         case("nin", {"$nin": [hit_iso]}, frozenset({r1, r2, r5}), "$nin"),
         case("nin-empty", {"$nin": []}, frozenset({r1, r2, r3, r4, r5}), "$nin"),
@@ -1215,15 +1230,15 @@ def _case(
 
     A thin constructor so the family generators read as a flat table of
     ``id · filter · expected_ids · exercises`` rows. The backend set is derived
-    via :func:`_backends_for_filter` — a metadata-only / ``occurred_at`` /
-    ``source_timestamp`` case widens to all backends (the in-memory oracle +
-    chronicle, the total-exact postgres + surrealdb, and the split cypher +
-    weaviate + sqlite_lance whose post-filter lands on the oracle); a case touching
-    a string document key or ``created_at`` is pruned with the documented
-    capability/seed reason. No family is silently skipped. A leaf on an unbacked
-    surreal system key keeps surrealdb in ``backends`` and unions it into
-    ``expect_unsupported`` (:func:`_surreal_unsupported`) so the surreal leg asserts
-    the raise rather than being skipped.
+    via :func:`_backends_for_filter` — every case widens to all backends (the
+    in-memory oracle + chronicle, the total-exact postgres + surrealdb, and the
+    split cypher + weaviate + sqlite_lance whose post-filter lands on the oracle).
+    The only remaining exclusions are seed-mechanics (a duplicate non-NULL
+    ``external_id`` drops the Document-path :data:`_SEED_CASE_BACKENDS`) and surreal
+    representation quirks (:func:`_surreal_excluded`). No family is silently skipped.
+    A leaf on an unbacked surreal system key keeps surrealdb in ``backends`` and
+    unions it into ``expect_unsupported`` (:func:`_surreal_unsupported`) so the
+    surreal leg asserts the raise rather than being skipped.
     """
     backends = _backends_for_filter(filter_, seed)
     return ConformanceCase(

--- a/tests/integration/matrix/_conformance_neo4j.py
+++ b/tests/integration/matrix/_conformance_neo4j.py
@@ -24,20 +24,11 @@ form is what's under test on the write side. Each :class:`SeedRecord` is adapted
 :class:`TemporalChunk` (mirroring how ``_conformance_pg`` adapts to the skeleton
 store for the postgres leg) so both legs feed their production writer the same corpus.
 
-One corpus-fidelity adjustment: ``create_chunk_nodes_batch`` stamps an absent
-``created_at`` to ``now()`` (the production default), but the conformance corpus
-keeps ``created_at`` cases on the cypher leg *because* cypher is expected to leave an
-absent ``created_at`` NULL. So after the batch write, the seeder ``REMOVE``s
-``created_at`` from exactly the nodes whose ``SeedRecord`` left it ``None``, restoring
-the missing-property semantics the compiler relies on. The strip is forward-protection
-against false EXCLUSION, not against over-inclusion: the ``compile_python`` post-filter
-already rescues a stamped ``now()`` that over-includes on a lower-bound op (a post-filter
-can only narrow the Cypher candidate set), so no current case false-fails without the
-strip. But a ``$not``-wrapped or null-operand ``created_at`` predicate would false-
-EXCLUDE the absent row in the Cypher prefilter, and a post-filter cannot re-add an
-excluded row — so the strip is what keeps that exclusion class correct as the corpus
-grows. ``occurred_at`` / ``source_timestamp`` are user-supplied and the production
-writer already leaves them absent when ``None``, so they need no fixup.
+The corpus carries no absent-``created_at`` rows (``created_at`` is always-present —
+NOT NULL + default + writer stamping; ``_backends_for_filter`` raises on a seed that
+leaves it unset), so the production writer's ``now()`` stamping of an absent ``created_at`` is unreachable
+on conformance seeds. ``occurred_at`` / ``source_timestamp`` are user-supplied and the
+production writer leaves them absent when ``None``.
 
 Seed/read split (write-once, read-many), mirroring the live-Postgres leg. The graph
 is seeded ONCE by ``_conformance_seed`` (the workflow's one-time step), which also
@@ -177,14 +168,6 @@ async def build_seed_map() -> dict[str, dict[str, str]]:
     not namespace, but a per-case namespace keeps the nodes corpus-faithful). Chunk
     UUIDs are stringified for JSON. Called only by the one-time seed entrypoint —
     never by the test.
-
-    The production writer stamps an absent ``created_at`` to ``now()``; the corpus
-    expects cypher to leave it NULL (see module docstring), so after the batch write
-    every node whose ``SeedRecord`` left ``created_at`` ``None`` has the property
-    removed, restoring the missing-value semantics the compiler relies on. This is
-    forward-protection against false EXCLUSION in the Cypher prefilter (a post-filter
-    can only narrow, never re-add an excluded row), not against the over-inclusion the
-    post-filter already rescues.
     """
     driver = _connect()
     seed_map: dict[str, dict[str, str]] = {}
@@ -195,43 +178,15 @@ async def build_seed_map() -> dict[str, dict[str, str]]:
             namespace_id = uuid4()
             id_map: dict[str, str] = {}
             chunks: list[TemporalChunk] = []
-            absent_created_at: list[str] = []
             for record in case.seed_records:
                 chunk_id = uuid4()
                 id_map[record.id] = str(chunk_id)
                 chunks.append(_to_temporal_chunk(record, chunk_id, namespace_id))
-                if record.created_at is None:
-                    absent_created_at.append(str(chunk_id))
             await manager.create_chunk_nodes_batch(chunks, namespace_id)
-            await _strip_stamped_created_at(driver, database, absent_created_at)
             seed_map[case.id] = id_map
     finally:
         await driver.close()
     return seed_map
-
-
-async def _strip_stamped_created_at(driver: Any, database: str, chunk_ids: Sequence[str]) -> None:
-    """Remove the writer-stamped ``created_at`` from nodes whose seed left it absent.
-
-    ``create_chunk_nodes_batch`` defaults an absent ``created_at`` to ``now()`` (the
-    production behavior). The conformance corpus keeps ``created_at`` cases on the
-    cypher leg because cypher is expected to leave an absent ``created_at`` NULL.
-    Re-establish the missing-property semantics by removing the stamped value on
-    exactly those nodes. The payoff is forward-protection against false EXCLUSION: a
-    ``$not``-wrapped or null-operand ``created_at`` predicate would drop the absent row
-    in the Cypher prefilter, and the ``compile_python`` post-filter can only narrow the
-    candidate set — it cannot re-add an excluded row. (Over-inclusion from a stamped
-    ``now()`` on a lower-bound op is already rescued by that post-filter, so the strip
-    is not needed for any current case — it guards the exclusion class as the corpus
-    grows.)
-    """
-    if not chunk_ids:
-        return
-    async with driver.session(database=database) as session:
-        await session.run(
-            f"MATCH ({_NODE_ALIAS}:Chunk) WHERE {_NODE_ALIAS}.id IN $ids REMOVE {_NODE_ALIAS}.created_at",
-            ids=list(chunk_ids),
-        )
 
 
 def write_seed_map(seed_map: Mapping[str, Mapping[str, str]]) -> None:


### PR DESCRIPTION
## Summary
- `created_at` is always-present in production (NOT NULL column + default + writer stamping), so the filter-conformance corpus no longer models an absent `created_at`.
- The F-OP `created_at` `-5` seed row now sits at the miss instant instead of NULL; the `$lt` / `$lte` / `$in` expected sets pick it up accordingly. The other seven date operators are unchanged — the Python oracle leg recomputes every survivor set and would catch any mis-edit.
- Deletes the `_CREATED_AT_STAMP_BACKENDS` prune. It dropped every `created_at` case from the postgres / sqlite_lance / weaviate legs because those legs stamp `now()` on an absent value while the oracle saw the declared seed as absent — a divergence that can no longer occur once the corpus never leaves `created_at` unset.
- Replaces the `created_at` branch in `_backends_for_filter` with a mandatory guard that raises at corpus-construction time if any seed record leaves `created_at` unset (an unreachable production state), so a future hand-authored regression fails loudly instead of silently diverging.
- Removes the now-dead `_strip_stamped_created_at` helper and its call site from the neo4j conformance runner.
- `occurred_at` / `source_timestamp` stay nullable and keep their NULL `-5` rows. No production runtime code is changed — only the conformance corpus definition and the neo4j conformance runner.

## Collection-count impact
Re-enabling the `created_at` cases on the three stamping legs widens collection by exactly the 10 F-OP `created_at` cases + `F-DATES-and-compose`:

| backend | before | after | Δ |
|---|---|---|---|
| postgres | 190 | 201 | +11 |
| sqlite_lance | 190 | 201 | +11 |
| weaviate | 190 | 201 | +11 |
| python | 209 | 209 | 0 |
| chronicle | 209 | 209 | 0 |
| cypher | 209 | 209 | 0 |
| surrealdb | 190 | 190 | 0 |

Total case count is unchanged (209).

## Test plan
- [x] Python oracle leg: `KHORA_CONFORMANCE_BACKEND=python pytest tests/integration/matrix/test_filter_conformance.py -m filter_conformance` → **209 passed** (recomputes every survivor set; confirms the `lt` / `lte` / `in` edits)
- [x] Chronicle leg → **209 passed**
- [x] Grep gates clean: no remaining `_CREATED_AT_STAMP_BACKENDS` or `_strip_stamped_created_at` references in source
- [x] Construction guard verified: a `created_at` filter over a seed with an unset `created_at` raises `ValueError` at corpus build; an all-stamped seed does not; an `occurred_at` filter with an unset value does not (guard correctly scoped to `created_at`)
- [x] Unit guards: `test_conformance_harness` / `test_conformance_catalog` / `test_system_keys_coverage` → **692 passed** (the 9 failures are the optional `weaviate-client` extra being absent in the local venv — identical on the base branch, environmental)
- [ ] Full cross-store conformance matrix (postgres / sqlite_lance / weaviate / surrealdb / cypher live legs) — runs in CI