### PR TITLE
Add between_entity_ids filter to list_relationships across storage backends

### DIFF
--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -3345,15 +3345,11 @@ class VectorCypherRetriever:
             # return value hardcoded ``entities=[]`` and ``relationships=[]``,
             # so backends without a Neo4j driver (sqlite_lance, surrealdb,
             # postgres-only) surfaced empty entity lists from ``recall()``
-            # even when the graph was populated. Entities are pushed down via
-            # ``source_chunk_ids`` overlap (#1448); relationships still fetch
-            # the namespace-wide list (capped at 1000) and filter by overlap
-            # with the recalled chunk ids in Python.
-            # TODO: replace the namespace-wide relationship list + Python
-            #       filter with a per-backend ``list_relationships_by_chunk_ids``
-            #       query method once it lands across sqlite_lance / surrealdb /
-            #       pgvector (perf follow-up to #857). The entity half is now
-            #       pushed down via ``list_entities(source_chunk_ids=...)``.
+            # even when the graph was populated. Both halves are now pushed
+            # down: entities via ``list_entities(source_chunk_ids=...)`` overlap
+            # (#1448), relationships via ``list_relationships(between_entity_ids=...)``
+            # so only edges whose BOTH endpoints are in the recalled entity set
+            # come back (#1451) — no namespace-wide list + Python filter.
             entities_with_scores: list[tuple[Entity, float]] = []
             relationships_with_scores: list[tuple[Relationship, float]] = []
             if chunk_results and self._storage is not None:
@@ -3380,20 +3376,20 @@ class VectorCypherRetriever:
                         entities_with_scores.append((entity, score))
 
                 if entities_with_scores:
+                    matched_entity_ids = [e.id for e, _ in entities_with_scores]
                     with trace_span(
                         "khora.vectorcypher.simple_projection.list_relationships",
                         namespace_id=str(namespace_id),
                     ) as rel_span:
                         try:
-                            all_relationships = await self._storage.list_relationships(namespace_id, limit=1000)
+                            all_relationships = await self._storage.list_relationships(
+                                namespace_id, limit=1000, between_entity_ids=matched_entity_ids
+                            )
                         except Exception as e:
                             logger.warning(f"#857 simple-path relationship projection failed: {e}")
                             all_relationships = []
                         rel_span.set_attribute("relationship_count", len(all_relationships))
-                    recalled_entity_ids = {e.id for e, _ in entities_with_scores}
-                    for rel in all_relationships:
-                        if rel.source_entity_id in recalled_entity_ids and rel.target_entity_id in recalled_entity_ids:
-                            relationships_with_scores.append((rel, 1.0))
+                    relationships_with_scores = [(rel, 1.0) for rel in all_relationships]
 
             # Honest per-channel filter-pushdown plans for the simple path. Each
             # plan is the one its channel appended to the sink from the BACKEND's

--- a/src/khora/storage/backends/age.py
+++ b/src/khora/storage/backends/age.py
@@ -792,21 +792,31 @@ class AGEBackend(GraphBackendBase):
         namespace_id: UUID,
         *,
         relationship_type: str | None = None,
+        between_entity_ids: list[UUID] | None = None,
         limit: int = 1000,
         offset: int = 0,
     ) -> list[Relationship]:
+        # Pushdown unverified on this openCypher subset; filtered in-method (see #1451).
+        if between_entity_ids is not None and not between_entity_ids:
+            return []
+
         rel_filter = ""
         if relationship_type:
             rel_filter = f":{self._sanitize_label(relationship_type)}"
+
+        if between_entity_ids is not None:
+            page_clause = ""
+        else:
+            page_clause = f"""
+            SKIP {offset}
+            LIMIT {limit}"""
 
         ns_lit_val = self._uuid_lit(namespace_id)
         cypher = f"""
             MATCH (source:Entity)-[r{rel_filter}]->(target:Entity)
             WHERE r.namespace_id = '{ns_lit_val}'
             RETURN r, source.id as source_id, target.id as target_id, type(r) as rel_type
-            ORDER BY r.created_at DESC
-            SKIP {offset}
-            LIMIT {limit}
+            ORDER BY r.created_at DESC{page_clause}
         """
         async with self._get_session_factory()() as session:
             async with session.begin():
@@ -821,7 +831,7 @@ class AGEBackend(GraphBackendBase):
                         "rel_type agtype",
                     ],
                 )
-                return [
+                relationships = [
                     self._relationship_from_agtype(
                         row["r"],
                         str(row["source_id"]),
@@ -830,6 +840,13 @@ class AGEBackend(GraphBackendBase):
                     )
                     for row in rows
                 ]
+
+        if between_entity_ids is not None:
+            id_set = set(between_entity_ids)
+            relationships = [r for r in relationships if r.source_entity_id in id_set and r.target_entity_id in id_set]
+            relationships = relationships[offset : offset + limit]
+
+        return relationships
 
     # ------------------------------------------------------------------
     # Episode operations

--- a/src/khora/storage/backends/base.py
+++ b/src/khora/storage/backends/base.py
@@ -680,10 +680,22 @@ class GraphBackendProtocol(Protocol):
         namespace_id: UUID,
         *,
         relationship_type: str | None = None,
+        between_entity_ids: list[UUID] | None = None,
         limit: int = 1000,
         offset: int = 0,
     ) -> list[Relationship]:
