### PR TITLE
Memgraph & Neptune: scope list_relationships endpoints + guard null endpoint ids (#1238)

### DIFF
--- a/src/khora/storage/backends/memgraph.py
+++ b/src/khora/storage/backends/memgraph.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from loguru import logger
 
@@ -22,6 +22,7 @@ from khora.storage.backends.mixins import (
     GraphBackendBase,
     deserialize_dict,
     element_to_dict,
+    parse_uuid_list,
     sanitize_cypher_label,
     serialize_dict,
 )
@@ -148,8 +149,8 @@ class MemgraphBackend(GraphBackendBase):
             entity_type=node["entity_type"],
             description=node.get("description", ""),
             attributes=deserialize_dict(node.get("attributes")),
-            source_document_ids=[UUID(d) for d in node.get("source_document_ids", [])],
-            source_chunk_ids=[UUID(c) for c in node.get("source_chunk_ids", [])],
+            source_document_ids=parse_uuid_list(node.get("source_document_ids")),
+            source_chunk_ids=parse_uuid_list(node.get("source_chunk_ids")),
             mention_count=node.get("mention_count", 1),
             valid_from=datetime.fromisoformat(node["valid_from"]) if node.get("valid_from") else None,
             valid_until=datetime.fromisoformat(node["valid_until"]) if node.get("valid_until") else None,
@@ -160,18 +161,39 @@ class MemgraphBackend(GraphBackendBase):
         )
 
     def _record_to_relationship(
-        self, rel: dict[str, Any], source_id: str, target_id: str, rel_type: str
-    ) -> Relationship:
+        self, rel: dict[str, Any], source_id: str | None, target_id: str | None, rel_type: str
+    ) -> Relationship | None:
+        """Convert a Memgraph relationship to a domain Relationship.
+
+        Returns ``None`` when an endpoint id is null: a synthesized endpoint id
+        would be a dangling FK, so the malformed row is skipped (#1238, porting
+        the Neo4j #1237 guard). Missing ``id`` / ``namespace_id`` on the edge
+        itself are synthesized (porting #767, which Memgraph never received).
+        """
+        if source_id is None or target_id is None:
+            logger.warning(
+                f"Dropping relationship with null endpoint id (type={rel_type}, "
+                f"source_id={source_id}, target_id={target_id}); endpoint node is "
+                "missing its id property."
+            )
+            return None
+        rel_id = rel.get("id")
+        rel_ns = rel.get("namespace_id")
+        if rel_id is None or rel_ns is None:
+            logger.warning(
+                f"Relationship missing id/namespace_id (type={rel_type}, "
+                f"{source_id}->{target_id}); using synthesized identity"
+            )
         return Relationship(
-            id=UUID(rel["id"]),
-            namespace_id=UUID(rel["namespace_id"]),
+            id=UUID(rel_id) if rel_id else uuid4(),
+            namespace_id=UUID(rel_ns) if rel_ns else uuid4(),
             source_entity_id=UUID(source_id),
             target_entity_id=UUID(target_id),
             relationship_type=rel_type,
             description=rel.get("description", ""),
             properties=deserialize_dict(rel.get("properties")),
-            source_document_ids=[UUID(d) for d in rel.get("source_document_ids", [])],
-            source_chunk_ids=[UUID(c) for c in rel.get("source_chunk_ids", [])],
+            source_document_ids=parse_uuid_list(rel.get("source_document_ids")),
+            source_chunk_ids=parse_uuid_list(rel.get("source_chunk_ids")),
             valid_from=datetime.fromisoformat(rel["valid_from"]) if rel.get("valid_from") else None,
             valid_until=datetime.fromisoformat(rel["valid_until"]) if rel.get("valid_until") else None,
             confidence=rel.get("confidence", 1.0),
@@ -189,9 +211,9 @@ class MemgraphBackend(GraphBackendBase):
             description=node.get("description", ""),
             occurred_at=datetime.fromisoformat(node["occurred_at"]),
             duration_seconds=node.get("duration_seconds"),
-            entity_ids=[UUID(e) for e in node.get("entity_ids", [])],
-            source_document_ids=[UUID(d) for d in node.get("source_document_ids", [])],
-            source_chunk_ids=[UUID(c) for c in node.get("source_chunk_ids", [])],
+            entity_ids=parse_uuid_list(node.get("entity_ids")),
+            source_document_ids=parse_uuid_list(node.get("source_document_ids")),
+            source_chunk_ids=parse_uuid_list(node.get("source_chunk_ids")),
             metadata=deserialize_dict(node.get("metadata")),
             created_at=datetime.fromisoformat(node["created_at"]) if node.get("created_at") else datetime.now(),
             updated_at=datetime.fromisoformat(node["updated_at"]) if node.get("updated_at") else datetime.now(),
@@ -758,10 +780,11 @@ class MemgraphBackend(GraphBackendBase):
                 limit=limit,
             )
             records = await result.data()
