### PR TITLE
Filter entities by provenance on Chronicle recall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 
 ## [Unreleased]
 
-### Fixed
-
-- **Chronicle filtered recalls enforce `occurred_at` consistently across the chunk and entity surfaces** (#1458, #1487): the `∃`-over-provenance entity filter now evaluates each provenance chunk through the same `COALESCE(occurred_at, source_timestamp)` view chronicle's chunk post-filter uses, so an `occurred_at` predicate the chunk channel satisfies no longer false-drops the provenance entity whose chunk carries its event time only in `source_timestamp` (chronicle's shape — the raw `occurred_at` column is NULL). VectorCypher is unaffected (its chunks carry `occurred_at` natively; the shared `filter_items_by_provenance` helper defaults to the raw-chunk view).
-
 ## [0.22.2] - recall-quality correctness, HNSW index-backed search, durable reconcilers
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 
 ## [Unreleased]
 
+### Fixed
+
+- **Chronicle filtered recalls enforce `occurred_at` consistently across the chunk and entity surfaces** (#1458, #1487): the `∃`-over-provenance entity filter now evaluates each provenance chunk through the same `COALESCE(occurred_at, source_timestamp)` view chronicle's chunk post-filter uses, so an `occurred_at` predicate the chunk channel satisfies no longer false-drops the provenance entity whose chunk carries its event time only in `source_timestamp` (chronicle's shape — the raw `occurred_at` column is NULL). VectorCypher is unaffected (its chunks carry `occurred_at` natively; the shared `filter_items_by_provenance` helper defaults to the raw-chunk view).
+
 ## [0.22.2] - recall-quality correctness, HNSW index-backed search, durable reconcilers
 
 ### Added

--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -1677,7 +1677,7 @@
       "unit": "1",
       "owner": "filter",
       "labels": [
-        {"name": "component", "values": ["vectorcypher.entity_filter", "vectorcypher.relationship_filter"], "_comment": "Low-cardinality enum: the caller's per-surface value. Chronicle reuses the helper (#1458) and will add chronicle.* values."},
+        {"name": "component", "values": ["vectorcypher.entity_filter", "vectorcypher.relationship_filter", "chronicle.entity_filter"], "_comment": "Low-cardinality enum: the caller's per-surface value. Chronicle reuses the helper (#1458) via chronicle.entity_filter."},
         {"name": "reason", "values": ["provenance_fetch_failed"], "_comment": "Low-cardinality enum; extend when adding new provenance-filter fallback paths."}
       ],
       "description": "GitHub #1457 (ADR-001). Engine-agnostic ∃-over-provenance item-filter fallback (khora.filter.provenance.filter_items_by_provenance) - incremented when a provenance-chunk fetch page raises while re-applying the caller filter over a graph-derived result surface (entities / relationships). The metric name is engine-agnostic because the counter is emitted from within the reusable module (Chronicle #1458 reuses it); the component label carries the caller identity. Items with no filter-passing provenance chunk in the pages fetched so far are DROPPED (fail-closed - an unverified item is never returned), and the verified survivors are returned; the surface stays legitimately enforced. The same event is also appended to RecallResult.engine_info['degradations']. NO namespace_id label - cardinality rule. See docs/architecture/failure-observability-contract.md."

--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -2320,6 +2320,12 @@ class ChronicleEngine:
                 storage=storage,
                 component="chronicle.entity_filter",
                 degradations=degradations,
+                # Enforce the filter against each provenance chunk with the SAME
+                # field semantics the chunk channel uses (COALESCE(occurred_at,
+                # source_timestamp) etc.), so an entity is not false-dropped on an
+                # occurred_at predicate its provenance chunk satisfies only through
+                # source_timestamp — the chunk post-filter above keeps that chunk.
+                chunk_record_adapter=_chunk_to_record,
             )
             entity_hits = [(entity, score_by_id[entity.id]) for entity in kept_entities]
 

--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -2419,12 +2419,17 @@ class ChronicleEngine:
             # entity's provenance, so the entity/relationship surfaces are enforced
             # and added to covered_surfaces — otherwise a HYBRID recall surfacing
             # entities the filter never constrained would honestly force the filter's
-            # leaves into unenforced_keys. Chronicle keeps relationships=[].
+            # leaves into unenforced_keys.
             surface_sizes={
                 "chunks": len(recall_chunks),
                 "entities": len(recall_entities),
                 "relationships": 0,
             },
+            # Chronicle's relationships surface is ALWAYS empty (size 0), so
+            # including "relationships" in covered_surfaces is harmless either way —
+            # build_filter_report only forces a filter's leaves into unenforced_keys
+            # for an uncovered surface with size > 0. Listed for parity with the
+            # VectorCypher pass, which covers both surfaces together.
             covered_surfaces={"chunks"} | ({"entities", "relationships"} if provenance_pass_ran else set()),
         )
 

--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -2296,6 +2296,33 @@ class ChronicleEngine:
             for (chunk, _), score in zip(chunks_with_scores, normalized_chunk_scores, strict=False)
         ]
 
+        # GitHub #1458: ∃-over-provenance entity filtering. The entity channel
+        # (search_similar_entities) is assembled from vector similarity the chunk
+        # post-filter never touched, so a caller filter that narrows chunks would
+        # otherwise leak entities it never constrained. Re-apply the SAME "Chunk"
+        # predicate to each entity's provenance chunks via the engine-agnostic
+        # helper: an entity survives iff ≥1 of its source_chunk_ids passes. Only
+        # runs under a filter; unfiltered recalls take the zero-cost path (no
+        # extra fetch). ``provenance_pass_ran`` marks the entity surface covered
+        # for the honest report — True whenever the pass executed, including the
+        # fetch-failure degraded path (the helper fail-closes by DROPPING
+        # unverified entities, so every survivor is verified).
+        provenance_pass_ran = False
+        if filter_ast is not None and bool(filter_ast.children) and entity_hits:
+            from khora.filter.provenance import filter_items_by_provenance
+
+            provenance_pass_ran = True
+            score_by_id = {entity.id: score for entity, score in entity_hits}
+            kept_entities = await filter_items_by_provenance(
+                [entity for entity, _ in entity_hits],
+                filter_ast,
+                namespace_id=namespace_id,
+                storage=storage,
+                component="chronicle.entity_filter",
+                degradations=degradations,
+            )
+            entity_hits = [(entity, score_by_id[entity.id]) for entity in kept_entities]
+
         recall_entities = [
             RecallEntity(
                 id=entity.id,
@@ -2386,17 +2413,19 @@ class ChronicleEngine:
                     defensive_recheck=(filter_ast is not None and bool(filter_ast.children)),
                 )
             },
