### PR TITLE
Add integration tests for core temporal and ranking relocation

### DIFF
--- a/tests/unit/core/test_ranking.py
+++ b/tests/unit/core/test_ranking.py
@@ -108,6 +108,33 @@ def test_parity_default_ratio() -> None:
     assert util == legacy
 
 
+def test_parity_two_chunk_ids_and_scores() -> None:
+    """The n==2 small-doc case: util matches legacy on BOTH ids and scores.
+
+    The two-chunk path is the smallest case the engine's len<=2 fast path
+    guards; this pins core-id ordering AND the per-chunk PageRank score map
+    against the legacy ``SkeletonIndexer`` (real ``khora._accel``, not mocked).
+    """
+    chunks = [
+        _chunk("Machine learning models require large datasets for training."),
+        _chunk("PostgreSQL provides transactional guarantees and rich indexing."),
+    ]
+    ratio = 0.5
+
+    indexer = SkeletonIndexer(core_ratio=ratio)
+    indexer.add_chunks_batch(chunks)
+    legacy_ids = indexer.build_skeleton()
+
+    result = select_core_chunks(chunks, ratio)
+
+    # Core-id ordering parity.
+    assert result.core_ids == legacy_ids
+
+    # Per-chunk score parity against the legacy indexer's node state.
+    for c in chunks:
+        assert result.scores[c.id] == indexer.get_pagerank_score(c.id)
+
+
 # ---------------------------------------------------------------------------
 # CoreSelection shape
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/test_ranking.py
+++ b/tests/unit/core/test_ranking.py
@@ -111,9 +111,11 @@ def test_parity_default_ratio() -> None:
 def test_parity_two_chunk_ids_and_scores() -> None:
     """The n==2 small-doc case: util matches legacy on BOTH ids and scores.
 
-    The two-chunk path is the smallest case the engine's len<=2 fast path
-    guards; this pins core-id ordering AND the per-chunk PageRank score map
-    against the legacy ``SkeletonIndexer`` (real ``khora._accel``, not mocked).
+    Two chunks is the boundary at which callers (e.g. the VectorCypher engine)
+    skip skeleton selection entirely; the ranking util itself has no small-n
+    shortcut and runs full PageRank here. This pins core-id ordering AND the
+    per-chunk PageRank score map against the legacy ``SkeletonIndexer`` (real
+    ``khora._accel``, not mocked).
     """
     chunks = [
         _chunk("Machine learning models require large datasets for training."),

--- a/tests/unit/core/test_temporal.py
+++ b/tests/unit/core/test_temporal.py
@@ -161,6 +161,116 @@ def test_leaf_purity_static_import_closure() -> None:
     )
 
 