-            return [
+            rels = (
                 self._record_to_relationship(element_to_dict(r["r"]), r["source_id"], r["target_id"], r["rel_type"])
                 for r in records
-            ]
+            )
+            return [rel for rel in rels if rel is not None]
 
     async def list_relationships(
         self,
@@ -775,8 +798,11 @@ class MemgraphBackend(GraphBackendBase):
 
         rel_filter = f":{sanitize_cypher_label(relationship_type)}" if relationship_type else ""
 
+        # Both endpoints constrained to in-namespace ``:Entity`` nodes, matching
+        # get_relationship() / get_entity_relationships() (IDOR family): edges
+        # with non-Entity or cross-namespace endpoints never surface (#1238).
         query = f"""
-        MATCH (source)-[r{rel_filter}]->(target)
+        MATCH (source:Entity {{namespace_id: $namespace_id}})-[r{rel_filter}]->(target:Entity {{namespace_id: $namespace_id}})
         WHERE r.namespace_id = $namespace_id
         RETURN properties(r) as rel_props, source.id as source_id, target.id as target_id, type(r) as rel_type
         ORDER BY r.created_at DESC
@@ -792,10 +818,11 @@ class MemgraphBackend(GraphBackendBase):
                 limit=limit,
             )
             records = await result.data()
-            return [
+            rels = (
                 self._record_to_relationship(r["rel_props"], r["source_id"], r["target_id"], r["rel_type"])
                 for r in records
-            ]
+            )
+            return [rel for rel in rels if rel is not None]
 
     # ------------------------------------------------------------------
     # Episode operations

--- a/src/khora/storage/backends/neptune.py
+++ b/src/khora/storage/backends/neptune.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from loguru import logger
 
@@ -23,6 +23,7 @@ from khora.storage.backends.mixins import (
     GraphBackendBase,
     deserialize_dict,
     element_to_dict,
+    parse_uuid_list,
     sanitize_cypher_label,
     serialize_dict,
 )
@@ -202,8 +203,8 @@ class NeptuneBackend(GraphBackendBase):
             entity_type=node["entity_type"],
             description=node.get("description", ""),
             attributes=deserialize_dict(node.get("attributes")),
-            source_document_ids=[UUID(d) for d in node.get("source_document_ids", [])],
-            source_chunk_ids=[UUID(c) for c in node.get("source_chunk_ids", [])],
+            source_document_ids=parse_uuid_list(node.get("source_document_ids")),
+            source_chunk_ids=parse_uuid_list(node.get("source_chunk_ids")),
             mention_count=node.get("mention_count", 1),
             valid_from=datetime.fromisoformat(node["valid_from"]) if node.get("valid_from") else None,
             valid_until=datetime.fromisoformat(node["valid_until"]) if node.get("valid_until") else None,
@@ -214,18 +215,39 @@ class NeptuneBackend(GraphBackendBase):
         )
 
     def _record_to_relationship(
-        self, rel: dict[str, Any], source_id: str, target_id: str, rel_type: str
-    ) -> Relationship:
+        self, rel: dict[str, Any], source_id: str | None, target_id: str | None, rel_type: str
+    ) -> Relationship | None:
+        """Convert a Neptune relationship to a domain Relationship.
+
+        Returns ``None`` when an endpoint id is null: a synthesized endpoint id
+        would be a dangling FK, so the malformed row is skipped (#1238, porting
+        the Neo4j #1237 guard). Missing ``id`` / ``namespace_id`` on the edge
+        itself are synthesized (porting #767, which Neptune never received).
+        """
+        if source_id is None or target_id is None:
+            logger.warning(
+                f"Dropping relationship with null endpoint id (type={rel_type}, "
+                f"source_id={source_id}, target_id={target_id}); endpoint node is "
+                "missing its id property."
+            )
+            return None
+        rel_id = rel.get("id")
+        rel_ns = rel.get("namespace_id")
+        if rel_id is None or rel_ns is None:
+            logger.warning(
+                f"Relationship missing id/namespace_id (type={rel_type}, "
+                f"{source_id}->{target_id}); using synthesized identity"
+            )
         return Relationship(
-            id=UUID(rel["id"]),
-            namespace_id=UUID(rel["namespace_id"]),
+            id=UUID(rel_id) if rel_id else uuid4(),
+            namespace_id=UUID(rel_ns) if rel_ns else uuid4(),
             source_entity_id=UUID(source_id),
             target_entity_id=UUID(target_id),
             relationship_type=rel_type,
             description=rel.get("description", ""),
             properties=deserialize_dict(rel.get("properties")),
-            source_document_ids=[UUID(d) for d in rel.get("source_document_ids", [])],
-            source_chunk_ids=[UUID(c) for c in rel.get("source_chunk_ids", [])],
+            source_document_ids=parse_uuid_list(rel.get("source_document_ids")),
+            source_chunk_ids=parse_uuid_list(rel.get("source_chunk_ids")),
             valid_from=datetime.fromisoformat(rel["valid_from"]) if rel.get("valid_from") else None,
             valid_until=datetime.fromisoformat(rel["valid_until"]) if rel.get("valid_until") else None,
             confidence=rel.get("confidence", 1.0),
@@ -243,9 +265,9 @@ class NeptuneBackend(GraphBackendBase):
             description=node.get("description", ""),
             occurred_at=datetime.fromisoformat(node["occurred_at"]),
             duration_seconds=node.get("duration_seconds"),
-            entity_ids=[UUID(e) for e in node.get("entity_ids", [])],
-            source_document_ids=[UUID(d) for d in node.get("source_document_ids", [])],
-            source_chunk_ids=[UUID(c) for c in node.get("source_chunk_ids", [])],
+            entity_ids=parse_uuid_list(node.get("entity_ids")),
+            source_document_ids=parse_uuid_list(node.get("source_document_ids")),
+            source_chunk_ids=parse_uuid_list(node.get("source_chunk_ids")),
             metadata=deserialize_dict(node.get("metadata")),
             created_at=datetime.fromisoformat(node["created_at"]) if node.get("created_at") else datetime.now(),
             updated_at=datetime.fromisoformat(node["updated_at"]) if node.get("updated_at") else datetime.now(),
@@ -603,7 +625,7 @@ class NeptuneBackend(GraphBackendBase):
                 limit=limit,
             )
             records = await result.data()
-            return [
+            rels = (
                 self._record_to_relationship(
                     element_to_dict(r["r"]),
                     r["source_id"],
@@ -611,7 +633,8 @@ class NeptuneBackend(GraphBackendBase):
                     r["rel_type"],
                 )
                 for r in records
-            ]
+            )
+            return [rel for rel in rels if rel is not None]
 
     async def list_relationships(
         self,
@@ -625,8 +648,11 @@ class NeptuneBackend(GraphBackendBase):
 
         rel_filter = f":{sanitize_cypher_label(relationship_type)}" if relationship_type else ""
 
+        # Both endpoints constrained to in-namespace ``:Entity`` nodes, matching
+        # get_relationship() / get_entity_relationships() (IDOR family): edges
+        # with non-Entity or cross-namespace endpoints never surface (#1238).
         query = f"""
-        MATCH (source)-[r{rel_filter}]->(target)
+        MATCH (source:Entity {{namespace_id: $namespace_id}})-[r{rel_filter}]->(target:Entity {{namespace_id: $namespace_id}})
         WHERE r.namespace_id = $namespace_id
         RETURN properties(r) as rel_props, source.id as source_id, target.id as target_id, type(r) as rel_type
         ORDER BY r.created_at DESC
@@ -642,7 +668,7 @@ class NeptuneBackend(GraphBackendBase):
                 limit=limit,
             )
             records = await result.data()
-            return [
+            rels = (
                 self._record_to_relationship(
                     r["rel_props"],
                     r["source_id"],
@@ -650,7 +676,8 @@ class NeptuneBackend(GraphBackendBase):
                     r["rel_type"],
                 )
                 for r in records
-            ]
+            )
+            return [rel for rel in rels if rel is not None]
 
     # ------------------------------------------------------------------
     # Episode operations

--- a/tests/unit/storage/backends/test_memgraph_coverage.py
+++ b/tests/unit/storage/backends/test_memgraph_coverage.py
@@ -986,3 +986,65 @@ async def test_search_entities_by_attribute_prefilters_on_key() -> None:
     assert "e.attributes[$attribute_name]" not in cypher
     assert "CONTAINS $key_pattern" in cypher
     assert session.run.await_args.kwargs["key_pattern"] == '"role"'
+
+
+def _rel_props() -> dict[str, Any]:
+    """Minimal post-fix relationship properties dict (the `properties(r)` shape)."""
+    return {
+        "id": str(uuid4()),
+        "namespace_id": str(_NS),
+        "description": "edge",
+        "properties": "{}",
+        "source_document_ids": [],
+        "source_chunk_ids": [],
+        "confidence": 1.0,
+        "weight": 1.0,
+        "metadata": "{}",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-02T00:00:00+00:00",
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.security
+class TestMemgraphListRelationshipsScoping:
+    """list_relationships endpoint scoping + null-endpoint guard (#1238, port of #1237)."""
+
+    @pytest.mark.asyncio
+    async def test_constrains_both_endpoints_to_namespace(self) -> None:
+        session = _make_session_with_records(records=[])
+        b = _connected_backend(session)
+        await b.list_relationships(_NS)
+        query = session.run.await_args.args[0]
+        assert "(source:Entity {namespace_id: $namespace_id})" in query
+        assert "(target:Entity {namespace_id: $namespace_id})" in query
+        # Negative check: the pre-fix unlabeled endpoints must be gone.
+        assert "MATCH (source)-[r" not in query
+
+    @pytest.mark.asyncio
+    async def test_skips_rows_with_null_endpoint_without_raising(self) -> None:
+        good = {"rel_props": _rel_props(), "source_id": str(uuid4()), "target_id": str(uuid4()), "rel_type": "KNOWS"}
+        bad = {"rel_props": _rel_props(), "source_id": None, "target_id": str(uuid4()), "rel_type": "KNOWS"}
+        session = _make_session_with_records(records=[good, bad])
+        b = _connected_backend(session)
+        rels = await b.list_relationships(_NS)
+        assert len(rels) == 1
+        assert all(isinstance(r, Relationship) for r in rels)
+
+    def test_record_to_relationship_null_endpoint_returns_none(self) -> None:
+        b = MemgraphBackend("bolt://h:7687")
+        assert b._record_to_relationship(_rel_props(), None, str(uuid4()), "KNOWS") is None
+        assert b._record_to_relationship(_rel_props(), str(uuid4()), None, "KNOWS") is None
+
+    def test_record_to_relationship_filters_null_provenance_elements(self) -> None:
+        b = MemgraphBackend("bolt://h:7687")
+        good = str(uuid4())
+        rel = b._record_to_relationship(
+            dict(_rel_props(), source_document_ids=[good, None], source_chunk_ids=[None]),
+            str(uuid4()),
+            str(uuid4()),
+            "WORKS_FOR",
+        )
+        assert rel is not None
+        assert [str(d) for d in rel.source_document_ids] == [good]
+        assert rel.source_chunk_ids == []

--- a/tests/unit/storage/backends/test_memgraph_coverage.py
+++ b/tests/unit/storage/backends/test_memgraph_coverage.py
@@ -1052,17 +1052,17 @@ class TestMemgraphListRelationshipsScoping:
     def test_record_to_relationship_synthesizes_missing_id_and_namespace(self) -> None:
         """Missing edge id/namespace_id are synthesized + warned (porting #767), not crashed on.
 
-        Memgraph previously did ``UUID(rel["id"])`` (KeyError on a missing id);
-        the row is now kept with a synthesized identity.
+        Memgraph previously did ``UUID(rel["id"])`` -> ``UUID(None)`` -> TypeError;
+        the row is now kept with a freshly synthesized identity.
         """
         b = MemgraphBackend("bolt://h:7687")
-        rel = b._record_to_relationship(
-            dict(_rel_props(), id=None, namespace_id=None),
-            str(uuid4()),
-            str(uuid4()),
-            "KNOWS",
-        )
-        assert rel is not None
+        src, tgt = str(uuid4()), str(uuid4())
+        rel = b._record_to_relationship(dict(_rel_props(), id=None, namespace_id=None), src, tgt, "KNOWS")
+        assert rel is not None  # synthesized identity, row kept (not crashed)
+        # endpoints preserved; id/namespace_id freshly synthesized, not echoed.
+        assert rel.source_entity_id == UUID(src) and rel.target_entity_id == UUID(tgt)
+        assert str(rel.id) not in (src, tgt)
+        assert rel.id != rel.namespace_id
 
     @pytest.mark.asyncio
     async def test_relationship_type_filter_applied(self) -> None:

--- a/tests/unit/storage/backends/test_memgraph_coverage.py
+++ b/tests/unit/storage/backends/test_memgraph_coverage.py
@@ -1048,3 +1048,27 @@ class TestMemgraphListRelationshipsScoping:
         assert rel is not None
         assert [str(d) for d in rel.source_document_ids] == [good]
         assert rel.source_chunk_ids == []
+
+    def test_record_to_relationship_synthesizes_missing_id_and_namespace(self) -> None:
+        """Missing edge id/namespace_id are synthesized + warned (porting #767), not crashed on.
+
+        Memgraph previously did ``UUID(rel["id"])`` (KeyError on a missing id);
+        the row is now kept with a synthesized identity.
+        """
+        b = MemgraphBackend("bolt://h:7687")
+        rel = b._record_to_relationship(
+            dict(_rel_props(), id=None, namespace_id=None),
+            str(uuid4()),
+            str(uuid4()),
+            "KNOWS",
+        )
+        assert rel is not None
+
+    @pytest.mark.asyncio
+    async def test_relationship_type_filter_applied(self) -> None:
+        """``relationship_type`` is injected as ``:TYPE`` into the constrained pattern."""
+        session = _make_session_with_records(records=[])
+        b = _connected_backend(session)
+        await b.list_relationships(_NS, relationship_type="KNOWS")
+        query = session.run.await_args.args[0]
+        assert ":KNOWS]" in query

--- a/tests/unit/storage/backends/test_neptune_coverage.py
+++ b/tests/unit/storage/backends/test_neptune_coverage.py
@@ -958,3 +958,65 @@ async def test_search_entities_by_attribute_prefilters_on_key() -> None:
     assert "e.attributes[$attribute_name]" not in cypher
     assert "CONTAINS $key_pattern" in cypher
     assert session.run.await_args.kwargs["key_pattern"] == '"role"'
+
+
+def _rel_props() -> dict[str, Any]:
+    """Minimal post-fix relationship properties dict (the `properties(r)` shape)."""
+    return {
+        "id": str(uuid4()),
+        "namespace_id": str(_NS),
+        "description": "edge",
+        "properties": "{}",
+        "source_document_ids": [],
+        "source_chunk_ids": [],
+        "confidence": 1.0,
+        "weight": 1.0,
+        "metadata": "{}",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-02T00:00:00+00:00",
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.security
+class TestNeptuneListRelationshipsScoping:
+    """list_relationships endpoint scoping + null-endpoint guard (#1238, port of #1237)."""
+
+    @pytest.mark.asyncio
+    async def test_constrains_both_endpoints_to_namespace(self) -> None:
+        session = _make_session_with_records(records=[])
+        b = _connected_backend(session)
+        await b.list_relationships(_NS)
+        query = session.run.await_args.args[0]
+        assert "(source:Entity {namespace_id: $namespace_id})" in query
+        assert "(target:Entity {namespace_id: $namespace_id})" in query
+        # Negative check: the pre-fix unlabeled endpoints must be gone.
+        assert "MATCH (source)-[r" not in query
+
+    @pytest.mark.asyncio
+    async def test_skips_rows_with_null_endpoint_without_raising(self) -> None:
+        good = {"rel_props": _rel_props(), "source_id": str(uuid4()), "target_id": str(uuid4()), "rel_type": "KNOWS"}
+        bad = {"rel_props": _rel_props(), "source_id": None, "target_id": str(uuid4()), "rel_type": "KNOWS"}
+        session = _make_session_with_records(records=[good, bad])
+        b = _connected_backend(session)
+        rels = await b.list_relationships(_NS)
+        assert len(rels) == 1
+        assert all(isinstance(r, Relationship) for r in rels)
+
+    def test_record_to_relationship_null_endpoint_returns_none(self) -> None:
+        b = NeptuneBackend("bolt://cluster:8182")
+        assert b._record_to_relationship(_rel_props(), None, str(uuid4()), "KNOWS") is None
+        assert b._record_to_relationship(_rel_props(), str(uuid4()), None, "KNOWS") is None
+
+    def test_record_to_relationship_filters_null_provenance_elements(self) -> None:
+        b = NeptuneBackend("bolt://cluster:8182")
+        good = str(uuid4())
+        rel = b._record_to_relationship(
+            dict(_rel_props(), source_document_ids=[good, None], source_chunk_ids=[None]),
+            str(uuid4()),
+            str(uuid4()),
+            "WORKS_FOR",
+        )
+        assert rel is not None
+        assert [str(d) for d in rel.source_document_ids] == [good]
+        assert rel.source_chunk_ids == []

--- a/tests/unit/storage/backends/test_neptune_coverage.py
+++ b/tests/unit/storage/backends/test_neptune_coverage.py
@@ -1024,17 +1024,17 @@ class TestNeptuneListRelationshipsScoping:
     def test_record_to_relationship_synthesizes_missing_id_and_namespace(self) -> None:
         """Missing edge id/namespace_id are synthesized + warned (porting #767), not crashed on.
 
-        Neptune previously did ``UUID(rel["id"])`` (KeyError on a missing id);
-        the row is now kept with a synthesized identity.
+        Neptune previously did ``UUID(rel["id"])`` -> ``UUID(None)`` -> TypeError;
+        the row is now kept with a freshly synthesized identity.
         """
         b = NeptuneBackend("bolt://cluster:8182")
-        rel = b._record_to_relationship(
-            dict(_rel_props(), id=None, namespace_id=None),
-            str(uuid4()),
-            str(uuid4()),
-            "KNOWS",
-        )
-        assert rel is not None
+        src, tgt = str(uuid4()), str(uuid4())
+        rel = b._record_to_relationship(dict(_rel_props(), id=None, namespace_id=None), src, tgt, "KNOWS")
+        assert rel is not None  # synthesized identity, row kept (not crashed)
+        # endpoints preserved; id/namespace_id freshly synthesized, not echoed.
+        assert rel.source_entity_id == UUID(src) and rel.target_entity_id == UUID(tgt)
+        assert str(rel.id) not in (src, tgt)
+        assert rel.id != rel.namespace_id
 
     @pytest.mark.asyncio
     async def test_relationship_type_filter_applied(self) -> None:

--- a/tests/unit/storage/backends/test_neptune_coverage.py
+++ b/tests/unit/storage/backends/test_neptune_coverage.py
@@ -1020,3 +1020,27 @@ class TestNeptuneListRelationshipsScoping:
         assert rel is not None
         assert [str(d) for d in rel.source_document_ids] == [good]
         assert rel.source_chunk_ids == []
+
+    def test_record_to_relationship_synthesizes_missing_id_and_namespace(self) -> None:
+        """Missing edge id/namespace_id are synthesized + warned (porting #767), not crashed on.
+
+        Neptune previously did ``UUID(rel["id"])`` (KeyError on a missing id);
+        the row is now kept with a synthesized identity.
+        """
+        b = NeptuneBackend("bolt://cluster:8182")
+        rel = b._record_to_relationship(
+            dict(_rel_props(), id=None, namespace_id=None),
+            str(uuid4()),
+            str(uuid4()),
+            "KNOWS",
+        )
+        assert rel is not None
+
+    @pytest.mark.asyncio
+    async def test_relationship_type_filter_applied(self) -> None:
+        """``relationship_type`` is injected as ``:TYPE`` into the constrained pattern."""
+        session = _make_session_with_records(records=[])
+        b = _connected_backend(session)
+        await b.list_relationships(_NS, relationship_type="KNOWS")
+        query = session.run.await_args.args[0]
+        assert ":KNOWS]" in query


### PR DESCRIPTION
Fixes #1238

Ports the merged Neo4j fix (#1237 / #1240) to the **byte-identical** Memgraph and Neptune backends.

## Problem
`Memgraph.list_relationships` and `Neptune.list_relationships` had the same unconstrained-endpoint bug as Neo4j pre-#1237 — `MATCH (source)-[r]->(target) WHERE r.namespace_id = $ns` with no `:Entity` label or namespace predicate on the endpoints:
1. **Correctness (IDOR family):** endpoints could resolve cross-namespace / to non-`Entity` nodes.
2. **Robustness:** a null endpoint `id` → `UUID(None)` → `TypeError`, aborting the whole call. Their `_record_to_relationship` was in fact *strictly worse* than Neo4j's — it guarded nothing, even doing `UUID(rel["id"])` (KeyError on a missing edge id).

Both are reachable only via external/legacy/raw-Cypher data (khora's own writes always produce in-namespace `:Entity {id}` endpoints) — robustness hardening, same threat model as #1237.

## Changes (mirror #1237 exactly)
- **`list_relationships`**: constrain both endpoints to `(:Entity {namespace_id: $ns})`, matching each backend's already-hardened `get_relationship` / `get_entity_relationships`; callers filter the skipped rows.
- **`_record_to_relationship → Relationship | None`**: skip-and-warn on a null endpoint id (no `uuid4()` synthesis — a fabricated endpoint is a dangling FK). Also **back-ports the #767 `id`/`namespace_id` synthesis guard**, which Memgraph/Neptune never received.
- **Null list-elements** filtered via the shared `mixins.parse_uuid_list` in the relationship / entity / episode deserializers.

## Scope
- The forget-cascade malformed-orphan **sweep is intentionally NOT ported** — that family (#1241 / #1242) was closed as not-planned; the sweep stays Neo4j-only.
- **AGE (#1239) closed separately** — bespoke string-literal Cypher (`_uuid_lit`), no CI conformance coverage; needs its own review.

### Behavior-change note (Memgraph/Neptune `forget()`)
On these two backends the net change for a **malformed** edge (null endpoint id) is **crash → skip-and-warn**: pre-PR, `list_relationships` raised `UUID(None)` `TypeError` and aborted the whole `forget()` cascade; post-PR it cleanly skips the row. Because the malformed-orphan sweep is Neo4j-only (the cascade dispatches it via `getattr`, a no-op here), such an edge now **silently survives `forget()`** instead of crashing it. This is strictly better than the prior crash and is reachable only on external/legacy/raw-Cypher data (khora's own writes always produce in-namespace `:Entity {id}` endpoints) — same threat model as #1237. Flagged for visibility; no reaper on these backends is the deliberate, closed-as-not-planned scope decision above.

## Tests
- Unit query-shape tests asserting **both** endpoints are constrained (and the old unlabeled form is gone), for both backends.
- Null-endpoint skip tests (no `TypeError`; malformed row excluded) + null-provenance-element filtering, for both.
- Full unit suite green (the only failures are the pre-existing `test_accel.py` Rust-parity issues, unrelated). `make format` + `make lint` clean.

Note: Memgraph/Neptune have unit coverage only (no live-instance conformance leg in CI), so these tests are the regression guard.
