### PR TITLE
Compute filter report unenforced_keys from result surfaces

### DIFF
--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -2386,10 +2386,11 @@ class ChronicleEngine:
                     defensive_recheck=(filter_ast is not None and bool(filter_ast.children)),
                 )
             },
-            # Chronicle is a single "chunks" channel with no relationships; the
-            # entity surface is co-derived from the same chunk-side filter, so
-            # only "chunks" is covered and the rule is inert unless entities are
-            # ever emitted uncovered.
+            # Chronicle covers only the "chunks" surface: the entity channel
+            # (search_similar_entities) receives no filter_ast (#1458), so a HYBRID
+            # recall that surfaces entities emits an UNCOVERED entity surface and the
+            # builder honestly forces the filter's leaves into unenforced_keys. The
+            # #1458 fix filters the entity surface and adds it to covered_surfaces.
             surface_sizes={
                 "chunks": len(recall_chunks),
                 "entities": len(recall_entities),

--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -2386,6 +2386,16 @@ class ChronicleEngine:
                     defensive_recheck=(filter_ast is not None and bool(filter_ast.children)),
                 )
             },
+            # Chronicle is a single "chunks" channel with no relationships; the
+            # entity surface is co-derived from the same chunk-side filter, so
+            # only "chunks" is covered and the rule is inert unless entities are
+            # ever emitted uncovered.
+            surface_sizes={
+                "chunks": len(recall_chunks),
+                "entities": len(recall_entities),
+                "relationships": 0,
+            },
+            covered_surfaces={"chunks"},
         )
 
         return RecallResult(

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -637,6 +637,14 @@ class SkeletonConstructionEngine:
         engine_info["filter"] = build_filter_report(
             filter_ast,
             {self._backend_type: backend_plan},
+            # Skeleton emits chunks only (no entities / relationships), and the
+            # single backend channel gates the chunk surface, so covered_surfaces
+            # defaults to {"chunks"} and the surface-coverage rule is inert here.
+            surface_sizes={
+                "chunks": len(recall_chunks),
+                "entities": 0,
+                "relationships": 0,
+            },
         ).model_dump(mode="json")
 
         return RecallResult(

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -2658,6 +2658,18 @@ class VectorCypherEngine:
 
         filter_channel_plans = result.metadata.pop("_filter_channel_plans", {})
 
+        # Surface coverage for the honest filter report: the filter channels gate
+        # the chunk surface on every recall. Only "simple_" search modes (vector /
+        # vector+bm25, no graph path) return entities / relationships that the same
+        # chunk-side filter narrowed; a graph-path recall emits graph-derived
+        # entities / relationships the chunk filter never touched, so those
+        # surfaces stay uncovered and force the filter's leaves unenforced.
+        covered = {"chunks"} | (
+            {"entities", "relationships"}
+            if str(result.metadata.get("search_mode", "")).startswith("simple_")
+            else set()
+        )
+
         # Project materialized dream communities (#1276) onto the result (#1308):
         # the GraphRAG query-time payoff. Backend-capability-gated and zero-cost
         # when no entities matched, no communities are materialized, or the
@@ -2688,7 +2700,16 @@ class VectorCypherEngine:
                 "engine": "vectorcypher",
                 "mode": mode.name.lower(),
                 "channels_used": channels_used,
-                "filter": build_filter_report(filter_ast, filter_channel_plans).model_dump(mode="json"),
+                "filter": build_filter_report(
+                    filter_ast,
+                    filter_channel_plans,
+                    surface_sizes={
+                        "chunks": len(recall_chunks),
+                        "entities": len(recall_entities),
+                        "relationships": len(recall_relationships),
+                    },
+                    covered_surfaces=covered,
+                ).model_dump(mode="json"),
                 "rrf_k": self._vc_config.fusion_rrf_k,
                 "temporal_signal": (
                     {"category": temporal_signal.category.value, "source": temporal_signal.source}

--- a/src/khora/filter/report.py
+++ b/src/khora/filter/report.py
@@ -17,6 +17,18 @@ and whether it ran a defensive in-memory re-check over the full predicate even
 though every leaf compiled down (``defensive_recheck``). :func:`build_filter_report`
 folds those plans into the top-level partition and the per-channel breakdown.
 
+Beyond the per-channel plans, the builder honours an optional *surface-coverage*
+signal: an engine may report the row counts of each result surface (``chunks`` /
+``entities`` / ``relationships``) and the set of surfaces the filter's channels
+actually gate. When a surface came back non-empty but is NOT in the covered set,
+the filter did not constrain the rows on that surface, so every leaf of the
+filter is *unenforced* for that surface — the builder forces those leaves into
+``unenforced_keys`` (out of ``pushed_keys`` / ``post_filtered_keys``) and clears
+``pushed_down``. This keeps the report honest for multi-surface engines that push
+a filter through the chunk channel but emit entities / relationships the filter
+never touched. The signal is opt-in: with ``surface_sizes=None`` the builder is
+byte-for-byte its legacy self.
+
 The module is **pure**: it imports only the filter AST + the canonical leaf
 enumerator (:func:`khora.filter.execute.filter_leaf_keys`) and never an engine
 or a backend. Engines construct the :class:`ChannelPlan` carriers from their own
@@ -26,6 +38,7 @@ compile results and call :func:`build_filter_report`.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from collections.abc import Set as AbstractSet
 from dataclasses import dataclass, field
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -69,12 +82,16 @@ class FilterPushdownReport(BaseModel):
     gates it pushed it into the backend query; in ``post_filtered_keys`` when at
     least one gating channel had to re-check it in memory; and in
     ``unenforced_keys`` when no channel gates it at all (the filter constrains it
-    but nothing — pushdown nor in-memory re-check — actually enforces it). On a
-    correct recall every leaf is enforced, so ``unenforced_keys == []``. A
-    single-channel engine like skeleton (whose one channel gates every leaf)
-    always reports ``unenforced_keys == []``; the list is defined for
-    multi-channel engines where a leaf may slip past every channel. All three
-    lists are sorted and JSON-stable.
+    but nothing — pushdown nor in-memory re-check — actually enforces it), OR when
+    the recall returned a non-empty result surface (``entities`` /
+    ``relationships``) that the filter's channels do not cover, so the filter's
+    leaves went unenforced against that surface's rows. On a correct recall every
+    leaf is enforced, so ``unenforced_keys == []``. A single-channel engine like
+    skeleton (whose one channel gates every leaf) always reports
+    ``unenforced_keys == []``; the list is defined for multi-channel /
+    multi-surface engines where a leaf may slip past every channel or go
+    unenforced on an uncovered result surface. All three lists are sorted and
+    JSON-stable.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -99,11 +116,14 @@ class FilterPushdownReport(BaseModel):
     ``post_filtered=True`` but does NOT move a fully-pushed leaf here."""
 
     unenforced_keys: list[str] = Field(default_factory=list)
-    """Constraint-leaf keys that NO channel gates — neither pushed down nor
-    re-checked in memory — so the filter constrains them but nothing enforces
-    them (sorted). Together with ``pushed_keys`` and ``post_filtered_keys`` this
-    forms a total, disjoint partition of every constraint leaf. A correct recall
-    enforces every leaf, so this list is empty (``unenforced_keys == []``)."""
+    """Constraint-leaf keys the filter did not enforce (sorted). A leaf lands here
+    when NO channel gates it — neither pushed down nor re-checked in memory — or
+    when the recall returned a non-empty result surface not covered by the
+    filter's channels (an uncovered ``entities`` / ``relationships`` surface makes
+    every filter leaf unenforced against that surface's rows). Together with
+    ``pushed_keys`` and ``post_filtered_keys`` this forms a total, disjoint
+    partition of every constraint leaf. A correct recall enforces every leaf, so
+    this list is empty (``unenforced_keys == []``)."""
 
     channels: dict[str, FilterChannelReport] = Field(default_factory=dict)
     """Per-channel breakdown, keyed by channel name. One entry per channel the
@@ -137,6 +157,9 @@ class ChannelPlan:
 def build_filter_report(
     filter_ast: FilterNode | None,
     channel_inputs: Mapping[str, ChannelPlan],
+    *,
+    surface_sizes: Mapping[str, int] | None = None,
+    covered_surfaces: AbstractSet[str] = frozenset({"chunks"}),
 ) -> FilterPushdownReport:
     """Fold per-channel :class:`ChannelPlan` facts into a :class:`FilterPushdownReport`.
 
@@ -150,7 +173,8 @@ def build_filter_report(
     * Top-level ``pushed_keys`` — leaves pushed on *every* gating channel.
     * Top-level ``post_filtered_keys`` — leaves re-checked in memory on *any*
       gating channel.
-    * Top-level ``unenforced_keys`` — leaves that no channel gates at all.
+    * Top-level ``unenforced_keys`` — leaves that no channel gates at all, plus
+      any leaf forced unenforced by the surface-coverage rule below.
 
     These three lists form a TOTAL, disjoint partition of the constraint leaves:
     every leaf lands in exactly one. A leaf that no channel gates lands in
@@ -160,6 +184,20 @@ def build_filter_report(
     pushed). ``post_filtered`` is ``True`` when any leaf was post-filtered OR any
     channel ran a defensive full-predicate re-check (which does NOT demote a
     fully-pushed leaf — NO-DEMOTE).
+
+    **Surface coverage** (opt-in via ``surface_sizes``): an engine may emit rows
+    on more than one result surface (``chunks`` / ``entities`` /
+    ``relationships``) while its filter channels only gate some of them. Pass
+    ``surface_sizes`` mapping each surface to its returned row count and
+    ``covered_surfaces`` naming the surfaces the filter actually constrains
+    (default ``{"chunks"}``). When any of the three known surfaces came back
+    non-empty (``surface_sizes.get(s, 0) > 0``) but is not in ``covered_surfaces``,
+    the filter went unenforced against that surface's rows, so ALL of the filter's
+    leaves are forced into ``unenforced_keys`` (removed from ``pushed_keys`` /
+    ``post_filtered_keys``) and ``pushed_down`` becomes ``False``. With
+    ``surface_sizes=None`` this rule is inert and the builder is byte-for-byte its
+    legacy self. The rule only applies on the non-empty-leaves path — an empty /
+    constraint-free filter has no leaves to force.
 
     A constraint-free filter (``None``, or a root with no children) carries no
     leaves: ``pushed_keys`` / ``post_filtered_keys`` are empty and ``pushed_down``
@@ -201,13 +239,28 @@ def build_filter_report(
         elif gating:  # all gating channels pushed it (NO-DEMOTE: stays pushed)
             pushed.add(leaf)
 
+    # Surface coverage (opt-in): a non-empty result surface the filter's channels
+    # do not cover means the filter went unenforced against that surface's rows,
+    # so ALL filter leaves are forced unenforced. Inert when surface_sizes is None.
+    surface_unenforced: frozenset[str] = frozenset()
+    if surface_sizes is not None and any(
+        surface_sizes.get(s, 0) > 0 and s not in covered_surfaces for s in ("chunks", "entities", "relationships")
+    ):
+        surface_unenforced = frozenset(all_leaves)
+
+    # Keep the three top-level lists a total, disjoint partition: forced-unenforced
+    # leaves leave both pushed and post_filtered.
+    pushed -= surface_unenforced
+    post_filtered -= surface_unenforced
+
     return FilterPushdownReport(
         # Fully pushed only when nothing was post-filtered AND every constraint
-        # leaf landed in pushed_keys (so all leaves were gated + pushed).
+        # leaf landed in pushed_keys (so all leaves were gated + pushed). Any
+        # surface-forced unenforced leaf drops it out of pushed, so this is False.
         pushed_down=not post_filtered and pushed == set(all_leaves),
         post_filtered=bool(post_filtered) or any_defensive,
         pushed_keys=sorted(pushed),
         post_filtered_keys=sorted(post_filtered),
-        unenforced_keys=sorted(all_leaves - pushed - post_filtered),
+        unenforced_keys=sorted((all_leaves - pushed - post_filtered) | surface_unenforced),
         channels=channels,
     )

--- a/tests/e2e/test_filter_report_invariant.py
+++ b/tests/e2e/test_filter_report_invariant.py
@@ -47,6 +47,7 @@ from khora import Khora
 from khora.filter.conformance import ConformanceCase
 from khora.query import SearchMode
 from tests.e2e import _harness
+from tests.test_helpers.filter_spy import plan_extraction
 
 pytestmark = [pytest.mark.e2e, pytest.mark.slow]
 
@@ -321,3 +322,124 @@ async def test_report_invariants_rowset_chronicle(chronicle_kb, case) -> None:
 async def test_report_invariants_empty_chronicle(chronicle_kb, spec) -> None:
     """A no-filter / filter={} recall on live Chronicle is the canonical empty carrier."""
     await _assert_empty_carrier(chronicle_kb, spec)
+
+
+# --------------------------------------------------------------------------- #
+# Entity-bearing graph/chronicle leak cases (#1457 / #1458).
+#
+# The row-set cases above seed generic ``"conformance anchor"`` content with the
+# extractor staging NOTHING (no ``plan_extraction``), so those recalls return an
+# EMPTY entity surface and the surface-coverage rule stays inert — they remain
+# invariant-clean. These two cases are the opposite: they stage a real entity
+# corpus so the graph (VectorCypher) / entity (Chronicle) channel surfaces
+# entities the date filter never constrained. On a graph-path VectorCypher recall
+# and a HYBRID Chronicle recall the engine covers only the ``chunks`` surface, so
+# the non-empty uncovered entity surface forces every filter leaf into
+# ``unenforced_keys`` — the cross-engine ``unenforced_keys == []`` invariant is
+# genuinely violated until the #1457 / #1458 fix filters the entity surface.
+#
+# Marked ``xfail(strict=True)``: the body asserts the CLEAN invariant the fix
+# restores (so the fix flips it to xpass), and an anti-vacuity gate asserts the
+# recall actually surfaced entities first (so a no-entity path cannot pass the
+# ``unenforced_keys == []`` assertion for the wrong reason). Both self-skip on a
+# no-Docker run via the lane reachability marks, exactly like the row-set cases.
+# --------------------------------------------------------------------------- #
+
+_LEAK_MARKER = "leakmark"
+_LEAK_ENTITIES = [("Falcon", "PERSON"), ("Orbit", "ORG")]
+_LEAK_RELATIONSHIPS = [("Falcon", "Orbit", "WORKS_ON")]
+# A date filter on a beyond-corpus horizon is the #1457 repro trigger: it is a
+# date-key predicate (drives the VectorCypher EXPLICIT graph path) that the
+# entity surface never gates. The seed corpus carries no occurred_at, so the
+# clean recall would keep the chunks via COALESCE fallback; the leaf is the one
+# forced unenforced by the uncovered entity surface.
+_LEAK_DATE_FILTER: dict = {"occurred_at": {"$gte": "2020-01-01T00:00:00Z"}}
+
+
+async def _seed_leak_corpus(kb: Khora, namespace_id) -> None:
+    """Seed an entity-bearing corpus through the real ingest path (populates entities)."""
+    plan_extraction(_LEAK_MARKER, _LEAK_ENTITIES, _LEAK_RELATIONSHIPS)
+    for content in _harness.entity_seed_docs(_LEAK_MARKER, count=3):
+        await kb.remember(
+            content=content,
+            namespace=namespace_id,
+            entity_types=[t for _, t in _LEAK_ENTITIES],
+            relationship_types=[rt for _, _, rt in _LEAK_RELATIONSHIPS],
+        )
+
+
+@_harness.lane_skip("vc_full")
+@pytest.mark.skipif(
+    not _harness.lane_reachable("vc_full"),
+    reason="set NEO4J_INTEGRATION_TEST=1 and start PG+Neo4j (make dev) to exercise the live graph lane",
+)
+@pytest.mark.xfail(
+    strict=True,
+    reason="entity filter leak on the graph path (#1457): a graph-path recall surfaces an uncovered "
+    "entity surface the date filter never constrained, so the report flags the filter unenforced; "
+    "flips to xpass when the fix filters the entity surface",
+)
+async def test_report_invariant_graph_entity_bearing_date_filter_vc_full(vectorcypher_kb) -> None:
+    """A graph-path VectorCypher recall over an entity corpus + date filter reports clean.
+
+    The seeded entities make the graph channel surface a non-empty entity set the
+    chunk-side date filter does not cover, so the emitted report currently forces
+    the date leaf into ``unenforced_keys``. This asserts the CLEAN invariant the
+    #1457 fix restores (``unenforced_keys == []``), gated on a real entity surface
+    so it is not vacuous.
+    """
+    kb = vectorcypher_kb
+    namespace_id = (await kb.create_namespace()).namespace_id
+    await _seed_leak_corpus(kb, namespace_id)
+
+    # Anti-vacuity gate: the GRAPH channel really surfaced entities (fails loud if
+    # the graph never fired — then the leak below would be vacuous).
+    gate = await _harness.assert_graph_contributes(kb, namespace_id, _LEAK_MARKER)
+    assert gate.engine_info.get("graph_chunk_count", 0) > 0
+
+    result = await kb.recall(
+        _LEAK_MARKER,
+        namespace=namespace_id,
+        mode=SearchMode.GRAPH,
+        limit=_RECALL_LIMIT,
+        min_similarity=_RECALL_MIN_SIMILARITY,
+        filter=_LEAK_DATE_FILTER,
+    )
+    assert result.entities, "graph recall surfaced no entities — the surface-coverage rule is inert (vacuous)"
+    _assert_report(result, _LEAK_DATE_FILTER)
+
+
+@_harness.lane_skip("chronicle")
+@pytest.mark.skipif(
+    not _harness.lane_reachable("chronicle"), reason="start Postgres (make dev) to exercise this live lane"
+)
+@pytest.mark.xfail(
+    strict=True,
+    reason="entity filter leak on the chronicle path (#1458): a HYBRID recall surfaces an uncovered "
+    "entity surface the date filter never constrained, so the report flags the filter unenforced; "
+    "flips to xpass when the fix filters the entity surface",
+)
+async def test_report_invariant_entity_bearing_date_filter_chronicle(chronicle_kb) -> None:
+    """A HYBRID Chronicle recall over an entity corpus + date filter reports clean.
+
+    Chronicle's entity channel surfaces a non-empty entity set the chunk-side date
+    filter does not cover, so the emitted report currently forces the date leaf
+    into ``unenforced_keys``. This asserts the CLEAN invariant the #1458 fix
+    restores (``unenforced_keys == []``), gated on a real entity surface so it is
+    not vacuous. Chronicle has no GRAPH mode — the entity channel runs in HYBRID.
+    """
+    kb = chronicle_kb
+    namespace_id = (await kb.create_namespace()).namespace_id
+    await _seed_leak_corpus(kb, namespace_id)
+
+    result = await kb.recall(
+        _LEAK_MARKER,
+        namespace=namespace_id,
+        mode=SearchMode.HYBRID,
+        limit=_RECALL_LIMIT,
+        min_similarity=_RECALL_MIN_SIMILARITY,
+        filter=_LEAK_DATE_FILTER,
+    )
+    # Anti-vacuity gate: the entity channel really surfaced entities.
+    assert result.entities, "chronicle recall surfaced no entities — the surface-coverage rule is inert (vacuous)"
+    _assert_report(result, _LEAK_DATE_FILTER)

--- a/tests/e2e/test_filter_report_invariant.py
+++ b/tests/e2e/test_filter_report_invariant.py
@@ -416,21 +416,24 @@ async def test_report_invariant_graph_entity_bearing_date_filter_vc_full(vectorc
 @pytest.mark.skipif(
     not _harness.lane_reachable("chronicle"), reason="start Postgres (make dev) to exercise this live lane"
 )
-@pytest.mark.xfail(
-    strict=True,
-    raises=AssertionError,
-    reason="entity filter leak on the chronicle path (#1458): a HYBRID recall surfaces an uncovered "
-    "entity surface the date filter never constrained, so the report flags the filter unenforced; "
-    "flips to xpass when the fix filters the entity surface",
+@pytest.mark.skip(
+    reason="#1458 chronicle entity-surface leak is not exercisable on this live e2e lane: the HYBRID "
+    "recall surfaces no entities here (entity vector search does not clear the entity surface for the "
+    "seeded corpus on the credential-degraded e2e lane), so the surface-coverage rule stays inert and "
+    "the leak cannot be reproduced. The #1458 leak is pinned hermetically by "
+    "tests/recall/test_chronicle_filter_composition.py::test_filter_report_entity_bearing_date_filter_is_clean, "
+    "which forces the entity surface via a mocked engine. Re-enable (as xfail) once the live lane surfaces entities."
 )
 async def test_report_invariant_entity_bearing_date_filter_chronicle(chronicle_kb) -> None:
     """A HYBRID Chronicle recall over an entity corpus + date filter reports clean.
 
-    Chronicle's entity channel surfaces a non-empty entity set the chunk-side date
-    filter does not cover, so the emitted report currently forces the date leaf
-    into ``unenforced_keys``. This asserts the CLEAN invariant the #1458 fix
-    restores (``unenforced_keys == []``), gated on a real entity surface so it is
-    not vacuous. Chronicle has no GRAPH mode — the entity channel runs in HYBRID.
+    Chronicle's entity channel is meant to surface a non-empty entity set the
+    chunk-side date filter does not cover, so the emitted report would force the
+    date leaf into ``unenforced_keys``. Skipped: on the live e2e lane the HYBRID
+    recall does not surface entities for the seeded corpus, so the anti-vacuity
+    gate cannot hold and the leak is not exercisable here (the #1458 leak is
+    pinned hermetically in tests/recall/). Chronicle has no GRAPH mode — the
+    entity channel runs in HYBRID.
     """
     kb = chronicle_kb
     namespace_id = (await kb.create_namespace()).namespace_id

--- a/tests/e2e/test_filter_report_invariant.py
+++ b/tests/e2e/test_filter_report_invariant.py
@@ -375,6 +375,7 @@ async def _seed_leak_corpus(kb: Khora, namespace_id) -> None:
 )
 @pytest.mark.xfail(
     strict=True,
+    raises=AssertionError,
     reason="entity filter leak on the graph path (#1457): a graph-path recall surfaces an uncovered "
     "entity surface the date filter never constrained, so the report flags the filter unenforced; "
     "flips to xpass when the fix filters the entity surface",
@@ -395,7 +396,8 @@ async def test_report_invariant_graph_entity_bearing_date_filter_vc_full(vectorc
     # Anti-vacuity gate: the GRAPH channel really surfaced entities (fails loud if
     # the graph never fired — then the leak below would be vacuous).
     gate = await _harness.assert_graph_contributes(kb, namespace_id, _LEAK_MARKER)
-    assert gate.engine_info.get("graph_chunk_count", 0) > 0
+    if gate.engine_info.get("graph_chunk_count", 0) <= 0:
+        pytest.fail("graph channel spliced no chunks — the graph-path leak is not exercised (vacuous)")
 
     result = await kb.recall(
         _LEAK_MARKER,
@@ -405,7 +407,8 @@ async def test_report_invariant_graph_entity_bearing_date_filter_vc_full(vectorc
         min_similarity=_RECALL_MIN_SIMILARITY,
         filter=_LEAK_DATE_FILTER,
     )
-    assert result.entities, "graph recall surfaced no entities — the surface-coverage rule is inert (vacuous)"
+    if not result.entities:
+        pytest.fail("graph recall surfaced no entities — the surface-coverage rule is inert (vacuous)")
     _assert_report(result, _LEAK_DATE_FILTER)
 
 
@@ -415,6 +418,7 @@ async def test_report_invariant_graph_entity_bearing_date_filter_vc_full(vectorc
 )
 @pytest.mark.xfail(
     strict=True,
+    raises=AssertionError,
     reason="entity filter leak on the chronicle path (#1458): a HYBRID recall surfaces an uncovered "
     "entity surface the date filter never constrained, so the report flags the filter unenforced; "
     "flips to xpass when the fix filters the entity surface",
@@ -441,5 +445,6 @@ async def test_report_invariant_entity_bearing_date_filter_chronicle(chronicle_k
         filter=_LEAK_DATE_FILTER,
     )
     # Anti-vacuity gate: the entity channel really surfaced entities.
-    assert result.entities, "chronicle recall surfaced no entities — the surface-coverage rule is inert (vacuous)"
+    if not result.entities:
+        pytest.fail("chronicle recall surfaced no entities — the surface-coverage rule is inert (vacuous)")
     _assert_report(result, _LEAK_DATE_FILTER)

--- a/tests/integration/matrix/test_vectorcypher_sqlite_lance.py
+++ b/tests/integration/matrix/test_vectorcypher_sqlite_lance.py
@@ -943,6 +943,12 @@ async def test_vc_filter_report_partial_pushdown_json1_off(kb: Khora, namespace_
     assert report["post_filtered"] is True
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="entity-surface filter leak (#1457): the embedded graph fallback surfaces a non-empty "
+    "entity surface the chunk-only channels don't cover, so build_filter_report forces both leaves "
+    "into unenforced_keys; restored once the #1457 fix filters the entity surface",
+)
 async def test_vc_filter_report_graph_nothing_pushed_embedded(kb: Khora, namespace_id: UUID) -> None:
     """The embedded graph fallback pushes NOTHING — every leaf re-checked in memory.
 

--- a/tests/integration/test_channel_filter_operator_matrix.py
+++ b/tests/integration/test_channel_filter_operator_matrix.py
@@ -83,6 +83,16 @@ def _neo4j_reachable() -> bool:
 pytestmark = [
     pytest.mark.integration,
     pytest.mark.filter_enforcement,
+    # Expected-red until #1457 lands: every cell here runs a filtered graph/recency
+    # recall that surfaces a non-empty entity surface the chunk-only channels don't
+    # cover, so build_filter_report now forces the filter's leaves into
+    # unenforced_keys and the `unenforced_keys == []` invariant no longer holds. The
+    # #1457 fix filters the entity surface and flips these back to green.
+    pytest.mark.xfail(
+        strict=True,
+        reason="entity-surface filter leak (#1457): filtered graph/recency recall surfaces an "
+        "uncovered entity surface, so unenforced_keys is non-empty until the #1457 fix filters it",
+    ),
     pytest.mark.skipif(
         not os.environ.get("NEO4J_INTEGRATION_TEST") or not _pg_reachable() or not _neo4j_reachable(),
         reason="set NEO4J_INTEGRATION_TEST=1 and start PG+Neo4j (make dev) to exercise the live matrix cells",

--- a/tests/integration/test_channel_filter_operator_matrix_change.py
+++ b/tests/integration/test_channel_filter_operator_matrix_change.py
@@ -70,7 +70,19 @@ from tests.recall.test_channel_filter_operator_matrix import (
 )
 from tests.test_helpers.filter_spy import stub_llm
 
-pytestmark = [pytest.mark.integration, pytest.mark.filter_enforcement]
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.filter_enforcement,
+    # Expected-red until #1457 lands: these session/change/recency cells run filtered
+    # recalls that surface a non-empty entity surface the chunk-only channels don't
+    # cover, so build_filter_report forces the filter's leaves into unenforced_keys.
+    # The #1457 fix filters the entity surface and flips these back to green.
+    pytest.mark.xfail(
+        strict=True,
+        reason="entity-surface filter leak (#1457): filtered recall surfaces an uncovered entity "
+        "surface, so unenforced_keys is non-empty until the #1457 fix filters it",
+    ),
+]
 
 # The Postgres pgvector column is fixed at 1536, so the live-DB suite sizes its
 # deterministic vectors at 1536 (mirrors test_filter_pushdown_graph.py).

--- a/tests/integration/test_vectorcypher_recency_channel_pg.py
+++ b/tests/integration/test_vectorcypher_recency_channel_pg.py
@@ -520,6 +520,12 @@ _LEAK_SOURCE = "leakdoc"
 _CLEAN_SOURCE = "cleandoc"
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="entity-surface filter leak (#1457): the recall surfaces a non-empty entity surface the "
+    "chunk-only channels don't cover, so build_filter_report reports source_name unenforced; the "
+    "chunk-level no-leak still holds and unenforced_keys == [] is restored once the #1457 fix filters entities",
+)
 @pytest.mark.skipif(
     not _neo4j_reachable() or not os.environ.get("NEO4J_INTEGRATION_TEST"),
     reason="set NEO4J_INTEGRATION_TEST=1 and run `make dev` (needs Neo4j for the full vectorcypher path)",

--- a/tests/recall/test_chronicle_filter_composition.py
+++ b/tests/recall/test_chronicle_filter_composition.py
@@ -685,3 +685,89 @@ async def test_filter_report_source_timestamp_under_not_is_post_filter_only() ->
     assert report["pushed_down"] is False
     assert report["post_filtered"] is True
     assert report["channels"][_CHUNKS_CHANNEL] == {"pushed_keys": [], "post_filtered_keys": ["source_timestamp"]}
+
+
+# ===========================================================================
+# Cross-engine gate: an entity-bearing Chronicle recall under a date filter
+# emits an uncovered ``entities`` surface, so the top-level report honestly
+# flags the filter unenforced (#1458).
+#
+# The Chronicle engine feeds ``build_filter_report`` a single ``"chunks"``
+# channel with ``covered_surfaces={"chunks"}`` and ``surface_sizes["entities"] =
+# len(recall_entities)`` (engine.py). The entity channel gates only the chunk
+# surface, so when a HYBRID recall surfaces entities the date-keyed filter never
+# constrained, the surface-coverage rule forces every filter leaf into
+# ``unenforced_keys`` and clears ``pushed_down`` — the cross-engine
+# ``unenforced_keys == []`` invariant is genuinely violated until the #1458 fix
+# filters the entity surface. Marked ``xfail(strict=True)``: the assertion body
+# encodes the CLEAN report the fix restores, so the fix flips it to xpass.
+# ===========================================================================
+
+
+def _engine_with_entity(
+    chunk_results: list[tuple[Chunk, float]],
+    entity: Any,
+    entity_score: float,
+) -> ChronicleEngine:
+    """A connected ChronicleEngine whose entity channel resolves one Entity.
+
+    Extends :func:`_engine_with_semantic` with the two entity-channel seams
+    (``search_similar_entities`` → one ``(id, score)`` hit, ``get_entities_batch``
+    → the resolved record) so a HYBRID recall surfaces ``result.entities``.
+    ``_router_enabled`` is turned OFF so the always-on ``run_entity`` gate is not
+    routed away to SIMPLE (which would skip the entity channel) — the entity
+    channel only runs in HYBRID/ALL mode, and this keeps that path live.
+    """
+    engine = _engine_with_semantic(chunk_results)
+    engine._storage.search_similar_entities = AsyncMock(return_value=[(entity.id, entity_score)])
+    engine._storage.get_entities_batch = AsyncMock(return_value={entity.id: entity})
+    engine._storage.get_chunks_batch = AsyncMock(return_value={})
+    engine._storage.get_entities_by_names_batch = AsyncMock(return_value={})
+    engine._router_enabled = False
+    return engine
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="entity filter leak on the chronicle path (#1458): the recall surfaces an uncovered "
+    "entity surface the date filter never constrained, so the report honestly flags the filter "
+    "unenforced until the fix filters the entity surface",
+)
+@pytest.mark.asyncio
+async def test_filter_report_entity_bearing_date_filter_is_clean() -> None:
+    from khora.core.models import Entity
+
+    in_scope = _chunk(
+        "alpha recent",
+        source_timestamp=datetime(2026, 6, 1, tzinfo=UTC),
+        created_at=datetime(2026, 6, 1, tzinfo=UTC),
+    )
+    entity = Entity(
+        id=uuid4(),
+        namespace_id=uuid4(),
+        name="Falcon",
+        entity_type="EVENT",
+        description="d",
+        attributes={},
+        mention_count=1,
+        source_document_ids=[],
+        source_chunk_ids=[],
+    )
+    engine = _engine_with_entity([(in_scope, 0.9)], entity, 0.95)
+
+    result = await engine.recall(
+        "Falcon",
+        uuid4(),
+        limit=10,
+        mode=SearchMode.HYBRID,
+        filter_ast=_filter_ast({"occurred_at": {"$gte": "2026-01-01T00:00:00Z"}}),
+    )
+    report = result.engine_info["filter"]
+    _validates(report)
+
+    # The recall genuinely surfaced entities (the leak precondition) — guards
+    # against a vacuous pass where the entity channel silently no-opped.
+    assert result.entities, "entity channel produced no entities — the surface-coverage rule is inert"
+    # CLEAN report the #1458 fix restores: the date leaf is enforced against the
+    # (then-filtered) entity surface, so nothing is left unenforced.
+    assert report["unenforced_keys"] == []

--- a/tests/recall/test_chronicle_filter_composition.py
+++ b/tests/recall/test_chronicle_filter_composition.py
@@ -729,6 +729,7 @@ def _engine_with_entity(
 
 @pytest.mark.xfail(
     strict=True,
+    raises=AssertionError,
     reason="entity filter leak on the chronicle path (#1458): the recall surfaces an uncovered "
     "entity surface the date filter never constrained, so the report honestly flags the filter "
     "unenforced until the fix filters the entity surface",
@@ -766,8 +767,11 @@ async def test_filter_report_entity_bearing_date_filter_is_clean() -> None:
     _validates(report)
 
     # The recall genuinely surfaced entities (the leak precondition) — guards
-    # against a vacuous pass where the entity channel silently no-opped.
-    assert result.entities, "entity channel produced no entities — the surface-coverage rule is inert"
+    # against a vacuous pass where the entity channel silently no-opped. pytest.fail
+    # (raises Failed, not AssertionError) so a no-op channel surfaces as a real
+    # failure rather than being masked as the expected AssertionError XFAIL.
+    if not result.entities:
+        pytest.fail("entity channel produced no entities — the surface-coverage rule is inert")
     # CLEAN report the #1458 fix restores: the date leaf is enforced against the
     # (then-filtered) entity surface, so nothing is left unenforced.
     assert report["unenforced_keys"] == []

--- a/tests/unit/engines/test_vectorcypher_filter_report.py
+++ b/tests/unit/engines/test_vectorcypher_filter_report.py
@@ -79,6 +79,20 @@ pytestmark = pytest.mark.unit
 _RECALL_FILTER: dict[str, Any] = {"source_name": "linear", "metadata.tier": "gold"}
 
 
+# Shared marker for the graph-path entity/relationship filter leak (#1457): the
+# report honestly flags the filter unenforced against the uncovered entity
+# surface until the #1457 fix filters it. ``raises=AssertionError`` scopes the
+# xfail to the CLEAN-report assertion the fix flips — precondition / anti-vacuity
+# gates use ``pytest.fail`` (which raises ``Failed``, not ``AssertionError``) so a
+# broken seed / mock / graph channel surfaces as a real failure, not a masked XFAIL.
+_XFAIL_1457 = pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
+    "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
+)
+
+
 def _ast(spec: dict[str, Any] | None) -> FilterNode | None:
     """Build the canonical AST exactly as the public facade does (khora.py)."""
     if spec is None:
@@ -342,11 +356,7 @@ async def _recall_filter_report(
 class TestHybridReport:
     """HYBRID recall folds vector / bm25 / graph plans into the canonical report."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
-        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
-    )
+    @_XFAIL_1457
     async def test_hybrid_vector_bm25_graph(self) -> None:
         """vector+bm25 push both keys; graph pushes source_name, post-filters metadata.tier.
 
@@ -382,11 +392,7 @@ class TestHybridReport:
         assert report["pushed_down"] is False
         assert report["post_filtered"] is True
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
-        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
-    )
+    @_XFAIL_1457
     async def test_hybrid_vector_graph_default_no_bm25(self) -> None:
         """Default HYBRID (bm25 channel OFF) still reports vector + graph honestly.
 
@@ -415,11 +421,7 @@ class TestHybridReport:
 class TestGraphModeReport:
     """GRAPH mode drops the vector + bm25 chunk channels; only graph gates."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
-        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
-    )
+    @_XFAIL_1457
     async def test_graph_only_disposition(self) -> None:
         """GRAPH mode: source_name pushed, metadata.tier post-filtered, by graph alone.
 
@@ -444,11 +446,7 @@ class TestGraphModeReport:
         assert report["pushed_down"] is False
         assert report["post_filtered"] is True
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
-        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
-    )
+    @_XFAIL_1457
     async def test_graph_fetch_that_spliced_nothing_pushes_no_keys(self) -> None:
         """A graph fetch that never touched the sink reports ``pushed_keys == []``.
 
@@ -642,11 +640,7 @@ class TestFilterEdgeCases:
         for ch in report["channels"].values():
             assert ch == {"pushed_keys": [], "post_filtered_keys": []}
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
-        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
-    )
+    @_XFAIL_1457
     async def test_system_only_filter_is_fully_pushed(self) -> None:
         """A system-key-only filter pushes down on every channel -> ``pushed_down``.
 
@@ -678,11 +672,7 @@ class TestFilterEdgeCases:
         # Graph pushed source_name (no residual); SQL channels too.
         assert report["channels"]["graph"] == {"pushed_keys": ["source_name"], "post_filtered_keys": []}
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
-        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
-    )
+    @_XFAIL_1457
     async def test_metadata_only_filter_is_post_filtered_on_graph(self) -> None:
         """A metadata-only filter: SQL channels push it, the graph channel re-checks it.
 
@@ -809,11 +799,7 @@ class TestRecencyChannelPresence:
 class TestGraphFallbackReport:
     """Under a graph fallback, the graph channel is absent (not fabricated)."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
-        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
-    )
+    @_XFAIL_1457
     async def test_graph_fallback_omits_graph_channel(self) -> None:
         """A transient Neo4j error during expand -> graph channel ABSENT.
 
@@ -916,11 +902,7 @@ def _typed_entity_retriever(ns_id: UUID, rows: list[dict[str, Any]]) -> VectorCy
 class TestTypedEntityFastPathHonesty:
     """Typed-recent reports: REAL report when filtered, no-filter carrier when not."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
-        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
-    )
+    @_XFAIL_1457
     async def test_filtered_typed_recent_emits_real_report(self) -> None:
         """TYPED_ENTITY_RECENT routed WITH a filter -> non-empty, valid report.
 
@@ -1330,11 +1312,6 @@ class TestSessionAwareFanoutSingleVectorPlan:
 class TestConcurrentRecallsNoCrossContamination:
     """Concurrent recalls with distinct filters keep distinct reports."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
-        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
-    )
     async def test_five_concurrent_recalls_distinct_keys(self) -> None:
         """5 concurrent recalls, each a different filter -> each report is scoped.
 
@@ -1368,7 +1345,11 @@ class TestConcurrentRecallsNoCrossContamination:
             assert report["channels"]["vector"]["pushed_keys"] == expected[i], (
                 f"recall {i} cross-contaminated: {report['channels']['vector']['pushed_keys']} != {expected[i]}"
             )
-            assert report["pushed_keys"] == expected[i]
+            # Top-level pushed_keys is surface-rule-dependent on the graph path
+            # (leaves are forced into unenforced_keys until the #1457 fix filters
+            # the entity surface), so pin the cross-contamination scoping at the
+            # channel level only — channel lists are unaffected by the surface rule
+            # and are the real per-call sink-isolation signal.
 
 
 # ---------------------------------------------------------------------------
@@ -1388,12 +1369,7 @@ class TestConcurrentRecallsNoCrossContamination:
 class TestDateKeyedExplicitSynthesisLeak:
     """A date-keyed filter on the graph path leaks the uncovered entity surface."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="graph-path entity/relationship filter leak (#1457): a date-keyed filter forces the "
-        "EXPLICIT graph path, which surfaces an uncovered entity surface the filter never constrained; "
-        "the report honestly flags the date leaf unenforced until the #1457 fix filters the surface",
-    )
+    @_XFAIL_1457
     async def test_date_filter_graph_path_report_is_clean(self) -> None:
         """A ``occurred_at $gte 2027`` filter on the graph path reports a clean pushdown.
 
@@ -1416,20 +1392,29 @@ class TestDateKeyedExplicitSynthesisLeak:
             filter_ast=_ast({"occurred_at": {"$gte": "2027-01-01T00:00:00Z"}}),
         )
         report = result.engine_info["filter"]
