### PR TITLE
Rewire internal temporal data-type imports to khora.core.temporal

### DIFF
--- a/docs/engines/hybrid-search.md
+++ b/docs/engines/hybrid-search.md
@@ -196,12 +196,12 @@ results = await engine.recall(
 After fusion, results are filtered by temporal constraints:
 
 ```python
-from khora.engines.skeleton.backends import TemporalFilter
+from khora.core.temporal import ChunkTemporalFilter
 
 results = await engine.recall(
     "project updates",
     namespace_id=namespace_id,
-    temporal_filter=TemporalFilter(
+    temporal_filter=ChunkTemporalFilter(
         occurred_after=datetime(2024, 1, 1),
         occurred_before=datetime(2024, 6, 30),
         author="alice@company.com",
@@ -232,9 +232,9 @@ Filters are converted to SQL WHERE clauses:
 ```python
 def _build_filter_conditions(
     self,
-    tf: TemporalFilter,
+    tf: ChunkTemporalFilter,
 ) -> tuple[str, dict]:
-    """Build SQL conditions from TemporalFilter."""
+    """Build SQL conditions from ChunkTemporalFilter."""
     conditions = []
     params = {}
 
@@ -270,7 +270,7 @@ async def search(
     limit: int = 10,
     hybrid_alpha: float | None = None,
     query_text: str | None = None,
-    temporal_filter: TemporalFilter | None = None,
+    temporal_filter: ChunkTemporalFilter | None = None,
 ) -> list[TemporalSearchResult]:
     """Search with optional hybrid mode."""
 
@@ -314,7 +314,7 @@ async def search(
     limit: int = 10,
     hybrid_alpha: float | None = None,
     query_text: str | None = None,
-    temporal_filter: TemporalFilter | None = None,
+    temporal_filter: ChunkTemporalFilter | None = None,
 ) -> list[TemporalSearchResult]:
     """Search using Weaviate's native hybrid."""
 

--- a/docs/engines/skeleton-engine.md
+++ b/docs/engines/skeleton-engine.md
@@ -373,7 +373,7 @@ the client fuses with Reciprocal Rank Fusion. Consequence: the
 rank-based, not score-weighted. If you need true server-blended linear
 alpha scores, stay on Weaviate.
 
-**Filter expressibility:** every `TemporalFilter` predicate compiles
+**Filter expressibility:** every `ChunkTemporalFilter` predicate compiles
 to turbopuffer's filter DSL (`Eq`, `Gte`, `Lte`, `Lt`, `In`, `Contains`,
 `ContainsAny`). The one workaround: ALL-tags semantics fold into an
 `And` of N `Contains` clauses (turbopuffer has no native `ContainsAll`).
