### PR TITLE
feat(telemetry): add LLM cost tracking and UsageSummary

### DIFF
--- a/src/khora/__init__.py
+++ b/src/khora/__init__.py
@@ -75,6 +75,7 @@ from .khora import (
     RecallResult,
     RememberResult,
     Stats,
+    UsageSummary,
 )
 from .search_mode import SearchMode
 
@@ -85,6 +86,7 @@ __all__ = [
     "KhoraError",
     "Khora",
     "LLMUsage",
+    "UsageSummary",
     "RememberResult",
     "RecallResult",
     "DocumentProjection",

--- a/src/khora/config/llm.py
+++ b/src/khora/config/llm.py
@@ -560,6 +560,10 @@ async def acompletion(
     _prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
     _completion_tokens = getattr(usage, "completion_tokens", 0) or 0
     _total_tokens = getattr(usage, "total_tokens", 0) or 0
+
+    from khora.khora import LLMUsage, _safe_completion_cost
+
+    _cost = _safe_completion_cost(response, model=config.model)
     get_collector().record_llm_call(
         operation=_operation,
         model=config.model,
@@ -567,12 +571,9 @@ async def acompletion(
         completion_tokens=_completion_tokens,
         total_tokens=_total_tokens,
         latency_ms=_latency,
+        cost_usd=_cost,
     )
 
-    # Extractors call litellm.acompletion() directly, not this helper.
-    # If they switch to this helper, remove their own record_usage() calls to
-    # avoid double-counting.
-    from khora.khora import LLMUsage
     from khora.telemetry.context import record_usage
 
     record_usage(
@@ -583,6 +584,7 @@ async def acompletion(
             completion_tokens=_completion_tokens,
             total_tokens=_total_tokens,
             latency_ms=_latency,
+            cost_usd=_cost,
         )
     )
 
@@ -633,6 +635,10 @@ async def aembedding(
     usage = getattr(response, "usage", None)
     _prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
     _total_tokens = getattr(usage, "total_tokens", 0) or 0
+
+    from khora.khora import LLMUsage, _safe_completion_cost
+
+    _cost = _safe_completion_cost(response, model=config.embedding_model, call_type="aembedding")
     get_collector().record_llm_call(
         operation="embedding",
         model=config.embedding_model,
@@ -640,12 +646,9 @@ async def aembedding(
         total_tokens=_total_tokens,
         latency_ms=_latency,
         metadata={"batch_size": len(text)},
+        cost_usd=_cost,
     )
 
-    # Embedders call litellm.aembedding() directly, not this helper.
-    # If they switch to this helper, remove their own record_usage() calls to
-    # avoid double-counting.
-    from khora.khora import LLMUsage
     from khora.telemetry.context import record_usage
 
     record_usage(
@@ -657,6 +660,7 @@ async def aembedding(
             total_tokens=_total_tokens,
             latency_ms=_latency,
             batch_size=len(text),
+            cost_usd=_cost,
         )
     )
 

--- a/src/khora/core/models/recall.py
+++ b/src/khora/core/models/recall.py
@@ -136,7 +136,7 @@ class RecallResult:
     chunks: list[RecallChunk]
     entities: list[RecallEntity]
     relationships: list[RecallRelationship]
-    usage: list[LLMUsage] = field(default_factory=list)
+    llm_usage: list[LLMUsage] = field(default_factory=list)
     engine_info: dict[str, Any] = field(default_factory=dict)
     communities: list[CommunityNode] = field(default_factory=list)
 

--- a/src/khora/engines/chronicle/compression.py
+++ b/src/khora/engines/chronicle/compression.py
@@ -298,14 +298,34 @@ class FactExtractor:
 
         _latency = (_time.perf_counter() - _t0) * 1000
         usage = getattr(response, "usage", None)
+        _pt = getattr(usage, "prompt_tokens", 0) or 0
+        _ct = getattr(usage, "completion_tokens", 0) or 0
+        _tt = getattr(usage, "total_tokens", 0) or 0
+
+        from khora.khora import LLMUsage, _safe_completion_cost
+        from khora.telemetry.context import record_usage
+
+        _cost = _safe_completion_cost(response, model=self._model)
         get_collector().record_llm_call(
             operation="fact_extraction",
             model=self._model,
-            prompt_tokens=getattr(usage, "prompt_tokens", 0) or 0,
-            completion_tokens=getattr(usage, "completion_tokens", 0) or 0,
-            total_tokens=getattr(usage, "total_tokens", 0) or 0,
+            prompt_tokens=_pt,
+            completion_tokens=_ct,
+            total_tokens=_tt,
             latency_ms=_latency,
             namespace_id=namespace_id,
+            cost_usd=_cost,
+        )
+        record_usage(
+            LLMUsage(
+                operation="fact_extraction",
+                model=self._model,
+                prompt_tokens=_pt,
+                completion_tokens=_ct,
+                total_tokens=_tt,
+                latency_ms=_latency,
+                cost_usd=_cost,
+            )
         )
 
         facts: list[MemoryFact] = []
@@ -478,13 +498,33 @@ class MemoryCompressor:
 
         _latency = (_time.perf_counter() - _t0) * 1000
         usage = getattr(response, "usage", None)
+        _pt = getattr(usage, "prompt_tokens", 0) or 0
+        _ct = getattr(usage, "completion_tokens", 0) or 0
+        _tt = getattr(usage, "total_tokens", 0) or 0
+
+        from khora.khora import LLMUsage, _safe_completion_cost
+        from khora.telemetry.context import record_usage
+
+        _cost = _safe_completion_cost(response, model=self._model)
         get_collector().record_llm_call(
             operation="fact_reconcile",
             model=self._model,
-            prompt_tokens=getattr(usage, "prompt_tokens", 0) or 0,
-            completion_tokens=getattr(usage, "completion_tokens", 0) or 0,
-            total_tokens=getattr(usage, "total_tokens", 0) or 0,
+            prompt_tokens=_pt,
+            completion_tokens=_ct,
+            total_tokens=_tt,
             latency_ms=_latency,
+            cost_usd=_cost,
+        )
+        record_usage(
+            LLMUsage(
+                operation="fact_reconcile",
+                model=self._model,
+                prompt_tokens=_pt,
+                completion_tokens=_ct,
+                total_tokens=_tt,
+                latency_ms=_latency,
+                cost_usd=_cost,
+            )
         )
 
         op_str = str(result.get("operation", "add")).lower()

--- a/src/khora/engines/chronicle/events.py
+++ b/src/khora/engines/chronicle/events.py
@@ -233,14 +233,34 @@ class EventExtractor:
 
         _latency = (_time.perf_counter() - _t0) * 1000
         usage = getattr(response, "usage", None)
+        _pt = getattr(usage, "prompt_tokens", 0) or 0
+        _ct = getattr(usage, "completion_tokens", 0) or 0
+        _tt = getattr(usage, "total_tokens", 0) or 0
+
+        from khora.khora import LLMUsage, _safe_completion_cost
+        from khora.telemetry.context import record_usage
+
+        _cost = _safe_completion_cost(response, model=self._model)
         get_collector().record_llm_call(
             operation="event_extraction",
             model=self._model,
-            prompt_tokens=getattr(usage, "prompt_tokens", 0) or 0,
-            completion_tokens=getattr(usage, "completion_tokens", 0) or 0,
-            total_tokens=getattr(usage, "total_tokens", 0) or 0,
+            prompt_tokens=_pt,
+            completion_tokens=_ct,
+            total_tokens=_tt,
             latency_ms=_latency,
             namespace_id=namespace_id,
+            cost_usd=_cost,
+        )
+        record_usage(
+            LLMUsage(
+                operation="event_extraction",
+                model=self._model,
+                prompt_tokens=_pt,
+                completion_tokens=_ct,
+                total_tokens=_tt,
+                latency_ms=_latency,
+                cost_usd=_cost,
+            )
         )
 
         events = []

--- a/src/khora/extraction/embedders/litellm.py
+++ b/src/khora/extraction/embedders/litellm.py
@@ -438,6 +438,9 @@ class LiteLLMEmbedder(Embedder):
                     req_span.set_attribute("prompt_tokens", prompt_tokens)
                     req_span.set_attribute("total_tokens", total_tokens)
 
+                    from khora.khora import LLMUsage, _safe_completion_cost
+
+                    _cost = _safe_completion_cost(response, model=self._model, call_type="aembedding")
                     get_collector().record_llm_call(
                         operation="embedding",
                         model=self._model,
@@ -446,9 +449,9 @@ class LiteLLMEmbedder(Embedder):
                         latency_ms=_latency,
                         batch_size=len(texts),
                         cache_hit=False,
+                        cost_usd=_cost,
                     )
 
-                    from khora.khora import LLMUsage
                     from khora.telemetry.context import record_usage
 
                     record_usage(
@@ -460,6 +463,7 @@ class LiteLLMEmbedder(Embedder):
                             total_tokens=total_tokens,
                             latency_ms=_latency,
                             batch_size=len(texts),
+                            cost_usd=_cost,
                         )
                     )
 

--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -961,6 +961,10 @@ class LLMEntityExtractor(EntityExtractor):
         _pt = getattr(usage, "prompt_tokens", 0) or 0
         _ct = getattr(usage, "completion_tokens", 0) or 0
         _tt = getattr(usage, "total_tokens", 0) or 0
+
+        from khora.khora import LLMUsage, _safe_completion_cost
+
+        _cost = _safe_completion_cost(response, model=self._model)
         get_collector().record_llm_call(
             operation="entity_extraction",
             model=self._model,
@@ -968,9 +972,9 @@ class LLMEntityExtractor(EntityExtractor):
             completion_tokens=_ct,
             total_tokens=_tt,
             latency_ms=_latency,
+            cost_usd=_cost,
         )
 
-        from khora.khora import LLMUsage
         from khora.telemetry.context import record_usage
 
         record_usage(
@@ -981,6 +985,7 @@ class LLMEntityExtractor(EntityExtractor):
                 completion_tokens=_ct,
                 total_tokens=_tt,
                 latency_ms=_latency,
+                cost_usd=_cost,
             )
         )
 
@@ -1227,6 +1232,10 @@ class LLMEntityExtractor(EntityExtractor):
                 _pt = getattr(usage, "prompt_tokens", 0) or 0
                 _ct = getattr(usage, "completion_tokens", 0) or 0
                 _tt = getattr(usage, "total_tokens", 0) or 0
+
+                from khora.khora import LLMUsage, _safe_completion_cost
+
+                _cost = _safe_completion_cost(response, model=self._model)
                 get_collector().record_llm_call(
                     operation="relationship_extraction_second_pass",
                     model=self._model,
@@ -1234,9 +1243,9 @@ class LLMEntityExtractor(EntityExtractor):
                     completion_tokens=_ct,
                     total_tokens=_tt,
                     latency_ms=_latency,
+                    cost_usd=_cost,
                 )
 
-                from khora.khora import LLMUsage
                 from khora.telemetry.context import record_usage
 
                 record_usage(
@@ -1247,6 +1256,7 @@ class LLMEntityExtractor(EntityExtractor):
                         completion_tokens=_ct,
                         total_tokens=_tt,
                         latency_ms=_latency,
+                        cost_usd=_cost,
                     )
                 )
 
@@ -2036,6 +2046,10 @@ Return ONLY valid JSON, no other text."""
                             _pt,
                             _ct,
                         )
+
+                        from khora.khora import LLMUsage, _safe_completion_cost
+
+                        _cost = _safe_completion_cost(response, model=self._model)
                         get_collector().record_llm_call(
                             operation="entity_extraction_multi",
                             model=self._model,
@@ -2044,9 +2058,9 @@ Return ONLY valid JSON, no other text."""
                             total_tokens=_tt,
                             latency_ms=_latency,
                             metadata={"batch_size": len(texts)},
+                            cost_usd=_cost,
                         )
 
-                        from khora.khora import LLMUsage
                         from khora.telemetry.context import record_usage
 
                         record_usage(
@@ -2058,6 +2072,7 @@ Return ONLY valid JSON, no other text."""
                                 total_tokens=_tt,
                                 latency_ms=_latency,
                                 batch_size=len(texts),
+                                cost_usd=_cost,
                             )
                         )
 

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -13,7 +13,7 @@ import asyncio
 import hashlib
 import os
 import warnings
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator, Callable, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
@@ -211,6 +211,91 @@ class LLMUsage:
     latency_ms: float
     batch_size: int = 1
     """>1 for embedding batches."""
+    cost_usd: float = 0.0
+    """Estimated USD cost via litellm pricing tables. 0.0 when unknown."""
+
+
+def _safe_completion_cost(
+    response: Any = None,
+    *,
+    model: str = "",
+    call_type: str = "acompletion",
+) -> float:
+    """Best-effort USD cost from litellm pricing tables.
+
+    Returns 0.0 on any failure (unknown model, missing litellm, etc.).
+    """
+    try:
+        import litellm
+
+        return float(
+            litellm.completion_cost(
+                completion_response=response,
+                model=model,
+                call_type=call_type,
+            )
+        )
+    except Exception:
+        return 0.0
+
+
+@dataclass(slots=True, frozen=True)
+class _OperationUsage:
+    """Per-operation aggregate."""
+
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+    cost_usd: float
+    call_count: int
+
+
+@dataclass(slots=True, frozen=True)
+class UsageSummary:
+    """Aggregate view over a list of :class:`LLMUsage` entries."""
+
+    total_prompt_tokens: int
+    total_completion_tokens: int
+    total_tokens: int
+    total_cost_usd: float
+    total_latency_ms: float
+    by_operation: dict[str, _OperationUsage]
+    by_model: dict[str, _OperationUsage]
+
+    @staticmethod
+    def from_usage(entries: Iterable[LLMUsage]) -> UsageSummary:
+        """Build a summary from LLMUsage entries."""
+        prompt = comp = total = 0
+        cost = latency = 0.0
+        ops: dict[str, list[LLMUsage]] = {}
+        models: dict[str, list[LLMUsage]] = {}
+        for u in entries:
+            prompt += u.prompt_tokens
+            comp += u.completion_tokens
+            total += u.total_tokens
+            cost += u.cost_usd
+            latency += u.latency_ms
+            ops.setdefault(u.operation, []).append(u)
+            models.setdefault(u.model, []).append(u)
+
+        def _agg(items: list[LLMUsage]) -> _OperationUsage:
+            return _OperationUsage(
+                prompt_tokens=sum(i.prompt_tokens for i in items),
+                completion_tokens=sum(i.completion_tokens for i in items),
+                total_tokens=sum(i.total_tokens for i in items),
+                cost_usd=sum(i.cost_usd for i in items),
+                call_count=len(items),
+            )
+
+        return UsageSummary(
+            total_prompt_tokens=prompt,
+            total_completion_tokens=comp,
+            total_tokens=total,
+            total_cost_usd=cost,
+            total_latency_ms=latency,
+            by_operation={k: _agg(v) for k, v in ops.items()},
+            by_model={k: _agg(v) for k, v in models.items()},
+        )
 
 
 @dataclass(slots=True, frozen=True)
@@ -2254,7 +2339,7 @@ class Khora:
                 except Exception as exc:  # pragma: no cover - defensive
                     logger.warning("Hook dispatch failed for {}: {}", EventType.RECALL_RESULTS_READY.value, exc)
 
-                packaged = replace(result, usage=collect_usage())
+                packaged = replace(result, llm_usage=collect_usage())
 
                 # Emit RECALL_COMPLETED with end-to-end timing.
                 try:

--- a/src/khora/query/reranking.py
+++ b/src/khora/query/reranking.py
@@ -275,7 +275,26 @@ class CrossEncoderReranker(Reranker):
             # Score in batches
             # Offload synchronous PyTorch inference to a thread to avoid
             # blocking the event loop during cross-encoder scoring.
+            import time as _time
+
+            _t0 = _time.perf_counter()
             scores = await asyncio.to_thread(model.predict, pairs, batch_size=self._batch_size)
+            _latency = (_time.perf_counter() - _t0) * 1000
+
+            from khora.khora import LLMUsage
+            from khora.telemetry.context import record_usage
+
+            record_usage(
+                LLMUsage(
+                    operation="cross_encoder_rerank",
+                    model=self._model_name,
+                    prompt_tokens=0,
+                    completion_tokens=0,
+                    total_tokens=0,
+                    latency_ms=_latency,
+                    batch_size=len(pairs),
+                )
+            )
 
             # Convert all scores to floats for normalization
             # Cross-encoders output logits (roughly -3 to 3), we need to normalize

--- a/src/khora/query/reranking.py
+++ b/src/khora/query/reranking.py
@@ -297,7 +297,7 @@ class CrossEncoderReranker(Reranker):
                     )
                 )
             except Exception:
-                pass
+                logger.debug("Cross-encoder usage recording failed", exc_info=True)
 
             # Convert all scores to floats for normalization
             # Cross-encoders output logits (roughly -3 to 3), we need to normalize

--- a/src/khora/query/reranking.py
+++ b/src/khora/query/reranking.py
@@ -281,20 +281,23 @@ class CrossEncoderReranker(Reranker):
             scores = await asyncio.to_thread(model.predict, pairs, batch_size=self._batch_size)
             _latency = (_time.perf_counter() - _t0) * 1000
 
-            from khora.khora import LLMUsage
-            from khora.telemetry.context import record_usage
+            try:
+                from khora.khora import LLMUsage
+                from khora.telemetry.context import record_usage
 
-            record_usage(
-                LLMUsage(
-                    operation="cross_encoder_rerank",
-                    model=self._model_name,
-                    prompt_tokens=0,
-                    completion_tokens=0,
-                    total_tokens=0,
-                    latency_ms=_latency,
-                    batch_size=len(pairs),
+                record_usage(
+                    LLMUsage(
+                        operation="cross_encoder_rerank",
+                        model=self._model_name,
+                        prompt_tokens=0,
+                        completion_tokens=0,
+                        total_tokens=0,
+                        latency_ms=_latency,
+                        batch_size=len(pairs),
+                    )
                 )
-            )
+            except Exception:
+                pass
 
             # Convert all scores to floats for normalization
             # Cross-encoders output logits (roughly -3 to 3), we need to normalize

--- a/tests/unit/test_llm_usage.py
+++ b/tests/unit/test_llm_usage.py
@@ -103,7 +103,7 @@ class TestResultLLMUsageField:
             entities=[],
             relationships=[],
         )
-        assert r.usage == []
+        assert r.llm_usage == []
 
     def test_remember_result_with_usage(self) -> None:
         usage = [

--- a/tests/unit/test_public_surface.py
+++ b/tests/unit/test_public_surface.py
@@ -61,6 +61,7 @@ EXPECTED_PUBLIC_SURFACE = frozenset(
         "SearchMode",
         "SemanticFilter",
         "Stats",
+        "UsageSummary",
         "StringOps",
         "context_text",
         "create_engine",


### PR DESCRIPTION
## Summary

- Adds `cost_usd` field to `LLMUsage` via a best-effort `_safe_completion_cost()` wrapper around litellm's pricing tables (returns 0.0 on unknown models)
- Threads cost tracking through all 10 LLM call sites: `acompletion`, `aembedding`, entity/relationship extraction, fact extraction/reconciliation, event extraction, and the direct embedder path
- Introduces `UsageSummary` (public) and `_OperationUsage` aggregation types with `UsageSummary.from_usage()` for per-operation and per-model breakdowns
- Renames `RecallResult.usage` → `RecallResult.llm_usage` to align with `RememberResult.llm_usage`
- Adds `record_usage()` to chronicle compression, chronicle events, and cross-encoder reranking sites that previously only had `record_llm_call`, closing gaps in per-request usage accumulation

## Test plan

- [x] Existing `test_llm_usage.py` updated for the `RecallResult` field rename
- [ ] Verify `UsageSummary.from_usage()` with real recall/remember results in integration tests
- [ ] Confirm `_safe_completion_cost` returns 0.0 for unknown/custom models without raising
- [ ] Check that cross-encoder reranking entries appear in `RecallResult.llm_usage`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added best-effort USD cost tracking (`cost_usd`) to LLM, embeddings, and extraction telemetry, plus cross-encoder reranking.
  * Introduced `UsageSummary` to aggregate usage metrics by operation and model, and exposed it as part of the public API.
* **Chores**
  * Updated recall results to store telemetry under `RecallResult.llm_usage` (instead of `usage`).
  * `LLMUsage.cost_usd` now defaults to `0.0` when cost can’t be determined.
* **Tests**
  * Updated unit tests and public surface snapshot to reflect `llm_usage` and the new `UsageSummary` export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->