-        """List all relationships in a namespace."""
+        """List all relationships in a namespace.
+
+        ``between_entity_ids`` filters by endpoint membership (#1451):
+
+        - ``None`` (default): no filter — behavior byte-identical to today.
+        - Non-empty list: return only relationships whose BOTH endpoints
+          (source AND target) are in the given id set.
+        - Empty list ``[]``: return ``[]`` (matches nothing).
+
+        Composes with AND against all existing conditions (``relationship_type``,
+        live/tombstone filters) and applies BEFORE ``limit``/``offset``.
+        """
         ...
 
     # Episode operations

--- a/src/khora/storage/backends/memgraph.py
+++ b/src/khora/storage/backends/memgraph.py
@@ -859,12 +859,23 @@ class MemgraphBackend(GraphBackendBase):
         namespace_id: UUID,
         *,
         relationship_type: str | None = None,
+        between_entity_ids: list[UUID] | None = None,
         limit: int = 1000,
         offset: int = 0,
     ) -> list[Relationship]:
+        if between_entity_ids is not None and not between_entity_ids:
+            return []
+
         driver = self._get_driver()
 
         rel_filter = f":{sanitize_cypher_label(relationship_type)}" if relationship_type else ""
+
+        # Constrain both endpoints to the given id set when requested (#1451):
+        # AND semantics — an edge surfaces only when source AND target are in
+        # the set.
+        endpoint_clause = ""
+        if between_entity_ids is not None:
+            endpoint_clause = " AND source.id IN $between_entity_ids AND target.id IN $between_entity_ids"
 
         # Both endpoints constrained to in-namespace ``:Entity`` nodes, matching
         # get_relationship() / get_entity_relationships() (IDOR family): edges
@@ -877,21 +888,24 @@ class MemgraphBackend(GraphBackendBase):
         query = f"""
         MATCH (source:Entity {{namespace_id: $namespace_id}})-[r{rel_filter}]->(target:Entity {{namespace_id: $namespace_id}})
         WHERE r.namespace_id = $namespace_id
-          AND (r.valid_until IS NULL OR r.valid_until > $now)
+          AND (r.valid_until IS NULL OR r.valid_until > $now){endpoint_clause}
         RETURN properties(r) as rel_props, source.id as source_id, target.id as target_id, type(r) as rel_type
         ORDER BY r.created_at DESC
         SKIP $offset
         LIMIT $limit
         """
 
+        params: dict[str, Any] = {
+            "namespace_id": str(namespace_id),
+            "offset": offset,
+            "limit": limit,
+            "now": datetime.now(UTC).isoformat(),
+        }
+        if endpoint_clause:
+            params["between_entity_ids"] = [str(e) for e in between_entity_ids]
+
         async with driver.session() as session:
-            result = await session.run(
-                query,
-                namespace_id=str(namespace_id),
-                offset=offset,
-                limit=limit,
-                now=datetime.now(UTC).isoformat(),
-            )
+            result = await session.run(query, **params)
             records = await result.data()
             rels = (
                 self._record_to_relationship(r["rel_props"], r["source_id"], r["target_id"], r["rel_type"])

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -3570,6 +3570,7 @@ RETURN DISTINCT com ORDER BY com.id
         namespace_id: UUID,
         *,
         relationship_type: str | None = None,
+        between_entity_ids: list[UUID] | None = None,
         limit: int = 1000,
         offset: int = 0,
     ) -> list[Relationship]:
@@ -3580,9 +3581,18 @@ RETURN DISTINCT com ORDER BY com.id
         ``valid_to`` / ``invalidated_at``), and recall now filters it out in
         lockstep with the PG read filter so the two stores agree on the live set.
         """
+        if between_entity_ids is not None and not between_entity_ids:
+            return []
 
         # Build relationship type filter
         rel_filter = f":{_sanitize_neo4j_label(relationship_type)}" if relationship_type else ""
+
+        # Constrain both endpoints to the given id set when requested (#1451):
+        # AND semantics — an edge surfaces only when source AND target are in
+        # the set.
+        endpoint_clause = ""
+        if between_entity_ids is not None:
+            endpoint_clause = " AND source.id IN $between_entity_ids AND target.id IN $between_entity_ids"
 
         # Both endpoints are constrained to in-namespace ``:Entity`` nodes,
         # matching get_relationship() / get_entity_relationships() (IDOR
@@ -3593,21 +3603,24 @@ RETURN DISTINCT com ORDER BY com.id
         query = f"""
         MATCH (source:Entity {{namespace_id: $namespace_id}})-[r{rel_filter}]->(target:Entity {{namespace_id: $namespace_id}})
         WHERE r.namespace_id = $namespace_id