-        assert "_filter_channel_plans" not in result.engine_info
+        # Precondition (holds before AND after the fix): no private channel-plan
+        # sink leaks into the public engine_info. A pytest.fail guard (raises
+        # Failed, not AssertionError) so a regression here is a real failure, not
+        # a masked XFAIL under the raises=AssertionError marker.
+        if "_filter_channel_plans" in result.engine_info:
+            pytest.fail("_filter_channel_plans leaked into public engine_info")
         FilterPushdownReport.model_validate(report)
 
         # Precondition (holds before AND after the fix): the recall genuinely ran
         # the GRAPH path (non-``simple_*`` search_mode or graph chunks spliced)
         # and surfaced entities — so the surface-coverage rule has real fuel and
-        # the leak below is not a vacuous fall-through to the simple path.
+        # the leak below is not a vacuous fall-through to the simple path. These
+        # gates use pytest.fail so a broken mock / graph channel surfaces as a
+        # real failure rather than being masked as the expected AssertionError XFAIL.
         search_mode = str(result.engine_info.get("search_mode", ""))
-        assert result.entities, "graph path surfaced no entities — the surface-coverage rule is inert"
-        assert not search_mode.startswith("simple_") or result.engine_info.get("graph_chunk_count", 0) > 0, (
-            f"recall fell through to the simple path (search_mode={search_mode!r}, "
-            f"graph_chunk_count={result.engine_info.get('graph_chunk_count')}) — the graph-path leak "
-            "is not exercised"
-        )
+        if not result.entities:
+            pytest.fail("graph path surfaced no entities — the surface-coverage rule is inert")
+        if search_mode.startswith("simple_") and result.engine_info.get("graph_chunk_count", 0) <= 0:
+            pytest.fail(
+                f"recall fell through to the simple path (search_mode={search_mode!r}, "
+                f"graph_chunk_count={result.engine_info.get('graph_chunk_count')}) — the graph-path leak "
+                "is not exercised"
+            )
 
         # The single date leaf is enforced (nothing unenforced) on a clean report.
         assert report["unenforced_keys"] == []

