### PR TITLE
Backfill khora_chunks bookkeeping keys from metadata into chunker_info

### DIFF
--- a/src/khora/db/migrations/versions/053_khora_chunks_bookkeeping_to_chunker_info.py
+++ b/src/khora/db/migrations/versions/053_khora_chunks_bookkeeping_to_chunker_info.py
@@ -1,0 +1,398 @@
+"""Move chunk bookkeeping keys from khora_chunks.metadata into chunker_info.
+
+Revision ID: 053_khora_chunks_bookkeeping_to_chunker_info
+Revises: 052_entities_source_chunk_ids_gin
+Create Date: 2026-07-10
+
+Data change only — NO schema change. The four chunk-bookkeeping keys
+``chunk_index`` / ``start_char`` / ``end_char`` / ``token_count`` used to
+live in ``khora_chunks.metadata`` (the temporal store's user/document
+metadata blob). The writer/reader refactor (khora#1491) moved them into
+``khora_chunks.chunker_info`` at every chunk-writer site and the
+temporal-chunk reader now sources the four fields from ``chunker_info``
+**exclusively, with no metadata fallback** — a legacy row that still
+carries them only in ``metadata`` reads back as zeros. This migration is
+the backfill companion: it relocates the four keys on every existing row
+so those rows keep reading correctly after the reader change lands. It
+must run before release for the same reason.
+
+Cross-dialect: unlike 043/044 this migration runs on **both** dialects.
+``khora_chunks`` exists on Postgres (``PgVectorTemporalStore``) and on the
+sqlite_lance embedded stack, so the SQLite branch performs the same
+relocation with the JSON1 functions (``json_patch`` / ``json_remove`` /
+``json_extract``) instead of the Postgres JSONB operators. The
+sqlite_lance fixture stack runs the full Alembic chain, so a SQLite no-op
+would leave embedded rows unmigrated — the SQLite branch is load-bearing,
+not a green-keeper.
+
+Two tiers per row, keyed on whether the row has a twin in the main
+``chunks`` table (``chunks.id = khora_chunks.id``, the same UUID):
+
+* **Tier 1 (twin exists).** The main ``chunks`` row carries the four
+  values in *typed* columns (``chunk_index`` etc., ``NOT NULL`` integers)
+  plus its own ``chunker_info``. The relocation copies the typed column
+  values into ``khora_chunks.chunker_info`` (merged after the twin's
+  ``chunker_info``) and strips a metadata key **only where its metadata
+  value equals the typed column value**. A metadata key whose value
+  differs from the column is a user key that merely collides on name — it
+  is left in ``metadata`` untouched, while ``chunker_info`` still gets the
+  authoritative column value.
+
+* **Tier 2 (no twin).** No typed columns to trust, so the values are read
+  from ``metadata`` itself. A key is moved only when its metadata value is
+  number-typed (``jsonb_typeof = 'number'`` on Postgres, ``json_type =
+  'integer'`` on SQLite); a string-typed collision is a user key and stays
+  in ``metadata``. Exactly the moved keys are stripped. No synthetic
+  ``chunker`` name is fabricated — only the four numeric keys move.
+
+Merge precedence (both tiers, both dialects): the row's own existing
+``chunker_info`` is the base and always wins over nothing, the twin's
+``chunker_info`` (Tier 1) layers on top, and the four bookkeeping keys are
+stamped **last** so they win any collision — mirroring the writer, which
+stamps the bookkeeping keys last. On Postgres this is
+``kc.chunker_info || c.chunker_info || bookkeeping`` (right operand wins in
+JSONB concat). On SQLite ``json_patch(a, b)`` lets ``b`` win, so the calls
+nest ``json_patch(json_patch(kc.chunker_info, c.chunker_info),
+bookkeeping)`` to reproduce the same base → twin → bookkeeping order.
+
+Idempotency / convergence (both tiers, both dialects): the UPDATE is
+guarded by ``metadata ?| ARRAY[four keys] AND NOT (chunker_info ?
+'chunk_index')`` — a row is visited only while it still carries any of the
+four keys in ``metadata`` *and* has not yet had ``chunk_index`` written to
+``chunker_info``. Once relocated, ``chunker_info`` carries ``chunk_index``
+so the row is skipped, and re-running the migration touches zero rows. A
+row where a differing-value user key legitimately remains in ``metadata``
+is still skipped on re-run because ``chunker_info`` now has ``chunk_index``.
+
+Scale (~1M chunk rows): the relocation runs namespace-batched — one Tier-1
+UPDATE and one Tier-2 UPDATE per distinct ``khora_chunks.namespace_id`` —
+so no single statement spans the whole table. The whole Alembic chain runs
+inside ONE transaction (``env.py:do_run_migrations``), so batching bounds
+per-statement cost and planning, not lock-hold duration.
+
+Trigger suppression (Postgres): ``khora_chunks`` carries a
+``BEFORE INSERT OR UPDATE`` trigger (``khora_chunks_content_tsv_update``)
+that recomputes ``to_tsvector('english', content)`` on every updated row.
+This migration touches only ``metadata`` / ``chunker_info`` and never
+``content``, so re-deriving the tsvector is wasted CPU on a ~1M-row table.
+The trigger is disabled for the relocation and re-enabled in a ``finally``
+so it is restored on every exit path. ``DISABLE TRIGGER`` / ``ENABLE
+TRIGGER`` is transactional, so a rolled-back migration leaves the trigger
+enabled. SQLite has no such trigger and skips the toggle.
+
+Lock-timeout safety (Postgres): a ``SET lock_timeout = '5s'`` bounds the
+brief ``ACCESS EXCLUSIVE`` lock ``DISABLE TRIGGER`` takes and the row
+locks the UPDATEs take. On lock-timeout the upgrade logs
+``khora.migration.applied`` at ERROR with ``lock_timeout_tripped=True``
+(Postgres SQLSTATE ``55P03`` on ``OperationalError.orig.pgcode``); any
+other ``OperationalError`` logs ``lock_timeout_tripped=False`` so
+dashboards don't conflate deadlocks / connection drops with the
+lock-timeout signal. Either path re-raises so Alembic rolls back.
+
+Runtime-def convergence: ``khora_chunks`` is created at runtime by
+``PgVectorTemporalStore.connect()`` (and the embedded store's DDL), not by
+the Alembic-managed schema, and the main ``chunks`` table is
+Alembic-managed. Both ``has_table`` guards early-return ``(0, 0)`` when
+either table is absent (fresh deploys where the temporal store hasn't
+booted yet) — new chunks already carry the split from the ingest path, so
+there is nothing to relocate.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from loguru import logger
+from sqlalchemy.exc import OperationalError
+
+revision: str = "053_khora_chunks_bookkeeping_to_chunker_info"
+down_revision: str | Sequence[str] | None = "052_entities_source_chunk_ids_gin"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# PostgreSQL SQLSTATE for "lock_not_available" — what `lock_timeout` raises
+# when an acquisition exceeds the configured timeout.
+_PG_LOCK_NOT_AVAILABLE = "55P03"
+
+# Name of the BEFORE INSERT OR UPDATE trigger on khora_chunks that recomputes
+# content_tsv. Defined at runtime in
+# ``src/khora/storage/temporal/pgvector.py``.
+_CONTENT_TSV_TRIGGER = "khora_chunks_content_tsv_update"
+
+
+# ---------------------------------------------------------------------------
+# Postgres statements
+# ---------------------------------------------------------------------------
+
+# Tier 1 — the row has a twin in the main ``chunks`` table. Copy the twin's
+# typed column values into chunker_info (merged after the twin's own
+# chunker_info, bookkeeping stamped last so it wins), and strip a metadata key
+# ONLY where its metadata value equals the typed column value (a differing
+# value is a user key that merely collides on name and stays put).
+_PG_TIER1_SQL = sa.text(
+    """
+    UPDATE khora_chunks kc
+    SET chunker_info = kc.chunker_info || c.chunker_info || jsonb_build_object(
+            'chunk_index', c.chunk_index, 'start_char', c.start_char,
+            'end_char', c.end_char, 'token_count', c.token_count),
+        metadata = kc.metadata - ARRAY(
+            SELECT t.k FROM (VALUES
+                ('chunk_index', to_jsonb(c.chunk_index)),
+                ('start_char',  to_jsonb(c.start_char)),
+                ('end_char',    to_jsonb(c.end_char)),
+                ('token_count', to_jsonb(c.token_count))) AS t(k, v)
+            WHERE kc.metadata -> t.k = t.v)
+    FROM chunks c
+    WHERE c.id = kc.id AND kc.namespace_id = :namespace_id
+      AND kc.metadata ?| ARRAY['chunk_index','start_char','end_char','token_count']
+      AND NOT (kc.chunker_info ? 'chunk_index')
+    """
+)
+
+# Tier 2 — no twin. Read the values from metadata itself, moving a key only
+# when its metadata value is number-typed (a string-typed collision is a user
+# key and stays). Strip exactly the moved keys. No synthetic chunker name.
+_PG_TIER2_SQL = sa.text(
+    """
+    UPDATE khora_chunks kc
+    SET chunker_info = kc.chunker_info || (
+            SELECT COALESCE(jsonb_object_agg(t.k, kc.metadata -> t.k), '{}'::jsonb)
+            FROM (VALUES ('chunk_index'), ('start_char'), ('end_char'), ('token_count')) AS t(k)
+            WHERE jsonb_typeof(kc.metadata -> t.k) = 'number'),
+        metadata = kc.metadata - ARRAY(
+            SELECT t.k FROM (VALUES
+                ('chunk_index'), ('start_char'), ('end_char'), ('token_count')) AS t(k)
+            WHERE jsonb_typeof(kc.metadata -> t.k) = 'number')
+    WHERE kc.namespace_id = :namespace_id
+      AND NOT EXISTS (SELECT 1 FROM chunks c WHERE c.id = kc.id)
+      AND kc.metadata ?| ARRAY['chunk_index','start_char','end_char','token_count']
+      AND NOT (kc.chunker_info ? 'chunk_index')
+    """
+)
+
+
+# ---------------------------------------------------------------------------
+# SQLite statements (JSON1)
+# ---------------------------------------------------------------------------
+
+# Tier 1 — SQLite JSON1. ``json_patch(a, b)`` lets ``b`` win, so the nesting
+# base(kc.chunker_info) → twin(c.chunker_info) → bookkeeping reproduces the
+# Postgres ``||`` precedence. The bookkeeping object carries the twin's typed
+# column values. A metadata key is stripped only where its value equals the
+# typed column value (compared via json_extract on both sides). ``id`` is TEXT
+# on SQLite, so the twin join is a plain equality. json_type() returns
+# 'integer' for whole numbers (not 'number'); the guard on chunker_info uses
+# the same ``json_extract(... , '$.chunk_index') IS NULL`` skip as the Postgres
+# ``NOT (chunker_info ? 'chunk_index')``.
+#
+# DIVERGENCE from Postgres ``||``: ``json_patch`` follows RFC 7386 and DELETES
+# a key whose patch value is JSON null, where Postgres ``||`` would keep it as
+# an explicit null. This is moot in practice — the bookkeeping overlay carries
+# concrete integers from the twin's NOT NULL typed columns (never null), and a
+# twin's ``chunker_info`` values (chunker-name string + ints) are non-null too
+# — so no special-casing is added; the note stands only to explain why the
+# two dialects can be trusted to converge on real data.
+#
+# NOTE on the strip: SQLite ``json_remove(x, path)`` returns NULL if *any*
+# path argument is NULL, but is a plain no-op when the path does not exist. So
+# the strip is expressed as nested ``json_remove`` calls, each keying the real
+# path only when the metadata value equals the twin column and otherwise a
+# guaranteed-absent sentinel path (a no-op) — never a NULL path arg (which
+# would null out the NOT NULL ``metadata`` column). This mirrors the Postgres
+# ``metadata - ARRAY(... WHERE value = column)`` value-equality strip.
+_SQLITE_TIER1_SQL = sa.text(
+    """
+    UPDATE khora_chunks AS kc
+    SET chunker_info = json_patch(
+            json_patch(kc.chunker_info, c.chunker_info),
+            json_object(
+                'chunk_index', c.chunk_index, 'start_char', c.start_char,
+                'end_char', c.end_char, 'token_count', c.token_count)),
+        metadata = json_remove(json_remove(json_remove(json_remove(
+            kc.metadata,
+            CASE WHEN json_extract(kc.metadata, '$.chunk_index') = c.chunk_index
+                 THEN '$.chunk_index' ELSE '$."__khora_noop__"' END),
+            CASE WHEN json_extract(kc.metadata, '$.start_char') = c.start_char
+                 THEN '$.start_char' ELSE '$."__khora_noop__"' END),
+            CASE WHEN json_extract(kc.metadata, '$.end_char') = c.end_char
+                 THEN '$.end_char' ELSE '$."__khora_noop__"' END),
+            CASE WHEN json_extract(kc.metadata, '$.token_count') = c.token_count
+                 THEN '$.token_count' ELSE '$."__khora_noop__"' END)
+    FROM chunks AS c
+    WHERE c.id = kc.id AND kc.namespace_id = :namespace_id
+      AND (json_extract(kc.metadata, '$.chunk_index') IS NOT NULL
+           OR json_extract(kc.metadata, '$.start_char') IS NOT NULL
+           OR json_extract(kc.metadata, '$.end_char') IS NOT NULL
+           OR json_extract(kc.metadata, '$.token_count') IS NOT NULL)
+      AND json_extract(kc.chunker_info, '$.chunk_index') IS NULL
+    """
+)
+
+# Tier 2 — no twin. Move a key only when its metadata value is integer-typed
+# (SQLite ``json_type`` returns 'integer' for whole numbers, not 'number').
+#
+# The values are set with nested ``json_set`` guarded per key so ONLY
+# integer-typed keys are ever set — never introducing a JSON ``null`` value.
+# This matters: ``json_patch`` follows RFC 7386 and DELETES a target key whose
+# patch value is ``null``, so a ``json_object`` with ``CASE ... ELSE NULL``
+# would silently drop keys. ``json_set`` with a NULL *path* is a clean no-op
+# (the value is ignored), so a non-integer key contributes nothing; this
+# mirrors the Postgres ``jsonb_object_agg(... WHERE jsonb_typeof = 'number')``,
+# which likewise only aggregates the number-typed keys.
+#
+# The strip uses the same nested-``json_remove`` + absent-path-sentinel pattern
+# as Tier 1 (``json_remove`` returns NULL on a NULL path but no-ops on an
+# absent path, so the two functions need different sentinels) — a non-integer
+# key never contributes a NULL path arg that would null out the NOT NULL
+# ``metadata`` column.
+_SQLITE_TIER2_SQL = sa.text(
+    """
+    UPDATE khora_chunks AS kc
+    SET chunker_info = json_set(json_set(json_set(json_set(
+            kc.chunker_info,
+            CASE WHEN json_type(kc.metadata, '$.chunk_index') = 'integer'
+                 THEN '$.chunk_index' ELSE NULL END,
+            json_extract(kc.metadata, '$.chunk_index')),
+            CASE WHEN json_type(kc.metadata, '$.start_char') = 'integer'
+                 THEN '$.start_char' ELSE NULL END,
+            json_extract(kc.metadata, '$.start_char')),
+            CASE WHEN json_type(kc.metadata, '$.end_char') = 'integer'
+                 THEN '$.end_char' ELSE NULL END,
+            json_extract(kc.metadata, '$.end_char')),
+            CASE WHEN json_type(kc.metadata, '$.token_count') = 'integer'
+                 THEN '$.token_count' ELSE NULL END,
+            json_extract(kc.metadata, '$.token_count')),
+        metadata = json_remove(json_remove(json_remove(json_remove(
+            kc.metadata,
+            CASE WHEN json_type(kc.metadata, '$.chunk_index') = 'integer'
+                 THEN '$.chunk_index' ELSE '$."__khora_noop__"' END),
+            CASE WHEN json_type(kc.metadata, '$.start_char') = 'integer'
+                 THEN '$.start_char' ELSE '$."__khora_noop__"' END),
+            CASE WHEN json_type(kc.metadata, '$.end_char') = 'integer'
+                 THEN '$.end_char' ELSE '$."__khora_noop__"' END),
+            CASE WHEN json_type(kc.metadata, '$.token_count') = 'integer'
+                 THEN '$.token_count' ELSE '$."__khora_noop__"' END)
+    WHERE kc.namespace_id = :namespace_id
+      AND NOT EXISTS (SELECT 1 FROM chunks c WHERE c.id = kc.id)
+      AND (json_extract(kc.metadata, '$.chunk_index') IS NOT NULL
+           OR json_extract(kc.metadata, '$.start_char') IS NOT NULL
+           OR json_extract(kc.metadata, '$.end_char') IS NOT NULL
+           OR json_extract(kc.metadata, '$.token_count') IS NOT NULL)
+      AND json_extract(kc.chunker_info, '$.chunk_index') IS NULL
+    """
+)
+
+
+def _is_postgres() -> bool:
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def _is_lock_timeout(exc: OperationalError) -> bool:
+    """Distinguish a real lock_timeout trip from any other OperationalError.
+
+    OperationalError is a broad SQLAlchemy class — it wraps deadlocks,
+    connection drops, syntax errors, server shutdowns, AND lock_timeout
+    failures. The structured log field ``lock_timeout_tripped`` must
+    only be True for the latter so monitoring dashboards aren't misled.
+    """
+    orig = getattr(exc, "orig", None)
+    if orig is None:
+        return False
+    return getattr(orig, "pgcode", None) == _PG_LOCK_NOT_AVAILABLE
+
+
+def _upgrade_impl() -> tuple[int, int]:
+    """Run the namespace-batched relocation. Returns ``(namespaces, rows)``.
+
+    Both dialects share the same two-tier, per-namespace shape; only the SQL
+    statements differ (JSONB operators vs JSON1 functions) and the Postgres
+    branch adds the lock-timeout / trigger-toggle safety.
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("khora_chunks") or not inspector.has_table("chunks"):
+        # ``khora_chunks`` is created at runtime by the temporal store and the
+        # main ``chunks`` table is Alembic-managed. On fresh deploys / before
+        # the temporal store has booted one or both may be absent; new chunks
+        # already carry the bookkeeping in chunker_info from the ingest path,
+        # so there is nothing to relocate here.
+        return 0, 0
+
+    is_pg = _is_postgres()
+    tier1_sql = _PG_TIER1_SQL if is_pg else _SQLITE_TIER1_SQL
+    tier2_sql = _PG_TIER2_SQL if is_pg else _SQLITE_TIER2_SQL
+
+    if is_pg:
+        # Bound every lock acquisition — the brief ACCESS EXCLUSIVE lock that
+        # ``DISABLE TRIGGER`` takes and the row locks the UPDATEs take — so a
+        # stuck pg_stat_activity entry on khora_chunks cannot stall the deploy
+        # past 5s. Issued before the trigger toggle.
+        op.execute("SET lock_timeout = '5s'")
+        # The content_tsv trigger only matters when ``content`` changes; this
+        # relocation touches only ``metadata`` / ``chunker_info``, so
+        # re-deriving the tsvector for every updated row is wasted CPU. Disable
+        # it for the relocation and restore it in the ``finally``.
+        op.execute(f"ALTER TABLE khora_chunks DISABLE TRIGGER {_CONTENT_TSV_TRIGGER}")
+
+    try:
+        namespace_ids = [row[0] for row in bind.execute(sa.text("SELECT DISTINCT namespace_id FROM khora_chunks"))]
+        total_rows = 0
+        for namespace_id in namespace_ids:
+            # Tier 1 (twin) then Tier 2 (twinless) per namespace. The guard
+            # predicates are disjoint per row (twin exists vs NOT EXISTS), so a
+            # row is touched by at most one tier.
+            r1 = bind.execute(tier1_sql, {"namespace_id": namespace_id})
+            r2 = bind.execute(tier2_sql, {"namespace_id": namespace_id})
+            total_rows += int(r1.rowcount or 0) + int(r2.rowcount or 0)
+        return len(namespace_ids), total_rows
+    finally:
+        if is_pg:
+            op.execute(f"ALTER TABLE khora_chunks ENABLE TRIGGER {_CONTENT_TSV_TRIGGER}")
+
+
+def upgrade() -> None:
+    start = time.monotonic()
+    # Initialize log fields up-front so the error path always emits a uniform
+    # event for dashboards / alerts.
+    namespaces_migrated = 0
+    rows_migrated = 0
+    try:
+        namespaces_migrated, rows_migrated = _upgrade_impl()
+    except OperationalError as exc:
+        duration_ms = int((time.monotonic() - start) * 1000)
+        logger.bind(
+            migration_id=revision,
+            duration_ms=duration_ms,
+            lock_timeout_tripped=_is_lock_timeout(exc),
+            namespaces_migrated=namespaces_migrated,
+            rows_migrated=rows_migrated,
+        ).error("khora.migration.applied")
+        # Bare ``raise`` re-raises the active exception with the original
+        # traceback preserved. env.py's wrapping context.begin_transaction()
+        # rolls back the UPDATEs from this revision (and the trigger toggle).
+        raise
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+    logger.bind(
+        migration_id=revision,
+        duration_ms=duration_ms,
+        lock_timeout_tripped=False,
+        namespaces_migrated=namespaces_migrated,
+        rows_migrated=rows_migrated,
+    ).info("khora.migration.applied")
+
+
+def downgrade() -> None:
+    """Irreversible relocation — no-op.
+
+    The upgrade moves the four bookkeeping keys from ``metadata`` into
+    ``chunker_info`` (stripping only the keys whose metadata value matched
+    the authoritative source). Once moved, the migration cannot distinguish
+    a bookkeeping key that originated in ``metadata`` from one the writer
+    always wrote to ``chunker_info``, so the relocation cannot be cleanly
+    un-done. The downgrade is therefore a no-op on both dialects.
+    """

