### PR TITLE
Filter entities and relationships by provenance on the VectorCypher graph path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 
 ## [Unreleased]
 
-### Changed
-
-- **Filtered VectorCypher graph-path recalls now filter the entity/relationship surfaces by provenance** (#1457): a recall filter narrows not just chunks but also the graph-derived entities and relationships. An entity survives iff at least one of its provenance chunks satisfies the filter; a relationship survives iff both its endpoints survived AND (it carries no provenance OR at least one of its own provenance chunks satisfies the filter). A filter matching zero chunks now returns four empty lists (documents, chunks, entities, relationships). Cost is a paged `get_chunks_batch` (pages of 500) per FILTERED graph-path recall, bounded by the entity/relationship count × their provenance; unfiltered recalls are unchanged and add no extra fetch. The honest filter report (`engine_info["filter"]`) now reports these surfaces as covered, so a purely metadata filter no longer shows spurious `unenforced_keys`. On a provenance-fetch failure the filter fails closed — unverified items are dropped (never returned unverified) and one `Degradation` (`reason="provenance_fetch_failed"`) is recorded on `engine_info["degradations"]`. The reusable ∃-over-provenance primitive lives in `khora.filter.provenance.filter_items_by_provenance`.
-
 ## [0.22.2] - recall-quality correctness, HNSW index-backed search, durable reconcilers
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 
 ## [Unreleased]
 
+### Changed
+
+- **Filtered VectorCypher graph-path recalls now filter the entity/relationship surfaces by provenance** (#1457): a recall filter narrows not just chunks but also the graph-derived entities and relationships. An entity survives iff at least one of its provenance chunks satisfies the filter; a relationship survives iff both its endpoints survived AND (it carries no provenance OR at least one of its own provenance chunks satisfies the filter). A filter matching zero chunks now returns four empty lists (documents, chunks, entities, relationships). Cost is a paged `get_chunks_batch` (pages of 500) per FILTERED graph-path recall, bounded by the entity/relationship count × their provenance; unfiltered recalls are unchanged and add no extra fetch. The honest filter report (`engine_info["filter"]`) now reports these surfaces as covered, so a purely metadata filter no longer shows spurious `unenforced_keys`. On a provenance-fetch failure the filter fails closed — unverified items are dropped (never returned unverified) and one `Degradation` (`reason="provenance_fetch_failed"`) is recorded on `engine_info["degradations"]`. The reusable ∃-over-provenance primitive lives in `khora.filter.provenance.filter_items_by_provenance`.
+
 ## [0.22.2] - recall-quality correctness, HNSW index-backed search, durable reconcilers
 
 ### Added

--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -1671,6 +1671,18 @@
       "description": "Filtered recalls whose graph channel returned no candidates because the deterministic recall filter narrowed the graph side to empty. NO namespace_id label - cardinality rule."
     },
     {
+      "name": "khora.filter.provenance.degraded_total",
+      "type": "counter",
+      "stability": "internal",
+      "unit": "1",
+      "owner": "filter",
+      "labels": [
+        {"name": "component", "values": ["vectorcypher.entity_filter", "vectorcypher.relationship_filter"], "_comment": "Low-cardinality enum: the caller's per-surface value. Chronicle reuses the helper (#1458) and will add chronicle.* values."},
+        {"name": "reason", "values": ["provenance_fetch_failed"], "_comment": "Low-cardinality enum; extend when adding new provenance-filter fallback paths."}
+      ],
+      "description": "GitHub #1457 (ADR-001). Engine-agnostic ∃-over-provenance item-filter fallback (khora.filter.provenance.filter_items_by_provenance) - incremented when a provenance-chunk fetch page raises while re-applying the caller filter over a graph-derived result surface (entities / relationships). The metric name is engine-agnostic because the counter is emitted from within the reusable module (Chronicle #1458 reuses it); the component label carries the caller identity. Items with no filter-passing provenance chunk in the pages fetched so far are DROPPED (fail-closed - an unverified item is never returned), and the verified survivors are returned; the surface stays legitimately enforced. The same event is also appended to RecallResult.engine_info['degradations']. NO namespace_id label - cardinality rule. See docs/architecture/failure-observability-contract.md."
+    },
+    {
       "name": "khora.hooks.subscription.persistent_count",
       "type": "counter",
       "stability": "internal",

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -2664,9 +2664,19 @@ class VectorCypherEngine:
         # chunk-side filter narrowed; a graph-path recall emits graph-derived
         # entities / relationships the chunk filter never touched, so those
         # surfaces stay uncovered and force the filter's leaves unenforced.
+        # #1457: the graph path now runs an ∃-over-provenance post-filter on the
+        # entity/relationship surfaces (retriever._filter_surfaces_by_provenance),
+        # so mark them covered whenever that pass ran under a filter — mirroring
+        # how the simple path covers them. The flag is True even on the degraded
+        # (provenance-fetch-failure) path: the helper fail-closes by DROPPING
+        # unverified items, so every returned entity/relationship is verified and
+        # the surface is legitimately enforced (the failure is recorded as a
+        # separate Degradation on engine_info). Stays uncovered only when the
+        # filter is absent.
         covered = {"chunks"} | (
             {"entities", "relationships"}
             if str(result.metadata.get("search_mode", "")).startswith("simple_")
+            or result.metadata.get("provenance_filtered_surfaces")
             else set()
         )
 

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -2620,11 +2620,14 @@ class VectorCypherRetriever:
                 # the flag is off or when the path fell back to vector-only.
                 "ppr_path_used": ppr_path_used,
                 "ppr_entity_count": len(ppr_entity_scores),
-                # GitHub #1457: True when the ∃-over-provenance filter actually
-                # narrowed the entity/relationship surfaces (filter present and
-                # the provenance fetch succeeded). The engine reads this to add
-                # {"entities","relationships"} to the honest report's covered
-                # surfaces. Stays False on the fetch-failure degraded path.
+                # GitHub #1457: True whenever the ∃-over-provenance filter ran
+                # (filter present and there were entity/relationship surfaces to
+                # prune). The engine reads this to add {"entities","relationships"}
+                # to the honest report's covered surfaces. Stays True even on the
+                # fetch-failure degraded path: the helper fail-closes by DROPPING
+                # unverified items, so every returned survivor is VERIFIED and the
+                # surface is legitimately enforced (the failure is recorded
+                # separately as a Degradation on ``degradations``).
                 "provenance_filtered_surfaces": provenance_filtered_surfaces,
                 # Private carrier (popped by the engine before the public spread):
                 # the per-channel honest filter-pushdown plans the engine folds

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -2548,6 +2548,28 @@ class VectorCypherRetriever:
             relationships.append((rel, rel_score))
         relationships.sort(key=lambda x: x[1], reverse=True)
 
+        # GitHub #1457: ∃-over-provenance entity/relationship filtering. A
+        # caller filter narrows the chunk surface via the per-channel post-
+        # filters above, but the graph-derived entity/relationship surfaces are
+        # assembled from graph traversal the chunk filter never touched. Apply
+        # the SAME "Chunk" predicate to each item's provenance chunks: an item
+        # survives iff ≥1 of its provenance chunks passes. Only runs under a
+        # filter; unfiltered recalls take the zero-cost path (no extra fetch).
+        # ``provenance_filtered_surfaces`` tells the engine to mark the
+        # entities/relationships surfaces covered. It is True whenever the ∃ pass
+        # ran under a filter: every returned item is VERIFIED (the helper
+        # fail-closes by dropping items whose provenance couldn't be fetched), so
+        # the surface is legitimately enforced even on the degraded path.
+        provenance_filtered_surfaces = False
+        if filter_ast is not None and filter_ast.children and (entity_results or relationships):
+            entity_results, relationships, provenance_filtered_surfaces = await self._filter_surfaces_by_provenance(
+                entity_results,
+                relationships,
+                filter_ast=filter_ast,
+                namespace_id=namespace_id,
+                degradations=degradations,
+            )
+
         return VectorCypherResult(
             chunks=chunk_results,
             entities=entity_results,
@@ -2598,12 +2620,89 @@ class VectorCypherRetriever:
                 # the flag is off or when the path fell back to vector-only.
                 "ppr_path_used": ppr_path_used,
                 "ppr_entity_count": len(ppr_entity_scores),
+                # GitHub #1457: True when the ∃-over-provenance filter actually
+                # narrowed the entity/relationship surfaces (filter present and
+                # the provenance fetch succeeded). The engine reads this to add
+                # {"entities","relationships"} to the honest report's covered
+                # surfaces. Stays False on the fetch-failure degraded path.
+                "provenance_filtered_surfaces": provenance_filtered_surfaces,
                 # Private carrier (popped by the engine before the public spread):
                 # the per-channel honest filter-pushdown plans the engine folds
                 # into ``engine_info["filter"]``. Never leaks into engine_info.
                 "_filter_channel_plans": filter_channel_plans,
             },
         )
+
+    async def _filter_surfaces_by_provenance(
+        self,
+        entity_results: list[tuple[Entity, float]],
+        relationships: list[tuple[Relationship, float]],
+        filter_ast: FilterNode,
+        namespace_id: UUID,
+        degradations: list[Degradation],
+    ) -> tuple[list[tuple[Entity, float]], list[tuple[Relationship, float]], bool]:
+        """Thin orchestrator: ∃-over-provenance prune of the graph-path surfaces.
+
+        GitHub #1457. The caller filter narrows chunks via the per-channel chunk
+        post-filters, but the graph-derived entities/relationships are assembled
+        from traversal the chunk filter never touched. The engine-agnostic
+        :func:`~khora.filter.provenance.filter_items_by_provenance` re-applies the
+        SAME ``"Chunk"`` predicate over each item's provenance chunks; this method
+        just unwraps/re-associates the ``(obj, score)`` tuples and applies the
+        relationship endpoint rule.
+
+        Keep rules:
+
+        - **Entity** survives iff ≥1 of its ``source_chunk_ids`` chunks passes
+          the predicate. An entity with no provenance (stub) is dropped.
+        - **Relationship** survives iff BOTH endpoints survived AND (it carries no
+          provenance OR ≥1 of its own provenance chunks passes). Provenance-less
+          legacy edges use the endpoint rule only.
+
+        A filter matching zero chunks empties both surfaces. Input order is
+        preserved. ``filtered`` is always ``True`` here: the ∃ pass ran under a
+        filter, so even on the degraded (fetch-failure) path the returned survivors
+        are VERIFIED — the helper fail-closes by dropping unverified items — so the
+        surface is legitimately enforced and the engine marks it covered.
+        """
+        from khora.filter.provenance import filter_items_by_provenance
+
+        # Entities: ∃ over each entity's own provenance.
+        kept_entity_objs = await filter_items_by_provenance(
+            [entity for entity, _ in entity_results],
+            filter_ast,
+            namespace_id=namespace_id,
+            storage=self._storage,
+            component="vectorcypher.entity_filter",
+            degradations=degradations,
+        )
+        kept_entity_ids = {entity.id for entity in kept_entity_objs}
+        kept_entities = [(entity, score) for entity, score in entity_results if entity.id in kept_entity_ids]
+
+        # Relationships: endpoint rule AND ∃-over-own-provenance. Legacy edges
+        # (no provenance) use the endpoint rule alone; the provenance-bearing
+        # ones run through the ∃ helper as their own surface.
+        prov_rels = [(rel, score) for rel, score in relationships if rel.source_chunk_ids]
+        rels_passing_existential = {
+            rel.id
+            for rel in await filter_items_by_provenance(
+                [rel for rel, _ in prov_rels],
+                filter_ast,
+                namespace_id=namespace_id,
+                storage=self._storage,
+                component="vectorcypher.relationship_filter",
+                degradations=degradations,
+            )
+        }
+        kept_relationships = [
+            (rel, score)
+            for rel, score in relationships
+            if rel.source_entity_id in kept_entity_ids
+            and rel.target_entity_id in kept_entity_ids
+            and (not rel.source_chunk_ids or rel.id in rels_passing_existential)
+        ]
+
+        return kept_entities, kept_relationships, True
 
     async def _vector_only_fallback(
         self,

--- a/src/khora/filter/conformance.py
+++ b/src/khora/filter/conformance.py
@@ -86,6 +86,7 @@ __all__ = [
     "SurrealExecutor",
     "WeaviateExecutor",
     "assert_case",
+    "assert_recall_conformance",
     "f_array_cases",
     "f_coerce_cases",
     "f_dates_cases",
@@ -625,6 +626,79 @@ def oracle_survivors(case: ConformanceCase) -> frozenset[str]:
     expectation to whatever it currently computes.
     """
     return run_case_for_backend(case, "python", executor=PythonExecutor())
+
+
+# --------------------------------------------------------------------------- #
+# Recall-result conformance oracle (implementation-blind).
+#
+# The executors above check a filter's COMPILE against seed records — the SQL/
+# Cypher WHERE agrees with the Python oracle. This oracle instead checks a real
+# recall's OUTPUT against the same Python predicate, WITHOUT knowing how the engine
+# produced it: given the filter and the recall's returned chunk records + the
+# per-entity provenance-chunk records, it asserts the two surface invariants a
+# correctly-filtered multi-surface recall must satisfy:
+#
+#   1. every RETURNED chunk passes the compiled ``"Chunk"`` predicate (the chunk
+#      surface was narrowed), and
+#   2. every RETURNED entity has ≥1 provenance chunk that passes the predicate
+#      (the ∃-over-provenance rule #1457 enforces on the graph-derived surface).
+#
+# It is engine-agnostic and reuses the SAME ``compile_python`` predicate the
+# production filter path compiles, so a green oracle is evidence about the real
+# recall, not a parallel re-implementation. A record is anything ``compile_python``
+# can read — a ``Chunk`` dataclass or a plain mapping (the predicate resolves a
+# system key off the object attribute, its ``source_document`` projection, or a
+# mapping key, indifferently).
+# --------------------------------------------------------------------------- #
+
+
+def _chunk_predicate(filter_ast: FilterNode) -> Callable[[Any], bool]:
+    """Compile the recall filter to the ``"Chunk"`` predicate the engine applies.
+
+    ``@internal``. Uses the SAME context the production chunk channels + the #1457
+    provenance filter compile with (``build_compile_context("Chunk",
+    on_unsupported="split")``), so the oracle re-checks with the exact predicate the
+    recall path enforced — never a divergent re-derivation.
+    """
+    return compile_python(filter_ast, build_compile_context("Chunk", on_unsupported="split")).predicate
+
+
+def assert_recall_conformance(
+    filter_ast: FilterNode,
+    *,
+    returned_chunks: Sequence[Any],
+    entity_provenance: Sequence[Sequence[Any]],
+) -> None:
+    """Assert a filtered recall's surfaces conform to the compiled predicate.
+
+    ``@internal``. Implementation-blind: it inspects only the recall OUTPUT, not how
+    the engine produced it.
+
+    * ``returned_chunks`` — the chunk records the recall returned. EVERY one must
+      pass the compiled ``"Chunk"`` predicate (the chunk surface was narrowed).
+    * ``entity_provenance`` — one provenance-chunk-record sequence per RETURNED
+      entity, in the same order as the recall's ``entities``. For each entity, ≥1 of
+      its provenance chunks must pass the predicate (the ∃-over-provenance rule).
+      An entity with an EMPTY provenance sequence fails the existential — a
+      correctly-filtered recall never surfaces such an entity under a filter.
+
+    Raises :class:`AssertionError` on the first violation, naming the offending
+    surface + index so a failure is diagnosable.
+    """
+    predicate = _chunk_predicate(filter_ast)
+
+    for i, chunk in enumerate(returned_chunks):
+        assert predicate(chunk), (
+            f"returned chunk #{i} does not pass the recall filter predicate — the "
+            f"chunk surface was not narrowed by the filter"
+        )
+
+    for e, provenance in enumerate(entity_provenance):
+        assert any(predicate(chunk) for chunk in provenance), (
+            f"returned entity #{e} has no provenance chunk passing the recall filter "
+            f"predicate (∃ over {len(provenance)} provenance chunk(s) failed) — the "
+            f"entity surface was not enforced by the ∃-over-provenance rule"
+        )
 
 
 # --------------------------------------------------------------------------- #

--- a/src/khora/filter/provenance.py
+++ b/src/khora/filter/provenance.py
@@ -36,8 +36,8 @@ from khora.filter.execute import build_compile_context
 from khora.telemetry.metrics import metric_counter
 
 # Page size for the provenance-chunk fetch. Bounds the backend IN-list per round
-# trip (Chronicle can pass many items) and, with the early-exit below, caps the
-# cost at one page per 500 undecided provenance chunks.
+# trip (Chronicle can pass many items); total cost is bounded by the number of
+# unique provenance chunk ids across the items, fetched in pages of this size.
 _PAGE_SIZE = 500
 
 # Provenance-filter degradation counter (GitHub #1457, ADR-001). The metric name

--- a/src/khora/filter/provenance.py
+++ b/src/khora/filter/provenance.py
@@ -1,0 +1,146 @@
+"""Engine-agnostic ∃-over-provenance item filter — ``@internal``.
+
+GitHub #1457. A recall filter narrows the chunk surface, but a graph-derived
+result surface (entities, relationships) is assembled from traversal the chunk
+filter never touched. :func:`filter_items_by_provenance` re-applies the SAME
+``"Chunk"`` predicate the chunk channels use to each item's *provenance* chunks
+and keeps an item iff at least one of its provenance chunks passes (the
+existential / ∃ rule).
+
+The function is deliberately engine-agnostic — it takes anything exposing a
+``.source_chunk_ids`` sequence, compiles the predicate itself from the filter
+AST, and fetches provenance itself in bounded pages. The VectorCypher retriever
+is the first caller; the Chronicle follow-up (#1458) reuses it verbatim.
+
+Fail-closed (ADR-001): if a provenance-chunk fetch page raises, every item not
+yet proven to have a passing chunk is DROPPED (never returned unverified — that
+would re-introduce the #1457 leak), exactly ONE
+:class:`~khora.core.diagnostics.Degradation` is appended (WARNING + ``exc_info``),
+and the verified survivors are returned. The call never re-raises. Because every
+returned item is verified, the surface is legitimately enforced even on the
+degraded path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Protocol, runtime_checkable
+from uuid import UUID
+
+from loguru import logger
+
+from khora.core.diagnostics import Degradation
+from khora.filter.ast import FilterNode
+from khora.filter.compilers.python import compile_python
+from khora.filter.execute import build_compile_context
+from khora.telemetry.metrics import metric_counter
+
+# Page size for the provenance-chunk fetch. Bounds the backend IN-list per round
+# trip (Chronicle can pass many items) and, with the early-exit below, caps the
+# cost at one page per 500 undecided provenance chunks.
+_PAGE_SIZE = 500
+
+# Provenance-filter degradation counter (GitHub #1457, ADR-001). The metric name
+# is engine-agnostic to match the module: this counter is emitted from within the
+# reusable helper, so it must NOT hard-code an engine (Chronicle #1458 reuses the
+# same module). The ``component`` label carries the caller's per-surface identity
+# (``vectorcypher.entity_filter`` / ``vectorcypher.relationship_filter`` / future
+# ``chronicle.*``), a low-cardinality enum. NO namespace_id label.
+_PROVENANCE_FILTER_DEGRADED_COUNTER = metric_counter(
+    "khora.filter.provenance.degraded_total",
+    unit="1",
+    description=(
+        "GitHub #1457. Engine-agnostic ∃-over-provenance item-filter fallbacks "
+        "(khora.filter.provenance.filter_items_by_provenance). Incremented when a "
+        "provenance-chunk fetch page raises; items with no filter-passing chunk in "
+        "the pages fetched so far are dropped (fail-closed) and the verified "
+        "survivors returned. Labels: component (the caller's per-surface value, "
+        "e.g. vectorcypher.entity_filter), reason (provenance_fetch_failed). "
+        "NO namespace_id label - cardinality rule."
+    ),
+)
+
+
+@runtime_checkable
+class _HasProvenance(Protocol):
+    """Any item carrying a provenance chunk-id sequence."""
+
+    @property
+    def source_chunk_ids(self) -> Sequence[UUID]: ...
+
+
+@runtime_checkable
+class _ChunkStore(Protocol):
+    """The storage seam the filter needs: a batched chunk fetch by id."""
+
+    async def get_chunks_batch(self, chunk_ids: list[UUID], *, namespace_id: UUID) -> dict[UUID, Any]: ...
+
+
+async def filter_items_by_provenance[T: _HasProvenance](
+    items: Sequence[T],
+    filter_ast: FilterNode,
+    *,
+    namespace_id: UUID,
+    storage: _ChunkStore,
+    component: str,
+    degradations: list[Degradation],
+) -> list[T]:
+    """Keep the items whose provenance satisfies ``filter_ast`` (∃ rule).
+
+    An item survives iff at least one of its ``source_chunk_ids`` chunks passes
+    the compiled ``"Chunk"`` predicate. Items with no provenance can never
+    satisfy the existential and are dropped. Input order is preserved.
+
+    The provenance chunks are fetched in pages of :data:`_PAGE_SIZE` (the storage
+    seam issues a single ``IN (...)`` per call with no internal paging, so an
+    unbounded union would blow the backend variable limit once a caller feeds it
+    many items). Each page's filter-passing chunk ids accumulate into a shared
+    ``surviving`` set; an item is kept iff any of its ids landed in that set.
+
+    Fail-closed (ADR-001): on a fetch-page exception the accumulated set is taken
+    as final — items with a hit in the pages fetched SO FAR survive, the rest are
+    dropped (their provenance could not be verified). Exactly one
+    :class:`Degradation` (``reason="provenance_fetch_failed"``, ``component`` as
+    passed in) is appended, logged at WARNING with ``exc_info=True``. Never
+    re-raises.
+    """
+    if not items:
+        return []
+
+    predicate = compile_python(filter_ast, build_compile_context("Chunk", on_unsupported="split")).predicate
+
+    # Unique, order-stable provenance chunk ids across every item. Items with no
+    # provenance contribute nothing and are dropped by the ∃ test at the end.
+    ordered_ids = list(dict.fromkeys(cid for item in items for cid in item.source_chunk_ids))
+
+    # Ids whose chunk passes the predicate, accumulated across pages. A chunk id
+    # that did not resolve is silently absent → treated as predicate False.
+    surviving: set[UUID] = set()
+    for start in range(0, len(ordered_ids), _PAGE_SIZE):
+        page = ordered_ids[start : start + _PAGE_SIZE]
+        try:
+            chunks_map = await storage.get_chunks_batch(page, namespace_id=namespace_id)
+        except Exception as exc:
+            # ADR-001 fail-closed: stop fetching and take the set-so-far as final;
+            # items with no hit yet drop (unverified), record ONE degradation.
+            logger.warning(
+                "Provenance chunk fetch failed ({component}); items unverified after this page drop",
+                component=component,
+                exc_info=True,
+            )
+            degradations.append(
+                Degradation(
+                    component=component,
+                    reason="provenance_fetch_failed",
+                    detail=str(exc)[:200] or None,
+                    exception=type(exc).__name__,
+                )
+            )
+            _PROVENANCE_FILTER_DEGRADED_COUNTER.add(
+                1, attributes={"component": component, "reason": "provenance_fetch_failed"}
+            )
+            break
+
+        surviving.update(cid for cid, ch in chunks_map.items() if predicate(ch))
+
+    return [item for item in items if any(cid in surviving for cid in item.source_chunk_ids)]

--- a/tests/e2e/test_filter_report_invariant.py
+++ b/tests/e2e/test_filter_report_invariant.py
@@ -373,13 +373,6 @@ async def _seed_leak_corpus(kb: Khora, namespace_id) -> None:
     not _harness.lane_reachable("vc_full"),
     reason="set NEO4J_INTEGRATION_TEST=1 and start PG+Neo4j (make dev) to exercise the live graph lane",
 )
-@pytest.mark.xfail(
-    strict=True,
-    raises=AssertionError,
-    reason="entity filter leak on the graph path (#1457): a graph-path recall surfaces an uncovered "
-    "entity surface the date filter never constrained, so the report flags the filter unenforced; "
-    "flips to xpass when the fix filters the entity surface",
-)
 async def test_report_invariant_graph_entity_bearing_date_filter_vc_full(vectorcypher_kb) -> None:
     """A graph-path VectorCypher recall over an entity corpus + date filter reports clean.
 

--- a/tests/integration/matrix/test_vectorcypher_sqlite_lance.py
+++ b/tests/integration/matrix/test_vectorcypher_sqlite_lance.py
@@ -943,12 +943,6 @@ async def test_vc_filter_report_partial_pushdown_json1_off(kb: Khora, namespace_
     assert report["post_filtered"] is True
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="entity-surface filter leak (#1457): the embedded graph fallback surfaces a non-empty "
-    "entity surface the chunk-only channels don't cover, so build_filter_report forces both leaves "
-    "into unenforced_keys; restored once the #1457 fix filters the entity surface",
-)
 async def test_vc_filter_report_graph_nothing_pushed_embedded(kb: Khora, namespace_id: UUID) -> None:
     """The embedded graph fallback pushes NOTHING — every leaf re-checked in memory.
 

--- a/tests/integration/test_channel_filter_operator_matrix.py
+++ b/tests/integration/test_channel_filter_operator_matrix.py
@@ -83,16 +83,6 @@ def _neo4j_reachable() -> bool:
 pytestmark = [
     pytest.mark.integration,
     pytest.mark.filter_enforcement,
-    # Expected-red until #1457 lands: every cell here runs a filtered graph/recency
-    # recall that surfaces a non-empty entity surface the chunk-only channels don't
-    # cover, so build_filter_report now forces the filter's leaves into
-    # unenforced_keys and the `unenforced_keys == []` invariant no longer holds. The
-    # #1457 fix filters the entity surface and flips these back to green.
-    pytest.mark.xfail(
-        strict=True,
-        reason="entity-surface filter leak (#1457): filtered graph/recency recall surfaces an "
-        "uncovered entity surface, so unenforced_keys is non-empty until the #1457 fix filters it",
-    ),
     pytest.mark.skipif(
         not os.environ.get("NEO4J_INTEGRATION_TEST") or not _pg_reachable() or not _neo4j_reachable(),
         reason="set NEO4J_INTEGRATION_TEST=1 and start PG+Neo4j (make dev) to exercise the live matrix cells",

--- a/tests/integration/test_channel_filter_operator_matrix_change.py
+++ b/tests/integration/test_channel_filter_operator_matrix_change.py
@@ -73,15 +73,6 @@ from tests.test_helpers.filter_spy import stub_llm
 pytestmark = [
     pytest.mark.integration,
     pytest.mark.filter_enforcement,
-    # Expected-red until #1457 lands: these session/change/recency cells run filtered
-    # recalls that surface a non-empty entity surface the chunk-only channels don't
-    # cover, so build_filter_report forces the filter's leaves into unenforced_keys.
-    # The #1457 fix filters the entity surface and flips these back to green.
-    pytest.mark.xfail(
-        strict=True,
-        reason="entity-surface filter leak (#1457): filtered recall surfaces an uncovered entity "
-        "surface, so unenforced_keys is non-empty until the #1457 fix filters it",
-    ),
 ]
 
 # The Postgres pgvector column is fixed at 1536, so the live-DB suite sizes its

--- a/tests/integration/test_vectorcypher_recency_channel_pg.py
+++ b/tests/integration/test_vectorcypher_recency_channel_pg.py
@@ -520,12 +520,6 @@ _LEAK_SOURCE = "leakdoc"
 _CLEAN_SOURCE = "cleandoc"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="entity-surface filter leak (#1457): the recall surfaces a non-empty entity surface the "
-    "chunk-only channels don't cover, so build_filter_report reports source_name unenforced; the "
-    "chunk-level no-leak still holds and unenforced_keys == [] is restored once the #1457 fix filters entities",
-)
 @pytest.mark.skipif(
     not _neo4j_reachable() or not os.environ.get("NEO4J_INTEGRATION_TEST"),
     reason="set NEO4J_INTEGRATION_TEST=1 and run `make dev` (needs Neo4j for the full vectorcypher path)",

--- a/tests/recall/test_channel_filter_operator_matrix.py
+++ b/tests/recall/test_channel_filter_operator_matrix.py
@@ -203,6 +203,14 @@ _EXCLUDED_CHANNELS: dict[str, str] = {
     "_simple_retrieve": (
         "Simple/VECTOR/KEYWORD dispatcher — delegates to the pushdown vector / BM25 channels; not a post-filter seam."
     ),
+    "_filter_surfaces_by_provenance": (
+        "Entity/relationship SURFACE post-filter (#1457, ∃-over-provenance): runs on the "
+        "assembled entity/relationship surfaces AFTER chunk fusion, never on chunks feeding "
+        "RRF. It enforces the caller filter existentially over each item's provenance chunks "
+        "(via khora.filter.provenance.filter_items_by_provenance) — so it is not a chunk "
+        "post-filter seam and cannot smuggle a filter-violating chunk into fusion; it has no "
+        "chunk-channel matrix row."
+    ),
 }
 
 
@@ -323,7 +331,7 @@ def test_partition_total_and_disjoint() -> None:
     """The two seam-sets totally and disjointly partition the filter-aware methods.
 
     ``_POST_FILTER_CHANNELS`` ∪ ``_EXCLUDED_CHANNELS.keys()`` == the audit gate's
-    ``_FILTER_AWARE_METHODS`` (currently 2 + 9 = 11), and the two sets are disjoint.
+    ``_FILTER_AWARE_METHODS`` (currently 2 + 10 = 12), and the two sets are disjoint.
     A new filter-aware channel added to ``retriever.py`` (which ``test_param_set_is_current``
     in the audit gate forces into ``_FILTER_AWARE_METHODS``) lands in NEITHER set
     until it is classified, failing this — the new-channel backstop.

--- a/tests/recall/test_filter_enforcement_audit_gate.py
+++ b/tests/recall/test_filter_enforcement_audit_gate.py
@@ -46,6 +46,10 @@ _FILTER_AWARE_METHODS = frozenset(
         "_lexical_search_chunks",
         "_keyword_ppr_search_chunks",
         "_vector_only_fallback",
+        # #1457 entity/relationship ∃-over-provenance SURFACE post-filter. Not a
+        # chunk channel (runs after chunk fusion, on the entity/relationship
+        # surfaces) — classified in the matrix's _EXCLUDED_CHANNELS.
+        "_filter_surfaces_by_provenance",
     }
 )
 

--- a/tests/unit/engines/test_vectorcypher_filter_report.py
+++ b/tests/unit/engines/test_vectorcypher_filter_report.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
@@ -57,6 +58,7 @@ import pytest
 from neo4j.exceptions import ServiceUnavailable
 
 from khora.core.models import Chunk
+from khora.core.models.entity import Entity
 from khora.engines.vectorcypher.engine import VectorCypherConfig, VectorCypherEngine
 from khora.engines.vectorcypher.retriever import (
     RetrieverConfig,
@@ -77,20 +79,6 @@ pytestmark = pytest.mark.unit
 # channel cannot push and re-checks in memory. The SQL chunk channels (vector /
 # bm25) push BOTH.
 _RECALL_FILTER: dict[str, Any] = {"source_name": "linear", "metadata.tier": "gold"}
-
-
-# Shared marker for the graph-path entity/relationship filter leak (#1457): the
-# report honestly flags the filter unenforced against the uncovered entity
-# surface until the #1457 fix filters it. ``raises=AssertionError`` scopes the
-# xfail to the CLEAN-report assertion the fix flips — precondition / anti-vacuity
-# gates use ``pytest.fail`` (which raises ``Failed``, not ``AssertionError``) so a
-# broken seed / mock / graph channel surfaces as a real failure, not a masked XFAIL.
-_XFAIL_1457 = pytest.mark.xfail(
-    strict=True,
-    raises=AssertionError,
-    reason="graph-path entity/relationship filter leak (#1457): report honestly flags the "
-    "filter unenforced against the uncovered entity surface until the #1457 fix filters it",
-)
 
 
 def _ast(spec: dict[str, Any] | None) -> FilterNode | None:
@@ -120,6 +108,37 @@ def _graph_chunk(ns_id: UUID, *, tier: str) -> Chunk:
         content=f"graph chunk tier={tier}",
         metadata={"tier": tier},
     )
+
+
+def _wire_graph_entity(
+    retriever: VectorCypherRetriever,
+    entity: Entity,
+    *,
+    provenance_chunks: list[Chunk],
+    score: float = 0.9,
+) -> None:
+    """Wire the graph-path entity seams so ``entity`` surfaces with real provenance.
+
+    The #1457 ∃-over-provenance filter (``retriever._filter_surfaces_by_provenance``)
+    keeps a graph-derived entity iff ≥1 of its ``source_chunk_ids`` chunk passes the
+    ``compile_python("Chunk")`` predicate. To exercise that on the unit retriever we
+    must give the graph path a REAL ``Entity`` (not the empty-provenance stub the
+    default ``_make_retriever`` builds when ``get_entities_batch`` returns ``{}``):
+
+    * ``search_similar_entities`` returns ``entity.id`` as the single entry entity,
+    * ``get_entities_batch`` resolves that id to ``entity`` (so its
+      ``source_chunk_ids`` reach the ∃ filter), and
+    * ``get_chunks_batch`` returns ``provenance_chunks`` keyed by id (the chunks the
+      predicate is applied to).
+
+    The caller sets each provenance chunk's fields (``occurred_at`` /
+    ``source_document`` / ``metadata``) so it passes — or fails — the filter under
+    test. Order-preserving; the entity's own ``source_chunk_ids`` must reference the
+    provided chunk ids.
+    """
+    retriever._storage.search_similar_entities = AsyncMock(return_value=[(entity.id, score)])
+    retriever._storage.get_entities_batch = AsyncMock(return_value={entity.id: entity})
+    retriever._storage.get_chunks_batch = AsyncMock(return_value={c.id: c for c in provenance_chunks})
 
 
 def _make_retriever(
@@ -356,7 +375,6 @@ async def _recall_filter_report(
 class TestHybridReport:
     """HYBRID recall folds vector / bm25 / graph plans into the canonical report."""
 
-    @_XFAIL_1457
     async def test_hybrid_vector_bm25_graph(self) -> None:
         """vector+bm25 push both keys; graph pushes source_name, post-filters metadata.tier.
 
@@ -392,7 +410,6 @@ class TestHybridReport:
         assert report["pushed_down"] is False
         assert report["post_filtered"] is True
 
-    @_XFAIL_1457
     async def test_hybrid_vector_graph_default_no_bm25(self) -> None:
         """Default HYBRID (bm25 channel OFF) still reports vector + graph honestly.
 
@@ -421,7 +438,6 @@ class TestHybridReport:
 class TestGraphModeReport:
     """GRAPH mode drops the vector + bm25 chunk channels; only graph gates."""
 
-    @_XFAIL_1457
     async def test_graph_only_disposition(self) -> None:
         """GRAPH mode: source_name pushed, metadata.tier post-filtered, by graph alone.
 
@@ -446,7 +462,6 @@ class TestGraphModeReport:
         assert report["pushed_down"] is False
         assert report["post_filtered"] is True
 
-    @_XFAIL_1457
     async def test_graph_fetch_that_spliced_nothing_pushes_no_keys(self) -> None:
         """A graph fetch that never touched the sink reports ``pushed_keys == []``.
 
@@ -640,7 +655,6 @@ class TestFilterEdgeCases:
         for ch in report["channels"].values():
             assert ch == {"pushed_keys": [], "post_filtered_keys": []}
 
-    @_XFAIL_1457
     async def test_system_only_filter_is_fully_pushed(self) -> None:
         """A system-key-only filter pushes down on every channel -> ``pushed_down``.
 
@@ -672,7 +686,6 @@ class TestFilterEdgeCases:
         # Graph pushed source_name (no residual); SQL channels too.
         assert report["channels"]["graph"] == {"pushed_keys": ["source_name"], "post_filtered_keys": []}
 
-    @_XFAIL_1457
     async def test_metadata_only_filter_is_post_filtered_on_graph(self) -> None:
         """A metadata-only filter: SQL channels push it, the graph channel re-checks it.
 
@@ -799,7 +812,6 @@ class TestRecencyChannelPresence:
 class TestGraphFallbackReport:
     """Under a graph fallback, the graph channel is absent (not fabricated)."""
 
-    @_XFAIL_1457
     async def test_graph_fallback_omits_graph_channel(self) -> None:
         """A transient Neo4j error during expand -> graph channel ABSENT.
 
@@ -902,7 +914,6 @@ def _typed_entity_retriever(ns_id: UUID, rows: list[dict[str, Any]]) -> VectorCy
 class TestTypedEntityFastPathHonesty:
     """Typed-recent reports: REAL report when filtered, no-filter carrier when not."""
 
-    @_XFAIL_1457
     async def test_filtered_typed_recent_emits_real_report(self) -> None:
         """TYPED_ENTITY_RECENT routed WITH a filter -> non-empty, valid report.
 
@@ -1353,35 +1364,68 @@ class TestConcurrentRecallsNoCrossContamination:
 
 
 # ---------------------------------------------------------------------------
-# The #1457 repro shape, pinned: a date-keyed filter drives the graph path via
+# The #1457 fix, pinned green: a date-keyed filter drives the graph path via
 # EXPLICIT temporal synthesis (engine.py's ``filter_constrains_date_key`` gate),
 # so the recall surfaces graph-derived entities the chunk filter never touched.
-# The engine passes ``covered_surfaces={"chunks"}`` on the graph path, so the
-# uncovered entity surface forces the date leaf into ``unenforced_keys``.
+# Before #1457 the engine passed ``covered_surfaces={"chunks"}`` unconditionally,
+# so an uncovered entity surface forced the date leaf into ``unenforced_keys``
+# (the leak the #1462 xfail pinned).
 #
-# This is the same leak the Task-of-record graph/hybrid tests above encode; this
-# test pins the SPECIFIC trigger the fix targets — a date predicate on a
-# beyond-corpus horizon (2027 against a 2026-ish corpus) — so the #1457 fix, which
-# filters the entity surface, flips it to xpass.
+# #1457 applies the SAME ``"Chunk"`` predicate to each entity's provenance chunks
+# (via ``khora.filter.provenance.filter_items_by_provenance``): an entity survives
+# iff ≥1 of its ``source_chunk_ids`` chunk passes the date filter. A date filter on
+# a BEYOND-CORPUS horizon (2027 against a 2026-ish corpus) matches nothing, so every
+# surface empties — the CORRECT end state — and the graph channel that ran under the
+# filter leaves the single ``occurred_at`` leaf enforced, so the report is CLEAN
+# (``unenforced_keys == []``). Empty entities is the RIGHT behavior for that filter,
+# not a leak: no entity's provenance cleared the horizon, so none is surfaced.
 # ---------------------------------------------------------------------------
 
 
 class TestDateKeyedExplicitSynthesisLeak:
-    """A date-keyed filter on the graph path leaks the uncovered entity surface."""
+    """A beyond-corpus date filter empties every surface and leaves a clean report."""
 
-    @_XFAIL_1457
     async def test_date_filter_graph_path_report_is_clean(self) -> None:
-        """A ``occurred_at $gte 2027`` filter on the graph path reports a clean pushdown.
+        """A ``occurred_at $gte 2027`` filter on a 2026 corpus -> four empty surfaces, clean report.
 
         The date predicate trips ``filter_constrains_date_key`` -> EXPLICIT
-        temporal synthesis -> the full graph path (``search_mode`` is NOT
-        ``simple_*``). The mocked entity search returns an entity, so the recall's
-        ``entities`` surface is non-empty and uncovered on the graph path. The
-        CLEAN report the #1457 fix restores enforces the single ``occurred_at``
-        leaf on the (then-filtered) entity surface, so nothing is unenforced.
+        temporal synthesis and the full graph path. NOTHING clears the 2027 horizon
+        on a 2026 corpus: the SQL chunk channels push down and match zero rows, the
+        graph channel's post-filter drops its 2026 chunk, and the ∃-over-provenance
+        filter drops the graph entity (its provenance is 2026). So chunks / entities
+        / relationships / documents are ALL empty — the correct zero-match end state
+        — and the graph channel that ran under the filter leaves ``occurred_at``
+        enforced, so ``unenforced_keys == []`` (no surface leaked). Empty entities is
+        CORRECT here, so this pins the zero-match end state directly (no fabricated
+        surviving entity, no non-empty-surface precondition).
         """
         ns_id = uuid4()
-        retriever = _make_retriever(ns_id, enable_bm25=True, graph_chunks=[_graph_chunk(ns_id, tier="gold")])
+        # The graph channel returns a 2026 chunk (its post-filter drops it under the
+        # 2027 bound) so the graph channel runs + records that it enforced the leaf.
+        graph_2026 = _graph_chunk(ns_id, tier="gold")
+        graph_2026.occurred_at = datetime(2026, 6, 1, tzinfo=UTC)
+        retriever = _make_retriever(ns_id, enable_bm25=True, graph_chunks=[graph_2026])
+        # The SQL chunk channels push down and match zero rows (2027 bound, 2026 corpus).
+        retriever._vector_store.search = AsyncMock(return_value=[])
+        retriever._vector_store.search_fulltext = AsyncMock(return_value=[])
+        # An entry entity exists in the traversal (so the graph channel runs and the
+        # ∃ filter fires), but its provenance chunk is 2026 -> it DROPS. This is the
+        # correct behavior, not a fabricated survivor.
+        prov_2026 = Chunk(
+            id=uuid4(),
+            namespace_id=ns_id,
+            document_id=uuid4(),
+            content="provenance chunk (2026)",
+            occurred_at=datetime(2026, 6, 1, tzinfo=UTC),
+        )
+        entity = Entity(
+            id=uuid4(),
+            namespace_id=ns_id,
+            name="Ancient",
+            entity_type="EVENT",
+            source_chunk_ids=[prov_2026.id],
+        )
+        _wire_graph_entity(retriever, entity, provenance_chunks=[prov_2026])
         engine = _build_engine(retriever)
 
         result = await engine.recall(
@@ -1392,29 +1436,15 @@ class TestDateKeyedExplicitSynthesisLeak:
             filter_ast=_ast({"occurred_at": {"$gte": "2027-01-01T00:00:00Z"}}),
         )
         report = result.engine_info["filter"]
-        # Precondition (holds before AND after the fix): no private channel-plan
-        # sink leaks into the public engine_info. A pytest.fail guard (raises
-        # Failed, not AssertionError) so a regression here is a real failure, not
-        # a masked XFAIL under the raises=AssertionError marker.
-        if "_filter_channel_plans" in result.engine_info:
-            pytest.fail("_filter_channel_plans leaked into public engine_info")
+        # The private channel-plan sink never leaks into the public engine_info.
+        assert "_filter_channel_plans" not in result.engine_info, "_filter_channel_plans leaked into engine_info"
         FilterPushdownReport.model_validate(report)
 
-        # Precondition (holds before AND after the fix): the recall genuinely ran
-        # the GRAPH path (non-``simple_*`` search_mode or graph chunks spliced)
-        # and surfaced entities — so the surface-coverage rule has real fuel and
-        # the leak below is not a vacuous fall-through to the simple path. These
-        # gates use pytest.fail so a broken mock / graph channel surfaces as a
-        # real failure rather than being masked as the expected AssertionError XFAIL.
-        search_mode = str(result.engine_info.get("search_mode", ""))
-        if not result.entities:
-            pytest.fail("graph path surfaced no entities — the surface-coverage rule is inert")
-        if search_mode.startswith("simple_") and result.engine_info.get("graph_chunk_count", 0) <= 0:
-            pytest.fail(
-                f"recall fell through to the simple path (search_mode={search_mode!r}, "
-                f"graph_chunk_count={result.engine_info.get('graph_chunk_count')}) — the graph-path leak "
-                "is not exercised"
-            )
+        # Zero-match end state: every result surface is empty.
+        assert result.chunks == []
+        assert result.entities == []
+        assert result.relationships == []
+        assert result.documents == []
 
         # The single date leaf is enforced (nothing unenforced) on a clean report.
         assert report["unenforced_keys"] == []

--- a/tests/unit/engines/test_vectorcypher_provenance_filter.py
+++ b/tests/unit/engines/test_vectorcypher_provenance_filter.py
@@ -1,0 +1,535 @@
+"""Regression coverage for the #1457 ∃-over-provenance entity/relationship filter.
+
+VectorCypher's graph path surfaces entities / relationships assembled from graph
+traversal the caller's chunk filter never touched. GitHub #1457 closes that leak:
+``VectorCypherRetriever._filter_surfaces_by_provenance`` re-applies the SAME
+``compile_python("Chunk")`` predicate the graph chunk channel uses to each item's
+provenance chunks — an entity survives iff ≥1 of its ``source_chunk_ids`` chunk
+passes; a relationship with its own provenance follows the same ∃ rule, else the
+endpoint-survival fallback. When the provenance fetch succeeds the engine marks
+the entity / relationship surfaces COVERED, so the honest ``engine_info["filter"]``
+report stops forcing their leaves into ``unenforced_keys``.
+
+This file is the engine-level (no live DB) regression suite for that behavior. It
+reuses the fully-wired retriever + engine builders from the sibling report suite
+(:mod:`tests.unit.engines.test_vectorcypher_filter_report`) and the
+``_wire_graph_entity`` seam that gives the graph path a REAL ``Entity`` with
+provenance (the default ``_make_retriever`` builds an empty-provenance stub, which
+always drops under a filter). Each case sets its provenance chunks' fields so they
+pass — or fail — the filter under test.
+
+The four scenarios (GitHub #1457):
+
+* **Case B** — a beyond-corpus date filter (``occurred_at $gte 2027`` on a 2026
+  corpus) empties ALL FOUR result surfaces (chunks / entities / relationships /
+  documents).
+* **Partial match** — a ``source``-keyed filter narrows the entity surface to
+  exactly the entities whose provenance carries the matching source.
+* **Truncation** — an entity whose only filter-passing provenance chunk is
+  truncated OUT of the returned top-k is STILL returned (entities need not come
+  from the returned chunks — the ∃ filter fetches provenance separately).
+* **Fail-closed** — a ``get_chunks_batch`` raise DROPS the unverified entity and
+  records a ``Degradation``; because every returned item is verified, an
+  unverified surface is never returned or reported as enforced (ADR-001).
+
+Two devil's-advocate completeness cases round out the branch coverage:
+
+* **Mixed-provenance relationships (same endpoints)** — the two relationship rules
+  compose: on a shared surviving-endpoint pair, an edge whose OWN provenance fails
+  drops while a provenance-less legacy edge survives on the endpoint rule.
+* **Multi-page fail-closed** — provenance spanning >1 fetch page with a LATER page
+  raising keeps the item already decided on an earlier page and drops only the
+  still-undecided one (exercised directly against ``filter_items_by_provenance``).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from khora.core.models import Chunk
+from khora.core.models.document import DocumentSource
+from khora.core.models.entity import Entity, Relationship
+from khora.filter.report import FilterPushdownReport
+from khora.query import SearchMode
+from tests.unit.engines.test_vectorcypher_filter_report import (
+    _ast,
+    _build_engine,
+    _graph_chunk,
+    _make_retriever,
+    _wire_graph_entity,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# The beyond-corpus horizon: a 2027 lower bound against a 2026-ish corpus.
+_DATE_FILTER: dict[str, Any] = {"occurred_at": {"$gte": "2027-01-01T00:00:00Z"}}
+
+
+def _prov_chunk(ns_id: Any, *, year: int, source: str | None = None) -> Chunk:
+    """A provenance chunk whose ``occurred_at`` sits in ``year`` (+ optional source).
+
+    ``occurred_at`` decides whether the chunk clears the ``$gte 2027`` horizon;
+    ``source`` (threaded via a ``DocumentSource`` projection, where the ``"Chunk"``
+    predicate resolves the denormalized ``source`` key) decides a ``source``-keyed
+    filter.
+    """
+    return Chunk(
+        id=uuid4(),
+        namespace_id=ns_id,
+        document_id=uuid4(),
+        content=f"provenance chunk ({year})",
+        occurred_at=datetime(year, 6, 1, tzinfo=UTC),
+        source_document=(DocumentSource(id=uuid4(), source=source) if source is not None else None),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case B: a beyond-corpus date filter empties all four result surfaces.
+# ---------------------------------------------------------------------------
+
+
+class TestBeyondCorpusDateFilterEmptiesAllSurfaces:
+    """``occurred_at $gte 2027`` on a 2026 corpus -> chunks/entities/rels/docs all empty."""
+
+    async def test_case_b_four_empty_lists(self) -> None:
+        """A 2027 lower bound against 2026 provenance drops every surface.
+
+        Every channel's candidate is 2026-dated, so nothing clears the horizon:
+        the vector / bm25 stores push down and match zero rows, the graph channel's
+        full-AST post-filter drops its 2026 chunk, and the ∃-over-provenance filter
+        drops the entity (its sole provenance chunk is 2026). Relationships fall
+        with the entity (endpoint fallback). Documents are derived from the (now
+        empty) chunk + entity surfaces, so they are empty too. The report stays
+        clean — nothing surfaced that the filter did not constrain.
+        """
+        ns_id = uuid4()
+        # Graph channel returns a 2026 chunk (its post-filter drops it under the 2027 bound).
+        graph_2026 = _graph_chunk(ns_id, tier="gold")
+        graph_2026.occurred_at = datetime(2026, 6, 1, tzinfo=UTC)
+        retriever = _make_retriever(ns_id, enable_bm25=True, graph_chunks=[graph_2026])
+        # The vector + bm25 store pushdowns matched zero rows (2027 bound, 2026 corpus).
+        retriever._vector_store.search = AsyncMock(return_value=[])
+        retriever._vector_store.search_fulltext = AsyncMock(return_value=[])
+        # One entity whose sole provenance chunk is 2026 -> dropped by the ∃ filter.
+        prov_2026 = _prov_chunk(ns_id, year=2026)
+        entity = Entity(
+            id=uuid4(),
+            namespace_id=ns_id,
+            name="Ancient",
+            entity_type="EVENT",
+            source_chunk_ids=[prov_2026.id],
+        )
+        _wire_graph_entity(retriever, entity, provenance_chunks=[prov_2026])
+        engine = _build_engine(retriever)
+
+        result = await engine.recall(
+            "alpha bravo charlie",
+            ns_id,
+            limit=10,
+            mode=SearchMode.HYBRID,
+            filter_ast=_ast(_DATE_FILTER),
+        )
+
+        # Four empty result surfaces.
+        assert result.chunks == []
+        assert result.entities == []
+        assert result.relationships == []
+        assert result.documents == []
+
+        # The ∃ filter ran and the surfaces are covered -> the report is clean.
+        assert result.engine_info.get("provenance_filtered_surfaces") is True
+        report = result.engine_info["filter"]
+        FilterPushdownReport.model_validate(report)
+        assert report["unenforced_keys"] == []
+
+
+# ---------------------------------------------------------------------------
+# Partial match: a source-keyed filter narrows entities by provenance source.
+# ---------------------------------------------------------------------------
+
+
+class TestPartialMatchNarrowsBySourceProvenance:
+    """A ``source``-keyed filter keeps only entities whose provenance matches."""
+
+    async def test_source_filter_keeps_only_matching_source_entity(self) -> None:
+        """``{"source": "linear", ...}`` -> only the linear-provenance entity survives.
+
+        The filter is composed with a date key so it constrains a date system key
+        (``filter_constrains_date_key`` -> EXPLICIT temporal synthesis routes the
+        graph path). BOTH entities' provenance clears the date, so ONLY the
+        ``source`` leaf differentiates them: the entity whose provenance chunk
+        carries ``source="linear"`` survives; the ``source="slack"`` one drops.
+        This pins that the ∃ filter narrows to exactly the matching-source
+        provenance, not merely "any surviving chunk".
+        """
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, enable_bm25=True)
+        # Two 2027 provenance chunks differing only in source.
+        linear_chunk = _prov_chunk(ns_id, year=2027, source="linear")
+        slack_chunk = _prov_chunk(ns_id, year=2027, source="slack")
+        linear_entity = Entity(
+            id=uuid4(),
+            namespace_id=ns_id,
+            name="LinearEvent",
+            entity_type="EVENT",
+            source_chunk_ids=[linear_chunk.id],
+        )
+        slack_entity = Entity(
+            id=uuid4(),
+            namespace_id=ns_id,
+            name="SlackEvent",
+            entity_type="EVENT",
+            source_chunk_ids=[slack_chunk.id],
+        )
+        retriever._storage.search_similar_entities = AsyncMock(
+            return_value=[(linear_entity.id, 0.9), (slack_entity.id, 0.8)]
+        )
+        retriever._storage.get_entities_batch = AsyncMock(
+            return_value={linear_entity.id: linear_entity, slack_entity.id: slack_entity}
+        )
+        retriever._storage.get_chunks_batch = AsyncMock(
+            return_value={linear_chunk.id: linear_chunk, slack_chunk.id: slack_chunk}
+        )
+        # Two surviving-eligible entities reach the Neo4j relationship fetch; stub
+        # it (this case is about the entity surface, not relationships).
+        retriever._dual_nodes.get_relationships_between = AsyncMock(return_value=[])
+        engine = _build_engine(retriever)
+
+        result = await engine.recall(
+            "alpha bravo charlie",
+            ns_id,
+            limit=10,
+            mode=SearchMode.HYBRID,
+            filter_ast=_ast({"source": "linear", "occurred_at": {"$gte": "2027-01-01T00:00:00Z"}}),
+        )
+
+        # Exactly the linear-provenance entity survives; the slack one is dropped.
+        assert [e.name for e in result.entities] == ["LinearEvent"]
+        assert result.engine_info.get("provenance_filtered_surfaces") is True
+        report = result.engine_info["filter"]
+        FilterPushdownReport.model_validate(report)
+        assert report["unenforced_keys"] == []
+
+
+# ---------------------------------------------------------------------------
+# Truncation: an entity whose passing provenance chunk is not in the returned
+# top-k is still returned (entities need not come from the returned chunks).
+# ---------------------------------------------------------------------------
+
+
+class TestEntityNeedNotComeFromReturnedChunks:
+    """A truncated-out provenance chunk still keeps its entity (∃ fetches separately)."""
+
+    async def test_entity_kept_when_its_provenance_chunk_is_truncated_out(self) -> None:
+        """``limit=1`` truncates the provenance chunk out of the top-k; the entity survives.
+
+        The entity's ONLY filter-passing provenance chunk is fetched separately by
+        the ∃ filter (via ``get_chunks_batch``), NOT drawn from the returned chunk
+        set. With ``limit=1`` the returned chunks are a single vector-channel chunk
+        that is NOT the entity's provenance chunk — yet the entity is still returned,
+        pinning that entities need not come from the returned top-k chunks.
+        """
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, enable_bm25=True)
+        prov = _prov_chunk(ns_id, year=2027)
+        entity = Entity(
+            id=uuid4(),
+            namespace_id=ns_id,
+            name="Kept",
+            entity_type="EVENT",
+            source_chunk_ids=[prov.id],
+        )
+        _wire_graph_entity(retriever, entity, provenance_chunks=[prov])
+        engine = _build_engine(retriever)
+
+        result = await engine.recall(
+            "alpha bravo charlie",
+            ns_id,
+            limit=1,
+            mode=SearchMode.HYBRID,
+            filter_ast=_ast(_DATE_FILTER),
+        )
+
+        # The entity survives.
+        assert [e.name for e in result.entities] == ["Kept"]
+        # Its provenance chunk is NOT among the returned (truncated) top-k chunks.
+        returned_chunk_ids = {c.id for c in result.chunks}
+        assert prov.id not in returned_chunk_ids, (
+            "the entity's provenance chunk leaked into the returned top-k — the truncation invariant is not exercised"
+        )
+        # Precondition: the top-k was genuinely truncated to the single vector chunk.
+        assert len(result.chunks) == 1, f"expected limit=1 to truncate to one chunk, got {len(result.chunks)}"
+        assert result.engine_info.get("provenance_filtered_surfaces") is True
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: a provenance fetch failure DROPS the unverified entity and records
+# a Degradation — an unverified surface is never returned (ADR-001).
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceFetchFailureIsFailClosed:
+    """A ``get_chunks_batch`` raise fail-closes: unverified entities dropped + Degradation."""
+
+    async def test_fetch_failure_drops_entity_and_records_degradation(self) -> None:
+        """A provenance fetch raise -> the unverified entity is DROPPED + a Degradation.
+
+        ADR-001 fail-closed (``khora.filter.provenance.filter_items_by_provenance``):
+        the entity's provenance could not be verified, so it is DROPPED rather than
+        returned unverified (which would re-introduce the #1457 leak). A structured
+        ``Degradation`` (``component="vectorcypher.entity_filter"``,
+        ``reason="provenance_fetch_failed"``) rides ``engine_info["degradations"]``.
+        Because every RETURNED entity is verified, the surface is still legitimately
+        enforced — the honest report is clean (``unenforced_keys == []``) and the
+        engine marks the surface covered.
+        """
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, enable_bm25=True)
+        prov = _prov_chunk(ns_id, year=2027)
+        entity = Entity(
+            id=uuid4(),
+            namespace_id=ns_id,
+            name="Unverifiable",
+            entity_type="EVENT",
+            source_chunk_ids=[prov.id],
+        )
+        retriever._storage.search_similar_entities = AsyncMock(return_value=[(entity.id, 0.9)])
+        retriever._storage.get_entities_batch = AsyncMock(return_value={entity.id: entity})
+        # The provenance fetch raises -> the ∃ filter cannot verify the surface.
+        retriever._storage.get_chunks_batch = AsyncMock(side_effect=RuntimeError("provenance store down"))
+        engine = _build_engine(retriever)
+
+        result = await engine.recall(
+            "alpha bravo charlie",
+            ns_id,
+            limit=10,
+            mode=SearchMode.HYBRID,
+            filter_ast=_ast(_DATE_FILTER),
+        )
+
+        # Fail-closed: the unverified entity is DROPPED, not returned.
+        assert result.entities == [], "an unverified entity leaked into the result on the degraded path"
+
+        # A structured Degradation names the entity-filter component + reason.
+        degradations = result.engine_info.get("degradations", [])
+        provenance_degs = [
+            d
+            for d in degradations
+            if d.get("component") == "vectorcypher.entity_filter" and d.get("reason") == "provenance_fetch_failed"
+        ]
+        assert provenance_degs, (
+            f"expected a vectorcypher.entity_filter / provenance_fetch_failed Degradation, "
+            f"got: {[(d.get('component'), d.get('reason')) for d in degradations]}"
+        )
+
+        # Every returned entity is verified (here: none), so the surface is
+        # legitimately enforced — the honest report stays clean.
+        assert result.engine_info.get("provenance_filtered_surfaces") is True
+        report = result.engine_info["filter"]
+        FilterPushdownReport.model_validate(report)
+        assert report["unenforced_keys"] == []
+
+
+# ---------------------------------------------------------------------------
+# Relationship endpoint fallback: a provenance-less legacy edge survives iff
+# BOTH its endpoints survived the ∃ filter (the impl's endpoint rule).
+# ---------------------------------------------------------------------------
+
+
+class TestRelationshipEndpointFallback:
+    """A provenance-less relationship follows the endpoint-survival rule."""
+
+    async def test_legacy_edge_kept_iff_both_endpoints_survive(self) -> None:
+        """A provenance-less edge between a surviving + a dropped entity is dropped.
+
+        A relationship carrying no ``source_chunk_ids`` cannot use the ∃-over-
+        provenance rule, so the impl keeps it iff BOTH endpoints survived. Here one
+        endpoint's provenance clears the date and the other's does not, so the edge
+        is dropped even though one endpoint survives — pinning the endpoint-survival
+        fallback for legacy edges.
+        """
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, enable_bm25=True)
+        keep_chunk = _prov_chunk(ns_id, year=2027)
+        drop_chunk = _prov_chunk(ns_id, year=2026)
+        keep_entity = Entity(
+            id=uuid4(),
+            namespace_id=ns_id,
+            name="Survivor",
+            entity_type="EVENT",
+            source_chunk_ids=[keep_chunk.id],
+        )
+        drop_entity = Entity(
+            id=uuid4(),
+            namespace_id=ns_id,
+            name="Casualty",
+            entity_type="EVENT",
+            source_chunk_ids=[drop_chunk.id],
+        )
+        # A provenance-less legacy edge between the two.
+        legacy_edge = Relationship(
+            id=uuid4(),
+            namespace_id=ns_id,
+            source_entity_id=keep_entity.id,
+            target_entity_id=drop_entity.id,
+            relationship_type="RELATES_TO",
+            source_chunk_ids=[],
+        )
+        retriever._storage.search_similar_entities = AsyncMock(
+            return_value=[(keep_entity.id, 0.9), (drop_entity.id, 0.8)]
+        )
+        retriever._storage.get_entities_batch = AsyncMock(
+            return_value={keep_entity.id: keep_entity, drop_entity.id: drop_entity}
+        )
+        retriever._storage.get_chunks_batch = AsyncMock(
+            return_value={keep_chunk.id: keep_chunk, drop_chunk.id: drop_chunk}
+        )
+        # Feed the legacy edge through the retriever's provenance filter directly:
+        # the ∃ filter is the unit under test, exercised via its own seam so the
+        # relationship-fetch mock shape is not load-bearing.
+        kept_entities, kept_rels, filtered = await retriever._filter_surfaces_by_provenance(
+            [(keep_entity, 0.9), (drop_entity, 0.8)],
+            [(legacy_edge, 0.9)],
+            _ast(_DATE_FILTER),
+            ns_id,
+            [],
+        )
+
+        assert filtered is True
+        assert {e.name for e, _ in kept_entities} == {"Survivor"}
+        # The edge drops: one endpoint (Casualty) did not survive.
+        assert kept_rels == []
+
+    async def test_mixed_provenance_edges_same_endpoints(self) -> None:
+        """Two edges between the SAME surviving endpoints: the ∃ rule splits them.
+
+        Both endpoints survive (both provenance chunks clear the date), so the
+        endpoint rule alone would keep BOTH edges. But one edge carries its own
+        provenance that FAILS the date (2026) and the other carries none: the
+        provenance-bearing edge is dropped by the ∃-over-own-provenance rule while
+        the provenance-less legacy edge survives on the endpoint rule. This pins
+        that the two relationship rules compose (``endpoint AND (no-prov OR ∃)``),
+        isolating them on a shared-endpoint pair so ONLY the provenance status
+        differs.
+        """
+        ns_id = uuid4()
+        retriever = _make_retriever(ns_id, enable_bm25=True)
+        e1_chunk = _prov_chunk(ns_id, year=2027)
+        e2_chunk = _prov_chunk(ns_id, year=2027)
+        e1 = Entity(id=uuid4(), namespace_id=ns_id, name="E1", entity_type="EVENT", source_chunk_ids=[e1_chunk.id])
+        e2 = Entity(id=uuid4(), namespace_id=ns_id, name="E2", entity_type="EVENT", source_chunk_ids=[e2_chunk.id])
+        # A provenance-bearing edge whose own provenance FAILS the date (2026).
+        stale_prov_chunk = _prov_chunk(ns_id, year=2026)
+        edge_with_stale_prov = Relationship(
+            id=uuid4(),
+            namespace_id=ns_id,
+            source_entity_id=e1.id,
+            target_entity_id=e2.id,
+            relationship_type="OWN_PROV",
+            source_chunk_ids=[stale_prov_chunk.id],
+        )
+        # A provenance-less legacy edge between the SAME endpoints.
+        legacy_edge = Relationship(
+            id=uuid4(),
+            namespace_id=ns_id,
+            source_entity_id=e1.id,
+            target_entity_id=e2.id,
+            relationship_type="LEGACY",
+            source_chunk_ids=[],
+        )
+        retriever._storage.get_chunks_batch = AsyncMock(
+            return_value={
+                e1_chunk.id: e1_chunk,
+                e2_chunk.id: e2_chunk,
+                stale_prov_chunk.id: stale_prov_chunk,
+            }
+        )
+
+        _kept_entities, kept_rels, filtered = await retriever._filter_surfaces_by_provenance(
+            [(e1, 0.9), (e2, 0.8)],
+            [(edge_with_stale_prov, 0.9), (legacy_edge, 0.85)],
+            _ast(_DATE_FILTER),
+            ns_id,
+            [],
+        )
+
+        assert filtered is True
+        # Both endpoints survived, so only the ∃-over-own-provenance rule splits the
+        # edges: the stale-provenance edge drops, the legacy (endpoint-rule) edge stays.
+        assert [rel.relationship_type for rel, _ in kept_rels] == ["LEGACY"]
+
+
+# ---------------------------------------------------------------------------
+# Multi-page fail-closed: provenance spanning >1 fetch page, with a LATER page
+# raising, keeps the items already decided on an earlier page (QA gap #1).
+# ---------------------------------------------------------------------------
+
+
+class _ProvItem:
+    """A minimal ``_HasProvenance`` item: an id + a provenance chunk-id sequence."""
+
+    def __init__(self, chunk_ids: list[UUID]) -> None:
+        self.id = uuid4()
+        self.source_chunk_ids = chunk_ids
+
+
+class TestMultiPageFailClosedKeepsDecidedItems:
+    """A later-page fetch failure drops only the still-undecided items."""
+
+    async def test_page_two_failure_keeps_page_one_survivor(self) -> None:
+        """Item decided on page 1 survives; item pending on page 2 drops on the raise.
+
+        ``filter_items_by_provenance`` fetches provenance in ``_PAGE_SIZE`` (500)
+        pages. Item A carries a full page of passing (2027) provenance chunks, so it
+        is decided on page 1; Item B's single provenance chunk lands on page 2, which
+        raises. The fail-closed rule drops only the still-undecided B — A (already
+        proven) is kept — and records exactly ONE Degradation. This closes the
+        devil's-advocate gap the earlier fail-closed test left (that one fails the
+        FIRST fetch, so every item is undecided).
+        """
+        from khora.filter.provenance import _PAGE_SIZE, filter_items_by_provenance
+
+        ns_id = uuid4()
+        # Item A: a full first page of passing (2027) provenance chunks.
+        a_chunks = [_prov_chunk(ns_id, year=2027) for _ in range(_PAGE_SIZE)]
+        a_map = {c.id: c for c in a_chunks}
+        item_a = _ProvItem([c.id for c in a_chunks])
+        # Item B: a single provenance chunk that lands on page 2.
+        b_chunk = _prov_chunk(ns_id, year=2027)
+        item_b = _ProvItem([b_chunk.id])
+
+        calls = {"n": 0}
+
+        async def _paged_fetch(chunk_ids: list[UUID], *, namespace_id: UUID) -> dict[UUID, Chunk]:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return {cid: a_map[cid] for cid in chunk_ids if cid in a_map}
+            raise RuntimeError("page 2 store down")
+
+        storage = AsyncMock()
+        storage.get_chunks_batch = _paged_fetch
+        degradations: list[Any] = []
+
+        kept = await filter_items_by_provenance(
+            [item_a, item_b],
+            _ast(_DATE_FILTER),
+            namespace_id=ns_id,
+            storage=storage,
+            component="vectorcypher.entity_filter",
+            degradations=degradations,
+        )
+
+        # Two fetch pages were attempted (page 1 succeeded, page 2 raised).
+        assert calls["n"] == 2
+        # A (decided on page 1) survives; B (pending on page 2) is dropped fail-closed.
+        assert kept == [item_a]
+        # Exactly one Degradation names the entity-filter component + reason.
+        assert [(d.get("component"), d.get("reason")) for d in degradations] == [
+            ("vectorcypher.entity_filter", "provenance_fetch_failed")
+        ]

--- a/tests/unit/filter/test_recall_conformance_oracle.py
+++ b/tests/unit/filter/test_recall_conformance_oracle.py
@@ -1,0 +1,242 @@
+"""Recall-result conformance oracle over filtered VectorCypher recalls — ``@internal``.
+
+The compile-side conformance harness (:mod:`tests.unit.filter.test_conformance_catalog`
++ :mod:`~tests.unit.filter.test_conformance_harness`) checks that each backend's
+filter COMPILE agrees with the Python oracle over seed records. This module checks
+the complementary, OUTPUT-side invariant: a real filtered recall's returned
+surfaces conform to the SAME compiled predicate, WITHOUT knowing how the engine
+produced them.
+
+For every filtered corpus case it drives a VectorCypher recall (engine-level, no
+live DB — reusing the report suite's fully-wired retriever + the #1457 provenance
+wiring) and calls the implementation-blind oracle
+:func:`khora.filter.conformance.assert_recall_conformance`:
+
+  1. every RETURNED chunk passes the compiled ``"Chunk"`` predicate, and
+  2. every RETURNED entity has ≥1 provenance chunk that passes (the ∃-over-
+     provenance rule #1457 enforces on the graph-derived entity surface).
+
+The oracle is fed the SEEDED ``Chunk`` objects the returned ids point back to (the
+``RecallChunk`` / ``RecallEntity`` projections drop the metadata / document-key
+fields a filter can address), so the predicate sees the full filterable surface —
+the "implementation-blind" contract: seed known chunks, recall, verify the
+invariant over what came back.
+
+A falsifiability test proves the oracle has teeth (it must REJECT a recall that
+surfaces a chunk / entity the predicate excludes), mirroring the compile harness's
+``test_assert_case_fails_on_wrong_expected_ids``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from khora.core.models import Chunk
+from khora.core.models.document import DocumentSource
+from khora.core.models.entity import Entity
+from khora.filter import parse_to_ast
+from khora.filter.ast import FilterNode
+from khora.filter.conformance import assert_recall_conformance
+from khora.filter.model import RecallFilter
+from khora.query import SearchMode
+from tests.unit.engines.test_vectorcypher_filter_report import (
+    _build_engine,
+    _make_retriever,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _ast(spec: dict[str, Any]) -> FilterNode:
+    """Lower a wire filter to its canonical AST exactly as the facade does."""
+    return parse_to_ast(RecallFilter.model_validate(spec))
+
+
+def _chunk(
+    ns_id: UUID,
+    *,
+    year: int,
+    source: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Chunk:
+    """A seed chunk carrying the filterable fields a recall filter can address."""
+    return Chunk(
+        id=uuid4(),
+        namespace_id=ns_id,
+        document_id=uuid4(),
+        content=f"seed chunk {year}",
+        occurred_at=datetime(year, 6, 1, tzinfo=UTC),
+        metadata=metadata or {},
+        source_document=(DocumentSource(id=uuid4(), source=source) if source is not None else None),
+    )
+
+
+async def _recall_surfaces(
+    filter_spec: dict[str, Any],
+    *,
+    ns_id: UUID,
+    passing_entity_chunk: Chunk,
+    failing_entity_chunk: Chunk | None,
+    chunk_registry: dict[UUID, Chunk],
+) -> tuple[list[Chunk], list[list[Chunk]]]:
+    """Drive a filtered recall and map the returned surfaces back to seed chunks.
+
+    Wires the graph path with one entity whose provenance is ``passing_entity_chunk``
+    and (optionally) one whose provenance is ``failing_entity_chunk``, runs the
+    recall, and returns ``(returned_chunk_objects, entity_provenance_objects)`` — the
+    exact inputs :func:`assert_recall_conformance` consumes. Returned/provenance ids
+    are resolved back to the seeded ``Chunk`` objects via ``chunk_registry`` (the
+    ``RecallChunk`` / ``RecallEntity`` projections drop the fields a filter reads).
+    """
+    retriever = _make_retriever(ns_id, enable_bm25=True)
+
+    passing_entity = Entity(
+        id=uuid4(),
+        namespace_id=ns_id,
+        name="Passing",
+        entity_type="EVENT",
+        source_chunk_ids=[passing_entity_chunk.id],
+    )
+    sim: list[tuple[UUID, float]] = [(passing_entity.id, 0.9)]
+    ents: dict[UUID, Entity] = {passing_entity.id: passing_entity}
+    if failing_entity_chunk is not None:
+        failing_entity = Entity(
+            id=uuid4(),
+            namespace_id=ns_id,
+            name="Failing",
+            entity_type="EVENT",
+            source_chunk_ids=[failing_entity_chunk.id],
+        )
+        sim.append((failing_entity.id, 0.8))
+        ents[failing_entity.id] = failing_entity
+
+    retriever._storage.search_similar_entities = AsyncMock(return_value=sim)
+    retriever._storage.get_entities_batch = AsyncMock(return_value=ents)
+    retriever._storage.get_chunks_batch = AsyncMock(return_value=dict(chunk_registry))
+    retriever._dual_nodes.get_relationships_between = AsyncMock(return_value=[])
+    engine = _build_engine(retriever)
+
+    result = await engine.recall(
+        "alpha bravo charlie",
+        ns_id,
+        limit=10,
+        mode=SearchMode.HYBRID,
+        filter_ast=_ast(filter_spec),
+    )
+
+    returned_chunks = [chunk_registry[c.id] for c in result.chunks if c.id in chunk_registry]
+    entity_provenance = [
+        [chunk_registry[cid] for cid in ent.source_chunk_ids if cid in chunk_registry] for ent in result.entities
+    ]
+    return returned_chunks, entity_provenance
+
+
+# The filtered corpus: each case is a filter whose passing/failing chunk fields the
+# oracle re-checks over the recall's surfaces. Every case surfaces exactly one
+# entity (its provenance passes) and drops a decoy entity (its provenance fails),
+# so the ∃-over-provenance leg is exercised, not vacuous.
+_CASES = ("date_gte_2027", "source_linear", "metadata_tier_gold")
+
+
+def _seed_for_case(case: str, ns_id: UUID) -> tuple[dict[str, Any], Chunk, Chunk]:
+    """Return ``(filter_spec, passing_chunk, failing_chunk)`` for a corpus case."""
+    if case == "date_gte_2027":
+        return (
+            {"occurred_at": {"$gte": "2027-01-01T00:00:00Z"}},
+            _chunk(ns_id, year=2027),
+            _chunk(ns_id, year=2026),
+        )
+    if case == "source_linear":
+        return (
+            {"source": "linear", "occurred_at": {"$gte": "2027-01-01T00:00:00Z"}},
+            _chunk(ns_id, year=2027, source="linear"),
+            _chunk(ns_id, year=2027, source="slack"),
+        )
+    if case == "metadata_tier_gold":
+        return (
+            {"metadata.tier": "gold", "occurred_at": {"$gte": "2027-01-01T00:00:00Z"}},
+            _chunk(ns_id, year=2027, metadata={"tier": "gold"}),
+            _chunk(ns_id, year=2027, metadata={"tier": "silver"}),
+        )
+    raise AssertionError(f"unknown case {case!r}")
+
+
+class TestRecallConformanceOracle:
+    """Every filtered corpus case: the recall's surfaces conform to the predicate."""
+
+    @pytest.mark.parametrize("case", _CASES)
+    async def test_recall_surfaces_conform(self, case: str) -> None:
+        """The returned chunks + entity provenance pass the compiled recall predicate.
+
+        Drives a real filtered recall, then asserts the implementation-blind oracle:
+        every returned chunk passes the ``"Chunk"`` predicate AND every returned
+        entity has ≥1 provenance chunk that passes. The decoy entity (failing
+        provenance) is dropped, so exactly the passing entity survives — the ∃ leg
+        is genuinely exercised.
+        """
+        ns_id = uuid4()
+        filter_spec, passing_chunk, failing_chunk = _seed_for_case(case, ns_id)
+        registry = {passing_chunk.id: passing_chunk, failing_chunk.id: failing_chunk}
+
+        returned_chunks, entity_provenance = await _recall_surfaces(
+            filter_spec,
+            ns_id=ns_id,
+            passing_entity_chunk=passing_chunk,
+            failing_entity_chunk=failing_chunk,
+            chunk_registry=registry,
+        )
+
+        # Precondition: the ∃ leg is not vacuous — exactly the passing entity
+        # survived (the decoy with failing provenance was dropped).
+        assert len(entity_provenance) == 1, (
+            f"expected exactly the passing entity to survive, got {len(entity_provenance)} entities"
+        )
+        assert entity_provenance[0], "the surviving entity carried no provenance — the ∃ leg is vacuous"
+
+        # The implementation-blind oracle: chunk surface + ∃-over-provenance.
+        assert_recall_conformance(
+            _ast(filter_spec),
+            returned_chunks=returned_chunks,
+            entity_provenance=entity_provenance,
+        )
+
+
+class TestRecallConformanceOracleIsFalsifiable:
+    """The oracle must REJECT a recall surface the predicate excludes (it has teeth)."""
+
+    def test_oracle_rejects_a_chunk_that_fails_the_predicate(self) -> None:
+        """A returned chunk outside the filter must raise — the chunk-surface leg has teeth."""
+        ns_id = uuid4()
+        filter_ast = _ast({"occurred_at": {"$gte": "2027-01-01T00:00:00Z"}})
+        # A 2026 chunk fails the 2027 lower bound; surfacing it violates the invariant.
+        bad_chunk = _chunk(ns_id, year=2026)
+        with pytest.raises(AssertionError, match="does not pass the recall filter predicate"):
+            assert_recall_conformance(filter_ast, returned_chunks=[bad_chunk], entity_provenance=[])
+
+    def test_oracle_rejects_an_entity_with_no_passing_provenance(self) -> None:
+        """An entity whose every provenance chunk fails must raise — the ∃ leg has teeth."""
+        ns_id = uuid4()
+        filter_ast = _ast({"occurred_at": {"$gte": "2027-01-01T00:00:00Z"}})
+        # The entity's only provenance chunk is 2026 (fails); ∃ over it is False.
+        failing_prov = _chunk(ns_id, year=2026)
+        with pytest.raises(AssertionError, match="no provenance chunk passing"):
+            assert_recall_conformance(filter_ast, returned_chunks=[], entity_provenance=[[failing_prov]])
+
+    def test_oracle_rejects_an_entity_with_empty_provenance(self) -> None:
+        """An entity with empty provenance fails the existential (a filtered recall never surfaces one)."""
+        filter_ast = _ast({"occurred_at": {"$gte": "2027-01-01T00:00:00Z"}})
+        with pytest.raises(AssertionError, match="no provenance chunk passing"):
+            assert_recall_conformance(filter_ast, returned_chunks=[], entity_provenance=[[]])
+
+    def test_oracle_accepts_a_conformant_recall(self) -> None:
+        """The control: a recall whose surfaces all pass must NOT raise (no degenerate always-raise)."""
+        ns_id = uuid4()
+        filter_ast = _ast({"occurred_at": {"$gte": "2027-01-01T00:00:00Z"}})
+        good_chunk = _chunk(ns_id, year=2027)
+        prov = _chunk(ns_id, year=2027)
+        assert_recall_conformance(filter_ast, returned_chunks=[good_chunk], entity_provenance=[[prov]])


### PR DESCRIPTION
## Summary
- Under a caller filter, the VectorCypher **graph path** returned entities/relationships the chunk-side filter never touched, so a date-keyed filter (which deterministically routes to the graph path) leaked unfiltered entities even when zero chunks matched.
- Enforce filter compliance **existentially over provenance**: an entity is returned iff ≥1 of its `source_chunk_ids` passes the same compiled `Chunk` predicate the chunk channel uses; a relationship is returned iff **both endpoints survive** and, when it carries its own provenance, that provenance also passes. A filter matching zero chunks now yields empty entities/relationships/documents.
- New engine-agnostic helper `khora.filter.provenance.filter_items_by_provenance` (paged fetch in 500s; **fail-closed** — on a provenance-fetch failure unverified items are dropped and a single `Degradation` is recorded per the failure-observability contract). Reusable by other engines.
- The entity/relationship surfaces are marked **covered** in the honest filter report when the pass runs, so a metadata-only filter on the graph path no longer reports spurious `unenforced_keys`. Unfiltered recalls are unchanged (zero extra cost).
- Registered the new filter-aware method in the retriever filter-enforcement audit registries.

**Behavioral change:** filtered recalls now return fewer (possibly zero) entities/relationships/documents; a filter matching zero chunks returns four empty lists. Cost: one paged `get_chunks_batch` per *filtered* graph-path recall.

## Test plan
- [x] Unit tests pass locally: new provenance-module suite (paging, early-exit, fail-closed mid-paging, dedup, relationship endpoint+∃), conformance oracle with falsifiability tests, flipped graph-path filter-report pins, recall audit-gate/partition registries
- [x] `make format` / `make lint` (ruff + ty + optional-imports) clean
- [ ] Integration tests pass (CI — Postgres/Neo4j)
- [ ] e2e tests pass (CI)

Fixes #1457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provenance-aware “∃-over-provenance” filtering for graph-path recall, including correct entity/relationship survivorship and provenance-backed enforcement.
  * Introduced recall conformance validation to verify returned chunks and entities against the active filter.
* **Bug Fixes**
  * Made filter reporting reflect enforced coverage more accurately, including provenance-filtered surfaces.
  * Fail-closed behavior now drops unverified items and records structured degradation when provenance cannot be fetched.
* **Documentation**
  * Added telemetry metric for provenance degradation tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->