### PR TITLE
Round-trip chunker_info through the weaviate and turbopuffer temporal stores

### DIFF
--- a/src/khora/storage/temporal/turbopuffer.py
+++ b/src/khora/storage/temporal/turbopuffer.py
@@ -580,7 +580,9 @@ def _row_to_chunk(row: Any, namespace_id: UUID) -> TemporalChunk:
     chunker_info_json = _row_get(row, "chunker_info_json")
     if chunker_info_json:
         try:
-            chunker_info = json.loads(chunker_info_json)
+            decoded = json.loads(chunker_info_json)
+            if isinstance(decoded, dict):
+                chunker_info = decoded
         except (json.JSONDecodeError, TypeError):
             pass
 

--- a/src/khora/storage/temporal/turbopuffer.py
+++ b/src/khora/storage/temporal/turbopuffer.py
@@ -533,6 +533,7 @@ _INCLUDE_ATTRS = [
     "tags",
     "confidence",
     "metadata_json",
+    "chunker_info_json",
 ]
 
 
@@ -554,6 +555,7 @@ def _chunk_to_row(chunk: TemporalChunk) -> dict[str, Any]:
         "tags": list(chunk.tags or []),
         "confidence": float(chunk.confidence) if chunk.confidence is not None else 1.0,
         "metadata_json": json.dumps(chunk.metadata or {}),
+        "chunker_info_json": json.dumps(chunk.chunker_info or {}),
     }
 
 
@@ -571,6 +573,14 @@ def _row_to_chunk(row: Any, namespace_id: UUID) -> TemporalChunk:
     if metadata_json:
         try:
             metadata = json.loads(metadata_json)
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    chunker_info: dict[str, Any] = {}
+    chunker_info_json = _row_get(row, "chunker_info_json")
+    if chunker_info_json:
+        try:
+            chunker_info = json.loads(chunker_info_json)
         except (json.JSONDecodeError, TypeError):
             pass
 
@@ -592,6 +602,7 @@ def _row_to_chunk(row: Any, namespace_id: UUID) -> TemporalChunk:
         tags=list(_row_get(row, "tags") or []),
         confidence=float(_row_get(row, "confidence", 1.0) or 1.0),
         metadata=metadata,
+        chunker_info=chunker_info,
     )
 
 

--- a/src/khora/storage/temporal/weaviate.py
+++ b/src/khora/storage/temporal/weaviate.py
@@ -681,7 +681,9 @@ class WeaviateTemporalStore(TemporalVectorStore):
         chunker_info: dict[str, Any] = {}
         if props.get("chunker_info_json"):
             try:
-                chunker_info = json.loads(props["chunker_info_json"])
+                decoded = json.loads(props["chunker_info_json"])
+                if isinstance(decoded, dict):
+                    chunker_info = decoded
             except (json.JSONDecodeError, TypeError):
                 pass
 

--- a/src/khora/storage/temporal/weaviate.py
+++ b/src/khora/storage/temporal/weaviate.py
@@ -279,6 +279,7 @@ class WeaviateTemporalStore(TemporalVectorStore):
                     Property(name="tags", data_type=DataType.TEXT_ARRAY),
                     Property(name="confidence", data_type=DataType.NUMBER),
                     Property(name="metadata_json", data_type=DataType.TEXT),  # JSON string
+                    Property(name="chunker_info_json", data_type=DataType.TEXT),  # JSON string
                     *_denorm_properties(),
                 ],
                 multi_tenancy_config=Configure.multi_tenancy(enabled=True),
@@ -292,6 +293,8 @@ class WeaviateTemporalStore(TemporalVectorStore):
             for prop in _denorm_properties():
                 if prop.name not in existing:
                     await collection.config.add_property(prop)
