### PR TITLE
Add source_chunk_ids overlap filter to list_entities across storage backends

### DIFF
--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -3345,13 +3345,15 @@ class VectorCypherRetriever:
             # return value hardcoded ``entities=[]`` and ``relationships=[]``,
             # so backends without a Neo4j driver (sqlite_lance, surrealdb,
             # postgres-only) surfaced empty entity lists from ``recall()``
-            # even when the graph was populated. We fetch all entities /
-            # relationships in the namespace (capped at 1000) and filter by
-            # overlap with the recalled chunk ids.
-            # TODO: replace the namespace-wide list + Python filter with a
-            #       per-backend ``list_entities_by_chunk_ids`` query method
-            #       once it lands across sqlite_lance / surrealdb / pgvector
-            #       (perf follow-up to #857).
+            # even when the graph was populated. Entities are pushed down via
+            # ``source_chunk_ids`` overlap (#1448); relationships still fetch
+            # the namespace-wide list (capped at 1000) and filter by overlap
+            # with the recalled chunk ids in Python.
+            # TODO: replace the namespace-wide relationship list + Python
+            #       filter with a per-backend ``list_relationships_by_chunk_ids``
+            #       query method once it lands across sqlite_lance / surrealdb /
+            #       pgvector (perf follow-up to #857). The entity half is now
+            #       pushed down via ``list_entities(source_chunk_ids=...)``.
             entities_with_scores: list[tuple[Entity, float]] = []
             relationships_with_scores: list[tuple[Relationship, float]] = []
             if chunk_results and self._storage is not None:
@@ -3361,7 +3363,9 @@ class VectorCypherRetriever:
                     namespace_id=str(namespace_id),
                 ) as ent_span:
                     try:
-                        all_entities = await self._storage.list_entities(namespace_id, limit=1000)
+                        all_entities = await self._storage.list_entities(
+                            namespace_id, limit=1000, source_chunk_ids=list(recalled_chunk_ids)
+                        )
                     except Exception as e:
                         logger.warning(f"#857 simple-path entity projection failed: {e}")
                         all_entities = []

--- a/src/khora/storage/backends/age.py
+++ b/src/khora/storage/backends/age.py
@@ -560,22 +560,32 @@ class AGEBackend(GraphBackendBase):
         namespace_id: UUID,
         *,
         entity_type: str | None = None,
+        source_chunk_ids: list[UUID] | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[Entity]:
+        # Pushdown unverified on this openCypher subset; filtered in-method (see #1448).
+        if source_chunk_ids is not None and not source_chunk_ids:
+            return []
+
         ns_lit_val = self._uuid_lit(namespace_id)
         match_clause = f"MATCH (e:Entity {{namespace_id: '{ns_lit_val}'}})"
         where_clause = ""
         if entity_type:
             where_clause = f" WHERE e.entity_type = '{self._escape(entity_type)}'"
 
+        if source_chunk_ids is not None:
+            page_clause = ""
+        else:
+            page_clause = f"""
+            SKIP {offset}
+            LIMIT {limit}"""
+
         cypher = f"""
             {match_clause}
             {where_clause}
             RETURN e
-            ORDER BY e.name
-            SKIP {offset}
-            LIMIT {limit}
+            ORDER BY e.name{page_clause}
         """
         async with self._get_session_factory()() as session:
             async with session.begin():
@@ -586,7 +596,13 @@ class AGEBackend(GraphBackendBase):
                     entity = self._entity_from_agtype(row["e"])
                     if entity is not None:
                         entities.append(entity)
-                return entities
+
+        if source_chunk_ids is not None:
+            wanted = {str(c) for c in source_chunk_ids}
+            entities = [e for e in entities if wanted & {str(c) for c in e.source_chunk_ids}]
+            entities = entities[offset : offset + limit]
+
+        return entities
 
     @trace("khora.age.count_entities")
     async def count_entities(self, namespace_id: UUID) -> int:

--- a/src/khora/storage/backends/base.py
+++ b/src/khora/storage/backends/base.py
@@ -612,10 +612,22 @@ class GraphBackendProtocol(Protocol):
         namespace_id: UUID,
         *,
         entity_type: str | None = None,
