### PR TITLE
chore: release v0.21.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,3 +396,57 @@ jobs:
           else
             gh release create "$TAG" --title "$TAG" --generate-notes $LATEST_FLAG
           fi
+
+  # ============================================================================
+  # Notify Slack — runs on success or failure once we know a release was
+  # attempted. Uses the org-wide SLACK_WEBHOOK_PRODUCTION secret.
+  # ============================================================================
+  notify:
+    needs: [publish-khora, smoke-install, github-release]
+    if: always() && needs.publish-khora.result != 'skipped'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Extract version
+        id: ver
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_PRODUCTION }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ needs.github-release.result == 'success' && ':white_check_mark:' || ':x:' }} *khora* ${{ needs.github-release.result == 'success' && 'published' || 'failed to publish' }} *${{ github.ref_name }}*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    { "type": "mrkdwn", "text": "*Version:*\n`${{ steps.ver.outputs.version }}`" },
+                    { "type": "mrkdwn", "text": "*Actor:*\n${{ github.actor }}" }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": { "type": "plain_text", "text": "View Run" },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    },
+                    {
+                      "type": "button",
+                      "text": { "type": "plain_text", "text": "View on PyPI" },
+                      "url": "https://pypi.org/project/khora/${{ steps.ver.outputs.version }}/"
+                    }
+                  ]
+                }
+              ]
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Khora are documented here.
 
 Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were internal (no git tags).
 
+## [0.21.1] - keyword-PPR retrieval, KET-RAG foundation, namespace metadata
+
+### Added
+
+- **Namespace metadata at creation time** (#1369): `Khora.create_namespace` now accepts an optional `metadata` parameter, threaded through `MemoryEngineProtocol` and all three engine implementations (VectorCypher, Chronicle, Skeleton).
+- **Keyword-PPR retrieval channel** (#1391, #1392): a new `keyword_ppr` lexical channel writes keyword-chunk edges at ingest (`keyword_chunks` edge table + migration), retrieves via windowed Personalized PageRank at query time, and plugs into the fusion layer as a `RetrieverConfig.lexical_channel` option.
+- **KET-RAG foundation** (#1383, #1385): multilingual tokenizer with keyword-PageRank chunk selection (flag-gated), co-occurrence skeleton kept out of the entity graph.
+- **CJK bigram + Indic mark-aware tokenization** (#1388, #1390): dependency-free tokenizer handles CJK bigrams, mixed CJK/non-CJK segmentation, and Indic combining marks.
+- **Extraction `wave_size` configurable** (#1374, #1375): default changed to 20 (was hardcoded at 8).
+
+### Fixed
+
+- **SurrealDB HNSW dimension mismatch** (#1386, #1389): index DDL now reads `llm.embedding_dimension` from config instead of hardcoding 1536.
+- **PPR seed-anchored graph** (#1373, #1378): query entities survive large namespaces by seed-anchoring the PPR graph.
+- **PPR chunk hydration from pgvector** (#1372, #1380): chunks hydrate via `khora_chunks` fallback in PgVectorBackend.
+- **PPR density gate** (#1377, #1381): verdict is now edge-quality- and connectivity-aware.
+- **Orphan-report PageRank graph built bidirectionally** (#1376, #1382).
+- **BM25 tokenizer Unicode-aware** (#1384): non-Latin recall no longer silently drops tokens.
+- **Intra-batch identity-scope dedup** (#1352, #1353, #1370): legacy `remember_batch` path deduplicates within the batch.
+- **Langsmith bumped to patched version** (GHSA-f4xh-w4cj-qxq8) (#1371).
+
 ## [0.21.0] - dream-on-graph bi-temporal mirror and recall/temporal hardening
 
 Minor release. The dominant theme is **dream-on-graph**: dream-apply now mirrors its PostgreSQL soft-deletes and tombstones onto every graph backend, so a pruned edge, a deduped/absorbed entity, or a merged endpoint stops being silently live in graph recall while PG hides it. This lands as a coupled system: the bi-temporal soft-delete columns reserved since #888 are now **active on read** in lockstep across PG and the graph, a post-commit reconciler heals the crash window, undo reverses both stores, dedupe re-points incident edges, GraphRAG communities are materialized and projected into recall, and a contradiction/dedupe judge can reconcile conflicts, all gated by a cross-store live-set invariant CI gate. The second theme is **recall and temporal correctness hardening**: the query temporal classifier becomes word-boundary-aware with Tier-1 disambiguation and an opt-in Tier-2 LLM fallback, recall reports absolute cosine relevance, LLM cost is tracked per call, cross-tenant read isolation is closed across the graph backends, and a broad sweep of chronicle, recency-channel, budget, and dependency-security fixes. Also relocates the temporal vector-store layer out of the engines package into `khora.core.temporal` / `khora.storage.temporal`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ nlp = ["spacy>=3.8.0"]
 # LOCKSTEP: this pin must match rust/khora-accel/Cargo.toml's version exactly.
 # Bump both in the same PR. See CLAUDE.md → Version Bumps.
 rust = [
-    "khora-accel==0.21.0",
+    "khora-accel==0.21.1",
 ]
 # SurrealDB unified backend (graph + vector + relational in one DB)
 surrealdb = ["surrealdb>=2.0.0,<3.0"]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -271,9 +271,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "khora-accel"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "aho-corasick",
  "criterion",
@@ -708,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -731,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -744,18 +744,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/rust/khora-accel/Cargo.toml
+++ b/rust/khora-accel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khora-accel"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Rust-accelerated operations for Khora"


### PR DESCRIPTION
## Summary

- Bump khora + khora-accel version to 0.21.1 (lockstep contract)
- Add CHANGELOG entry covering all changes since v0.21.0: namespace metadata on `create_namespace`, keyword-PPR retrieval channel, KET-RAG foundation with multilingual tokenizer, CJK/Indic tokenization, SurrealDB HNSW dimension fix, PPR hardening, BM25 Unicode fix, batch dedup, and langsmith security patch
- Add Slack notification to the release workflow (mirrors typescript-sdk), posting success/failure via `SLACK_WEBHOOK_PRODUCTION`

## Post-merge

```
git tag v0.21.1 && git push origin v0.21.1
```

This triggers the `release.yml` pipeline to publish to PyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added namespace creation-time metadata support.
  * Introduced improved keyword-based retrieval with multilingual and mark-aware tokenization.
  * Added configurable extraction window sizing, with an updated default.
* **Bug Fixes**
  * Improved retrieval reliability for Unicode/CJK/Indic text, orphan-report handling, batch deduplication, and chunk hydration fallback.
  * Fixed embedding dimension mismatches and strengthened query survivability in graph-based retrieval.
  * Corrected tokenizer Unicode behavior and added a density-aware retrieval gate.
* **Chores**
  * Updated the release workflow to send a Slack notification after publish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->