### PR TITLE
Extract core-chunk PageRank selection into khora.core.ranking

### DIFF
--- a/docs/architecture/rust-acceleration.md
+++ b/docs/architecture/rust-acceleration.md
@@ -232,8 +232,8 @@ Weighted PageRank for skeleton indexing (where ~10% of chunks are identified as 
 - **Convergence check** - Absolute diff sum checked each iteration for early termination.
 
 **Python consumers:**
-- `khora._accel.pagerank` - called by the skeleton engine's `_calculate_pagerank` (uniform init, document-time)
-- `khora._accel.build_chunk_edges` - called by the skeleton engine's `_build_chunk_edges`
+- `khora._accel.pagerank` - called by `khora.core.ranking.select_core_chunks` (uniform init, document-time)
+- `khora._accel.build_chunk_edges` - called by `khora.core.ranking.select_core_chunks`
 
 The `personalization` parameter (Issue #597) is the enabler for the HippoRAG-2 query-time graph scoring tracked in Issue #542 - seeding PPR from query entities can produce sharper passage scores than BFS + RRF on dense graphs. The actual VectorCypher swap from BFS+RRF → PPR remains gated on the graph-density audit (`scripts/audit_graph_density.py`, Issue #598) and is not enabled by default; passing `personalization=None` runs uniform PageRank.
 

--- a/docs/engines/skeleton-indexing.md
+++ b/docs/engines/skeleton-indexing.md
@@ -76,6 +76,12 @@ Chunk 3 ──── "neural"       (shared keyword)
         └─── "architecture"
 ```
 
+> **Note:** Steps 3–6 below describe the core-chunk selection algorithm. This
+> logic lives in the leaf module `khora.core.ranking`
+> (`select_core_chunks` / `select_core_chunk_ids`); `SkeletonIndexer` delegates
+> to it. The pseudocode here is illustrative of the algorithm, which is
+> unchanged.
+
 ### 3. Calculate IDF Scores
 
 ```python

--- a/src/khora/core/ranking.py
+++ b/src/khora/core/ranking.py
@@ -1,0 +1,128 @@
+"""PageRank-based core chunk selection (KET-RAG inspired).
+
+Identifies the "core" chunks of a document set via a keyword-chunk bipartite
+graph and PageRank, so an upstream caller can run full LLM extraction on only
+the highest-signal fraction of chunks.
+
+Strict-leaf module: imports only the standard library, ``khora.core``, and
+``khora._accel`` (the Rust/Python acceleration boundary). It must never import
+from ``khora.engines`` — the engines depend on this util, not the reverse.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from khora.core.temporal import TemporalChunk
+
+
+@dataclass
+class CoreSelection:
+    """Result of a core-chunk selection.
+
+    Attributes:
+        core_ids: Chunk IDs selected as core, ordered by descending PageRank
+            score (stable for ties).
+        scores: PageRank score per chunk ID, for every input chunk.
+    """
+
+    core_ids: list[UUID]
+    scores: dict[UUID, float]
+
+
+def select_core_chunks(
+    chunks: list[TemporalChunk],
+    core_ratio: float,
+    *,
+    damping_factor: float = 0.85,
+    max_iterations: int = 100,
+    convergence_threshold: float = 1e-6,
+) -> CoreSelection:
+    """Select core chunks via a keyword-chunk PageRank graph.
+
+    1. Extract keywords from each chunk (fast, no LLM).
+    2. Build a keyword-chunk bipartite graph weighted by keyword IDF.
+    3. Run PageRank to score chunks.
+    4. Select the top ``core_ratio`` fraction (at least one).
+
+    Args:
+        chunks: Chunks to rank (must carry ``.id`` and ``.content``).
+        core_ratio: Fraction of chunks to mark as core.
+        damping_factor: PageRank damping factor.
+        max_iterations: Maximum PageRank iterations.
+        convergence_threshold: PageRank convergence threshold.
+
+    Returns:
+        A :class:`CoreSelection` with the core IDs (score-descending) and the
+        per-chunk score map. Empty input yields an empty selection.
+    """
+    if not chunks:
+        return CoreSelection([], {})
+
+    from khora._accel import build_chunk_edges, extract_keywords, pagerank
+
+    # Per-chunk keyword sets, in chunk order. The keyword dict is built in
+    # first-seen order; each keyword node accumulates the chunk ids it appears
+    # in. Mirrors the original SkeletonIndexer.add_chunk insertion semantics.
+    chunk_keywords: list[set[str]] = []
+    keywords: dict[str, list[UUID]] = {}
+    for chunk in chunks:
+        kw_set = set(extract_keywords(chunk.content))
+        chunk_keywords.append(kw_set)
+        for keyword in kw_set:
+            if keyword not in keywords:
+                keywords[keyword] = []
+            keywords[keyword].append(chunk.id)
+
+    # Map chunk ids to integer indices for accelerated computation.
+    chunk_ids = [chunk.id for chunk in chunks]
+    n = len(chunk_ids)
+    chunk_idx = {cid: i for i, cid in enumerate(chunk_ids)}
+
+    # IDF per keyword: log(n_docs / (1 + df)) + 1.
+    n_docs = n
+    keyword_list = list(keywords.values())
+    keyword_chunk_ids = [[chunk_idx[cid] for cid in kw_chunk_ids if cid in chunk_idx] for kw_chunk_ids in keyword_list]
+    idf_scores = [math.log(n_docs / (1 + len(kw_chunk_ids))) + 1 for kw_chunk_ids in keyword_list]
+
+    # Build edges and run PageRank via _accel (Rust or Python fallback).
+    edges = build_chunk_edges(n, keyword_chunk_ids, idf_scores)
+    raw_scores = pagerank(n, edges, damping_factor, max_iterations, convergence_threshold)
+
+    scores = {cid: raw_scores[i] for i, cid in enumerate(chunk_ids)}
+
+    # Select the top N% by score (stable sort, descending).
+    sorted_ids = sorted(chunk_ids, key=lambda cid: scores[cid], reverse=True)
+    n_core = max(1, int(n * core_ratio))
+    core_ids = sorted_ids[:n_core]
+
+    logger.info(f"Core selection: {len(core_ids)}/{n} core chunks ({len(core_ids) / n * 100:.1f}%)")
+
+    return CoreSelection(core_ids=core_ids, scores=scores)
+
+
+def select_core_chunk_ids(
+    chunks: list[TemporalChunk],
+    core_ratio: float,
+    *,
+    damping_factor: float = 0.85,
+    max_iterations: int = 100,
+    convergence_threshold: float = 1e-6,
+) -> list[UUID]:
+    """Return just the core chunk IDs (thin wrapper over :func:`select_core_chunks`)."""
+    return select_core_chunks(
+        chunks,
+        core_ratio,
+        damping_factor=damping_factor,
+        max_iterations=max_iterations,
+        convergence_threshold=convergence_threshold,
+    ).core_ids
+
+
+__all__ = ["CoreSelection", "select_core_chunk_ids", "select_core_chunks"]

--- a/src/khora/core/ranking.py
+++ b/src/khora/core/ranking.py
@@ -67,14 +67,12 @@ def select_core_chunks(
 
     from khora._accel import build_chunk_edges, extract_keywords, pagerank
 
-    # Per-chunk keyword sets, in chunk order. The keyword dict is built in
-    # first-seen order; each keyword node accumulates the chunk ids it appears
-    # in. Mirrors the original SkeletonIndexer.add_chunk insertion semantics.
-    chunk_keywords: list[set[str]] = []
+    # Build the keyword -> chunk-ids map in first-seen order; each keyword
+    # accumulates the chunk ids it appears in. Mirrors the original
+    # SkeletonIndexer.add_chunk insertion semantics.
     keywords: dict[str, list[UUID]] = {}
     for chunk in chunks:
         kw_set = set(extract_keywords(chunk.content))
-        chunk_keywords.append(kw_set)
         for keyword in kw_set:
             if keyword not in keywords:
                 keywords[keyword] = []

--- a/src/khora/engines/skeleton/skeleton.py
+++ b/src/khora/engines/skeleton/skeleton.py
@@ -11,7 +11,6 @@ Expected cost reduction: 5-10x fewer LLM extraction calls compared to full KG.
 
 from __future__ import annotations
 
-import math
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -118,42 +117,44 @@ class SkeletonIndexer:
         if not self._chunks:
             return []
 
-        from khora._accel import build_chunk_edges, pagerank
+        import math
+        from types import SimpleNamespace
 
-        # Calculate IDF scores for keywords
-        self._calculate_idf_scores()
+        from khora.core.ranking import select_core_chunks
 
-        # Map UUIDs to integer indices for accelerated computation
-        chunk_ids = list(self._chunks.keys())
-        n = len(chunk_ids)
-        chunk_idx = {cid: i for i, cid in enumerate(chunk_ids)}
+        # Populate keyword IDF on the indexer's own keyword nodes so the
+        # keyword-search helpers (get_related_chunks / search_by_keywords) keep
+        # their IDF weighting. The ranking util computes IDF internally for the
+        # graph; this mirrors it onto the retained per-keyword state.
+        n_docs = len(self._chunks)
+        for keyword_node in self._keywords.values():
+            df = len(keyword_node.chunk_ids)
+            keyword_node.idf_score = math.log(n_docs / (1 + df)) + 1
 
-        # Build keyword data for accelerated edge construction
-        keyword_list = list(self._keywords.values())
-        keyword_chunk_ids = [
-            [chunk_idx[cid] for cid in kw_node.chunk_ids if cid in chunk_idx] for kw_node in keyword_list
-        ]
-        idf_scores = [kw_node.idf_score for kw_node in keyword_list]
-
-        # Build edges via _accel (Rust or Python fallback)
-        edges = build_chunk_edges(n, keyword_chunk_ids, idf_scores)
-
-        # Run PageRank via _accel (Rust or Python fallback)
-        scores = pagerank(n, edges, self._damping_factor, self._max_iterations, self._convergence_threshold)
-
-        # Store scores back to chunk nodes
-        for i, cid in enumerate(chunk_ids):
-            self._chunks[cid].pagerank_score = scores[i]
-
-        # Select core chunks
-        core_ids = self._select_core_chunks()
-
-        logger.info(
-            f"Skeleton built: {len(core_ids)}/{len(self._chunks)} core chunks "
-            f"({len(core_ids) / len(self._chunks) * 100:.1f}%)"
+        # Rank the accumulated chunks in insertion order. The util re-derives
+        # keywords / IDF / edges from chunk content, so the ChunkNode carriers
+        # only need to expose ``.id`` / ``.content``.
+        carriers = [SimpleNamespace(id=node.chunk_id, content=node.content) for node in self._chunks.values()]
+        result = select_core_chunks(
+            carriers,
+            self._core_ratio,
+            damping_factor=self._damping_factor,
+            max_iterations=self._max_iterations,
+            convergence_threshold=self._convergence_threshold,
         )
 
-        return core_ids
+        # Repopulate node state from the result.
+        core_set = set(result.core_ids)
+        for cid, node in self._chunks.items():
+            node.pagerank_score = result.scores.get(cid, 0.0)
+            node.is_core = cid in core_set
+
+        logger.info(
+            f"Skeleton built: {len(result.core_ids)}/{len(self._chunks)} core chunks "
+            f"({len(result.core_ids) / len(self._chunks) * 100:.1f}%)"
+        )
+
+        return result.core_ids
 
     def get_core_chunks(self) -> list[UUID]:
         """Get list of core chunk IDs.
@@ -444,117 +445,6 @@ class SkeletonIndexer:
         from khora._accel import extract_keywords
 
         return set(extract_keywords(content))
-
-    def _calculate_idf_scores(self) -> None:
-        """Calculate IDF scores for all keywords."""
-        n_docs = len(self._chunks)
-        if n_docs == 0:
-            return
-
-        for keyword_node in self._keywords.values():
-            df = len(keyword_node.chunk_ids)
-            keyword_node.idf_score = math.log(n_docs / (1 + df)) + 1
-
-    def _build_chunk_edges(self) -> dict[UUID, list[tuple[UUID, float]]]:
-        """Build weighted edges between chunks via shared keywords.
-
-        Returns:
-            Dict mapping chunk_id -> list of (neighbor_id, weight)
-        """
-        edges: dict[UUID, list[tuple[UUID, float]]] = defaultdict(list)
-
-        # For each keyword, connect all chunks that share it
-        for keyword_node in self._keywords.values():
-            chunk_list = list(keyword_node.chunk_ids)
-            weight = keyword_node.idf_score
-
-            for i, cid1 in enumerate(chunk_list):
-                for cid2 in chunk_list[i + 1 :]:
-                    edges[cid1].append((cid2, weight))
-                    edges[cid2].append((cid1, weight))
-
-        return edges
-
-    def _calculate_pagerank(
-        self,
-        edges: dict[UUID, list[tuple[UUID, float]]],
-    ) -> None:
-        """Calculate PageRank scores for all chunks."""
-        if not self._chunks:
-            return
-
-        n = len(self._chunks)
-        chunk_ids = list(self._chunks.keys())
-
-        # Initialize scores
-        scores = {cid: 1.0 / n for cid in chunk_ids}
-
-        # Calculate out-degree (sum of weights)
-        out_degree: dict[UUID, float] = {}
-        for cid in chunk_ids:
-            if cid in edges:
-                out_degree[cid] = sum(w for _, w in edges[cid])
-            else:
-                out_degree[cid] = 0.0
-
-        # Iterative PageRank
-        d = self._damping_factor
-        base = (1 - d) / n
-
-        for iteration in range(self._max_iterations):
-            new_scores: dict[UUID, float] = {}
-            diff = 0.0
-
-            for cid in chunk_ids:
-                # Sum contributions from neighbors
-                contrib = 0.0
-                if cid in edges:
-                    for neighbor_id, weight in edges[cid]:
-                        if out_degree[neighbor_id] > 0:
-                            contrib += scores[neighbor_id] * weight / out_degree[neighbor_id]
-
-                new_score = base + d * contrib
-                diff += abs(new_score - scores[cid])
-                new_scores[cid] = new_score
-
-            scores = new_scores
-
-            if diff < self._convergence_threshold:
-                logger.debug(f"PageRank converged after {iteration + 1} iterations")
-                break
-
-        # Store scores
-        for cid, score in scores.items():
-            self._chunks[cid].pagerank_score = score
-
-    def _select_core_chunks(self) -> list[UUID]:
-        """Select core chunks based on PageRank scores.
-
-        Returns:
-            List of core chunk IDs
-        """
-        if not self._chunks:
-            return []
-
-        # Sort by PageRank score
-        sorted_chunks = sorted(
-            self._chunks.items(),
-            key=lambda x: x[1].pagerank_score,
-            reverse=True,
-        )
-
-        # Select top N%
-        n_core = max(1, int(len(sorted_chunks) * self._core_ratio))
-        core_ids = []
-
-        for i, (cid, node) in enumerate(sorted_chunks):
-            if i < n_core:
-                node.is_core = True
-                core_ids.append(cid)
-            else:
-                node.is_core = False
-
-        return core_ids
 
 
 class LazyEntityExpander:

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -43,6 +43,7 @@ from khora.core.models.recall import (
     RecallEntity,
     RecallRelationship,
 )
+from khora.core.ranking import select_core_chunk_ids
 from khora.core.recall_abstention import compute_abstention_signals
 from khora.core.temporal import (
     ChunkTemporalFilter,
@@ -55,7 +56,6 @@ from khora.engines._storage_config import build_storage_config
 from khora.engines.skeleton.backends import (
     create_temporal_store,
 )
-from khora.engines.skeleton.skeleton import SkeletonIndexer
 from khora.exceptions import EngineCapabilityError
 from khora.extraction.embedders import LiteLLMEmbedder
 from khora.khora import BatchResult, RecallResult, RememberResult, Stats
@@ -1370,14 +1370,14 @@ class VectorCypherEngine:
             if len(chunks) <= 2:
                 core_ids = {c.id for c in chunks}
             else:
-                skeleton = SkeletonIndexer(core_ratio=self._vc_config.skeleton_core_ratio)
-                skeleton.add_chunks_batch(chunks)
                 with trace_span(
                     "khora.vectorcypher.skeleton_build",
                     chunk_count=len(chunks),
                     core_ratio=self._vc_config.skeleton_core_ratio,
                 ):
-                    core_ids = await asyncio.to_thread(skeleton.build_skeleton)
+                    core_ids = await asyncio.to_thread(
+                        select_core_chunk_ids, chunks, self._vc_config.skeleton_core_ratio
+                    )
 
             logger.debug(f"Skeleton indexing: {len(core_ids)}/{len(chunks)} core chunks")
             span.set_attribute("core_chunks", len(core_ids))
@@ -1552,14 +1552,12 @@ class VectorCypherEngine:
             core_ids = {c.id for c in chunks}
         else:
             effective_ratio = skeleton_ratio_override or self._vc_config.skeleton_core_ratio
-            skeleton = SkeletonIndexer(core_ratio=effective_ratio)
-            skeleton.add_chunks_batch(chunks)
             with trace_span(
                 "khora.vectorcypher.skeleton_build",
                 chunk_count=len(chunks),
                 core_ratio=effective_ratio,
             ):
-                core_ids = await asyncio.to_thread(skeleton.build_skeleton)
+                core_ids = await asyncio.to_thread(select_core_chunk_ids, chunks, effective_ratio)
 
         logger.debug(f"Skeleton indexing (deferred): {len(core_ids)}/{len(chunks)} core chunks")
 
@@ -1740,7 +1738,6 @@ class VectorCypherEngine:
             if len(new_chunks) <= 2:
                 core_chunks = new_chunks
             else:
-                skeleton = SkeletonIndexer(core_ratio=self._vc_config.skeleton_core_ratio)
                 skeleton_input = [
                     TemporalChunk(
                         id=c.id,
@@ -1754,8 +1751,9 @@ class VectorCypherEngine:
                     )
                     for c in new_chunks
                 ]
-                skeleton.add_chunks_batch(skeleton_input)
-                core_ids = await asyncio.to_thread(skeleton.build_skeleton)
+                core_ids = await asyncio.to_thread(
+                    select_core_chunk_ids, skeleton_input, self._vc_config.skeleton_core_ratio
+                )
                 core_chunks = [c for c in new_chunks if c.id in core_ids]
 
             if core_chunks:
@@ -3011,9 +3009,7 @@ class VectorCypherEngine:
                         core_ids = {c.id for c in doc_chunks}
                     else:
                         effective_ratio = skeleton_ratio or self._vc_config.skeleton_core_ratio
-                        skeleton = SkeletonIndexer(core_ratio=effective_ratio)
-                        skeleton.add_chunks_batch(doc_chunks)
-                        core_ids = await asyncio.to_thread(skeleton.build_skeleton)
+                        core_ids = await asyncio.to_thread(select_core_chunk_ids, doc_chunks, effective_ratio)
 
                     for tc in doc_chunks:
                         if tc.id in core_ids:

--- a/tests/unit/core/test_ranking.py
+++ b/tests/unit/core/test_ranking.py
@@ -1,0 +1,222 @@
+"""Unit tests for the leaf core-chunk ranking util ``khora.core.ranking``.
+
+The util was extracted from ``SkeletonIndexer.build_skeleton`` (task #29). These
+tests lock in:
+
+* **Parity** — ``select_core_chunk_ids`` returns exactly the same core ids, in
+  the same order, as the legacy ``SkeletonIndexer`` path, including the
+  insertion-order tie-break under identical-content (tied-score) chunks.
+* **CoreSelection** shape — ``scores`` covers every input id (floats),
+  ``core_ids`` is a score-descending top-n subset of size ``max(1, int(n*r))``.
+* The thin wrapper equals ``CoreSelection.core_ids``.
+* Edge cases — empty input and single-chunk input.
+* ``SkeletonIndexer`` delegation — ``get_core_chunks`` / ``is_core_chunk`` /
+  ``get_pagerank_score`` still behave correctly after ``build_skeleton``.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from khora.core.ranking import CoreSelection, select_core_chunk_ids, select_core_chunks
+from khora.core.temporal import TemporalChunk
+from khora.engines.skeleton.skeleton import SkeletonIndexer
+
+_NS = uuid4()
+_DOC = uuid4()
+
+
+def _chunk(content: str) -> TemporalChunk:
+    """Build a TemporalChunk with a fresh uuid4 id and the given content."""
+    return TemporalChunk(
+        id=uuid4(),
+        namespace_id=_NS,
+        document_id=_DOC,
+        content=content,
+    )
+
+
+def _varied_chunks() -> list[TemporalChunk]:
+    """A fixed, varied multi-chunk input (>= 7 chunks) for parity testing."""
+    return [
+        _chunk("The quick brown fox jumps over the lazy dog near the river bank."),
+        _chunk("Machine learning models require large datasets for effective training."),
+        _chunk("PostgreSQL provides robust transactional guarantees and indexing."),
+        _chunk("The river bank flooded after heavy rain caused the dog to flee."),
+        _chunk("Neural networks learn hierarchical feature representations from data."),
+        _chunk("Vector search retrieves nearest neighbors using cosine similarity."),
+        _chunk("Knowledge graphs encode entities and relationships as nodes and edges."),
+        _chunk("The lazy dog slept while the quick fox hunted near the river."),
+        _chunk("Embeddings map text into a dense continuous vector space for search."),
+    ]
+
+
+def _legacy_core_ids(chunks: list[TemporalChunk], ratio: float) -> list[UUID]:
+    """Run the OLD SkeletonIndexer path and return its core ids."""
+    indexer = SkeletonIndexer(core_ratio=ratio)
+    indexer.add_chunks_batch(chunks)
+    return indexer.build_skeleton()
+
+
+# ---------------------------------------------------------------------------
+# Parity (most important)
+# ---------------------------------------------------------------------------
+
+
+def test_parity_varied_chunks_same_ids_and_order() -> None:
+    """Util core ids EQUAL legacy core ids — same elements AND same order."""
+    chunks = _varied_chunks()
+    ratio = 0.4
+
+    legacy = _legacy_core_ids(chunks, ratio)
+    util = select_core_chunk_ids(chunks, ratio)
+
+    assert util == legacy, f"order/element mismatch: util={util} legacy={legacy}"
+
+
+def test_parity_tied_scores_insertion_order_tiebreak() -> None:
+    """Identical-content chunks tie on score; insertion order must be the
+    tie-break, identically across both paths."""
+    # Several identical-content chunks plus a couple of distinct ones. The
+    # identical chunks score equally, so ordering among them is decided purely
+    # by the stable sort over the input (insertion) order.
+    chunks = [
+        _chunk("identical content shared across several tied chunks here"),
+        _chunk("identical content shared across several tied chunks here"),
+        _chunk("identical content shared across several tied chunks here"),
+        _chunk("identical content shared across several tied chunks here"),
+        _chunk("a wholly different sentence about databases and indexes"),
+        _chunk("another distinct sentence concerning vectors and embeddings"),
+        _chunk("identical content shared across several tied chunks here"),
+    ]
+    ratio = 0.5
+
+    legacy = _legacy_core_ids(chunks, ratio)
+    util = select_core_chunk_ids(chunks, ratio)
+
+    assert util == legacy, f"tie-break mismatch: util={util} legacy={legacy}"
+
+
+def test_parity_default_ratio() -> None:
+    """Parity holds at the SkeletonIndexer default core_ratio (0.1)."""
+    chunks = _varied_chunks()
+    ratio = 0.1
+
+    legacy = _legacy_core_ids(chunks, ratio)
+    util = select_core_chunk_ids(chunks, ratio)
+
+    assert util == legacy
+
+
+# ---------------------------------------------------------------------------
+# CoreSelection shape
+# ---------------------------------------------------------------------------
+
+
+def test_core_selection_scores_cover_every_input_id() -> None:
+    chunks = _varied_chunks()
+    result = select_core_chunks(chunks, 0.4)
+
+    input_ids = {c.id for c in chunks}
+    assert set(result.scores.keys()) == input_ids
+    assert all(isinstance(v, float) for v in result.scores.values())
+
+
+def test_core_selection_core_ids_subset_and_size() -> None:
+    chunks = _varied_chunks()
+    ratio = 0.4
+    n = len(chunks)
+    result = select_core_chunks(chunks, ratio)
+
+    assert set(result.core_ids).issubset(set(result.scores.keys()))
+    assert len(result.core_ids) == max(1, int(n * ratio))
+
+
+def test_core_selection_core_ids_are_top_n_by_score() -> None:
+    """core_ids are the highest-scoring ids, in descending score order."""
+    chunks = _varied_chunks()
+    result = select_core_chunks(chunks, 0.5)
+
+    core_scores = [result.scores[cid] for cid in result.core_ids]
+    # Descending.
+    assert core_scores == sorted(core_scores, reverse=True)
+    # No non-core chunk outscores the lowest core chunk.
+    non_core = [s for cid, s in result.scores.items() if cid not in set(result.core_ids)]
+    if non_core:
+        assert min(core_scores) >= max(non_core)
+
+
+# ---------------------------------------------------------------------------
+# Thin wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_thin_wrapper_equals_core_selection_core_ids() -> None:
+    chunks = _varied_chunks()
+    ratio = 0.4
+
+    full = select_core_chunks(chunks, ratio)
+    wrapper = select_core_chunk_ids(chunks, ratio)
+
+    assert wrapper == full.core_ids
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_input_returns_empty_selection() -> None:
+    result = select_core_chunks([], 0.4)
+    assert result == CoreSelection([], {})
+    assert select_core_chunk_ids([], 0.4) == []
+
+
+def test_single_chunk_yields_exactly_one_core() -> None:
+    chunks = [_chunk("a single lonely chunk with some words in it")]
+    result = select_core_chunks(chunks, 0.1)  # 0.1 * 1 == 0 -> max(1, 0) == 1
+
+    assert len(result.core_ids) == 1
+    assert result.core_ids[0] == chunks[0].id
+    assert set(result.scores.keys()) == {chunks[0].id}
+
+
+# ---------------------------------------------------------------------------
+# SkeletonIndexer delegation
+# ---------------------------------------------------------------------------
+
+
+def test_skeleton_delegation_state_after_build() -> None:
+    """After build_skeleton, the indexer's per-chunk state reflects the util's
+    result: core flags, pagerank scores, and the lookup helpers."""
+    chunks = _varied_chunks()
+    ratio = 0.4
+
+    indexer = SkeletonIndexer(core_ratio=ratio)
+    indexer.add_chunks_batch(chunks)
+    core_ids = indexer.build_skeleton()
+
+    # get_core_chunks matches the returned core ids (set-wise).
+    assert set(indexer.get_core_chunks()) == set(core_ids)
+
+    # is_core_chunk: True for core ids, False otherwise.
+    core_set = set(core_ids)
+    for c in chunks:
+        assert indexer.is_core_chunk(c.id) == (c.id in core_set)
+
+    # get_pagerank_score matches the util's scores for the same input.
+    util_scores = select_core_chunks(chunks, ratio).scores
+    for c in chunks:
+        assert indexer.get_pagerank_score(c.id) == util_scores[c.id]
+
+
+def test_skeleton_delegation_unknown_id_defaults() -> None:
+    """Helpers degrade gracefully for an id never added to the indexer."""
+    chunks = _varied_chunks()
+    indexer = SkeletonIndexer(core_ratio=0.4)
+    indexer.add_chunks_batch(chunks)
+    indexer.build_skeleton()
+
+    missing = uuid4()
+    assert indexer.is_core_chunk(missing) is False
+    assert indexer.get_pagerank_score(missing) == 0.0


### PR DESCRIPTION
## Summary
- Add a new leaf module `khora.core.ranking` that owns the core-chunk selection capability (keyword extraction + IDF + bipartite keyword↔chunk graph + PageRank + top-ratio selection). It exposes `CoreSelection(core_ids, scores)`, `select_core_chunks(...)` returning both the selected ids and the per-chunk PageRank scores, and a `select_core_chunk_ids(...)` thin wrapper for callers that only need the ids. The module imports only the standard library and `khora._accel` — never `khora.engines`.
- Rewire `vectorcypher/engine.py` to call `select_core_chunk_ids(...)` directly at all four extraction sites and drop its `SkeletonIndexer` import, removing the engine→skeleton dependency edge.
- `SkeletonIndexer.build_skeleton()` now delegates core-selection to the same util and repopulates per-node `pagerank_score` / `is_core` so `get_pagerank_score()` / `is_core_chunk()` / `get_core_chunks()` keep returning correct values. The now-dead private PageRank/edge/IDF/select helpers are removed; the keyword-search helpers retain their IDF weighting.
- Selection output is byte-for-byte identical to the previous `SkeletonIndexer` path: same insertion-order traversal and stable score-descending sort (tie-breaking preserved).

## Test plan
- [x] Unit tests pass — new `tests/unit/core/test_ranking.py` (parity vs. the old `SkeletonIndexer` path including a tied-score case, `CoreSelection` score map, thin-wrapper equality, empty/single-chunk edge cases) plus the existing skeleton suite (31 passed: 20 skeleton + 11 ranking).
- [x] Lint/format clean (`make format`, `make lint`).
- [ ] Full CI suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized PageRank-based “core chunk” ranking utility for selecting the most relevant chunks.

* **Refactoring**
  * Updated skeleton indexing to delegate core chunk selection to the new ranking utility.
  * Updated vector-based cypher engine to use the shared core chunk selection helper across extraction and deferred updates.

* **Tests**
  * Added unit tests validating parity with the legacy selection behavior and covering empty/single-chunk scenarios.

* **Documentation**
  * Refreshed architecture docs to reflect the new core ranking flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->