### PR TITLE
Populate first-class temporal fields in recall producers

### DIFF
--- a/src/khora/engines/vectorcypher/dual_nodes.py
+++ b/src/khora/engines/vectorcypher/dual_nodes.py
@@ -753,6 +753,7 @@ class DualNodeManager:
                c.content AS content,
                c.document_id AS document_id,
                c.occurred_at AS occurred_at,
+               c.source_timestamp AS source_timestamp,
                c.metadata AS metadata,
                c.chunker_info AS chunker_info,
                collect(DISTINCT e.id) AS entity_ids,

--- a/src/khora/engines/vectorcypher/ppr_retrieval.py
+++ b/src/khora/engines/vectorcypher/ppr_retrieval.py
@@ -487,6 +487,8 @@ async def ppr_retrieve_chunks(
                             **(chunk.metadata if isinstance(chunk.metadata, dict) else {}),
                         },
                         created_at=getattr(chunk, "created_at", None),
+                        occurred_at=chunk.occurred_at,
+                        source_timestamp=chunk.source_timestamp,
                     ),
                 )
             )

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -46,6 +46,7 @@ from khora.filter.telemetry import record_graph_channel_empty
 from khora.query import SearchMode
 from khora.query.degree_stats import build_degree_stats
 from khora.query.hyde import HyDEExpander
+from khora.storage.backends.mixins import deserialize_dict
 from khora.telemetry import bounded_text_hash, trace_span
 from khora.telemetry.metrics import metric_counter
 
@@ -1521,15 +1522,17 @@ class VectorCypherRetriever:
                         namespace_id=namespace_id,
                         document_id=UUID(c_data["document_id"]),
                         content=c_data.get("content", ""),
-                        metadata={"occurred_at": c_data.get("occurred_at")},
+                        # The :Chunk node stores the serialized user metadata
+                        # blob; deserialize it with the same helper the
+                        # get_chunks_by_entities path uses (→ {} when absent).
+                        metadata=deserialize_dict(c_data.get("metadata")),
                         chunker_info=_decode_chunker_info(c_data.get("chunker_info")),
-                        # The graph store carries only the chunk event-time;
-                        # surface it as occurred_at so the recall projection
-                        # uses it. Neo4j stores it as an ISO-8601 string;
-                        # coerce to datetime. source_timestamp mirrors it as
-                        # the projection fallback carrier.
+                        # The graph store carries the chunk event-time
+                        # (occurred_at) and the producer time (source_timestamp)
+                        # as separate node properties. Neo4j stores them as
+                        # ISO-8601 strings; coerce both to datetime.
                         occurred_at=_coerce_occurred_at(c_data.get("occurred_at")),
-                        source_timestamp=_coerce_occurred_at(c_data.get("occurred_at")),
+                        source_timestamp=_coerce_occurred_at(c_data.get("source_timestamp")),
                     )
                     chunks.append((chunk, rank_score))
 
@@ -4166,7 +4169,9 @@ class VectorCypherRetriever:
                                     "embedding": chunk.embedding,
                                     "total_mentions": 1,
                                     "entity_ids": [],
-                                    "occurred_at": getattr(chunk, "source_timestamp", None),
+                                    "metadata": chunk.metadata,
+                                    "occurred_at": chunk.occurred_at,
+                                    "source_timestamp": chunk.source_timestamp,
                                     "chunker_info": getattr(chunk, "chunker_info", None) or {},
                                 }
                             )
@@ -4195,14 +4200,13 @@ class VectorCypherRetriever:
                         **(record.get("metadata") or {}),
                     },
                     chunker_info=_decode_chunker_info(record.get("chunker_info")),
-                    # The graph store carries only the chunk event-time;
-                    # surface it as occurred_at so the recall projection uses
-                    # it. record["occurred_at"] is an ISO-8601 string from
-                    # Neo4j or a datetime from the SurrealDB fallback above.
-                    # source_timestamp mirrors it as the projection fallback
-                    # carrier.
+                    # The graph store carries the chunk event-time (occurred_at)
+                    # and the producer time (source_timestamp) as separate
+                    # record fields. From Neo4j both are ISO-8601 strings; from
+                    # the SurrealDB fallback above both are datetimes. Coerce
+                    # each independently — do NOT mirror occurred_at.
                     occurred_at=_coerce_occurred_at(record.get("occurred_at")),