-            # Chronicle covers only the "chunks" surface: the entity channel
-            # (search_similar_entities) receives no filter_ast (#1458), so a HYBRID
-            # recall that surfaces entities emits an UNCOVERED entity surface and the
-            # builder honestly forces the filter's leaves into unenforced_keys. The
-            # #1458 fix filters the entity surface and adds it to covered_surfaces.
+            # Chronicle covers the "chunks" surface unconditionally; the entity
+            # surface is covered iff the ∃-over-provenance pass ran (#1458). When a
+            # filter is present the pass re-applies the chunk predicate to each
+            # entity's provenance, so the entity/relationship surfaces are enforced
+            # and added to covered_surfaces — otherwise a HYBRID recall surfacing
+            # entities the filter never constrained would honestly force the filter's
+            # leaves into unenforced_keys. Chronicle keeps relationships=[].
             surface_sizes={
                 "chunks": len(recall_chunks),
                 "entities": len(recall_entities),
                 "relationships": 0,
             },
-            covered_surfaces={"chunks"},
+            covered_surfaces={"chunks"} | ({"entities", "relationships"} if provenance_pass_ran else set()),
         )
 
         return RecallResult(

--- a/src/khora/filter/provenance.py
+++ b/src/khora/filter/provenance.py
@@ -23,7 +23,7 @@ degraded path.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import Any, Protocol, runtime_checkable
 from uuid import UUID
 
@@ -84,6 +84,7 @@ async def filter_items_by_provenance[T: _HasProvenance](
     storage: _ChunkStore,
     component: str,
     degradations: list[Degradation],
+    chunk_record_adapter: Callable[[Any], Any] | None = None,
 ) -> list[T]:
     """Keep the items whose provenance satisfies ``filter_ast`` (∃ rule).
 
@@ -96,6 +97,16 @@ async def filter_items_by_provenance[T: _HasProvenance](
     unbounded union would blow the backend variable limit once a caller feeds it
     many items). Each page's filter-passing chunk ids accumulate into a shared
     ``surviving`` set; an item is kept iff any of its ids landed in that set.
+
+    ``chunk_record_adapter`` maps each fetched provenance chunk to the record the
+    predicate is evaluated against, so the entity/relationship surface enforces
+    the filter with the SAME field semantics its chunk channel uses. Chronicle
+    passes its ``_chunk_to_record`` (which resolves ``occurred_at`` as
+    ``COALESCE(occurred_at, source_timestamp)``, matching its chunk post-filter);
+    without it a raw chunk carrying its event time only in ``source_timestamp``
+    would false-drop the entity even though the chunk channel kept the chunk.
+    When ``None`` the raw chunk is used directly (VectorCypher, whose chunks
+    carry ``occurred_at`` natively — the adapter would be identity there anyway).
 
     Fail-closed (ADR-001): on a fetch-page exception the accumulated set is taken
     as final — items with a hit in the pages fetched SO FAR survive, the rest are
@@ -141,6 +152,10 @@ async def filter_items_by_provenance[T: _HasProvenance](
             )
             break
 
-        surviving.update(cid for cid, ch in chunks_map.items() if predicate(ch))
+        surviving.update(
+            cid
+            for cid, ch in chunks_map.items()
+            if predicate(chunk_record_adapter(ch) if chunk_record_adapter is not None else ch)
+        )
 
     return [item for item in items if any(cid in surviving for cid in item.source_chunk_ids)]

--- a/tests/e2e/test_filter_report_invariant.py
+++ b/tests/e2e/test_filter_report_invariant.py
@@ -332,17 +332,17 @@ async def test_report_invariants_empty_chronicle(chronicle_kb, spec) -> None:
 # EMPTY entity surface and the surface-coverage rule stays inert — they remain
 # invariant-clean. These two cases are the opposite: they stage a real entity
 # corpus so the graph (VectorCypher) / entity (Chronicle) channel surfaces
-# entities the date filter never constrained. On a graph-path VectorCypher recall
-# and a HYBRID Chronicle recall the engine covers only the ``chunks`` surface, so
-# the non-empty uncovered entity surface forces every filter leaf into
-# ``unenforced_keys`` — the cross-engine ``unenforced_keys == []`` invariant is
-# genuinely violated until the #1457 / #1458 fix filters the entity surface.
+# entities the date filter never constrained. Before the #1457 / #1458 fix the
+# non-empty uncovered entity surface forced every filter leaf into
+# ``unenforced_keys``; the fix re-applies the "Chunk" predicate to each entity's
+# provenance (∃-over-provenance) and marks the entity surface covered, so the
+# report is CLEAN again.
 #
-# Marked ``xfail(strict=True)``: the body asserts the CLEAN invariant the fix
-# restores (so the fix flips it to xpass), and an anti-vacuity gate asserts the
-# recall actually surfaced entities first (so a no-entity path cannot pass the
-# ``unenforced_keys == []`` assertion for the wrong reason). Both self-skip on a
-# no-Docker run via the lane reachability marks, exactly like the row-set cases.
+# Each body asserts the CLEAN post-fix invariant (``unenforced_keys == []``)
+# directly, with an anti-vacuity gate that fails loud unless the recall actually
+# surfaced entities first (so a no-entity path cannot pass the assertion for the
+# wrong reason). Both self-skip on a no-Docker run via the lane reachability
+# marks, exactly like the row-set cases.
 # --------------------------------------------------------------------------- #
 
 _LEAK_MARKER = "leakmark"
@@ -409,26 +409,30 @@ async def test_report_invariant_graph_entity_bearing_date_filter_vc_full(vectorc
 @pytest.mark.skipif(
     not _harness.lane_reachable("chronicle"), reason="start Postgres (make dev) to exercise this live lane"
 )
-@pytest.mark.skip(
-    reason="#1458 chronicle entity-surface leak is not exercisable on this live e2e lane: the HYBRID "
-    "recall surfaces no entities here (entity vector search does not clear the entity surface for the "
-    "seeded corpus on the credential-degraded e2e lane), so the surface-coverage rule stays inert and "
-    "the leak cannot be reproduced. The #1458 leak is pinned hermetically by "
-    "tests/recall/test_chronicle_filter_composition.py::test_filter_report_entity_bearing_date_filter_is_clean, "
-    "which forces the entity surface via a mocked engine. Re-enable (as xfail) once the live lane surfaces entities."
-)
 async def test_report_invariant_entity_bearing_date_filter_chronicle(chronicle_kb) -> None:
     """A HYBRID Chronicle recall over an entity corpus + date filter reports clean.
 
-    Chronicle's entity channel is meant to surface a non-empty entity set the
-    chunk-side date filter does not cover, so the emitted report would force the
-    date leaf into ``unenforced_keys``. Skipped: on the live e2e lane the HYBRID
-    recall does not surface entities for the seeded corpus, so the anti-vacuity
-    gate cannot hold and the leak is not exercisable here (the #1458 leak is
-    pinned hermetically in tests/recall/). Chronicle has no GRAPH mode — the
-    entity channel runs in HYBRID.
+    Chronicle's entity channel surfaces a non-empty entity set the chunk-side date
+    filter does not cover, so before the #1458 fix the emitted report forced the
+    date leaf into ``unenforced_keys``. The fix re-applies the "Chunk" predicate to
+    each entity's provenance (∃-over-provenance) and marks the entity surface
+    covered, so the report is CLEAN (``unenforced_keys == []``). Chronicle has no
+    GRAPH mode — the entity channel runs in HYBRID.
+
+    The #1462 vacuity skip diagnosed the wrong cause (it blamed the entity-similarity
+    floor / a credential-degraded lane). The real reason the entity surface was empty
+    is that the single-token ``_LEAK_MARKER`` query routes SIMPLE through the query
+    complexity router, which sets ``run_entity=False`` and skips the entity channel
+    entirely in HYBRID. Disabling the router keeps all channels live (the product knob
+    for "run every channel", and exactly what the hermetic composition test does), so
+    the entity channel resolves the seeded entities and the coverage rule is exercised.
     """
     kb = chronicle_kb
+    # Keep every channel live: the single-token marker query would otherwise route
+    # SIMPLE and skip the entity channel (run_entity=False), leaving result.entities
+    # empty and the surface-coverage rule inert. Turning the router off is the
+    # documented "run all channels" knob (mirrors the hermetic composition test).
+    kb._engine._router_enabled = False
     namespace_id = (await kb.create_namespace()).namespace_id
     await _seed_leak_corpus(kb, namespace_id)
 

--- a/tests/e2e/test_filter_report_invariant.py
+++ b/tests/e2e/test_filter_report_invariant.py
@@ -41,6 +41,8 @@ while the conftest tripwire still enforces the live store per leg.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 
 from khora import Khora
@@ -348,11 +350,18 @@ async def test_report_invariants_empty_chronicle(chronicle_kb, spec) -> None:
 _LEAK_MARKER = "leakmark"
 _LEAK_ENTITIES = [("Falcon", "PERSON"), ("Orbit", "ORG")]
 _LEAK_RELATIONSHIPS = [("Falcon", "Orbit", "WORKS_ON")]
-# A date filter on a beyond-corpus horizon is the #1457 repro trigger: it is a
-# date-key predicate (drives the VectorCypher EXPLICIT graph path) that the
-# entity surface never gates. The seed corpus carries no occurred_at, so the
-# clean recall would keep the chunks via COALESCE fallback; the leaf is the one
-# forced unenforced by the uncovered entity surface.
+# The seed's event time, seeded via ``source_timestamp`` so every chunk carries a
+# real event-time anchor after the filter horizon below. VectorCypher chunks pick
+# up an event time from ingest either way; Chronicle chunks only carry one when
+# ``source_timestamp`` is supplied (its recall resolves ``occurred_at`` as
+# ``COALESCE(occurred_at, source_timestamp)``), so an anchor-less seed would make
+# the ``occurred_at`` filter empty every chunk AND drop every provenance entity.
+_LEAK_SOURCE_TIMESTAMP = datetime(2025, 6, 1, tzinfo=UTC)
+# A date filter whose horizon predates the seed's event time: a date-key predicate
+# (drives the VectorCypher EXPLICIT graph path) that the entity surface never
+# gates. The seed's ``source_timestamp`` clears it, so the clean recall keeps the
+# chunks; the leaf is the one forced unenforced by an uncovered entity surface
+# before the #1457 / #1458 provenance fix.
 _LEAK_DATE_FILTER: dict = {"occurred_at": {"$gte": "2020-01-01T00:00:00Z"}}
 
 
@@ -363,6 +372,7 @@ async def _seed_leak_corpus(kb: Khora, namespace_id) -> None:
         await kb.remember(
             content=content,
             namespace=namespace_id,
+            source_timestamp=_LEAK_SOURCE_TIMESTAMP,
             entity_types=[t for _, t in _LEAK_ENTITIES],
             relationship_types=[rt for _, _, rt in _LEAK_RELATIONSHIPS],
         )
@@ -419,13 +429,22 @@ async def test_report_invariant_entity_bearing_date_filter_chronicle(chronicle_k
     covered, so the report is CLEAN (``unenforced_keys == []``). Chronicle has no
     GRAPH mode — the entity channel runs in HYBRID.
 
-    The #1462 vacuity skip diagnosed the wrong cause (it blamed the entity-similarity
-    floor / a credential-degraded lane). The real reason the entity surface was empty
-    is that the single-token ``_LEAK_MARKER`` query routes SIMPLE through the query
-    complexity router, which sets ``run_entity=False`` and skips the entity channel
-    entirely in HYBRID. Disabling the router keeps all channels live (the product knob
-    for "run every channel", and exactly what the hermetic composition test does), so
-    the entity channel resolves the seeded entities and the coverage rule is exercised.
+    Two conditions must both hold for the entity surface to be non-empty here (so
+    the coverage rule is exercised, not vacuously inert):
+
+    1. The query-complexity router is disabled. The single-token ``_LEAK_MARKER``
+       query routes SIMPLE, which sets ``run_entity=False`` and skips the entity
+       channel entirely in HYBRID; turning the router off is the documented
+       "run all channels" knob (mirrors the hermetic composition test).
+    2. The seed carries an event time after the filter horizon. Chronicle chunks
+       land with ``occurred_at=NULL`` and take their event time from
+       ``source_timestamp`` (its recall resolves ``occurred_at`` as
+       ``COALESCE(occurred_at, source_timestamp)``). ``_seed_leak_corpus`` stamps
+       ``source_timestamp=_LEAK_SOURCE_TIMESTAMP`` (2025, past the 2020 horizon), so
+       the ∃-over-provenance pass keeps the entities instead of dropping them for a
+       missing event time. The pass evaluates each provenance chunk through the same
+       ``_chunk_to_record`` COALESCE view the chunk channel uses (#1458), so the
+       entity surface enforces ``occurred_at`` identically to the chunk surface.
     """
     kb = chronicle_kb
     # Keep every channel live: the single-token marker query would otherwise route