--- a/tests/unit/engines/test_vectorcypher_filter_report.py
+++ b/tests/unit/engines/test_vectorcypher_filter_report.py
@@ -342,6 +342,11 @@ async def _recall_filter_report(
 class TestHybridReport:
     """HYBRID recall folds vector / bm25 / graph plans into the canonical report."""
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
+        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
+    )
     async def test_hybrid_vector_bm25_graph(self) -> None:
         """vector+bm25 push both keys; graph pushes source_name, post-filters metadata.tier.
 
@@ -377,6 +382,11 @@ class TestHybridReport:
         assert report["pushed_down"] is False
         assert report["post_filtered"] is True
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
+        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
+    )
     async def test_hybrid_vector_graph_default_no_bm25(self) -> None:
         """Default HYBRID (bm25 channel OFF) still reports vector + graph honestly.
 
@@ -405,6 +415,11 @@ class TestHybridReport:
 class TestGraphModeReport:
     """GRAPH mode drops the vector + bm25 chunk channels; only graph gates."""
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
+        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
+    )
     async def test_graph_only_disposition(self) -> None:
         """GRAPH mode: source_name pushed, metadata.tier post-filtered, by graph alone.
 
@@ -429,6 +444,11 @@ class TestGraphModeReport:
         assert report["pushed_down"] is False
         assert report["post_filtered"] is True
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
+        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
+    )
     async def test_graph_fetch_that_spliced_nothing_pushes_no_keys(self) -> None:
         """A graph fetch that never touched the sink reports ``pushed_keys == []``.
 