+        source_chunk_ids: list[UUID] | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[Entity]:
-        """List entities in a namespace."""
+        """List entities in a namespace.
+
+        ``source_chunk_ids`` filters by chunk provenance (#1448):
+
+        - ``None`` (default): no filter — behavior byte-identical to today.
+        - Non-empty list: return only entities whose ``source_chunk_ids``
+          contains AT LEAST ONE of the given ids (any-overlap, not subset).
+        - Empty list ``[]``: return ``[]`` (matches nothing).
+
+        Composes with AND against all existing conditions (``entity_type``,
+        live/``valid_until`` filters) and applies BEFORE ``limit``/``offset``.
+        """
         ...
 
     # Relationship operations

--- a/src/khora/storage/backends/memgraph.py
+++ b/src/khora/storage/backends/memgraph.py
@@ -398,6 +398,7 @@ class MemgraphBackend(GraphBackendBase):
         namespace_id: UUID,
         *,
         entity_type: str | None = None,
+        source_chunk_ids: list[UUID] | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[Entity]:
@@ -423,6 +424,13 @@ class MemgraphBackend(GraphBackendBase):
         if entity_type:
             conditions.append("e.entity_type = $entity_type")
             params["entity_type"] = entity_type
+        if source_chunk_ids is not None:
+            if not source_chunk_ids:
+                return []
+            conditions.append(
+                "(e.source_chunk_ids IS NOT NULL AND any(cid IN e.source_chunk_ids WHERE cid IN $source_chunk_ids))"
+            )
+            params["source_chunk_ids"] = [str(c) for c in source_chunk_ids]
         query += " WHERE " + " AND ".join(conditions)
 
         query += " RETURN e ORDER BY e.name SKIP $offset LIMIT $limit"

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -1633,6 +1633,7 @@ class Neo4jBackend(GraphBackendBase):
         namespace_id: UUID,
         *,
         entity_type: str | None = None,
+        source_chunk_ids: list[UUID] | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[Entity]:
@@ -1660,6 +1661,13 @@ class Neo4jBackend(GraphBackendBase):
         if entity_type:
             conditions.append("e.entity_type = $entity_type")
             params["entity_type"] = entity_type
+        if source_chunk_ids is not None:
+            if not source_chunk_ids:
+                return []
+            conditions.append(
+                "(e.source_chunk_ids IS NOT NULL AND any(cid IN e.source_chunk_ids WHERE cid IN $source_chunk_ids))"
+            )
+            params["source_chunk_ids"] = [str(c) for c in source_chunk_ids]
         query += " WHERE " + " AND ".join(conditions)
 
         query += " RETURN e ORDER BY e.name SKIP $offset LIMIT $limit"

--- a/src/khora/storage/backends/neptune.py
+++ b/src/khora/storage/backends/neptune.py
@@ -452,10 +452,15 @@ class NeptuneBackend(GraphBackendBase):
         namespace_id: UUID,
         *,
         entity_type: str | None = None,
+        source_chunk_ids: list[UUID] | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[Entity]:
         driver = self._get_driver()
+
+        # Pushdown unverified on this openCypher subset; filtered in-method (see #1448).
+        if source_chunk_ids is not None and not source_chunk_ids:
+            return []
 
         query = "MATCH (e:Entity {namespace_id: $namespace_id})"
         params: dict[str, Any] = {"namespace_id": str(namespace_id)}
@@ -464,14 +469,24 @@ class NeptuneBackend(GraphBackendBase):
             query += " WHERE e.entity_type = $entity_type"
             params["entity_type"] = entity_type
 
-        query += " RETURN e ORDER BY e.name SKIP $offset LIMIT $limit"
-        params["offset"] = offset
-        params["limit"] = limit
+        if source_chunk_ids is not None:
+            query += " RETURN e ORDER BY e.name"
+        else:
+            query += " RETURN e ORDER BY e.name SKIP $offset LIMIT $limit"
+            params["offset"] = offset
+            params["limit"] = limit
 
         async with driver.session() as session:
             result = await session.run(query, **params)
             records = await result.data()