@@ -421,13 +421,13 @@ wired into CI yet (would need a repo secret for the sandbox key).
 ### Temporal Filtering
 
 ```python
-from khora.engines.skeleton.backends import TemporalFilter
+from khora.core.temporal import ChunkTemporalFilter
 
 # By time range
 results = await engine.recall(
     "project updates",
     namespace_id=namespace_id,
-    temporal_filter=TemporalFilter(
+    temporal_filter=ChunkTemporalFilter(
         occurred_after=datetime(2024, 1, 1),
         occurred_before=datetime(2024, 3, 31),
     )
@@ -437,7 +437,7 @@ results = await engine.recall(
 results = await engine.recall(
     "decisions",
     namespace_id=namespace_id,
-    temporal_filter=TemporalFilter(
+    temporal_filter=ChunkTemporalFilter(
         author="alice@company.com",
         channel="leadership",
         tags=["important", "decision"]
@@ -448,7 +448,7 @@ results = await engine.recall(
 results = await engine.recall(
     "Q1 decisions",
     namespace_id=namespace_id,
-    temporal_filter=TemporalFilter(
+    temporal_filter=ChunkTemporalFilter(
         occurred_after=datetime(2024, 1, 1),
         occurred_before=datetime(2024, 3, 31),
         author="alice@company.com",

--- a/src/khora/engines/skeleton/backends/pgvector.py
+++ b/src/khora/engines/skeleton/backends/pgvector.py
@@ -35,12 +35,14 @@ from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 
 from khora.core.models.document import Chunk
-from khora.engines.skeleton.backends import (
+from khora.core.temporal import (
+    ChunkTemporalFilter,
     TemporalChunk,
-    TemporalFilter,
     TemporalSearchResult,
-    TemporalVectorStore,
     temporal_chunk_to_chunk,
+)
+from khora.engines.skeleton.backends import (
+    TemporalVectorStore,
 )
 from khora.filter.model import Op
 from khora.filter.report import ChannelPlan
@@ -93,7 +95,7 @@ khora_chunks_table = Table(
 )
 
 
-# Legacy ``TemporalFilter.additional`` range-op names → the canonical filter Op,
+# Legacy ``ChunkTemporalFilter.additional`` range-op names → the canonical filter Op,
 # so the deterministic-filter compiler can build a type-gated metadata compare.
 _LEGACY_RANGE_OPS: dict[str, Op] = {
     "gt": Op.GT,
@@ -405,7 +407,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
         *,
         limit: int = 10,
         min_similarity: float = 0.0,
-        temporal_filter: TemporalFilter | None = None,
+        temporal_filter: ChunkTemporalFilter | None = None,
         hybrid_alpha: float | None = None,
         query_text: str | None = None,
         filter_ast: FilterNode | None = None,
@@ -424,7 +426,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
         ``filter_ast`` is the deterministic recall-filter AST. When
         provided it is compiled to a single-table ``khora_chunks`` WHERE predicate
         and AND-ed alongside the legacy ``temporal_filter`` conditions. The two
-        coexist during the ``TemporalFilter`` deprecation window.
+        coexist during the ``ChunkTemporalFilter`` deprecation window.
         """
         with trace_span(
             "khora.temporal_store.search",
@@ -453,7 +455,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
         *,
         limit: int = 10,
         min_similarity: float = 0.0,
-        temporal_filter: TemporalFilter | None = None,
+        temporal_filter: ChunkTemporalFilter | None = None,
         hybrid_alpha: float | None = None,
         query_text: str | None = None,
         filter_ast: FilterNode | None = None,
@@ -827,8 +829,8 @@ class PgVectorTemporalStore(TemporalVectorStore):
 
         return results
 
-    def _build_filter_conditions(self, f: TemporalFilter) -> list:
-        """Build SQL conditions from TemporalFilter."""
+    def _build_filter_conditions(self, f: ChunkTemporalFilter) -> list:
+        """Build SQL conditions from ChunkTemporalFilter."""
         conditions = []
 
         if f.occurred_after:

--- a/src/khora/engines/skeleton/backends/sqlite_lance.py
+++ b/src/khora/engines/skeleton/backends/sqlite_lance.py
@@ -34,12 +34,14 @@ import pyarrow as pa
 from loguru import logger
 
 from khora.core.models.document import Chunk
-from khora.engines.skeleton.backends import (
+from khora.core.temporal import (
+    ChunkTemporalFilter,
     TemporalChunk,
-    TemporalFilter,
     TemporalSearchResult,
-    TemporalVectorStore,
     temporal_chunk_to_chunk,
+)
+from khora.engines.skeleton.backends import (
+    TemporalVectorStore,
 )
 from khora.filter.report import ChannelPlan
 from khora.storage.backends._fts5 import escape_fts5_query
@@ -387,7 +389,7 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         *,
         limit: int = 10,
         min_similarity: float = 0.0,
-        temporal_filter: TemporalFilter | None = None,
+        temporal_filter: ChunkTemporalFilter | None = None,
         hybrid_alpha: float | None = None,
         query_text: str | None = None,
         filter_ast: FilterNode | None = None,
@@ -423,7 +425,7 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         *,
         limit: int,
         min_similarity: float,
-        temporal_filter: TemporalFilter | None,
+        temporal_filter: ChunkTemporalFilter | None,
         hybrid_alpha: float | None,
         query_text: str | None,
         filter_ast: FilterNode | None = None,
@@ -519,7 +521,7 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         self,
         namespace_id: UUID,
         query_embedding: list[float],
-        temporal_filter: TemporalFilter | None,
+        temporal_filter: ChunkTemporalFilter | None,
         limit: int,
         min_similarity: float,
         filter_ast: FilterNode | None = None,
@@ -646,9 +648,9 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
                 )
             else:
                 filter_plan_out.append(ChannelPlan())
-        temporal_filter: TemporalFilter | None = None
+        temporal_filter: ChunkTemporalFilter | None = None
         if created_after is not None or created_before is not None:
-            temporal_filter = TemporalFilter(
+            temporal_filter = ChunkTemporalFilter(
                 created_after=created_after,
                 created_before=created_before,
             )
@@ -659,7 +661,7 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         self,
         namespace_id: UUID,
         query_text: str,
-        temporal_filter: TemporalFilter | None,
+        temporal_filter: ChunkTemporalFilter | None,
         limit: int,
         filter_ast: FilterNode | None = None,
         post_filter: Callable[[TemporalChunk], bool] | None = None,
@@ -764,7 +766,7 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
 
     def _build_filter_clause(
         self,
-        f: TemporalFilter | None,
+        f: ChunkTemporalFilter | None,
         *,
         alias: str | None = None,
     ) -> tuple[str, list[Any]]:

--- a/src/khora/engines/skeleton/backends/surrealdb.py
+++ b/src/khora/engines/skeleton/backends/surrealdb.py
@@ -15,12 +15,14 @@ from uuid import UUID, uuid4
 from loguru import logger
 
 from khora.core.models.document import Chunk
-from khora.engines.skeleton.backends import (
+from khora.core.temporal import (
+    ChunkTemporalFilter,
     TemporalChunk,
-    TemporalFilter,
     TemporalSearchResult,
-    TemporalVectorStore,
     temporal_chunk_to_chunk,
+)
+from khora.engines.skeleton.backends import (
+    TemporalVectorStore,
 )
 from khora.filter.model import Op
 from khora.filter.report import ChannelPlan
@@ -98,7 +100,7 @@ DEFINE INDEX IF NOT EXISTS idx_tc_embedding ON temporal_chunk FIELDS embedding H
 DEFINE INDEX IF NOT EXISTS idx_tc_content_ft ON temporal_chunk FIELDS content SEARCH ANALYZER khora_fulltext BM25;
 """
 
-# Legacy ``TemporalFilter.additional`` range-op names → the canonical filter Op,
+# Legacy ``ChunkTemporalFilter.additional`` range-op names → the canonical filter Op,
 # so the deterministic-filter compiler can build a type-gated metadata compare.
 _LEGACY_RANGE_OPS: dict[str, Op] = {
     "gt": Op.GT,
@@ -366,7 +368,7 @@ class SurrealDBTemporalStore(TemporalVectorStore):
         *,
         limit: int = 10,
         min_similarity: float = 0.0,
-        temporal_filter: TemporalFilter | None = None,
+        temporal_filter: ChunkTemporalFilter | None = None,
         hybrid_alpha: float | None = None,
         query_text: str | None = None,
         filter_ast: FilterNode | None = None,
@@ -405,7 +407,7 @@ class SurrealDBTemporalStore(TemporalVectorStore):
         *,
         limit: int = 10,
         min_similarity: float = 0.0,
-        temporal_filter: TemporalFilter | None = None,
+        temporal_filter: ChunkTemporalFilter | None = None,
         hybrid_alpha: float | None = None,
         query_text: str | None = None,
         filter_ast: FilterNode | None = None,
@@ -556,9 +558,9 @@ class SurrealDBTemporalStore(TemporalVectorStore):
         """
         if not query_text or not query_text.strip():
             return []
-        temporal_filter: TemporalFilter | None = None
+        temporal_filter: ChunkTemporalFilter | None = None
         if created_after is not None or created_before is not None:
-            temporal_filter = TemporalFilter(
+            temporal_filter = ChunkTemporalFilter(
                 created_after=created_after,
                 created_before=created_before,
             )
@@ -767,9 +769,9 @@ class SurrealDBTemporalStore(TemporalVectorStore):
     @staticmethod
     def _build_filter_clauses(
         namespace_id: UUID,
-        temporal_filter: TemporalFilter | None,
+        temporal_filter: ChunkTemporalFilter | None,
     ) -> tuple[list[str], dict[str, Any]]:
-        """Build WHERE clauses and bindings from a TemporalFilter.
+        """Build WHERE clauses and bindings from a ChunkTemporalFilter.
 
         The namespace_id may be either the row-level ``id`` or the stable
         ``namespace_id`` — we match both so the filter works regardless of
@@ -828,7 +830,7 @@ class SurrealDBTemporalStore(TemporalVectorStore):
 
         # Additional structured filters. EVERY user key is routed through the
         # deterministic-filter SurrealDB compiler so its injection guard validates
-        # each path segment (``TemporalFilter.additional`` keys are NOT
+        # each path segment (``ChunkTemporalFilter.additional`` keys are NOT
         # char-restricted upstream — interpolating one verbatim is an injection
         # surface). Range comparisons additionally get a ``type::is::*`` gate
         # (numeric ordering, not lexicographic; wrong-typed values gated out);

--- a/src/khora/engines/skeleton/backends/turbopuffer.py
+++ b/src/khora/engines/skeleton/backends/turbopuffer.py
@@ -46,10 +46,12 @@ from uuid import UUID, uuid4
 from loguru import logger
 from pydantic import SecretStr
 
-from khora.engines.skeleton.backends import (
+from khora.core.temporal import (
+    ChunkTemporalFilter,
     TemporalChunk,
-    TemporalFilter,
     TemporalSearchResult,
+)
+from khora.engines.skeleton.backends import (
     TemporalVectorStore,
 )
 from khora.filter import RecallFilterUnsupportedError
@@ -326,7 +328,7 @@ class TurbopufferTemporalStore(TemporalVectorStore):
         *,
         limit: int = 10,
         min_similarity: float = 0.0,
-        temporal_filter: TemporalFilter | None = None,
+        temporal_filter: ChunkTemporalFilter | None = None,
         hybrid_alpha: float | None = None,
         query_text: str | None = None,
         filter_ast: FilterNode | None = None,
@@ -546,8 +548,8 @@ def _coerce_datetime(value: Any) -> datetime | None:
     return None
 
 
-def _build_turbopuffer_filter(f: TemporalFilter | None) -> Any:
-    """Translate a ``TemporalFilter`` to turbopuffer's filter tuple grammar.
+def _build_turbopuffer_filter(f: ChunkTemporalFilter | None) -> Any:
+    """Translate a ``ChunkTemporalFilter`` to turbopuffer's filter tuple grammar.
 
     turbopuffer's filter language is a recursive tuple form:
         ("And", (clause1, clause2, ...))

--- a/src/khora/engines/skeleton/backends/weaviate.py
+++ b/src/khora/engines/skeleton/backends/weaviate.py
@@ -43,10 +43,12 @@ from uuid import UUID, uuid4
 from loguru import logger
 from pydantic import SecretStr
 
-from khora.engines.skeleton.backends import (
+from khora.core.temporal import (
+    ChunkTemporalFilter,
     TemporalChunk,
-    TemporalFilter,
     TemporalSearchResult,
+)
+from khora.engines.skeleton.backends import (
     TemporalVectorStore,
 )
 from khora.filter.report import ChannelPlan
@@ -439,7 +441,7 @@ class WeaviateTemporalStore(TemporalVectorStore):
         *,
         limit: int = 10,
         min_similarity: float = 0.0,
-        temporal_filter: TemporalFilter | None = None,
+        temporal_filter: ChunkTemporalFilter | None = None,
         hybrid_alpha: float | None = None,
         query_text: str | None = None,
         filter_ast: FilterNode | None = None,
@@ -460,7 +462,7 @@ class WeaviateTemporalStore(TemporalVectorStore):
            the two DATE properties ``occurred_at`` / ``created_at`` are stored as
            queryable Weaviate properties, so only date predicates push down). That
            filter is AND-ed alongside the legacy ``temporal_filter`` result and
-           passed as ``filters=``; the two coexist during the ``TemporalFilter``
+           passed as ``filters=``; the two coexist during the ``ChunkTemporalFilter``
            deprecation window.
         2. **Post-filter.** ``compile_python`` compiles the *whole* AST to an
            in-memory predicate that is re-applied to every returned chunk. Because
@@ -596,8 +598,8 @@ class WeaviateTemporalStore(TemporalVectorStore):
 
         return search_results
 
-    def _build_weaviate_filter(self, f: TemporalFilter) -> Any:
-        """Build Weaviate filter from TemporalFilter."""
+    def _build_weaviate_filter(self, f: ChunkTemporalFilter) -> Any:
+        """Build Weaviate filter from ChunkTemporalFilter."""
         from weaviate.classes.query import Filter
 
         filters = []

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -28,6 +28,11 @@ from khora.core.models import (
 )
 from khora.core.models.recall import DocumentProjection, RecallChunk
 from khora.core.recall_scoring import min_max_normalize
+from khora.core.temporal import (
+    ChunkTemporalFilter,
+    TemporalChunk,
+    document_denorm_fields,
+)
 from khora.engines._stats import gather_counts
 from khora.engines._storage_config import build_storage_config
 from khora.exceptions import EngineCapabilityError, UnsupportedEngineKwargError
@@ -39,11 +44,8 @@ from khora.storage import StorageConfig, StorageCoordinator, create_storage_coor
 from khora.telemetry import trace, trace_span
 
 from .backends import (
-    TemporalChunk,
-    TemporalFilter,
     TemporalVectorStore,
     create_temporal_store,
-    document_denorm_fields,
 )
 
 if TYPE_CHECKING:
@@ -499,7 +501,7 @@ class SkeletonConstructionEngine:
         mode: SearchMode = SearchMode.HYBRID,
         min_similarity: float = 0.0,
         # Khora-specific parameters
-        temporal_filter: TemporalFilter | None = None,
+        temporal_filter: ChunkTemporalFilter | None = None,
         temporal_reference: datetime | None = None,
         hybrid_alpha: float | None = None,
         filters: dict[str, Any] | None = None,
@@ -517,7 +519,7 @@ class SkeletonConstructionEngine:
             temporal_filter: Structured temporal filter
             temporal_reference: Reference point for relative time (e.g., message timestamp)
             hybrid_alpha: Blend factor for hybrid search (0=BM25, 1=vector)
-            filters: Additional structured filters (converted to TemporalFilter)
+            filters: Additional structured filters (converted to ChunkTemporalFilter)
             filter_ast: Canonical recall-filter AST. Threaded through to the
                 temporal store's ``search``; the pgvector backend compiles it
                 to a WHERE predicate, the other backends accept-and-ignore it.
@@ -682,8 +684,8 @@ class SkeletonConstructionEngine:
             engine_info=engine_info,
         )
 
-    def _build_temporal_filter_from_dict(self, filters: dict[str, Any]) -> TemporalFilter:
-        """Convert a filters dict to a TemporalFilter.
+    def _build_temporal_filter_from_dict(self, filters: dict[str, Any]) -> ChunkTemporalFilter:
+        """Convert a filters dict to a ChunkTemporalFilter.
 
         Example:
             filters = {
@@ -693,7 +695,7 @@ class SkeletonConstructionEngine:
             }
         """
 
-        tf = TemporalFilter()
+        tf = ChunkTemporalFilter()
 
         for key, value in filters.items():
             if not isinstance(value, dict):
@@ -759,9 +761,9 @@ class SkeletonConstructionEngine:
 
     def _adjust_relative_time(
         self,
-        temporal_filter: TemporalFilter,
+        temporal_filter: ChunkTemporalFilter,
         reference: datetime,
-    ) -> TemporalFilter:
+    ) -> ChunkTemporalFilter:
         """Adjust temporal filter for relative time references.
 
         This enables queries like "yesterday" to be relative to the message timestamp,

--- a/src/khora/engines/skeleton/skeleton.py
+++ b/src/khora/engines/skeleton/skeleton.py
@@ -20,7 +20,7 @@ from uuid import UUID
 from loguru import logger
 
 if TYPE_CHECKING:
-    from khora.engines.skeleton.backends import TemporalChunk
+    from khora.core.temporal import TemporalChunk
 
 
 @dataclass

--- a/src/khora/engines/vectorcypher/dual_nodes.py
+++ b/src/khora/engines/vectorcypher/dual_nodes.py
@@ -32,7 +32,7 @@ from khora.telemetry import trace, trace_span
 if TYPE_CHECKING:
     from neo4j import AsyncDriver, AsyncSession
 
-    from khora.engines.skeleton.backends import TemporalChunk, TemporalFilter
+    from khora.core.temporal import ChunkTemporalFilter, TemporalChunk
     from khora.filter import FilterNode
     from khora.storage.backends.neo4j import Neo4jBackend
 
@@ -470,7 +470,7 @@ class DualNodeManager:
         entity_ids: list[UUID],
         namespace_id: UUID,
         *,
-        temporal_filter: TemporalFilter | None = None,
+        temporal_filter: ChunkTemporalFilter | None = None,
         temporal_sort: bool = False,
         prefer_current: bool = False,
         limit: int = 50,

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -44,14 +44,16 @@ from khora.core.models.recall import (
     RecallRelationship,
 )
 from khora.core.recall_abstention import compute_abstention_signals
+from khora.core.temporal import (
+    ChunkTemporalFilter,
+    TemporalChunk,
+    document_denorm_fields,
+)
 from khora.engines._forget_cascade import cascade_forget_extraction
 from khora.engines._stats import gather_counts
 from khora.engines._storage_config import build_storage_config
 from khora.engines.skeleton.backends import (
-    TemporalChunk,
-    TemporalFilter,
     create_temporal_store,
-    document_denorm_fields,
 )
 from khora.engines.skeleton.skeleton import SkeletonIndexer
 from khora.exceptions import EngineCapabilityError
@@ -2095,7 +2097,7 @@ class VectorCypherEngine:
         mode: SearchMode = SearchMode.HYBRID,
         min_similarity: float = 0.0,
         # VectorCypher-specific parameters
-        temporal_filter: TemporalFilter | None = None,
+        temporal_filter: ChunkTemporalFilter | None = None,
         graph_depth: int | None = None,
         hybrid_alpha: float | None = None,
         recency_bias: float | None = None,
@@ -2177,7 +2179,7 @@ class VectorCypherEngine:
                 td_span.set_attribute("category", temporal_signal.category.value)
                 td_span.set_attribute("confidence", temporal_signal.confidence)
                 td_span.set_attribute("source", temporal_signal.source)
-                # EXPLICIT category produces a date-range TemporalFilter for pushdown
+                # EXPLICIT category produces a date-range ChunkTemporalFilter for pushdown
                 if temporal_signal.temporal_filter is not None:
                     temporal_filter = temporal_signal.temporal_filter
 
@@ -3430,10 +3432,10 @@ class VectorCypherEngine:
         re.IGNORECASE,
     )
 
-    def _detect_temporal_filter(self, query: str) -> TemporalFilter | None:
+    def _detect_temporal_filter(self, query: str) -> ChunkTemporalFilter | None:
         """Lightweight regex-based temporal detection — no LLM call.
 
-        Returns a TemporalFilter if temporal keywords and parseable dates
+        Returns a ChunkTemporalFilter if temporal keywords and parseable dates
         are found, otherwise None. Cost: ~0.25ms.
         """
         if not self._TEMPORAL_KW_RE.search(query):
@@ -3448,14 +3450,14 @@ class VectorCypherEngine:
                 # "before" / "after" / default to "around that date" (±30 days)
                 query_lower = query.lower()
                 if "before" in query_lower:
-                    return TemporalFilter(occurred_before=parsed_dt)
+                    return ChunkTemporalFilter(occurred_before=parsed_dt)
                 elif "after" in query_lower or "since" in query_lower:
-                    return TemporalFilter(occurred_after=parsed_dt)
+                    return ChunkTemporalFilter(occurred_after=parsed_dt)
                 else:
                     # Within ±30 days of the mentioned date
                     from datetime import timedelta
 
-                    return TemporalFilter(
+                    return ChunkTemporalFilter(
                         occurred_after=parsed_dt - timedelta(days=30),
                         occurred_before=parsed_dt + timedelta(days=30),
                     )

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -66,7 +66,8 @@ from .temporal_detection import (
 if TYPE_CHECKING:
     from neo4j import AsyncDriver
 
-    from khora.engines.skeleton.backends import TemporalFilter, TemporalVectorStore
+    from khora.core.temporal import ChunkTemporalFilter
+    from khora.engines.skeleton.backends import TemporalVectorStore
     from khora.extraction.embedders import EmbedderProtocol  # type: ignore[unresolved-import]
     from khora.filter import FilterNode
     from khora.query.reranking import CrossEncoderReranker, LLMReranker
@@ -315,7 +316,7 @@ class RetrieverConfig:
     #   or when ``KHORA_BENCH_MODE=true`` overrides for benchmark replay.
     # ``temporal_recency_floor_enabled``: when True, RECENCY/CHANGE queries
     #   that lack an explicit date and contain no anti-recency token receive
-    #   a synthesized ``TemporalFilter(occurred_after=now-default_window_days)``.
+    #   a synthesized ``ChunkTemporalFilter(occurred_after=now-default_window_days)``.
     # ``temporal_per_source_decay``: when True, ``_calculate_recency_scores``
     #   looks up a per-chunk decay window via
     #   ``chunk.metadata["source_system"]`` against
@@ -647,7 +648,7 @@ class VectorCypherRetriever:
         query: str,
         namespace_id: UUID,
         *,
-        temporal_filter: TemporalFilter | None = None,
+        temporal_filter: ChunkTemporalFilter | None = None,
         temporal_signal: TemporalSignal | None = None,
         graph_depth: int | None = None,
         limit: int | None = None,
@@ -758,7 +759,7 @@ class VectorCypherRetriever:
                             veto = True
 
                     if not veto:
-                        from khora.engines.skeleton.backends import TemporalFilter as _SynthTF
+                        from khora.core.temporal import ChunkTemporalFilter as _SynthTF
 
                         temporal_filter = _SynthTF(
                             occurred_after=datetime.now(UTC) - timedelta(days=params.default_window_days),
@@ -963,7 +964,7 @@ class VectorCypherRetriever:
         query: str,
         query_embedding: list[float],
         namespace_id: UUID,
-        temporal_filter: TemporalFilter | None,
+        temporal_filter: ChunkTemporalFilter | None,
         graph_depth: int | None,
         limit: int,
         routing: RoutingDecision,
@@ -1168,7 +1169,7 @@ class VectorCypherRetriever:
         query: str,
         query_embedding: list[float],
         namespace_id: UUID,
-        temporal_filter: TemporalFilter | None,
+        temporal_filter: ChunkTemporalFilter | None,
         graph_depth: int | None,
         limit: int,
         routing: RoutingDecision,
@@ -1417,7 +1418,7 @@ class VectorCypherRetriever:
                     f"Session-aware search: {len(fanout_channels)} sessions, {per_session_limit} chunks/session"
                 )
 
-                from khora.engines.skeleton.backends import TemporalFilter as _TF
+                from khora.core.temporal import ChunkTemporalFilter as _TF
 
                 session_tasks: list[asyncio.Task[list[tuple[UUID, float, Chunk]]]] = []
                 for ch in fanout_channels:
@@ -1442,7 +1443,7 @@ class VectorCypherRetriever:
                     # partitioning of the same query — it replaces the cancelled
                     # global vector task), so it carries the caller filter.
                     # filter_ast composes orthogonally with the per-session
-                    # TemporalFilter (both AND in the same conditions list).
+                    # ChunkTemporalFilter (both AND in the same conditions list).
                     session_tasks.append(
                         asyncio.create_task(
                             self._vector_search_chunks(
@@ -2291,7 +2292,7 @@ class VectorCypherRetriever:
         query: str,
         query_embedding: list[float],
         namespace_id: UUID,
-        temporal_filter: TemporalFilter | None,
+        temporal_filter: ChunkTemporalFilter | None,
         limit: int,
         routing: RoutingDecision,
         *,
@@ -2642,7 +2643,7 @@ class VectorCypherRetriever:
         query: str,
         query_embedding: list[float],
         namespace_id: UUID,
-        temporal_filter: TemporalFilter | None,
+        temporal_filter: ChunkTemporalFilter | None,
         limit: int,
         routing: RoutingDecision,
         *,
@@ -3452,7 +3453,7 @@ class VectorCypherRetriever:
         self,
         entity_ids: list[UUID],
         namespace_id: UUID,
-        temporal_filter: TemporalFilter | None,
+        temporal_filter: ChunkTemporalFilter | None,
         limit: int,
         *,
         temporal_sort: bool = False,
@@ -3569,7 +3570,7 @@ class VectorCypherRetriever:
         self,
         query_embedding: list[float],
         namespace_id: UUID,
-        temporal_filter: TemporalFilter | None,
+        temporal_filter: ChunkTemporalFilter | None,
         query_text: str,
         limit: int,
         *,
@@ -3645,7 +3646,7 @@ class VectorCypherRetriever:
         *,
         query_embedding: list[float],
         namespace_id: UUID,
-        temporal_filter: TemporalFilter | None,
+        temporal_filter: ChunkTemporalFilter | None,
         filter_ast: FilterNode | None = None,
         filter_channel_plans: dict[str, ChannelPlan] | None = None,
         degradations: list[Degradation] | None = None,

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -2136,7 +2136,7 @@ class Khora:
                 # Normalize tz: naive → UTC, aware → UTC.
                 norm_start = _normalize_recall_bound(start_time)
                 norm_end = _normalize_recall_bound(end_time)
-                from khora.engines.skeleton.backends import TemporalFilter as SkeletonTemporalFilter
+                from khora.core.temporal import ChunkTemporalFilter as SkeletonTemporalFilter
 
                 # Window-axis only: the recency bounds narrow on
                 # ``COALESCE(source_timestamp, created_at)`` inside each engine.

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -1087,7 +1087,7 @@ async def process_document(
                 if temporal_store is not None:
                     from datetime import UTC, datetime
 
-                    from khora.engines.skeleton.backends import TemporalChunk, document_denorm_fields
+                    from khora.core.temporal import TemporalChunk, document_denorm_fields
                     from khora.telemetry import trace_span
                     from khora.telemetry.temporal_metrics import record_ingestion_fallback
 

--- a/src/khora/query/temporal_detection.py
+++ b/src/khora/query/temporal_detection.py
@@ -301,8 +301,8 @@ class TemporalDetector:
         )
 
     def _extract_date_filter(self, query: str) -> Any | None:
-        """Extract a TemporalFilter from explicit date mentions in the query."""
-        from khora.engines.skeleton.backends import TemporalFilter
+        """Extract a ChunkTemporalFilter from explicit date mentions in the query."""
+        from khora.core.temporal import ChunkTemporalFilter
 
         date_match = _DATE_EXTRACT_RE.search(query)
         if not date_match:
@@ -316,12 +316,12 @@ class TemporalDetector:
 
         query_lower = query.lower()
         if "before" in query_lower:
-            return TemporalFilter(occurred_before=parsed_dt)
+            return ChunkTemporalFilter(occurred_before=parsed_dt)
         elif "after" in query_lower or "since" in query_lower:
-            return TemporalFilter(occurred_after=parsed_dt)
+            return ChunkTemporalFilter(occurred_after=parsed_dt)
         else:
             # Within ±30 days of the mentioned date
-            return TemporalFilter(
+            return ChunkTemporalFilter(
                 occurred_after=parsed_dt - timedelta(days=30),
                 occurred_before=parsed_dt + timedelta(days=30),
             )

--- a/src/khora/query/temporal_resolver.py
+++ b/src/khora/query/temporal_resolver.py
@@ -286,7 +286,7 @@ def resolve_temporal_filter(
     Parses relative date expressions ("last 7 days", "this week", "since Monday")
     into absolute datetime ranges suitable for WHERE clause filtering.
 
-    Returns a ``khora.engines.skeleton.backends.TemporalFilter`` with
+    Returns a ``khora.core.temporal.ChunkTemporalFilter`` with
     ``occurred_after`` / ``occurred_before`` set, or *None* if the query
     doesn't contain parseable temporal expressions.
 
@@ -307,7 +307,7 @@ def resolve_temporal_filter(
         resolver = TemporalResolver()
         resolved = resolver.resolve_fast(query)
         if resolved and resolved.start:
-            from khora.engines.skeleton.backends import TemporalFilter as SkeletonTemporalFilter
+            from khora.core.temporal import ChunkTemporalFilter as SkeletonTemporalFilter
 
             return SkeletonTemporalFilter(
                 occurred_after=resolved.start,
@@ -322,7 +322,7 @@ def resolve_temporal_filter(
 def to_query_temporal_filter(
     skeleton_filter: Any,
 ) -> Any | None:
-    """Convert a skeleton TemporalFilter to a ``khora.query.temporal.TemporalFilter``.
+    """Convert a ChunkTemporalFilter to a ``khora.query.temporal.TemporalFilter``.
 
     Useful for engines (VectorCypher, Chronicle) that pass the filter into
     ``HybridQueryEngine`` or ``_temporal_channel`` which read

--- a/tests/unit/core/test_temporal.py
+++ b/tests/unit/core/test_temporal.py
@@ -185,6 +185,73 @@ def test_deprecated_import_emits_warning() -> None:
     assert "khora.core.temporal" in result.stderr
 
 
+def test_no_internal_importer_uses_deprecated_path_for_moved_types() -> None:
+    """No internal module imports a relocated temporal *data type* from the
+    deprecated ``khora.engines.skeleton.backends`` path.
+
+    Locks in the import-rewire: every internal consumer must resolve
+    ``TemporalChunk`` / ``ChunkTemporalFilter`` (and its legacy ``TemporalFilter``
+    alias) / ``TemporalSearchResult`` / ``document_denorm_fields`` /
+    ``temporal_chunk_to_chunk`` from :mod:`khora.core.temporal`. If a future
+    change re-introduces an old-path import of one of these names, the module
+    re-acquires the import-time ``DeprecationWarning`` and this test fails.
+
+    The ``TemporalVectorStore`` protocol and the ``create_temporal_store``
+    factory are *not* moved types — they legitimately remain on the old path
+    until a later slice — so importing those from the shim is allowed. A static
+    scan is the right tool here because the shim warns eagerly at module-import
+    time regardless of which symbol is requested, so a runtime ``-W error``
+    import check would false-fail on the still-legal ``TemporalVectorStore``
+    imports.
+
+    The shim module itself (``.../skeleton/backends/__init__.py``) is the
+    deprecated re-export and is excluded.
+    """
+    moved_type_names = {
+        "TemporalChunk",
+        "TemporalFilter",  # legacy alias of ChunkTemporalFilter
+        "ChunkTemporalFilter",
+        "TemporalSearchResult",
+        "document_denorm_fields",
+        "temporal_chunk_to_chunk",
+    }
+    deprecated_module = "khora.engines.skeleton.backends"
+    khora_src = Path(khora.__file__).resolve().parent  # .../src/khora
+    src_root = khora_src.parent  # .../src
+    shim = (khora_src / "engines" / "skeleton" / "backends" / "__init__.py").resolve()
+
+    def _absolute_from_module(path: Path, node: ast.ImportFrom) -> str | None:
+        """Resolve an ``ImportFrom`` node to its absolute dotted module name."""
+        if not node.level:
+            return node.module
+        dotted = ".".join(path.resolve().relative_to(src_root).with_suffix("").parts)
+        # Containing package, for both a plain ``.py`` module and an
+        # ``__init__.py`` (whose dotted form already ends in ``.__init__``).
+        package = dotted.rsplit(".", 1)[0]
+        base_parts = package.split(".")
+        anchor = base_parts[: len(base_parts) - (node.level - 1)]
+        return ".".join([*anchor, node.module]) if node.module else ".".join(anchor)
+
+    offenders: list[str] = []
+    for py in khora_src.rglob("*.py"):
+        if py.resolve() == shim:
+            continue  # the shim is the re-export; it must keep the old names
+        tree = ast.parse(py.read_text(), filename=str(py))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            if _absolute_from_module(py, node) != deprecated_module:
+                continue
+            for alias in node.names:
+                if alias.name in moved_type_names:
+                    offenders.append(f"{py.relative_to(khora_src)}:{node.lineno} imports {alias.name}")
+
+    assert not offenders, (
+        "internal modules import relocated temporal data types from the deprecated "
+        "khora.engines.skeleton.backends path; rewire them to khora.core.temporal:\n  " + "\n  ".join(sorted(offenders))
+    )
+
+
 def test_legacy_alias_preserves_identity() -> None:
     """``TemporalFilter`` is the very same object as ``ChunkTemporalFilter``."""
     with warnings.catch_warnings():


### PR DESCRIPTION
## Summary
- Migrate every internal importer of the relocated temporal **data types** — `TemporalChunk`, `ChunkTemporalFilter`, `TemporalSearchResult`, `document_denorm_fields`, `temporal_chunk_to_chunk` — off the deprecated `engines/skeleton/backends` path onto the `khora.core.temporal` leaf module, adopting the `ChunkTemporalFilter` name at call sites.
- This silences the internal `DeprecationWarning` that fired whenever internal code imported a moved type from the old path.
- Behavior-preserving: pure import/name changes, no logic touched.
- The `TemporalVectorStore` **protocol** import is intentionally left on the old path (it relocates in a follow-up); the deprecated re-export shim at `engines/skeleton/backends/__init__.py` is left intact so external callers keep working.
- Touches `vectorcypher` (engine/retriever/dual_nodes), the `skeleton` engine + its five concrete backend stores, the `khora` facade, the ingest pipeline, and the temporal query helpers. Docs (`hybrid-search.md`, `skeleton-engine.md`) updated to show the new import path.

## Test plan
- [x] `make format` clean (ruff format + check)
- [x] Stale-import grep confirms no internal moved-type import remains on the old path (only `TemporalVectorStore`/`create_temporal_store` still resolve from the shim, by design)
- [x] Unit + recall suite green (9028 passed, coverage ≥ threshold)
- [x] Integration suite green (633 passed)
- [ ] CI green on all required checks