### PR TITLE
Reduce redundant reranking extra to a no-op alias

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,7 @@ Programmatic values take priority over environment variables.
 | `sqlite` | SQLite embedded relational + vector | `aiosqlite>=0.21.0` |
 | `lancedb` | LanceDB embedded vector store | `lancedb>=0.30.0`, `pyarrow>=24.0.0` |
 | `sqlite-lance` | **[experimental]** Unified SQLite + LanceDB embedded backend. Recommended embedded stack; covers VectorCypher / Skeleton / Chronicle | `lancedb>=0.30.0`, `aiosqlite>=0.21.0`, `pyarrow>=24.0.0` |
-| `reranking` | Neural reranking via cross-encoders | `sentence-transformers>=5.4.1` |
+| `reranking` | Cross-encoder reranking now ships in core; this extra is a reserved no-op kept for back-compat | - |
 | `binary-readers` | docx / xlsx readers (used by downstream ingestors). PDF extraction is not bundled — preprocess PDFs upstream. | `openpyxl>=3.1.0`, `python-docx>=1.2.0` |
 | `parquet` | Parquet readers | `pyarrow>=24.0.0` |
 | `accel` | Accelerated CPU ops (string-matching fuzz, used by dream-phase centroid recompute) | `rapidfuzz>=3.0.0` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,9 +115,7 @@ all-backends = [
     "pyarrow>=24.0.0",
 ]
 # Neural reranking
-reranking = [
-    "sentence-transformers>=5.4.1",
-]
+reranking = []
 # Binary file readers (Excel, Word text extraction) — used by khora-cli
 binary-readers = ["openpyxl>=3.1.0", "python-docx>=1.2.0"]
 # Parquet file support (used by khora-cli)

--- a/uv.lock
+++ b/uv.lock
@@ -2475,9 +2475,6 @@ postgres = [
     { name = "asyncpg" },
     { name = "pgvector" },
 ]
-reranking = [
-    { name = "sentence-transformers" },
-]
 rust = [
     { name = "khora-accel" },
 ]
@@ -2593,7 +2590,6 @@ requires-dist = [
     { name = "rapidfuzz", marker = "extra == 'accel'", specifier = ">=3.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "~=0.15.12" },
     { name = "sentence-transformers", specifier = ">=5.4.1" },
-    { name = "sentence-transformers", marker = "extra == 'reranking'", specifier = ">=5.4.1" },
     { name = "spacy", marker = "extra == 'nlp'", specifier = ">=3.8.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.49" },
     { name = "surrealdb", marker = "extra == 'all-backends'", specifier = ">=2.0.0,<3.0" },


### PR DESCRIPTION
## Summary
- The `reranking` optional-dependency extra re-declared `sentence-transformers`, which is already a core dependency — so the extra only duplicated a dependency the base install already pulls (a manifest bug).
- Reduce the extra to an empty no-op alias (`reranking = []`). This keeps `pip install <pkg>[reranking]` resolving and byte-equivalent to a bare install, preserves back-compat for anyone who already pins the extra, and reserves the name for a future slim-core carve-out.
- `uv.lock`: drop the two `reranking` → `sentence-transformers` mapping entries so the lockfile stays in sync with the manifest (no other lock churn; the extra remains listed in `provides-extras`).
- `docs/configuration.md`: update the extras-table row to reflect that cross-encoder reranking ships in core and the extra is now a reserved no-op.

No behavior change: no Python is touched, `sentence-transformers` stays in core, and the cross-encoder reranker default (`enable_reranking=True`) is unchanged — default recall still reranks exactly as before.

## Test plan
- [x] `make format` clean (944 files unchanged)
- [x] `make lint` passes (exit 0)
- [x] Unit suite green except pre-existing, unrelated local Rust-accel parity failures (reproduce on a clean tree; CI builds the accel extension fresh)
- [ ] CI: `uv sync --locked` resolves with the updated lockfile
- [x] Manual: `pip install <pkg>[reranking]` resolves to the empty extra (byte-equivalent to bare install)