### PR TITLE
Add StorageCoordinator.temporal_store() factory accessor

### DIFF
--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -36,7 +36,9 @@ from khora.storage.backends.base import PaginatedResult
 from khora.telemetry import get_collector, metric_counter, trace_span
 
 if TYPE_CHECKING:
+    from khora.config.schema import KhoraConfig
     from khora.filter.ast import FilterNode
+    from khora.storage.temporal import TemporalVectorStore
 
     from .backends.base import (
         EventStoreProtocol,
@@ -381,6 +383,74 @@ class StorageCoordinator:
             raise
         finally:
             await session.close()
+
+    async def temporal_store(
+        self,
+        backend: str,
+        config: KhoraConfig,
+        *,
+        weaviate_url: str | Any | None = None,
+        turbopuffer_config: str | Any | None = None,
+    ) -> TemporalVectorStore:
+        """Build a connected ``TemporalVectorStore`` for ``backend``.
+
+        Factory method (not an accessor): every call returns a fresh,
+        already-``connect()``-ed store. The instance is intentionally NOT
+        cached on the coordinator — callers own its lifecycle and must
+        disconnect it.
+
+        Backend selection is delegated to
+        :func:`khora.storage.temporal.create_temporal_store` (imported
+        lazily so optional backend dependencies stay lazy). The coordinator
+        only gathers the per-backend shared resource so the store reuses the
+        coordinator's existing connections instead of opening its own:
+
+        - ``pgvector``: shares the coordinator's SQLAlchemy engine (vector
+          adapter's, falling back to the relational adapter's) so the
+          connection pool is not doubled.
+        - ``surrealdb``: shares the coordinator's ``SurrealDBConnection``.
+          Embedded ``surrealkv://`` allows only one open handle per
+          directory, so a second connection would fail on first write.
+        - ``sqlite_lance``: shares the vector adapter's
+          ``EmbeddedStorageHandle`` (single aiosqlite + LanceDB pair).
+        - ``weaviate`` / ``turbopuffer``: pass through the caller-supplied
+          connection config. ``weaviate``/``turbopuffer`` require their
+          respective config kwarg; the factory raises ``ValueError`` if it
+          is missing.
+        """
+        from khora.storage.temporal import create_temporal_store
+
+        shared_pg_engine = None
+        surrealdb_connection = None
+        sqlite_lance_handle = None
+
+        if backend == "pgvector":
+            if self._vector is not None:
+                shared_pg_engine = getattr(self._vector, "_engine", None)
+            if shared_pg_engine is None and self._relational is not None:
+                shared_pg_engine = getattr(self._relational, "_engine", None)
+        elif backend == "surrealdb":
+            if self._relational is not None:
+                surrealdb_connection = getattr(self._relational, "_conn", None)
+        elif backend == "sqlite_lance":
+            if self._vector is None:
+                raise RuntimeError("sqlite_lance backend requires a vector adapter on the coordinator")
+            sqlite_lance_handle = getattr(self._vector, "_handle", None)
+            if sqlite_lance_handle is None:
+                raise RuntimeError("sqlite_lance vector adapter is missing its EmbeddedStorageHandle")
+
+        store = create_temporal_store(
+            backend,
+            config,
+            weaviate_url=weaviate_url,
+            turbopuffer_config=turbopuffer_config,
+            surrealdb_config=config.storage.surrealdb if backend == "surrealdb" else None,
+            surrealdb_connection=surrealdb_connection,
+            engine=shared_pg_engine,
+            sqlite_lance_handle=sqlite_lance_handle,
+        )
+        await store.connect()
+        return store
 
     # =========================================================================
     # Tenancy operations (delegated to relational)

--- a/tests/unit/test_coordinator_temporal_store.py
+++ b/tests/unit/test_coordinator_temporal_store.py
@@ -1,0 +1,226 @@
+"""Unit tests for StorageCoordinator.temporal_store() backend wiring.
+
+The coordinator's ``temporal_store()`` is a factory that delegates backend
+selection to ``khora.storage.temporal.create_temporal_store`` (imported lazily
+at call time) and only gathers the per-backend shared resource so the temporal
+store reuses the coordinator's existing connections. These tests assert the
+kwargs forwarded for each backend, the error guards, and the factory semantics
+(connected once, never cached).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from khora.config import KhoraConfig
+from khora.storage.coordinator import StorageCoordinator
+
+
+@pytest.fixture
+def config() -> KhoraConfig:
+    """A real KhoraConfig (offline, no DB)."""
+    return KhoraConfig(app_name="khora-test", environment="test", debug=True)
+
+
+def _make_store() -> MagicMock:
+    """A mock temporal store whose connect() is an awaitable."""
+    store = MagicMock(name="temporal_store")
+    store.connect = AsyncMock()
+    return store
+
+
+def _coordinator(*, vector=None, relational=None) -> StorageCoordinator:
+    """Build a coordinator with the given (raw) adapters.
+
+    Passing ``vector=`` / ``relational=`` routes through ``__setattr__`` which
+    sets ``_vector`` / ``_relational`` to the raw object, which is what
+    ``temporal_store`` reads via ``getattr(self._vector, "_engine", ...)``.
+    """
+    return StorageCoordinator(relational=relational, vector=vector)
+
+
+class TestTemporalStorePgvector:
+    """pgvector backend shares the coordinator's SQLAlchemy engine."""
+
+    @pytest.mark.asyncio
+    async def test_engine_from_vector_adapter(self, config: KhoraConfig) -> None:
+        """engine kwarg is taken from the vector adapter's _engine."""
+        sentinel_engine = MagicMock(name="vector_engine")
+        vec = MagicMock()
+        vec._engine = sentinel_engine
+        rel = MagicMock()
+        rel._engine = MagicMock(name="rel_engine")
+        coord = _coordinator(vector=vec, relational=rel)
+        store = _make_store()
+
+        with patch("khora.storage.temporal.create_temporal_store", return_value=store) as factory:
+            result = await coord.temporal_store("pgvector", config)
+
+        assert result is store
+        _, kwargs = factory.call_args
+        assert kwargs["engine"] is sentinel_engine
+
+    @pytest.mark.asyncio
+    async def test_engine_falls_back_to_relational_when_vector_none(self, config: KhoraConfig) -> None:
+        """With no vector adapter, engine falls back to relational._engine."""
+        rel_engine = MagicMock(name="rel_engine")
+        rel = MagicMock()
+        rel._engine = rel_engine
+        coord = _coordinator(vector=None, relational=rel)
+        store = _make_store()
+
+        with patch("khora.storage.temporal.create_temporal_store", return_value=store) as factory:
+            await coord.temporal_store("pgvector", config)
+
+        _, kwargs = factory.call_args
+        assert kwargs["engine"] is rel_engine
+
+    @pytest.mark.asyncio
+    async def test_engine_falls_back_when_vector_engine_none(self, config: KhoraConfig) -> None:
+        """A vector adapter whose _engine is None still falls back to relational."""
+        rel_engine = MagicMock(name="rel_engine")
+        vec = MagicMock()
+        vec._engine = None
+        rel = MagicMock()
+        rel._engine = rel_engine
+        coord = _coordinator(vector=vec, relational=rel)
+        store = _make_store()
+
+        with patch("khora.storage.temporal.create_temporal_store", return_value=store) as factory:
+            await coord.temporal_store("pgvector", config)
+
+        _, kwargs = factory.call_args
+        assert kwargs["engine"] is rel_engine
+
+
+class TestTemporalStoreSurrealDB:
+    """surrealdb backend shares the coordinator's SurrealDBConnection."""
+
+    @pytest.mark.asyncio
+    async def test_connection_and_config_forwarded(self, config: KhoraConfig) -> None:
+        """surrealdb_connection from relational._conn, surrealdb_config from config."""
+        conn = MagicMock(name="surreal_conn")
+        rel = MagicMock()
+        rel._conn = conn
+        coord = _coordinator(relational=rel)
+        store = _make_store()
+
+        with patch("khora.storage.temporal.create_temporal_store", return_value=store) as factory:
+            await coord.temporal_store("surrealdb", config)
+
+        _, kwargs = factory.call_args
+        assert kwargs["surrealdb_connection"] is conn
+        assert kwargs["surrealdb_config"] is config.storage.surrealdb
+
+
+class TestTemporalStoreSqliteLance:
+    """sqlite_lance backend shares the vector adapter's EmbeddedStorageHandle."""
+
+    @pytest.mark.asyncio
+    async def test_handle_from_vector_adapter(self, config: KhoraConfig) -> None:
+        """sqlite_lance_handle is taken from the vector adapter's _handle."""
+        handle = MagicMock(name="handle")
+        vec = MagicMock()
+        vec._handle = handle
+        coord = _coordinator(vector=vec)
+        store = _make_store()
+
+        with patch("khora.storage.temporal.create_temporal_store", return_value=store) as factory:
+            await coord.temporal_store("sqlite_lance", config)
+
+        _, kwargs = factory.call_args
+        assert kwargs["sqlite_lance_handle"] is handle
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_vector_adapter(self, config: KhoraConfig) -> None:
+        """sqlite_lance without a vector adapter raises RuntimeError."""
+        coord = _coordinator(vector=None)
+
+        with patch("khora.storage.temporal.create_temporal_store") as factory:
+            with pytest.raises(
+                RuntimeError,
+                match="sqlite_lance backend requires a vector adapter on the coordinator",
+            ):
+                await coord.temporal_store("sqlite_lance", config)
+        factory.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_handle_none(self, config: KhoraConfig) -> None:
+        """sqlite_lance with a handle-less vector adapter raises RuntimeError."""
+        vec = MagicMock()
+        vec._handle = None
+        coord = _coordinator(vector=vec)
+
+        with patch("khora.storage.temporal.create_temporal_store") as factory:
+            with pytest.raises(
+                RuntimeError,
+                match="sqlite_lance vector adapter is missing its EmbeddedStorageHandle",
+            ):
+                await coord.temporal_store("sqlite_lance", config)
+        factory.assert_not_called()
+
+
+class TestTemporalStorePassthrough:
+    """weaviate / turbopuffer pass their connection config straight through."""
+
+    @pytest.mark.asyncio
+    async def test_weaviate_url_passthrough(self, config: KhoraConfig) -> None:
+        """weaviate_url is forwarded unchanged."""
+        coord = _coordinator()
+        store = _make_store()
+        sentinel_url = MagicMock(name="weaviate_url")
+
+        with patch("khora.storage.temporal.create_temporal_store", return_value=store) as factory:
+            await coord.temporal_store("weaviate", config, weaviate_url=sentinel_url)
+
+        _, kwargs = factory.call_args
+        assert kwargs["weaviate_url"] is sentinel_url
+
+    @pytest.mark.asyncio
+    async def test_turbopuffer_config_passthrough(self, config: KhoraConfig) -> None:
+        """turbopuffer_config is forwarded unchanged."""
+        coord = _coordinator()
+        store = _make_store()
+        sentinel_cfg = MagicMock(name="turbopuffer_config")
+
+        with patch("khora.storage.temporal.create_temporal_store", return_value=store) as factory:
+            await coord.temporal_store("turbopuffer", config, turbopuffer_config=sentinel_cfg)
+
+        _, kwargs = factory.call_args
+        assert kwargs["turbopuffer_config"] is sentinel_cfg
+
+
+class TestTemporalStoreFactorySemantics:
+    """The store is connected once and never cached on the coordinator."""
+
+    @pytest.mark.asyncio
+    async def test_returns_connected_store(self, config: KhoraConfig) -> None:
+        """The returned store is the factory's, with connect() awaited once."""
+        coord = _coordinator()
+        store = _make_store()
+
+        with patch("khora.storage.temporal.create_temporal_store", return_value=store):
+            result = await coord.temporal_store("weaviate", config)
+
+        assert result is store
+        store.connect.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_not_cached_two_calls_two_stores(self, config: KhoraConfig) -> None:
+        """Two calls invoke the factory twice and return distinct stores."""
+        coord = _coordinator()
+        first, second = _make_store(), _make_store()
+
+        with patch(
+            "khora.storage.temporal.create_temporal_store",
+            side_effect=[first, second],
+        ) as factory:
+            r1 = await coord.temporal_store("weaviate", config)
+            r2 = await coord.temporal_store("weaviate", config)
+
+        assert factory.call_count == 2
+        assert r1 is first
+        assert r2 is second
+        assert r1 is not r2


### PR DESCRIPTION
## Summary
- Add `async StorageCoordinator.temporal_store(backend, config, *, weaviate_url=None, turbopuffer_config=None) -> TemporalVectorStore`, a factory method that builds and connects a temporal vector store.
- Backend selection is **delegated** to `khora.storage.temporal.create_temporal_store` (lazily imported, so optional backend deps stay lazy) — the coordinator does not re-implement the backend switch. It only gathers the per-backend shared resource off its own relational/vector adapters so the temporal store reuses the coordinator's existing connections instead of opening its own:
  - **pgvector** — shares the SQLAlchemy engine (vector adapter's, falling back to the relational adapter's), avoiding a doubled connection pool.
  - **surrealdb** — shares the `SurrealDBConnection` (embedded mode allows only one open handle per directory).
  - **sqlite_lance** — shares the vector adapter's embedded storage handle (single aiosqlite + LanceDB pair), with the existing guards.
  - **weaviate / turbopuffer** — pass the caller-supplied connection config straight through.
- All existing `None`-guards are preserved, including the two `RuntimeError` guards for the sqlite_lance handle.
- **Factory semantics, not a cache**: every call returns a fresh, already-connected store; nothing is memoized on the coordinator, so the caller owns the lifecycle and is responsible for `disconnect()`.
- This consolidates connection-sharing logic that was previously duplicated in the engines into a single seam. Engines are intentionally left unchanged in this PR; rewiring them to call the accessor is follow-up work.

## Test plan
- [x] Unit tests pass — new `tests/unit/test_coordinator_temporal_store.py` covers every backend branch's resource wiring (pgvector engine + both fallback paths, surrealdb connection + config, sqlite_lance handle + both error guards, weaviate/turbopuffer passthrough) and the factory semantics (connect awaited once; two calls → two distinct stores, no caching).
- [x] Full suite green (`make test`): unit + integration, coverage above the enforced gate.
- [ ] Integration/e2e in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a factory method for creating and connecting temporal vector stores with support for multiple backends (pgvector, SurrealDB, SQLite+Lance, Weaviate, and Turbopuffer), with automatic backend-specific resource management and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->