### PR TITLE
Thread metadata through create_namespace

### DIFF
--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -3517,10 +3517,12 @@ class ChronicleEngine:
         self,
         *,
         config_overrides: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> MemoryNamespace:
         """Create a new memory namespace."""
         namespace = MemoryNamespace(
             config_overrides=config_overrides or {},
+            metadata=metadata or {},
         )
         return await self._get_storage().create_namespace(namespace)
 

--- a/src/khora/engines/protocol.py
+++ b/src/khora/engines/protocol.py
@@ -205,11 +205,13 @@ class MemoryEngineProtocol(Protocol):
         self,
         *,
         config_overrides: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> MemoryNamespace:
         """Create a new memory namespace.
 
         Args:
             config_overrides: Optional configuration overrides
+            metadata: Optional namespace metadata
 
         Returns:
             Created MemoryNamespace

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -1112,10 +1112,12 @@ class SkeletonConstructionEngine:
         self,
         *,
         config_overrides: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> MemoryNamespace:
         """Create a new memory namespace."""
         namespace = MemoryNamespace(
             config_overrides=config_overrides or {},
+            metadata=metadata or {},
         )
         return await self._get_storage().create_namespace(namespace)
 

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -3709,10 +3709,12 @@ class VectorCypherEngine:
         self,
         *,
         config_overrides: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> MemoryNamespace:
         """Create a new memory namespace."""
         namespace = MemoryNamespace(
             config_overrides=config_overrides or {},
+            metadata=metadata or {},
         )
         return await self._get_storage().create_namespace(namespace)
 

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -1453,17 +1453,20 @@ class Khora:
         self,
         *,
         config_overrides: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> MemoryNamespace:
         """Create a new memory namespace.
 
         Args:
             config_overrides: Optional configuration overrides
+            metadata: Optional namespace metadata
 
         Returns:
             Created MemoryNamespace
         """
         return await self._get_engine().create_namespace(
             config_overrides=config_overrides,
+            metadata=metadata,
         )
 
     async def get_namespace(self, namespace_id: UUID) -> MemoryNamespace | None:


### PR DESCRIPTION
## Summary

- Add optional `metadata: dict[str, Any] | None = None` parameter to `Khora.create_namespace`, the `MemoryEngineProtocol`, and all three engine implementations (vectorcypher, chronicle, skeleton)
- The storage layer already persists `MemoryNamespace.metadata`, but the public API and engine layer never accepted it — this closes the gap so callers can set namespace metadata at creation time

## Test plan

- [ ] Existing tests pass (`make test`) — no signatures changed in a breaking way (new param is keyword-only with default `None`)
- [ ] Verify `Khora.create_namespace(metadata={"key": "value"})` round-trips metadata through to the stored namespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Namespace creation now supports optional metadata, allowing more information to be attached when creating new namespaces.
  * The main API and underlying engines now pass this metadata through consistently, so namespace details are preserved across supported creation flows.
  * If no metadata is provided, namespaces continue to be created with an empty default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->