+def test_leaf_purity_runtime_isolated_import() -> None:
+    """``khora.core.temporal``'s OWN closure loads with backends poisoned.
+
+    Runtime complement to the static-AST closure test. In a fresh
+    subprocess we poison ``sys.modules`` so any real import of an engine,
+    the recall-filter, or a DB driver raises, seed bare package stubs for
+    ``khora`` / ``khora.core`` / ``khora.core.models`` (so the import does
+    NOT execute the eager top-level ``khora/__init__.py``), then load the
+    real source of ``khora.core.temporal`` and its one declared dependency
+    ``khora.core.models.document`` and assert they import cleanly and that
+    no poisoned module was actually pulled in.
+
+    Why the stub seeding: a bare ``import khora.core.temporal`` TODAY would
+    execute ``khora/__init__.py``, which eagerly imports ``khora.engines`` /
+    ``khora.filter`` (dragging sqlalchemy in) — so a naive poisoned import
+    would fail on the *parent package*, not on the leaf module. Full runtime
+    ``sys.modules`` isolation for a bare import awaits a later
+    dependency-inversion slice that makes the top-level package lazy; until
+    then this test proves the achievable guarantee — the module's own import
+    closure is genuinely leaf-pure at runtime, not just statically.
+    """
+    script = textwrap.dedent(
+        """
+        import importlib.util
+        import sys
+        import types
+        from pathlib import Path
+
+        import khora  # locate the source tree only
+
+        src_root = Path(khora.__file__).resolve().parent  # .../src/khora
+
+        heavy = ["khora.engines", "khora.filter", "sqlalchemy", "neo4j", "lancedb", "surrealdb"]
+
+        # Drop every khora.* + heavy module so package state rebuilds cleanly.
+        heavy_roots = {"sqlalchemy", "neo4j", "lancedb", "surrealdb"}
+        for name in list(sys.modules):
+            if name == "khora" or name.startswith("khora.") or name.split(".")[0] in heavy_roots:
+                del sys.modules[name]
+
+        # Poison: importing any heavy module now raises ImportError.
+        for h in heavy:
+            sys.modules[h] = None
+
+        # Seed bare package stubs so importing a submodule does NOT run the
+        # eager khora/__init__.py.
+        def _seed_pkg(dotted, path):
+            mod = types.ModuleType(dotted)
+            mod.__path__ = [str(path)]
+            mod.__package__ = dotted
+            sys.modules[dotted] = mod
+
+        _seed_pkg("khora", src_root)
+        _seed_pkg("khora.core", src_root / "core")
+        _seed_pkg("khora.core.models", src_root / "core" / "models")
+
+        def _load(dotted, file):
+            spec = importlib.util.spec_from_file_location(dotted, file)
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules[dotted] = mod
+            spec.loader.exec_module(mod)
+            return mod
+
+        _load("khora.core.models.document", src_root / "core" / "models" / "document.py")
+        temporal = _load("khora.core.temporal", src_root / "core" / "temporal.py")
+
+        assert hasattr(temporal, "TemporalChunk")
+        assert hasattr(temporal, "ChunkTemporalFilter")
+        leaked = [h for h in heavy if isinstance(sys.modules.get(h), types.ModuleType)]
+        assert not leaked, f"heavy modules imported: {leaked}"
+        """
+    )
+    result = subprocess.run(  # noqa: S603 — test harness, sys.executable is trusted
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"isolated leaf import failed:\nstdout: {result.stdout.strip()}\nstderr: {result.stderr.strip()}"
+    )
+
+
+def test_deprecated_re_exports_all_five_names_resolve() -> None:
+    """All five relocated names resolve from the deprecated shim path.
+
+    Complements :func:`test_legacy_alias_preserves_identity` (which only
+    checks ``TemporalFilter``) and :func:`test_deprecated_import_emits_warning`
+    (which owns the warning guarantee via a fresh subprocess — asserting it
+    again here would be flaky, since the shim is module-cached and only warns
+    on first import). Here we just assert every relocated name is reachable as
+    an attribute of the shim, and that ``TemporalFilter`` is the very
+    ``khora.core.temporal.ChunkTemporalFilter`` object.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        import khora.engines.skeleton.backends as shim
+
+    for name in (
+        "TemporalChunk",
+        "TemporalFilter",
+        "TemporalSearchResult",
+        "document_denorm_fields",
+        "temporal_chunk_to_chunk",
+    ):
+        assert hasattr(shim, name), f"{name} not re-exported from the deprecated shim"
+
+    assert shim.TemporalFilter is ChunkTemporalFilter
+
+
 def test_deprecated_import_emits_warning() -> None:
     """Importing the relocated names from the old path raises under -W error.
 


### PR DESCRIPTION
## Summary
- Add a runtime leaf-purity test that loads the neutral temporal module's own import closure in an isolated subprocess (heavy backends/DB drivers poisoned, bare package stubs seeded to bypass the eager top-level package init) and asserts none are pulled in. Complements the existing static-AST closure check; documents that full bare-import isolation awaits the later package-laziness work.
- Add a test asserting all five relocated temporal names resolve through the deprecated re-export shim and that the legacy filter alias preserves object identity with the relocated type.
- Add a two-chunk PageRank golden-parity test pinning both core-id ordering and the per-chunk score map against the legacy skeleton indexer, exercising the real native acceleration path (not mocked).

All changes are test-only; no production source is modified.

## Test plan
- [x] Unit tests pass (`tests/unit/core/test_temporal.py`, `tests/unit/core/test_ranking.py`, `tests/unit/test_accel.py`)
- [x] Embedded VectorCypher temporal e2e lane passes unchanged
- [x] Full `make test` suite green; `make lint` / `make format` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for ranking parity verification at the two-chunk boundary, including score correctness
  * Added runtime import-isolation tests to confirm temporal modules load correctly even when related heavy modules are unavailable
  * Added shim-path compatibility checks to ensure relocated temporal symbols and filter objects resolve consistently
<!-- end of auto-generated comment: release notes by coderabbit.ai -->