### PR TITLE
Make checksum dedup ordering deterministic

### DIFF
--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -698,8 +698,10 @@ async def stage_documents_batch(
         total_dups = sum(len(idxs) for idxs in dup_groups.values())
         logger.debug(f"Intra-batch dedup: {total_dups} duplicate(s) across {len(dup_groups)} identity key(s)")
 
-    # Single batch query for existing documents — query only unique checksums
-    unique_checksums = list({checksums[i] for i in range(len(doc_inputs))})
+    # Single batch query for existing documents — query only unique checksums.
+    # dict.fromkeys preserves insertion order so the argument order to
+    # get_documents_by_checksums is deterministic (not hash-seed dependent).
+    unique_checksums = list(dict.fromkeys(checksums))
     existing = await storage.get_documents_by_checksums(namespace_id, unique_checksums)
 
     results: list[Document | None] = [None] * len(doc_inputs)


### PR DESCRIPTION
## Summary
- `stage_documents_batch` built its unique-checksum list from a `set`, whose iteration order is `PYTHONHASHSEED`-dependent. That made the order of the list passed to `get_documents_by_checksums` vary run-to-run. Replaced the set comprehension with `list(dict.fromkeys(checksums))`, which dedups while preserving insertion order — deterministic, and behavior-identical otherwise (dedup keeps the first occurrence; downstream consumes the result by dict lookup, not by position).

> Note: the companion test fix originally in this PR (re-keying the `test_existing_checksum_skipped` mock off the content checksum) has since landed on `main` independently, so after rebasing this PR is now just the source-side determinism hardening.

## Test plan
- [x] `tests/unit/pipelines/test_ingest_coverage_push.py` unit tests pass
- [x] `ruff format` / `ruff check` clean; typecheck has no new findings on touched files
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved document batch processing consistency through enhanced checksum deduplication handling, ensuring more predictable behavior during document ingestion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->