### PR TITLE
examples: recall(filter=...) metadata-filtering tutorial

### DIFF
--- a/examples/10_core_apis/08_recall_with_metadata_filters.py
+++ b/examples/10_core_apis/08_recall_with_metadata_filters.py
@@ -107,7 +107,9 @@ _DOCS: list[dict[str, Any]] = [
     },
 ]
 
-_QUERY = "engineering work this year"
+# Purely semantic, no temporal words: time is demonstrated only via filter= below,
+# not smuggled into the query (which would trip VectorCypher's temporal detection).
+_QUERY = "engineering work"
 
 
 def _print(label: str, result: Any) -> None:

--- a/examples/10_core_apis/08_recall_with_metadata_filters.py
+++ b/examples/10_core_apis/08_recall_with_metadata_filters.py
@@ -1,0 +1,195 @@
+"""Core API — recall with deterministic metadata filters.
+
+``remember()`` carries structured provenance alongside the text: the
+denormalized **system fields** (``source_name``, ``source_type``,
+``source_timestamp``, ...) and a free-form **metadata** dict. ``recall()``
+can then gate on those with ``filter=`` — a deterministic, operator-based
+predicate that runs as a hard AND on top of the semantic ranking. A chunk
+either satisfies the filter or it doesn't; relevance still orders what's left.
+
+This is the precise, repeatable complement to vector search: "relevant AND
+from Linear", "AND owned by the platform team", "AND priority ≥ 2".
+
+Two filter forms, same result:
+  * a plain ``dict`` — ``filter={"source_name": "linear"}`` (validated for you)
+  * a typed ``RecallFilter`` — IDE autocomplete on the system keys
+
+Filterable system keys: ``occurred_at`` / ``created_at`` / ``source_timestamp``
+(dates), and ``source_type`` / ``source_name`` / ``source_url`` /
+``external_id`` / ``content_type`` / ``source`` / ``title`` (strings). Plus the
+``metadata`` blob and any ``metadata.<path>`` predicate.
+
+Operators: ``$eq $ne $gt $gte $lt $lte $in $nin $exists`` and the logical
+``$and $or $nor $not``. Bare-value sugar: a scalar is ``$eq``; a *list* is
+exact-array equality (use ``$in`` for membership).
+
+Engine choice: **vectorcypher** on the embedded backend, where the recall
+filter compiles to a SQLite ``WHERE`` (system keys + JSON metadata pushdown)
+and re-checks the rest in memory. ``result.engine_info["filter"]`` reports
+exactly which keys were pushed down versus re-checked.
+
+Run it
+======
+uv run python examples/10_core_apis/08_recall_with_metadata_filters.py
+python examples/10_core_apis/08_recall_with_metadata_filters.py
+
+# Production stack (postgres + neo4j):
+python examples/10_core_apis/08_recall_with_metadata_filters.py --config examples/khora.standard.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from khora import Khora, RecallFilter
+from khora.config import KhoraConfig
+
+logger.remove()
+logger.add("khora.log", level="TRACE", enqueue=True)
+for _noisy in ("httpx", "httpcore", "LiteLLM", "openai", "sqlalchemy.engine"):
+    logging.getLogger(_noisy).setLevel(logging.ERROR)
+
+_DEFAULT_CONFIG = Path(__file__).parent.parent / "khora.embedded.yaml"
+
+
+# Sample corpus: engineering updates with provenance and metadata. The text is
+# deliberately similar so the filters — not the query — decide what comes back.
+# Edit freely; the filters below key on these fields.
+_DOCS: list[dict[str, Any]] = [
+    {
+        "content": "Released v2.0 of the data ingest pipeline.",
+        "source_name": "github",
+        "source_type": "release",
+        "source_timestamp": datetime(2026, 1, 15, tzinfo=UTC),
+        "metadata": {"team": "ingest", "priority": 1, "tier": "gold"},
+    },
+    {
+        "content": "Hot-fixed an out-of-memory regression in the ingest worker.",
+        "source_name": "linear",
+        "source_type": "ticket",
+        "source_timestamp": datetime(2026, 2, 3, tzinfo=UTC),
+        "metadata": {"team": "ingest", "priority": 1, "tier": "gold"},
+    },
+    {
+        "content": "Wrote a design doc for cross-region replication.",
+        "source_name": "notion",
+        "source_type": "doc",
+        "source_timestamp": datetime(2026, 2, 20, tzinfo=UTC),
+        "metadata": {"team": "platform", "priority": 2, "tier": "silver"},
+    },
+    {
+        "content": "Shipped the new admin UI for namespace management.",
+        "source_name": "github",
+        "source_type": "release",
+        "source_timestamp": datetime(2026, 3, 10, tzinfo=UTC),
+        "metadata": {"team": "frontend", "priority": 3, "tier": "bronze"},
+    },
+    {
+        "content": "Triaged intermittent 500s on the recall endpoint.",
+        "source_name": "linear",
+        "source_type": "ticket",
+        "source_timestamp": datetime(2026, 3, 22, tzinfo=UTC),
+        "metadata": {"team": "platform", "priority": 2, "tier": "silver"},
+    },
+    {
+        "content": "Closed all P0 tickets for the Q1 release.",
+        "source_name": "linear",
+        "source_type": "ticket",
+        "source_timestamp": datetime(2026, 4, 1, tzinfo=UTC),
+        "metadata": {"team": "platform", "priority": 1, "tier": "gold"},
+    },
+]
+
+_QUERY = "engineering work this year"
+
+
+def _print(label: str, result: Any) -> None:
+    """Print the matched chunks plus the honest pushdown report."""
+    print(f"\n{label}")
+    for chunk in result.chunks:
+        print(f"  [{chunk.score:.2f}] {chunk.content}")
+    if not result.chunks:
+        print("  (no matches)")
+    report = result.engine_info.get("filter")
+    if report is not None:
+        print(
+            f"  pushed_down={report['pushed_down']}  pushed_keys={report['pushed_keys']}  post_filtered_keys={report['post_filtered_keys']}"
+        )
+
+
+async def main(config_path: Path) -> None:
+    config = KhoraConfig.from_yaml(config_path)
+
+    async with Khora(config, engine="vectorcypher", run_migrations=True) as kb:
+        ns_id = (await kb.create_namespace()).namespace_id
+
+        for doc in _DOCS:
+            await kb.remember(
+                doc["content"],
+                namespace=ns_id,
+                source_name=doc["source_name"],
+                source_type=doc["source_type"],
+                source_timestamp=doc["source_timestamp"],
+                metadata=doc["metadata"],
+                entity_types=["EVENT", "CONCEPT"],
+                relationship_types=["RELATES_TO"],
+            )
+
+        # Baseline: no filter — every doc is a candidate, ranked by relevance.
+        _print("no filter — all candidates:", await kb.recall(_QUERY, namespace=ns_id, limit=10))
+
+        # 1. System key, scalar sugar: source_name == "linear" (the three tickets).
+        _print(
+            'filter={"source_name": "linear"}:',
+            await kb.recall(_QUERY, namespace=ns_id, limit=10, filter={"source_name": "linear"}),
+        )
+
+        # 2. Metadata membership: team in {ingest, platform}.
+        _print(
+            'filter={"metadata.team": {"$in": ["ingest", "platform"]}}:',
+            await kb.recall(
+                _QUERY,
+                namespace=ns_id,
+                limit=10,
+                filter={"metadata.team": {"$in": ["ingest", "platform"]}},
+            ),
+        )
+
+        # 3. Metadata range on a numeric field: priority >= 2.
+        _print(
+            'filter={"metadata.priority": {"$gte": 2}}:',
+            await kb.recall(_QUERY, namespace=ns_id, limit=10, filter={"metadata.priority": {"$gte": 2}}),
+        )
+
+        # 4. Logical AND across a system key and a metadata field — typed form.
+        gold_tickets = RecallFilter.model_validate({"$and": [{"source_type": "ticket"}, {"metadata.tier": "gold"}]})
+        _print(
+            "filter=$and(source_type=ticket, metadata.tier=gold):",
+            await kb.recall(_QUERY, namespace=ns_id, limit=10, filter=gold_tickets),
+        )
+
+        # 5. Time bound on the event axis. Prefer this over the deprecated
+        #    start_time/end_time kwargs (they cannot be combined with filter=).
+        _print(
+            'filter={"source_timestamp": {"$gte": 2026-03-01}}:',
+            await kb.recall(
+                _QUERY,
+                namespace=ns_id,
+                limit=10,
+                filter={"source_timestamp": {"$gte": datetime(2026, 3, 1, tzinfo=UTC)}},
+            ),
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=_DEFAULT_CONFIG, help="Path to a Khora YAML config.")
+    args = parser.parse_args()
+    asyncio.run(main(args.config))

--- a/examples/30_workloads/07_temporal_range_query.py
+++ b/examples/30_workloads/07_temporal_range_query.py
@@ -2,10 +2,11 @@
 
 Khora's Chronicle engine is **event-shaped**: every chunk carries an
 ``occurred_at`` timestamp distinct from when it was ingested. That
-distinction lets ``Khora.recall(..., start_time=..., end_time=...)``
-answer questions like "what happened between February and April?" by
-filtering at the SQL/Cypher layer before semantic ranking — much
-cheaper than post-filtering a vector hit-list.
+distinction lets a recall filter on ``occurred_at`` —
+``filter={"occurred_at": {"$gte": ..., "$lt": ...}}`` — answer questions
+like "what happened between February and April?" by filtering at the
+SQL/Cypher layer before semantic ranking, much cheaper than
+post-filtering a vector hit-list.
 
 This example seeds ~30 events spanning six simulated months, then
 runs increasingly specific time-bounded queries:
@@ -20,9 +21,10 @@ runs increasingly specific time-bounded queries:
 
 Pattern from Cognee's ``temporal_awareness_example.py`` ported to
 khora's primitives. Cognee uses ``SearchType.TEMPORAL``; khora's
-equivalent is the ``start_time`` / ``end_time`` kwargs on
-``Khora.recall()`` — applied via SQL pushdown so the time filter
-doesn't pay for embeddings outside the window.
+equivalent is an ``occurred_at`` recall filter on ``Khora.recall()`` —
+applied via SQL pushdown so the time filter doesn't pay for embeddings
+outside the window. (The older ``start_time`` / ``end_time`` kwargs do
+the same thing but are deprecated in favor of this filter.)
 
 Why Chronicle (engine="chronicle"):
 The bi-temporal model is the whole point. VectorCypher honors temporal
@@ -148,7 +150,7 @@ async def _seed(kb: Khora, namespace_id: UUID) -> None:
 
     ``source_timestamp=`` is the load-bearing kwarg — Chronicle reads it,
     writes it to ``chunk.occurred_at``, and indexes it for the
-    ``start_time`` / ``end_time`` filter pushdown. The ``metadata`` dict
+    ``occurred_at`` recall-filter pushdown. The ``metadata`` dict
     is opaque storage that the engine never consults; stuffing the
     timestamp there silently leaves every chunk with ``occurred_at=None``
     and breaks every windowed query that doesn't happen to span the
@@ -175,12 +177,24 @@ async def _query(
     start_time: datetime | None = None,
     end_time: datetime | None = None,
 ) -> None:
-    """Run a recall, print the top hits with their occurred_at."""
+    """Run a recall, print the top hits with their occurred_at.
+
+    The time window is expressed as a recall filter on the event-time
+    axis — ``filter={"occurred_at": {"$gte": start, "$lt": end}}``, lower
+    bound inclusive and upper bound exclusive. It pushes down to SQL, so
+    chunks outside the window never reach semantic ranking.
+    """
+    occurred_at: dict[str, datetime] = {}
+    if start_time is not None:
+        occurred_at["$gte"] = start_time
+    if end_time is not None:
+        occurred_at["$lt"] = end_time
+    time_filter = {"occurred_at": occurred_at} if occurred_at else None
+
     result = await kb.recall(
         question,
         namespace=namespace_id,
-        start_time=start_time,
-        end_time=end_time,
+        filter=time_filter,
         limit=4,
     )
     window = ""

--- a/examples/30_workloads/09_bulk_archive.py
+++ b/examples/30_workloads/09_bulk_archive.py
@@ -208,20 +208,19 @@ async def main() -> None:
         # spend on a single ingest.
 
         # ── Time-filtered recall ──────────────────────────────────
-        # Ask about events in the last 3 days — a natural-language
-        # temporal query. recall() takes explicit start_time/end_time
-        # so we bypass NLP detection for predictability. The filter
-        # gets pushed into the SQL WHERE clause (`temporal_sql_pushdown`,
-        # default on) instead of fetching everything then filtering in
-        # Python — that's what makes this scale.
+        # Ask about events in the last 3 days. Rather than rely on NLP
+        # temporal detection, pass an explicit recall filter on the
+        # event-time axis — filter={"occurred_at": {"$gte": ..., "$lt": ...}}
+        # (lower bound inclusive, upper bound exclusive). It's deterministic
+        # and pushes down into the SQL WHERE clause instead of fetching
+        # everything then filtering in Python — that's what makes this scale.
         window_start = anchor - timedelta(days=3)
         print("\nQ (time-filtered): What happened in the last 3 days?")
         print(f"   window = [{window_start.isoformat()}, {anchor.isoformat()}]")
         result = await kb.recall(
             "What happened in the last 3 days?",
             namespace=ns_id,
-            start_time=window_start,
-            end_time=anchor,
+            filter={"occurred_at": {"$gte": window_start, "$lt": anchor}},
             limit=5,
         )
         for chunk in result.chunks[:5]:

--- a/examples/README.md
+++ b/examples/README.md
@@ -74,7 +74,7 @@ Start here if Khora is new to you. Each is self-contained and under ~150 LOC.
 
 ## `10_core_apis/` — the API surface
 
-The everyday calls, one concept at a time. Most run on VectorCypher (the default); image ingestion (06) uses skeleton.
+The everyday calls, one concept at a time. Most run on VectorCypher (the default); image ingestion (07) uses skeleton.
 
 - [`01_remember_batch.py`](10_core_apis/01_remember_batch.py) —
   Bulk ingestion with `remember_batch` and `on_progress` (uses `data/support_tickets.jsonl`).
@@ -92,6 +92,9 @@ The everyday calls, one concept at a time. Most run on VectorCypher (the default
   Image ingestion: describe a set of figures with a vision model, remember the
   descriptions, then answer one question that spans several images (uses
   `OPENAI_API_KEY`).
+- [`08_recall_with_metadata_filters.py`](10_core_apis/08_recall_with_metadata_filters.py) —
+  `remember()` with custom metadata and provenance, then `recall(filter=...)` deterministic
+  filtering on system keys and `metadata.<path>`, printing the `engine_info["filter"]` pushdown report.
 
 ## `20_integrations/` — framework adapters
 
@@ -172,7 +175,9 @@ examples/
 │   ├── 03_ontology_config.py
 │   ├── 04_recall_entities_and_relationships.py
 │   ├── 05_find_related_entities.py
-│   └── 06_image_ingestion.py
+│   ├── 06_expertise_config.py
+│   ├── 07_image_ingestion.py
+│   └── 08_recall_with_metadata_filters.py
 ├── 20_integrations/                # framework adapter tutorials
 │   ├── 01_langgraph.py
 │   ├── 02_openai_agents.py


### PR DESCRIPTION
## What

Adds `examples/10_core_apis/08_recall_with_metadata_filters.py` — a runnable tutorial for the deterministic recall-filter API (`recall(filter=...)`), which previously had no example in the gallery (only the test suite exercised it).

It shows:
- `remember()` carrying a custom `metadata` dict plus provenance system fields (`source_name`, `source_type`, `source_timestamp`).
- Six `recall()` calls demonstrating scalar sugar, `$in`, a numeric `$gte` range, a typed `RecallFilter` with `$and`, and an event-time bound — each printing the `engine_info["filter"]` `FilterPushdownReport`.

## Verification

Runs end-to-end on the embedded backend (`sqlite_lance` + `vectorcypher`, real LLM extraction). Every filter returns exactly the expected subset and pushes down fully (`pushed_down=True`) on the embedded compiler. `ruff check` and `ruff format` clean.

## Also

- Lists the new example in `examples/README.md`.
- Corrects two stale example-number references in that README (image ingestion is `07`, not `06`; the file-layout tree was missing `06_expertise_config` / `07_image_ingestion`).