--- a/tests/integration/db/test_migration_032_dream_runs.py
+++ b/tests/integration/db/test_migration_032_dream_runs.py
@@ -304,7 +304,7 @@ class TestMigration032OnSqlite:
                 async with engine.connect() as conn:
                     # Chain reached head (sanity).
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "052_entities_source_chunk_ids_gin"
+                    assert result.scalar() == "053_khora_chunks_bookkeeping_to_chunker_info"
 
                     # khora_dream_runs exists on SQLite (#896) so dream_history /
                     # dream_status work on the embedded sqlite_lance stack.

--- a/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
+++ b/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
@@ -322,7 +322,7 @@ class TestMigration041OnPostgres:
                 async with engine.connect() as conn:
                     # Chain reached head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "052_entities_source_chunk_ids_gin"
+                    assert result.scalar() == "053_khora_chunks_bookkeeping_to_chunker_info"
 
                     # The migration did not create the table.
                     result = await conn.execute(
@@ -353,7 +353,7 @@ class TestMigration041OnSqlite:
             try:
                 async with engine.connect() as conn:
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "052_entities_source_chunk_ids_gin"
+                    assert result.scalar() == "053_khora_chunks_bookkeeping_to_chunker_info"
             finally:
                 await engine.dispose()
 

--- a/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
+++ b/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
@@ -69,7 +69,7 @@ pytestmark = pytest.mark.integration
 
 
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
-_HEAD = "052_entities_source_chunk_ids_gin"
+_HEAD = "053_khora_chunks_bookkeeping_to_chunker_info"
 _PREV = "041_khora_chunks_denormalized_columns"
 
 

--- a/tests/integration/db/test_migration_044_chunks_backfill.py
+++ b/tests/integration/db/test_migration_044_chunks_backfill.py
@@ -119,17 +119,22 @@ def _make_config(url: str) -> Config:
 
 
 # A runtime-shaped ``khora_chunks`` table: the identity/temporal/content
-# columns the runtime always creates, the eight denormalized columns 041 added
+# columns the runtime always creates, the ``metadata`` / ``chunker_info`` JSONB
+# columns the runtime always carries, the eight denormalized columns 041 added
 # and the widen migration resized (present, NULL), plus ``content_tsv`` and the
 # BEFORE INSERT OR UPDATE trigger that recomputes it. Creating this before the
 # upgrade exercises 044's existing-deployment backfill path including the
-# trigger DISABLE/ENABLE.
+# trigger DISABLE/ENABLE. ``metadata`` / ``chunker_info`` must be present because
+# the replayed ``upgrade head`` runs migration 053 (later in the chain), whose
+# relocation reads/writes both columns — the real runtime table always has them.
 _RUNTIME_KHORA_CHUNKS_DDL = """
 CREATE TABLE khora_chunks (
     id UUID PRIMARY KEY,
     namespace_id UUID NOT NULL,
     document_id UUID NOT NULL,
     content TEXT NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    chunker_info JSONB NOT NULL DEFAULT '{}'::jsonb,
     occurred_at TIMESTAMPTZ,
     created_at TIMESTAMPTZ,
     source_type VARCHAR(64),

--- a/tests/integration/db/test_migration_044_chunks_backfill.py
+++ b/tests/integration/db/test_migration_044_chunks_backfill.py
@@ -93,7 +93,7 @@ pytestmark = pytest.mark.integration
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
 
 _PREV_REVISION = "043_khora_chunks_metadata_backfill"
-_HEAD_REVISION = "052_entities_source_chunk_ids_gin"
+_HEAD_REVISION = "053_khora_chunks_bookkeeping_to_chunker_info"
 
 _TSV_TRIGGER = "khora_chunks_content_tsv_update"
 

--- a/tests/integration/db/test_migration_049_hook_subscriptions.py
+++ b/tests/integration/db/test_migration_049_hook_subscriptions.py
@@ -71,7 +71,7 @@ pytestmark = pytest.mark.integration
 
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
 
-_HEAD = "052_entities_source_chunk_ids_gin"
+_HEAD = "053_khora_chunks_bookkeeping_to_chunker_info"
 _PREV = "048_dream_conflicts_reconcile"
 
 

--- a/tests/integration/db/test_migration_053_bookkeeping_to_chunker_info.py
+++ b/tests/integration/db/test_migration_053_bookkeeping_to_chunker_info.py
@@ -1,0 +1,713 @@
+"""Coverage for migration ``053_khora_chunks_bookkeeping_to_chunker_info``.
+
+The writer/reader refactor (khora#1491) moved the four chunk-bookkeeping keys
+``chunk_index`` / ``start_char`` / ``end_char`` / ``token_count`` out of
+``khora_chunks.metadata`` and into ``khora_chunks.chunker_info``, and the
+temporal-chunk reader now sources them from ``chunker_info`` *exclusively*
+(no metadata fallback). Migration 053 is the backfill companion: it relocates
+those keys on every existing ``khora_chunks`` row, on BOTH Postgres and SQLite.
+
+Two tiers, keyed on whether the row has a twin in the main ``chunks`` table
+(``chunks.id = khora_chunks.id``):
+
+* Tier 1 (twin exists): copy the twin's *typed* column values into
+  ``chunker_info`` (merged after the twin's own ``chunker_info``, bookkeeping
+  stamped last), and strip a metadata key ONLY where its value equals the
+  typed column value — a differing value is a user key that stays.
+* Tier 2 (no twin): read from ``metadata`` itself, moving a key only when its
+  value is number-typed; a string-typed collision stays. Strip exactly the
+  moved keys.
+
+Both tiers are guarded so the relocation is convergent — re-running touches
+zero rows (``metadata`` still carries a key AND ``chunker_info`` lacks
+``chunk_index``).
+
+The archetypes exercised on both dialects:
+
+1. Tier-1, metadata values == typed columns → all four stripped from metadata;
+   chunker_info = twin chunker_info merged with the four column values.
+2. Tier-1 user collision (metadata ``chunk_index`` differs from the column) →
+   that metadata key PRESERVED; chunker_info still gets the column value.
+3. Tier-2 twinless, number-typed metadata → moved into chunker_info + stripped.
+4. Tier-2 twinless, string-typed ``chunk_index`` → left in metadata untouched.
+5. Post-fix clean row (chunker_info already has ``chunk_index``, user metadata
+   carries a ``chunk_index`` of its own) → untouched by the guard.
+6. Three-way merge precedence: the same bookkeeping key (``start_char``) is
+   present in kc.chunker_info (stale base), the twin's chunker_info, AND the
+   bookkeeping overlay (the typed column) with three distinct values → the
+   column value wins last, pinning the ``kc || c.chunker_info || bookkeeping``
+   nesting order.
+
+The SQLite lane runs the real relocation with the JSON1 functions and needs no
+Docker — it is the primary coverage and is marked ``unit``. The Postgres lane
+runs the same archetypes against real JSONB and skips when Postgres is
+unreachable.
+
+Run the Postgres lane locally::
+
+    make dev    # postgres on port 5434
+    KHORA_DATABASE_URL=postgresql+asyncpg://khora:khora@localhost:5434/khora \
+        uv run pytest tests/integration/db/test_migration_053_bookkeeping_to_chunker_info.py \
+        -v -m integration --no-cov
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import socket
+from pathlib import Path
+from urllib.parse import urlparse
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, create_async_engine
+
+from khora.db.session import run_migrations
+
+DATABASE_URL = os.environ.get(
+    "KHORA_DATABASE_URL",
+    "postgresql+asyncpg://khora:khora@localhost:5434/khora",
+)
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
+
+
+def _pg_reachable() -> bool:
+    parsed = urlparse(DATABASE_URL.replace("+asyncpg", ""))
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+_MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
+
+_HEAD_REVISION = "053_khora_chunks_bookkeeping_to_chunker_info"
+_PREV_REVISION = "052_entities_source_chunk_ids_gin"
+
+_TSV_TRIGGER = "khora_chunks_content_tsv_update"
+
+# Stable UUIDs for the archetype rows so assertions can target each.
+_ID_TIER1_MATCH = UUID("00000000-0000-0000-0000-000000000001")
+_ID_TIER1_COLLISION = UUID("00000000-0000-0000-0000-000000000002")
+_ID_TIER2_NUMBER = UUID("00000000-0000-0000-0000-000000000003")
+_ID_TIER2_STRING = UUID("00000000-0000-0000-0000-000000000004")
+_ID_CLEAN = UUID("00000000-0000-0000-0000-000000000005")
+# Three-way precedence archetype: the SAME bookkeeping key (start_char) appears
+# in kc.chunker_info (stale base), the twin's chunker_info, AND the bookkeeping
+# overlay (the typed column) with three DISTINCT values — the column value must
+# win last. Uses start_char (not chunk_index) as the colliding key so the
+# ``NOT (chunker_info ? 'chunk_index')`` guard still fires (chunk_index is
+# deliberately absent from this row's seeded chunker_info).
+_ID_TIER1_PRECEDENCE = UUID("00000000-0000-0000-0000-000000000006")
+
+# Three distinct start_char values for the precedence row.
+_PREC_BASE_START_CHAR = 111  # kc.chunker_info (stale base) — must lose
+_PREC_TWIN_START_CHAR = 222  # twin chunks.chunker_info — must lose
+_PREC_COLUMN_START_CHAR = 333  # bookkeeping (typed column c.start_char) — WINS
+
+_NS = UUID("00000000-0000-0000-0000-0000000000aa")
+
+
+def _make_config(url: str) -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", str(_MIGRATIONS_DIR))
+    # Alembic uses configparser.BasicInterpolation; escape any literal '%' in
+    # the URL so it isn't read as a config-interpolation token.
+    cfg.set_main_option("sqlalchemy.url", url.replace("%", "%%"))
+    cfg.attributes["database_url"] = url
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# SQLite lane — the real relocation via JSON1, no Docker (primary coverage)
+# ---------------------------------------------------------------------------
+
+# A runtime-shaped ``khora_chunks`` on SQLite: only the columns 053 touches or
+# joins on. ``id`` is stored as TEXT (matching how the embedded store persists
+# UUIDs) so the twin join is a plain string equality.
+_SQLITE_KHORA_CHUNKS_DDL = """
+CREATE TABLE khora_chunks (
+    id TEXT PRIMARY KEY,
+    namespace_id TEXT NOT NULL,
+    document_id TEXT NOT NULL,
+    content TEXT NOT NULL,
+    metadata TEXT NOT NULL DEFAULT '{}',
+    chunker_info TEXT NOT NULL DEFAULT '{}'
+)
+"""
+
+# A minimal ``chunks`` main table with the four typed columns + chunker_info.
+_SQLITE_CHUNKS_DDL = """
+CREATE TABLE chunks (
+    id TEXT PRIMARY KEY,
+    namespace_id TEXT NOT NULL,
+    document_id TEXT NOT NULL,
+    content TEXT NOT NULL,
+    chunk_index INTEGER NOT NULL DEFAULT 0,
+    start_char INTEGER NOT NULL DEFAULT 0,
+    end_char INTEGER NOT NULL DEFAULT 0,
+    token_count INTEGER NOT NULL DEFAULT 0,
+    metadata TEXT NOT NULL DEFAULT '{}',
+    chunker_info TEXT NOT NULL DEFAULT '{}'
+)
+"""
+
+# khora_chunks is NOT Alembic-managed, so alembic never creates it. We build the
+# two tables ourselves, stamp the version at 052, then run ``upgrade 053``.
+_ALEMBIC_VERSION_DDL = """
+CREATE TABLE khora_alembic_version (
+    version_num VARCHAR(64) NOT NULL,
+    CONSTRAINT khora_alembic_version_pkc PRIMARY KEY (version_num)
+)
+"""
+
+
+async def _seed_sqlite(url: str) -> None:
+    """Create both tables (stamped at 052) and seed the archetype rows."""
+    engine = create_async_engine(url)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(sa.text(_ALEMBIC_VERSION_DDL))
+            await conn.execute(
+                sa.text("INSERT INTO khora_alembic_version (version_num) VALUES (:v)"),
+                {"v": _PREV_REVISION},
+            )
+            await conn.execute(sa.text(_SQLITE_KHORA_CHUNKS_DDL))
+            await conn.execute(sa.text(_SQLITE_CHUNKS_DDL))
+
+            # Twin in the main chunks table for the two Tier-1 rows.
+            for cid in (_ID_TIER1_MATCH, _ID_TIER1_COLLISION):
+                await conn.execute(
+                    sa.text(
+                        "INSERT INTO chunks "
+                        "(id, namespace_id, document_id, content, chunk_index, "
+                        " start_char, end_char, token_count, chunker_info) "
+                        "VALUES (:id, :ns, :doc, 'c', 3, 10, 40, 7, :ci)"
+                    ),
+                    {
+                        "id": str(cid),
+                        "ns": str(_NS),
+                        "doc": str(uuid4()),
+                        "ci": json.dumps({"chunker": "sentence", "version": "1"}),
+                    },
+                )
+
+            # 1. Tier-1 match: metadata values == typed columns (+ a user key).
+            await _insert_khora_chunk(
+                conn,
+                _ID_TIER1_MATCH,
+                metadata={"chunk_index": 3, "start_char": 10, "end_char": 40, "token_count": 7, "author": "alice"},
+                chunker_info={},
+            )
+            # 2. Tier-1 collision: metadata chunk_index differs from the column.
+            await _insert_khora_chunk(
+                conn,
+                _ID_TIER1_COLLISION,
+                metadata={"chunk_index": 999, "start_char": 10, "end_char": 40, "token_count": 7},
+                chunker_info={},
+            )
+            # 3. Tier-2 twinless, number-typed metadata (no chunks row).
+            await _insert_khora_chunk(
+                conn,
+                _ID_TIER2_NUMBER,
+                metadata={"chunk_index": 5, "start_char": 0, "end_char": 12, "token_count": 4, "topic": "x"},
+                chunker_info={},
+            )
+            # 4. Tier-2 twinless, string-typed chunk_index → stays in metadata.
+            await _insert_khora_chunk(
+                conn,
+                _ID_TIER2_STRING,
+                metadata={"chunk_index": "abc"},
+                chunker_info={},
+            )
+            # 5. Post-fix clean row: chunker_info already has chunk_index; a
+            #    user metadata.chunk_index of its own must be left untouched.
+            await _insert_khora_chunk(
+                conn,
+                _ID_CLEAN,
+                metadata={"chunk_index": 42},
+                chunker_info={"chunk_index": 1, "start_char": 0, "end_char": 5, "token_count": 2},
+            )
+
+            # 6. Three-way precedence: dedicated twin whose typed start_char
+            #    column (C=333) differs from both the twin's own chunker_info
+            #    start_char (B=222) and the kc.chunker_info base (A=111). The
+            #    column value must win last (kc || twin || bookkeeping).
+            await conn.execute(
+                sa.text(
+                    "INSERT INTO chunks "
+                    "(id, namespace_id, document_id, content, chunk_index, "
+                    " start_char, end_char, token_count, chunker_info) "
+                    "VALUES (:id, :ns, :doc, 'c', 1, :sc, 40, 7, :ci)"
+                ),
+                {
+                    "id": str(_ID_TIER1_PRECEDENCE),
+                    "ns": str(_NS),
+                    "doc": str(uuid4()),
+                    "sc": _PREC_COLUMN_START_CHAR,
+                    "ci": json.dumps({"chunker": "sentence", "start_char": _PREC_TWIN_START_CHAR}),
+                },
+            )
+            await _insert_khora_chunk(
+                conn,
+                _ID_TIER1_PRECEDENCE,
+                # metadata carries a bookkeeping key (chunk_index) so the row is
+                # eligible; chunker_info holds the STALE start_char base (A) but
+                # deliberately NO chunk_index, so the guard fires.
+                metadata={"chunk_index": 1, "start_char": 10, "author": "bob"},
+                chunker_info={"start_char": _PREC_BASE_START_CHAR},
+            )
+    finally:
+        await engine.dispose()
+
+
+async def _insert_khora_chunk(conn: AsyncConnection, cid: UUID, *, metadata: dict, chunker_info: dict) -> None:
+    await conn.execute(
+        sa.text(
+            "INSERT INTO khora_chunks "
+            "(id, namespace_id, document_id, content, metadata, chunker_info) "
+            "VALUES (:id, :ns, :doc, 'body', :md, :ci)"
+        ),
+        {
+            "id": str(cid),
+            "ns": str(_NS),
+            "doc": str(uuid4()),
+            "md": json.dumps(metadata),
+            "ci": json.dumps(chunker_info),
+        },
+    )
+
+
+async def _read_row(url: str, cid: UUID) -> tuple[dict, dict]:
+    """Return ``(metadata, chunker_info)`` for a khora_chunks row as dicts."""
+    engine = create_async_engine(url)
+    try:
+        async with engine.connect() as conn:
+            row = (
+                await conn.execute(
+                    sa.text("SELECT metadata, chunker_info FROM khora_chunks WHERE id = :id"),
+                    {"id": str(cid)},
+                )
+            ).one()
+            return _as_dict(row[0]), _as_dict(row[1])
+    finally:
+        await engine.dispose()
+
+
+def _as_dict(value) -> dict:
+    if isinstance(value, dict):
+        return value
+    return json.loads(value)
+
+
+async def _step_version_back_sqlite(url: str) -> None:
+    engine = create_async_engine(url)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                sa.text("UPDATE khora_alembic_version SET version_num = :v"),
+                {"v": _PREV_REVISION},
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.unit
+class TestMigration053OnSqlite:
+    @pytest.fixture
+    def sqlite_url(self, tmp_path: Path) -> str:
+        return f"sqlite+aiosqlite:///{tmp_path / 'test.db'}"
+
+    def test_archetypes(self, sqlite_url: str) -> None:
+        asyncio.run(_seed_sqlite(sqlite_url))
+        cfg = _make_config(sqlite_url)
+        command.upgrade(cfg, _HEAD_REVISION)
+
+        # 1. Tier-1 match: all four stripped from metadata (user key survives);
+        #    chunker_info carries the twin's info + the four column values.
+        md, ci = asyncio.run(_read_row(sqlite_url, _ID_TIER1_MATCH))
+        assert "chunk_index" not in md and "start_char" not in md
+        assert "end_char" not in md and "token_count" not in md
+        assert md == {"author": "alice"}
+        assert ci["chunk_index"] == 3
+        assert ci["start_char"] == 10
+        assert ci["end_char"] == 40
+        assert ci["token_count"] == 7
+        assert ci["chunker"] == "sentence"  # twin chunker_info preserved
+
+        # 2. Tier-1 collision: the differing metadata.chunk_index stays; the
+        #    other three (which matched) are stripped; chunker_info gets the
+        #    authoritative column value (3), not the user value (999).
+        md, ci = asyncio.run(_read_row(sqlite_url, _ID_TIER1_COLLISION))
+        assert md == {"chunk_index": 999}
+        assert ci["chunk_index"] == 3
+        assert ci["start_char"] == 10 and ci["end_char"] == 40 and ci["token_count"] == 7
+
+        # 3. Tier-2 number-typed: moved + stripped, user key preserved.
+        md, ci = asyncio.run(_read_row(sqlite_url, _ID_TIER2_NUMBER))
+        assert md == {"topic": "x"}
+        assert ci == {"chunk_index": 5, "start_char": 0, "end_char": 12, "token_count": 4}
+
+        # 4. Tier-2 string-typed chunk_index: left in metadata; not moved.
+        md, ci = asyncio.run(_read_row(sqlite_url, _ID_TIER2_STRING))
+        assert md == {"chunk_index": "abc"}
+        assert "chunk_index" not in ci
+
+        # 5. Clean row: chunker_info already has chunk_index → guard skips it,
+        #    the user metadata.chunk_index is left untouched.
+        md, ci = asyncio.run(_read_row(sqlite_url, _ID_CLEAN))
+        assert md == {"chunk_index": 42}
+        assert ci == {"chunk_index": 1, "start_char": 0, "end_char": 5, "token_count": 2}
+
+        # 6. Three-way precedence: start_char collides across kc.chunker_info
+        #    (111), the twin's chunker_info (222), and the bookkeeping column
+        #    (333). The column value MUST win last (kc || twin || bookkeeping),
+        #    pinning the nesting order so a future regression in the merge
+        #    precedence is caught.
+        md, ci = asyncio.run(_read_row(sqlite_url, _ID_TIER1_PRECEDENCE))
+        assert ci["start_char"] == _PREC_COLUMN_START_CHAR, (
+            f"precedence broken: expected column value {_PREC_COLUMN_START_CHAR}, got {ci['start_char']} "
+            f"(base was {_PREC_BASE_START_CHAR}, twin was {_PREC_TWIN_START_CHAR})"
+        )
+        assert ci["chunk_index"] == 1  # bookkeeping column value landed
+        assert ci["chunker"] == "sentence"  # twin's non-colliding key preserved
+
+    def test_idempotent_rerun(self, sqlite_url: str) -> None:
+        asyncio.run(_seed_sqlite(sqlite_url))
+        cfg = _make_config(sqlite_url)
+        command.upgrade(cfg, _HEAD_REVISION)
+
+        first = {
+            cid: asyncio.run(_read_row(sqlite_url, cid))
+            for cid in (
+                _ID_TIER1_MATCH,
+                _ID_TIER1_COLLISION,
+                _ID_TIER2_NUMBER,
+                _ID_TIER2_STRING,
+                _ID_CLEAN,
+                _ID_TIER1_PRECEDENCE,
+            )
+        }
+
+        # Step the version back and re-run: the guarded UPDATEs must touch zero
+        # rows (chunker_info now carries chunk_index everywhere it was moved).
+        asyncio.run(_step_version_back_sqlite(sqlite_url))
+        command.upgrade(cfg, _HEAD_REVISION)
+
+        second = {cid: asyncio.run(_read_row(sqlite_url, cid)) for cid in first}
+        assert first == second, "re-run changed an already-migrated row"
+
+
+# ---------------------------------------------------------------------------
+# Postgres lane — same archetypes against real JSONB (skips without a bind)
+# ---------------------------------------------------------------------------
+
+
+_PG_KHORA_CHUNKS_DDL = """
+CREATE TABLE khora_chunks (
+    id UUID PRIMARY KEY,
+    namespace_id UUID NOT NULL,
+    document_id UUID NOT NULL,
+    content TEXT NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    chunker_info JSONB NOT NULL DEFAULT '{}'::jsonb,
+    content_tsv TSVECTOR
+)
+"""
+
+_PG_TSV_FUNCTION_DDL = """
+CREATE OR REPLACE FUNCTION khora_chunks_content_tsv_trigger() RETURNS trigger AS $$
+BEGIN
+    NEW.content_tsv := to_tsvector('english', NEW.content);
+    RETURN NEW;
+END
+$$ LANGUAGE plpgsql
+"""
+
+_PG_TSV_TRIGGER_DDL = """
+CREATE TRIGGER khora_chunks_content_tsv_update
+BEFORE INSERT OR UPDATE ON khora_chunks
+FOR EACH ROW EXECUTE FUNCTION khora_chunks_content_tsv_trigger()
+"""
+
+
+async def _reset_public_schema(eng: AsyncEngine) -> None:
+    """Wipe ``public`` and pre-create the wide khora_alembic_version table.
+
+    Mirrors the sibling migration tests: alembic creates
+    ``khora_alembic_version`` as ``VARCHAR(32)`` but several revision ids are
+    wider, so pre-create it at VARCHAR(64) and let the chain apply cleanly.
+    """
+    async with eng.begin() as conn:
+        r = await conn.execute(
+            sa.text("SELECT typname FROM pg_type WHERE typnamespace = 'public'::regnamespace AND typtype = 'e'")
+        )
+        for (typname,) in r.fetchall():
+            await conn.execute(sa.text(f"DROP TYPE IF EXISTS public.{typname} CASCADE"))
+        await conn.execute(sa.text("DROP SCHEMA public CASCADE"))
+        await conn.execute(sa.text("CREATE SCHEMA public"))
+        await conn.execute(sa.text("CREATE EXTENSION IF NOT EXISTS vector"))
+        await conn.execute(
+            sa.text(
+                "CREATE TABLE khora_alembic_version ("
+                "  version_num VARCHAR(64) NOT NULL,"
+                "  CONSTRAINT khora_alembic_version_pkc PRIMARY KEY (version_num)"
+                ")"
+            )
+        )
+
+
+async def _seed_pg(url: str) -> None:
+    """Re-migrate the schema to head, then drop+recreate a runtime-shaped
+    ``khora_chunks`` (with its content_tsv trigger), seed the archetype
+    rows into it and the twin ``chunks`` rows, and step the version to 052."""
+    eng = create_async_engine(url)
+    try:
+        await _reset_public_schema(eng)
+    finally:
+        await eng.dispose()
+    result = await run_migrations(url)
+    assert result.success, f"migrations failed: {result.error}"
+
+    engine = create_async_engine(url)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(sa.text("DROP TABLE IF EXISTS khora_chunks CASCADE"))
+            await conn.execute(sa.text(_PG_KHORA_CHUNKS_DDL))
+            await conn.execute(sa.text(_PG_TSV_FUNCTION_DDL))
+            await conn.execute(sa.text(_PG_TSV_TRIGGER_DDL))
+
+            await conn.execute(
+                sa.text(
+                    "INSERT INTO memory_namespaces "
+                    "(id, namespace_id, version, is_active, created_at, updated_at) "
+                    "VALUES (:id, :id, 1, TRUE, NOW(), NOW())"
+                ),
+                {"id": _NS},
+            )
+
+            for cid in (_ID_TIER1_MATCH, _ID_TIER1_COLLISION):
+                doc_id = uuid4()
+                await _pg_seed_document(conn, doc_id)
+                await conn.execute(
+                    sa.text(
+                        "INSERT INTO chunks "
+                        "(id, namespace_id, document_id, content, chunk_index, "
+                        " start_char, end_char, token_count, chunker_info) "
+                        "VALUES (:id, :ns, :doc, 'c', 3, 10, 40, 7, "
+                        ' \'{"chunker": "sentence", "version": "1"}\'::jsonb)'
+                    ),
+                    {"id": cid, "ns": _NS, "doc": doc_id},
+                )
+
+            await _pg_insert_khora_chunk(
+                conn,
+                _ID_TIER1_MATCH,
+                metadata={"chunk_index": 3, "start_char": 10, "end_char": 40, "token_count": 7, "author": "alice"},
+                chunker_info={},
+            )
+            await _pg_insert_khora_chunk(
+                conn,
+                _ID_TIER1_COLLISION,
+                metadata={"chunk_index": 999, "start_char": 10, "end_char": 40, "token_count": 7},
+                chunker_info={},
+            )
+            await _pg_insert_khora_chunk(
+                conn,
+                _ID_TIER2_NUMBER,
+                metadata={"chunk_index": 5, "start_char": 0, "end_char": 12, "token_count": 4, "topic": "x"},
+                chunker_info={},
+            )
+            await _pg_insert_khora_chunk(
+                conn,
+                _ID_TIER2_STRING,
+                metadata={"chunk_index": "abc"},
+                chunker_info={},
+            )
+            await _pg_insert_khora_chunk(
+                conn,
+                _ID_CLEAN,
+                metadata={"chunk_index": 42},
+                chunker_info={"chunk_index": 1, "start_char": 0, "end_char": 5, "token_count": 2},
+            )
+
+            # 6. Three-way precedence: dedicated twin whose typed start_char
+            #    column (C=333) differs from both the twin's own chunker_info
+            #    start_char (B=222) and the kc.chunker_info base (A=111). The
+            #    column value must win last (kc || c.chunker_info || bookkeeping).
+            prec_doc = uuid4()
+            await _pg_seed_document(conn, prec_doc)
+            await conn.execute(
+                sa.text(
+                    "INSERT INTO chunks "
+                    "(id, namespace_id, document_id, content, chunk_index, "
+                    " start_char, end_char, token_count, chunker_info) "
+                    "VALUES (:id, :ns, :doc, 'c', 1, :sc, 40, 7, CAST(:ci AS JSONB))"
+                ),
+                {
+                    "id": _ID_TIER1_PRECEDENCE,
+                    "ns": _NS,
+                    "doc": prec_doc,
+                    "sc": _PREC_COLUMN_START_CHAR,
+                    "ci": json.dumps({"chunker": "sentence", "start_char": _PREC_TWIN_START_CHAR}),
+                },
+            )
+            await _pg_insert_khora_chunk(
+                conn,
+                _ID_TIER1_PRECEDENCE,
+                metadata={"chunk_index": 1, "start_char": 10, "author": "bob"},
+                chunker_info={"start_char": _PREC_BASE_START_CHAR},
+            )
+
+            await conn.execute(
+                sa.text("UPDATE khora_alembic_version SET version_num = :v"),
+                {"v": _PREV_REVISION},
+            )
+    finally:
+        await engine.dispose()
+
+
+async def _pg_seed_document(conn: AsyncConnection, doc_id: UUID) -> None:
+    await conn.execute(
+        sa.text(
+            "INSERT INTO documents "
+            "(id, namespace_id, content, status, source_type, source_name, "
+            " external_id, content_type, source, title, created_at, updated_at) "
+            "VALUES (:id, :ns, 'body', 'completed', 'slack', 'general', "
+            " :eid, 'text/plain', 's', 't', NOW(), NOW())"
+        ),
+        {"id": doc_id, "ns": _NS, "eid": str(doc_id)},
+    )
+
+
+async def _pg_insert_khora_chunk(conn: AsyncConnection, cid: UUID, *, metadata: dict, chunker_info: dict) -> None:
+    await conn.execute(
+        sa.text(
+            "INSERT INTO khora_chunks "
+            "(id, namespace_id, document_id, content, metadata, chunker_info) "
+            "VALUES (:id, :ns, :doc, 'body', CAST(:md AS JSONB), CAST(:ci AS JSONB))"
+        ),
+        {
+            "id": cid,
+            "ns": _NS,
+            "doc": uuid4(),
+            "md": json.dumps(metadata),
+            "ci": json.dumps(chunker_info),
+        },
+    )
+
+
+@pytest.mark.integration
+class TestMigration053OnPostgres:
+    @pytest.fixture
+    def pg_url(self) -> str:
+        if not _pg_reachable():
+            pytest.skip("PostgreSQL not reachable (run `make dev` first)")
+        asyncio.run(_seed_pg(DATABASE_URL))
+        return DATABASE_URL
+
+    def test_archetypes(self, pg_url: str) -> None:
+        cfg = _make_config(pg_url)
+        command.upgrade(cfg, "head")
+
+        # 1. Tier-1 match.
+        md, ci = asyncio.run(_read_row(pg_url, _ID_TIER1_MATCH))
+        assert md == {"author": "alice"}
+        assert ci["chunk_index"] == 3 and ci["start_char"] == 10
+        assert ci["end_char"] == 40 and ci["token_count"] == 7
+        assert ci["chunker"] == "sentence"
+
+        # 2. Tier-1 collision.
+        md, ci = asyncio.run(_read_row(pg_url, _ID_TIER1_COLLISION))
+        assert md == {"chunk_index": 999}
+        assert ci["chunk_index"] == 3
+
+        # 3. Tier-2 number-typed.
+        md, ci = asyncio.run(_read_row(pg_url, _ID_TIER2_NUMBER))
+        assert md == {"topic": "x"}
+        assert ci == {"chunk_index": 5, "start_char": 0, "end_char": 12, "token_count": 4}
+
+        # 4. Tier-2 string-typed.
+        md, ci = asyncio.run(_read_row(pg_url, _ID_TIER2_STRING))
+        assert md == {"chunk_index": "abc"}
+        assert "chunk_index" not in ci
+
+        # 5. Clean row untouched.
+        md, ci = asyncio.run(_read_row(pg_url, _ID_CLEAN))
+        assert md == {"chunk_index": 42}
+        assert ci == {"chunk_index": 1, "start_char": 0, "end_char": 5, "token_count": 2}
+
+        # 6. Three-way precedence: start_char in kc.chunker_info (111), twin
+        #    chunker_info (222), and bookkeeping column (333) — column wins last.
+        md, ci = asyncio.run(_read_row(pg_url, _ID_TIER1_PRECEDENCE))
+        assert ci["start_char"] == _PREC_COLUMN_START_CHAR, (
+            f"precedence broken: expected column value {_PREC_COLUMN_START_CHAR}, got {ci['start_char']} "
+            f"(base was {_PREC_BASE_START_CHAR}, twin was {_PREC_TWIN_START_CHAR})"
+        )
+        assert ci["chunk_index"] == 1
+        assert ci["chunker"] == "sentence"
+
+    def test_idempotent_rerun_and_trigger_restored(self, pg_url: str) -> None:
+        cfg = _make_config(pg_url)
+        command.upgrade(cfg, "head")
+
+        first = {
+            cid: asyncio.run(_read_row(pg_url, cid))
+            for cid in (
+                _ID_TIER1_MATCH,
+                _ID_TIER1_COLLISION,
+                _ID_TIER2_NUMBER,
+                _ID_TIER2_STRING,
+                _ID_CLEAN,
+                _ID_TIER1_PRECEDENCE,
+            )
+        }
+
+        # The content_tsv trigger must be re-enabled after the relocation.
+        async def _trigger_state() -> str:
+            engine = create_async_engine(pg_url)
+            try:
+                async with engine.connect() as conn:
+                    return (
+                        await conn.execute(
+                            sa.text(
+                                "SELECT t.tgenabled::text FROM pg_trigger t "
+                                "JOIN pg_class c ON c.oid = t.tgrelid "
+                                "WHERE c.relname = 'khora_chunks' AND t.tgname = :trg"
+                            ),
+                            {"trg": _TSV_TRIGGER},
+                        )
+                    ).scalar()
+            finally:
+                await engine.dispose()
+
+        assert asyncio.run(_trigger_state()) == "O", "content_tsv trigger not re-enabled"
+
+        # Step version back and re-run: guarded UPDATEs touch zero rows.
+        async def _step_back() -> None:
+            engine = create_async_engine(pg_url)
+            try:
+                async with engine.begin() as conn:
+                    await conn.execute(
+                        sa.text("UPDATE khora_alembic_version SET version_num = :v"),
+                        {"v": _PREV_REVISION},
+                    )
+            finally:
+                await engine.dispose()
+
+        asyncio.run(_step_back())
+        command.upgrade(cfg, "head")
+
+        second = {cid: asyncio.run(_read_row(pg_url, cid)) for cid in first}
+        assert first == second, "re-run changed an already-migrated row"

--- a/tests/integration/db/test_migration_053_bookkeeping_to_chunker_info.py
+++ b/tests/integration/db/test_migration_053_bookkeeping_to_chunker_info.py
@@ -376,6 +376,10 @@ class TestMigration053OnSqlite:
         #    pinning the nesting order so a future regression in the merge
         #    precedence is caught.
         md, ci = asyncio.run(_read_row(sqlite_url, _ID_TIER1_PRECEDENCE))
+        # Strip side of the same row: metadata.chunk_index (1) equals the twin
+        # column and is stripped; metadata.start_char (10) differs from the
+        # column (333) and survives as a user key.
+        assert md == {"start_char": 10, "author": "bob"}
         assert ci["start_char"] == _PREC_COLUMN_START_CHAR, (
             f"precedence broken: expected column value {_PREC_COLUMN_START_CHAR}, got {ci['start_char']} "
             f"(base was {_PREC_BASE_START_CHAR}, twin was {_PREC_TWIN_START_CHAR})"
@@ -651,6 +655,9 @@ class TestMigration053OnPostgres:
         # 6. Three-way precedence: start_char in kc.chunker_info (111), twin
         #    chunker_info (222), and bookkeeping column (333) — column wins last.
         md, ci = asyncio.run(_read_row(pg_url, _ID_TIER1_PRECEDENCE))
+        # Strip side: chunk_index (== column) stripped; start_char (10 != 333)
+        # and author survive as user keys.
+        assert md == {"start_char": 10, "author": "bob"}
         assert ci["start_char"] == _PREC_COLUMN_START_CHAR, (
             f"precedence broken: expected column value {_PREC_COLUMN_START_CHAR}, got {ci['start_char']} "
             f"(base was {_PREC_BASE_START_CHAR}, twin was {_PREC_TWIN_START_CHAR})"

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -442,14 +442,14 @@ class TestMigrationPackageStructure:
         assert env_path.exists(), f"env.py not found at {env_path}"
 
     @pytest.mark.unit
-    def test_versions_dir_has_53_files(self):
-        """versions/ directory contains 53 migration files."""
+    def test_versions_dir_has_54_files(self):
+        """versions/ directory contains 54 migration files."""
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
         # Filter out __pycache__ and __init__
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
-        assert len(migration_files) == 53, (
-            f"Expected 53 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
+        assert len(migration_files) == 54, (
+            f"Expected 54 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
         )
 
     @pytest.mark.unit

--- a/tests/unit/test_sqlite_migrations.py
+++ b/tests/unit/test_sqlite_migrations.py
@@ -84,7 +84,7 @@ class TestSqliteMigrations:
                     # Version table must point at head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
                     version = result.scalar()
-                    assert version == "052_entities_source_chunk_ids_gin"
+                    assert version == "053_khora_chunks_bookkeeping_to_chunker_info"
             finally:
                 await engine.dispose()
 


### PR DESCRIPTION
## Summary
- Adds Alembic data migration `053_khora_chunks_bookkeeping_to_chunker_info` that relocates the four chunk-bookkeeping keys (`chunk_index`, `start_char`, `end_char`, `token_count`) out of `khora_chunks.metadata` and into `khora_chunks.chunker_info` on every existing row. Backfill companion to the writer/reader change in #1490: the temporal-chunk reader now sources those fields from `chunker_info` with **no metadata fallback**, so legacy rows must be migrated before release (they otherwise read back as zeros).
- Runs on **both** Postgres (JSONB `||` / `-` operators) and SQLite (JSON1 `json_patch` / `json_remove`), since `khora_chunks` exists on both the pgvector store and the embedded sqlite_lance stack — the SQLite branch is load-bearing, not a green-keeper.
- Two tiers per row, keyed on whether the row has a twin in the main `chunks` table:
  - **Tier 1 (twin exists):** copy the twin's typed column values into `chunker_info`, merged as `kc.chunker_info || c.chunker_info || bookkeeping` (bookkeeping stamped last so it wins), and strip a metadata key **only where its value equals the typed column** — a differing value is a user key that merely collides on name and stays.
  - **Tier 2 (no twin):** read from `metadata` itself, moving a key only when its value is number-typed (`jsonb_typeof='number'` / `json_type='integer'`); string-typed collisions stay.
- Idempotent / convergent: guarded by `metadata ?| [four keys] AND NOT (chunker_info ? 'chunk_index')`, so a re-run touches zero rows. Postgres path bounds `lock_timeout` to 5s and suppresses the `content_tsv` trigger during the relocation (restored in a `finally`); no-op downgrade (a relocated key's origin is not reversibly disambiguable). Both `has_table` guards early-return `(0,0)` on fresh deploys.
- Two SQLite JSON1 traps handled explicitly: `json_remove(x, NULL)` nulling the `NOT NULL` column (guarded with an absent-path sentinel) and `json_patch` deleting keys whose patch value is JSON `null` per RFC 7386 (guarded via nested `json_set` with a NULL *path* no-op).
- Bumps the head-revision assertions in the sibling migration tests to the new head and the bundled-migration count.

## Test plan
- [x] Unit tests pass — SQLite lane: six archetypes (incl. a three-way base→twin→bookkeeping merge-precedence case) + idempotent re-run; full Alembic chain reaches the new head on a fresh SQLite DB; migration-bundling + sqlite-migration guards
- [ ] Integration tests pass — Postgres lane runs in CI: the same six archetypes against real JSONB plus `content_tsv` trigger restoration (requires Docker Postgres, unavailable in the authoring sandbox)
- [x] `make format` / `make lint` clean
- [ ] Manual verification: `uv run alembic upgrade head` on a populated store; confirm `khora_chunks.metadata` no longer carries the four keys (except equality-gate-preserved user values) and `chunker_info` carries them

Fixes #1491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Data Migration**
  - Backfilled chunk bookkeeping values into the dedicated chunk information store from existing per-row metadata.
  - Preserves user-supplied metadata when keys collide, moving only the numeric bookkeeping fields.
  - Runs safely on PostgreSQL and SQLite with idempotent behavior; PostgreSQL includes operational safeguards and restores related refresh behavior after the move.

- **Tests**
  - Added comprehensive coverage for relocation rules, collision handling, and idempotent reruns (including SQLite and PostgreSQL lanes).
  - Updated existing integration/unit expectations for the new migration “head” version and adjusted migration bundling file count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->