-                    source_timestamp=_coerce_occurred_at(record.get("occurred_at")),
+                    source_timestamp=_coerce_occurred_at(record.get("source_timestamp")),
                 )
                 results.append((chunk_id, score, chunk))
 
@@ -4438,6 +4442,7 @@ class VectorCypherRetriever:
                             },
                             chunker_info=getattr(chunk, "chunker_info", None) or {},
                             created_at=getattr(chunk, "created_at", None) or getattr(chunk, "occurred_at", None),
+                            occurred_at=getattr(chunk, "occurred_at", None),
                             # The temporal store carries the chunk event-time
                             # (occurred_at, surfaced into metadata above) and the
                             # producer time (source_timestamp); the projection

--- a/tests/unit/engines/vectorcypher/test_source_timestamp_recall_859.py
+++ b/tests/unit/engines/vectorcypher/test_source_timestamp_recall_859.py
@@ -212,6 +212,66 @@ class TestFetchChunksFromEntitiesSourceTimestamp:
         _, _, returned_chunk = results[0]
         assert returned_chunk.source_timestamp is None
 
+    async def test_fallback_preserves_metadata_and_reads_occurred_at_not_mirror(
+        self,
+    ) -> None:
+        """SurrealDB/embedded fallback: the stored metadata blob must survive
+        and ``occurred_at`` must come from ``chunk.occurred_at`` - never be
+        mirrored from ``source_timestamp``.
+
+        Before this change the record builder dropped ``metadata`` entirely and
+        sourced ``occurred_at`` from ``chunk.source_timestamp``; a persisted
+        chunk with a NULL ``source_timestamp`` therefore lost both the user key
+        and its event-time. The pre-existing cases above only assert
+        ``source_timestamp`` pass-through, so they pass against the old code
+        too - this case pins the new behavior.
+        """
+        namespace_id = uuid4()
+        document_id = uuid4()
+        persisted = Chunk(
+            id=uuid4(),
+            namespace_id=namespace_id,
+            document_id=document_id,
+            content="persisted-meta",
+            metadata={"author": "gina"},
+            occurred_at=T_SOURCE,
+            source_timestamp=None,
+        )
+        entity = Entity(
+            id=uuid4(),
+            namespace_id=namespace_id,
+            name="Gina",
+            entity_type="PERSON",
+            source_chunk_ids=[persisted.id],
+        )
+
+        retriever = VectorCypherRetriever.__new__(VectorCypherRetriever)
+        retriever._config = RetrieverConfig()
+        retriever._dual_nodes = None
+        retriever._vector_store = MagicMock()
+        retriever._neo4j_driver = None
+        storage = MagicMock()
+        storage.get_entities_batch = AsyncMock(return_value={entity.id: entity})
+        storage.get_chunks_batch = AsyncMock(return_value={persisted.id: persisted})
+        retriever._storage = storage
+
+        results = await retriever._fetch_chunks_from_entities(
+            entity_ids=[entity.id],
+            namespace_id=namespace_id,
+            temporal_filter=None,
+            limit=10,
+        )
+
+        assert len(results) == 1
+        _, _, returned_chunk = results[0]
+        # Both were lost before this PR: the record builder dropped the blob and
+        # mirrored occurred_at from the (NULL) source_timestamp.
+        assert returned_chunk.metadata.get("author") == "gina"
+        assert returned_chunk.occurred_at == T_SOURCE
+        # source_timestamp was NULL and must stay NULL — proves the two fields
+        # are read from their own sources, never mirrored onto each other.
+        assert returned_chunk.source_timestamp is None
+
 
 # A producer time distinct from the chunk event-time — used to prove the two
 # fields are read from their own authoritative sources, never mirrored.