+            if "chunker_info_json" not in existing:
+                await collection.config.add_property(Property(name="chunker_info_json", data_type=DataType.TEXT))
 
         self._connected = True
         logger.info(
@@ -675,6 +678,13 @@ class WeaviateTemporalStore(TemporalVectorStore):
             except (json.JSONDecodeError, TypeError):
                 pass
 
+        chunker_info: dict[str, Any] = {}
+        if props.get("chunker_info_json"):
+            try:
+                chunker_info = json.loads(props["chunker_info_json"])
+            except (json.JSONDecodeError, TypeError):
+                pass
+
         return TemporalChunk(
             id=UUID(str(obj.uuid)),
             namespace_id=namespace_id,
@@ -689,6 +699,7 @@ class WeaviateTemporalStore(TemporalVectorStore):
             tags=props.get("tags") or [],
             confidence=props.get("confidence", 1.0),
             metadata=metadata,
+            chunker_info=chunker_info,
             source_type=props.get("source_type"),
             source_name=props.get("source_name"),
             source_url=props.get("source_url"),
@@ -895,6 +906,7 @@ def _chunk_to_properties(chunk: TemporalChunk) -> dict[str, Any]:
         "tags": chunk.tags or [],
         "confidence": chunk.confidence,
         "metadata_json": json.dumps(chunk.metadata or {}),
+        "chunker_info_json": json.dumps(chunk.chunker_info or {}),
         "source_type": chunk.source_type,
         "source_name": chunk.source_name,
         "source_url": chunk.source_url,

--- a/tests/integration/test_weaviate_async_integration.py
+++ b/tests/integration/test_weaviate_async_integration.py
@@ -83,6 +83,7 @@ async def test_create_get_delete_roundtrip(store: WeaviateTemporalStore) -> None
         source_system="test",
         author="Alice",
         tags=["release"],
+        chunker_info={"chunker": "semantic"},
     )
 
     out = await store.create_chunk(chunk)
@@ -92,6 +93,7 @@ async def test_create_get_delete_roundtrip(store: WeaviateTemporalStore) -> None
     assert fetched is not None
     assert fetched.content == chunk.content
     assert fetched.author == "Alice"
+    assert fetched.chunker_info == {"chunker": "semantic"}
 
     deleted = await store.delete_chunk(chunk_id, namespace_id)
     assert deleted is True

--- a/tests/unit/engines/skeleton/backends/test_turbopuffer.py
+++ b/tests/unit/engines/skeleton/backends/test_turbopuffer.py
@@ -228,6 +228,19 @@ class TestChunkRowRoundtrip:
         }
         assert _row_to_chunk(row, ns_id).chunker_info == {}
 
+    @pytest.mark.parametrize("payload", ["null", "[1, 2]", '"a string"', "42", "true"])
+    def test_row_non_dict_chunker_info_json_degrades_to_empty_dict(self, payload: str) -> None:
+        """Valid-but-non-dict JSON (null/list/scalar) degrades to {} rather than leaking a non-dict."""
+        ns_id = uuid4()
+        row = {
+            "id": str(uuid4()),
+            "document_id": str(uuid4()),
+            "content": "body",
+            "vector": [0.2] * 4,
+            "chunker_info_json": payload,
+        }
+        assert _row_to_chunk(row, ns_id).chunker_info == {}
+
     def test_include_attrs_requests_chunker_info(self) -> None:
         """Read paths must fetch chunker_info_json or it hydrates to {} forever."""
         assert "chunker_info_json" in _INCLUDE_ATTRS