--- a/tests/recall/test_chronicle_filter_composition.py
+++ b/tests/recall/test_chronicle_filter_composition.py
@@ -689,25 +689,45 @@ async def test_filter_report_source_timestamp_under_not_is_post_filter_only() ->
 
 # ===========================================================================
 # Cross-engine gate: an entity-bearing Chronicle recall under a date filter
-# emits an uncovered ``entities`` surface, so the top-level report honestly
-# flags the filter unenforced (#1458).
+# used to emit an uncovered ``entities`` surface, so the top-level report
+# honestly flagged the filter unenforced. The #1458 fix re-applies the SAME
+# "Chunk" predicate to each entity's provenance (∃-over-provenance): an entity
+# survives iff ≥1 of its ``source_chunk_ids`` passes, and the entity surface is
+# then marked covered.
 #
 # The Chronicle engine feeds ``build_filter_report`` a single ``"chunks"``
-# channel with ``covered_surfaces={"chunks"}`` and ``surface_sizes["entities"] =
-# len(recall_entities)`` (engine.py). The entity channel gates only the chunk
-# surface, so when a HYBRID recall surfaces entities the date-keyed filter never
-# constrained, the surface-coverage rule forces every filter leaf into
-# ``unenforced_keys`` and clears ``pushed_down`` — the cross-engine
-# ``unenforced_keys == []`` invariant is genuinely violated until the #1458 fix
-# filters the entity surface. Marked ``xfail(strict=True)``: the assertion body
-# encodes the CLEAN report the fix restores, so the fix flips it to xpass.
+# channel with ``covered_surfaces = {"chunks"} | {"entities","relationships"}``
+# (the latter iff the ∃-over-provenance pass ran) and ``surface_sizes["entities"]
+# = len(recall_entities)`` (engine.py). With the pass covering the entity surface,
+# a HYBRID recall that surfaces filter-passing entities emits a CLEAN report
+# (``unenforced_keys == []``).
 # ===========================================================================