-            return [self._record_to_entity(element_to_dict(r["e"])) for r in records]
+            entities = [self._record_to_entity(element_to_dict(r["e"])) for r in records]
+
+        if source_chunk_ids is not None:
+            wanted = {str(c) for c in source_chunk_ids}
+            entities = [e for e in entities if wanted & {str(c) for c in e.source_chunk_ids}]
+            entities = entities[offset : offset + limit]
+
+        return entities
 
     async def count_entities(self, namespace_id: UUID) -> int:
         driver = self._get_driver()

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -1557,6 +1557,7 @@ class PgVectorBackend(AsyncSessionMixin):
         namespace_id: UUID,
         *,
         entity_type: str | None = None,
+        source_chunk_ids: list[UUID] | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list:
@@ -1574,6 +1575,10 @@ class PgVectorBackend(AsyncSessionMixin):
             )
             if entity_type:
                 stmt = stmt.where(EntityModel.entity_type == entity_type)
+            if source_chunk_ids is not None:
+                if not source_chunk_ids:
+                    return []
+                stmt = stmt.where(EntityModel.source_chunk_ids.overlap(source_chunk_ids))
             stmt = stmt.order_by(EntityModel.name).limit(limit).offset(offset)
             result = await session.execute(stmt)
             return [self._entity_model_to_domain(model) for model in result.scalars()]

--- a/src/khora/storage/backends/sqlite_lance/graph.py
+++ b/src/khora/storage/backends/sqlite_lance/graph.py
@@ -427,11 +427,11 @@ class SQLiteLanceGraphAdapter(GraphBackendBase):
         if source_chunk_ids is not None:
             if not source_chunk_ids:
                 return []
-            placeholders = ", ".join("?" for _ in source_chunk_ids)
             conditions.append(
-                f"EXISTS (SELECT 1 FROM json_each(entities.source_chunk_ids) WHERE json_each.value IN ({placeholders}))"  # noqa: S608
+                "EXISTS (SELECT 1 FROM json_each(entities.source_chunk_ids)"
+                " WHERE json_each.value IN (SELECT value FROM json_each(?)))"
             )