--- a/tests/unit/engines/skeleton/backends/test_turbopuffer.py
+++ b/tests/unit/engines/skeleton/backends/test_turbopuffer.py
@@ -27,6 +27,7 @@ from khora.filter import (
 )
 from khora.storage.temporal import TemporalChunk, TemporalFilter
 from khora.storage.temporal.turbopuffer import (
+    _INCLUDE_ATTRS,
     TurbopufferBackendConfig,
     TurbopufferTemporalStore,
     _build_turbopuffer_filter,
@@ -173,6 +174,63 @@ class TestChunkRowRoundtrip:
         assert chunk.confidence == 1.0  # default fallback
         assert chunk.tags == []
         assert chunk.metadata == {}
+
+    def test_chunker_info_survives_row_round_trip(self) -> None:
+        """chunker_info must round-trip through _chunk_to_row -> _row_to_chunk."""
+        ns_id = uuid4()
+        chunk = TemporalChunk(
+            id=uuid4(),
+            namespace_id=ns_id,
+            document_id=uuid4(),
+            content="body",
+            embedding=[0.1] * 4,
+            chunker_info={"chunker": "semantic"},
+        )
+        row = _chunk_to_row(chunk)
+        assert row["chunker_info_json"] == '{"chunker": "semantic"}'
+
+        restored = _row_to_chunk(row, ns_id)
+        assert restored.chunker_info == {"chunker": "semantic"}
+
+    def test_chunk_to_row_empty_chunker_info_defaults_to_object(self) -> None:
+        """A chunk with no chunker_info serializes to an empty JSON object."""
+        chunk = TemporalChunk(
+            id=uuid4(),
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="body",
+            embedding=[0.1] * 4,
+        )
+        row = _chunk_to_row(chunk)
+        assert row["chunker_info_json"] == "{}"
+        assert _row_to_chunk(row, chunk.namespace_id).chunker_info == {}
+
+    def test_row_missing_chunker_info_hydrates_to_empty_dict(self) -> None:
+        """A row lacking chunker_info_json (older schema) hydrates to {}."""
+        ns_id = uuid4()
+        row = {
+            "id": str(uuid4()),
+            "document_id": str(uuid4()),
+            "content": "body",
+            "vector": [0.2] * 4,
+        }
+        assert _row_to_chunk(row, ns_id).chunker_info == {}
+
+    def test_row_malformed_chunker_info_json_degrades_to_empty_dict(self) -> None:
+        """Invalid chunker_info_json degrades to {} rather than raising."""
+        ns_id = uuid4()
+        row = {
+            "id": str(uuid4()),
+            "document_id": str(uuid4()),
+            "content": "body",
+            "vector": [0.2] * 4,
+            "chunker_info_json": "{not valid json",
+        }
+        assert _row_to_chunk(row, ns_id).chunker_info == {}
+
+    def test_include_attrs_requests_chunker_info(self) -> None:
+        """Read paths must fetch chunker_info_json or it hydrates to {} forever."""
+        assert "chunker_info_json" in _INCLUDE_ATTRS
 
 
 @pytest.mark.unit
@@ -499,6 +557,37 @@ class TestCRUD:
         # The ns_handle.query default returns rows=[] - so get_chunk -> None.
         chunk = await store.get_chunk(uuid4(), uuid4())
         assert chunk is None
+
+    @pytest.mark.asyncio
+    async def test_create_then_get_chunk_preserves_chunker_info(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """chunker_info survives the full store write -> read path."""
+        _tp, client = _install_fake_turbopuffer(monkeypatch)
+        store = _build_store("k")
+        await store.connect()
+
+        ns_id = uuid4()
+        chunk = TemporalChunk(
+            id=uuid4(),
+            namespace_id=ns_id,
+            document_id=uuid4(),
+            content="x",
+            embedding=[0.1] * 4,
+            chunker_info={"chunker": "semantic"},
+        )
+        await store.create_chunk(chunk)
+
+        # The written row carries the serialized chunker_info.
+        written = client.namespaces.write.call_args.kwargs["upsert_rows"][0]
+        assert written["chunker_info_json"] == '{"chunker": "semantic"}'
+
+        # Reading that row back hydrates chunker_info via get_chunk's query path.
+        ns_handle = MagicMock()
+        ns_handle.query = AsyncMock(return_value=SimpleNamespace(rows=[written]))
+        client.namespace = MagicMock(return_value=ns_handle)
+
+        fetched = await store.get_chunk(chunk.id, ns_id)
+        assert fetched is not None
+        assert fetched.chunker_info == {"chunker": "semantic"}
 
 
 @pytest.mark.unit

--- a/tests/unit/engines/skeleton/backends/test_weaviate_async.py
+++ b/tests/unit/engines/skeleton/backends/test_weaviate_async.py
@@ -178,7 +178,7 @@ def _reconcile_noop_collection() -> MagicMock:
     no-op — what every connect-path test that doesn't exercise reconcile expects.
     """
     collection = MagicMock(name="CollectionAsync")
-    full = [*_BASE_PROPERTY_NAMES, *_DENORM_TEXT_KEYS, "source_timestamp"]
+    full = [*_BASE_PROPERTY_NAMES, *_DENORM_TEXT_KEYS, "source_timestamp", "chunker_info_json"]
     collection.config.get = AsyncMock(return_value=SimpleNamespace(properties=[SimpleNamespace(name=n) for n in full]))
     collection.config.add_property = AsyncMock()
     return collection
@@ -917,6 +917,7 @@ class TestDenormFieldsReconciliation:
         client.collections.exists = AsyncMock(return_value=True)
 
         # The OLD property set (no denorm props): only the pre-denorm columns.
+        # chunker_info_json is present so this test stays scoped to denorm reconcile.
         old_props = [
             SimpleNamespace(name=name)
             for name in (
@@ -931,6 +932,7 @@ class TestDenormFieldsReconciliation:
                 "tags",
                 "confidence",
                 "metadata_json",
+                "chunker_info_json",
             )
         ]
         collection = MagicMock(name="CollectionAsync")
@@ -973,6 +975,7 @@ class TestDenormFieldsReconciliation:
             "tags",
             "confidence",
             "metadata_json",
+            "chunker_info_json",
             *(p.name for p in _denorm_properties()),
         ]
         full_props = [SimpleNamespace(name=name) for name in existing_names]
@@ -985,6 +988,31 @@ class TestDenormFieldsReconciliation:
         await store.connect()
 
         collection.config.add_property.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_connect_adds_missing_chunker_info_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A pre-existing collection whose schema predates chunker_info_json gets the
+        # TEXT property added on connect (add-on-connect, not a collection recreate).
+        _weaviate, client = _install_fake_weaviate(monkeypatch)
+        client.collections.exists = AsyncMock(return_value=True)
+
+        # Full reconciled schema EXCEPT chunker_info_json.
+        existing_names = [
+            *_BASE_PROPERTY_NAMES,
+            *(p.name for p in _denorm_properties()),
+        ]
+        props = [SimpleNamespace(name=name) for name in existing_names]
+        collection = MagicMock(name="CollectionAsync")
+        collection.config.get = AsyncMock(return_value=SimpleNamespace(properties=props))
+        collection.config.add_property = AsyncMock()
+        client.collections.get = MagicMock(return_value=collection)
+
+        store = _build_store("http://localhost:8090")
+        await store.connect()
+
+        added = [call.args[0] for call in collection.config.add_property.await_args_list]
+        assert [p.name for p in added] == ["chunker_info_json"]
+        assert added[0].data_type == "TEXT"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/engines/skeleton/backends/test_weaviate_async.py
+++ b/tests/unit/engines/skeleton/backends/test_weaviate_async.py
@@ -907,6 +907,74 @@ class TestDenormFieldsRoundTrip:
 
 
 @pytest.mark.unit
+class TestChunkerInfoRoundTrip:
+    """``_object_to_chunk`` chunker_info parse branches (hermetic).
+
+    The store-level round-trip is only exercised by the live-gated Weaviate
+    integration test, so these pin the write→read parse branches — valid dict,
+    empty/absent, non-dict JSON, and malformed JSON — in the default suite.
+    """
+
+    def _chunk(self, ns_id: UUID, chunker_info: dict[str, Any] | None = None) -> TemporalChunk:
+        return TemporalChunk(
+            id=uuid4(),
+            namespace_id=ns_id,
+            document_id=uuid4(),
+            content="hello",
+            embedding=[0.1] * 1536,
+            chunker_info=chunker_info if chunker_info is not None else {},
+        )
+
+    def test_valid_dict_round_trips(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_fake_weaviate(monkeypatch)
+        store = _build_store("http://localhost:8090")
+
+        ns_id = uuid4()
+        chunk = self._chunk(ns_id, {"chunker": "semantic"})
+        props = _chunk_to_properties(chunk)
+        assert props["chunker_info_json"] == '{"chunker": "semantic"}'
+
+        back = store._object_to_chunk(_readback_object(props, chunk.id), ns_id)
+        assert back.chunker_info == {"chunker": "semantic"}
+
+    def test_empty_and_absent_hydrate_to_empty_dict(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_fake_weaviate(monkeypatch)
+        store = _build_store("http://localhost:8090")
+
+        ns_id = uuid4()
+        chunk = self._chunk(ns_id)
+        props = _chunk_to_properties(chunk)
+        # A chunk with no chunker_info serializes to the empty JSON object.
+        assert props["chunker_info_json"] == "{}"
+        assert store._object_to_chunk(_readback_object(props, chunk.id), ns_id).chunker_info == {}
+
+        # Drop the key entirely (an older object that never carried it).
+        props.pop("chunker_info_json", None)
+        assert store._object_to_chunk(_readback_object(props, chunk.id), ns_id).chunker_info == {}
+
+    @pytest.mark.parametrize("payload", ["null", "[1, 2]", '"a string"', "42", "true"])
+    def test_non_dict_json_degrades_to_empty_dict(self, monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+        _install_fake_weaviate(monkeypatch)
+        store = _build_store("http://localhost:8090")
+
+        ns_id = uuid4()
+        chunk = self._chunk(ns_id)
+        props = _chunk_to_properties(chunk)
+        props["chunker_info_json"] = payload
+        assert store._object_to_chunk(_readback_object(props, chunk.id), ns_id).chunker_info == {}
+
+    def test_malformed_json_degrades_to_empty_dict(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_fake_weaviate(monkeypatch)
+        store = _build_store("http://localhost:8090")
+
+        ns_id = uuid4()
+        chunk = self._chunk(ns_id)
+        props = _chunk_to_properties(chunk)
+        props["chunker_info_json"] = "{not valid json"
+        assert store._object_to_chunk(_readback_object(props, chunk.id), ns_id).chunker_info == {}
+
+
+@pytest.mark.unit
 class TestDenormFieldsReconciliation:
     @pytest.mark.asyncio
     async def test_connect_adds_missing_denorm_properties(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

`TemporalChunk.chunker_info` round-trips on the pgvector, surrealdb, and
sqlite_lance temporal stores, but the **weaviate** and **turbopuffer** stores
neither wrote nor read it — the field was silently dropped on write and every
hydrated chunk came back with the dataclass default `{}`. This is live data
loss on those two backends today (the vectorcypher ingest/replace paths
populate `chunker_info` from the chunker's output).

This change mirrors the existing `metadata_json` treatment exactly:

- **weaviate** (`storage/temporal/weaviate.py`)
  - Add a `chunker_info_json` TEXT property to the collection-create schema.
  - Add the property to **pre-existing** collections on connect (add-on-connect
    via the v4 `config.add_property` API — collections are never recreated).
  - Serialize `chunker_info` in `_chunk_to_properties`; hydrate it in
    `_object_to_chunk` with the same try/except `json.loads` pattern as
    `metadata_json`.
- **turbopuffer** (`storage/temporal/turbopuffer.py`)
  - Append `chunker_info_json` to `_INCLUDE_ATTRS` so every read path fetches it.
  - Serialize it in `_chunk_to_row`; hydrate it in `_row_to_chunk`.

Backward compatible: rows/objects written before this change (no
`chunker_info_json`) hydrate to `{}` without raising.

Fixes #1488

## Test plan

- [x] Unit tests pass (turbopuffer round-trip + empty/missing/malformed cases;
      weaviate add-on-connect reconciliation for the new property)
- [ ] Integration tests pass (weaviate live-gated round-trip runs in CI)
- [x] `chunker_info` survives write→read on both stores, including pre-existing
      weaviate collections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Chunker information is now persisted and restored with temporal chunks across Turbopuffer and Weaviate.
  - Weaviate schema reconciliation automatically adds support for the new chunker information field in existing collections.
- **Bug Fixes**
  - Older records or malformed chunker information no longer break reads; chunker information now safely falls back to an empty value when missing or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->