### PR TITLE
Add trace spans to simple-path entity/relationship projection

### DIFF
--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -440,6 +440,16 @@
       "owner": "vectorcypher"
     },
     {
+      "name": "khora.vectorcypher.simple_projection.list_entities",
+      "stability": "internal",
+      "owner": "vectorcypher"
+    },
+    {
+      "name": "khora.vectorcypher.simple_projection.list_relationships",
+      "stability": "internal",
+      "owner": "vectorcypher"
+    },
+    {
       "name": "khora.vectorcypher.cypher_expand",
       "stability": "internal",
       "owner": "vectorcypher"

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -3356,11 +3356,16 @@ class VectorCypherRetriever:
             relationships_with_scores: list[tuple[Relationship, float]] = []
             if chunk_results and self._storage is not None:
                 recalled_chunk_ids = {c.id for c, _ in chunk_results}
-                try:
-                    all_entities = await self._storage.list_entities(namespace_id, limit=1000)
-                except Exception as e:
-                    logger.warning(f"#857 simple-path entity projection failed: {e}")
-                    all_entities = []
+                with trace_span(
+                    "khora.vectorcypher.simple_projection.list_entities",
+                    namespace_id=str(namespace_id),
+                ) as ent_span:
+                    try:
+                        all_entities = await self._storage.list_entities(namespace_id, limit=1000)
+                    except Exception as e:
+                        logger.warning(f"#857 simple-path entity projection failed: {e}")
+                        all_entities = []
+                    ent_span.set_attribute("entity_count", len(all_entities))
                 for entity in all_entities:
                     src_chunks = entity.source_chunk_ids or []
                     overlap = sum(1 for cid in src_chunks if cid in recalled_chunk_ids)
@@ -3371,11 +3376,16 @@ class VectorCypherRetriever:
                         entities_with_scores.append((entity, score))
 
                 if entities_with_scores:
-                    try:
-                        all_relationships = await self._storage.list_relationships(namespace_id, limit=1000)
-                    except Exception as e:
-                        logger.warning(f"#857 simple-path relationship projection failed: {e}")
-                        all_relationships = []
+                    with trace_span(
+                        "khora.vectorcypher.simple_projection.list_relationships",
+                        namespace_id=str(namespace_id),
+                    ) as rel_span:
+                        try:
+                            all_relationships = await self._storage.list_relationships(namespace_id, limit=1000)
+                        except Exception as e:
+                            logger.warning(f"#857 simple-path relationship projection failed: {e}")
+                            all_relationships = []
+                        rel_span.set_attribute("relationship_count", len(all_relationships))
                     recalled_entity_ids = {e.id for e, _ in entities_with_scores}
                     for rel in all_relationships:
                         if rel.source_entity_id in recalled_entity_ids and rel.target_entity_id in recalled_entity_ids:


### PR DESCRIPTION
## Summary
- Wrap the two storage calls in the simple (graph-less) recall projection path — `list_entities` and `list_relationships` in `_simple_retrieve` — in `trace_span` context managers so their storage-I/O cost shows up in the trace waterfall. This projection is the dominant cost of a simple-path recall on graph-less backends, but previously had no spans, so it was invisible in traces and had to be reconstructed from backend debug logs.
- New spans: `khora.vectorcypher.simple_projection.list_entities` (attribute `entity_count`) and `khora.vectorcypher.simple_projection.list_relationships` (attribute `relationship_count`). `namespace_id` is recorded as a span attribute (allowed on spans; the cardinality rule forbids it on metrics only). No new metrics.
- Register both span names in `docs/telemetry-contract.json` (`stability: internal`, `owner: vectorcypher`) so the telemetry-contract drift gate stays green.
- Observability-only, no behavior change: the `try/except` + warning-log fallbacks are byte-identical, and the entity/relationship matching loops stay outside the spans so the spans measure storage I/O, not Python filtering.

Fixes #1446

## Test plan
- [x] `make format` clean; `make lint` passes (exit 0)
- [x] Telemetry contract drift gate: `uv run pytest tests/unit/telemetry/test_contract.py` → 14 passed
- [x] Simple-path unit coverage: `tests/unit/engines/vectorcypher/test_simple_retrieve_entities_857.py` → 6 passed
- [x] `trace_span` no-op path (logfire absent) yields an OTel `NonRecordingSpan` that supports `.set_attribute` — no crash risk on the default install
- [ ] Integration / e2e suite — runs in CI (Docker not available in the local sandbox)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved telemetry coverage for simple projection retrieval, adding visibility into entity and relationship listing steps.
  * Retrieval now records counts for listed entities and relationships when available, helping with troubleshooting and monitoring.
  * Existing fallback behavior remains unchanged when these lookups fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->