### PR TITLE
Bump langsmith to patched version (GHSA-f4xh-w4cj-qxq8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -351,7 +351,7 @@ exclude-newer = "7 days"
 # staging window so a same-week CVE fix isn't held back. Use sparingly —
 # every entry here is an explicit "we trust this package enough to skip
 # the staging window".
-exclude-newer-package = { urllib3 = "0 days", litellm = "0 days", idna = "0 days", "turbopuffer" = "0 days", aiohttp = "0 days", "pydantic-settings" = "0 days" }  # urllib3: CVE-2026-44431/44432; litellm: CVE-2026-42208/42271/40217 (1.83.10+); idna: CVE-2026-45409 (3.15+); turbopuffer: 2.1.0 newer than the 7-day window when introduced in #824 - opt-in extra so safe to bypass; aiohttp: CVE-2026-34993/47265 (3.14.0+), CVE-2026-54273..54280 (3.14.1+); pydantic-settings: GHSA-4xgf-cpjx-pc3j (fixed 2.14.2).
+exclude-newer-package = { urllib3 = "0 days", litellm = "0 days", idna = "0 days", "turbopuffer" = "0 days", aiohttp = "0 days", "pydantic-settings" = "0 days", langsmith = "0 days" }  # urllib3: CVE-2026-44431/44432; litellm: CVE-2026-42208/42271/40217 (1.83.10+); idna: CVE-2026-45409 (3.15+); turbopuffer: 2.1.0 newer than the 7-day window when introduced in #824 - opt-in extra so safe to bypass; aiohttp: CVE-2026-34993/47265 (3.14.0+), CVE-2026-54273..54280 (3.14.1+); pydantic-settings: GHSA-4xgf-cpjx-pc3j (fixed 2.14.2); langsmith: GHSA-f4xh-w4cj-qxq8 (0.8.18, released within the 7-day window).
 constraint-dependencies = [
     # Security: CVE-2026-25645 fixed in 2.33.0
     "requests>=2.33.1",
@@ -368,6 +368,9 @@ constraint-dependencies = [
     "python-multipart>=0.0.30",
     # Security: GHSA-xgmm-8j9v-c9wx (JWK accepted as HMAC secret) fixed in 2.13.0
     "pyjwt>=2.13.0",
+    # Security: GHSA-f4xh-w4cj-qxq8 (TracingMiddleware arbitrary server-side
+    # file read) fixed in 0.8.18; transitive via langchain-core (langgraph extra)
+    "langsmith>=0.8.18",
     # #1163: keep logfire consistent with the opentelemetry-sdk that each
     # conflict fork resolves. The crewai fork pins opentelemetry-api<1.35
     # (so otel-sdk stays 1.34.x), where only logfire<4.7 is installable

--- a/uv.lock
+++ b/uv.lock
@@ -11,21 +11,23 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-18T10:14:34.65213Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-idna = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-urllib3 = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-litellm = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-aiohttp = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-pydantic-settings = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-turbopuffer = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+idna = { timestamp = "2026-06-25T10:14:34.652157Z", span = "PT0S" }
+urllib3 = { timestamp = "2026-06-25T10:14:34.652152Z", span = "PT0S" }
+litellm = { timestamp = "2026-06-25T10:14:34.652157Z", span = "PT0S" }
+aiohttp = { timestamp = "2026-06-25T10:14:34.652158Z", span = "PT0S" }
+langsmith = { timestamp = "2026-06-25T10:14:34.652159Z", span = "PT0S" }
+pydantic-settings = { timestamp = "2026-06-25T10:14:34.652158Z", span = "PT0S" }
+turbopuffer = { timestamp = "2026-06-25T10:14:34.652157Z", span = "PT0S" }
 
 [manifest]
 constraints = [
     { name = "aiohttp", specifier = ">=3.14.1" },
     { name = "cryptography", specifier = ">=48.0.1" },
+    { name = "langsmith", specifier = ">=0.8.18" },
     { name = "logfire", marker = "extra == 'crewai'", specifier = "<4.7" },
     { name = "logfire", marker = "extra != 'crewai'", specifier = ">=4.32.1" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -2824,9 +2826,11 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.8.3"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
     { name = "httpx" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-5-khora-crewai' and extra == 'extra-5-khora-google-adk')" },
     { name = "packaging" },
@@ -2834,13 +2838,16 @@ dependencies = [
     { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-5-khora-google-adk' or extra != 'extra-5-khora-crewai'" },
     { name = "requests" },
     { name = "requests-toolbelt" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
     { name = "uuid-utils" },
+    { name = "websockets" },
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/8a/1e8ea5e8bab2a65fa95bd36229ef38e8723ec46e430e20ca2d953487a7f1/langsmith-0.8.3.tar.gz", hash = "sha256:767ff7a8d136ed42926bf99059ac631dc6883542d6e3104b32e71c7625e1fa05", size = 4460330, upload-time = "2026-05-07T19:56:56.18Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/26/b72987d947278f63ec1e85f01ce85ca7ab2621c7efc0845d4a3a8e5d5dfb/langsmith-0.9.1.tar.gz", hash = "sha256:e5eb905224d156bcece4985285c55b51fffcb06c9353b2c4adb42e1c48b0d05d", size = 4557557, upload-time = "2026-06-23T17:04:23.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/a9/51e644c1f1dbc3dd7d22dfd6412eab206d538c81e024e4f287373544bdcb/langsmith-0.8.3-py3-none-any.whl", hash = "sha256:b2e40e308222fa0beb2dccee3b4b30bfee9062d7a4f20a3e3e93df3c51a08ab4", size = 399048, upload-time = "2026-05-07T19:56:53.994Z" },
+    { url = "https://files.pythonhosted.org/packages/63/42/13c67eb24cddb368df2c8af13e319c86b1d270c90f5b8c9e8baed3593e04/langsmith-0.9.1-py3-none-any.whl", hash = "sha256:1160bf667af63d9bc081821f1df351cb84f7875740858f2a97ffef62b21800a9", size = 578856, upload-time = "2026-06-23T17:04:21.47Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Pins `langsmith>=0.8.18` via `constraint-dependencies` to clear **Dependabot alert #36** (high). `uv lock` resolves **0.9.1**. langsmith is transitive via `langchain-core` (the `langgraph` extra).

## Why

langsmith `<0.8.18` is vulnerable to **GHSA-f4xh-w4cj-qxq8** — arbitrary server-side file read via the SDK's `TracingMiddleware`. Patched in 0.8.18.

## Notes

- Same `constraint-dependencies` pattern as #1253.
- The fix (0.8.18, released 2026-06-19; 0.9.1 released 2026-06-23) is still inside the repo's `exclude-newer = "7 days"` staging window, so this adds a `langsmith = "0 days"` per-package opt-out (alongside the existing security opt-outs).
- Lockfile churn is limited to langsmith only (0.8.3 → 0.9.1).
- No CHANGELOG entry — matches #1253; security dep bumps fold into the next release notes.

Resolves #36.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened a package compatibility constraint to require a safer, newer version of one dependency.
  * Adjusted dependency update behavior so this package is included sooner in staged resolution, helping avoid known security and compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->