### PR TITLE
Neo4j: scope list_relationships endpoints + guard null endpoint ids (#1237)

### DIFF
--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -1108,9 +1108,9 @@
       "unit": "1",
       "owner": "engines",
       "labels": [
-        {"name": "reason", "values": ["no_store_with_primitives", "memory_facts_cleanup_failed"], "_comment": "Low-cardinality enum; extend when adding new forget-cascade fallback paths."}
+        {"name": "reason", "values": ["no_store_with_primitives", "memory_facts_cleanup_failed", "malformed_relationship_swept"], "_comment": "Low-cardinality enum; extend when adding new forget-cascade fallback paths."}
       ],
-      "description": "Issue #923 (ADR-001). Forget-cascade cleanup degradations. reason=no_store_with_primitives: entity/relationship cleanup could not run because no configured store (vector or graph) exposes the list/delete primitives; a Degradation is returned from _cascade_forget_extraction. reason=memory_facts_cleanup_failed (#1140): chronicle could not delete the memory_facts derived from the forgotten document's chunks. The forget still deletes the document + chunks. NO namespace_id label - cardinality rule. See docs/architecture/failure-observability-contract.md."
+      "description": "Issue #923 (ADR-001). Forget-cascade cleanup degradations. reason=no_store_with_primitives: entity/relationship cleanup could not run because no configured store (vector or graph) exposes the list/delete primitives; a Degradation is returned from _cascade_forget_extraction. reason=memory_facts_cleanup_failed (#1140): chronicle could not delete the memory_facts derived from the forgotten document's chunks. reason=malformed_relationship_swept (#1237): orphan relationship(s) whose endpoint node was missing its id (so list_relationships could not deserialize them) were force-deleted via direct Cypher; the count is the number swept. The forget still deletes the document + chunks. NO namespace_id label - cardinality rule. See docs/architecture/failure-observability-contract.md."
     },
     {
       "name": "khora.ingest.relationships_skipped_total",

--- a/src/khora/engines/_forget_cascade.py
+++ b/src/khora/engines/_forget_cascade.py
@@ -119,12 +119,41 @@ async def cascade_forget_extraction(
     orphan_rel_ids = [r.id for r in relationships if _is_orphan(r, document_id)]
     survive_rel_ids = [r.id for r in relationships if _is_survivor(r, document_id)]
 
+    degradations: list[Degradation] = []
+
     if orphan_ent_ids:
         await primary.delete_entities_batch(orphan_ent_ids, namespace_id=namespace_id)
         await _delete_entities(mirror, orphan_ent_ids, namespace_id)
     if orphan_rel_ids:
         await primary.delete_relationships_batch(orphan_rel_ids, namespace_id=namespace_id)
         await _delete_relationships(mirror, orphan_rel_ids, namespace_id)
+
+    # Orphan relationships whose endpoint node is missing its id cannot be
+    # deserialized by ``list_relationships`` (skip-and-warn, #1237), so their
+    # ids never reach the enumerate-and-delete path above and they would
+    # survive the forget. Sweep them directly in the graph store (Cypher,
+    # no deserialization). Neo4j-only today; a getattr miss is a no-op so
+    # other graph backends keep current behavior.
+    swept = await _sweep_malformed_orphan_relationships(graph, document_id, namespace_id)
+    if swept:
+        _FORGET_DEGRADED_COUNTER.add(swept, {"reason": "malformed_relationship_swept"})
+        logger.warning(
+            "{}: forget cascade swept {} malformed orphan relationship(s) for document {} that "
+            "list_relationships could not deserialize (null endpoint id)",
+            engine,
+            swept,
+            document_id,
+        )
+        degradations.append(
+            Degradation(
+                component="forget_cascade",
+                reason="malformed_relationship_swept",
+                detail=(
+                    f"{swept} orphan relationship(s) with a null endpoint id were force-deleted via "
+                    "direct Cypher; they could not be enumerated by list_relationships."
+                ),
+            )
+        )
 
     if survive_ent_ids:
         await _strip_entities(primary, survive_ent_ids, document_id, namespace_id)
@@ -143,7 +172,20 @@ async def cascade_forget_extraction(
         len(survive_ent_ids),
         len(survive_rel_ids),
     )
-    return []
+    return degradations
+
+
+async def _sweep_malformed_orphan_relationships(store: Any, document_id: UUID, namespace_id: UUID) -> int:
+    """Force-delete orphan relationships the enumeration path can't deserialize.
+
+    Neo4j exposes ``delete_malformed_orphan_relationships``; other graph
+    backends don't yet, so a getattr miss returns 0 (no-op) and they keep
+    their current behavior (#1237).
+    """
+    fn = getattr(store, "delete_malformed_orphan_relationships", None)
+    if not callable(fn):
+        return 0
+    return await fn(document_id, namespace_id=namespace_id)
 
 
 def _is_orphan(record: Any, document_id: UUID) -> bool:

--- a/src/khora/engines/_forget_cascade.py
+++ b/src/khora/engines/_forget_cascade.py
@@ -134,7 +134,15 @@ async def cascade_forget_extraction(
     # survive the forget. Sweep them directly in the graph store (Cypher,
     # no deserialization). Neo4j-only today; a getattr miss is a no-op so
     # other graph backends keep current behavior.
-    swept = await _sweep_malformed_orphan_relationships(graph, document_id, namespace_id)
+    #
+    # Only sweep when the namespace had at least one deserializable
+    # relationship: the sweep is an unindexed full-relationship scan (#1241)
+    # and the common forget_session/expire_sessions case is a document whose
+    # namespace has no graph edges at all. Trade-off: a namespace whose edges
+    # are *all* malformed (so enumeration returns nothing) is not swept until a
+    # well-formed edge exists — a transient/repair-tool concern, tracked in
+    # #1241. (Multi-source malformed survivors are also not handled here: #1242.)
+    swept = await _sweep_malformed_orphan_relationships(graph, document_id, namespace_id) if relationships else 0
     if swept:
         _FORGET_DEGRADED_COUNTER.add(swept, {"reason": "malformed_relationship_swept"})
         logger.warning(

--- a/src/khora/storage/backends/mixins.py
+++ b/src/khora/storage/backends/mixins.py
@@ -142,10 +142,16 @@ def parse_uuid(val: Any) -> UUID:
 
 
 def parse_uuid_list(val: list | None) -> list[UUID]:
-    """Parse a list of UUIDs."""
+    """Parse a list of UUIDs, dropping null / empty elements.
+
+    Graph backends store provenance ids (``source_document_ids`` etc.) as
+    list properties that can carry stray ``None`` / ``""`` entries on
+    partial or externally-written data. Filtering them here keeps a single
+    malformed element from aborting the whole deserialize (#1237).
+    """
     if not val:
         return []
-    return [parse_uuid(v) for v in val]
+    return [parse_uuid(v) for v in val if v]
 
 
 def parse_datetime(val: str | datetime | None, default: datetime | None = None) -> datetime | None:

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -24,6 +24,7 @@ from neo4j.exceptions import ClientError, ConnectionAcquisitionTimeoutError
 from khora.core.models import Entity, Episode, Relationship
 from khora.storage.backends.mixins import (
     GraphBackendBase,
+    parse_uuid_list,
     sanitize_cypher_label,
 )
 from khora.storage.backends.mixins import deserialize_dict as _deserialize_dict
@@ -2508,8 +2509,8 @@ RETURN count(r) AS updated
             entity_type=node["entity_type"],
             description=node.get("description", ""),
             attributes=_deserialize_dict(node.get("attributes")),
-            source_document_ids=[UUID(d) for d in node.get("source_document_ids", [])],
-            source_chunk_ids=[UUID(c) for c in node.get("source_chunk_ids", [])],
+            source_document_ids=parse_uuid_list(node.get("source_document_ids")),
+            source_chunk_ids=parse_uuid_list(node.get("source_chunk_ids")),
             mention_count=node.get("mention_count", 1),
             valid_from=datetime.fromisoformat(node["valid_from"]) if node.get("valid_from") else None,
             valid_until=datetime.fromisoformat(node["valid_until"]) if node.get("valid_until") else None,
@@ -2661,6 +2662,39 @@ RETURN count(r) AS updated
             deleted = await session.execute_write(_delete)
             return deleted > 0
 
+    async def delete_malformed_orphan_relationships(self, document_id: UUID, *, namespace_id: UUID) -> int:
+        """Force-delete orphan relationships whose endpoints are malformed.
+
+        The forget cascade enumerates relationships via ``list_relationships``
+        and deletes them by id. A relationship whose endpoint node is missing
+        its ``id`` property cannot be deserialized into a domain
+        ``Relationship`` (its id never reaches ``delete_relationships_batch``),
+        so it would survive ``forget()``. This sweep deletes such edges
+        directly in Cypher — no deserialization — scoped to ``namespace_id``
+        and limited to edges whose sole source document is the one being
+        forgotten (orphans). Returns the number of edges deleted (#1237).
+        """
+
+        async def _sweep(tx: AsyncManagedTransaction) -> int:
+            result = await tx.run(
+                """
+                MATCH (source)-[r]->(target)
+                WHERE r.namespace_id = $namespace_id
+                  AND $document_id IN r.source_document_ids
+                  AND size(r.source_document_ids) = 1
+                  AND (source.id IS NULL OR target.id IS NULL)
+                DELETE r
+                RETURN count(r) as deleted
+                """,
+                namespace_id=str(namespace_id),
+                document_id=str(document_id),
+            )
+            record = await result.single()
+            return record["deleted"] if record else 0
+
+        async with self._session() as session:
+            return await session.execute_write(_sweep)
+
     class RetirementRow(TypedDict):
         """A row for retire_orphaned_relationships_batch()."""
 
@@ -2774,14 +2808,30 @@ RETURN count(r) AS updated
                 limit=limit,
             )
             records = await result.data()
-            return [
+            rels = (
                 self._record_to_relationship(r["r"], r["source_id"], r["target_id"], r["rel_type"]) for r in records
-            ]
+            )
+            return [rel for rel in rels if rel is not None]
 
     def _record_to_relationship(
-        self, rel: dict[str, Any], source_id: str, target_id: str, rel_type: str
-    ) -> Relationship:
-        """Convert a Neo4j relationship to a domain Relationship."""
+        self, rel: dict[str, Any], source_id: str | None, target_id: str | None, rel_type: str
+    ) -> Relationship | None:
+        """Convert a Neo4j relationship to a domain Relationship.
+
+        Returns ``None`` when an endpoint id is null. Unlike ``id`` /
+        ``namespace_id`` (scalar attributes that are synthesized when absent,
+        #767), an endpoint id is a foreign key: synthesizing a ``uuid4()`` for
+        it would point at a non-existent entity — a dangling FK that the
+        ``forget()`` cascade and graph traversal would then act on. Dropping
+        the malformed row (skip-and-warn) is the honest behavior (#1237).
+        """
+        if source_id is None or target_id is None:
+            logger.warning(
+                f"Dropping relationship with null endpoint id (type={rel_type}, "
+                f"source_id={source_id}, target_id={target_id}); endpoint node is "
+                "missing its id property."
+            )
+            return None
         rel_id = rel.get("id")
         rel_ns = rel.get("namespace_id")
         if rel_id is None or rel_ns is None:
@@ -2797,8 +2847,8 @@ RETURN count(r) AS updated
             relationship_type=rel_type,
             description=rel.get("description", ""),
             properties=_deserialize_dict(rel.get("properties")),
-            source_document_ids=[UUID(d) for d in rel.get("source_document_ids", [])],
-            source_chunk_ids=[UUID(c) for c in rel.get("source_chunk_ids", [])],
+            source_document_ids=parse_uuid_list(rel.get("source_document_ids")),
+            source_chunk_ids=parse_uuid_list(rel.get("source_chunk_ids")),
             valid_from=datetime.fromisoformat(rel["valid_from"]) if rel.get("valid_from") else None,
             valid_until=datetime.fromisoformat(rel["valid_until"]) if rel.get("valid_until") else None,
             confidence=rel.get("confidence", 1.0),
@@ -2821,8 +2871,12 @@ RETURN count(r) AS updated
         # Build relationship type filter
         rel_filter = f":{_sanitize_neo4j_label(relationship_type)}" if relationship_type else ""
 
+        # Both endpoints are constrained to in-namespace ``:Entity`` nodes,
+        # matching get_relationship() / get_entity_relationships() (IDOR
+        # family): edges whose endpoints are non-Entity or live in another
+        # namespace never surface here (#1237).
         query = f"""
-        MATCH (source)-[r{rel_filter}]->(target)
+        MATCH (source:Entity {{namespace_id: $namespace_id}})-[r{rel_filter}]->(target:Entity {{namespace_id: $namespace_id}})
         WHERE r.namespace_id = $namespace_id
         RETURN properties(r) as rel_props, source.id as source_id, target.id as target_id, type(r) as rel_type
         ORDER BY r.created_at DESC
@@ -2838,10 +2892,11 @@ RETURN count(r) AS updated
                 limit=limit,
             )
             records = await result.data()
-            return [
+            rels = (
                 self._record_to_relationship(r["rel_props"], r["source_id"], r["target_id"], r["rel_type"])
                 for r in records
-            ]
+            )
+            return [rel for rel in rels if rel is not None]
 
     # =========================================================================
     # Episode operations
@@ -2956,9 +3011,9 @@ RETURN count(r) AS updated
             description=node.get("description", ""),
             occurred_at=datetime.fromisoformat(node["occurred_at"]),
             duration_seconds=node.get("duration_seconds"),
-            entity_ids=[UUID(e) for e in node.get("entity_ids", [])],
-            source_document_ids=[UUID(d) for d in node.get("source_document_ids", [])],
-            source_chunk_ids=[UUID(c) for c in node.get("source_chunk_ids", [])],
+            entity_ids=parse_uuid_list(node.get("entity_ids")),
+            source_document_ids=parse_uuid_list(node.get("source_document_ids")),
+            source_chunk_ids=parse_uuid_list(node.get("source_chunk_ids")),
             metadata=_deserialize_dict(node.get("metadata")),
             created_at=datetime.fromisoformat(node["created_at"]) if node.get("created_at") else datetime.now(),
             updated_at=datetime.fromisoformat(node["updated_at"]) if node.get("updated_at") else datetime.now(),

--- a/tests/integration/test_neo4j_list_relationships_scoping_integration.py
+++ b/tests/integration/test_neo4j_list_relationships_scoping_integration.py
@@ -1,0 +1,112 @@
+"""Real-Neo4j integration test for ``list_relationships`` endpoint scoping (#1237).
+
+Unlike the mock-based unit tests (which stub ``.data()`` and so can't detect a
+regression in the Cypher shape), this test plants — via raw Cypher — the two
+data shapes the public API can't create:
+
+  1. a relationship whose endpoint ``:Entity`` node is missing its ``id``
+     property (the ``UUID(None)`` crash trigger), and
+  2. a cross-namespace endpoint edge,
+
+then asserts ``list_relationships`` (a) does not raise and (b) returns only the
+well-formed in-namespace edge — and that ``delete_malformed_orphan_relationships``
+sweeps the malformed orphan that the enumerate-and-delete path can't reach.
+
+Gated by ``NEO4J_INTEGRATION_TEST=1`` (khora CI does not provision Neo4j). Run:
+
+    make dev
+    NEO4J_INTEGRATION_TEST=1 uv run pytest \
+        tests/integration/test_neo4j_list_relationships_scoping_integration.py -v
+"""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+
+from khora.core.models.entity import Entity, Relationship
+from khora.storage.backends.neo4j import Neo4jBackend
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("NEO4J_INTEGRATION_TEST"),
+    reason="set NEO4J_INTEGRATION_TEST=1 to run against real Neo4j (requires make dev)",
+)
+class TestNeo4jListRelationshipsScopingIntegration:
+    @pytest.mark.asyncio
+    async def test_excludes_malformed_and_cross_namespace_edges(self) -> None:
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        ns_a, ns_b = uuid4(), uuid4()
+        doc_id = uuid4()
+        marker = uuid4().hex
+        alice = Entity(namespace_id=ns_a, name=f"alice-{marker}", entity_type="PERSON")
+        carol = Entity(namespace_id=ns_a, name=f"carol-{marker}", entity_type="PERSON")
+        bob = Entity(namespace_id=ns_b, name=f"bob-{marker}", entity_type="PERSON")
+        good = Relationship(
+            namespace_id=ns_a,
+            source_entity_id=alice.id,
+            target_entity_id=carol.id,
+            relationship_type="KNOWS",
+            description="well-formed in-namespace edge",
+        )
+
+        try:
+            await backend.create_entity(alice)
+            await backend.create_entity(carol)
+            await backend.create_entity(bob)
+            await backend.create_relationship(good)
+
+            async with backend._session() as session:
+                # (1) malformed endpoint: an :Entity in ns_a with NO id property,
+                # plus an orphan edge (sole source = doc_id) pointing at it.
+                await session.run(
+                    "MATCH (a:Entity {id: $aid}) "
+                    "CREATE (x:Entity {namespace_id: $ns, marker: $marker}) "
+                    "CREATE (a)-[r:KNOWS {id: $rid, namespace_id: $ns, "
+                    "source_document_ids: [$doc], created_at: $now}]->(x)",
+                    aid=str(alice.id),
+                    ns=str(ns_a),
+                    marker=marker,
+                    rid=str(uuid4()),
+                    doc=str(doc_id),
+                    now="2026-01-01T00:00:00+00:00",
+                )
+                # (2) cross-namespace endpoint: alice (ns_a) -> bob (ns_b),
+                # edge stamped with ns_a.
+                await session.run(
+                    "MATCH (a:Entity {id: $aid}) MATCH (b:Entity {id: $bid}) "
+                    "CREATE (a)-[r:KNOWS {id: $rid, namespace_id: $ns, created_at: $now}]->(b)",
+                    aid=str(alice.id),
+                    bid=str(bob.id),
+                    rid=str(uuid4()),
+                    ns=str(ns_a),
+                    now="2026-01-01T00:00:00+00:00",
+                )
+
+            # Must not raise, and must return ONLY the well-formed in-ns edge.
+            rels = await backend.list_relationships(ns_a, limit=100)
+            assert [r.id for r in rels] == [good.id]
+
+            # The malformed orphan edge survives the enumerate-and-delete path
+            # (it can't be deserialized) but the sweep removes it.
+            swept = await backend.delete_malformed_orphan_relationships(doc_id, namespace_id=ns_a)
+            assert swept == 1
+        finally:
+            # DETACH DELETE removes the nodes and every edge incident to them
+            # (the well-formed, cross-namespace, and malformed edges alike).
+            async with backend._session() as session:
+                await session.run(
+                    "MATCH (n:Entity) WHERE n.id IN $ids OR n.marker = $marker DETACH DELETE n",
+                    ids=[str(alice.id), str(carol.id), str(bob.id)],
+                    marker=marker,
+                )
+            await backend.disconnect()

--- a/tests/unit/engines/test_chronicle_engine.py
+++ b/tests/unit/engines/test_chronicle_engine.py
@@ -69,6 +69,9 @@ class TestChronicleEngineForget:
         engine._storage.graph.delete_relationships_batch = AsyncMock()
         engine._storage.graph.remove_document_from_entity_sources_batch = AsyncMock()
         engine._storage.graph.remove_document_from_relationship_sources_batch = AsyncMock()
+        # #1237: the Neo4j graph backend now sweeps malformed orphan edges that
+        # list_relationships can't deserialize. Default to "nothing swept".
+        engine._storage.graph.delete_malformed_orphan_relationships = AsyncMock(return_value=0)
         return engine
 
     @pytest.mark.asyncio

--- a/tests/unit/engines/test_forget_cascade.py
+++ b/tests/unit/engines/test_forget_cascade.py
@@ -1,0 +1,98 @@
+"""Unit tests for the forget-cascade malformed-orphan sweep (#1237).
+
+A relationship whose endpoint node is missing its id cannot be deserialized
+by ``list_relationships`` (skip-and-warn), so its id never reaches the
+enumerate-and-delete path and it would survive ``forget()``. The cascade now
+sweeps such edges directly in the graph store and surfaces a ``Degradation``.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from khora.engines._forget_cascade import cascade_forget_extraction
+
+
+class _FakeGraph:
+    """Graph backend exposing the cascade primitives + the sweep hook."""
+
+    def __init__(self, *, swept: int, has_sweep: bool = True) -> None:
+        self._swept = swept
+        self._has_sweep = has_sweep
+        self.sweep_calls: list[tuple] = []
+        if has_sweep:
+            self.delete_malformed_orphan_relationships = self._sweep  # type: ignore[attr-defined]
+
+    async def list_entities(self, namespace_id, limit=0):
+        return []
+
+    async def list_relationships(self, namespace_id, limit=0):
+        return []
+
+    async def delete_entities_batch(self, ids, *, namespace_id):
+        return None
+
+    async def delete_relationships_batch(self, ids, *, namespace_id):
+        return None
+
+    async def _sweep(self, document_id, *, namespace_id):
+        self.sweep_calls.append((document_id, namespace_id))
+        return self._swept
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sweep_records_degradation_when_malformed_edges_deleted() -> None:
+    doc_id, ns_id = uuid4(), uuid4()
+    graph = _FakeGraph(swept=3)
+
+    degradations = await cascade_forget_extraction(
+        graph=graph,
+        vector=None,
+        document_id=doc_id,
+        namespace_id=ns_id,
+        engine="vectorcypher",
+    )
+
+    assert graph.sweep_calls == [(doc_id, ns_id)]
+    assert len(degradations) == 1
+    deg = degradations[0]
+    assert deg["component"] == "forget_cascade"
+    assert deg["reason"] == "malformed_relationship_swept"
+    assert "3" in (deg["detail"] or "")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_no_degradation_when_nothing_swept() -> None:
+    graph = _FakeGraph(swept=0)
+
+    degradations = await cascade_forget_extraction(
+        graph=graph,
+        vector=None,
+        document_id=uuid4(),
+        namespace_id=uuid4(),
+        engine="vectorcypher",
+    )
+
+    assert graph.sweep_calls  # sweep still attempted
+    assert degradations == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_backend_without_sweep_hook_is_a_noop() -> None:
+    """Non-Neo4j graph backends lack the sweep method → getattr miss, no error."""
+    graph = _FakeGraph(swept=99, has_sweep=False)
+
+    degradations = await cascade_forget_extraction(
+        graph=graph,
+        vector=None,
+        document_id=uuid4(),
+        namespace_id=uuid4(),
+        engine="chronicle",
+    )
+
+    assert degradations == []

--- a/tests/unit/engines/test_forget_cascade.py
+++ b/tests/unit/engines/test_forget_cascade.py
@@ -4,14 +4,19 @@ A relationship whose endpoint node is missing its id cannot be deserialized
 by ``list_relationships`` (skip-and-warn), so its id never reaches the
 enumerate-and-delete path and it would survive ``forget()``. The cascade now
 sweeps such edges directly in the graph store and surfaces a ``Degradation``.
+
+The sweep is gated on the namespace having ≥1 deserializable relationship
+(#1241), so the fake graph below returns one unrelated edge to exercise it.
 """
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
 
+import khora.engines._forget_cascade as fc
 from khora.engines._forget_cascade import cascade_forget_extraction
 
 
@@ -20,8 +25,11 @@ class _FakeGraph:
 
     def __init__(self, *, swept: int, has_sweep: bool = True) -> None:
         self._swept = swept
-        self._has_sweep = has_sweep
         self.sweep_calls: list[tuple] = []
+        # One relationship unrelated to the forgotten doc: keeps the namespace
+        # non-empty (so the #1241 early-out lets the sweep run) without being
+        # classified as an orphan/survivor of the document being forgotten.
+        self._rels = [SimpleNamespace(id=uuid4(), source_document_ids=[uuid4()])]
         if has_sweep:
             self.delete_malformed_orphan_relationships = self._sweep  # type: ignore[attr-defined]
 
@@ -29,7 +37,7 @@ class _FakeGraph:
         return []
 
     async def list_relationships(self, namespace_id, limit=0):
-        return []
+        return list(self._rels)
 
     async def delete_entities_batch(self, ids, *, namespace_id):
         return None
@@ -44,9 +52,18 @@ class _FakeGraph:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_sweep_records_degradation_when_malformed_edges_deleted() -> None:
+async def test_sweep_records_degradation_when_malformed_edges_deleted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     doc_id, ns_id = uuid4(), uuid4()
     graph = _FakeGraph(swept=3)
+
+    counter_calls: list[tuple] = []
+    monkeypatch.setattr(
+        fc,
+        "_FORGET_DEGRADED_COUNTER",
+        SimpleNamespace(add=lambda value, attrs: counter_calls.append((value, attrs))),
+    )
 
     degradations = await cascade_forget_extraction(
         graph=graph,
@@ -57,11 +74,13 @@ async def test_sweep_records_degradation_when_malformed_edges_deleted() -> None:
     )
 
     assert graph.sweep_calls == [(doc_id, ns_id)]
+    # Counter incremented by the swept magnitude (3), labelled by reason only.
+    assert counter_calls == [(3, {"reason": "malformed_relationship_swept"})]
     assert len(degradations) == 1
     deg = degradations[0]
     assert deg["component"] == "forget_cascade"
     assert deg["reason"] == "malformed_relationship_swept"
-    assert "3" in (deg["detail"] or "")
+    assert "3 orphan relationship" in (deg["detail"] or "")
 
 
 @pytest.mark.unit
@@ -77,7 +96,7 @@ async def test_no_degradation_when_nothing_swept() -> None:
         engine="vectorcypher",
     )
 
-    assert graph.sweep_calls  # sweep still attempted
+    assert graph.sweep_calls  # sweep still attempted (namespace had relationships)
     assert degradations == []
 
 
@@ -95,4 +114,25 @@ async def test_backend_without_sweep_hook_is_a_noop() -> None:
         engine="chronicle",
     )
 
+    assert degradations == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sweep_skipped_when_namespace_has_no_relationships() -> None:
+    """#1241 early-out: a namespace with zero deserializable edges skips the
+    sweep (the common forget_session/expire_sessions case), avoiding the
+    unindexed full-relationship scan."""
+    graph = _FakeGraph(swept=5)
+    graph._rels = []  # namespace has no deserializable relationships
+
+    degradations = await cascade_forget_extraction(
+        graph=graph,
+        vector=None,
+        document_id=uuid4(),
+        namespace_id=uuid4(),
+        engine="vectorcypher",
+    )
+
+    assert graph.sweep_calls == []  # sweep not attempted
     assert degradations == []

--- a/tests/unit/engines/test_vectorcypher_engine.py
+++ b/tests/unit/engines/test_vectorcypher_engine.py
@@ -1562,6 +1562,9 @@ class TestVectorCypherEngineForget:
         engine._storage.graph.delete_relationships_batch = AsyncMock()
         engine._storage.graph.remove_document_from_entity_sources_batch = AsyncMock()
         engine._storage.graph.remove_document_from_relationship_sources_batch = AsyncMock()
+        # #1237: the Neo4j graph backend now sweeps malformed orphan edges that
+        # list_relationships can't deserialize. Default to "nothing swept".
+        engine._storage.graph.delete_malformed_orphan_relationships = AsyncMock(return_value=0)
         engine._temporal_store = AsyncMock()
         engine._dual_nodes = AsyncMock()
         engine._neo4j_driver = AsyncMock()

--- a/tests/unit/test_neo4j_backend.py
+++ b/tests/unit/test_neo4j_backend.py
@@ -944,3 +944,113 @@ class TestNeo4jBackendCountRelationships:
         count = await backend.count_relationships(uuid4())
 
         assert count == 100
+
+
+@pytest.mark.unit
+@pytest.mark.security
+class TestNeo4jBackendListRelationships:
+    """list_relationships endpoint scoping + null-endpoint hardening (#1237)."""
+
+    @pytest.mark.asyncio
+    async def test_constrains_both_endpoints_to_namespace(self) -> None:
+        """Both endpoints must be ``:Entity {namespace_id: $namespace_id}``.
+
+        Matches the already-hardened get_relationship / get_entity_relationships
+        (IDOR family); the old unlabeled ``(source)-[r]->(target)`` form must
+        be gone so cross-namespace / non-Entity endpoints can't leak.
+        """
+        driver, session = _make_neo4j_driver()
+        result = MagicMock()
+        result.data = AsyncMock(return_value=[])
+        session.run = AsyncMock(return_value=result)
+
+        backend = Neo4jBackend.from_driver(driver, query_timeout=None)
+        await backend.list_relationships(uuid4())
+
+        query = session.run.call_args.args[0]
+        assert "(source:Entity {namespace_id: $namespace_id})" in query
+        assert "(target:Entity {namespace_id: $namespace_id})" in query
+        # Negative check: the pre-fix unlabeled endpoints must be gone.
+        assert "MATCH (source)-[r" not in query
+
+    @pytest.mark.asyncio
+    async def test_relationship_type_filter_applied(self) -> None:
+        """``relationship_type`` is injected as ``:TYPE`` into the pattern."""
+        driver, session = _make_neo4j_driver()
+        result = MagicMock()
+        result.data = AsyncMock(return_value=[])
+        session.run = AsyncMock(return_value=result)
+
+        backend = Neo4jBackend.from_driver(driver, query_timeout=None)
+        await backend.list_relationships(uuid4(), relationship_type="KNOWS")
+
+        query = session.run.call_args.args[0]
+        assert ":KNOWS]" in query
+
+    @pytest.mark.asyncio
+    async def test_skips_rows_with_null_endpoint_without_raising(self) -> None:
+        """A row with a null endpoint id is skipped (not crashed on).
+
+        Pre-#1237 a single null ``source.id`` / ``target.id`` made
+        ``_record_to_relationship`` call ``UUID(None)`` → TypeError, aborting
+        the whole call (and the forget() cascade). Now the malformed row is
+        dropped and the well-formed rows still return.
+        """
+        driver, session = _make_neo4j_driver()
+        good = {
+            "rel_props": _make_rel_props(),
+            "source_id": str(uuid4()),
+            "target_id": str(uuid4()),
+            "rel_type": "KNOWS",
+        }
+        null_source = {
+            "rel_props": _make_rel_props(),
+            "source_id": None,
+            "target_id": str(uuid4()),
+            "rel_type": "KNOWS",
+        }
+        result = MagicMock()
+        result.data = AsyncMock(return_value=[good, null_source])
+        session.run = AsyncMock(return_value=result)
+
+        backend = Neo4jBackend.from_driver(driver, query_timeout=None)
+        rels = await backend.list_relationships(uuid4())
+
+        assert len(rels) == 1
+        assert all(isinstance(r, Relationship) for r in rels)
+
+
+@pytest.mark.unit
+class TestRecordToRelationshipEndpointGuard:
+    """_record_to_relationship null-endpoint + null-element hardening (#1237)."""
+
+    def _backend(self) -> Neo4jBackend:
+        return Neo4jBackend("bolt://localhost:7687", query_timeout=None)
+
+    def test_null_source_id_returns_none(self) -> None:
+        backend = self._backend()
+        rel = backend._record_to_relationship(_make_rel_props(), None, str(uuid4()), "RELATES_TO")
+        assert rel is None
+
+    def test_null_target_id_returns_none(self) -> None:
+        backend = self._backend()
+        rel = backend._record_to_relationship(_make_rel_props(), str(uuid4()), None, "RELATES_TO")
+        assert rel is None
+
+    def test_well_formed_endpoints_return_relationship(self) -> None:
+        backend = self._backend()
+        source, target = uuid4(), uuid4()
+        rel = backend._record_to_relationship(_make_rel_props(), str(source), str(target), "RELATES_TO")
+        assert rel is not None
+        assert rel.source_entity_id == source
+        assert rel.target_entity_id == target
+
+    def test_null_provenance_elements_filtered(self) -> None:
+        """A null element inside source_document_ids/source_chunk_ids is dropped."""
+        backend = self._backend()
+        good = uuid4()
+        props = _make_rel_props(source_document_ids=[str(good), None], source_chunk_ids=[None])
+        rel = backend._record_to_relationship(props, str(uuid4()), str(uuid4()), "WORKS_FOR")
+        assert rel is not None
+        assert rel.source_document_ids == [good]
+        assert rel.source_chunk_ids == []


### PR DESCRIPTION
Fixes #1237

## Problem

`Neo4jBackend.list_relationships()` matched relationship endpoints with **no `:Entity` label and no namespace predicate** (`MATCH (source)-[r]->(target) WHERE r.namespace_id = $ns`), so:

1. **Correctness:** endpoints could resolve cross-namespace / to non-`Entity` nodes.
2. **Robustness:** a null endpoint `id` made `_record_to_relationship` call `UUID(None)` → `TypeError`, aborting the **entire** call (and the `forget()` cascade) on a single malformed row.

## Key finding (multi-agent investigation)

The issue's suggested query constraint is **necessary but not sufficient**. The batch upsert sets `e.id` `ON CREATE` only (`neo4j.py:1697`), so an `:Entity {namespace_id}` node *missing* `id` still matches `(:Entity {namespace_id: $ns})` and yields `source.id = NULL`. **The deserializer skip-and-warn is therefore load-bearing**, not just defense-in-depth — the two halves close different subsets (query → non-Entity/cross-ns endpoints; deserializer → null endpoint id).

Verified non-issue: the feared `MENTIONED_IN` (entity→chunk) regression is a false alarm — those edges set no `r.namespace_id` (`dual_nodes.py:392`) and are already excluded by today's `WHERE`.

## Changes

- **`list_relationships`**: constrain both endpoints to `(:Entity {namespace_id: $ns})`, matching the already-hardened `get_relationship` / `get_entity_relationships` (IDOR family).
- **`_record_to_relationship → Relationship | None`**: skip-and-warn on a null endpoint id (never synthesize `uuid4()` — a fabricated endpoint is a dangling FK, worse than dropping); callers filter `None`.
- **`mixins.parse_uuid_list`**: hardened to drop null/empty elements; used in the relationship/entity/episode deserializers (issue fix #3, benefits all backends).
- **forget() cascade gap** (devil's-advocate finding): a malformed orphan edge that `list_relationships` can't deserialize would survive `forget()` (delete is by enumerated id). Added `Neo4jBackend.delete_malformed_orphan_relationships()` (pure Cypher, no deserialization) + a cascade sweep that force-deletes such edges and records a `Degradation` (`khora.forget.cascade.degraded_total{reason=malformed_relationship_swept}`).

## Scope

**Neo4j only**, per decision. Follow-ups filed: **#1238** (Memgraph/Neptune — byte-identical, strictly-worse deserializers) and **#1239** (AGE — partial: missing endpoint namespace predicate + unguarded deserializer).

## Tests

- Unit (no live DB): the issue's exact `UUID(None)` repro now returns `None` + WARNING (no `TypeError`); null endpoint (source/target) skip; null provenance-element filtering.
- Unit query-shape: asserts **both** endpoints are constrained to `:Entity {namespace_id}` and the old unlabeled form is gone.
- Unit: forget-cascade sweep records a `Degradation`; no-op on backends without the sweep hook.
- Integration (gated by `NEO4J_INTEGRATION_TEST=1`): plants a malformed + cross-namespace edge via raw Cypher; asserts `list_relationships` doesn't raise and excludes them, and the sweep deletes the malformed orphan.

Full unit suite green (the only failures are pre-existing `test_accel.py` Rust-parity issues, reproduced with this branch's source changes stashed). `make format` + `make lint` clean.
