### PR TITLE
Read recall temporal fields from first-class Chunk columns

### DIFF
--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -2964,20 +2964,21 @@ class VectorCypherRetriever:
         score_range = score_max - score_min
         candidates = []
         for r in candidates_to_rerank:
-            # Build content with optional temporal prefix for cross-encoder context
+            # Build content with optional temporal prefix for cross-encoder
+            # context. occurred_at is a first-class column, so the Date prefix is
+            # built independently of the metadata blob; session_id stays gated on
+            # the blob because it is a user-space key that only lives there.
             chunk_content = r.item.content if hasattr(r.item, "content") else str(r.item)
-            if hasattr(r.item, "metadata") and isinstance(r.item.metadata, dict):
-                raw = r.item.metadata
-                if raw:
-                    prefix_parts = []
-                    session_id = raw.get("session_id") or raw.get("conversation_id")
-                    if session_id:
-                        prefix_parts.append(f"Session: {session_id}")
-                    occurred_at = getattr(r.item, "occurred_at", None) or getattr(r.item, "source_timestamp", None)
-                    if occurred_at:
-                        prefix_parts.append(f"Date: {str(occurred_at)[:10]}")
-                    if prefix_parts:
-                        chunk_content = f"[{', '.join(prefix_parts)}] {chunk_content}"
+            prefix_parts = []
+            if hasattr(r.item, "metadata") and isinstance(r.item.metadata, dict) and r.item.metadata:
+                session_id = r.item.metadata.get("session_id") or r.item.metadata.get("conversation_id")
+                if session_id:
+                    prefix_parts.append(f"Session: {session_id}")
+            occurred_at = getattr(r.item, "occurred_at", None) or getattr(r.item, "source_timestamp", None)
+            if occurred_at:
+                prefix_parts.append(f"Date: {str(occurred_at)[:10]}")
+            if prefix_parts:
+                chunk_content = f"[{', '.join(prefix_parts)}] {chunk_content}"
             candidates.append(
                 RerankCandidate(
                     item=r,
@@ -3166,21 +3167,22 @@ class VectorCypherRetriever:
         candidates = []
         for r in candidates_to_rerank:
             # Build content with temporal prefix (date from the first-class
-            # column; session id still from the metadata blob) for LLM context
+            # column, independent of the metadata blob; session id stays gated on
+            # the blob where it lives) for LLM context.
             chunk_content = r.item.content if hasattr(r.item, "content") else str(r.item)
+            prefix_parts = []
             if hasattr(r.item, "metadata") and r.item.metadata:
                 meta = r.item.metadata
                 raw = meta.custom if hasattr(meta, "custom") else (meta if isinstance(meta, dict) else {})
                 if raw:
-                    prefix_parts = []
                     session_id = raw.get("session_id") or raw.get("conversation_id")
                     if session_id:
                         prefix_parts.append(f"Session: {session_id}")
-                    occurred_at = getattr(r.item, "occurred_at", None) or getattr(r.item, "source_timestamp", None)
-                    if occurred_at:
-                        prefix_parts.append(f"Date: {str(occurred_at)[:10]}")
-                    if prefix_parts:
-                        chunk_content = f"[{', '.join(prefix_parts)}] {chunk_content}"
+            occurred_at = getattr(r.item, "occurred_at", None) or getattr(r.item, "source_timestamp", None)
+            if occurred_at:
+                prefix_parts.append(f"Date: {str(occurred_at)[:10]}")
+            if prefix_parts:
+                chunk_content = f"[{', '.join(prefix_parts)}] {chunk_content}"
             candidates.append(
                 RerankCandidate(
                     item=r,

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -559,12 +559,20 @@ class RetrieverConfig:
     metadata_overfetch_multiplier: int = 3
 
 
-def _extract_occurred_at(item: Any) -> str | None:
-    """Extract occurred_at string from a Chunk or dict item."""
+def _extract_occurred_at(item: Any) -> datetime | None:
+    """Extract the ``occurred_at`` datetime from a Chunk or dict item.
+
+    Chunk-shaped items read the first-class ``occurred_at`` column
+    (already a ``datetime``); there is deliberately no fallback to
+    ``source_timestamp`` so the boost/sort semantics match the column
+    that the (now dead) ``metadata['occurred_at']`` blob mirrored. Dict
+    items are coerced via :func:`_coerce_occurred_at` so the return type
+    is always ``datetime | None``.
+    """
     if isinstance(item, Chunk):
-        return (item.metadata or {}).get("occurred_at")
+        return item.occurred_at
     elif isinstance(item, dict):
-        return item.get("occurred_at")
+        return _coerce_occurred_at(item.get("occurred_at"))
     return None
 
 
@@ -1325,12 +1333,8 @@ class VectorCypherRetriever:
                     # depending on the path; unwrap defensively.
                     raw = result.chunks[0]
                     top_chunk = raw[0] if isinstance(raw, tuple) else raw
-                    occurred_at_iso = None
-                    meta = getattr(top_chunk, "metadata", None)
-                    if isinstance(meta, dict):
-                        occurred_at_iso = meta.get("occurred_at")
-                    if occurred_at_iso:
-                        occurred_at = datetime.fromisoformat(occurred_at_iso.replace("Z", "+00:00"))
+                    occurred_at = getattr(top_chunk, "occurred_at", None)
+                    if occurred_at is not None:
                         if occurred_at.tzinfo is None:
                             occurred_at = occurred_at.replace(tzinfo=UTC)
                         age_days = (datetime.now(UTC) - occurred_at).total_seconds() / 86400.0
@@ -2969,7 +2973,7 @@ class VectorCypherRetriever:
                     session_id = raw.get("session_id") or raw.get("conversation_id")
                     if session_id:
                         prefix_parts.append(f"Session: {session_id}")
-                    occurred_at = raw.get("occurred_at") or raw.get("source_timestamp")
+                    occurred_at = getattr(r.item, "occurred_at", None) or getattr(r.item, "source_timestamp", None)
                     if occurred_at:
                         prefix_parts.append(f"Date: {str(occurred_at)[:10]}")
                     if prefix_parts:
@@ -3171,7 +3175,7 @@ class VectorCypherRetriever:
                     session_id = raw.get("session_id") or raw.get("conversation_id")
                     if session_id:
                         prefix_parts.append(f"Session: {session_id}")
-                    occurred_at = raw.get("occurred_at") or raw.get("source_timestamp")
+                    occurred_at = getattr(r.item, "occurred_at", None) or getattr(r.item, "source_timestamp", None)
                     if occurred_at:
                         prefix_parts.append(f"Date: {str(occurred_at)[:10]}")
                     if prefix_parts:
@@ -3527,24 +3531,20 @@ class VectorCypherRetriever:
             if temporal_sort and chunk_results and not self._config.enable_reranking:
                 from datetime import datetime as _dt
 
-                # Normalize every key to tz-aware UTC: metadata occurred_at
-                # may be a user-supplied naive ISO string (it overrides the
-                # column value in the metadata dict), created_at is tz-aware
-                # from the DB, and the sentinel must match. Mixing naive and
-                # aware datetimes in one sort raises TypeError (#1115). Same
+                # Normalize every key to tz-aware UTC: the first-class
+                # occurred_at column may be naive (embedded backends carry no
+                # tz) or tz-aware (Postgres), created_at is tz-aware from the
+                # DB, and the sentinel must match. Mixing naive and aware
+                # datetimes in one sort raises TypeError (#1115). Same
                 # normalization as _calculate_recency_scores.
                 _ts_sentinel = _dt.min.replace(tzinfo=UTC)
 
                 def _ts(pair: tuple[Chunk, float]) -> _dt:
-                    occ = (pair[0].metadata or {}).get("occurred_at") if isinstance(pair[0].metadata, dict) else None
-                    if occ:
-                        try:
-                            parsed = _dt.fromisoformat(occ.replace("Z", "+00:00"))
-                            if parsed.tzinfo is None:
-                                parsed = parsed.replace(tzinfo=UTC)
-                            return parsed
-                        except (ValueError, TypeError, AttributeError):
-                            pass
+                    occ = pair[0].occurred_at
+                    if occ is not None:
+                        if occ.tzinfo is None:
+                            occ = occ.replace(tzinfo=UTC)
+                        return occ
                     created = pair[0].created_at
                     if created is None:
                         return _ts_sentinel
@@ -5226,18 +5226,16 @@ class VectorCypherRetriever:
         """
         scores: dict[UUID, float] = {}
 
-        # First pass: extract all occurred_at timestamps.
+        # First pass: extract all occurred_at timestamps. The reader now
+        # returns a first-class ``datetime`` (not an ISO string), so the
+        # only normalization left is naive→UTC before the reference math.
         parsed_times: dict[UUID, datetime] = {}
         for r in results:
-            occurred_at_str = _extract_occurred_at(r.item)
-            if occurred_at_str:
-                try:
-                    occurred_at = datetime.fromisoformat(occurred_at_str.replace("Z", "+00:00"))
-                    if occurred_at.tzinfo is None:
-                        occurred_at = occurred_at.replace(tzinfo=UTC)
-                    parsed_times[r.item_id] = occurred_at
-                except (ValueError, TypeError):
-                    pass
+            occurred_at = _extract_occurred_at(r.item)
+            if occurred_at is not None:
+                if occurred_at.tzinfo is None:
+                    occurred_at = occurred_at.replace(tzinfo=UTC)
+                parsed_times[r.item_id] = occurred_at
 
         # Resolve reference mode from explicit arg → bench env → config flag.
         # Bench-mode env wins to keep benchmark replays deterministic even

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -1326,7 +1326,7 @@ class VectorCypherRetriever:
             # operators can spot temporal-quality drift in production
             # (the dashboard slices it by temporal_category via the span
             # parent context). Only fires when the top chunk carries a
-            # parseable occurred_at; skipped on empty result sets.
+            # non-null occurred_at column; skipped on empty result sets.
             if result.chunks:
                 try:
                     # result.chunks may be list[Chunk] or list[tuple[Chunk, score]]
@@ -3165,7 +3165,8 @@ class VectorCypherRetriever:
 
         candidates = []
         for r in candidates_to_rerank:
-            # Build content with temporal metadata prefix
+            # Build content with temporal prefix (date from the first-class
+            # column; session id still from the metadata blob) for LLM context
             chunk_content = r.item.content if hasattr(r.item, "content") else str(r.item)
             if hasattr(r.item, "metadata") and r.item.metadata:
                 meta = r.item.metadata

--- a/tests/integration/matrix/test_recency_channel_matrix_occurred_at.py
+++ b/tests/integration/matrix/test_recency_channel_matrix_occurred_at.py
@@ -1,0 +1,148 @@
+"""Cross-channel recency-visibility contract for first-class ``occurred_at``.
+
+The recall-path recency reader (``VectorCypherRetriever._extract_occurred_at``
+/ ``_calculate_recency_scores``) now reads the first-class ``Chunk.occurred_at``
+column instead of the ``metadata['occurred_at']`` blob. This test pins the
+consequence for the non-vector channels: chunks surfaced through the **BM25**
+lexical channel and the **keyword_ppr** channel are hydrated straight from
+storage (``search_fulltext`` / ``get_chunks_batch``), so they must carry a
+populated first-class ``occurred_at`` and be recency-scored on the same footing
+as vector-channel chunks - not stranded at the 0.5 "missing date" default.
+
+Before the reader flip a channel that surfaced chunks without stamping the
+``metadata`` blob would have been recency-invisible; this exercises the real
+embedded storage round-trip + the real channels + the real recency scorer to
+prove they now line up.
+
+Hermetic - deterministic fake embeddings, real SQLite + LanceDB in tmp_path.
+Mirrors ``test_keyword_ppr_channel.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+try:
+    import aiosqlite  # noqa: F401
+    import lancedb  # noqa: F401
+
+    _HAS_EMBEDDED = True
+except ImportError:
+    _HAS_EMBEDDED = False
+
+from khora.core.models import Chunk, Document, MemoryNamespace
+from khora.engines.vectorcypher.fusion import FusedResult
+from khora.engines.vectorcypher.keyword_edges import persist_keyword_chunk_edges
+from khora.engines.vectorcypher.retriever import RetrieverConfig, VectorCypherRetriever
+from khora.extraction.tokenize import tokenize_multilingual
+from khora.query.keyword_ppr import keyword_ppr_retrieve_chunks
+from tests.integration._sqlite_lance_fixtures import build_sqlite_lance_coordinator, fake_embedding
+
+pytestmark = [
+    pytest.mark.embedded,
+    pytest.mark.integration,
+    pytest.mark.skipif(not _HAS_EMBEDDED, reason="aiosqlite/lancedb not installed"),
+]
+
+
+def _recency_retriever() -> VectorCypherRetriever:
+    """A retriever whose only exercised surface is ``_calculate_recency_scores``.
+
+    ``temporal_reference_wall_clock=True`` anchors recency to ``now`` so a
+    genuinely old chunk scores near 0 (not 1.0 via the relative newest-in-set
+    anchor) - the discriminating reference for "recency-visible".
+    """
+    return VectorCypherRetriever(
+        vector_store=AsyncMock(),
+        neo4j_driver=None,
+        embedder=AsyncMock(),
+        config=RetrieverConfig(temporal_reference_wall_clock=True, recency_decay_days=30),
+    )
+
+
+async def test_bm25_and_keyword_ppr_chunks_are_recency_visible(tmp_path: Path) -> None:
+    coord = await build_sqlite_lance_coordinator(tmp_path)
+    try:
+        ns = await coord.create_namespace(MemoryNamespace())
+        ns_id = await coord.resolve_namespace(ns.namespace_id)
+
+        now = datetime.now(UTC)
+        fresh_ts = now - timedelta(days=2)
+        stale_ts = now - timedelta(days=400)
+
+        # Both chunks mention "photosynthesis" so the lexical channels surface
+        # both; their occurred_at columns are far apart so recency must separate
+        # them. The metadata blob is deliberately left empty - the reader must
+        # rely on the first-class column alone.
+        doc = Document(namespace_id=ns_id, content="bio", external_id="doc-0", title="bio")
+        await coord.create_document(doc)
+        fresh = Chunk(
+            namespace_id=ns_id,
+            document_id=doc.id,
+            content="photosynthesis converts sunlight into chemical energy in plants",
+            chunk_index=0,
+            embedding=fake_embedding("fresh"),
+            embedding_model="fake",
+            occurred_at=fresh_ts,
+        )
+        stale = Chunk(
+            namespace_id=ns_id,
+            document_id=doc.id,
+            content="photosynthesis was catalogued by early botanists long ago",
+            chunk_index=1,
+            embedding=fake_embedding("stale"),
+            embedding_model="fake",
+            occurred_at=stale_ts,
+        )
+        await coord.create_chunks_batch([fresh, stale])
+
+        # --- keyword_ppr channel: rank -> hydrate via get_chunks_batch --------
+        await persist_keyword_chunk_edges(coord, ns_id, [fresh, stale])
+        ranked = await keyword_ppr_retrieve_chunks(
+            coord,
+            ns_id,
+            "tell me about photosynthesis",
+            tokenizer=tokenize_multilingual,
+            damping=0.85,
+            max_iter=50,
+            tol=1e-6,
+            limit=10,
+            max_edges=50_000,
+        )
+        assert ranked, "keyword_ppr channel returned no chunks"
+        ppr_map = await coord.get_chunks_batch([cid for cid, _ in ranked], namespace_id=ns_id)
+        ppr_chunks = {c.content: c for c in ppr_map.values()}
+        assert set(ppr_chunks) == {fresh.content, stale.content}
+        # The channel-hydrated chunks carry the first-class column (blob empty).
+        for c in ppr_chunks.values():
+            assert c.occurred_at is not None
+            assert (c.metadata or {}).get("occurred_at") is None
+
+        # --- bm25 channel: search_fulltext_chunks -> (Chunk, score) -----------
+        bm25 = await coord.search_fulltext_chunks(ns_id, "photosynthesis", limit=10)
+        bm25_chunks = {c.content: c for c, _score in bm25}
+        assert set(bm25_chunks) == {fresh.content, stale.content}
+        for c in bm25_chunks.values():
+            assert c.occurred_at is not None
+
+        # --- recency scorer reads the column for BOTH channels' chunks --------
+        retriever = _recency_retriever()
+        for label, chunk_by_content in (("keyword_ppr", ppr_chunks), ("bm25", bm25_chunks)):
+            fresh_c = chunk_by_content[fresh.content]
+            stale_c = chunk_by_content[stale.content]
+            scores = retriever._calculate_recency_scores(
+                [
+                    FusedResult(item_id=fresh_c.id, item=fresh_c, rrf_score=0.5),
+                    FusedResult(item_id=stale_c.id, item=stale_c, rrf_score=0.5),
+                ]
+            )
+            # Fresh scores near 1.0, stale near 0.0. Both are strictly on either
+            # side of the 0.5 missing-date default, proving neither channel's
+            # chunk fell through to "no occurred_at".
+            assert scores[fresh_c.id] > 0.5 > scores[stale_c.id], f"{label}: {scores}"
+    finally:
+        await coord.disconnect()

--- a/tests/integration/matrix/test_recency_channel_matrix_occurred_at.py
+++ b/tests/integration/matrix/test_recency_channel_matrix_occurred_at.py
@@ -14,6 +14,14 @@ Before the reader flip a channel that surfaced chunks without stamping the
 embedded storage round-trip + the real channels + the real recency scorer to
 prove they now line up.
 
+The entity-PPR channel (``ppr_retrieval.ppr_retrieve_chunks``, #1492 §(b)) runs
+PageRank over the graph and is not exercisable on the embedded stack, so it is
+covered compositionally rather than driven here: stage-1 re-wrap tests pin that
+its re-wrapped chunks carry the first-class ``occurred_at`` / ``source_timestamp``
+fields, and this PR's reader/scorer tests pin that ``_calculate_recency_scores``
+reads that column - the two compose to the same recency visibility proven here
+for the keyword_ppr channel.
+
 Hermetic - deterministic fake embeddings, real SQLite + LanceDB in tmp_path.
 Mirrors ``test_keyword_ppr_channel.py``.
 """

--- a/tests/unit/engines/test_retriever_coverage_push.py
+++ b/tests/unit/engines/test_retriever_coverage_push.py
@@ -34,6 +34,7 @@ from khora.engines.vectorcypher.retriever import (
     RetrieverConfig,
     VectorCypherResult,
     VectorCypherRetriever,
+    _coerce_occurred_at,
     _extract_occurred_at,
     _extract_source_system,
     _has_target_date,
@@ -70,6 +71,9 @@ def _make_chunk(
         document_id=uuid4(),
         content=content,
         metadata=custom,
+        # Mirror occurred_at onto the first-class column - the recency reader
+        # reads it there now; the blob above is a transitional dead write.
+        occurred_at=_coerce_occurred_at(occurred_at),
     )
 
 
@@ -98,15 +102,14 @@ def _make_retriever(
 class TestModuleHelpers:
     def test_extract_occurred_at_from_chunk(self) -> None:
         chunk = _make_chunk(occurred_at="2026-04-01T00:00:00+00:00")
-        assert _extract_occurred_at(chunk) == "2026-04-01T00:00:00+00:00"
+        assert _extract_occurred_at(chunk) == datetime(2026, 4, 1, tzinfo=UTC)
 
-    def test_extract_occurred_at_chunk_without_metadata(self) -> None:
+    def test_extract_occurred_at_chunk_without_occurred_at(self) -> None:
         chunk = Chunk(id=uuid4(), namespace_id=uuid4(), document_id=uuid4(), content="x")
-        chunk.metadata = None  # type: ignore[assignment]
         assert _extract_occurred_at(chunk) is None
 
     def test_extract_occurred_at_from_dict(self) -> None:
-        assert _extract_occurred_at({"occurred_at": "2026-01-02"}) == "2026-01-02"
+        assert _extract_occurred_at({"occurred_at": "2026-01-02"}) == datetime(2026, 1, 2)
 
     def test_extract_occurred_at_from_unknown(self) -> None:
         assert _extract_occurred_at("not a chunk") is None
@@ -478,14 +481,15 @@ class TestApplyReranking:
 
     @pytest.mark.asyncio
     async def test_temporal_prefix_in_candidate_content(self) -> None:
-        """Reranker receives content with [Session: X, Date: Y] prefix when metadata
-        contains session_id / occurred_at."""
+        """Reranker receives content with [Session: X, Date: Y] prefix.
+
+        ``session_id`` is a user-space blob key (still read from metadata);
+        ``occurred_at`` is now read from the first-class column.
+        """
         chunk = _make_chunk(
             "the meeting notes",
-            extra={
-                "session_id": "S123",
-                "occurred_at": "2026-04-01T12:34:56+00:00",
-            },
+            occurred_at="2026-04-01T12:34:56+00:00",
+            extra={"session_id": "S123"},
         )
         fused = [FusedResult(item=chunk, item_id=chunk.id, rrf_score=0.5)]
         retriever = _make_retriever()
@@ -585,6 +589,50 @@ class TestApplyLLMReranking:
 
         result = await retriever._apply_llm_reranking("q", fused, limit=5, namespace_id=uuid4())
         assert result == fused
+
+    @pytest.mark.asyncio
+    async def test_temporal_prefix_in_candidate_content(self) -> None:
+        """LLM reranker candidate content carries [Session: X, Date: Y].
+
+        Mirrors the cross-encoder prefix test: ``session_id`` is a user-space
+        blob key, ``occurred_at`` is read from the first-class column.
+        """
+        chunk = _make_chunk(
+            "the meeting notes",
+            occurred_at="2026-04-01T12:34:56+00:00",
+            extra={"session_id": "S123"},
+        )
+        fused = [FusedResult(item=chunk, item_id=chunk.id, rrf_score=0.5)]
+        retriever = _make_retriever()
+
+        from khora.query.reranking import RerankResult
+
+        captured: list[Any] = []
+
+        class CaptureReranker:
+            async def rerank(
+                self,
+                query: str,
+                candidates: Any,
+                *,
+                top_k: int = 10,
+                blend_weight: float = 0.7,
+            ) -> list[RerankResult]:
+                captured.extend(candidates)
+                return [
+                    RerankResult(
+                        item=candidates[0].item,
+                        original_score=0.5,
+                        rerank_score=0.7,
+                        final_score=0.7,
+                    )
+                ]
+
+        retriever._llm_reranker = CaptureReranker()  # type: ignore[assignment]
+        await retriever._apply_llm_reranking("q", fused, limit=5, namespace_id=uuid4())
+        assert captured
+        assert "Session: S123" in captured[0].content
+        assert "Date: 2026-04-01" in captured[0].content
 
     @pytest.mark.asyncio
     async def test_lazy_init_llm_reranker(self) -> None:

--- a/tests/unit/engines/test_retriever_coverage_push.py
+++ b/tests/unit/engines/test_retriever_coverage_push.py
@@ -484,12 +484,18 @@ class TestApplyReranking:
         """Reranker receives content with [Session: X, Date: Y] prefix.
 
         ``session_id`` is a user-space blob key (still read from metadata);
-        ``occurred_at`` is now read from the first-class column.
+        ``occurred_at`` is now read from the first-class column. The blob's
+        ``occurred_at`` is deliberately set to a stale, divergent value so this
+        test fails if the reader is reverted to sourcing the prefix from the
+        blob instead of the column.
         """
-        chunk = _make_chunk(
-            "the meeting notes",
-            occurred_at="2026-04-01T12:34:56+00:00",
-            extra={"session_id": "S123"},
+        chunk = Chunk(
+            id=uuid4(),
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="the meeting notes",
+            metadata={"session_id": "S123", "occurred_at": "1999-01-01T00:00:00+00:00"},
+            occurred_at=datetime(2026, 4, 1, 12, 34, 56, tzinfo=UTC),
         )
         fused = [FusedResult(item=chunk, item_id=chunk.id, rrf_score=0.5)]
         retriever = _make_retriever()
@@ -522,6 +528,8 @@ class TestApplyReranking:
         assert captured
         assert "Session: S123" in captured[0].content
         assert "Date: 2026-04-01" in captured[0].content
+        # The stale blob date must NOT leak: prefix is sourced from the column.
+        assert "1999" not in captured[0].content
 
 
 # ---------------------------------------------------------------------------
@@ -595,12 +603,17 @@ class TestApplyLLMReranking:
         """LLM reranker candidate content carries [Session: X, Date: Y].
 
         Mirrors the cross-encoder prefix test: ``session_id`` is a user-space
-        blob key, ``occurred_at`` is read from the first-class column.
+        blob key, ``occurred_at`` is read from the first-class column. The
+        blob's ``occurred_at`` is a stale, divergent value so the test fails if
+        the reader is reverted to sourcing the prefix from the blob.
         """
-        chunk = _make_chunk(
-            "the meeting notes",
-            occurred_at="2026-04-01T12:34:56+00:00",
-            extra={"session_id": "S123"},
+        chunk = Chunk(
+            id=uuid4(),
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="the meeting notes",
+            metadata={"session_id": "S123", "occurred_at": "1999-01-01T00:00:00+00:00"},
+            occurred_at=datetime(2026, 4, 1, 12, 34, 56, tzinfo=UTC),
         )
         fused = [FusedResult(item=chunk, item_id=chunk.id, rrf_score=0.5)]
         retriever = _make_retriever()
@@ -633,6 +646,8 @@ class TestApplyLLMReranking:
         assert captured
         assert "Session: S123" in captured[0].content
         assert "Date: 2026-04-01" in captured[0].content
+        # The stale blob date must NOT leak: prefix is sourced from the column.
+        assert "1999" not in captured[0].content
 
     @pytest.mark.asyncio
     async def test_lazy_init_llm_reranker(self) -> None:

--- a/tests/unit/engines/test_retriever_coverage_push.py
+++ b/tests/unit/engines/test_retriever_coverage_push.py
@@ -531,6 +531,56 @@ class TestApplyReranking:
         # The stale blob date must NOT leak: prefix is sourced from the column.
         assert "1999" not in captured[0].content
 
+    @pytest.mark.asyncio
+    async def test_date_prefix_with_empty_metadata_blob(self) -> None:
+        """Date prefix is built from the column even when the blob is empty.
+
+        This is the empty-blob BM25/PPR population the reader flip targets: the
+        ``occurred_at`` column drives the ``Date:`` prefix independently of the
+        metadata blob, and ``Session:`` (a blob-only key) is absent. Guards the
+        follow-up stage that removes the transitional dead-write injections from
+        silently dropping the rerank date prefix.
+        """
+        chunk = Chunk(
+            id=uuid4(),
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="the meeting notes",
+            metadata={},
+            occurred_at=datetime(2026, 4, 1, 12, 34, 56, tzinfo=UTC),
+        )
+        fused = [FusedResult(item=chunk, item_id=chunk.id, rrf_score=0.5)]
+        retriever = _make_retriever()
+
+        from khora.query.reranking import RerankResult
+
+        captured: list[Any] = []
+
+        class CaptureReranker:
+            async def rerank(
+                self,
+                query: str,
+                candidates: Any,
+                *,
+                top_k: int = 10,
+                blend_weight: float = 0.7,
+            ) -> list[RerankResult]:
+                captured.extend(candidates)
+                return [
+                    RerankResult(
+                        item=candidates[0].item,
+                        original_score=0.5,
+                        rerank_score=0.7,
+                        final_score=0.7,
+                    )
+                ]
+
+        retriever._reranker = CaptureReranker()  # type: ignore[assignment]
+        await retriever._apply_reranking("q", fused, limit=5, namespace_id=uuid4())
+        assert captured
+        assert "Date: 2026-04-01" in captured[0].content
+        assert "Session:" not in captured[0].content
+
 
 # ---------------------------------------------------------------------------
 # _apply_llm_reranking — LLM path mirrors cross-encoder shape
@@ -648,6 +698,54 @@ class TestApplyLLMReranking:
         assert "Date: 2026-04-01" in captured[0].content
         # The stale blob date must NOT leak: prefix is sourced from the column.
         assert "1999" not in captured[0].content
+
+    @pytest.mark.asyncio
+    async def test_date_prefix_with_empty_metadata_blob(self) -> None:
+        """LLM path: Date prefix comes from the column with an empty blob.
+
+        Mirrors the cross-encoder empty-blob test: the ``occurred_at`` column
+        drives the ``Date:`` prefix independently of the metadata blob, and
+        ``Session:`` (a blob-only key) is absent.
+        """
+        chunk = Chunk(
+            id=uuid4(),
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="the meeting notes",
+            metadata={},
+            occurred_at=datetime(2026, 4, 1, 12, 34, 56, tzinfo=UTC),
+        )
+        fused = [FusedResult(item=chunk, item_id=chunk.id, rrf_score=0.5)]
+        retriever = _make_retriever()
+
+        from khora.query.reranking import RerankResult
+
+        captured: list[Any] = []
+
+        class CaptureReranker:
+            async def rerank(
+                self,
+                query: str,
+                candidates: Any,
+                *,
+                top_k: int = 10,
+                blend_weight: float = 0.7,
+            ) -> list[RerankResult]:
+                captured.extend(candidates)
+                return [
+                    RerankResult(
+                        item=candidates[0].item,
+                        original_score=0.5,
+                        rerank_score=0.7,
+                        final_score=0.7,
+                    )
+                ]
+
+        retriever._llm_reranker = CaptureReranker()  # type: ignore[assignment]
+        await retriever._apply_llm_reranking("q", fused, limit=5, namespace_id=uuid4())
+        assert captured
+        assert "Date: 2026-04-01" in captured[0].content
+        assert "Session:" not in captured[0].content
 
     @pytest.mark.asyncio
     async def test_lazy_init_llm_reranker(self) -> None:

--- a/tests/unit/engines/test_temporal_detection.py
+++ b/tests/unit/engines/test_temporal_detection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
@@ -330,6 +331,7 @@ class TestRelativeRecency:
             document_id=uuid4(),
             content="January event",
             metadata={"occurred_at": "2024-01-15T00:00:00+00:00"},
+            occurred_at=datetime(2024, 1, 15, tzinfo=UTC),
         )
         chunk_may = Chunk(
             id=may_id,
@@ -337,6 +339,7 @@ class TestRelativeRecency:
             document_id=uuid4(),
             content="May event",
             metadata={"occurred_at": "2024-05-15T00:00:00+00:00"},
+            occurred_at=datetime(2024, 5, 15, tzinfo=UTC),
         )
 
         fused = [
@@ -381,6 +384,7 @@ class TestRelativeRecency:
             document_id=uuid4(),
             content="Old",
             metadata={"occurred_at": "2020-01-01T00:00:00+00:00"},
+            occurred_at=datetime(2020, 1, 1, tzinfo=UTC),
         )
         chunk2 = Chunk(
             id=id2,
@@ -388,6 +392,7 @@ class TestRelativeRecency:
             document_id=uuid4(),
             content="New",
             metadata={"occurred_at": "2020-05-01T00:00:00+00:00"},
+            occurred_at=datetime(2020, 5, 1, tzinfo=UTC),
         )
 
         fused = [
@@ -457,6 +462,7 @@ class TestRelativeRecency:
             document_id=uuid4(),
             content="Old",
             metadata={"occurred_at": "2024-01-01T00:00:00+00:00"},
+            occurred_at=datetime(2024, 1, 1, tzinfo=UTC),
         )
         chunk2 = Chunk(
             id=id2,
@@ -464,6 +470,7 @@ class TestRelativeRecency:
             document_id=uuid4(),
             content="New",
             metadata={"occurred_at": "2024-01-08T00:00:00+00:00"},
+            occurred_at=datetime(2024, 1, 8, tzinfo=UTC),
         )
 
         fused = [

--- a/tests/unit/engines/test_temporal_phase_a_retriever.py
+++ b/tests/unit/engines/test_temporal_phase_a_retriever.py
@@ -32,7 +32,12 @@ from khora.storage.temporal import TemporalFilter
 
 
 def _chunk(occurred_at: datetime | None, *, source_system: str | None = None) -> Chunk:
-    """Build a chunk with optional occurred_at and source_system metadata."""
+    """Build a chunk with optional occurred_at and source_system metadata.
+
+    ``occurred_at`` is stamped on the first-class column (the recency reader
+    now reads it there); the metadata blob keeps mirroring it as the pipeline
+    still does during the reader-flip transition.
+    """
     custom: dict[str, object] = {}
     if occurred_at is not None:
         custom["occurred_at"] = occurred_at.isoformat()
@@ -44,6 +49,7 @@ def _chunk(occurred_at: datetime | None, *, source_system: str | None = None) ->
         document_id=uuid4(),
         content="test",
         metadata=custom,
+        occurred_at=occurred_at,
     )
 
 

--- a/tests/unit/engines/test_vectorcypher_retriever.py
+++ b/tests/unit/engines/test_vectorcypher_retriever.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
@@ -512,6 +512,7 @@ class TestRetrieverRecencyScores:
             document_id=uuid4(),
             content="old",
             metadata={"occurred_at": "2020-01-01T00:00:00+00:00"},
+            occurred_at=datetime(2020, 1, 1, tzinfo=UTC),
         )
         chunk2 = Chunk(
             id=id2,
@@ -519,6 +520,7 @@ class TestRetrieverRecencyScores:
             document_id=uuid4(),
             content="recent",
             metadata={"occurred_at": "2026-02-14T00:00:00+00:00"},
+            occurred_at=datetime(2026, 2, 14, tzinfo=UTC),
         )
         results = [
             FusedResult(item_id=id1, item=chunk1, rrf_score=0.9),

--- a/tests/unit/engines/vectorcypher/test_retriever_coverage.py
+++ b/tests/unit/engines/vectorcypher/test_retriever_coverage.py
@@ -29,6 +29,8 @@ from khora.engines.vectorcypher.fusion import FusedResult
 from khora.engines.vectorcypher.retriever import (
     RetrieverConfig,
     VectorCypherRetriever,
+    _coerce_occurred_at,
+    _extract_occurred_at,
 )
 from khora.engines.vectorcypher.router import QueryComplexity, RoutingDecision
 from khora.engines.vectorcypher.temporal_detection import (
@@ -62,6 +64,9 @@ def _make_chunk(
         document_id=uuid4(),
         content=content,
         metadata=custom,
+        # Mirror occurred_at onto the first-class column - the recency reader
+        # reads it there now; the blob above is a transitional dead write.
+        occurred_at=_coerce_occurred_at(occurred_at),
     )
 
 
@@ -224,12 +229,62 @@ class TestCalculateRecencyScoresReferenceModes:
         retriever = _make_retriever()
         assert retriever._calculate_recency_scores([]) == {}
 
+    def test_naive_occurred_at_column_is_normalized(self) -> None:
+        """A naive first-class occurred_at (embedded backends carry no tz) is
+        normalized to UTC instead of crashing on a naive/aware subtraction."""
+        retriever = _make_retriever()
+        now = datetime.now(UTC)
+        chunk = Chunk(
+            id=uuid4(),
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="naive",
+            occurred_at=(now - timedelta(days=10)).replace(tzinfo=None),
+        )
+        scores = retriever._calculate_recency_scores(
+            [FusedResult(item_id=chunk.id, item=chunk, rrf_score=0.9)],
+            reference_mode="wall_clock",
+        )
+        assert 0.0 < scores[chunk.id] < 1.0
+
     def test_unparseable_date_gets_default_score(self) -> None:
         """Chunks with no parseable occurred_at get the 0.5 default score."""
         retriever = _make_retriever()
         c = _make_chunk(occurred_at="not-a-date")
         scores = retriever._calculate_recency_scores([FusedResult(item_id=c.id, item=c, rrf_score=0.9)])
         assert scores[c.id] == 0.5
+
+    def test_first_class_column_overrides_dead_metadata_blob(self) -> None:
+        """Recency reads the occurred_at column, not the (now dead) blob.
+
+        Stage 1 keeps mirroring occurred_at into the metadata blob. A chunk
+        whose stale 1999 blob disagrees with a fresh 2026 column must be both
+        extracted and scored from the column - if the blob leaked, ``fresh``
+        would tie the genuinely-1999 ``stale`` chunk.
+        """
+        retriever = _make_retriever()
+        fresh = Chunk(
+            id=uuid4(),
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="fresh",
+            metadata={"occurred_at": "1999-01-01T00:00:00+00:00"},
+            occurred_at=datetime(2026, 5, 1, tzinfo=UTC),
+        )
+        stale = Chunk(
+            id=uuid4(),
+            namespace_id=uuid4(),
+            document_id=uuid4(),
+            content="stale",
+            occurred_at=datetime(1999, 1, 1, tzinfo=UTC),
+        )
+        assert _extract_occurred_at(fresh) == datetime(2026, 5, 1, tzinfo=UTC)
+        results = [
+            FusedResult(item_id=fresh.id, item=fresh, rrf_score=0.9),
+            FusedResult(item_id=stale.id, item=stale, rrf_score=0.9),
+        ]
+        scores = retriever._calculate_recency_scores(results, reference_mode="wall_clock")
+        assert scores[fresh.id] > scores[stale.id]
 
     def test_decay_zero_falls_back_to_config(self) -> None:
         """A pathological decay=0 override falls back to recency_decay_days."""

--- a/tests/unit/engines/vectorcypher/test_temporal_sort_tz_1115.py
+++ b/tests/unit/engines/vectorcypher/test_temporal_sort_tz_1115.py
@@ -2,14 +2,14 @@
 
 The temporal sort in ``VectorCypherRetriever._simple_retrieve`` re-orders
 chunks by ``occurred_at`` for RECENCY / STATE_QUERY style queries. The sort
-key ``_ts`` parsed ``metadata['occurred_at']`` via ``fromisoformat`` with no
-tzinfo normalization, fell back to ``created_at`` (tz-aware from the DB), and
-finally to naive ``datetime.min``. Sorting a list that mixes naive and aware
-datetimes raises ``TypeError: can't compare offset-naive and offset-aware
-datetimes`` and crashes the whole recall. The metadata dict is built as
-``{'occurred_at': <column iso>, **(chunk.metadata or {})}``, so a
-user-supplied naive ISO string overrides the column value - reachable by
-default since ``enable_reranking`` defaults to ``False``.
+key ``_ts`` reads the first-class ``occurred_at`` column, falls back to
+``created_at`` (tz-aware from the DB), and finally to naive ``datetime.min``.
+The first-class column is naive on embedded backends (no tz) and tz-aware on
+Postgres, so ``_ts`` must normalize naive→UTC: sorting a list that mixes
+naive and aware datetimes otherwise raises ``TypeError: can't compare
+offset-naive and offset-aware datetimes`` and crashes the whole recall. This
+path is reachable by default since ``enable_reranking`` defaults to
+``False``.
 
 Same tz-boundary class as fb6ede76; ``_calculate_recency_scores`` in the
 same file is the reference normalization pattern.
@@ -83,20 +83,18 @@ class TestTemporalSortTimezoneNormalization1115:
 
     @pytest.mark.asyncio
     async def test_mixed_naive_and_aware_timestamps_sort_without_typeerror(self) -> None:
-        """Naive metadata occurred_at + aware created_at + datetime.min sentinel.
+        """Naive occurred_at column + aware created_at + datetime.min sentinel.
 
         Pre-fix this raised ``TypeError: can't compare offset-naive and
         offset-aware datetimes`` mid-recall. Post-fix all keys are normalized
         to UTC and the descending order is (aware created_at 2024-05-01) >
         (naive occurred_at 2024-03-01, treated as UTC) > (sentinel).
         """
-        # (a) user-supplied NAIVE ISO string in chunk metadata overrides the
-        # occurred_at column value in the metadata dict.
+        # (a) NAIVE first-class occurred_at column (embedded backends carry no
+        # tz) -> _ts must normalize it to UTC before comparing.
         naive_meta = _make_search_result(
             "naive-meta",
-            occurred_at=datetime(2024, 1, 1, tzinfo=UTC),
-            created_at=datetime(2024, 1, 1, tzinfo=UTC),
-            metadata={"occurred_at": "2024-03-01T12:00:00"},
+            occurred_at=datetime(2024, 3, 1, 12, 0, 0),
         )
         # (b) no occurred_at -> falls back to tz-AWARE created_at.
         aware_created = _make_search_result(
@@ -123,15 +121,15 @@ class TestTemporalSortTimezoneNormalization1115:
         assert contents == ["aware-created", "naive-meta", "sentinel"]
 
     @pytest.mark.asyncio
-    async def test_z_suffix_occurred_at_parses_and_sorts(self) -> None:
-        """'Z'-suffixed ISO strings normalize like _calculate_recency_scores."""
+    async def test_aware_and_naive_occurred_at_columns_sort(self) -> None:
+        """Aware + naive first-class occurred_at columns normalize and sort."""
         z_suffix = _make_search_result(
             "z-suffix",
-            metadata={"occurred_at": "2024-06-01T00:00:00Z"},
+            occurred_at=datetime(2024, 6, 1, tzinfo=UTC),
         )
         naive = _make_search_result(
             "naive",
-            metadata={"occurred_at": "2024-02-01T00:00:00"},
+            occurred_at=datetime(2024, 2, 1),
         )
 
         retriever = _make_retriever()


### PR DESCRIPTION
## Summary

Flip the recall-path temporal **readers** from the chunk `metadata` blob to the first-class `Chunk.occurred_at` / `Chunk.source_timestamp` columns. Stage 1 already made every recall-path chunk constructor populate those columns; this change makes the readers consume them.

Reader sites migrated (all in `src/khora/engines/vectorcypher/retriever.py`):
- `_extract_occurred_at` — now returns `datetime | None` off the first-class column (no `source_timestamp` fallback in the boost path); its consumer `_calculate_recency_scores` drops the now-redundant `fromisoformat` parse and keeps naive→UTC normalization.
- Temporal-sort key `_ts` — sorts on `chunk.occurred_at` with the same naive→UTC coercion and None/ordering semantics.
- Rerank date-prefix builders (cross-encoder + LLM) — read `item.occurred_at or item.source_timestamp` off the object, preserving the existing fallback order and rendered date format. The date prefix is built independently of the metadata blob; the adjacent `session_id` / `conversation_id` reads stay gated on the blob (user-space keys).
- Top-1-age telemetry — reads the first-class `occurred_at`; metric name and semantics unchanged.

### Behavior changes (all corrections, confined to temporally-ranked recalls)
- PPR-sourced and BM25-sourced chunks gain temporal visibility across **recency scoring, temporal sort, and the rerank date prefix** — they were previously blind because their metadata blob carried no usable `occurred_at`.
- A stale user-stored blob `occurred_at` can no longer silently override the authoritative column value during ranking.
- Vector / graph / recency / skeleton-sourced chunks are value-identical (their injections copied the column), so no ordering change there.

### Scope notes
- The metadata blob injections are intentionally left in place as dead writes; a follow-up removes them. Ungating the rerank date prefix from the blob (this PR) is what keeps that follow-up from silently dropping the prefix for empty-metadata chunks.

## Test plan
- [x] Unit tests pass (engines unit suite green; `retriever.py` reader lines executed)
- [x] Rewrote the tz-contract sort test to set the first-class column; added a blob-override-death test (stale blob + fresh column → column wins) and a naive-normalization test
- [x] Rerank date-prefix tests (cross-encoder + LLM) diverge a stale metadata-blob `occurred_at` from a fresh column so they fail if the reader regresses to the blob; added an empty-blob test per site (`metadata={}` + populated column → `Date:` present, no `Session:`) guarding the blob-gate removal
- [x] New embedded (no-Docker) integration test drives the real BM25 and keyword-PPR channels end-to-end and asserts both are recency-visible via the column; entity-PPR coverage noted as compositional in the test docstring
- [x] Docker-backed Postgres/Neo4j integration + e2e legs and the integration coverage gate — green in CI

Part of #1492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Retrieval, reranking, and temporal sorting now consistently use each chunk’s dedicated occurred-at timestamp for freshness and date context.
  * Recency handling no longer relies on legacy/metadata date values, preventing incorrect freshness when metadata is missing or stale.
  * Naive and timezone-aware timestamps are normalized to avoid ordering and typing issues across retrieval channels.
* **Tests**
  * Added integration coverage to confirm occurred-at recency works across lexical retrieval channels when metadata dates are unset.
  * Updated unit tests for occurred-at extraction, timezone normalization, reranking date prefixes, and temporal sort regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->