### PR TITLE
Align project description to README across repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,9 @@
 # Contributing to Khora
 
-Thanks for your interest in contributing. Khora is an open-source knowledge
-memory library - knowledge graphs + vector search + PostgreSQL (with an
-optional SQLite + LanceDB embedded path).
+Thanks for your interest in contributing. Khora is a Python library for
+creating knowledge repositories that ingest unstructured and structured
+multi-source data and expose a single query substrate, built for integrating
+into long-horizon AI agents.
 
 ## Local setup
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-Khora is our open source python library for creating knowledge repositories that ingest unstructured and structured multi-source data and expose a single query substrate, built for integrating into long-horizon AI agents.
+Khora is a Python library for creating knowledge repositories that ingest unstructured and structured multi-source data and expose a single query substrate, built for integrating into long-horizon AI agents.
 
 ## The Big Picture
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "khora"
 dynamic = ["version", "readme"]
-description = "Knowledge memory library for long-horizon AI agents — hybrid retrieval over documents, embeddings, and graph relationships"
+description = "A Python library for creating knowledge repositories that ingest unstructured and structured multi-source data and expose a single query substrate, built for integrating into long-horizon AI agents"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]
 authors = [


### PR DESCRIPTION
## Summary

- **pyproject.toml**: replaced old "Knowledge memory library for long-horizon AI agents — hybrid retrieval over documents, embeddings, and graph relationships" with the README's canonical one-liner
- **CONTRIBUTING.md**: replaced "knowledge memory library - knowledge graphs + vector search + PostgreSQL …" with the same
- **docs/architecture/overview.md**: dropped "our open source" prefix, capitalised "Python", now matches README verbatim

The CHANGELOG.md entry (line 1052) references the old pyproject description historically and was left as-is.

## Test plan

- [ ] `make format` passes (no code changes)
- [ ] PyPI description renders correctly after next release