@@ -622,6 +642,11 @@ class TestFilterEdgeCases:
         for ch in report["channels"].values():
             assert ch == {"pushed_keys": [], "post_filtered_keys": []}
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
+        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
+    )
     async def test_system_only_filter_is_fully_pushed(self) -> None:
         """A system-key-only filter pushes down on every channel -> ``pushed_down``.
 
@@ -653,6 +678,11 @@ class TestFilterEdgeCases:
         # Graph pushed source_name (no residual); SQL channels too.
         assert report["channels"]["graph"] == {"pushed_keys": ["source_name"], "post_filtered_keys": []}
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
+        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
+    )
     async def test_metadata_only_filter_is_post_filtered_on_graph(self) -> None:
         """A metadata-only filter: SQL channels push it, the graph channel re-checks it.
 
@@ -779,6 +809,11 @@ class TestRecencyChannelPresence:
 class TestGraphFallbackReport:
     """Under a graph fallback, the graph channel is absent (not fabricated)."""
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
+        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
+    )
     async def test_graph_fallback_omits_graph_channel(self) -> None:
         """A transient Neo4j error during expand -> graph channel ABSENT.
 
@@ -881,6 +916,11 @@ def _typed_entity_retriever(ns_id: UUID, rows: list[dict[str, Any]]) -> VectorCy
 class TestTypedEntityFastPathHonesty:
     """Typed-recent reports: REAL report when filtered, no-filter carrier when not."""
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
+        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
+    )
     async def test_filtered_typed_recent_emits_real_report(self) -> None:
         """TYPED_ENTITY_RECENT routed WITH a filter -> non-empty, valid report.
 
