### PR TITLE
Relocate temporal data types to a leaf khora.core.temporal module

### DIFF
--- a/src/khora/core/temporal.py
+++ b/src/khora/core/temporal.py
@@ -1,0 +1,160 @@
+"""Neutral temporal data types for chunk storage.
+
+Strict-leaf module: imports only the standard library and
+``khora.core.models``. It must never pull an engine, a DB driver, or the
+recall-filter machinery into ``sys.modules`` — so callers can depend on the
+temporal data shapes without paying the cost of importing a backend.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from khora.core.models.document import Chunk
+
+if TYPE_CHECKING:
+    from khora.core.models.document import Document
+
+
+@dataclass
+class TemporalChunk:
+    """Chunk with temporal metadata for the Skeleton engine."""
+
+    id: UUID
+    namespace_id: UUID
+    document_id: UUID
+    content: str
+    embedding: list[float] | None = None
+
+    # Temporal fields
+    occurred_at: datetime | None = None  # When the event/fact happened
+    created_at: datetime | None = None  # When the chunk was created
+
+    # Metadata for filtering
+    source_system: str | None = None
+    author: str | None = None
+    channel: str | None = None
+    tags: list[str] = field(default_factory=list)
+    confidence: float = 1.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+    chunker_info: dict[str, Any] = field(default_factory=dict)
+
+    # Denormalized document-grained fields (copied from the parent document)
+    # for deterministic recall filters. All nullable. ``source_timestamp`` is
+    # the producer's verbatim event time, distinct from ``occurred_at``.
+    source_type: str | None = None
+    source_name: str | None = None
+    source_url: str | None = None
+    source_timestamp: datetime | None = None
+    external_id: str | None = None
+    content_type: str | None = None
+    source: str | None = None
+    title: str | None = None
+
+
+def document_denorm_fields(document: Document) -> dict[str, Any]:
+    """Return the denormalized document-grained chunk fields from a Document.
+
+    Copies the eight provenance fields off the typed Document so chunk
+    builders can stamp them onto a :class:`TemporalChunk` without repeating
+    the mapping at every write site. ``source_timestamp`` is the producer's
+    verbatim time, kept distinct from the chunk event-time ``occurred_at``.
+    """
+    return {
+        "source_type": document.source_type,
+        "source_name": document.source_name,
+        "source_url": document.source_url,
+        "source_timestamp": document.source_timestamp,
+        "external_id": document.external_id,
+        "content_type": document.content_type,
+        "source": document.source,
+        "title": document.title,
+    }
+
+
+@dataclass
+class TemporalSearchResult:
+    """Result from a temporal search."""
+
+    chunk: TemporalChunk
+    similarity: float
+    bm25_score: float | None = None  # Only for hybrid search
+    combined_score: float | None = None  # After fusion
+
+
+@dataclass
+class ChunkTemporalFilter:
+    """Filter for temporal queries."""
+
+    # Time range filters
+    occurred_after: datetime | None = None
+    occurred_before: datetime | None = None
+    created_after: datetime | None = None
+    created_before: datetime | None = None
+
+    # Keyword filters
+    source_system: str | None = None
+    author: str | None = None
+    channel: str | None = None
+    tags: list[str] | None = None  # Chunks must have ALL of these tags
+
+    # Additional structured filters (key -> value or operator dict)
+    # Example: {"confidence": {"gte": 0.8}, "metadata.priority": {"eq": "high"}}
+    additional: dict[str, Any] = field(default_factory=dict)
+
+
+def temporal_chunk_to_chunk(tc: TemporalChunk) -> Chunk:
+    """Adapt a ``TemporalChunk`` (skeleton storage) to a public ``Chunk``.
+
+    Preserves fields the retriever and rerankers depend on:
+    ``chunker_info`` (#800), ``created_at`` (#810), and ``session_id``
+    (#620 — stamped into ``TemporalChunk.metadata`` by the engines).
+    Surfaces ``occurred_at`` (the chunk event-time) and ``source_timestamp``
+    (the producer's verbatim time) as distinct values; the recall projection
+    applies the event-time-then-producer-time fallback downstream.
+    """
+    md = tc.metadata or {}
+    sid_raw = md.get("session_id")
+    session_id: UUID | None
+    if isinstance(sid_raw, UUID):
+        session_id = sid_raw
+    elif sid_raw:
+        try:
+            session_id = UUID(str(sid_raw))
+        except (TypeError, ValueError):
+            session_id = None
+    else:
+        session_id = None
+
+    return Chunk(
+        id=tc.id,
+        namespace_id=tc.namespace_id,
+        document_id=tc.document_id,
+        content=tc.content,
+        chunk_index=int(md.get("chunk_index", 0) or 0),
+        start_char=int(md.get("start_char", 0) or 0),
+        end_char=int(md.get("end_char", 0) or 0),
+        token_count=int(md.get("token_count", 0) or 0),
+        metadata=md,
+        chunker_info=tc.chunker_info or {},
+        embedding=tc.embedding,
+        embedding_model=str(md.get("embedding_model", "") or ""),
+        created_at=tc.created_at or datetime.now(UTC),
+        # Carry the chunk event-time and the producer's verbatim time as
+        # distinct values; the recall projection applies the fallback.
+        occurred_at=tc.occurred_at,
+        source_timestamp=tc.source_timestamp,
+        session_id=session_id,
+    )
+
+
+__all__ = [
+    "ChunkTemporalFilter",
+    "TemporalChunk",
+    "TemporalSearchResult",
+    "document_denorm_fields",
+    "temporal_chunk_to_chunk",
+]

--- a/src/khora/engines/skeleton/backends/__init__.py
+++ b/src/khora/engines/skeleton/backends/__init__.py
@@ -3,110 +3,45 @@
 The Skeleton engine supports multiple backends for temporal vector storage:
 - pgvector: PostgreSQL+pgvector (default, no additional infrastructure)
 - weaviate: Weaviate (advanced hybrid search, multi-field filtering)
+
+.. deprecated::
+    The neutral temporal data types (``TemporalChunk``, ``TemporalFilter``,
+    ``TemporalSearchResult``, ``document_denorm_fields``,
+    ``temporal_chunk_to_chunk``) now live in :mod:`khora.core.temporal`.
+    Importing them from this module still works but is deprecated.
 """
 
 from __future__ import annotations
 
+import warnings
 from abc import abstractmethod
-from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Protocol
 from uuid import UUID
 
 from khora.core.models.document import Chunk
+from khora.core.temporal import (
+    ChunkTemporalFilter,
+    TemporalChunk,
+    TemporalSearchResult,
+    document_denorm_fields,
+    temporal_chunk_to_chunk,
+)
+
+# Legacy alias — identity-preserving. ``TemporalFilter is ChunkTemporalFilter``.
+TemporalFilter = ChunkTemporalFilter
+
+warnings.warn(
+    "Importing temporal data types from khora.engines.skeleton.backends is "
+    "deprecated; import from khora.core.temporal instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 if TYPE_CHECKING:
     from khora.config import KhoraConfig
-    from khora.core.models.document import Document
     from khora.filter.ast import FilterNode
     from khora.filter.report import ChannelPlan
-
-
-@dataclass
-class TemporalChunk:
-    """Chunk with temporal metadata for the Skeleton engine."""
-
-    id: UUID
-    namespace_id: UUID
-    document_id: UUID
-    content: str
-    embedding: list[float] | None = None
-
-    # Temporal fields
-    occurred_at: datetime | None = None  # When the event/fact happened
-    created_at: datetime | None = None  # When the chunk was created
-
-    # Metadata for filtering
-    source_system: str | None = None
-    author: str | None = None
-    channel: str | None = None
-    tags: list[str] = field(default_factory=list)
-    confidence: float = 1.0
-    metadata: dict[str, Any] = field(default_factory=dict)
-    chunker_info: dict[str, Any] = field(default_factory=dict)
-
-    # Denormalized document-grained fields (copied from the parent document)
-    # for deterministic recall filters. All nullable. ``source_timestamp`` is
-    # the producer's verbatim event time, distinct from ``occurred_at``.
-    source_type: str | None = None
-    source_name: str | None = None
-    source_url: str | None = None
-    source_timestamp: datetime | None = None
-    external_id: str | None = None
-    content_type: str | None = None
-    source: str | None = None
-    title: str | None = None
-
-
-def document_denorm_fields(document: Document) -> dict[str, Any]:
-    """Return the denormalized document-grained chunk fields from a Document.
-
-    Copies the eight provenance fields off the typed Document so chunk
-    builders can stamp them onto a :class:`TemporalChunk` without repeating
-    the mapping at every write site. ``source_timestamp`` is the producer's
-    verbatim time, kept distinct from the chunk event-time ``occurred_at``.
-    """
-    return {
-        "source_type": document.source_type,
-        "source_name": document.source_name,
-        "source_url": document.source_url,
-        "source_timestamp": document.source_timestamp,
-        "external_id": document.external_id,
-        "content_type": document.content_type,
-        "source": document.source,
-        "title": document.title,
-    }
-
-
-@dataclass
-class TemporalSearchResult:
-    """Result from a temporal search."""
-
-    chunk: TemporalChunk
-    similarity: float
-    bm25_score: float | None = None  # Only for hybrid search
-    combined_score: float | None = None  # After fusion
-
-
-@dataclass
-class TemporalFilter:
-    """Filter for temporal queries."""
-
-    # Time range filters
-    occurred_after: datetime | None = None
-    occurred_before: datetime | None = None
-    created_after: datetime | None = None
-    created_before: datetime | None = None
-
-    # Keyword filters
-    source_system: str | None = None
-    author: str | None = None
-    channel: str | None = None
-    tags: list[str] | None = None  # Chunks must have ALL of these tags
-
-    # Additional structured filters (key -> value or operator dict)
-    # Example: {"confidence": {"gte": 0.8}, "metadata.priority": {"eq": "high"}}
-    additional: dict[str, Any] = field(default_factory=dict)
 
 
 class TemporalVectorStore(Protocol):
@@ -275,51 +210,6 @@ class TemporalVectorStore(Protocol):
         (sqlite_lance support tracked in GitHub issue #1182).
         """
         return []
-
-
-def temporal_chunk_to_chunk(tc: TemporalChunk) -> Chunk:
-    """Adapt a ``TemporalChunk`` (skeleton storage) to a public ``Chunk``.
-
-    Preserves fields the retriever and rerankers depend on:
-    ``chunker_info`` (#800), ``created_at`` (#810), and ``session_id``
-    (#620 — stamped into ``TemporalChunk.metadata`` by the engines).
-    Surfaces ``occurred_at`` (the chunk event-time) and ``source_timestamp``
-    (the producer's verbatim time) as distinct values; the recall projection
-    applies the event-time-then-producer-time fallback downstream.
-    """
-    md = tc.metadata or {}
-    sid_raw = md.get("session_id")
-    session_id: UUID | None
-    if isinstance(sid_raw, UUID):
-        session_id = sid_raw
-    elif sid_raw:
-        try:
-            session_id = UUID(str(sid_raw))
-        except (TypeError, ValueError):
-            session_id = None
-    else:
-        session_id = None
-
-    return Chunk(
-        id=tc.id,
-        namespace_id=tc.namespace_id,
-        document_id=tc.document_id,
-        content=tc.content,
-        chunk_index=int(md.get("chunk_index", 0) or 0),
-        start_char=int(md.get("start_char", 0) or 0),
-        end_char=int(md.get("end_char", 0) or 0),
-        token_count=int(md.get("token_count", 0) or 0),
-        metadata=md,
-        chunker_info=tc.chunker_info or {},
-        embedding=tc.embedding,
-        embedding_model=str(md.get("embedding_model", "") or ""),
-        created_at=tc.created_at or datetime.now(UTC),
-        # Carry the chunk event-time and the producer's verbatim time as
-        # distinct values; the recall projection applies the fallback.
-        occurred_at=tc.occurred_at,
-        source_timestamp=tc.source_timestamp,
-        session_id=session_id,
-    )
 
 
 def create_temporal_store(

--- a/tests/unit/core/test_temporal.py
+++ b/tests/unit/core/test_temporal.py
@@ -1,0 +1,252 @@
+"""Acceptance tests for the strict-leaf ``khora.core.temporal`` module.
+
+Locks in the guarantees of the temporal-types relocation:
+
+* the public surface lives in ``khora.core.temporal``,
+* the module's static import closure is leaf-pure — it reaches only stdlib
+  and ``khora.core.models`` (no engine / DB-driver / filter machinery),
+* the old ``khora.engines.skeleton.backends`` import path still works but
+  emits a ``DeprecationWarning`` and preserves object identity,
+* behaviour (chunk adaptation, denorm mapping) round-trips unchanged.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import textwrap
+import warnings
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import khora
+import khora.core.temporal as temporal_mod
+from khora.core.models.document import Chunk, Document
+from khora.core.temporal import (
+    ChunkTemporalFilter,
+    TemporalChunk,
+    TemporalSearchResult,
+    document_denorm_fields,
+    temporal_chunk_to_chunk,
+)
+
+
+def test_public_surface_present_and_exported() -> None:
+    """All five neutral temporal names are importable and in ``__all__``."""
+    expected = {
+        "TemporalChunk",
+        "ChunkTemporalFilter",
+        "TemporalSearchResult",
+        "document_denorm_fields",
+        "temporal_chunk_to_chunk",
+    }
+    for name in expected:
+        assert hasattr(temporal_mod, name), f"{name} missing from khora.core.temporal"
+        assert name in temporal_mod.__all__, f"{name} missing from __all__"
+
+
+# NOTE on scope: this test verifies the *static import closure* of
+# ``khora.core.temporal`` — the guarantee this additive slice actually
+# delivers ("the module imports only stdlib + ``khora.core.models``"). It
+# deliberately does NOT assert runtime ``sys.modules`` isolation. A bare
+# ``import khora.core.temporal`` still forces Python to execute the
+# top-level ``khora/__init__.py``, which eagerly imports the engine and
+# recall-filter subpackages (dragging sqlalchemy etc. into ``sys.modules``).
+# Making that import lazy is a behavior-changing, dependency-inversion
+# refactor that is out of scope here; the full runtime-isolation check is
+# left to a later dependency-inversion slice.
+
+
+def _resolve_khora_module_to_path(module: str) -> Path | None:
+    """Map a ``khora.*`` dotted module name to its source file under ``src``.
+
+    Returns the ``__init__.py`` for a package, the ``.py`` for a module, or
+    ``None`` if no source file exists (e.g. a re-exported attribute name that
+    is not itself a module).
+    """
+    khora_root = Path(khora.__file__).resolve().parent  # .../src/khora
+    rel = module.split(".")[1:]  # drop leading "khora"
+    base = khora_root.joinpath(*rel)
+    candidate = base.with_suffix(".py")
+    if candidate.is_file():
+        return candidate
+    pkg_init = base / "__init__.py"
+    if pkg_init.is_file():
+        return pkg_init
+    return None
+
+
+def _imports_of(path: Path) -> set[str]:
+    """Return the set of top-level dotted module names imported by ``path``.
+
+    Resolves ``from . import x`` / ``from .sub import y`` relative imports
+    against the file's own package so the closure walk follows them.
+    """
+    source = path.read_text()
+    tree = ast.parse(source, filename=str(path))
+    khora_root = Path(khora.__file__).resolve().parent.parent  # .../src
+    dotted = ".".join(path.resolve().relative_to(khora_root).with_suffix("").parts)
+    # The containing package is the module's parent for both a plain ``.py``
+    # module and an ``__init__.py`` (whose dotted form already ends in
+    # ``.__init__``).
+    package = dotted.rsplit(".", 1)[0]
+
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                found.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                # Relative import: resolve against this file's package.
+                base_parts = package.split(".")
+                # level 1 == current package, level 2 == parent, ...
+                anchor = base_parts[: len(base_parts) - (node.level - 1)]
+                target = ".".join([*anchor, node.module]) if node.module else ".".join(anchor)
+                found.add(target)
+            elif node.module:
+                found.add(node.module)
+    return found
+
+
+def test_leaf_purity_static_import_closure() -> None:
+    """``khora.core.temporal``'s static import closure is leaf-pure.
+
+    Parses the module with :mod:`ast`, recursively follows only ``khora.*``
+    imports to their source files, and asserts the transitive closure never
+    references ``khora.filter`` / ``khora.engines`` / any DB driver — every
+    reachable ``khora.*`` module must live under ``khora.core.models`` or be
+    ``khora.core.temporal`` itself. Non-khora imports must be standard
+    library only. Immune to the unrelated top-level package's eager imports
+    (see the module-level scope note above).
+    """
+    start = "khora.core.temporal"
+    allowed_prefixes = ("khora.core.models", "khora.core.temporal")
+
+    seen: set[str] = set()
+    queue = [start]
+    non_khora_imports: set[str] = set()
+
+    while queue:
+        module = queue.pop()
+        if module in seen:
+            continue
+        seen.add(module)
+
+        if not module.startswith("khora.") and module != "khora":
+            non_khora_imports.add(module)
+            continue
+
+        # Every reachable khora module in the closure must be on the allowlist.
+        assert module == "khora" or module.startswith(allowed_prefixes), (
+            f"khora.core.temporal's import closure reaches a non-leaf module: "
+            f"{module!r} (only stdlib + khora.core.models allowed)"
+        )
+
+        path = _resolve_khora_module_to_path(module)
+        if path is None:
+            # Re-exported attribute (e.g. a class name), not a module.
+            continue
+        for imported in _imports_of(path):
+            if imported not in seen:
+                queue.append(imported)
+
+    # Non-khora imports reached through the closure must all be stdlib.
+    stdlib = sys.stdlib_module_names
+    non_stdlib = {m for m in non_khora_imports if m.split(".")[0] not in stdlib}
+    assert not non_stdlib, (
+        f"khora.core.temporal's import closure reaches non-stdlib third-party modules: {sorted(non_stdlib)}"
+    )
+
+
+def test_deprecated_import_emits_warning() -> None:
+    """Importing the relocated names from the old path raises under -W error.
+
+    A fresh subprocess guarantees the backends module isn't already cached,
+    so the import-time ``warnings.warn`` actually fires.
+    """
+    script = textwrap.dedent(
+        """
+        import warnings
+        warnings.simplefilter("error", DeprecationWarning)
+        import khora.engines.skeleton.backends  # noqa: F401
+        """
+    )
+    result = subprocess.run(  # noqa: S603 — test harness, sys.executable is trusted
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0, "expected DeprecationWarning to be raised as error"
+    assert "DeprecationWarning" in result.stderr
+    assert "khora.core.temporal" in result.stderr
+
+
+def test_legacy_alias_preserves_identity() -> None:
+    """``TemporalFilter`` is the very same object as ``ChunkTemporalFilter``."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        from khora.engines.skeleton.backends import TemporalFilter
+
+    assert TemporalFilter is ChunkTemporalFilter
+    assert isinstance(ChunkTemporalFilter(), TemporalFilter)
+
+
+def test_temporal_chunk_round_trips_to_chunk() -> None:
+    """``temporal_chunk_to_chunk`` yields a ``Chunk`` with preserved identity."""
+    cid, nsid, did = uuid4(), uuid4(), uuid4()
+    tc = TemporalChunk(
+        id=cid,
+        namespace_id=nsid,
+        document_id=did,
+        content="hello temporal",
+    )
+    result = TemporalSearchResult(chunk=tc, similarity=0.9)
+
+    chunk = temporal_chunk_to_chunk(result.chunk)
+
+    assert isinstance(chunk, Chunk)
+    assert chunk.id == cid
+    assert chunk.namespace_id == nsid
+    assert chunk.content == "hello temporal"
+
+
+def test_document_denorm_fields_returns_eight_keys() -> None:
+    """The denorm mapping surfaces exactly the eight provenance fields."""
+    doc = Document(content="doc body", title="A Title", source_url="https://x")
+    fields = document_denorm_fields(doc)
+
+    assert set(fields) == {
+        "source_type",
+        "source_name",
+        "source_url",
+        "source_timestamp",
+        "external_id",
+        "content_type",
+        "source",
+        "title",
+    }
+    assert fields["title"] == "A Title"
+    assert fields["source_url"] == "https://x"
+
+
+def test_temporal_chunk_to_chunk_carries_event_and_producer_time() -> None:
+    """Distinct ``occurred_at`` and ``source_timestamp`` survive adaptation."""
+    occurred = datetime(2026, 1, 2, tzinfo=UTC)
+    produced = datetime(2026, 1, 1, tzinfo=UTC)
+    tc = TemporalChunk(
+        id=uuid4(),
+        namespace_id=uuid4(),
+        document_id=uuid4(),
+        content="body",
+        occurred_at=occurred,
+        source_timestamp=produced,
+    )
+
+    chunk = temporal_chunk_to_chunk(tc)
+
+    assert chunk.occurred_at == occurred
+    assert chunk.source_timestamp == produced


### PR DESCRIPTION
## Summary
- Add a new strict-leaf module `khora.core.temporal` holding the neutral temporal data types: `TemporalChunk`, `TemporalSearchResult`, `ChunkTemporalFilter` (formerly the skeleton-backends `TemporalFilter`), and the `document_denorm_fields` / `temporal_chunk_to_chunk` helpers. The module imports only the standard library and `khora.core.models`, so depending on the temporal data shapes no longer drags in an engine, a DB driver, or the recall-filter machinery.
- Keep the old `khora.engines.skeleton.backends` import path fully working: the relocated names are re-exported from `khora.core.temporal`, and the legacy `TemporalFilter` name is an identity-preserving alias of `ChunkTemporalFilter` (`TemporalFilter is ChunkTemporalFilter`, so `isinstance` / `is` checks still hold). Importing from the old path now emits a `DeprecationWarning` pointing at the new module.
- Leave the `TemporalVectorStore` protocol and the `create_temporal_store` factory in the backends package (unchanged behavior).
- Additive and behavior-preserving: no internal importers are rewired in this change — every existing `from khora.engines.skeleton.backends import ...` keeps resolving through the shim.

## Notes
- New unit tests lock in the public surface, the deprecation warning, the identity-preserving alias, behavior round-trips, and a static import-closure purity check for the new leaf module. Full *runtime* `sys.modules` isolation additionally requires the top-level package to defer its eager engine/filter imports; that is out of scope for this additive slice and left for a later dependency-inversion change.

## Test plan
- [x] Unit tests pass (`tests/unit/core/test_temporal.py`, 7/7; full unit suite green apart from pre-existing Rust-accel parity failures unrelated to this change)
- [x] `make format` and `make lint` clean
- [ ] CI integration / e2e suites pass