--- a/tests/unit/engines/vectorcypher/test_source_timestamp_recall_859.py
+++ b/tests/unit/engines/vectorcypher/test_source_timestamp_recall_859.py
@@ -24,7 +24,7 @@ at each site, coercing strings to datetimes via ``_coerce_occurred_at``.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -211,3 +211,325 @@ class TestFetchChunksFromEntitiesSourceTimestamp:
         assert len(results) == 1
         _, _, returned_chunk = results[0]
         assert returned_chunk.source_timestamp is None
+
+
+# A producer time distinct from the chunk event-time — used to prove the two
+# fields are read from their own authoritative sources, never mirrored.
+T_PRODUCER = datetime(2024, 6, 10, 8, 0, 0, tzinfo=UTC)
+
+
+def _bare_retriever() -> VectorCypherRetriever:
+    """A retriever instance with the attributes the recency channel touches,
+    bypassing ``__init__`` (matches ``TestSimpleRetrieveSourceTimestamp``)."""
+    retriever = VectorCypherRetriever.__new__(VectorCypherRetriever)
+    retriever._config = RetrieverConfig()
+    retriever._dual_nodes = None
+    retriever._neo4j_driver = None
+    retriever._storage = None
+    return retriever
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestRecencyChannelFirstClassOccurredAt:
+    """Recency channel (``_recency_channel_chunks``) now populates the
+    first-class ``Chunk.occurred_at`` from the source chunk's own
+    ``occurred_at``, not just the metadata blob."""
+
+    async def test_first_class_occurred_at_surfaces(self) -> None:
+        """A source chunk carrying ``occurred_at`` produces a Chunk whose
+        first-class ``occurred_at`` is that value (not None)."""
+        retriever = _bare_retriever()
+        namespace_id = uuid4()
+
+        # The temporal store returns a chunk-shaped object with an embedding
+        # (required to survive the cosine gate) and its own occurred_at.
+        src = MagicMock()
+        src.id = uuid4()
+        src.namespace_id = namespace_id
+        src.document_id = uuid4()
+        src.content = "recent"
+        src.embedding = [1.0, 0.0, 0.0]
+        src.occurred_at = T_SOURCE
+        src.source_timestamp = None
+        src.created_at = None
+        src.metadata = None
+        src.chunker_info = None
+
+        retriever._vector_store = MagicMock()
+        retriever._vector_store.search_recent_chunks = AsyncMock(return_value=[(src, None)])
+
+        with patch("khora._accel.batch_cosine_similarity", return_value=[(0, 0.9)]):
+            result = await retriever._recency_channel_chunks(
+                query_embedding=[1.0, 0.0, 0.0],
+                namespace_id=namespace_id,
+                temporal_filter=None,
+            )
+
+        assert len(result) == 1
+        _, _, chunk = result[0]
+        assert chunk.occurred_at == T_SOURCE
+
+    async def test_occurred_at_column_set_but_source_timestamp_null(self) -> None:
+        """Regression: a chunk with the ``occurred_at`` column set but
+        ``source_timestamp`` NULL now surfaces ``occurred_at`` on the recall
+        chunk. Before the fix the recency channel never passed ``occurred_at``
+        to the constructor, so the field was silently None."""
+        retriever = _bare_retriever()
+        namespace_id = uuid4()
+
+        src = MagicMock()
+        src.id = uuid4()
+        src.namespace_id = namespace_id
+        src.document_id = uuid4()
+        src.content = "recent-no-producer"
+        src.embedding = [1.0, 0.0, 0.0]
+        src.occurred_at = T_SOURCE
+        src.source_timestamp = None
+        src.created_at = None
+        src.metadata = None
+        src.chunker_info = None
+
+        retriever._vector_store = MagicMock()
+        retriever._vector_store.search_recent_chunks = AsyncMock(return_value=[(src, None)])
+
+        with patch("khora._accel.batch_cosine_similarity", return_value=[(0, 0.9)]):
+            result = await retriever._recency_channel_chunks(
+                query_embedding=[1.0, 0.0, 0.0],
+                namespace_id=namespace_id,
+                temporal_filter=None,
+            )
+
+        assert len(result) == 1
+        _, _, chunk = result[0]
+        assert chunk.occurred_at == T_SOURCE
+        assert chunk.source_timestamp is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestPPRRewrapTemporalFields:
+    """The PPR channel re-wraps hydrated chunks (``ppr_retrieve_chunks``);
+    the re-wrap now carries BOTH first-class ``occurred_at`` and
+    ``source_timestamp`` from the hydrated source chunk."""
+
+    def _seed_storage(self, chunk: Chunk, entity: Entity) -> MagicMock:
+        """A storage coordinator that resolves the single-entity PPR graph and
+        hydrates the one source chunk."""
+        storage = MagicMock()
+        storage.list_entities = AsyncMock(return_value=[entity])
+        storage.list_relationships = AsyncMock(return_value=[])
+        storage.get_chunks_batch = AsyncMock(return_value={chunk.id: chunk})
+        return storage
+
+    async def test_rewrap_carries_both_occurred_at_and_source_timestamp(self) -> None:
+        """The hydrated source chunk carries distinct ``occurred_at`` and
+        ``source_timestamp``; the re-wrapped Chunk must carry both verbatim
+        (source_timestamp is NOT a mirror of occurred_at)."""
+        from khora.engines.vectorcypher.ppr_retrieval import ppr_retrieve_chunks
+
+        namespace_id = uuid4()
+        hydrated = Chunk(
+            id=uuid4(),
+            namespace_id=namespace_id,
+            document_id=uuid4(),
+            content="ppr hit",
+            occurred_at=T_SOURCE,
+            source_timestamp=T_PRODUCER,
+        )
+        entity = Entity(
+            id=uuid4(),
+            namespace_id=namespace_id,
+            name="Carol",
+            entity_type="PERSON",
+            source_chunk_ids=[hydrated.id],
+        )
+        storage = self._seed_storage(hydrated, entity)
+
+        results, _scores = await ppr_retrieve_chunks(
+            storage=storage,
+            namespace_id=namespace_id,
+            entry_entities=[(entity.id, 1.0)],
+            damping=0.85,
+            max_iter=50,
+            tol=1e-6,
+            top_entities=10,
+            limit=10,
+        )
+
+        assert len(results) == 1
+        _, _, chunk = results[0]
+        assert chunk.occurred_at == T_SOURCE
+        assert chunk.source_timestamp == T_PRODUCER
+
+    async def test_rewrap_occurred_at_set_source_timestamp_null(self) -> None:
+        """Regression: hydrated chunk has the ``occurred_at`` column set but
+        ``source_timestamp`` NULL. The re-wrapped Chunk surfaces ``occurred_at``
+        (was None before the fix — the re-wrap constructor never received it)."""
+        from khora.engines.vectorcypher.ppr_retrieval import ppr_retrieve_chunks
+
+        namespace_id = uuid4()
+        hydrated = Chunk(
+            id=uuid4(),
+            namespace_id=namespace_id,
+            document_id=uuid4(),
+            content="ppr hit no producer",
+            occurred_at=T_SOURCE,
+            source_timestamp=None,
+        )
+        entity = Entity(
+            id=uuid4(),
+            namespace_id=namespace_id,
+            name="Dave",
+            entity_type="PERSON",
+            source_chunk_ids=[hydrated.id],
+        )
+        storage = self._seed_storage(hydrated, entity)
+
+        results, _scores = await ppr_retrieve_chunks(
+            storage=storage,
+            namespace_id=namespace_id,
+            entry_entities=[(entity.id, 1.0)],
+            damping=0.85,
+            max_iter=50,
+            tol=1e-6,
+            top_entities=10,
+            limit=10,
+        )
+
+        assert len(results) == 1
+        _, _, chunk = results[0]
+        assert chunk.occurred_at == T_SOURCE
+        assert chunk.source_timestamp is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestTypedEntityFastPathTemporalFields:
+    """Typed-entity fast path (``_typed_entity_recent_retrieve``): the graph
+    node's serialized user metadata blob is preserved (no injected
+    ``occurred_at`` key that erases user keys) and the real ``source_timestamp``
+    node property is read (not mirrored from ``occurred_at``)."""
+
+    def _fast_path_retriever(self, rows: list) -> VectorCypherRetriever:
+        retriever = VectorCypherRetriever.__new__(VectorCypherRetriever)
+        retriever._config = RetrieverConfig()
+        session_ctx = AsyncMock()
+        session_ctx.__aenter__.return_value = session_ctx
+        session_ctx.__aexit__.return_value = None
+        session_ctx.execute_read = AsyncMock(return_value=rows)
+        retriever._dual_nodes = MagicMock()
+        retriever._dual_nodes._session.return_value = session_ctx
+        return retriever
+
+    async def test_preserves_user_metadata_and_reads_real_source_timestamp(self) -> None:
+        """``c_data.metadata`` is the serialized user blob and the node's
+        ``source_timestamp`` differs from ``occurred_at``. The produced Chunk
+        must keep the deserialized user keys (no ``occurred_at`` key injected
+        that would erase them) and read the real ``source_timestamp``."""
+        from khora.storage.backends.mixins import serialize_dict
+
+        namespace_id = uuid4()
+        entity_id = uuid4()
+        chunk_id = uuid4()
+        doc_id = uuid4()
+
+        user_blob = {"author": "erin", "topic": "roadmap"}
+        rows = [
+            {
+                "entity": {
+                    "id": str(entity_id),
+                    "name": "Ship the prototype",
+                    "entity_type": "ACTION_ITEM",
+                    "description": "",
+                },
+                "last_mention": T_SOURCE.isoformat(),
+                "evidence_chunk": {
+                    "id": str(chunk_id),
+                    "document_id": str(doc_id),
+                    "content": "Action: ship the prototype",
+                    # The :Chunk node stores the user metadata as a JSON string.
+                    "metadata": serialize_dict(user_blob),
+                    "occurred_at": T_SOURCE.isoformat(),
+                    "source_timestamp": T_PRODUCER.isoformat(),
+                },
+            }
+        ]
+        retriever = self._fast_path_retriever(rows)
+
+        from khora.engines.vectorcypher.router import QueryComplexity, RoutingDecision
+
+        routing = RoutingDecision(
+            complexity=QueryComplexity.TYPED_ENTITY_RECENT,
+            use_graph=True,
+            graph_depth=1,
+            confidence=0.9,
+            reasoning="typed",
+        )
+        result = await retriever._typed_entity_recent_retrieve(
+            query="latest action items",
+            query_embedding=[0.0],
+            namespace_id=namespace_id,
+            temporal_filter=None,
+            graph_depth=1,
+            limit=5,
+            routing=routing,
+        )
+
+        assert len(result.chunks) == 1
+        chunk, _score = result.chunks[0]
+        # User keys survive verbatim; no injected occurred_at key erased them.
+        assert chunk.metadata == user_blob
+        assert "occurred_at" not in chunk.metadata
+        # Real node property read, distinct from occurred_at (not a mirror).
+        assert chunk.occurred_at == T_SOURCE
+        assert chunk.source_timestamp == T_PRODUCER
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestNeo4jGraphBranchSourceTimestamp:
+    """Neo4j graph channel (``_fetch_chunks_from_entities`` shared result
+    loop): the ``source_timestamp`` record field is read verbatim, NOT
+    mirrored from ``occurred_at``."""
+
+    async def test_reads_real_source_timestamp_not_mirror(self) -> None:
+        """The Neo4j ``get_chunks_by_entities`` record carries distinct
+        ``occurred_at`` and ``source_timestamp`` ISO strings. The produced
+        Chunk must read the real ``source_timestamp`` (not occurred_at)."""
+        namespace_id = uuid4()
+        chunk_id = uuid4()
+        doc_id = uuid4()
+
+        retriever = VectorCypherRetriever.__new__(VectorCypherRetriever)
+        retriever._config = RetrieverConfig()
+        retriever._storage = None
+        retriever._dual_nodes = MagicMock()
+        retriever._dual_nodes.get_chunks_by_entities = AsyncMock(
+            return_value=[
+                {
+                    "chunk_id": str(chunk_id),
+                    "document_id": str(doc_id),
+                    "content": "graph hit",
+                    "total_mentions": 1,
+                    "entity_ids": ["a"],
+                    "occurred_at": T_SOURCE.isoformat(),
+                    "source_timestamp": T_PRODUCER.isoformat(),
+                    "metadata": {"author": "frank"},
+                }
+            ]
+        )
+
+        results = await retriever._fetch_chunks_from_entities(
+            entity_ids=[uuid4()],
+            namespace_id=namespace_id,
+            temporal_filter=None,
+            limit=10,
+        )
+
+        assert len(results) == 1
+        _, _, chunk = results[0]
+        assert chunk.occurred_at == T_SOURCE
+        # The real source_timestamp field, not a mirror of occurred_at.
+        assert chunk.source_timestamp == T_PRODUCER
+        assert chunk.source_timestamp != chunk.occurred_at