@@ -1082,6 +1122,76 @@ class TestSimplePathModeChannels:
 
         assert set(report["channels"]) == {"vector", "bm25"}
 
+    async def test_simple_path_entity_bearing_report_is_clean(self) -> None:
+        """The simple path COVERS its entity surface, so ``unenforced_keys == []``.
+
+        Coverage-by-derivation (the green counterpart to the graph-path leak): a
+        ``simple_*`` search_mode makes the engine's covered set include
+        ``{"entities", "relationships"}``, so even when the recall surfaces
+        entities the surface-coverage rule stays inert and every filter leaf is
+        enforced. Here the simple-path entity projection returns a genuine entity
+        (its ``source_chunk_ids`` overlap the recalled chunk), so the assertion is
+        not vacuous — a covered, non-empty entity surface still yields a clean,
+        fully-pushed report. This is the PASSING invariant the graph/chronicle
+        leak tests are the strict-xfail mirror of.
+        """
+        ns_id = uuid4()
+        retriever = _simple_retriever(ns_id, enable_bm25=True)
+        # Make the simple-path entity projection return an entity whose
+        # source_chunk_ids overlap the recalled vector chunk, so recall surfaces
+        # a non-empty (but COVERED) entity surface.
+        recalled_id = uuid4()
+
+        sr = MagicMock()
+        sr.chunk = MagicMock()
+        sr.chunk.id = recalled_id
+        sr.chunk.namespace_id = ns_id
+        sr.chunk.document_id = uuid4()
+        sr.chunk.content = "vector chunk"
+        sr.chunk.occurred_at = None
+        sr.chunk.created_at = None
+        sr.chunk.source_timestamp = None
+        sr.chunk.metadata = {}
+        sr.chunk.chunker_info = {}
+        sr.similarity = 0.8
+        sr.combined_score = 0.8
+
+        async def _search(*_args: Any, **kwargs: Any) -> list[Any]:
+            sink = kwargs.get("filter_plan_out")
+            fast = kwargs.get("filter_ast")
+            if sink is not None and fast is not None:
+                sink.append(ChannelPlan(pushed_keys=filter_leaf_keys(fast)))
+            return [sr]
+
+        retriever._vector_store.search = _search
+
+        entity = MagicMock()
+        entity.id = uuid4()
+        entity.name = "acme"
+        entity.entity_type = "ORG"
+        entity.description = "d"
+        entity.attributes = {}
+        entity.mention_count = 1
+        entity.source_document_ids = []
+        entity.source_chunk_ids = [recalled_id]
+        retriever._storage.list_entities = AsyncMock(return_value=[entity])
+        retriever._storage.list_relationships = AsyncMock(return_value=[])
+        engine = _build_engine(retriever)
+
+        result = await engine.recall("q", ns_id, limit=10, mode=SearchMode.HYBRID, filter_ast=_ast(_RECALL_FILTER))
+        report = result.engine_info["filter"]
+        FilterPushdownReport.model_validate(report)
+
+        # Precondition: the simple path ran (``simple_*`` search_mode) AND surfaced
+        # an entity — so the coverage-by-derivation claim is exercised, not vacuous.
+        assert str(result.engine_info.get("search_mode", "")).startswith("simple_")
+        assert result.entities, "simple-path entity projection surfaced no entity — coverage claim is vacuous"
+
+        # The covered entity surface leaves the fully-pushed report clean.
+        assert report["unenforced_keys"] == []
+        assert report["pushed_keys"] == ["metadata.tier", "source_name"]
+        assert report["pushed_down"] is True
+
 
 # ---------------------------------------------------------------------------
 # Devil's-advocate scenario E: session-aware fan-out records the vector plan ONCE.
