### PR TITLE
Wire engines to coordinator temporal-store accessor

### DIFF
--- a/docs/engines/skeleton-engine.md
+++ b/docs/engines/skeleton-engine.md
@@ -297,7 +297,7 @@ backend accepts a `WeaviateBackendConfig` in place of the URL string
 for cloud, authenticated, or custom-port deployments:
 
 ```python
-from khora.engines.skeleton.backends.weaviate import WeaviateBackendConfig
+from khora.storage.temporal.weaviate import WeaviateBackendConfig
 
 # Weaviate Cloud
 cloud_config = WeaviateBackendConfig(
@@ -345,7 +345,7 @@ Pitched at scale tiers above what pgvector / self-hosted Weaviate
 make economical (2.5T vectors in production at Cursor, Notion):
 
 ```python
-from khora.engines.skeleton.backends.turbopuffer import TurbopufferBackendConfig
+from khora.storage.temporal.turbopuffer import TurbopufferBackendConfig
 
 cfg = TurbopufferBackendConfig(
     api_key="tpuf_...",            # str or SecretStr

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -41,12 +41,8 @@ from khora.filter.report import ChannelPlan, build_filter_report
 from khora.khora import BatchResult, RecallResult, RememberResult, Stats
 from khora.query import SearchMode
 from khora.storage import StorageConfig, StorageCoordinator, create_storage_coordinator
+from khora.storage.temporal import TemporalVectorStore
 from khora.telemetry import trace, trace_span
-
-from .backends import (
-    TemporalVectorStore,
-    create_temporal_store,
-)
 
 if TYPE_CHECKING:
     from khora.extraction.chunkers import ChunkStrategy
@@ -134,48 +130,16 @@ class SkeletonConstructionEngine:
         self._storage = create_storage_coordinator(self._storage_config)
         await self._storage.connect()
 
-        # Create and connect temporal vector store.
-        # Share the coordinator's PG engine so we don't double the pool.
-        shared_pg_engine = None
-        if self._backend_type == "pgvector":
-            if self._storage._vector is not None:
-                shared_pg_engine = getattr(self._storage._vector, "_engine", None)
-            if shared_pg_engine is None and self._storage._relational is not None:
-                shared_pg_engine = getattr(self._storage._relational, "_engine", None)
-
-        # For the sqlite_lance unified backend the temporal store reuses
-        # the coordinator's shared EmbeddedStorageHandle (single aiosqlite
-        # + LanceDB pair across all adapters).  The vector adapter holds
-        # the canonical reference.
-        sqlite_lance_handle = None
-        if self._backend_type == "sqlite_lance":
-            if self._storage._vector is None:
-                raise RuntimeError("sqlite_lance backend requires a vector adapter on the coordinator")
-            sqlite_lance_handle = getattr(self._storage._vector, "_handle", None)
-            if sqlite_lance_handle is None:
-                raise RuntimeError("sqlite_lance vector adapter is missing its EmbeddedStorageHandle")
-
-        # For the SurrealDB unified backend, reuse the coordinator's
-        # shared SurrealDBConnection. surrealkv (embedded mode) allows
-        # only one open handle per on-disk directory — opening a second
-        # connection raises ``InternalError: Invalid revision 0 for type
-        # Value`` on the first write (issue #718). Mirrors vectorcypher.
-        surrealdb_connection = None
-        if self._backend_type == "surrealdb":
-            if self._storage._relational is not None:
-                surrealdb_connection = getattr(self._storage._relational, "_conn", None)
-
-        self._temporal_store = create_temporal_store(
+        # Create and connect temporal vector store. The coordinator gathers the
+        # per-backend shared resource (PG engine / EmbeddedStorageHandle /
+        # SurrealDBConnection) so the store reuses existing connections, and
+        # returns an already-connected store.
+        self._temporal_store = await self._storage.temporal_store(
             self._backend_type,
             self._config,
             weaviate_url=self._weaviate_url,
             turbopuffer_config=self._turbopuffer_config,
-            surrealdb_config=self._config.storage.surrealdb if self._backend_type == "surrealdb" else None,
-            surrealdb_connection=surrealdb_connection,
-            engine=shared_pg_engine,
-            sqlite_lance_handle=sqlite_lance_handle,
         )
-        await self._temporal_store.connect()
 
         # Create embedder
         llm_config = LiteLLMConfig(

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -53,9 +53,6 @@ from khora.core.temporal import (
 from khora.engines._forget_cascade import cascade_forget_extraction
 from khora.engines._stats import gather_counts
 from khora.engines._storage_config import build_storage_config
-from khora.engines.skeleton.backends import (
-    create_temporal_store,
-)
 from khora.exceptions import EngineCapabilityError
 from khora.extraction.embedders import LiteLLMEmbedder
 from khora.khora import BatchResult, RecallResult, RememberResult, Stats
@@ -670,42 +667,11 @@ class VectorCypherEngine:
 
         await self._storage.connect()
 
-        # Create and connect temporal vector store
-        if is_surrealdb:
-            # Share the coordinator's SurrealDB connection to avoid isolated
-            # embedded views (each embedded connection has its own write buffer)
-            shared_conn = getattr(self._storage._relational, "_conn", None)
-            from khora.engines.skeleton.backends.surrealdb import SurrealDBTemporalStore
-
-            self._temporal_store = SurrealDBTemporalStore(
-                self._config,
-                connection=shared_conn,
-            )
-        elif is_sqlite_lance:
-            # Reuse the coordinator's shared EmbeddedStorageHandle (single
-            # aiosqlite + LanceDB pair across all adapters). The vector
-            # adapter holds the canonical reference. Mirrors the Skeleton
-            # engine wiring landed in #481.
-            if self._storage._vector is None:
-                raise RuntimeError("sqlite_lance coordinator did not provide a vector backend")
-            sqlite_lance_handle = getattr(self._storage._vector, "_handle", None)
-            if sqlite_lance_handle is None:
-                raise RuntimeError("sqlite_lance vector adapter is missing its EmbeddedStorageHandle")
-            self._temporal_store = create_temporal_store(
-                "sqlite_lance",
-                self._config,
-                sqlite_lance_handle=sqlite_lance_handle,
-            )
-        else:
-            # Share the coordinator's SQLAlchemy engine so the temporal store
-            # does not create a second connection pool against the same PG.
-            shared_pg_engine = None
-            if self._storage._vector is not None:
-                shared_pg_engine = getattr(self._storage._vector, "_engine", None)
-            if shared_pg_engine is None and self._storage._relational is not None:
-                shared_pg_engine = getattr(self._storage._relational, "_engine", None)
-            self._temporal_store = create_temporal_store("pgvector", self._config, engine=shared_pg_engine)
-        await self._temporal_store.connect()
+        # Create and connect temporal vector store. The coordinator gathers the
+        # per-backend shared resource (SurrealDB connection / EmbeddedStorageHandle
+        # / SQLAlchemy engine) and returns an already-connected store.
+        temporal_backend = backend if is_surrealdb or is_sqlite_lance else "pgvector"
+        self._temporal_store = await self._storage.temporal_store(temporal_backend, self._config)
 
         # Create embedder
         # Connector fields are forwarded so YAML-configured values reach the

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -67,11 +67,11 @@ if TYPE_CHECKING:
     from neo4j import AsyncDriver
 
     from khora.core.temporal import ChunkTemporalFilter
-    from khora.engines.skeleton.backends import TemporalVectorStore
     from khora.extraction.embedders import EmbedderProtocol  # type: ignore[unresolved-import]
     from khora.filter import FilterNode
     from khora.query.reranking import CrossEncoderReranker, LLMReranker
     from khora.storage import StorageCoordinator
+    from khora.storage.temporal import TemporalVectorStore
 
 # Transient Neo4j errors that trigger graceful degradation rather than
 # failing the entire request. Excludes ClientError (query bugs) and

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -49,11 +49,11 @@ if TYPE_CHECKING:
     from datetime import datetime
 
     from khora.core.models import Chunk, Document, Entity, Relationship
-    from khora.engines.skeleton.backends import TemporalVectorStore
     from khora.extraction.embedders import Embedder
     from khora.extraction.expansion.entity_index import EntityIndex
     from khora.extraction.skills import ExpertiseConfig
     from khora.storage import StorageCoordinator
+    from khora.storage.temporal import TemporalVectorStore
 
 
 def _should_skip_entity_embedding(

--- a/tests/integration/engines/skeleton/test_surrealdb_embedded_shared_connection.py
+++ b/tests/integration/engines/skeleton/test_surrealdb_embedded_shared_connection.py
@@ -30,7 +30,7 @@ import pytest
 
 pytest.importorskip("surrealdb")
 
-from khora.engines.skeleton.backends.surrealdb import SurrealDBTemporalStore  # noqa: E402
+from khora.storage.temporal.surrealdb import SurrealDBTemporalStore  # noqa: E402
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/engines/skeleton/test_surrealdb_store_filter_channels.py
+++ b/tests/integration/engines/skeleton/test_surrealdb_store_filter_channels.py
@@ -4,7 +4,7 @@ The compiler-level tests (``tests/unit/filter/test_compile_surrealdb.py``) and t
 predicate row-set tests (``tests/integration/filter/test_compile_surrealdb_embedded.py``)
 prove the SurrealDB compiler raises on an unbacked system key and pushes a backed
 one. This module proves the SAME contract holds at the STORE seam — through
-:class:`~khora.engines.skeleton.backends.surrealdb.SurrealDBTemporalStore`'s two
+:class:`~khora.storage.temporal.surrealdb.SurrealDBTemporalStore`'s two
 public read channels:
 
 * the **vector** channel — ``store.search(..., hybrid_alpha=1.0, filter_ast=…)``
@@ -35,13 +35,13 @@ import pytest
 pytest.importorskip("surrealdb")
 
 from khora.config import KhoraConfig  # noqa: E402
-from khora.engines.skeleton.backends import TemporalChunk  # noqa: E402
-from khora.engines.skeleton.backends.surrealdb import _BACKED_SYSTEM_KEYS, SurrealDBTemporalStore  # noqa: E402
 from khora.filter import RecallFilter  # noqa: E402
 from khora.filter.ast import FilterNode, parse_to_ast  # noqa: E402
 from khora.filter.context import RecallFilterUnsupportedError  # noqa: E402
 from khora.filter.model import SYSTEM_KEYS  # noqa: E402
 from khora.storage.backends.surrealdb.connection import SurrealDBConnection  # noqa: E402
+from khora.storage.temporal import TemporalChunk  # noqa: E402
+from khora.storage.temporal.surrealdb import _BACKED_SYSTEM_KEYS, SurrealDBTemporalStore  # noqa: E402
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/filter/test_compile_surrealdb_embedded.py
+++ b/tests/integration/filter/test_compile_surrealdb_embedded.py
@@ -28,8 +28,6 @@ import pytest
 
 pytest.importorskip("surrealdb")
 
-from khora.engines.skeleton.backends import TemporalFilter  # noqa: E402
-from khora.engines.skeleton.backends.surrealdb import SurrealDBTemporalStore  # noqa: E402
 from khora.filter import RecallFilter  # noqa: E402
 from khora.filter.ast import parse_to_ast  # noqa: E402
 from khora.filter.compilers.python import compile_python  # noqa: E402
@@ -37,6 +35,8 @@ from khora.filter.compilers.surrealdb import compile_surrealdb  # noqa: E402
 from khora.filter.context import CompileContext, RecallFilterUnsupportedError  # noqa: E402
 from khora.storage.backends.surrealdb._helpers import _rid  # noqa: E402
 from khora.storage.backends.surrealdb.connection import SurrealDBConnection  # noqa: E402
+from khora.storage.temporal import TemporalFilter  # noqa: E402
+from khora.storage.temporal.surrealdb import SurrealDBTemporalStore  # noqa: E402
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/matrix/_conformance_lance.py
+++ b/tests/integration/matrix/_conformance_lance.py
@@ -55,8 +55,6 @@ from uuid import UUID
 
 from khora.core.models import Chunk
 from khora.db.session import run_migrations
-from khora.engines.skeleton.backends import TemporalChunk
-from khora.engines.skeleton.backends.sqlite_lance import SQLiteLanceTemporalStore
 from khora.filter import CompiledFilter
 from khora.filter.ast import FilterNode
 from khora.filter.conformance import _DOC_STRING_KEYS, ConformanceCase, LanceExecutor, seed_case
@@ -67,6 +65,8 @@ from khora.storage.backends.sqlite_lance.connection import (
     EmbeddedStorageHandleConfig,
 )
 from khora.storage.coordinator import StorageCoordinator
+from khora.storage.temporal import TemporalChunk
+from khora.storage.temporal.sqlite_lance import SQLiteLanceTemporalStore
 from tests.integration._sqlite_lance_fixtures import EMBED_DIM
 
 # The 14 corpus family generators, by name (resolved off ``khora.filter.conformance``

--- a/tests/integration/matrix/_conformance_neo4j.py
+++ b/tests/integration/matrix/_conformance_neo4j.py
@@ -54,11 +54,11 @@ from functools import lru_cache
 from typing import Any
 from uuid import UUID, uuid4
 
-from khora.engines.skeleton.backends import TemporalChunk
 from khora.engines.vectorcypher.dual_nodes import DualNodeManager
 from khora.filter import CompiledFilter
 from khora.filter.ast import FilterNode
 from khora.filter.conformance import ConformanceCase, CypherExecutor, SeedRecord
+from khora.storage.temporal import TemporalChunk
 
 # The node alias the ``CypherExecutor`` compiles against (``Chunk`` node, alias
 # ``c`` — see ``VectorCypherRetriever`` graph-channel filter pushdown). The executor

--- a/tests/integration/matrix/_conformance_pg.py
+++ b/tests/integration/matrix/_conformance_pg.py
@@ -45,11 +45,6 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from khora.config import KhoraConfig
 from khora.core.models import Chunk
-from khora.engines.skeleton.backends import TemporalChunk
-from khora.engines.skeleton.backends.pgvector import (
-    PgVectorTemporalStore,
-    khora_chunks_table,
-)
 from khora.filter.conformance import (
     ConformanceCase,
     f_array_cases,
@@ -69,6 +64,11 @@ from khora.filter.conformance import (
 )
 from khora.storage.backends.postgresql import PostgreSQLBackend
 from khora.storage.coordinator import StorageCoordinator
+from khora.storage.temporal import TemporalChunk
+from khora.storage.temporal.pgvector import (
+    PgVectorTemporalStore,
+    khora_chunks_table,
+)
 from tests.integration._sqlite_lance_fixtures import fake_embedding
 
 # Same default + normalization as the sibling skeleton/chronicle PG modules.

--- a/tests/integration/matrix/_conformance_weaviate.py
+++ b/tests/integration/matrix/_conformance_weaviate.py
@@ -48,15 +48,15 @@ from typing import Any
 from uuid import UUID, uuid4
 
 from khora.config import KhoraConfig
-from khora.engines.skeleton.backends import TemporalChunk
-from khora.engines.skeleton.backends.weaviate import (
+from khora.filter import CompiledFilter
+from khora.filter.ast import FilterNode
+from khora.filter.conformance import _DOC_STRING_KEYS, ConformanceCase, SeedRecord, WeaviateExecutor
+from khora.storage.temporal import TemporalChunk
+from khora.storage.temporal.weaviate import (
     WeaviateBackendConfig,
     WeaviateTemporalStore,
     _coerce_datetime,
 )
-from khora.filter import CompiledFilter
-from khora.filter.ast import FilterNode
-from khora.filter.conformance import _DOC_STRING_KEYS, ConformanceCase, SeedRecord, WeaviateExecutor
 
 # One fixed tenant for the whole conformance corpus. Chunk ids are globally unique
 # (a fresh ``uuid4`` per seed record), so scoping a read by chunk id inside this one

--- a/tests/integration/matrix/test_compiler_registry_keys.py
+++ b/tests/integration/matrix/test_compiler_registry_keys.py
@@ -27,10 +27,10 @@ import pytest
 # Importing these modules fires their module-level ``CompilerRegistry.register``
 # calls (the registry is empty until an engine/backend module imports).
 import khora.engines.chronicle.engine  # noqa: F401
-import khora.engines.skeleton.backends.pgvector  # noqa: F401
-import khora.engines.skeleton.backends.sqlite_lance  # noqa: F401
-import khora.engines.skeleton.backends.surrealdb  # noqa: F401
-import khora.engines.skeleton.backends.weaviate  # noqa: F401
+import khora.storage.temporal.pgvector  # noqa: F401
+import khora.storage.temporal.sqlite_lance  # noqa: F401
+import khora.storage.temporal.surrealdb  # noqa: F401
+import khora.storage.temporal.weaviate  # noqa: F401
 from khora.filter.registry import CompilerRegistry
 
 pytestmark = [pytest.mark.filter_conformance]

--- a/tests/integration/matrix/test_filter_enforcement_surrealdb.py
+++ b/tests/integration/matrix/test_filter_enforcement_surrealdb.py
@@ -43,10 +43,10 @@ pytest.importorskip("surrealdb")
 
 from khora.config import KhoraConfig  # noqa: E402
 from khora.config.schema import SurrealDBConfig  # noqa: E402
-from khora.engines.skeleton.backends.surrealdb import SurrealDBTemporalStore  # noqa: E402
 from khora.extraction.skills import ExpertiseConfig  # noqa: E402
 from khora.filter import RecallFilter, parse_to_ast  # noqa: E402
 from khora.khora import Khora  # noqa: E402
+from khora.storage.temporal.surrealdb import SurrealDBTemporalStore  # noqa: E402
 from tests.test_helpers.filter_spy import EMBED_DIM, seed_corpus, stub_llm  # noqa: E402
 
 pytestmark = [

--- a/tests/integration/matrix/test_skeleton_pg.py
+++ b/tests/integration/matrix/test_skeleton_pg.py
@@ -45,9 +45,9 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from khora.config import KhoraConfig
 from khora.db.session import run_migrations
-from khora.engines.skeleton.backends import TemporalFilter
 from khora.khora import Khora
 from khora.query import SearchMode
+from khora.storage.temporal import TemporalFilter
 
 EMBED_DIM = 1536  # matches the khora_chunks.embedding Vector(1536) column
 

--- a/tests/integration/matrix/test_skeleton_sqlite_lance.py
+++ b/tests/integration/matrix/test_skeleton_sqlite_lance.py
@@ -39,9 +39,9 @@ except ImportError:
 
 from khora.config import KhoraConfig
 from khora.config.schema import SQLiteLanceConfig
-from khora.engines.skeleton.backends import TemporalFilter
 from khora.khora import Khora
 from khora.query import SearchMode
+from khora.storage.temporal import TemporalFilter
 
 EMBED_DIM = 32  # small dim keeps LanceDB index build cheap in tmp_path
 

--- a/tests/integration/test_channel_filter_operator_matrix_change.py
+++ b/tests/integration/test_channel_filter_operator_matrix_change.py
@@ -60,7 +60,7 @@ from pydantic import SecretStr
 
 from khora import Khora
 from khora.config import KhoraConfig
-from khora.engines.skeleton.backends.pgvector import PgVectorTemporalStore
+from khora.storage.temporal.pgvector import PgVectorTemporalStore
 from tests.recall.test_channel_filter_operator_matrix import (
     _CHANGE_QUERY,
     _assert_channel_cell,

--- a/tests/integration/test_vectorcypher_recency_channel_pg.py
+++ b/tests/integration/test_vectorcypher_recency_channel_pg.py
@@ -59,11 +59,11 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from khora.config import KhoraConfig
 from khora.db.session import run_migrations
-from khora.engines.skeleton.backends import TemporalChunk
-from khora.engines.skeleton.backends.pgvector import PgVectorTemporalStore
 from khora.extraction.extractors.base import ExtractedEntity, ExtractionResult
 from khora.khora import Khora
 from khora.query import SearchMode
+from khora.storage.temporal import TemporalChunk
+from khora.storage.temporal.pgvector import PgVectorTemporalStore
 
 EMBED_DIM = 1536  # matches the khora_chunks.embedding Vector(1536) column
 

--- a/tests/integration/test_weaviate_async_integration.py
+++ b/tests/integration/test_weaviate_async_integration.py
@@ -24,8 +24,8 @@ import pytest
 from pydantic_settings import BaseSettings
 
 from khora.config import KhoraConfig
-from khora.engines.skeleton.backends import TemporalChunk
-from khora.engines.skeleton.backends.weaviate import (
+from khora.storage.temporal import TemporalChunk
+from khora.storage.temporal.weaviate import (
     WeaviateBackendConfig,
     WeaviateTemporalStore,
 )

--- a/tests/recall/test_channel_filter_operator_matrix.py
+++ b/tests/recall/test_channel_filter_operator_matrix.py
@@ -885,7 +885,7 @@ def _install_recency_spy(monkeypatch: pytest.MonkeyPatch, kb: Khora, seeded: dic
     ``assert_fired`` sees the returned chunks AND the seeded violating doc id without
     a closure. Returns the live record list.
     """
-    from khora.engines.skeleton.backends.pgvector import PgVectorTemporalStore
+    from khora.storage.temporal.pgvector import PgVectorTemporalStore
 
     real = PgVectorTemporalStore.search_recent_chunks
     violating_doc_id = seeded[_VIOLATING_EXTERNAL_ID]

--- a/tests/recall/test_chronicle_filter_composition.py
+++ b/tests/recall/test_chronicle_filter_composition.py
@@ -403,7 +403,7 @@ async def test_unanchored_chunk_survives_recency_window_with_no_filter_ast() -> 
     # this chunk (the shape a plain remember() with no timestamp produces). The
     # window narrows on COALESCE(source_timestamp, created_at), so a chunk recent by
     # ingest time belongs in it even with no event-time anchor.
-    from khora.engines.skeleton.backends import TemporalFilter as SkeletonTemporalFilter
+    from khora.storage.temporal import TemporalFilter as SkeletonTemporalFilter
 
     unanchored = _chunk(
         "alpha unanchored",

--- a/tests/unit/engines/skeleton/backends/test_pgvector_coverage.py
+++ b/tests/unit/engines/skeleton/backends/test_pgvector_coverage.py
@@ -1,4 +1,4 @@
-"""Coverage tests for ``khora.engines.skeleton.backends.pgvector``.
+"""Coverage tests for ``khora.storage.temporal.pgvector``.
 
 Heavily mocks SQLAlchemy ``AsyncEngine`` / ``AsyncSession`` — no real DB.
 
@@ -19,12 +19,12 @@ from uuid import uuid4
 
 import pytest
 
-from khora.engines.skeleton.backends import (
+from khora.storage.temporal import (
     TemporalChunk,
     TemporalFilter,
     TemporalSearchResult,
 )
-from khora.engines.skeleton.backends.pgvector import (
+from khora.storage.temporal.pgvector import (
     PgVectorTemporalStore,
 )
 

--- a/tests/unit/engines/skeleton/backends/test_surrealdb_legacy_additional.py
+++ b/tests/unit/engines/skeleton/backends/test_surrealdb_legacy_additional.py
@@ -36,8 +36,8 @@ from uuid import uuid4
 
 import pytest
 
-from khora.engines.skeleton.backends import TemporalFilter
-from khora.engines.skeleton.backends.surrealdb import SurrealDBTemporalStore
+from khora.storage.temporal import TemporalFilter
+from khora.storage.temporal.surrealdb import SurrealDBTemporalStore
 
 # Hard import (NOT importorskip): ``_build_filter_clauses`` is a pure static
 # string-builder — it imports the recall-filter compiler (pure Python, no SDK)

--- a/tests/unit/engines/skeleton/backends/test_turbopuffer.py
+++ b/tests/unit/engines/skeleton/backends/test_turbopuffer.py
@@ -17,16 +17,6 @@ from uuid import UUID, uuid4
 import pytest
 from pydantic import SecretStr
 
-from khora.engines.skeleton.backends import TemporalChunk, TemporalFilter
-from khora.engines.skeleton.backends.turbopuffer import (
-    TurbopufferBackendConfig,
-    TurbopufferTemporalStore,
-    _build_turbopuffer_filter,
-    _chunk_to_row,
-    _coerce_datetime,
-    _row_to_chunk,
-    _rrf_fuse,
-)
 from khora.filter import (
     FilterClause,
     FilterNode,
@@ -34,6 +24,16 @@ from khora.filter import (
     RecallFilter,
     RecallFilterUnsupportedError,
     parse_to_ast,
+)
+from khora.storage.temporal import TemporalChunk, TemporalFilter
+from khora.storage.temporal.turbopuffer import (
+    TurbopufferBackendConfig,
+    TurbopufferTemporalStore,
+    _build_turbopuffer_filter,
+    _chunk_to_row,
+    _coerce_datetime,
+    _row_to_chunk,
+    _rrf_fuse,
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/engines/skeleton/backends/test_weaviate_async.py
+++ b/tests/unit/engines/skeleton/backends/test_weaviate_async.py
@@ -17,8 +17,10 @@ from uuid import UUID, uuid4
 import pytest
 from pydantic import SecretStr
 
-from khora.engines.skeleton.backends import TemporalChunk
-from khora.engines.skeleton.backends.weaviate import (
+from khora.filter import RecallFilter
+from khora.filter.ast import parse_to_ast
+from khora.storage.temporal import TemporalChunk
+from khora.storage.temporal.weaviate import (
     _DENORM_TEXT_KEYS,
     _FILTER_OVERFETCH,
     COLLECTION_NAME,
@@ -31,8 +33,6 @@ from khora.engines.skeleton.backends.weaviate import (
     _extract_vector,
     _parse_host_port,
 )
-from khora.filter import RecallFilter
-from khora.filter.ast import parse_to_ast
 
 # ---------------------------------------------------------------------------
 # WeaviateBackendConfig validation

--- a/tests/unit/engines/skeleton/test_create_temporal_store.py
+++ b/tests/unit/engines/skeleton/test_create_temporal_store.py
@@ -1,4 +1,4 @@
-"""Coverage: ``khora.engines.skeleton.backends.create_temporal_store``.
+"""Coverage: ``khora.storage.temporal.create_temporal_store``.
 
 Pins the dispatch table for the four supported backends (pgvector, weaviate,
 surrealdb, sqlite_lance) plus the validation errors. Each branch is covered
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from khora.engines.skeleton.backends import (
+from khora.storage.temporal import (
     TemporalChunk,
     TemporalFilter,
     TemporalSearchResult,

--- a/tests/unit/engines/skeleton/test_engine_paths.py
+++ b/tests/unit/engines/skeleton/test_engine_paths.py
@@ -21,9 +21,9 @@ from uuid import uuid4
 
 import pytest
 
-from khora.engines.skeleton.backends import TemporalChunk, TemporalFilter, TemporalSearchResult
 from khora.engines.skeleton.engine import SkeletonConstructionEngine
 from khora.query import SearchMode
+from khora.storage.temporal import TemporalChunk, TemporalFilter, TemporalSearchResult
 
 
 def _mock_config(*, backend: str = "pgvector") -> MagicMock:

--- a/tests/unit/engines/skeleton/test_tag_filter_cast.py
+++ b/tests/unit/engines/skeleton/test_tag_filter_cast.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 
 from sqlalchemy.dialects import postgresql
 
-from khora.engines.skeleton.backends import TemporalFilter
-from khora.engines.skeleton.backends.pgvector import PgVectorTemporalStore
+from khora.storage.temporal import TemporalFilter
+from khora.storage.temporal.pgvector import PgVectorTemporalStore
 
 
 def test_tag_filter_compiles_with_varchar_array_cast() -> None:

--- a/tests/unit/engines/skeleton/test_temporal_chunk_adapter.py
+++ b/tests/unit/engines/skeleton/test_temporal_chunk_adapter.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from uuid import uuid4
 
-from khora.engines.skeleton.backends import (
+from khora.storage.temporal import (
     TemporalChunk,
     temporal_chunk_to_chunk,
 )

--- a/tests/unit/engines/test_chronicle_temporal_shim.py
+++ b/tests/unit/engines/test_chronicle_temporal_shim.py
@@ -28,7 +28,7 @@ class TestChronicleTemporalShim:
 
     def test_skeleton_filter_primary_fields_used(self) -> None:
         """SkeletonTemporalFilter with occurred_after/occurred_before → primary fields used."""
-        from khora.engines.skeleton.backends import TemporalFilter as SkeletonTemporalFilter
+        from khora.storage.temporal import TemporalFilter as SkeletonTemporalFilter
 
         start = datetime(2024, 1, 1, tzinfo=UTC)
         end = datetime(2024, 12, 31, tzinfo=UTC)

--- a/tests/unit/engines/test_dual_nodes.py
+++ b/tests/unit/engines/test_dual_nodes.py
@@ -262,7 +262,7 @@ class TestDualNodeManagerCreateChunkNode:
     @pytest.mark.asyncio
     async def test_create_chunk_node(self, manager: DualNodeManager) -> None:
         """Test creating a single chunk node."""
-        from khora.engines.skeleton.backends import TemporalChunk
+        from khora.storage.temporal import TemporalChunk
 
         chunk = TemporalChunk(
             id=uuid4(),
@@ -278,7 +278,7 @@ class TestDualNodeManagerCreateChunkNode:
     @pytest.mark.asyncio
     async def test_create_chunk_node_generates_id(self, manager: DualNodeManager) -> None:
         """Test that a UUID is generated if chunk has no ID."""
-        from khora.engines.skeleton.backends import TemporalChunk
+        from khora.storage.temporal import TemporalChunk
 
         chunk = TemporalChunk(
             id=None,
@@ -305,7 +305,7 @@ class TestDualNodeManagerBatchOperations:
     @pytest.mark.asyncio
     async def test_create_chunk_nodes_batch(self, manager: DualNodeManager) -> None:
         """Test creating chunk nodes in batch."""
-        from khora.engines.skeleton.backends import TemporalChunk
+        from khora.storage.temporal import TemporalChunk
 
         namespace_id = uuid4()
         chunks = [
@@ -344,7 +344,7 @@ class TestDualNodeManagerDenormProjection:
 
     @staticmethod
     def _chunk(**overrides):
-        from khora.engines.skeleton.backends import TemporalChunk
+        from khora.storage.temporal import TemporalChunk
 
         base = dict(
             id=uuid4(),

--- a/tests/unit/engines/test_point_in_time_embedded_gate.py
+++ b/tests/unit/engines/test_point_in_time_embedded_gate.py
@@ -20,10 +20,10 @@ from uuid import uuid4
 
 import pytest
 
-from khora.engines.skeleton.backends import TemporalFilter as SkeletonTemporalFilter
 from khora.engines.vectorcypher.retriever import VectorCypherRetriever
 from khora.engines.vectorcypher.router import QueryComplexity, RoutingDecision
 from khora.engines.vectorcypher.temporal_detection import TemporalCategory, TemporalSignal
+from khora.storage.temporal import TemporalFilter as SkeletonTemporalFilter
 
 
 def _make_retriever(backend: str) -> VectorCypherRetriever:

--- a/tests/unit/engines/test_recency_channel.py
+++ b/tests/unit/engines/test_recency_channel.py
@@ -15,12 +15,12 @@ from uuid import UUID, uuid4
 import pytest
 
 from khora.core.models import Chunk
-from khora.engines.skeleton.backends import TemporalVectorStore
 from khora.engines.vectorcypher.retriever import RetrieverConfig, VectorCypherRetriever
 from khora.filter import FilterNode, RecallFilter, parse_to_ast
 from khora.filter.compilers.python import compile_python
 from khora.filter.execute import build_compile_context
 from khora.filter.report import ChannelPlan
+from khora.storage.temporal import TemporalVectorStore
 
 
 def _make_chunk(content: str, occurred_at: datetime | None, embedding: list[float]) -> Chunk:

--- a/tests/unit/engines/test_retriever_coverage_push.py
+++ b/tests/unit/engines/test_retriever_coverage_push.py
@@ -1147,7 +1147,7 @@ class TestRetrieveBackendGate:
                 metadata={},
             )
         )
-        from khora.engines.skeleton.backends import TemporalFilter
+        from khora.storage.temporal import TemporalFilter
 
         tf = TemporalFilter(occurred_after=datetime(2025, 6, 1, tzinfo=UTC))
         result = await retriever.retrieve("any", uuid4(), temporal_filter=tf)

--- a/tests/unit/engines/test_skeleton.py
+++ b/tests/unit/engines/test_skeleton.py
@@ -4,8 +4,8 @@ from uuid import uuid4
 
 import pytest
 
-from khora.engines.skeleton.backends import TemporalChunk
 from khora.engines.skeleton.skeleton import ChunkNode, KeywordNode, SkeletonIndexer
+from khora.storage.temporal import TemporalChunk
 
 
 class TestChunkNode:

--- a/tests/unit/engines/test_skeleton_engine.py
+++ b/tests/unit/engines/test_skeleton_engine.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 import pytest
 
-from khora.engines.skeleton.backends import TemporalChunk, TemporalFilter, TemporalSearchResult
+from khora.storage.temporal import TemporalChunk, TemporalFilter, TemporalSearchResult
 
 
 class TestTemporalFilter:
@@ -260,8 +260,8 @@ class TestCreateTemporalStore:
 
     def test_create_pgvector_store(self):
         """Test creating pgvector store."""
-        from khora.engines.skeleton.backends import create_temporal_store
-        from khora.engines.skeleton.backends.pgvector import PgVectorTemporalStore
+        from khora.storage.temporal import create_temporal_store
+        from khora.storage.temporal.pgvector import PgVectorTemporalStore
 
         config = MagicMock()
         config.get_postgresql_url.return_value = "postgresql://localhost/test"
@@ -272,8 +272,8 @@ class TestCreateTemporalStore:
 
     def test_create_weaviate_store(self):
         """Test creating weaviate store."""
-        from khora.engines.skeleton.backends import create_temporal_store
-        from khora.engines.skeleton.backends.weaviate import WeaviateTemporalStore
+        from khora.storage.temporal import create_temporal_store
+        from khora.storage.temporal.weaviate import WeaviateTemporalStore
 
         config = MagicMock()
         config.llm.embedding_dimension = 1536
@@ -283,7 +283,7 @@ class TestCreateTemporalStore:
 
     def test_create_weaviate_store_requires_url(self):
         """Test that weaviate store requires URL."""
-        from khora.engines.skeleton.backends import create_temporal_store
+        from khora.storage.temporal import create_temporal_store
 
         config = MagicMock()
 
@@ -292,7 +292,7 @@ class TestCreateTemporalStore:
 
     def test_create_unknown_backend_raises(self):
         """Test that unknown backend raises error."""
-        from khora.engines.skeleton.backends import create_temporal_store
+        from khora.storage.temporal import create_temporal_store
 
         config = MagicMock()
 

--- a/tests/unit/engines/test_skeleton_filter_ast.py
+++ b/tests/unit/engines/test_skeleton_filter_ast.py
@@ -32,7 +32,6 @@ from uuid import uuid4
 
 import pytest
 
-from khora.engines.skeleton.backends.turbopuffer import TurbopufferTemporalStore
 from khora.engines.skeleton.engine import SkeletonConstructionEngine
 from khora.filter import (
     FilterClause,
@@ -41,6 +40,7 @@ from khora.filter import (
     RecallFilterUnsupportedError,
 )
 from khora.query import SearchMode
+from khora.storage.temporal.turbopuffer import TurbopufferTemporalStore
 
 
 def _build_engine_with_stubs() -> tuple[SkeletonConstructionEngine, AsyncMock]:
@@ -194,12 +194,12 @@ def _all_search_owners() -> list[tuple[str, object]]:
     (weaviate / turbopuffer / surreal client) to a lazy in-method import, so
     the class object is reachable without the optional extra installed.
     """
-    from khora.engines.skeleton.backends import TemporalVectorStore
-    from khora.engines.skeleton.backends.pgvector import PgVectorTemporalStore
-    from khora.engines.skeleton.backends.sqlite_lance import SQLiteLanceTemporalStore
-    from khora.engines.skeleton.backends.surrealdb import SurrealDBTemporalStore
-    from khora.engines.skeleton.backends.turbopuffer import TurbopufferTemporalStore
-    from khora.engines.skeleton.backends.weaviate import WeaviateTemporalStore
+    from khora.storage.temporal import TemporalVectorStore
+    from khora.storage.temporal.pgvector import PgVectorTemporalStore
+    from khora.storage.temporal.sqlite_lance import SQLiteLanceTemporalStore
+    from khora.storage.temporal.surrealdb import SurrealDBTemporalStore
+    from khora.storage.temporal.turbopuffer import TurbopufferTemporalStore
+    from khora.storage.temporal.weaviate import WeaviateTemporalStore
 
     return [
         ("TemporalVectorStore", TemporalVectorStore),

--- a/tests/unit/engines/test_skeleton_search_mode.py
+++ b/tests/unit/engines/test_skeleton_search_mode.py
@@ -134,7 +134,7 @@ async def test_recall_chunk_scores_are_min_max_normalized() -> None:
     on an arbitrary scale (e.g. 0.013-0.015 for raw cosine). The unified
     contract: top chunk = 1.0, bottom chunk = 0.0 when 2+ chunks are returned.
     """
-    from khora.engines.skeleton.backends import TemporalChunk, TemporalSearchResult
+    from khora.storage.temporal import TemporalChunk, TemporalSearchResult
 
     engine, temporal_store = _build_engine_with_stubs()
     namespace_id = uuid4()
@@ -165,7 +165,7 @@ async def test_recall_chunk_scores_are_min_max_normalized() -> None:
 
 async def test_recall_chunk_scores_single_chunk_is_one() -> None:
     """Edge case: a single chunk gets score=1.0 (degenerate min-max)."""
-    from khora.engines.skeleton.backends import TemporalChunk, TemporalSearchResult
+    from khora.storage.temporal import TemporalChunk, TemporalSearchResult
 
     engine, temporal_store = _build_engine_with_stubs()
     namespace_id = uuid4()
@@ -191,7 +191,7 @@ async def test_recall_chunk_scores_single_chunk_is_one() -> None:
 
 async def test_recall_chunk_scores_all_tied_collapse_to_one() -> None:
     """Edge case: when max == min, every chunk collapses to 1.0."""
-    from khora.engines.skeleton.backends import TemporalChunk, TemporalSearchResult
+    from khora.storage.temporal import TemporalChunk, TemporalSearchResult
 
     engine, temporal_store = _build_engine_with_stubs()
     namespace_id = uuid4()

--- a/tests/unit/engines/test_temporal_phase_a_retriever.py
+++ b/tests/unit/engines/test_temporal_phase_a_retriever.py
@@ -21,7 +21,6 @@ from uuid import uuid4
 import pytest
 
 from khora.core.models import Chunk
-from khora.engines.skeleton.backends import TemporalFilter
 from khora.engines.vectorcypher.fusion import FusedResult
 from khora.engines.vectorcypher.retriever import (
     RetrieverConfig,
@@ -29,6 +28,7 @@ from khora.engines.vectorcypher.retriever import (
 )
 from khora.engines.vectorcypher.router import QueryComplexity, RoutingDecision
 from khora.query.temporal_detection import TemporalCategory, TemporalSignal
+from khora.storage.temporal import TemporalFilter
 
 
 def _chunk(occurred_at: datetime | None, *, source_system: str | None = None) -> Chunk:

--- a/tests/unit/engines/test_vectorcypher_bugs.py
+++ b/tests/unit/engines/test_vectorcypher_bugs.py
@@ -18,8 +18,8 @@ from uuid import uuid4
 
 import pytest
 
-from khora.engines.skeleton.backends import TemporalChunk
 from khora.engines.vectorcypher.dual_nodes import DualNodeManager
+from khora.storage.temporal import TemporalChunk
 
 # ---------------------------------------------------------------------------
 # Bug #1: pipeline vs pipelines attribute mismatch

--- a/tests/unit/engines/test_vectorcypher_engine.py
+++ b/tests/unit/engines/test_vectorcypher_engine.py
@@ -620,8 +620,8 @@ class TestVectorCypherEngineRemember:
         (via DualNodeManager) directly, so the replace path must mirror that or
         retrieval returns stale content after a replace.
         """
-        from khora.engines.skeleton.backends import TemporalChunk
         from khora.storage.coordinator import ReplaceResult
+        from khora.storage.temporal import TemporalChunk
 
         namespace_id = uuid4()
         old_doc_id = uuid4()
@@ -2623,8 +2623,8 @@ class TestVectorCypherEngineApiTemporalFilter:
         confidence=1.0, and forward it (along with the original filter) to the
         retriever — bypassing the dictionary/semantic temporal detector entirely.
         """
-        from khora.engines.skeleton.backends import TemporalFilter
         from khora.engines.vectorcypher.temporal_detection import TemporalCategory
+        from khora.storage.temporal import TemporalFilter
 
         # occurred_before is exclusive in pgvector; using two distinct dates.
         tf = TemporalFilter(

--- a/tests/unit/engines/test_vectorcypher_filter_pushdown.py
+++ b/tests/unit/engines/test_vectorcypher_filter_pushdown.py
@@ -1211,7 +1211,7 @@ class TestRestrictiveFallbackSkippedUnderFilter:
 
         retriever._vector_search_chunks = _spy  # type: ignore[method-assign]
 
-        from khora.engines.skeleton.backends import TemporalFilter
+        from khora.storage.temporal import TemporalFilter
 
         await retriever.retrieve(
             "what happened recently",
@@ -1245,7 +1245,7 @@ class TestRestrictiveFallbackSkippedUnderFilter:
 
         retriever._vector_search_chunks = _spy  # type: ignore[method-assign]
 
-        from khora.engines.skeleton.backends import TemporalFilter
+        from khora.storage.temporal import TemporalFilter
 
         await retriever.retrieve(
             "what happened recently",

--- a/tests/unit/engines/test_vectorcypher_retriever.py
+++ b/tests/unit/engines/test_vectorcypher_retriever.py
@@ -869,7 +869,7 @@ class TestGracefulDegradation:
         # Build temporal signal for EXPLICIT path (triggers _version_filter_entities)
         from datetime import datetime
 
-        from khora.engines.skeleton.backends import TemporalFilter
+        from khora.storage.temporal import TemporalFilter
 
         tf = TemporalFilter(occurred_before=datetime(2025, 1, 1, tzinfo=UTC))
         temporal_signal = TemporalSignal(
@@ -989,11 +989,11 @@ class TestGracefulDegradation:
 
         from neo4j.exceptions import ServiceUnavailable
 
-        from khora.engines.skeleton.backends import TemporalFilter
         from khora.engines.vectorcypher.temporal_detection import (
             TemporalCategory,
             TemporalSignal,
         )
+        from khora.storage.temporal import TemporalFilter
 
         expanded_id = uuid4()
         retriever._cypher_expand = AsyncMock(
@@ -1143,11 +1143,11 @@ class TestExplicitTemporalSignalSkipsFallback:
         from datetime import datetime
         from unittest.mock import patch
 
-        from khora.engines.skeleton.backends import TemporalFilter
         from khora.engines.vectorcypher.temporal_detection import (
             TemporalCategory,
             TemporalSignal,
         )
+        from khora.storage.temporal import TemporalFilter
 
         ns_id = uuid4()
 

--- a/tests/unit/engines/vectorcypher/test_chunker_info_propagation.py
+++ b/tests/unit/engines/vectorcypher/test_chunker_info_propagation.py
@@ -25,8 +25,8 @@ from uuid import uuid4
 import pytest
 
 from khora.core.models.document import Document, DocumentStatus
-from khora.engines.skeleton.backends import TemporalChunk
 from khora.engines.vectorcypher.engine import VectorCypherEngine
+from khora.storage.temporal import TemporalChunk
 
 # ---------------------------------------------------------------------------
 # Stub chunker — emits ChunkResult-shaped objects with a known metadata dict

--- a/tests/unit/engines/vectorcypher/test_chunker_info_read_paths.py
+++ b/tests/unit/engines/vectorcypher/test_chunker_info_read_paths.py
@@ -25,8 +25,8 @@ from uuid import uuid4
 
 import pytest
 
-from khora.engines.skeleton.backends.surrealdb import SurrealDBTemporalStore
 from khora.engines.vectorcypher.retriever import _decode_chunker_info
+from khora.storage.temporal.surrealdb import SurrealDBTemporalStore
 
 # ---------------------------------------------------------------------------
 # Neo4j retriever boundary — ``_decode_chunker_info`` helper

--- a/tests/unit/engines/vectorcypher/test_engine_coverage.py
+++ b/tests/unit/engines/vectorcypher/test_engine_coverage.py
@@ -962,7 +962,7 @@ class TestRecallContextFormatting:
     async def test_recall_explicit_temporal_filter_synthesizes_signal(self) -> None:
         """When the caller passes temporal_filter, the engine synthesizes an
         EXPLICIT TemporalSignal (source='api')."""
-        from khora.engines.skeleton.backends import TemporalFilter
+        from khora.storage.temporal import TemporalFilter
 
         engine = self._make_recall_engine()
         tf = TemporalFilter(occurred_after=datetime(2024, 1, 1, tzinfo=UTC))
@@ -1117,7 +1117,7 @@ class TestRunSkeletonExtractionDeferred:
     @pytest.mark.asyncio
     async def test_all_chunks_below_token_threshold_skipped(self) -> None:
         """If every chunk has ≤ min_extraction_tokens tokens, extraction is skipped."""
-        from khora.engines.skeleton.backends import TemporalChunk
+        from khora.storage.temporal import TemporalChunk
 
         engine = _make_connected_engine()
         # Use a tiny token budget so the short chunks below trip the threshold
@@ -1139,7 +1139,7 @@ class TestRunSkeletonExtractionDeferred:
     @pytest.mark.asyncio
     async def test_returns_entities_with_embeddings_and_links(self, monkeypatch) -> None:
         """When extraction yields entities, they get embeddings + chunk links."""
-        from khora.engines.skeleton.backends import TemporalChunk
+        from khora.storage.temporal import TemporalChunk
 
         engine = _make_connected_engine()
         engine._vc_config.min_extraction_tokens = 0  # Don't skip on token count
@@ -1181,7 +1181,7 @@ class TestRunSkeletonExtractionDeferred:
 
     @pytest.mark.asyncio
     async def test_no_entities_extracted_returns_empty_triple(self, monkeypatch) -> None:
-        from khora.engines.skeleton.backends import TemporalChunk
+        from khora.storage.temporal import TemporalChunk
 
         engine = _make_connected_engine()
         engine._vc_config.min_extraction_tokens = 0
@@ -1222,7 +1222,7 @@ class TestRunSkeletonExtraction:
     @pytest.mark.asyncio
     async def test_few_chunks_skip_skeleton(self, monkeypatch) -> None:
         """≤2 chunks bypass the skeleton indexer (all chunks are core)."""
-        from khora.engines.skeleton.backends import TemporalChunk
+        from khora.storage.temporal import TemporalChunk
 
         engine = _make_connected_engine()
         ns_id = uuid4()
@@ -1252,7 +1252,7 @@ class TestRunSkeletonExtraction:
 
     @pytest.mark.asyncio
     async def test_entities_extracted_writes_to_storage(self, monkeypatch) -> None:
-        from khora.engines.skeleton.backends import TemporalChunk
+        from khora.storage.temporal import TemporalChunk
 
         engine = _make_connected_engine()
         ns_id = uuid4()

--- a/tests/unit/engines/vectorcypher/test_llm_rerank_gate.py
+++ b/tests/unit/engines/vectorcypher/test_llm_rerank_gate.py
@@ -134,7 +134,7 @@ def _make_temporal_search_result(
     version: int | None = None,
 ):
     """Build a TemporalSearchResult mirroring the production shape."""
-    from khora.engines.skeleton.backends import TemporalChunk, TemporalSearchResult
+    from khora.storage.temporal import TemporalChunk, TemporalSearchResult
 
     metadata: dict[str, Any] = {}
     if version is not None:

--- a/tests/unit/engines/vectorcypher/test_retriever_coverage.py
+++ b/tests/unit/engines/vectorcypher/test_retriever_coverage.py
@@ -632,8 +632,8 @@ class TestRetrieveBackendGateExtra:
         entity-version narrowing; the occurred-bounds filter still pushes down,
         so retrieve() falls through to the normal path.
         """
-        from khora.engines.skeleton.backends import TemporalFilter
         from khora.engines.vectorcypher.retriever import VectorCypherResult
+        from khora.storage.temporal import TemporalFilter
 
         retriever = _make_retriever()
         retriever._backend = "sqlite_lance"
@@ -704,7 +704,7 @@ class TestRetrieveBackendGateExtra:
 
 
 def _make_temporal_search_result(content: str, occurred_at: datetime | None, similarity: float = 0.9):
-    from khora.engines.skeleton.backends import TemporalChunk, TemporalSearchResult
+    from khora.storage.temporal import TemporalChunk, TemporalSearchResult
 
     tc = TemporalChunk(
         id=uuid4(),
@@ -1032,7 +1032,7 @@ def _vectorcypher_retrieve_setup() -> tuple[VectorCypherRetriever, UUID, UUID]:
     retriever = _make_retriever(storage=storage)
     # Mock vector store search to return a chunk
     chunk = _make_chunk("hello world")
-    from khora.engines.skeleton.backends import TemporalChunk, TemporalSearchResult
+    from khora.storage.temporal import TemporalChunk, TemporalSearchResult
 
     tc = TemporalChunk(
         id=chunk.id, namespace_id=ns, document_id=chunk.document_id, content=chunk.content, embedding=None
@@ -1102,7 +1102,7 @@ class TestVectorCypherRetrieveFlow:
         assert retriever._dual_nodes is None
 
         # Mock vector store
-        from khora.engines.skeleton.backends import TemporalChunk, TemporalSearchResult
+        from khora.storage.temporal import TemporalChunk, TemporalSearchResult
 
         chunk_id = uuid4()
         tc = TemporalChunk(id=chunk_id, namespace_id=ns, document_id=uuid4(), content="hello", embedding=None)
@@ -1136,7 +1136,7 @@ class TestVectorCypherRetrieveFlow:
         storage.graph = MagicMock()
 
         retriever = _make_retriever(storage=storage)
-        from khora.engines.skeleton.backends import TemporalChunk, TemporalSearchResult
+        from khora.storage.temporal import TemporalChunk, TemporalSearchResult
 
         tc = TemporalChunk(id=uuid4(), namespace_id=ns, document_id=uuid4(), content="x", embedding=None)
         retriever._vector_store.search = AsyncMock(
@@ -1232,7 +1232,7 @@ class TestSessionAwareRetrieve:
         retriever._dual_nodes.get_relationships_between = AsyncMock(return_value=[])
 
         # Vector store returns one chunk per call
-        from khora.engines.skeleton.backends import TemporalChunk, TemporalSearchResult
+        from khora.storage.temporal import TemporalChunk, TemporalSearchResult
 
         def make_result(content: str):
             tc = TemporalChunk(id=uuid4(), namespace_id=ns, document_id=uuid4(), content=content, embedding=None)
@@ -1372,7 +1372,7 @@ def _make_temporal_search_result_with_version(
     similarity: float = 0.9,
 ):
     """Build a TemporalSearchResult with version metadata baked into the chunk metadata."""
-    from khora.engines.skeleton.backends import TemporalChunk, TemporalSearchResult
+    from khora.storage.temporal import TemporalChunk, TemporalSearchResult
 
     chunk_meta = {"version": version}
     if entity_refs:
@@ -1589,7 +1589,7 @@ class TestChangeDecompositionMerging:
         # Mock vector store search:
         # First call (main query) → empty
         # Second call (sub-query) → has a new chunk
-        from khora.engines.skeleton.backends import TemporalChunk, TemporalSearchResult
+        from khora.storage.temporal import TemporalChunk, TemporalSearchResult
 
         new_chunk_tc = TemporalChunk(id=uuid4(), namespace_id=ns, document_id=uuid4(), content="sub", embedding=None)
         new_result = TemporalSearchResult(chunk=new_chunk_tc, similarity=0.7, combined_score=0.7)
@@ -1607,7 +1607,7 @@ class TestChangeDecompositionMerging:
         retriever._embedder.embed = AsyncMock(return_value=[0.1] * 4)
 
         # Temporal signal: CHANGE with EXPLICIT filter
-        from khora.engines.skeleton.backends import TemporalFilter
+        from khora.storage.temporal import TemporalFilter
 
         change_tf = TemporalFilter(occurred_after=datetime(2024, 1, 1, tzinfo=UTC))
         signal = TemporalSignal(

--- a/tests/unit/engines/vectorcypher/test_simple_retrieve_entities_857.py
+++ b/tests/unit/engines/vectorcypher/test_simple_retrieve_entities_857.py
@@ -22,12 +22,12 @@ from uuid import UUID, uuid4
 import pytest
 
 from khora.core.models import Entity, Relationship
-from khora.engines.skeleton.backends import TemporalChunk, TemporalSearchResult
 from khora.engines.vectorcypher.retriever import (
     RetrieverConfig,
     VectorCypherRetriever,
 )
 from khora.engines.vectorcypher.router import QueryComplexity, RoutingDecision
+from khora.storage.temporal import TemporalChunk, TemporalSearchResult
 
 
 def _make_retriever(*, storage: Any | None = None) -> VectorCypherRetriever:

--- a/tests/unit/engines/vectorcypher/test_source_timestamp_recall_859.py
+++ b/tests/unit/engines/vectorcypher/test_source_timestamp_recall_859.py
@@ -30,12 +30,12 @@ from uuid import uuid4
 import pytest
 
 from khora.core.models import Chunk, Entity
-from khora.engines.skeleton.backends import TemporalChunk, TemporalSearchResult
 from khora.engines.vectorcypher.retriever import (
     RetrieverConfig,
     VectorCypherRetriever,
     _coerce_occurred_at,
 )
+from khora.storage.temporal import TemporalChunk, TemporalSearchResult
 
 T_SOURCE = datetime(2024, 6, 15, 12, 30, 0, tzinfo=UTC)
 

--- a/tests/unit/engines/vectorcypher/test_temporal_sort_tz_1115.py
+++ b/tests/unit/engines/vectorcypher/test_temporal_sort_tz_1115.py
@@ -24,12 +24,12 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from khora.engines.skeleton.backends import TemporalChunk, TemporalSearchResult
 from khora.engines.vectorcypher.retriever import (
     RetrieverConfig,
     VectorCypherRetriever,
 )
 from khora.engines.vectorcypher.router import QueryComplexity, RoutingDecision
+from khora.storage.temporal import TemporalChunk, TemporalSearchResult
 
 
 def _make_retriever() -> VectorCypherRetriever:

--- a/tests/unit/filter/test_compile_surrealdb.py
+++ b/tests/unit/filter/test_compile_surrealdb.py
@@ -16,7 +16,7 @@ string directly and check ``params`` for the bound values.
 
 **Backed vs unbacked system keys.** Only two of the ten :data:`SYSTEM_KEYS`
 (``occurred_at`` / ``created_at`` — the store's
-:data:`~khora.engines.skeleton.backends.surrealdb._BACKED_SYSTEM_KEYS`) are real
+:data:`~khora.storage.temporal.surrealdb._BACKED_SYSTEM_KEYS`) are real
 columns on the SCHEMAFULL ``temporal_chunk`` table; the other eight denormalized
 document keys are not. The live recall context only maps the backed keys (plus the
 ``metadata`` root), so the compiler FAILS LOUD (``RecallFilterUnsupportedError`` in
@@ -58,12 +58,12 @@ from datetime import UTC, datetime
 
 import pytest
 
-from khora.engines.skeleton.backends.surrealdb import _BACKED_SYSTEM_KEYS
 from khora.filter import RecallFilter
 from khora.filter.ast import FilterClause, FilterNode, canonical_hash, parse_to_ast
 from khora.filter.compilers.surrealdb import compile_surrealdb
 from khora.filter.context import CompileContext, RecallFilterUnsupportedError
 from khora.filter.model import SYSTEM_KEYS, Op
+from khora.storage.temporal.surrealdb import _BACKED_SYSTEM_KEYS
 
 # Hard import (NOT importorskip): the compiler is pure-Python string emission with
 # no SurrealDB SDK dependency, so an import failure here must be a LOUD test error,

--- a/tests/unit/filter/test_compile_surrealdb_injection.py
+++ b/tests/unit/filter/test_compile_surrealdb_injection.py
@@ -70,7 +70,7 @@ def test_safe_nested_segment_compiles() -> None:
 @pytest.fixture(name="store_module")
 def _store_module():  # noqa: ANN202 - test fixture
     """The skeleton SurrealDB backend module (importing it registers the compiler)."""
-    from khora.engines.skeleton.backends import surrealdb as mod
+    from khora.storage.temporal import surrealdb as mod
 
     return mod
 
@@ -92,7 +92,7 @@ def test_legacy_additional_unsafe_key_raises_compile_error(store_module, additio
     """
     from uuid import uuid4
 
-    from khora.engines.skeleton.backends import TemporalFilter
+    from khora.storage.temporal import TemporalFilter
 
     tf = TemporalFilter(additional=additional)
     with pytest.raises(CompileError):
@@ -109,7 +109,7 @@ def test_legacy_additional_eq_routes_through_guard(store_module) -> None:  # noq
     """
     from uuid import uuid4
 
-    from khora.engines.skeleton.backends import TemporalFilter
+    from khora.storage.temporal import TemporalFilter
 
     tf = TemporalFilter(
         additional={

--- a/tests/unit/filter/test_surrealdb_backed_keys_drift.py
+++ b/tests/unit/filter/test_surrealdb_backed_keys_drift.py
@@ -2,7 +2,7 @@
 
 The SurrealDB recall path can only push a predicate over a system key the
 ``temporal_chunk`` table actually backs with a real column. The store declares that
-queryable set as :data:`~khora.engines.skeleton.backends.surrealdb._BACKED_SYSTEM_KEYS`
+queryable set as :data:`~khora.storage.temporal.surrealdb._BACKED_SYSTEM_KEYS`
 (``{"occurred_at", "created_at"}``) and the compiler refuses (raising) any predicate
 over a system key outside it.
 
@@ -26,8 +26,8 @@ import re
 
 import pytest
 
-from khora.engines.skeleton.backends.surrealdb import _BACKED_SYSTEM_KEYS, _TEMPORAL_CHUNK_SCHEMA
 from khora.filter.model import SYSTEM_KEYS
+from khora.storage.temporal.surrealdb import _BACKED_SYSTEM_KEYS, _TEMPORAL_CHUNK_SCHEMA
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_ingest_temporal_chunks.py
+++ b/tests/unit/test_ingest_temporal_chunks.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 
 import pytest
 
-from khora.engines.skeleton.backends import TemporalChunk
+from khora.storage.temporal import TemporalChunk
 
 
 def _make_storage_mock() -> MagicMock:

--- a/tests/unit/test_pgvector_row_to_chunk.py
+++ b/tests/unit/test_pgvector_row_to_chunk.py
@@ -13,8 +13,8 @@ from uuid import uuid4
 import numpy as np
 import pytest
 
-from khora.engines.skeleton.backends import TemporalChunk
-from khora.engines.skeleton.backends.pgvector import PgVectorTemporalStore
+from khora.storage.temporal import TemporalChunk
+from khora.storage.temporal.pgvector import PgVectorTemporalStore
 
 
 def _make_row(embedding=None, tags=None):

--- a/tests/unit/test_resolve_temporal_filter.py
+++ b/tests/unit/test_resolve_temporal_filter.py
@@ -43,7 +43,7 @@ class TestResolveTemporalFilter:
 
     def test_explicit_signal_with_filter_passed_through(self) -> None:
         """If temporal_signal already has a filter, use it directly."""
-        from khora.engines.skeleton.backends import TemporalFilter
+        from khora.storage.temporal import TemporalFilter
 
         existing = TemporalFilter(occurred_after=datetime(2026, 1, 1, tzinfo=UTC))
         mock_signal = MagicMock()
@@ -73,7 +73,7 @@ class TestResolveTemporalFilter:
 
     def test_returns_skeleton_temporal_filter_type(self) -> None:
         """resolve_temporal_filter returns the skeleton TemporalFilter type."""
-        from khora.engines.skeleton.backends import TemporalFilter
+        from khora.storage.temporal import TemporalFilter
 
         result = resolve_temporal_filter("What happened in the last 3 days?")
         assert result is not None
@@ -94,8 +94,8 @@ class TestToQueryTemporalFilter:
 
     def test_converts_skeleton_to_query_filter(self) -> None:
         """Skeleton TemporalFilter is converted to query TemporalFilter."""
-        from khora.engines.skeleton.backends import TemporalFilter as SkeletonTF
         from khora.query.temporal import TemporalFilter as QueryTF
+        from khora.storage.temporal import TemporalFilter as SkeletonTF
 
         after = datetime(2026, 1, 1, tzinfo=UTC)
         before = datetime(2026, 2, 1, tzinfo=UTC)
@@ -109,7 +109,7 @@ class TestToQueryTemporalFilter:
 
     def test_returns_none_for_empty_filter(self) -> None:
         """Returns None when skeleton filter has no time bounds."""
-        from khora.engines.skeleton.backends import TemporalFilter as SkeletonTF
+        from khora.storage.temporal import TemporalFilter as SkeletonTF
 
         skeleton = SkeletonTF()
         result = to_query_temporal_filter(skeleton)


### PR DESCRIPTION
## Summary
- Replace direct temporal-store construction in the VectorCypher and Skeleton engines with the `StorageCoordinator.temporal_store()` factory accessor. The accessor returns a freshly connected store and owns the per-backend shared-resource wiring (pgvector engine, surrealdb connection, sqlite_lance handle), so the engines no longer reach into backend internals or manage that wiring themselves.
- This cuts the engines' back-edge into the skeleton backends package: `khora.engines.vectorcypher` now imports nothing from `khora.engines.skeleton`.
- Import the `TemporalVectorStore` protocol from `khora.storage.temporal` in the VectorCypher retriever and the ingest pipeline (previously imported from the skeleton backends package).
- Migrate backend-submodule test imports (`pgvector`/`surrealdb`/`weaviate`/`turbopuffer`/`sqlite_lance`) to the `khora.storage.temporal.*` paths. The deprecation-contract guard test is intentionally left on the old path to keep verifying the re-export shims.
- Update the skeleton-engine docs import examples to the new paths.
- Behavior-preserving: recall/ingest behavior is unchanged; the accessor returns an equivalent connected store.

## Test plan
- [x] Unit tests pass (444 passed, coverage 84.77%)
- [x] Integration tests pass
- [x] Embedded temporal e2e regression lanes pass (incl. the embedded VectorCypher lane)
- [x] `ruff format` / `ruff check` / typecheck clean
- [x] Engines import nothing from the skeleton backends package; no direct store construction remains in engine code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Refactor**
  * Reorganized internal temporal storage implementation structure, consolidating storage-related components into a dedicated storage module for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->