### PR DESCRIPTION
## Summary

Recall-path `Chunk` constructors now populate first-class `occurred_at` / `source_timestamp` from their authoritative source (the chunk column or graph-node property) instead of leaving them null or mirroring one field onto the other. Two sites that overwrote user metadata stop doing so.

- **Recency channel** — sets `occurred_at` (previously omitted).
- **PPR channel** — sets `occurred_at` and `source_timestamp` (previously only `created_at`).
- **Typed-entity fast path** — preserves the stored user-metadata blob (previously replaced wholesale with a single injected key) and reads the real `source_timestamp` node property instead of mirroring `occurred_at`. No key is injected on this path; it returns directly from `retrieve()` and is gated on "no constraining filter", so preserving the real blob does not change filter results here.
- **Graph channel (SurrealDB/embedded fallback)** — carries `metadata` plus both temporal fields into the record builder (metadata was previously dropped in memory, and `occurred_at` was mirrored from `source_timestamp`).
- **Graph channel (Neo4j)** — `get_chunks_by_entities` now returns `source_timestamp`, and the reader uses it instead of mirroring `occurred_at`.

### Scope / behavior notes

- **Temporal-ranking readers are deliberately untouched in this stage.** `_extract_occurred_at`, the `_ts` sort key, the cross-encoder / LLM rerank prefix builders, and the top-1-age telemetry all still consume the `metadata` blob, and every existing blob injection is preserved — so ranking, sort, and rerank **ordering** is unchanged here. Those readers flip to the first-class fields in a follow-up stage.
- **Intended output refinement.** Chunks that have `occurred_at` set but `source_timestamp` NULL — or a real `source_timestamp` with NULL `occurred_at` — now surface the real value in the recall output projection instead of `null`. This is the data-correctness fix this change exists for.
- **Metadata completeness.** The fast path and the SurrealDB/embedded graph fallback stop discarding the user-metadata blob in memory. This is additive (nothing that was present is removed).