-          AND (r.valid_until IS NULL OR r.valid_until > $now)
+          AND (r.valid_until IS NULL OR r.valid_until > $now){endpoint_clause}
         RETURN properties(r) as rel_props, source.id as source_id, target.id as target_id, type(r) as rel_type
         ORDER BY r.created_at DESC
         SKIP $offset
         LIMIT $limit
         """
 
+        params: dict[str, Any] = {
+            "namespace_id": str(namespace_id),
+            "offset": offset,
+            "limit": limit,
+            "now": datetime.now(UTC).isoformat(),
+        }
+        if endpoint_clause:
+            params["between_entity_ids"] = [str(e) for e in between_entity_ids]
+
         async with self._session() as session:
-            result = await session.run(
-                query,
-                namespace_id=str(namespace_id),
-                offset=offset,
-                limit=limit,
-                now=datetime.now(UTC).isoformat(),
-            )
+            result = await session.run(query, **params)
             records = await result.data()
             rels = (
                 self._record_to_relationship(r["rel_props"], r["source_id"], r["target_id"], r["rel_type"])

--- a/src/khora/storage/backends/neptune.py
+++ b/src/khora/storage/backends/neptune.py
@@ -657,10 +657,15 @@ class NeptuneBackend(GraphBackendBase):
         namespace_id: UUID,
         *,
         relationship_type: str | None = None,
+        between_entity_ids: list[UUID] | None = None,
         limit: int = 1000,
         offset: int = 0,
     ) -> list[Relationship]:
         driver = self._get_driver()
+
+        # Pushdown unverified on this openCypher subset; filtered in-method (see #1451).
+        if between_entity_ids is not None and not between_entity_ids:
+            return []
 
         rel_filter = f":{sanitize_cypher_label(relationship_type)}" if relationship_type else ""
 
@@ -672,17 +677,15 @@ class NeptuneBackend(GraphBackendBase):
         WHERE r.namespace_id = $namespace_id
         RETURN properties(r) as rel_props, source.id as source_id, target.id as target_id, type(r) as rel_type
         ORDER BY r.created_at DESC
-        SKIP $offset
-        LIMIT $limit
         """
+        params: dict[str, Any] = {"namespace_id": str(namespace_id)}
+        if between_entity_ids is None:
+            query += " SKIP $offset LIMIT $limit"
+            params["offset"] = offset
+            params["limit"] = limit
 
         async with driver.session() as session:
-            result = await session.run(
-                query,
-                namespace_id=str(namespace_id),
-                offset=offset,
-                limit=limit,
-            )
+            result = await session.run(query, **params)
             records = await result.data()
             rels = (
                 self._record_to_relationship(
@@ -693,7 +696,14 @@ class NeptuneBackend(GraphBackendBase):
                 )
                 for r in records
             )
-            return [rel for rel in rels if rel is not None]
+            relationships = [rel for rel in rels if rel is not None]
+
+        if between_entity_ids is not None:
+            id_set = set(between_entity_ids)
+            relationships = [r for r in relationships if r.source_entity_id in id_set and r.target_entity_id in id_set]
+            relationships = relationships[offset : offset + limit]
+
+        return relationships
 
     # ------------------------------------------------------------------
     # Episode operations

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -1609,6 +1609,7 @@ class PgVectorBackend(AsyncSessionMixin):
         namespace_id: UUID,
         *,
         relationship_type: str | None = None,
+        between_entity_ids: list[UUID] | None = None,
         limit: int = 1000,
         offset: int = 0,
     ) -> list:
@@ -1628,6 +1629,13 @@ class PgVectorBackend(AsyncSessionMixin):
             )
             if relationship_type:
                 stmt = stmt.where(RelationshipModel.relationship_type == relationship_type)
+            if between_entity_ids is not None:
+                if not between_entity_ids:
+                    return []
+                stmt = stmt.where(
+                    RelationshipModel.source_entity_id.in_(between_entity_ids),
+                    RelationshipModel.target_entity_id.in_(between_entity_ids),
+                )
             stmt = stmt.order_by(RelationshipModel.created_at.desc()).limit(limit).offset(offset)
             result = await session.execute(stmt)
             return [

--- a/src/khora/storage/backends/sqlite_lance/graph.py
+++ b/src/khora/storage/backends/sqlite_lance/graph.py
@@ -628,6 +628,7 @@ class SQLiteLanceGraphAdapter(GraphBackendBase):
         namespace_id: UUID,
         *,
         relationship_type: str | None = None,
+        between_entity_ids: list[UUID] | None = None,
         limit: int = 1000,
         offset: int = 0,
     ) -> list[Relationship]:
@@ -636,6 +637,15 @@ class SQLiteLanceGraphAdapter(GraphBackendBase):
         if relationship_type is not None:
             conditions.append("relationship_type = ?")
             params.append(relationship_type)