@@ -1220,6 +1330,11 @@ class TestSessionAwareFanoutSingleVectorPlan:
 class TestConcurrentRecallsNoCrossContamination:
     """Concurrent recalls with distinct filters keep distinct reports."""
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
+        "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
+    )
     async def test_five_concurrent_recalls_distinct_keys(self) -> None:
         """5 concurrent recalls, each a different filter -> each report is scoped.
 
@@ -1254,3 +1369,68 @@ class TestConcurrentRecallsNoCrossContamination:
                 f"recall {i} cross-contaminated: {report['channels']['vector']['pushed_keys']} != {expected[i]}"
             )
             assert report["pushed_keys"] == expected[i]
+
+
+# ---------------------------------------------------------------------------
+# The #1457 repro shape, pinned: a date-keyed filter drives the graph path via
+# EXPLICIT temporal synthesis (engine.py's ``filter_constrains_date_key`` gate),
+# so the recall surfaces graph-derived entities the chunk filter never touched.
+# The engine passes ``covered_surfaces={"chunks"}`` on the graph path, so the
+# uncovered entity surface forces the date leaf into ``unenforced_keys``.
+#
+# This is the same leak the Task-of-record graph/hybrid tests above encode; this
+# test pins the SPECIFIC trigger the fix targets — a date predicate on a
+# beyond-corpus horizon (2027 against a 2026-ish corpus) — so the #1457 fix, which
+# filters the entity surface, flips it to xpass.
+# ---------------------------------------------------------------------------
+
+
+class TestDateKeyedExplicitSynthesisLeak:
+    """A date-keyed filter on the graph path leaks the uncovered entity surface."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="graph-path entity/relationship filter leak (#1457): a date-keyed filter forces the "
+        "EXPLICIT graph path, which surfaces an uncovered entity surface the filter never constrained; "
+        "the report honestly flags the date leaf unenforced until the #1457 fix filters the surface",
+    )
+    async def test_date_filter_graph_path_report_is_clean(self) -> None:
+        """A ``occurred_at $gte 2027`` filter on the graph path reports a clean pushdown.
+
+        The date predicate trips ``filter_constrains_date_key`` -> EXPLICIT
+        temporal synthesis -> the full graph path (``search_mode`` is NOT
+        ``simple_*``). The mocked entity search returns an entity, so the recall's
+        ``entities`` surface is non-empty and uncovered on the graph path. The
+        CLEAN report the #1457 fix restores enforces the single ``occurred_at``
+        leaf on the (then-filtered) entity surface, so nothing is unenforced.
+        """
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, enable_bm25=True, graph_chunks=[_graph_chunk(ns_id, tier="gold")])
+        engine = _build_engine(retriever)
+
+        result = await engine.recall(
+            "alpha bravo charlie",
+            ns_id,
+            limit=10,
+            mode=SearchMode.HYBRID,
+            filter_ast=_ast({"occurred_at": {"$gte": "2027-01-01T00:00:00Z"}}),
+        )
+        report = result.engine_info["filter"]
+        assert "_filter_channel_plans" not in result.engine_info
+        FilterPushdownReport.model_validate(report)
+
+        # Precondition (holds before AND after the fix): the recall genuinely ran
+        # the GRAPH path (non-``simple_*`` search_mode or graph chunks spliced)
+        # and surfaced entities — so the surface-coverage rule has real fuel and
+        # the leak below is not a vacuous fall-through to the simple path.
+        search_mode = str(result.engine_info.get("search_mode", ""))
+        assert result.entities, "graph path surfaced no entities — the surface-coverage rule is inert"
+        assert not search_mode.startswith("simple_") or result.engine_info.get("graph_chunk_count", 0) > 0, (
+            f"recall fell through to the simple path (search_mode={search_mode!r}, "
+            f"graph_chunk_count={result.engine_info.get('graph_chunk_count')}) — the graph-path leak "
+            "is not exercised"
+        )
+
+        # The single date leaf is enforced (nothing unenforced) on a clean report.
+        assert report["unenforced_keys"] == []
+        assert report["pushed_keys"] == ["occurred_at"]

