### PR TITLE
Bump pyo3 and numpy to 0.29 (GHSA-36hh-v3qg-5jq4)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778da78c64ddc928ebf5ad9df5edf0789410ff3bdbf3619aed51cd789a6af1e2"
+checksum = "6a5b15d63a5ff39e378daed0e1340d3a5964703ea9712eb09a0dc66fade996f4"
 dependencies = [
  "libc",
  "ndarray",
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -483,18 +483,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -502,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -514,13 +514,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/rust/khora-accel/Cargo.toml
+++ b/rust/khora-accel/Cargo.toml
@@ -15,8 +15,8 @@ name = "khora_accel"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.28" }
-numpy = "0.28"
+pyo3 = { version = "0.29" }
+numpy = "0.29"
 ndarray = "0.17"
 rayon = "1.10"
 strsim = "0.11"


### PR DESCRIPTION
## Summary

Resolves the high-severity Dependabot alerts on **pyo3** by bumping it `0.28 → 0.29`:

| Dependabot alert | Manifest | Advisory |
|---|---|---|
| #18 | `rust/khora-accel/Cargo.toml` | GHSA-36hh-v3qg-5jq4 — out-of-bounds read in `nth` / `nth_back` for `PyList` / `PyTuple` iterators |
| #17 | `rust/Cargo.lock` | (same) |

`numpy` (the `rust-numpy` crate) is bumped in lockstep `0.28 → 0.29`: it's published against a specific pyo3 version and won't compile against a mismatched one.

## Changes

- `rust/khora-accel/Cargo.toml` — `pyo3` and `numpy` `0.28 → 0.29`.
- `rust/Cargo.lock` — regenerated: `pyo3`, `pyo3-ffi`, `pyo3-build-config`, `pyo3-macros`, `pyo3-macros-backend`, `numpy` → `0.29.0`.
- No source changes. khora-accel package version unchanged (`0.20.0`) — this is a transitive dependency patch, not a lockstep khora/khora-accel release.

## Verification

`cargo build --release` (the cdylib that actually ships) is **green** against pyo3/numpy 0.29 with zero source changes.

## ⚠️ Compatibility note

pyo3 0.29 ships **breaking API renames** (the "GIL is an attachment" / free-threading work):

- `Python::with_gil(...)` → `Python::attach(...)`
- `pyo3::prepare_freethreaded_python()` → `Python::initialize()`
- `Python::allow_threads(...)` → `Python::detach(...)`

**Why this PR needs no code changes:** khora-accel's production code already uses the cross-version-stable `py.detach(...)` API to release the GIL, and never calls the renamed functions. The shipping artifact is a `cdylib`, built via `cargo build --release` / `maturin` — verified clean on 0.29.

**Known, out-of-scope caveat:** the `#[cfg(test)]` modules in `pagerank.rs` and `community.rs` still call the now-removed `Python::with_gil` / `prepare_freethreaded_python`, so `cargo test` does not compile. This is **pre-existing** — those names were already gone in the previously-locked pyo3 0.28.3; the cdylib build skips `#[cfg(test)]` code, and CI does not run `cargo test`, so it was never surfaced. This PR neither introduces nor worsens it. The test-module rename (plus an unrelated `temporal.rs` false-positive the rename exposes) is deliberately left for a separate, focused PR so this security bump stays minimal.

**Downstream impact:** none. Anyone installing the `rust` extra builds khora-accel from source via maturin (cdylib, no test compilation), and khora-accel's Python-facing API is unchanged.