+
+
+def _prov_chunk(*, year: int, source: str | None = None) -> Chunk:
+    """A provenance chunk whose ``occurred_at`` sits in ``year`` (+ optional source).
+
+    ``occurred_at`` decides whether the chunk clears an ``occurred_at`` date bound;
+    ``source`` (via a ``DocumentSource`` projection) decides a ``source``-keyed
+    filter. Mirrors the sibling ``_prov_chunk`` in
+    ``tests/unit/engines/test_vectorcypher_provenance_filter.py``.
+    """
+    return Chunk(
+        id=uuid4(),
+        namespace_id=uuid4(),
+        document_id=uuid4(),
+        content=f"provenance chunk ({year})",
+        occurred_at=datetime(year, 6, 1, tzinfo=UTC),
+        source_document=(DocumentSource(id=uuid4(), source=source) if source is not None else None),
+    )
 
 
 def _engine_with_entity(
     chunk_results: list[tuple[Chunk, float]],
     entity: Any,
     entity_score: float,
+    *,
+    provenance_chunks: list[Chunk] | None = None,
 ) -> ChronicleEngine:
     """A connected ChronicleEngine whose entity channel resolves one Entity.
 
@@ -717,23 +737,21 @@ def _engine_with_entity(
     ``_router_enabled`` is turned OFF so the always-on ``run_entity`` gate is not
     routed away to SIMPLE (which would skip the entity channel) — the entity
     channel only runs in HYBRID/ALL mode, and this keeps that path live.
+
+    ``provenance_chunks`` feed the #1458 ∃-over-provenance ``get_chunks_batch``
+    seam: the entity survives the filter iff one of them passes the "Chunk"
+    predicate. Left empty by default (the entity then carries no provenance and
+    is dropped under a filter).
     """
     engine = _engine_with_semantic(chunk_results)
     engine._storage.search_similar_entities = AsyncMock(return_value=[(entity.id, entity_score)])
     engine._storage.get_entities_batch = AsyncMock(return_value={entity.id: entity})
-    engine._storage.get_chunks_batch = AsyncMock(return_value={})
+    engine._storage.get_chunks_batch = AsyncMock(return_value={c.id: c for c in (provenance_chunks or [])})
     engine._storage.get_entities_by_names_batch = AsyncMock(return_value={})
     engine._router_enabled = False
     return engine
 
 
-@pytest.mark.xfail(
-    strict=True,
-    raises=AssertionError,
-    reason="entity filter leak on the chronicle path (#1458): the recall surfaces an uncovered "
-    "entity surface the date filter never constrained, so the report honestly flags the filter "
-    "unenforced until the fix filters the entity surface",
-)
 @pytest.mark.asyncio
 async def test_filter_report_entity_bearing_date_filter_is_clean() -> None:
     from khora.core.models import Entity
@@ -743,6 +761,9 @@ async def test_filter_report_entity_bearing_date_filter_is_clean() -> None:
         source_timestamp=datetime(2026, 6, 1, tzinfo=UTC),
         created_at=datetime(2026, 6, 1, tzinfo=UTC),
     )
+    # The entity's sole provenance chunk clears the 2026 bound, so the
+    # ∃-over-provenance pass keeps it: the entity surface is enforced and covered.
+    prov = _prov_chunk(year=2026)
     entity = Entity(
         id=uuid4(),
         namespace_id=uuid4(),
@@ -752,9 +773,9 @@ async def test_filter_report_entity_bearing_date_filter_is_clean() -> None:
         attributes={},
         mention_count=1,
         source_document_ids=[],
-        source_chunk_ids=[],
+        source_chunk_ids=[prov.id],
     )