-            params.extend(uuid_to_text(c) for c in source_chunk_ids)
+            params.append(to_json_text([uuid_to_text(c) for c in source_chunk_ids]))
         sql = (
             f"SELECT {_ENTITY_COLUMNS} FROM entities "  # noqa: S608
             f"WHERE {' AND '.join(conditions)} "

--- a/src/khora/storage/backends/sqlite_lance/graph.py
+++ b/src/khora/storage/backends/sqlite_lance/graph.py
@@ -415,6 +415,7 @@ class SQLiteLanceGraphAdapter(GraphBackendBase):
         namespace_id: UUID,
         *,
         entity_type: str | None = None,
+        source_chunk_ids: list[UUID] | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[Entity]:
@@ -423,6 +424,14 @@ class SQLiteLanceGraphAdapter(GraphBackendBase):
         if entity_type is not None:
             conditions.append("entity_type = ?")
             params.append(entity_type)
+        if source_chunk_ids is not None:
+            if not source_chunk_ids:
+                return []
+            placeholders = ", ".join("?" for _ in source_chunk_ids)
+            conditions.append(
+                f"EXISTS (SELECT 1 FROM json_each(entities.source_chunk_ids) WHERE json_each.value IN ({placeholders}))"  # noqa: S608
+            )
+            params.extend(uuid_to_text(c) for c in source_chunk_ids)
         sql = (
             f"SELECT {_ENTITY_COLUMNS} FROM entities "  # noqa: S608
             f"WHERE {' AND '.join(conditions)} "

--- a/src/khora/storage/backends/surrealdb/graph.py
+++ b/src/khora/storage/backends/surrealdb/graph.py
@@ -385,6 +385,7 @@ class SurrealDBGraphAdapter(GraphBackendBase):
         namespace_id: UUID,
         *,
         entity_type: str | None = None,
+        source_chunk_ids: list[UUID] | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[Entity]:
@@ -401,6 +402,11 @@ class SurrealDBGraphAdapter(GraphBackendBase):
         if entity_type is not None:
             where.append("entity_type = $entity_type")
             bindings["entity_type"] = entity_type
+        if source_chunk_ids is not None:
+            if not source_chunk_ids:
+                return []
+            where.append("source_chunk_ids CONTAINSANY $source_chunk_ids")
+            bindings["source_chunk_ids"] = [str(c) for c in source_chunk_ids]
 
         sql = f"SELECT * FROM entity WHERE {' AND '.join(where)} ORDER BY created_at DESC LIMIT $limit START $offset"  # noqa: S608
         rows = await self._conn.query(sql, bindings)

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -1675,6 +1675,7 @@ class StorageCoordinator:
         namespace_id: UUID,
         *,
         entity_type: str | None = None,
+        source_chunk_ids: list[UUID] | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[Entity]:
@@ -1686,10 +1687,20 @@ class StorageCoordinator:
         """
         namespace_id = await self._resolve_read_namespace(namespace_id)
         if self._graph:
-            return await self._graph.list_entities(namespace_id, entity_type=entity_type, limit=limit, offset=offset)
+            return await self._graph.list_entities(
+                namespace_id,
+                entity_type=entity_type,
+                source_chunk_ids=source_chunk_ids,
+                limit=limit,
+                offset=offset,
+            )
         if self._vector and hasattr(self._vector, "list_entities"):
             return await self._vector.list_entities(  # type: ignore[unresolved-attribute]
-                namespace_id, entity_type=entity_type, limit=limit, offset=offset
+                namespace_id,
+                entity_type=entity_type,
+                source_chunk_ids=source_chunk_ids,
+                limit=limit,
+                offset=offset,
             )
         return []
 

--- a/tests/integration/storage/backends/surrealdb/test_source_document_ids_persistence.py
+++ b/tests/integration/storage/backends/surrealdb/test_source_document_ids_persistence.py
@@ -51,3 +51,43 @@ async def test_surrealdb_persists_entity_source_document_ids() -> None:
         )
     finally:
         await conn.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_surrealdb_list_entities_filters_by_source_chunk_ids() -> None:
+    """``list_entities(source_chunk_ids=...)`` filters by chunk provenance (#1448).
+
+    Seeds two entities — A sourced from chunks c1/c2, B from c3 — then pins
+    the four contract cases: no filter returns both; a filter for one of A's
+    chunks returns only A; an unknown chunk returns nothing; and an empty
+    list matches nothing (CONTAINSANY / any-overlap semantics).
+    """
+    conn = SurrealDBConnection(mode="memory", namespace="khora_test", database="scids1448")
+    await conn.connect()
+    graph = SurrealDBGraphAdapter(conn)
+    relational = SurrealDBRelationalAdapter(conn)
+    try:
+        ns_id = uuid4()
+        await relational.create_namespace(
+            MemoryNamespace(id=ns_id, namespace_id=ns_id, tenancy_mode=TenancyMode.SHARED)
+        )
+        c1, c2, c3, c4 = uuid4(), uuid4(), uuid4(), uuid4()
+
+        ent_a = Entity(id=uuid4(), namespace_id=ns_id, name="A", entity_type="PERSON", source_chunk_ids=[c1, c2])
+        ent_b = Entity(id=uuid4(), namespace_id=ns_id, name="B", entity_type="PERSON", source_chunk_ids=[c3])
+        await graph.upsert_entities_batch(ns_id, [ent_a, ent_b])
+
+        # 1. No filter → both entities.
+        assert {e.name for e in await graph.list_entities(ns_id, limit=10)} == {"A", "B"}
+
+        # 2. One of A's chunks → exactly A.
+        only_a = await graph.list_entities(ns_id, source_chunk_ids=[c1], limit=10)
+        assert {e.name for e in only_a} == {"A"}
+
+        # 3. Unknown chunk id → nothing.
+        assert await graph.list_entities(ns_id, source_chunk_ids=[c4], limit=10) == []
+
+        # 4. Empty list → matches nothing.
+        assert await graph.list_entities(ns_id, source_chunk_ids=[], limit=10) == []
+    finally:
+        await conn.disconnect()

--- a/tests/integration/test_neo4j_retire_orphaned_entities_integration.py
+++ b/tests/integration/test_neo4j_retire_orphaned_entities_integration.py
@@ -433,6 +433,70 @@ class TestNeo4jRetireOrphanedEntitiesBatchIntegration:
             await backend.disconnect()
 
     @pytest.mark.asyncio
+    async def test_list_entities_filters_by_source_chunk_ids(self) -> None:
+        """``list_entities(source_chunk_ids=...)`` filters by chunk provenance (#1448).
+
+        Seeds two entities — A sourced from chunks c1/c2, B from c3 — then pins
+        the four contract cases: no filter returns both; a filter for one of A's
+        chunks returns only A; an unknown chunk returns nothing; and an empty
+        list matches nothing (any-overlap semantics).
+        """
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        namespace_id = uuid4()
+        c1, c2, c3, c4 = uuid4(), uuid4(), uuid4(), uuid4()
+        entity_a = Entity(
+            namespace_id=namespace_id,
+            name=f"scid-A-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            source_chunk_ids=[c1, c2],
+        )
+        entity_b = Entity(
+            namespace_id=namespace_id,
+            name=f"scid-B-{uuid4().hex[:8]}",
+            entity_type="PERSON",
+            source_chunk_ids=[c3],
+        )
+
+        try:
+            await backend.create_entity(entity_a)
+            await backend.create_entity(entity_b)
+
+            # 1. No filter → both entities.
+            names = {e.name for e in await backend.list_entities(namespace_id)}
+            assert names == {entity_a.name, entity_b.name}
+
+            # 2. One of A's chunks → exactly A.
+            only_a = await backend.list_entities(namespace_id, source_chunk_ids=[c1])
+            assert {e.name for e in only_a} == {entity_a.name}
+
+            # 3. Unknown chunk id → nothing.
+            assert await backend.list_entities(namespace_id, source_chunk_ids=[c4]) == []
+
+            # 4. Empty list → matches nothing.
+            assert await backend.list_entities(namespace_id, source_chunk_ids=[]) == []
+
+        finally:
+            try:
+                async with backend._session() as session:
+
+                    async def _cleanup(tx):
+                        await tx.run(
+                            "MATCH (e:Entity) WHERE e.id IN $ids DETACH DELETE e",
+                            ids=[str(entity_a.id), str(entity_b.id)],
+                        )
+
+                    await session.execute_write(_cleanup)
+            except Exception:  # noqa: BLE001
+                pass
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
     async def test_retire_empty_input_returns_zero(self) -> None:
         """Calling retire_orphaned_entities_batch with an empty list returns 0."""
         url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")

--- a/tests/integration/test_pgvector_accumulate_source_ids.py
+++ b/tests/integration/test_pgvector_accumulate_source_ids.py
@@ -262,6 +262,13 @@ async def test_list_entities_filters_by_source_chunk_ids(backend: PgVectorBacken
     # 4. Empty list → matches nothing.
     assert await backend.list_entities(namespace_id, source_chunk_ids=[]) == []
 
+    # 5. Composes with entity_type (AND): matching type + A's chunk → exactly A.
+    typed = await backend.list_entities(namespace_id, entity_type="PERSON", source_chunk_ids=[c1])
+    assert {e.name for e in typed} == {name_a}
+
+    # 6. Composes with entity_type (AND): non-matching type + A's chunk → nothing.
+    assert await backend.list_entities(namespace_id, entity_type="ORGANIZATION", source_chunk_ids=[c1]) == []
+
 
 # =========================================================================
 # Single path (create_entity / _upsert_entity)

--- a/tests/integration/test_pgvector_accumulate_source_ids.py
+++ b/tests/integration/test_pgvector_accumulate_source_ids.py
@@ -222,6 +222,48 @@ async def test_batch_reextracting_same_doc_does_not_evict_prior_distinct_id(
 
 
 # =========================================================================
+# source_chunk_ids provenance filter on list_entities (#1448)
+# =========================================================================
+
+
+@pytest.mark.asyncio
+async def test_list_entities_filters_by_source_chunk_ids(backend: PgVectorBackend, namespace_id: UUID) -> None:
+    """``list_entities(source_chunk_ids=...)`` filters entities by chunk
+    provenance (any-overlap), per #1448.
+
+    Seeds two entities — A sourced from chunks c1/c2, B from c3 — then pins
+    the four contract cases: no filter returns both; a filter for one of A's
+    chunks returns only A; an unknown chunk returns nothing; and an empty
+    list matches nothing.
+    """
+    name_a = f"chunk-filter-A-{uuid4()}"
+    name_b = f"chunk-filter-B-{uuid4()}"
+    c1, c2, c3, c4 = uuid4(), uuid4(), uuid4(), uuid4()
+
+    await backend.upsert_entities_batch(
+        namespace_id,
+        [
+            _entity(namespace_id, name_a, source_chunk_ids=[c1, c2]),
+            _entity(namespace_id, name_b, source_chunk_ids=[c3]),
+        ],
+    )
+
+    # 1. No filter → both entities.
+    all_names = {e.name for e in await backend.list_entities(namespace_id)}
+    assert {name_a, name_b} <= all_names
+
+    # 2. One of A's chunks → exactly A.
+    only_a = await backend.list_entities(namespace_id, source_chunk_ids=[c1])
+    assert {e.name for e in only_a} == {name_a}
+
+    # 3. Unknown chunk id → nothing.
+    assert await backend.list_entities(namespace_id, source_chunk_ids=[c4]) == []
+
+    # 4. Empty list → matches nothing.
+    assert await backend.list_entities(namespace_id, source_chunk_ids=[]) == []
+
+
+# =========================================================================
 # Single path (create_entity / _upsert_entity)
 # =========================================================================
 

--- a/tests/integration/test_sqlite_lance_traversal.py
+++ b/tests/integration/test_sqlite_lance_traversal.py
@@ -8,6 +8,7 @@ extraction) and exercises ``find_paths`` / ``get_neighborhood`` /
 from __future__ import annotations
 
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 
@@ -168,5 +169,37 @@ class TestSQLiteLanceTraversal:
             assert b.id in {e.id for e in a_hood["entities"]}
             # D has only an inbound edge from C at depth 1 (directed chain).
             assert c.id in {e.id for e in d_hood["entities"]}
+        finally:
+            await coord.disconnect()
+
+    async def test_list_entities_filters_by_source_chunk_ids(self, tmp_path: Path) -> None:
+        """``list_entities(source_chunk_ids=...)`` filters by chunk provenance (#1448).
+
+        Seeds two entities — A sourced from chunks c1/c2, B from c3 — then pins
+        the four contract cases: no filter returns both; a filter for one of A's
+        chunks returns only A; an unknown chunk returns nothing; and an empty
+        list matches nothing (any-overlap semantics).
+        """
+        coord = await build_sqlite_lance_coordinator(tmp_path)
+        try:
+            ns = await coord.create_namespace(MemoryNamespace())
+            c1, c2, c3, c4 = uuid4(), uuid4(), uuid4(), uuid4()
+            entity_a = Entity(namespace_id=ns.id, name="A", entity_type="PERSON", source_chunk_ids=[c1, c2])
+            entity_b = Entity(namespace_id=ns.id, name="B", entity_type="PERSON", source_chunk_ids=[c3])
+            await coord.upsert_entities_batch(ns.id, [entity_a, entity_b])
+
+            # 1. No filter → both entities.
+            all_names = {e.name for e in await coord.list_entities(ns.id)}
+            assert all_names == {"A", "B"}
+
+            # 2. One of A's chunks → exactly A.
+            only_a = await coord.list_entities(ns.id, source_chunk_ids=[c1])
+            assert {e.name for e in only_a} == {"A"}
+
+            # 3. Unknown chunk id → nothing.
+            assert await coord.list_entities(ns.id, source_chunk_ids=[c4]) == []
+
+            # 4. Empty list → matches nothing.
+            assert await coord.list_entities(ns.id, source_chunk_ids=[]) == []
         finally:
             await coord.disconnect()

--- a/tests/unit/engines/vectorcypher/test_simple_retrieve_entities_857.py
+++ b/tests/unit/engines/vectorcypher/test_simple_retrieve_entities_857.py
@@ -118,6 +118,37 @@ class TestSimpleRetrieveEntityProjection857:
         assert storage.list_entities.await_args.kwargs.get("limit") == 1000
 
     @pytest.mark.asyncio
+    async def test_list_entities_called_with_recalled_chunk_ids(self) -> None:
+        """#1448: the entity projection pushes the recalled chunk ids down to
+        ``list_entities(source_chunk_ids=...)`` rather than scanning the whole
+        namespace and filtering in Python."""
+        c1, c2 = uuid4(), uuid4()
+        sr1 = _make_search_result("c1", chunk_id=c1)
+        sr2 = _make_search_result("c2", chunk_id=c2)
+
+        ns = uuid4()
+        storage = MagicMock()
+        storage.list_entities = AsyncMock(return_value=[])
+        storage.list_relationships = AsyncMock(return_value=[])
+
+        retriever = _make_retriever(storage=storage)
+        retriever._vector_store.search = AsyncMock(return_value=[sr1, sr2])
+
+        await retriever._simple_retrieve(
+            query="q",
+            query_embedding=[0.1],
+            namespace_id=ns,
+            temporal_filter=None,
+            limit=10,
+            routing=_routing(),
+        )
+
+        storage.list_entities.assert_awaited_once()
+        pushed = storage.list_entities.await_args.kwargs.get("source_chunk_ids")
+        assert pushed is not None, "recalled chunk ids must be pushed down to list_entities"
+        assert set(pushed) == {c1, c2}
+
+    @pytest.mark.asyncio
     async def test_relationships_filtered_to_recalled_entity_endpoints(self) -> None:
         """Relationship is included only when BOTH endpoints are in the
         recalled-entity set (i.e. both source_chunk_ids overlap)."""

--- a/tests/unit/test_expansion_flow.py
+++ b/tests/unit/test_expansion_flow.py
@@ -81,7 +81,7 @@ async def test_load_entities_graph_less_stack_returns_empty_list() -> None:
     result = await load_entities(ns_id, storage, limit=100)
 
     assert result == []
-    vector.list_entities.assert_awaited_once_with(ns_id, entity_type=None, limit=100, offset=0)
+    vector.list_entities.assert_awaited_once_with(ns_id, entity_type=None, source_chunk_ids=None, limit=100, offset=0)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

The VectorCypher simple-path (graph-less) recall projection fetched up to 1,000 entities for the **whole namespace** and filtered them in Python by overlap with the recalled chunk ids. That is wasteful (full entities incl. embeddings over the wire) and silently wrong on namespaces with more than 1,000 entities (the cap drops arbitrary entities relative to the recalled set).

This pushes the entity projection into the store. `list_entities` gains a keyword-only filter, mirroring the existing `entity_type` kwarg:

```python
list_entities(namespace_id, *, source_chunk_ids: list[UUID] | None = None, ...)
```

- `None` (default): no filter — behavior **byte-identical** to before.
- Non-empty list: return only entities whose `source_chunk_ids` overlaps **at least one** of the given ids (any-overlap, not subset).
- Empty list `[]`: return `[]` (matches nothing).

The filter composes with `AND` against existing conditions (`entity_type`, live/`valid_until`) and applies **before** `limit`/`offset`.

### Changes
- **Protocol** (`storage/backends/base.py`) and **Coordinator** (`storage/coordinator.py`, both graph + vector-fallback branches) carry the new kwarg.
- **Pushdown backends:** Neo4j / Memgraph (`any(cid IN e.source_chunk_ids ...)`), pgvector (`&&` array-overlap via `.overlap()`), sqlite_lance (`EXISTS json_each`), SurrealDB (`CONTAINSANY`).
- **Neptune / AGE:** predicate pushdown is unverified on those openCypher subsets, so they filter in-method (fetch without `SKIP`/`LIMIT`, Python set-overlap, then slice) — same page and ordering as the pushdown backends.
- **Retriever** (`engines/vectorcypher/retriever.py`, simple-path projection): now passes `source_chunk_ids=list(recalled_chunk_ids)` instead of listing the whole namespace; the Python scoring loop is unchanged.

Relationship-side projection (`list_relationships` / `between_entity_ids`) is intentionally left as a follow-up. No new spans or metrics.

## Test plan
- [x] Unit tests pass (`make test`: 478 passed, 257 skipped, 85% coverage)
- [x] `make format` / `make lint` clean
- [x] Backend behavior tests added for sqlite_lance, pgvector, Neo4j, SurrealDB — each pins the 4-case contract (no filter → both; one chunk → owning entity; unknown id → `[]`; `[]` → `[]`)
- [x] Retriever unit test asserts the recalled chunk ids are pushed down to `list_entities`
- [ ] Docker-backed pgvector/Neo4j integration lanes run in CI

Fixes #1448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entity listings can now be filtered by their originating chunk IDs via a new `source_chunk_ids` option, propagated through the main storage layer and supported backends.

* **Bug Fixes**
  * Improved retrieval accuracy by narrowing entity results to the relevant chunk provenance.
  * Passing an empty `source_chunk_ids` list now returns no results immediately.

* **Tests**
  * Added/updated unit and integration coverage to validate filtering behavior across backends and retrieval flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->