### PR TITLE
Add GIN index on entities.source_chunk_ids for array-overlap recall pushdown

### DIFF
--- a/src/khora/db/migrations/versions/052_entities_source_chunk_ids_gin.py
+++ b/src/khora/db/migrations/versions/052_entities_source_chunk_ids_gin.py
@@ -1,0 +1,52 @@
+"""Add GIN index on entities.source_chunk_ids for the #1448 overlap pushdown.
+
+Revision ID: 052_entities_source_chunk_ids_gin
+Revises: 051_documents_graph_mirror_pending
+Create Date: 2026-07-07
+
+PR #1449 pushes the #857 recall entity projection down into the store; on
+pgvector it compiles to an ``&&`` array-overlap
+(``EntityModel.source_chunk_ids.overlap(...)``) against
+``entities.source_chunk_ids`` (``ARRAY(UUID)``). Without an index that
+predicate is a sequential scan of ``entities`` on every recall on graph-less
+PostgreSQL stacks. A GIN index with the default ``array_ops`` operator class
+serves the ``&&`` operator directly.
+
+Concurrent index creation: Postgres ``CREATE INDEX CONCURRENTLY`` cannot run
+inside a transaction, so we open an autocommit block. ``IF NOT EXISTS`` makes
+the migration safe to re-run.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "052_entities_source_chunk_ids_gin"
+down_revision: str | Sequence[str] | None = "051_documents_graph_mirror_pending"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_postgres() -> bool:
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def upgrade() -> None:
+    # GIN and ``CREATE INDEX CONCURRENTLY`` are Postgres-only. The
+    # sqlite_lance test fixtures run the full Alembic chain against
+    # SQLite, so we skip silently on non-Postgres dialects rather than
+    # emit syntax SQLite cannot parse.
+    if not _is_postgres():
+        return
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_entities_source_chunk_ids_gin "
+            "ON entities USING GIN (source_chunk_ids)"
+        )
+
+
+def downgrade() -> None:
+    if not _is_postgres():
+        return
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_entities_source_chunk_ids_gin")

--- a/tests/integration/db/test_migration_032_dream_runs.py
+++ b/tests/integration/db/test_migration_032_dream_runs.py
@@ -304,7 +304,7 @@ class TestMigration032OnSqlite:
                 async with engine.connect() as conn:
                     # Chain reached head (sanity).
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "051_documents_graph_mirror_pending"
+                    assert result.scalar() == "052_entities_source_chunk_ids_gin"
 
                     # khora_dream_runs exists on SQLite (#896) so dream_history /
                     # dream_status work on the embedded sqlite_lance stack.

--- a/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
+++ b/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
@@ -322,7 +322,7 @@ class TestMigration041OnPostgres:
                 async with engine.connect() as conn:
                     # Chain reached head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "051_documents_graph_mirror_pending"
+                    assert result.scalar() == "052_entities_source_chunk_ids_gin"
 
                     # The migration did not create the table.
                     result = await conn.execute(
@@ -353,7 +353,7 @@ class TestMigration041OnSqlite:
             try:
                 async with engine.connect() as conn:
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "051_documents_graph_mirror_pending"
+                    assert result.scalar() == "052_entities_source_chunk_ids_gin"
             finally:
                 await engine.dispose()
 

--- a/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
+++ b/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
@@ -69,7 +69,7 @@ pytestmark = pytest.mark.integration
 
 
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
-_HEAD = "051_documents_graph_mirror_pending"
+_HEAD = "052_entities_source_chunk_ids_gin"
 _PREV = "041_khora_chunks_denormalized_columns"
 
 

--- a/tests/integration/db/test_migration_044_chunks_backfill.py
+++ b/tests/integration/db/test_migration_044_chunks_backfill.py
@@ -93,7 +93,7 @@ pytestmark = pytest.mark.integration
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
 
 _PREV_REVISION = "043_khora_chunks_metadata_backfill"
-_HEAD_REVISION = "051_documents_graph_mirror_pending"
+_HEAD_REVISION = "052_entities_source_chunk_ids_gin"
 
 _TSV_TRIGGER = "khora_chunks_content_tsv_update"
 

--- a/tests/integration/db/test_migration_049_hook_subscriptions.py
+++ b/tests/integration/db/test_migration_049_hook_subscriptions.py
@@ -71,7 +71,7 @@ pytestmark = pytest.mark.integration
 
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
 
-_HEAD = "051_documents_graph_mirror_pending"
+_HEAD = "052_entities_source_chunk_ids_gin"
 _PREV = "048_dream_conflicts_reconcile"
 
 

--- a/tests/integration/db/test_migration_052_entities_source_chunk_ids_gin.py
+++ b/tests/integration/db/test_migration_052_entities_source_chunk_ids_gin.py
@@ -111,8 +111,10 @@ class TestMigration052GinIndex:
             command.downgrade(cfg, _PREV)
             assert asyncio.run(_index_rows(DATABASE_URL)) == []
         finally:
-            # Always restore head so the shared dev DB is never left rewound.
-            command.upgrade(cfg, _HEAD)
+            # Always restore the true chain head so the shared dev DB is never
+            # left rewound — "head" (not the pinned _HEAD) stays correct once a
+            # future migration lands on top of 052.
+            command.upgrade(cfg, "head")
 
         # Re-running the upgrade re-creates the index — proves IF NOT EXISTS
         # re-run safety.

--- a/tests/integration/db/test_migration_052_entities_source_chunk_ids_gin.py
+++ b/tests/integration/db/test_migration_052_entities_source_chunk_ids_gin.py
@@ -1,0 +1,122 @@
+"""Live-PostgreSQL integration test for migration 052 — the GIN index on
+``entities.source_chunk_ids`` (#1452).
+
+Verifies on real Postgres that migration ``052_entities_source_chunk_ids_gin``:
+
+1. ``alembic upgrade head`` builds ``ix_entities_source_chunk_ids_gin`` as a
+   GIN index (the ``&&`` array-overlap pushdown of PR #1449 / #857 / #1448).
+2. Downgrade to ``051`` drops the index (symmetric ``DROP INDEX
+   CONCURRENTLY``).
+3. Re-running the upgrade re-creates it — proving the ``IF NOT EXISTS`` re-run
+   safety of the concurrent-index DDL.
+
+The index is Postgres-only (``CREATE INDEX CONCURRENTLY`` + GIN); the migration
+is a clean no-op on SQLite, so this test skips when Postgres is unreachable.
+
+The lifecycle rewinds the shared dev DB's alembic revision, so the restore
+``upgrade head`` runs in a ``finally`` block — the DB is never left rewound,
+even on assertion failure.
+
+Run with an explicit DB URL (the shell leaks a different one)::
+
+    KHORA_DATABASE_URL="postgresql://khora:khora@localhost:5434/khora" \
+        UV_NO_SYNC=1 uv run pytest \
+        tests/integration/db/test_migration_052_entities_source_chunk_ids_gin.py \
+        -o addopts="" -q
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+from sqlalchemy.ext.asyncio import create_async_engine
+
+DATABASE_URL = os.environ.get(
+    "KHORA_DATABASE_URL",
+    "postgresql+asyncpg://khora:khora@localhost:5434/khora",
+)
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
+
+
+def _pg_reachable() -> bool:
+    parsed = urlparse(DATABASE_URL.replace("+asyncpg", ""))
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+pytestmark = pytest.mark.integration
+
+_MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
+
+_HEAD = "052_entities_source_chunk_ids_gin"
+_PREV = "051_documents_graph_mirror_pending"
+
+_INDEX_NAME = "ix_entities_source_chunk_ids_gin"
+
+
+def _make_config(url: str) -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", str(_MIGRATIONS_DIR))
+    cfg.set_main_option("sqlalchemy.url", url.replace("%", "%%"))
+    cfg.attributes["database_url"] = url
+    return cfg
+
+
+async def _index_rows(url: str) -> list[tuple[str, str]]:
+    engine = create_async_engine(url)
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(
+                sa.text("SELECT indexname, indexdef FROM pg_indexes WHERE indexname = :name"),
+                {"name": _INDEX_NAME},
+            )
+            return [(row[0], row[1]) for row in result.fetchall()]
+    finally:
+        await engine.dispose()
+
+
+class TestMigration052GinIndex:
+    def test_gin_index_created_dropped_and_recreated(self) -> None:
+        if not _pg_reachable():
+            pytest.skip("PostgreSQL not reachable (run `make dev` first)")
+
+        cfg = _make_config(DATABASE_URL)
+
+        # Migration 052 builds the GIN index. Idempotent when the shared dev
+        # DB is already at head.
+        command.upgrade(cfg, _HEAD)
+        rows = asyncio.run(_index_rows(DATABASE_URL))
+        assert len(rows) == 1, f"expected the GIN index at head, found {rows}"
+        assert rows[0][0] == _INDEX_NAME
+        assert "USING gin" in rows[0][1], f"index is not GIN: {rows[0][1]}"
+
+        try:
+            # Downgrade drops just the GIN index (052 -> 051).
+            command.downgrade(cfg, _PREV)
+            assert asyncio.run(_index_rows(DATABASE_URL)) == []
+        finally:
+            # Always restore head so the shared dev DB is never left rewound.
+            command.upgrade(cfg, _HEAD)
+
+        # Re-running the upgrade re-creates the index — proves IF NOT EXISTS
+        # re-run safety.
+        rows = asyncio.run(_index_rows(DATABASE_URL))
+        assert len(rows) == 1
+        assert rows[0][0] == _INDEX_NAME
+        assert "USING gin" in rows[0][1]

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -442,14 +442,14 @@ class TestMigrationPackageStructure:
         assert env_path.exists(), f"env.py not found at {env_path}"
 
     @pytest.mark.unit
-    def test_versions_dir_has_52_files(self):
-        """versions/ directory contains 52 migration files."""
+    def test_versions_dir_has_53_files(self):
+        """versions/ directory contains 53 migration files."""
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
         # Filter out __pycache__ and __init__
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
-        assert len(migration_files) == 52, (
-            f"Expected 52 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
+        assert len(migration_files) == 53, (
+            f"Expected 53 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
         )
 
     @pytest.mark.unit

--- a/tests/unit/test_sqlite_migrations.py
+++ b/tests/unit/test_sqlite_migrations.py
@@ -84,7 +84,7 @@ class TestSqliteMigrations:
                     # Version table must point at head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
                     version = result.scalar()
-                    assert version == "051_documents_graph_mirror_pending"
+                    assert version == "052_entities_source_chunk_ids_gin"
             finally:
                 await engine.dispose()
 


### PR DESCRIPTION
## Summary
- The recall entity projection pushes a `source_chunk_ids && ...` array-overlap predicate into the pgvector store (PR #1449, follow-up to #857/#1448). Without an index that predicate is a sequential scan of `entities` on every recall on graph-less PostgreSQL stacks.
- Add migration `052_entities_source_chunk_ids_gin` creating a GIN index on `entities.source_chunk_ids` with the default `array_ops` operator class (which serves the `&&` operator), built via `CREATE INDEX CONCURRENTLY IF NOT EXISTS` inside an `autocommit_block()` and gated Postgres-only via `_is_postgres()` — mirroring the canonical concurrent-index migration `029_chunks_created_at_brin`. Downgrade is symmetric (`DROP INDEX CONCURRENTLY IF EXISTS`).
- No query-code or model changes: the `&&` operator uses the index automatically, and repo convention keeps concurrent-index DDL migration-only (029 does not model its index either).
- Bump the hardcoded alembic head-pin assertions in the migration tests (1 unit + 5 integration) to the new head `052_entities_source_chunk_ids_gin`.

## Test plan
- [x] `make format` clean; `make lint` clean (no new diagnostics on changed files)
- [x] Full SQLite migration chain green — `tests/unit/test_sqlite_migrations.py` + the SQLite classes of the five bumped `tests/integration/db/test_migration_*.py` (11 passed, PG-only classes skipped). The `_is_postgres()` gate makes 052 a clean no-op on SQLite.
- [x] `uv run alembic heads` → single head `052_entities_source_chunk_ids_gin`
- [x] PostgreSQL integration tests (live concurrent-index creation on the real `entities` table) — validated live on `pgvector/pgvector:pg17` via the new `tests/integration/db/test_migration_052_entities_source_chunk_ids_gin.py` (upgrade builds the GIN index → downgrade drops it → upgrade re-creates it, proving `IF NOT EXISTS` re-run safety); also re-run in CI by the `test` job.

### Verified EXPLAIN (live PG stack)
Captured on `pgvector/pgvector:pg17` after `alembic upgrade head`, with `entities` seeded to 5000 rows in one namespace (only a handful carrying the probe chunk id) so the array-overlap is the selective predicate, and `SET enable_seqscan = off`:

```sql
SET enable_seqscan = off;
EXPLAIN SELECT id FROM entities
WHERE namespace_id = '00000000-0000-0000-0000-000000000001'
  AND source_chunk_ids && ARRAY['00000000-0000-0000-0000-000000000000']::uuid[];
```

```
 Bitmap Heap Scan on entities  (cost=12.85..30.02 rows=5 width=16)
   Recheck Cond: (source_chunk_ids && '{00000000-0000-0000-0000-000000000000}'::uuid[])
   Filter: (namespace_id = '00000000-0000-0000-0000-000000000001'::uuid)
   ->  Bitmap Index Scan on ix_entities_source_chunk_ids_gin  (cost=0.00..12.85 rows=5 width=0)
         Index Cond: (source_chunk_ids && '{00000000-0000-0000-0000-000000000000}'::uuid[])
```

The planner uses a `Bitmap Index Scan on ix_entities_source_chunk_ids_gin` feeding a `Bitmap Heap Scan on entities` for the `&&` overlap, replacing the pre-index `Seq Scan on entities`.

Fixes #1452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PostgreSQL-only migration that creates a concurrent, idempotent GIN index on `entities.source_chunk_ids` to improve overlap-based query performance.

* **Bug Fixes**
  * Updated migration head/revision expectations so migration verification stays consistent across upgrade paths.

* **Tests**
  * Added an integration test that validates the GIN index is created, removed on downgrade, and recreated on re-upgrade.
  * Updated unit/integration assertions and the expected migration bundle count to reflect the new migration head.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