-    engine = _engine_with_entity([(in_scope, 0.9)], entity, 0.95)
+    engine = _engine_with_entity([(in_scope, 0.9)], entity, 0.95, provenance_chunks=[prov])
 
     result = await engine.recall(
         "Falcon",
@@ -766,12 +787,119 @@ async def test_filter_report_entity_bearing_date_filter_is_clean() -> None:
     report = result.engine_info["filter"]
     _validates(report)
 
-    # The recall genuinely surfaced entities (the leak precondition) — guards
-    # against a vacuous pass where the entity channel silently no-opped. pytest.fail
-    # (raises Failed, not AssertionError) so a no-op channel surfaces as a real
-    # failure rather than being masked as the expected AssertionError XFAIL.
+    # The recall genuinely surfaced entities (the enforcement precondition) —
+    # guards against a vacuous pass where the entity channel silently no-opped, or
+    # the ∃ filter dropped every entity so the CLEAN report is trivially clean.
+    # pytest.fail (raises Failed, not AssertionError) so a no-op surfaces as a real
+    # failure rather than being masked.
     if not result.entities:
         pytest.fail("entity channel produced no entities — the surface-coverage rule is inert")
-    # CLEAN report the #1458 fix restores: the date leaf is enforced against the
-    # (then-filtered) entity surface, so nothing is left unenforced.
+    # The #1458 fix: the date leaf is enforced against the (now-filtered) entity
+    # surface, so nothing is left unenforced.
+    assert report["unenforced_keys"] == []
+
+
+@pytest.mark.asyncio
+async def test_entity_filter_partial_match_narrows_by_provenance() -> None:
+    # #1458 partial match: two entities differing only in provenance source. A
+    # ``source``-keyed filter keeps ONLY the entity whose provenance carries the
+    # matching source; the other drops. Pins that the ∃ filter narrows to exactly
+    # the matching provenance, not merely "any surviving chunk".
+    from khora.core.models import Entity
+
+    in_scope = _chunk("alpha recent", source_timestamp=datetime(2026, 6, 1, tzinfo=UTC))
+    linear_chunk = _prov_chunk(year=2026, source="linear")
+    slack_chunk = _prov_chunk(year=2026, source="slack")
+    linear_entity = Entity(
+        id=uuid4(),
+        namespace_id=uuid4(),
+        name="LinearEvent",
+        entity_type="EVENT",
+        source_chunk_ids=[linear_chunk.id],
+    )
+    slack_entity = Entity(
+        id=uuid4(),
+        namespace_id=uuid4(),
+        name="SlackEvent",
+        entity_type="EVENT",
+        source_chunk_ids=[slack_chunk.id],
+    )
+    engine = _engine_with_semantic([(in_scope, 0.9)])
+    engine._storage.search_similar_entities = AsyncMock(return_value=[(linear_entity.id, 0.95), (slack_entity.id, 0.9)])
+    engine._storage.get_entities_batch = AsyncMock(
+        return_value={linear_entity.id: linear_entity, slack_entity.id: slack_entity}
+    )
+    engine._storage.get_chunks_batch = AsyncMock(
+        return_value={linear_chunk.id: linear_chunk, slack_chunk.id: slack_chunk}
+    )
+    engine._storage.get_entities_by_names_batch = AsyncMock(return_value={})
+    engine._router_enabled = False
+
+    result = await engine.recall(
+        "event",
+        uuid4(),
+        limit=10,
+        mode=SearchMode.HYBRID,
+        filter_ast=_filter_ast({"source": "linear"}),
+    )
+
+    # Exactly the linear-provenance entity survives; the slack one is dropped.
+    assert [e.name for e in result.entities] == ["LinearEvent"]
+    report = result.engine_info["filter"]
+    _validates(report)
+    assert report["unenforced_keys"] == []
+
+
+@pytest.mark.asyncio
+async def test_entity_filter_fail_closed_drops_entity_and_records_degradation() -> None:
+    # #1458 fail-closed (ADR-001): a ``get_chunks_batch`` raise means the entity's
+    # provenance cannot be verified, so it is DROPPED rather than returned unverified
+    # (which would re-introduce the leak). A structured Degradation
+    # (component="chronicle.entity_filter", reason="provenance_fetch_failed") rides
+    # engine_info["degradations"]. Because every RETURNED entity is verified (here:
+    # none), the report stays clean.
+    from khora.core.models import Entity
+
+    in_scope = _chunk("alpha recent", source_timestamp=datetime(2026, 6, 1, tzinfo=UTC))
+    prov = _prov_chunk(year=2026)
+    entity = Entity(
+        id=uuid4(),
+        namespace_id=uuid4(),
+        name="Unverifiable",
+        entity_type="EVENT",
+        source_chunk_ids=[prov.id],
+    )
+    engine = _engine_with_semantic([(in_scope, 0.9)])
+    engine._storage.search_similar_entities = AsyncMock(return_value=[(entity.id, 0.95)])
+    engine._storage.get_entities_batch = AsyncMock(return_value={entity.id: entity})
+    engine._storage.get_chunks_batch = AsyncMock(side_effect=RuntimeError("provenance store down"))
+    engine._storage.get_entities_by_names_batch = AsyncMock(return_value={})
+    engine._router_enabled = False
+
+    result = await engine.recall(
+        "event",
+        uuid4(),
+        limit=10,
+        mode=SearchMode.HYBRID,
+        filter_ast=_filter_ast({"occurred_at": {"$gte": "2026-01-01T00:00:00Z"}}),
+    )
+
+    # Fail-closed: the unverified entity is DROPPED, not returned.
+    assert result.entities == [], "an unverified entity leaked into the result on the degraded path"
+
+    # A structured Degradation names the chronicle entity-filter component + reason.
+    degradations = result.engine_info.get("degradations", [])
+    provenance_degs = [
+        d
+        for d in degradations
+        if d.get("component") == "chronicle.entity_filter" and d.get("reason") == "provenance_fetch_failed"
+    ]
+    assert provenance_degs, (
+        f"expected a chronicle.entity_filter / provenance_fetch_failed Degradation, "
+        f"got: {[(d.get('component'), d.get('reason')) for d in degradations]}"
+    )
+
+    # Every returned entity is verified (here: none), so the report stays clean.
+    report = result.engine_info["filter"]
+    _validates(report)
     assert report["unenforced_keys"] == []

--- a/tests/unit/engines/test_vectorcypher_provenance_filter.py
+++ b/tests/unit/engines/test_vectorcypher_provenance_filter.py
@@ -533,3 +533,112 @@ class TestMultiPageFailClosedKeepsDecidedItems:
         assert [(d.get("component"), d.get("reason")) for d in degradations] == [
             ("vectorcypher.entity_filter", "provenance_fetch_failed")
         ]
+
+
+# ---------------------------------------------------------------------------
+# chunk_record_adapter: the entity surface enforces the filter with the SAME
+# field semantics its chunk channel uses. Chronicle's chunks carry their event
+# time only in ``source_timestamp`` (raw ``occurred_at`` is NULL), so its
+# ``_chunk_to_record`` COALESCE adapter is what lets an ``occurred_at`` predicate
+# the chunk channel satisfied keep the provenance entity (GitHub #1458).
+# ---------------------------------------------------------------------------
+
+
+class TestChunkRecordAdapterCoalescesOccurredAt:
+    """The real chronicle ``_chunk_to_record`` adapter aligns entity + chunk enforcement.
+
+    Drives ``filter_items_by_provenance`` with chronicle's ACTUAL
+    ``_chunk_to_record`` (not a stand-in) so the entity surface enforces
+    ``occurred_at`` with the SAME ``COALESCE(occurred_at, source_timestamp)``
+    semantics chronicle's chunk post-filter uses. Both directions have teeth:
+    a source_timestamp-only chunk that CLEARS the horizon keeps its entity; a
+    chunk whose event time (via either field) FAILS the horizon drops it.
+    """
+
+    async def test_source_timestamp_only_chunk_needs_adapter_to_survive(self) -> None:
+        """A source_timestamp-only chunk drops under the raw predicate, survives via the adapter.
+
+        This is the chronicle shape: ``chunk.occurred_at`` is NULL and the real
+        event time lives in ``source_timestamp``. Without an adapter the raw chunk's
+        ``occurred_at`` resolves to ``None`` -> the ``$gte`` predicate fails ->
+        the entity false-drops even though the chunk channel (which reads via
+        ``_chunk_to_record``) kept the chunk. The real ``_chunk_to_record`` adapter
+        closes that gap.
+        """
+        from khora.engines.chronicle.engine import _chunk_to_record
+        from khora.filter.provenance import filter_items_by_provenance
+
+        ns_id = uuid4()
+        # A chunk carrying its event time ONLY in source_timestamp (occurred_at NULL).
+        chunk = Chunk(
+            id=uuid4(),
+            namespace_id=ns_id,
+            document_id=uuid4(),
+            content="source_timestamp-only provenance chunk",
+            occurred_at=None,
+            source_timestamp=datetime(2027, 6, 1, tzinfo=UTC),
+        )
+        item = _ProvItem([chunk.id])
+
+        storage = AsyncMock()
+        storage.get_chunks_batch = AsyncMock(return_value={chunk.id: chunk})
+
+        # Without an adapter: raw occurred_at is None -> the entity is dropped.
+        dropped = await filter_items_by_provenance(
+            [item],
+            _ast(_DATE_FILTER),
+            namespace_id=ns_id,
+            storage=storage,
+            component="chronicle.entity_filter",
+            degradations=[],
+        )
+        assert dropped == [], "raw occurred_at=None should fail the $gte predicate without a COALESCE adapter"
+
+        # With chronicle's real _chunk_to_record adapter: the entity survives, because
+        # the record's occurred_at is COALESCE(None, source_timestamp) = 2027 >= 2027.
+        kept = await filter_items_by_provenance(
+            [item],
+            _ast(_DATE_FILTER),
+            namespace_id=ns_id,
+            storage=storage,
+            component="chronicle.entity_filter",
+            degradations=[],
+            chunk_record_adapter=_chunk_to_record,
+        )
+        assert kept == [item], "the COALESCE adapter should let the source_timestamp event time satisfy the filter"
+
+    async def test_chunk_failing_both_fields_is_dropped_even_with_adapter(self) -> None:
+        """A chunk whose event time fails the horizon (via either field) drops WITH the adapter.
+
+        The adapter is not a blanket "keep everything": it only changes WHICH field
+        supplies the event time, not whether the predicate is enforced. A chunk whose
+        source_timestamp (COALESCE'd into occurred_at) is 2026 does NOT clear the 2027
+        horizon, so its entity is correctly dropped — the enforcement still has teeth.
+        """
+        from khora.engines.chronicle.engine import _chunk_to_record
+        from khora.filter.provenance import filter_items_by_provenance
+
+        ns_id = uuid4()
+        stale = Chunk(
+            id=uuid4(),
+            namespace_id=ns_id,
+            document_id=uuid4(),
+            content="pre-horizon provenance chunk",
+            occurred_at=None,
+            source_timestamp=datetime(2026, 6, 1, tzinfo=UTC),
+        )
+        item = _ProvItem([stale.id])
+
+        storage = AsyncMock()
+        storage.get_chunks_batch = AsyncMock(return_value={stale.id: stale})
+
+        kept = await filter_items_by_provenance(
+            [item],
+            _ast(_DATE_FILTER),
+            namespace_id=ns_id,
+            storage=storage,
+            component="chronicle.entity_filter",
+            degradations=[],
+            chunk_record_adapter=_chunk_to_record,
+        )
+        assert kept == [], "a 2026 event time must not clear the 2027 horizon even through the COALESCE adapter"

--- a/tests/unit/filter/test_recall_conformance_oracle.py
+++ b/tests/unit/filter/test_recall_conformance_oracle.py
@@ -1,4 +1,4 @@
-"""Recall-result conformance oracle over filtered VectorCypher recalls — ``@internal``.
+"""Recall-result conformance oracle over filtered recalls — ``@internal``.
 
 The compile-side conformance harness (:mod:`tests.unit.filter.test_conformance_catalog`
 + :mod:`~tests.unit.filter.test_conformance_harness`) checks that each backend's
@@ -7,20 +7,27 @@ the complementary, OUTPUT-side invariant: a real filtered recall's returned
 surfaces conform to the SAME compiled predicate, WITHOUT knowing how the engine
 produced them.
 
-For every filtered corpus case it drives a VectorCypher recall (engine-level, no
-live DB — reusing the report suite's fully-wired retriever + the #1457 provenance
-wiring) and calls the implementation-blind oracle
+For every filtered corpus case it drives a real recall (engine-level, no live DB)
+and calls the implementation-blind oracle
 :func:`khora.filter.conformance.assert_recall_conformance`:
 
   1. every RETURNED chunk passes the compiled ``"Chunk"`` predicate, and
   2. every RETURNED entity has ≥1 provenance chunk that passes (the ∃-over-
-     provenance rule #1457 enforces on the graph-derived entity surface).
+     provenance rule #1457 / #1458 enforce on the entity surface).
+
+Both multi-surface engines are exercised on the SAME corpus:
+
+* the **VectorCypher** leg reuses the report suite's fully-wired retriever + the
+  #1457 provenance wiring (``TestRecallConformanceOracleVectorCypher``), and
+* the **Chronicle** leg drives ``ChronicleEngine.recall`` with the #1458
+  ∃-over-provenance entity filter live (``TestRecallConformanceOracleChronicle``).
 
 The oracle is fed the SEEDED ``Chunk`` objects the returned ids point back to (the
 ``RecallChunk`` / ``RecallEntity`` projections drop the metadata / document-key
 fields a filter can address), so the predicate sees the full filterable surface —
 the "implementation-blind" contract: seed known chunks, recall, verify the
-invariant over what came back.
+invariant over what came back. The oracle asserts the INVARIANT, never the
+mechanism, so the SAME check runs unchanged against either engine's output.
 
 A falsifiability test proves the oracle has teeth (it must REJECT a recall that
 surfaces a chunk / entity the predicate excludes), mirroring the compile harness's
@@ -36,9 +43,12 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from khora.config import KhoraConfig
+from khora.config.schema import QuerySettings
 from khora.core.models import Chunk
 from khora.core.models.document import DocumentSource
 from khora.core.models.entity import Entity
+from khora.engines.chronicle.engine import ChronicleEngine
 from khora.filter import parse_to_ast
 from khora.filter.ast import FilterNode
 from khora.filter.conformance import assert_recall_conformance
@@ -136,10 +146,89 @@ async def _recall_surfaces(
     return returned_chunks, entity_provenance
 
 
+async def _recall_surfaces_chronicle(
+    filter_spec: dict[str, Any],
+    *,
+    ns_id: UUID,
+    passing_entity_chunk: Chunk,
+    failing_entity_chunk: Chunk,
+    chunk_registry: dict[UUID, Chunk],
+) -> tuple[list[Chunk], list[list[Chunk]]]:
+    """Drive a filtered Chronicle recall and map the returned surfaces back to seed chunks.
+
+    The Chronicle counterpart of :func:`_recall_surfaces`. Wires the semantic
+    channel to return the passing chunk (the chunk surface the filter narrows) and
+    the entity channel to resolve one entity whose provenance is
+    ``passing_entity_chunk`` and one whose provenance is ``failing_entity_chunk``;
+    the #1458 ∃-over-provenance pass drops the decoy so exactly the passing entity
+    survives. Runs a HYBRID recall with the router disabled (a single-token query
+    would otherwise route SIMPLE and skip the entity channel), then maps the
+    returned ``RecallChunk`` / ``RecallEntity`` ids back to the seeded ``Chunk``
+    objects via ``chunk_registry`` — the exact inputs
+    :func:`assert_recall_conformance` consumes.
+    """
+    engine = ChronicleEngine(KhoraConfig(query=QuerySettings(enable_reranking=False)))
+
+    passing_entity = Entity(
+        id=uuid4(),
+        namespace_id=ns_id,
+        name="Passing",
+        entity_type="EVENT",
+        source_chunk_ids=[passing_entity_chunk.id],
+    )
+    failing_entity = Entity(
+        id=uuid4(),
+        namespace_id=ns_id,
+        name="Failing",
+        entity_type="EVENT",
+        source_chunk_ids=[failing_entity_chunk.id],
+    )
+
+    storage = AsyncMock()
+    # Semantic channel returns the passing chunk; bm25 returns nothing so the
+    # chunk surface is the semantic result narrowed by the post-filter alone.
+    storage.search_similar_chunks = AsyncMock(return_value=[(passing_entity_chunk, 0.9)])
+    storage.search_fulltext_chunks = AsyncMock(return_value=[])
+    # Entity channel: both entities surface; ∃-over-provenance drops the decoy.
+    storage.search_similar_entities = AsyncMock(return_value=[(passing_entity.id, 0.95), (failing_entity.id, 0.9)])
+    storage.get_entities_batch = AsyncMock(
+        return_value={passing_entity.id: passing_entity, failing_entity.id: failing_entity}
+    )
+    storage.get_chunks_batch = AsyncMock(return_value=dict(chunk_registry))
+    storage.get_entities_by_names_batch = AsyncMock(return_value={})
+    # Doc-key hydration falls back to each chunk's source_document (a source filter
+    # resolves off there); an empty projection map keeps that fallback path clean.
+    storage.get_document_projections_batch = AsyncMock(return_value={})
+    engine._storage = storage
+
+    embedder = AsyncMock()
+    embedder.embed = AsyncMock(return_value=[0.1] * 1536)
+    engine._embedder = embedder
+    engine._connected = True
+    # Keep every channel live: the entity channel runs only in HYBRID/ALL and is
+    # gated off when the router classifies the query SIMPLE (mirrors the composition
+    # test's ``_engine_with_entity``).
+    engine._router_enabled = False
+
+    result = await engine.recall(
+        "alpha bravo charlie",
+        ns_id,
+        limit=10,
+        mode=SearchMode.HYBRID,
+        filter_ast=_ast(filter_spec),
+    )
+
+    returned_chunks = [chunk_registry[c.id] for c in result.chunks if c.id in chunk_registry]
+    entity_provenance = [
+        [chunk_registry[cid] for cid in ent.source_chunk_ids if cid in chunk_registry] for ent in result.entities
+    ]
+    return returned_chunks, entity_provenance
+
+
 # The filtered corpus: each case is a filter whose passing/failing chunk fields the
 # oracle re-checks over the recall's surfaces. Every case surfaces exactly one
 # entity (its provenance passes) and drops a decoy entity (its provenance fails),
-# so the ∃-over-provenance leg is exercised, not vacuous.
+# so the ∃-over-provenance leg is exercised, not vacuous. Both engine legs share it.
 _CASES = ("date_gte_2027", "source_linear", "metadata_tier_gold")
 
 
@@ -166,18 +255,18 @@ def _seed_for_case(case: str, ns_id: UUID) -> tuple[dict[str, Any], Chunk, Chunk
     raise AssertionError(f"unknown case {case!r}")
 
 
-class TestRecallConformanceOracle:
-    """Every filtered corpus case: the recall's surfaces conform to the predicate."""
+class TestRecallConformanceOracleVectorCypher:
+    """Every filtered corpus case: the VectorCypher recall's surfaces conform to the predicate."""
 
     @pytest.mark.parametrize("case", _CASES)
     async def test_recall_surfaces_conform(self, case: str) -> None:
         """The returned chunks + entity provenance pass the compiled recall predicate.
 
-        Drives a real filtered recall, then asserts the implementation-blind oracle:
-        every returned chunk passes the ``"Chunk"`` predicate AND every returned
-        entity has ≥1 provenance chunk that passes. The decoy entity (failing
-        provenance) is dropped, so exactly the passing entity survives — the ∃ leg
-        is genuinely exercised.
+        Drives a real filtered VectorCypher recall, then asserts the
+        implementation-blind oracle: every returned chunk passes the ``"Chunk"``
+        predicate AND every returned entity has ≥1 provenance chunk that passes. The
+        decoy entity (failing provenance) is dropped, so exactly the passing entity
+        survives — the ∃ leg is genuinely exercised.
         """
         ns_id = uuid4()
         filter_spec, passing_chunk, failing_chunk = _seed_for_case(case, ns_id)
@@ -191,6 +280,57 @@ class TestRecallConformanceOracle:
             chunk_registry=registry,
         )
 
+        # Precondition: the ∃ leg is not vacuous — exactly the passing entity
+        # survived (the decoy with failing provenance was dropped).
+        assert len(entity_provenance) == 1, (
+            f"expected exactly the passing entity to survive, got {len(entity_provenance)} entities"
+        )
+        assert entity_provenance[0], "the surviving entity carried no provenance — the ∃ leg is vacuous"
+
+        # The implementation-blind oracle: chunk surface + ∃-over-provenance.
+        assert_recall_conformance(
+            _ast(filter_spec),
+            returned_chunks=returned_chunks,
+            entity_provenance=entity_provenance,
+        )
+
+
+class TestRecallConformanceOracleChronicle:
+    """Every filtered corpus case: the Chronicle recall's surfaces conform to the predicate.
+
+    The Chronicle mirror of :class:`TestRecallConformanceOracleVectorCypher`,
+    running the SAME implementation-blind oracle over the SAME corpus against the
+    #1458 ∃-over-provenance entity filter. Chronicle returns ``relationships=[]``
+    and covers its ``chunks`` surface unconditionally; the entity surface is covered
+    (and its provenance filtered) only when a filter is present, which every case
+    here supplies — so the ∃ leg is live, not inert.
+    """
+
+    @pytest.mark.parametrize("case", _CASES)
+    async def test_recall_surfaces_conform(self, case: str) -> None:
+        """The returned chunks + entity provenance pass the compiled recall predicate.
+
+        Drives a real filtered Chronicle recall, then asserts the same
+        implementation-blind oracle as the VectorCypher leg: every returned chunk
+        passes the ``"Chunk"`` predicate AND every returned entity has ≥1 provenance
+        chunk that passes. The decoy entity (failing provenance) is dropped by the
+        #1458 pass, so exactly the passing entity survives — the ∃ leg is exercised.
+        """
+        ns_id = uuid4()
+        filter_spec, passing_chunk, failing_chunk = _seed_for_case(case, ns_id)
+        registry = {passing_chunk.id: passing_chunk, failing_chunk.id: failing_chunk}
+
+        returned_chunks, entity_provenance = await _recall_surfaces_chronicle(
+            filter_spec,
+            ns_id=ns_id,
+            passing_entity_chunk=passing_chunk,
+            failing_entity_chunk=failing_chunk,
+            chunk_registry=registry,
+        )
+
+        # Precondition: the chunk surface is non-empty (the semantic channel's
+        # passing chunk survived the post-filter) so the chunk-surface leg is live.
+        assert returned_chunks, "no chunk survived the Chronicle post-filter — the chunk-surface leg is vacuous"
         # Precondition: the ∃ leg is not vacuous — exactly the passing entity
         # survived (the decoy with failing provenance was dropped).
         assert len(entity_provenance) == 1, (


### PR DESCRIPTION
## Summary

Under a caller `filter_ast`, Chronicle's entity channel (`search_similar_entities`) was assembled from vector similarity the chunk post-filter never touched, so a filter that narrowed chunks could still leak entities it never constrained (the entity surface was reported uncovered, forcing every filter leaf into `unenforced_keys`). This re-applies the same `Chunk` predicate to each entity's provenance chunks (∃-over-provenance), reusing the engine-agnostic `filter_items_by_provenance` helper — mirroring the VectorCypher graph-path fix.

- An entity survives iff ≥1 of its `source_chunk_ids` passes the compiled filter predicate.
- Only runs under a filter with leaves and a non-empty entity set; unfiltered recalls take the zero-cost path (no extra fetch).
- Fail-closed: a provenance-fetch failure drops unverified entities and records one structured degradation (`component="chronicle.entity_filter"`) — every returned entity stays verified.
- The entity/relationship surfaces are marked covered in the honest filter report when the pass runs, so entity-bearing filtered recalls report `unenforced_keys == []`.

Fixes #1458

## Test plan

- [x] Unit — `tests/recall/test_chronicle_filter_composition.py`: flipped the previously-xfailed clean-report pin to green; added partial-match and fail-closed (degradation) cases.
- [x] Conformance oracle — `tests/unit/filter/test_recall_conformance_oracle.py`: added an implementation-blind Chronicle leg asserting the compiled predicate over returned chunks and ∃-over-provenance over returned entities.
- [x] E2E — `tests/e2e/test_filter_report_invariant.py`: re-enabled the entity-bearing chronicle report-invariant pin (previously skipped as vacuous); the entity channel now resolves real entities so the coverage rule is exercised.
- [x] Telemetry contract drift gate updated for the new `chronicle.entity_filter` component label.
- [x] CI: full conformance + e2e engine matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recall filtering to enforce entity constraints against provenance using an “∃ over provenance” strategy for date and source filters, while preserving original entity scores.
  * Entities are now omitted when provenance doesn’t satisfy the filter; filter reporting only marks entity constraints as enforced when the provenance pass actually ran.
  * If provenance fetching fails, the system fails closed by dropping affected entities and recording structured degradations.
* **Monitoring**
  * Updated telemetry contract for `khora.filter.provenance.degraded_total` to allow `chronicle.entity_filter` as a component value.
* **Tests**
  * Expanded/updated recall conformance and filter-report invariant coverage for Chronicle and HYBRID entity channels, including new provenance match and fail-closed scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->