+        if between_entity_ids is not None:
+            if not between_entity_ids:
+                return []
+            id_texts = [uuid_to_text(e) for e in between_entity_ids]
+            placeholders = ", ".join("?" for _ in id_texts)
+            conditions.append(f"source_entity_id IN ({placeholders})")
+            conditions.append(f"target_entity_id IN ({placeholders})")
+            params.extend(id_texts)
+            params.extend(id_texts)
         sql = (
             f"SELECT {_RELATIONSHIP_COLUMNS} FROM relationships "  # noqa: S608
             f"WHERE {' AND '.join(conditions)} "

--- a/src/khora/storage/backends/surrealdb/graph.py
+++ b/src/khora/storage/backends/surrealdb/graph.py
@@ -722,6 +722,7 @@ class SurrealDBGraphAdapter(GraphBackendBase):
         namespace_id: UUID,
         *,
         relationship_type: str | None = None,
+        between_entity_ids: list[UUID] | None = None,
         limit: int = 1000,
         offset: int = 0,
     ) -> list[Relationship]:
@@ -736,6 +737,12 @@ class SurrealDBGraphAdapter(GraphBackendBase):
         if relationship_type is not None:
             conditions.append("relationship_type = $rt")
             bindings["rt"] = relationship_type
+
+        if between_entity_ids is not None:
+            if not between_entity_ids:
+                return []
+            conditions.append("in IN $between_eids AND out IN $between_eids")
+            bindings["between_eids"] = [_rid("entity", e) for e in between_entity_ids]
 
         sql = (
             f"SELECT * FROM relates_to WHERE {' AND '.join(conditions)} "  # noqa: S608

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -1987,6 +1987,7 @@ class StorageCoordinator:
         namespace_id: UUID,
         *,
         relationship_type: str | None = None,
+        between_entity_ids: list[UUID] | None = None,
         limit: int = 1000,
         offset: int = 0,
     ) -> list[Relationship]:
@@ -2000,11 +2001,19 @@ class StorageCoordinator:
         namespace_id = await self._resolve_read_namespace(namespace_id)
         if self._graph:
             return await self._graph.list_relationships(
-                namespace_id, relationship_type=relationship_type, limit=limit, offset=offset
+                namespace_id,
+                relationship_type=relationship_type,
+                between_entity_ids=between_entity_ids,
+                limit=limit,
+                offset=offset,
             )
         if self._vector and hasattr(self._vector, "list_relationships"):
             return await self._vector.list_relationships(  # type: ignore[unresolved-attribute]
-                namespace_id, relationship_type=relationship_type, limit=limit, offset=offset
+                namespace_id,
+                relationship_type=relationship_type,
+                between_entity_ids=between_entity_ids,
+                limit=limit,
+                offset=offset,
             )
         return []
 

--- a/tests/integration/storage/backends/surrealdb/test_source_document_ids_persistence.py
+++ b/tests/integration/storage/backends/surrealdb/test_source_document_ids_persistence.py
@@ -19,7 +19,7 @@ import pytest
 
 pytest.importorskip("surrealdb")
 
-from khora.core.models import Entity, MemoryNamespace, TenancyMode  # noqa: E402
+from khora.core.models import Entity, MemoryNamespace, Relationship, TenancyMode  # noqa: E402
 from khora.storage.backends.surrealdb.connection import SurrealDBConnection  # noqa: E402
 from khora.storage.backends.surrealdb.graph import SurrealDBGraphAdapter  # noqa: E402
 from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter  # noqa: E402
@@ -89,5 +89,59 @@ async def test_surrealdb_list_entities_filters_by_source_chunk_ids() -> None:
 
         # 4. Empty list → matches nothing.
         assert await graph.list_entities(ns_id, source_chunk_ids=[], limit=10) == []