This is a staged change (1 of 3): stage 1 makes producers correct, stage 2 flips the readers to the first-class fields (with a ranking benchmark), stage 3 removes the now-redundant blob injections. Keeping the injections in place this stage is what makes stage 1 ordering-invisible.

Fixes #1507 (stage 1). Part of #1492 — the umbrella issue stays open for the final stage.

## Test plan

- [x] Unit tests pass (`make test-unit`: 9959 passed, 0 failed)
- [x] New/extended unit tests cover all five constructors plus regression tests for the null-emission bugs
- [x] Dedicated regression test for the SurrealDB/embedded fallback branch — pins that the stored metadata blob survives and `occurred_at` comes from the chunk column (not mirrored from `source_timestamp`); verified to fail on the pre-change code
- [x] Embedded (sqlite_lance) integration tests pass, incl. the source-timestamp contract and vectorcypher recall suites (30 passed)
- [x] Lint and format clean (`make lint`, `make format`)
- [x] Blob-invisibility guard (`test_retriever_coverage_push.py`) unmodified and still green
- [ ] Full PostgreSQL/Neo4j integration suite (validated in CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected retrieval of chunk event timestamps and source timestamps across graph, recency, typed-entity, and PPR search paths.
  * Preserved user-provided metadata during chunk retrieval and deserialized it correctly.
  * Prevented event timestamps from being incorrectly copied into source timestamps, including when values are missing.
  * Added source timestamp information to entity-based chunk results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->