--- a/tests/unit/filter/test_report.py
+++ b/tests/unit/filter/test_report.py
@@ -472,12 +472,16 @@ def test_model_json_schema_snapshot() -> None:
             "gates it pushed it into the backend query; in ``post_filtered_keys`` when at\n"
             "least one gating channel had to re-check it in memory; and in\n"
             "``unenforced_keys`` when no channel gates it at all (the filter constrains it\n"
-            "but nothing — pushdown nor in-memory re-check — actually enforces it). On a\n"
-            "correct recall every leaf is enforced, so ``unenforced_keys == []``. A\n"
-            "single-channel engine like skeleton (whose one channel gates every leaf)\n"
-            "always reports ``unenforced_keys == []``; the list is defined for\n"
-            "multi-channel engines where a leaf may slip past every channel. All three\n"
-            "lists are sorted and JSON-stable."
+            "but nothing — pushdown nor in-memory re-check — actually enforces it), OR when\n"
+            "the recall returned a non-empty result surface (``entities`` /\n"
+            "``relationships``) that the filter's channels do not cover, so the filter's\n"
+            "leaves went unenforced against that surface's rows. On a correct recall every\n"
+            "leaf is enforced, so ``unenforced_keys == []``. A single-channel engine like\n"
+            "skeleton (whose one channel gates every leaf) always reports\n"
+            "``unenforced_keys == []``; the list is defined for multi-channel /\n"
+            "multi-surface engines where a leaf may slip past every channel or go\n"
+            "unenforced on an uncovered result surface. All three lists are sorted and\n"
+            "JSON-stable."
         ),
         "properties": {
             "pushed_down": {
@@ -572,3 +576,128 @@ def test_hand_built_ast_folds_identically_to_wire_round_trip() -> None:
     assert build_filter_report(hand, plan).model_dump(mode="json") == build_filter_report(wire, plan).model_dump(
         mode="json"
     )
+
+
+# --------------------------------------------------------------------------- #
+# Surface coverage (opt-in via ``surface_sizes`` / ``covered_surfaces``).
+#
+# A non-empty result surface (``chunks`` / ``entities`` / ``relationships``) that
+# the filter's channels do NOT cover means the filter went unenforced against
+# that surface's rows, so ALL of the filter's leaves are forced into
+# ``unenforced_keys`` and ``pushed_down`` becomes ``False``. The rule is opt-in:
+# ``surface_sizes=None`` is byte-for-byte the legacy fold, and an empty surface
+# leaves the rule inert.
+# --------------------------------------------------------------------------- #
+
+
+def test_uncovered_nonempty_surface_forces_every_leaf_unenforced() -> None:
+    """A non-empty UNCOVERED entity surface forces every leaf into ``unenforced_keys``.
+
+    The channel pushed both leaves cleanly (a fully-pushed chunk filter), but the
+    recall returned 2 entities and the covered set is only ``{"chunks"}`` — the
+    filter never constrained those entity rows, so the report cannot claim a
+    pushdown. Every leaf is forced into ``unenforced_keys``, ``pushed_keys`` /
+    ``post_filtered_keys`` are emptied, and ``pushed_down`` flips ``False``.
+    """
+    leaves = _two_leaf_keys()
+    report = build_filter_report(
+        _ast(_TWO_LEAF_DOC),
+        {"vector": ChannelPlan(pushed_keys=leaves)},
+        surface_sizes={"chunks": 3, "entities": 2},
+        covered_surfaces=frozenset({"chunks"}),
+    )
+
+    assert set(report.unenforced_keys) == set(leaves)
+    assert report.pushed_keys == []
+    assert report.post_filtered_keys == []
+    assert report.pushed_down is False
+
+
+def test_covered_surface_leaves_the_fold_unchanged() -> None:
+    """When the non-empty surface IS covered, the rule is inert (legacy fold).
+
+    With ``covered_surfaces`` including ``entities``, the returned entity rows are
+    accounted for by the filter's channels, so the surface rule does not fire: the
+    fully-pushed report is byte-identical to the same fold with ``surface_sizes``
+    absent.
+    """
+    leaves = _two_leaf_keys()
+    plan = {"vector": ChannelPlan(pushed_keys=leaves)}
+
+    covered = build_filter_report(
+        _ast(_TWO_LEAF_DOC),
+        plan,
+        surface_sizes={"chunks": 3, "entities": 2},
+        covered_surfaces=frozenset({"chunks", "entities", "relationships"}),
+    )
+    legacy = build_filter_report(_ast(_TWO_LEAF_DOC), plan)
+
+    assert covered.model_dump(mode="json") == legacy.model_dump(mode="json")
+    assert covered.pushed_down is True
+    assert set(covered.pushed_keys) == set(leaves)
+    assert covered.unenforced_keys == []
+
+
+def test_surface_sizes_none_is_byte_for_byte_legacy() -> None:
+    """``surface_sizes=None`` folds byte-for-byte identically to omitting the param.
+
+    The signal is opt-in: passing ``surface_sizes=None`` explicitly must produce
+    the exact same JSON as a call that never mentions it, so the rule is provably
+    inert on the legacy path.
+    """
+    leaves = _two_leaf_keys()
+    plan = {"vector": ChannelPlan(pushed_keys=leaves)}
+
+    explicit_none = build_filter_report(_ast(_TWO_LEAF_DOC), plan, surface_sizes=None)
+    no_param = build_filter_report(_ast(_TWO_LEAF_DOC), plan)
+
+    assert explicit_none.model_dump(mode="json") == no_param.model_dump(mode="json")
+
+
+def test_empty_uncovered_surface_leaves_rule_inert() -> None:
+    """A ZERO-row uncovered surface does not fire the rule (legacy fold).
+
+    ``surface_sizes={"entities": 0}`` reports no entity rows, so there is nothing
+    the filter failed to constrain — the rule keys off ``> 0``. The report is the
+    fully-pushed legacy shape, identical to omitting ``surface_sizes``.
+    """
+    leaves = _two_leaf_keys()
+    plan = {"vector": ChannelPlan(pushed_keys=leaves)}
+
+    report = build_filter_report(
+        _ast(_TWO_LEAF_DOC),
+        plan,
+        surface_sizes={"chunks": 3, "entities": 0},
+        covered_surfaces=frozenset({"chunks"}),
+    )
+    legacy = build_filter_report(_ast(_TWO_LEAF_DOC), plan)
+
+    assert report.model_dump(mode="json") == legacy.model_dump(mode="json")
+    assert report.pushed_down is True
+    assert report.unenforced_keys == []
+
+
+def test_surface_rule_lands_leaf_only_in_unenforced_not_pushed_or_post() -> None:
+    """A would-be-pushed leaf under an uncovered surface lands ONLY in unenforced.
+
+    Disjointness guard: ``source_name`` WOULD be pushed for the chunk surface (the
+    channel consumed it), but the non-empty uncovered entity surface forces it
+    into ``unenforced_keys`` — and it appears in NEITHER ``pushed_keys`` nor
+    ``post_filtered_keys``. The three top-level lists stay a total, disjoint
+    partition and ``pushed_down`` is ``False``.
+    """
+    report = build_filter_report(
+        _ast({"source_name": "linear"}),
+        {"vector": ChannelPlan(pushed_keys=frozenset({"source_name"}))},
+        surface_sizes={"chunks": 1, "entities": 4},
+        covered_surfaces=frozenset({"chunks"}),
+    )
+
+    assert report.unenforced_keys == ["source_name"]
+    assert "source_name" not in report.pushed_keys
+    assert "source_name" not in report.post_filtered_keys
+    assert report.pushed_keys == []
+    assert report.post_filtered_keys == []
+    # Total, disjoint partition preserved.
+    assert set(report.pushed_keys) | set(report.post_filtered_keys) | set(report.unenforced_keys) == {"source_name"}
+    assert report.pushed_down is False


### PR DESCRIPTION
## Summary
- `build_filter_report` gains optional keyword-only `surface_sizes` / `covered_surfaces` params: when a result surface (chunks/entities/relationships) comes back non-empty but is **not** covered by the filter's channels, every constraint leaf of the filter is forced into `unenforced_keys` (out of `pushed_keys` / `post_filtered_keys`) and `pushed_down` is cleared — keeping the three lists a total, disjoint partition. With `surface_sizes=None` the builder is byte-for-byte its legacy self, so existing callers are unaffected.
- The VectorCypher, Chronicle, and Skeleton engines now pass their result-surface sizes. The VectorCypher **graph path** and Chronicle's **entity channel** honestly report the entity/relationship surface as *unenforced* when the caller filter is only applied to the chunk channel — so a filter that leaks unfiltered entities is now visible in `engine_info["filter"].unenforced_keys` instead of silently reporting `[]`.
- This is the **report-completeness** step: it makes the leak visible (red) via the honest report. The actual entity/relationship surface filtering is a follow-up; the simple path is already compliant by derivation (its entities come from already-filtered chunks) and stays green.

## Test plan
- [x] Unit tests: builder surface-coverage rule (uncovered non-empty → all leaves unenforced; covered → legacy; `surface_sizes=None` → byte-for-byte legacy; empty surface → inert; disjointness)
- [x] Graph-path and Chronicle entity-bearing leak pinned as `@pytest.mark.xfail(strict=True)` (they encode the clean report the follow-up fix restores → flip to xpass then); simple-path asserts `unenforced_keys == []` (coverage-by-derivation) and stays green
- [x] `make format` / `make lint` clean; `make test-unit` green for the affected suites (0 XPASS)
- [ ] Integration + e2e lanes (CI: live Postgres/Neo4j) — includes the cross-engine filter-report invariant gate

Refs #1457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter-report accuracy by explicitly tracking which result surfaces (chunks/entities/relationships) are covered across Chronicle, Skeleton, and VectorCypher recall modes.
  * Prevented filter “leaks” by disabling filter enforcement when a required surface is uncovered, keeping filter-pushdown invariants consistent.

* **Tests**
  * Added regression coverage for entity-surface leak scenarios under date filters (including graph-path cases), with affected cases marked as expected failures until the fix fully resolves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->