+    finally:
+        await conn.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_surrealdb_list_relationships_filters_by_between_entity_ids() -> None:
+    """``list_relationships(between_entity_ids=...)`` filters by endpoint membership (#1451).
+
+    Seeds A→B and B→C, then pins the four contract cases: no filter returns
+    both edges; ``[A, B]`` returns exactly A→B (B→C excluded — C outside the
+    set); ``[A]`` returns [] (no self-loops seeded); and an empty list
+    returns [] (BOTH-endpoints-in-set semantics).
+    """
+    conn = SurrealDBConnection(mode="memory", namespace="khora_test", database="beid1451")
+    await conn.connect()
+    graph = SurrealDBGraphAdapter(conn)
+    relational = SurrealDBRelationalAdapter(conn)
+    try:
+        ns_id = uuid4()
+        await relational.create_namespace(
+            MemoryNamespace(id=ns_id, namespace_id=ns_id, tenancy_mode=TenancyMode.SHARED)
+        )
+
+        ent_a = Entity(id=uuid4(), namespace_id=ns_id, name="A", entity_type="PERSON")
+        ent_b = Entity(id=uuid4(), namespace_id=ns_id, name="B", entity_type="PERSON")
+        ent_c = Entity(id=uuid4(), namespace_id=ns_id, name="C", entity_type="PERSON")
+        await graph.upsert_entities_batch(ns_id, [ent_a, ent_b, ent_c])
+
+        rel_ab = Relationship(
+            namespace_id=ns_id, source_entity_id=ent_a.id, target_entity_id=ent_b.id, relationship_type="KNOWS"
+        )
+        rel_bc = Relationship(
+            namespace_id=ns_id, source_entity_id=ent_b.id, target_entity_id=ent_c.id, relationship_type="KNOWS"
+        )
+        await graph.create_relationships_batch([rel_ab, rel_bc])
+
+        def _edges(rels: list[Relationship]) -> set[tuple]:
+            return {(r.source_entity_id, r.target_entity_id) for r in rels}
+
+        # 1. No filter → both edges.
+        assert _edges(await graph.list_relationships(ns_id)) == {
+            (ent_a.id, ent_b.id),
+            (ent_b.id, ent_c.id),
+        }
+
+        # 2. [A, B] → exactly A→B (B→C excluded — C outside the set).
+        filtered = await graph.list_relationships(ns_id, between_entity_ids=[ent_a.id, ent_b.id])
+        assert _edges(filtered) == {(ent_a.id, ent_b.id)}
+
+        # 3. [A] → nothing (no self-loops seeded).
+        assert await graph.list_relationships(ns_id, between_entity_ids=[ent_a.id]) == []
+
+        # 4. Empty list → nothing.
+        assert await graph.list_relationships(ns_id, between_entity_ids=[]) == []
     finally:
         await conn.disconnect()

--- a/tests/integration/test_neo4j_retire_orphaned_entities_integration.py
+++ b/tests/integration/test_neo4j_retire_orphaned_entities_integration.py
@@ -21,7 +21,7 @@ from uuid import uuid4
 
 import pytest
 
-from khora.core.models.entity import Entity
+from khora.core.models.entity import Entity, Relationship
 from khora.storage.backends.neo4j import Neo4jBackend
 
 
@@ -489,6 +489,77 @@ class TestNeo4jRetireOrphanedEntitiesBatchIntegration:
                         await tx.run(
                             "MATCH (e:Entity) WHERE e.id IN $ids DETACH DELETE e",
                             ids=[str(entity_a.id), str(entity_b.id)],
+                        )
+
+                    await session.execute_write(_cleanup)
+            except Exception:  # noqa: BLE001
+                pass
+            await backend.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_list_relationships_filters_by_between_entity_ids(self) -> None:
+        """``list_relationships(between_entity_ids=...)`` filters by endpoint membership (#1451).
+
+        Seeds A→B and B→C, then pins the four contract cases: no filter returns
+        both edges; ``[A, B]`` returns exactly A→B (B→C excluded — C outside the
+        set); ``[A]`` returns [] (no self-loops seeded); and an empty list
+        returns [] (BOTH-endpoints-in-set semantics).
+        """
+        url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+        user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+        password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+        backend = Neo4jBackend(url, user=user, password=password)
+        await backend.connect()
+
+        namespace_id = uuid4()
+        entity_a = Entity(namespace_id=namespace_id, name=f"beid-A-{uuid4().hex[:8]}", entity_type="PERSON")
+        entity_b = Entity(namespace_id=namespace_id, name=f"beid-B-{uuid4().hex[:8]}", entity_type="PERSON")
+        entity_c = Entity(namespace_id=namespace_id, name=f"beid-C-{uuid4().hex[:8]}", entity_type="PERSON")
+        rel_ab = Relationship(
+            namespace_id=namespace_id,
+            source_entity_id=entity_a.id,
+            target_entity_id=entity_b.id,
+            relationship_type="KNOWS",
+        )
+        rel_bc = Relationship(
+            namespace_id=namespace_id,
+            source_entity_id=entity_b.id,
+            target_entity_id=entity_c.id,
+            relationship_type="KNOWS",
+        )
+
+        def _edges(rels):
+            return {(r.source_entity_id, r.target_entity_id) for r in rels}
+
+        try:
+            await backend.upsert_entities_batch(namespace_id, [entity_a, entity_b, entity_c])
+            await backend.create_relationships_batch([rel_ab, rel_bc])
+
+            # 1. No filter → both edges.
+            assert _edges(await backend.list_relationships(namespace_id)) == {
+                (entity_a.id, entity_b.id),
+                (entity_b.id, entity_c.id),
+            }
+
+            # 2. [A, B] → exactly A→B (B→C excluded — C outside the set).
+            filtered = await backend.list_relationships(namespace_id, between_entity_ids=[entity_a.id, entity_b.id])
+            assert _edges(filtered) == {(entity_a.id, entity_b.id)}
+
+            # 3. [A] → nothing (no self-loops seeded).
+            assert await backend.list_relationships(namespace_id, between_entity_ids=[entity_a.id]) == []
+
+            # 4. Empty list → nothing.
+            assert await backend.list_relationships(namespace_id, between_entity_ids=[]) == []
+
+        finally:
+            try:
+                async with backend._session() as session:
+
+                    async def _cleanup(tx):
+                        await tx.run(
+                            "MATCH (e:Entity) WHERE e.id IN $ids DETACH DELETE e",
+                            ids=[str(entity_a.id), str(entity_b.id), str(entity_c.id)],
                         )
 
                     await session.execute_write(_cleanup)

--- a/tests/integration/test_pgvector_accumulate_source_ids.py
+++ b/tests/integration/test_pgvector_accumulate_source_ids.py
@@ -32,7 +32,7 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from khora.core.models import Entity
+from khora.core.models import Entity, Relationship
 from khora.storage.backends.pgvector import _SOURCE_CHUNK_IDS_CAP, PgVectorBackend
 
 # Match the schema's pgvector column dimension (Vector(1536)).
@@ -268,6 +268,60 @@ async def test_list_entities_filters_by_source_chunk_ids(backend: PgVectorBacken
 
     # 6. Composes with entity_type (AND): non-matching type + A's chunk → nothing.
     assert await backend.list_entities(namespace_id, entity_type="ORGANIZATION", source_chunk_ids=[c1]) == []
+
+
+# =========================================================================
+# between_entity_ids endpoint filter on list_relationships (#1451)
+# =========================================================================
+
+
+@pytest.mark.asyncio
+async def test_list_relationships_filters_by_between_entity_ids(backend: PgVectorBackend, namespace_id: UUID) -> None:
+    """``list_relationships(between_entity_ids=...)`` filters edges by endpoint
+    membership — BOTH endpoints must be in the set — per #1451.
+
+    Seeds A→B and B→C, then pins the four contract cases: no filter returns
+    both edges; ``[A, B]`` returns exactly A→B (B→C excluded — C outside the
+    set); ``[A]`` returns [] (no self-loops seeded); and an empty list
+    returns [].
+    """
+    ent_a = _entity(namespace_id, f"rel-A-{uuid4()}")
+    ent_b = _entity(namespace_id, f"rel-B-{uuid4()}")
+    ent_c = _entity(namespace_id, f"rel-C-{uuid4()}")
+    await backend.upsert_entities_batch(namespace_id, [ent_a, ent_b, ent_c])
+
+    rel_ab = Relationship(
+        namespace_id=namespace_id,
+        source_entity_id=ent_a.id,
+        target_entity_id=ent_b.id,
+        relationship_type="KNOWS",
+    )
+    rel_bc = Relationship(
+        namespace_id=namespace_id,
+        source_entity_id=ent_b.id,
+        target_entity_id=ent_c.id,
+        relationship_type="KNOWS",
+    )
+    await backend.create_relationships_batch([rel_ab, rel_bc])
+
+    def _edges(rels: list[Relationship]) -> set[tuple[UUID, UUID]]:
+        return {(r.source_entity_id, r.target_entity_id) for r in rels}
+
+    # 1. No filter → both edges.
+    assert _edges(await backend.list_relationships(namespace_id)) == {
+        (ent_a.id, ent_b.id),
+        (ent_b.id, ent_c.id),
+    }
+
+    # 2. [A, B] → exactly A→B (B→C excluded — C outside the set).
+    filtered = await backend.list_relationships(namespace_id, between_entity_ids=[ent_a.id, ent_b.id])
+    assert _edges(filtered) == {(ent_a.id, ent_b.id)}
+
+    # 3. [A] → nothing (no self-loops seeded).
+    assert await backend.list_relationships(namespace_id, between_entity_ids=[ent_a.id]) == []
+
+    # 4. Empty list → nothing.
+    assert await backend.list_relationships(namespace_id, between_entity_ids=[]) == []
 
 
 # =========================================================================

--- a/tests/integration/test_pgvector_accumulate_source_ids.py
+++ b/tests/integration/test_pgvector_accumulate_source_ids.py
@@ -323,6 +323,20 @@ async def test_list_relationships_filters_by_between_entity_ids(backend: PgVecto
     # 4. Empty list → nothing.
     assert await backend.list_relationships(namespace_id, between_entity_ids=[]) == []
 
+    # 5. Composes with relationship_type (AND): matching type + [A, B] → exactly A→B.
+    composed = await backend.list_relationships(
+        namespace_id, relationship_type="KNOWS", between_entity_ids=[ent_a.id, ent_b.id]
+    )
+    assert _edges(composed) == {(ent_a.id, ent_b.id)}
+
+    # 6. Composes with relationship_type (AND): non-matching type + [A, B] → nothing (in-set edge excluded).
+    assert (
+        await backend.list_relationships(
+            namespace_id, relationship_type="WORKS_WITH", between_entity_ids=[ent_a.id, ent_b.id]
+        )
+        == []
+    )
+
 
 # =========================================================================
 # Single path (create_entity / _upsert_entity)

--- a/tests/integration/test_sqlite_lance_traversal.py
+++ b/tests/integration/test_sqlite_lance_traversal.py
@@ -8,7 +8,7 @@ extraction) and exercises ``find_paths`` / ``get_neighborhood`` /
 from __future__ import annotations
 
 from pathlib import Path
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -201,5 +201,36 @@ class TestSQLiteLanceTraversal:
 
             # 4. Empty list → matches nothing.
             assert await coord.list_entities(ns.id, source_chunk_ids=[]) == []
+        finally:
+            await coord.disconnect()
+
+    async def test_list_relationships_filters_by_between_entity_ids(self, tmp_path: Path) -> None:
+        """``list_relationships(between_entity_ids=...)`` filters by endpoint membership (#1451).
+
+        Seeds A→B and B→C, then pins the four contract cases: no filter returns
+        both edges; ``[A, B]`` returns exactly A→B (B→C excluded — C outside the
+        set); ``[A]`` returns [] (no self-loops seeded); and an empty list
+        returns [] (BOTH-endpoints-in-set semantics).
+        """
+        coord = await build_sqlite_lance_coordinator(tmp_path)
+        try:
+            ns = await coord.create_namespace(MemoryNamespace())
+            a, b, c = await _seed_chain(coord, ns.id, ["a", "b", "c"])
+
+            def _edges(rels: list[Relationship]) -> set[tuple[UUID, UUID]]:
+                return {(r.source_entity_id, r.target_entity_id) for r in rels}
+
+            # 1. No filter → both edges.
+            assert _edges(await coord.list_relationships(ns.id)) == {(a.id, b.id), (b.id, c.id)}
+
+            # 2. [A, B] → exactly A→B (B→C excluded — C outside the set).
+            filtered = await coord.list_relationships(ns.id, between_entity_ids=[a.id, b.id])
+            assert _edges(filtered) == {(a.id, b.id)}
+
+            # 3. [A] → nothing (no self-loops seeded).
+            assert await coord.list_relationships(ns.id, between_entity_ids=[a.id]) == []
+
+            # 4. Empty list → nothing.
+            assert await coord.list_relationships(ns.id, between_entity_ids=[]) == []
         finally:
             await coord.disconnect()

--- a/tests/unit/engines/vectorcypher/test_simple_retrieve_entities_857.py
+++ b/tests/unit/engines/vectorcypher/test_simple_retrieve_entities_857.py
@@ -149,17 +149,56 @@ class TestSimpleRetrieveEntityProjection857:
         assert set(pushed) == {c1, c2}
 
     @pytest.mark.asyncio
-    async def test_relationships_filtered_to_recalled_entity_endpoints(self) -> None:
-        """Relationship is included only when BOTH endpoints are in the
-        recalled-entity set (i.e. both source_chunk_ids overlap)."""
+    async def test_list_relationships_called_with_recalled_entity_ids(self) -> None:
+        """#1451: the relationship projection pushes the recalled entity ids
+        down to ``list_relationships(between_entity_ids=...)`` — the
+        BOTH-endpoints filter now runs in the backend rather than a
+        namespace-wide scan + Python filter (the analog of the #1448 entity-side
+        chunk-id pushdown)."""
         chunk_id = uuid4()
         sr = _make_search_result("hit", chunk_id=chunk_id)
 
         ns = uuid4()
         ent_a = Entity(id=uuid4(), namespace_id=ns, name="A", source_chunk_ids=[chunk_id])
         ent_b = Entity(id=uuid4(), namespace_id=ns, name="B", source_chunk_ids=[chunk_id])
-        ent_c = Entity(id=uuid4(), namespace_id=ns, name="C", source_chunk_ids=[uuid4()])
 
+        storage = MagicMock()
+        storage.list_entities = AsyncMock(return_value=[ent_a, ent_b])
+        storage.list_relationships = AsyncMock(return_value=[])
+
+        retriever = _make_retriever(storage=storage)
+        retriever._vector_store.search = AsyncMock(return_value=[sr])
+
+        await retriever._simple_retrieve(
+            query="q",
+            query_embedding=[0.1],
+            namespace_id=ns,
+            temporal_filter=None,
+            limit=10,
+            routing=_routing(),
+        )
+
+        storage.list_relationships.assert_awaited_once()
+        pushed = storage.list_relationships.await_args.kwargs.get("between_entity_ids")
+        assert pushed is not None, "recalled entity ids must be pushed down to list_relationships"
+        assert set(pushed) == {ent_a.id, ent_b.id}
+
+    @pytest.mark.asyncio
+    async def test_relationships_from_storage_surface_verbatim(self) -> None:
+        """The endpoint filter is now pushed down to the backend (#1451): the
+        retriever passes ``between_entity_ids`` and trusts ``list_relationships``
+        to return only edges whose BOTH endpoints are in the recalled set. The
+        retriever no longer re-filters in Python — every edge the backend
+        returns must surface verbatim."""
+        chunk_id = uuid4()
+        sr = _make_search_result("hit", chunk_id=chunk_id)
+
+        ns = uuid4()
+        ent_a = Entity(id=uuid4(), namespace_id=ns, name="A", source_chunk_ids=[chunk_id])
+        ent_b = Entity(id=uuid4(), namespace_id=ns, name="B", source_chunk_ids=[chunk_id])
+
+        # Backend has already applied the between_entity_ids filter, so only the
+        # in-set edge A→B comes back.
         rel_ab = Relationship(
             id=uuid4(),
             namespace_id=ns,
@@ -167,17 +206,10 @@ class TestSimpleRetrieveEntityProjection857:
             target_entity_id=ent_b.id,
             relationship_type="KNOWS",
         )
-        rel_ac = Relationship(
-            id=uuid4(),
-            namespace_id=ns,
-            source_entity_id=ent_a.id,
-            target_entity_id=ent_c.id,  # C is not recalled
-            relationship_type="KNOWS",
-        )
 
         storage = MagicMock()
-        storage.list_entities = AsyncMock(return_value=[ent_a, ent_b, ent_c])
-        storage.list_relationships = AsyncMock(return_value=[rel_ab, rel_ac])
+        storage.list_entities = AsyncMock(return_value=[ent_a, ent_b])
+        storage.list_relationships = AsyncMock(return_value=[rel_ab])
 
         retriever = _make_retriever(storage=storage)
         retriever._vector_store.search = AsyncMock(return_value=[sr])
@@ -193,7 +225,7 @@ class TestSimpleRetrieveEntityProjection857:
 
         assert {e.name for e, _ in result.entities} == {"A", "B"}
         rel_ids = {r.id for r, _ in result.relationships}
-        assert rel_ids == {rel_ab.id}, "only the rel with both endpoints recalled should survive"
+        assert rel_ids == {rel_ab.id}, "every edge the backend returns must surface verbatim"
 
     @pytest.mark.asyncio
     async def test_empty_chunks_returns_empty_entities_no_storage_call(self) -> None:

--- a/tests/unit/test_expansion_flow.py
+++ b/tests/unit/test_expansion_flow.py
@@ -104,7 +104,9 @@ async def test_load_relationships_graph_less_stack_returns_empty_list() -> None:
     result = await load_relationships(ns_id, storage, limit=200)
 
     assert result == []
-    vector.list_relationships.assert_awaited_once_with(ns_id, relationship_type=None, limit=200, offset=0)
+    vector.list_relationships.assert_awaited_once_with(
+        ns_id, relationship_type=None, between_entity_ids=None, limit=200, offset=0
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add a keyword-only `between_entity_ids: list[UUID] | None = None` filter to `list_relationships` across every storage backend (Neo4j, Memgraph, pgvector, SQLite/LanceDB, SurrealDB, Neptune, AGE), the storage protocol, and the coordinator. When a non-empty list is supplied, only relationships whose **source and target entity ids are both in the list** are returned (both-endpoints-in-set). `None` (default) is byte-identical to prior behavior; `[]` returns `[]`. The filter composes with existing conditions and is applied before `limit`/`offset`.
- Push the simple-path relationship projection down into the store: the VectorCypher retriever now passes the recalled entity ids as `between_entity_ids` instead of fetching the namespace-wide relationship list and filtering endpoints in Python. This is the companion to #1449 (the entity half, `source_chunk_ids` on `list_entities`) — with both halves now pushed into the backend, the projection no longer pulls the whole namespace over the wire.
- Graph backends (Neo4j/Memgraph) push the predicate into the Cypher `WHERE`, binding the id list only when the clause is active; pgvector/SQLite/SurrealDB push it into the query; Neptune/AGE filter in-method (openCypher subset support unverified, no CI lane).
- Add backend behavior tests (sqlite_lance, pgvector, Neo4j, SurrealDB) and retriever unit tests pinning the pushdown contract (no-filter → all edges, `[A,B]` → only A→B, `[A]` → `[]`, `[]` → `[]`).

Fixes #1451

## Test plan
- [x] Unit tests pass (retriever simple-path projection + expansion-flow caller)
- [x] Embedded backend behavior tests pass locally (sqlite_lance, SurrealDB memory mode)
- [ ] Integration tests pass in CI (pgvector, Neo4j — require Docker)
- [x] `ruff format --check`, `ruff check`, and `ty` clean; `check_optional_imports` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relationship lookups can now be limited to connections between a specific set of entities using an optional entity-set filter.
  * Results now only include edges where **both endpoints** are in the selected set; explicitly empty sets return no relationships.
* **Bug Fixes**
  * Improved cross-backend consistency by pushing the entity-set constraint into backend queries and avoiding redundant post-filtering.
* **Tests**
  * Added/updated integration and unit tests to verify the new filter behavior (including relationship-type compatibility and empty-set cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->