### PR TITLE
Remove recall-time metadata injections; return stored blob verbatim on every recall channel

### DIFF
--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -571,10 +571,7 @@ class SkeletonConstructionEngine:
                 namespace_id=result.chunk.namespace_id,
                 document_id=result.chunk.document_id,
                 content=result.chunk.content,
-                metadata={
-                    "occurred_at": result.chunk.occurred_at.isoformat() if result.chunk.occurred_at else None,
-                    **(result.chunk.metadata or {}),
-                },
+                metadata=result.chunk.metadata or {},
                 created_at=result.chunk.created_at or result.chunk.occurred_at or datetime.now(UTC),
                 occurred_at=result.chunk.occurred_at,
                 source_timestamp=result.chunk.source_timestamp,

--- a/src/khora/engines/vectorcypher/ppr_retrieval.py
+++ b/src/khora/engines/vectorcypher/ppr_retrieval.py
@@ -479,13 +479,7 @@ async def ppr_retrieve_chunks(
                         namespace_id=chunk.namespace_id,
                         document_id=chunk.document_id,
                         content=chunk.content,
-                        metadata={
-                            "occurred_at": (
-                                chunk.metadata.get("occurred_at") if isinstance(chunk.metadata, dict) else None
-                            ),
-                            "ppr_score": score_map[cid],
-                            **(chunk.metadata if isinstance(chunk.metadata, dict) else {}),
-                        },
+                        metadata=chunk.metadata if isinstance(chunk.metadata, dict) else {},
                         created_at=getattr(chunk, "created_at", None),
                         occurred_at=chunk.occurred_at,
                         source_timestamp=chunk.source_timestamp,

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -3340,10 +3340,7 @@ class VectorCypherRetriever:
                     namespace_id=r.chunk.namespace_id,
                     document_id=r.chunk.document_id,
                     content=r.chunk.content,
-                    metadata={
-                        "occurred_at": r.chunk.occurred_at.isoformat() if r.chunk.occurred_at else None,
-                        **(r.chunk.metadata or {}),
-                    },
+                    metadata=r.chunk.metadata or {},
                     chunker_info=r.chunk.chunker_info or {},
                     created_at=r.chunk.created_at or r.chunk.occurred_at,
                     # Carry the chunk event-time and the producer's verbatim
@@ -4197,11 +4194,7 @@ class VectorCypherRetriever:
                     namespace_id=namespace_id,
                     document_id=UUID(record["document_id"]),
                     content=record["content"],
-                    metadata={
-                        "occurred_at": record.get("occurred_at"),
-                        "connected_entities": record.get("entity_ids", []),
-                        **(record.get("metadata") or {}),
-                    },
+                    metadata=record.get("metadata") or {},
                     chunker_info=_decode_chunker_info(record.get("chunker_info")),
                     # The graph store carries the chunk event-time (occurred_at)
                     # and the producer time (source_timestamp) as separate
@@ -4288,10 +4281,7 @@ class VectorCypherRetriever:
                         namespace_id=r.chunk.namespace_id,
                         document_id=r.chunk.document_id,
                         content=r.chunk.content,
-                        metadata={
-                            "occurred_at": r.chunk.occurred_at.isoformat() if r.chunk.occurred_at else None,
-                            **(r.chunk.metadata or {}),
-                        },
+                        metadata=r.chunk.metadata or {},
                         chunker_info=r.chunk.chunker_info or {},
                         created_at=r.chunk.created_at or r.chunk.occurred_at,
                         occurred_at=r.chunk.occurred_at,
@@ -4424,8 +4414,8 @@ class VectorCypherRetriever:
             for idx, sim in sim_pairs:
                 chunk, _emb = chunks_with_embedding[idx]
                 # Re-shape into ``(chunk_id, score, Chunk)`` matching
-                # ``_vector_search_chunks``. The Chunk's metadata dict
-                # carries ``occurred_at`` for the downstream recency
+                # ``_vector_search_chunks``. The Chunk's first-class
+                # ``occurred_at`` column feeds the downstream recency
                 # boost (RRF only uses rank position, so the score is
                 # informational).
                 filtered.append(
@@ -4437,19 +4427,14 @@ class VectorCypherRetriever:
                             namespace_id=chunk.namespace_id,
                             document_id=chunk.document_id,
                             content=chunk.content,
-                            metadata={
-                                "occurred_at": (
-                                    chunk.occurred_at.isoformat() if getattr(chunk, "occurred_at", None) else None
-                                ),
-                                **(getattr(chunk, "metadata", None) or {}),
-                            },
+                            metadata=getattr(chunk, "metadata", None) or {},
                             chunker_info=getattr(chunk, "chunker_info", None) or {},
                             created_at=getattr(chunk, "created_at", None) or getattr(chunk, "occurred_at", None),
                             occurred_at=getattr(chunk, "occurred_at", None),
                             # The temporal store carries the chunk event-time
-                            # (occurred_at, surfaced into metadata above) and the
-                            # producer time (source_timestamp); the projection
-                            # uses event-time first, then producer time.
+                            # (occurred_at) and the producer time
+                            # (source_timestamp); the projection uses
+                            # event-time first, then producer time.
                             source_timestamp=getattr(chunk, "source_timestamp", None),
                         ),
                     )

--- a/tests/integration/matrix/test_stored_blob_filter_invariant.py
+++ b/tests/integration/matrix/test_stored_blob_filter_invariant.py
@@ -1,0 +1,305 @@
+"""End-to-end cross-channel invariant: the stored metadata blob is what recall
+filters see, on every retrieval channel.
+
+The recall read paths carry the STORED chunk metadata blob verbatim — the
+first-class ``occurred_at`` column is never folded back into the blob at read
+time. This suite pins the user-observable consequence through a REAL recall:
+
+1. A chunk ingested with a producer ``source_timestamp`` (so its ``occurred_at``
+   column is populated) but a CLEAN metadata blob (no ``occurred_at`` key) is
+   selected identically by a ``metadata.occurred_at $exists false`` filter across
+   the vector, keyword/BM25, and hybrid (graph-bearing) recall channels. Before
+   the read paths stopped injecting the column into the blob, the graph channel's
+   in-memory post-filter saw an ``occurred_at`` key the SQL-pushdown channels
+   never saw — so the same filter kept the chunk on one channel and dropped it on
+   another. This is that cross-channel divergence, guarded end-to-end.
+
+2. The mirror ``metadata.occurred_at $exists true`` selects NOTHING — the blob
+   has no such key on any channel.
+
+3. A whole-blob ``$eq`` (the exact stored blob) selects the chunk — the in-memory
+   full-AST post-filter compares against the same stored blob the SQL pushdown
+   does.
+
+4. The raw ``khora_chunks`` blob is exactly what was written: user keys only, no
+   ``occurred_at`` / ``connected_entities`` / ``ppr_score`` injected. Reading the
+   stored row (rather than a recalled projection) also covers the skeleton engine
+   channel, whose rebuilt chunk is internal to the engine.
+
+Scope: sqlite_lance only — lightweight, no Docker. The embedded ``khora_chunks``
+table matches the production schema, so the write/read round-trip exercised here
+is faithful. VectorCypher's HYBRID recall fires the graph channel (an entity is
+extracted from the content); Skeleton is graph-less, so its HYBRID recall is the
+vector + BM25 legs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+try:
+    import aiosqlite  # noqa: F401
+    import lancedb  # noqa: F401
+
+    _HAS_EMBEDDED = True
+except ImportError:
+    _HAS_EMBEDDED = False
+
+from khora.config import KhoraConfig
+from khora.config.schema import SQLiteLanceConfig
+from khora.extraction.extractors.base import ExtractedEntity, ExtractionResult
+from khora.extraction.skills import ExpertiseConfig
+from khora.khora import Khora
+from khora.query import SearchMode
+
+EMBED_DIM = 32
+
+pytestmark = [
+    pytest.mark.embedded,
+    pytest.mark.integration,
+    pytest.mark.skipif(not _HAS_EMBEDDED, reason="aiosqlite/lancedb not installed"),
+]
+
+# The clean stored blob and the injection keys no channel may add to it.
+_STORED_BLOB: dict[str, Any] = {"author": "alice", "score": 3}
+_INJECTION_KEYS = ("occurred_at", "connected_entities", "ppr_score")
+_CONTENT = "Marie Curie won the Nobel Prize in Physics in 1903 for her work on radioactivity."
+
+
+# ---------------------------------------------------------------------------
+# Deterministic embedder + extractor stubs (no OPENAI_API_KEY required)
+# ---------------------------------------------------------------------------
+
+
+def _embed_for(text_in: str) -> list[float]:
+    seed = hashlib.sha256(text_in.encode("utf-8")).digest()
+    raw = [(seed[i % len(seed)] - 128) / 128.0 for i in range(EMBED_DIM)]
+    norm = sum(x * x for x in raw) ** 0.5 or 1.0
+    return [x / norm for x in raw]
+
+
+async def _stub_embed_batch(self: Any, texts: list[str]) -> list[list[float]]:
+    return [_embed_for(t) for t in texts]
+
+
+async def _stub_embed(self: Any, text_in: str) -> list[float]:
+    return _embed_for(text_in)
+
+
+async def _stub_extract_multi(self: Any, texts: list[str], **_kwargs: Any) -> list[ExtractionResult]:
+    out: list[ExtractionResult] = []
+    for t in texts:
+        if "Marie Curie" in t:
+            out.append(
+                ExtractionResult(
+                    entities=[ExtractedEntity(name="Marie Curie", entity_type="PERSON", confidence=0.99)],
+                )
+            )
+        else:
+            out.append(ExtractionResult())
+    return out
+
+
+@pytest.fixture(autouse=True)
+def _patch_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "khora.extraction.embedders.litellm.LiteLLMEmbedder.embed_batch",
+        _stub_embed_batch,
+    )
+    monkeypatch.setattr(
+        "khora.extraction.embedders.litellm.LiteLLMEmbedder.embed",
+        _stub_embed,
+    )
+    monkeypatch.setattr(
+        "khora.extraction.extractors.llm.LLMEntityExtractor.extract_multi",
+        _stub_extract_multi,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-engine Khora fixture (sqlite_lance) — seeded once with the clean-blob chunk
+# ---------------------------------------------------------------------------
+
+
+async def _build_kb(tmp_path: Path, engine: str) -> Khora:
+    config = KhoraConfig()
+    config.storage.backend = "sqlite_lance"
+    config.storage.sqlite_lance = SQLiteLanceConfig(
+        db_path=str(tmp_path / "khora.db"),
+        lance_path=str(tmp_path / "khora.lance"),
+        embedding_dimension=EMBED_DIM,
+    )
+    config.llm.embedding_dimension = EMBED_DIM
+    config.storage.embedding_dimension = EMBED_DIM
+    config.neo4j_url = None
+    config.pipelines.chunk_size = 1024
+    if engine == "vectorcypher":
+        config.pipelines.extract_entities = True
+        config.pipelines.selective_extraction = False
+
+    kb = Khora(config, engine=engine, run_migrations=True)
+    await kb.connect()
+    return kb
+
+
+def _types_for(engine: str) -> tuple[list[str], list[str]]:
+    if engine == "skeleton":
+        return [], []
+    return ["PERSON", "CONCEPT"], ["RELATES_TO"]
+
+
+def _expertise_for(engine: str) -> ExpertiseConfig | None:
+    if engine == "skeleton":
+        return None
+    return ExpertiseConfig(name=f"blob-invariant-{engine}")
+
+
+@pytest.fixture
+async def seeded_kb(tmp_path: Path, request: pytest.FixtureRequest) -> AsyncIterator[tuple[Khora, UUID]]:
+    """A Khora seeded with one clean-blob chunk whose occurred_at column is set.
+
+    ``source_timestamp`` populates the ``occurred_at`` column (via the document
+    fallback), while ``metadata`` is the CLEAN blob — no ``occurred_at`` key. That
+    is exactly the "populated column + clean blob" shape the invariant is about.
+    """
+    engine: str = request.param
+    kb = await _build_kb(tmp_path, engine)
+    namespace_id = (await kb.create_namespace()).namespace_id
+    entity_types, relationship_types = _types_for(engine)
+    await kb.remember(
+        content=_CONTENT,
+        namespace=namespace_id,
+        title="curie",
+        source_timestamp=datetime.now(UTC) - timedelta(days=20),
+        metadata=dict(_STORED_BLOB),
+        entity_types=entity_types,
+        relationship_types=relationship_types,
+        expertise=_expertise_for(engine),
+    )
+    try:
+        yield kb, namespace_id
+    finally:
+        try:
+            await kb.disconnect()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# 1. The raw stored blob is clean (no injected keys) + occurred_at column set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seeded_kb", ["vectorcypher", "skeleton"], indirect=True, ids=["vectorcypher", "skeleton"])
+async def test_stored_khora_chunks_blob_is_clean(seeded_kb: tuple[Khora, UUID]) -> None:
+    """The persisted ``khora_chunks`` blob holds user keys only; the event-time is
+    on the ``occurred_at`` column, not in the blob."""
+    kb, _ns = seeded_kb
+    db_path = str(kb._config.storage.sqlite_lance.db_path)  # type: ignore[attr-defined]
+    con = sqlite3.connect(db_path)
+    con.row_factory = sqlite3.Row
+    try:
+        rows = con.execute("SELECT metadata, occurred_at FROM khora_chunks").fetchall()
+    finally:
+        con.close()
+
+    assert rows, "expected at least one khora_chunks row"
+    for row in rows:
+        blob = json.loads(row["metadata"]) if row["metadata"] else {}
+        assert blob == _STORED_BLOB
+        for key in _INJECTION_KEYS:
+            assert key not in blob, f"stored blob carries injected key {key!r}"
+        # The event-time lives on the first-class column.
+        assert row["occurred_at"] is not None
+
+
+# ---------------------------------------------------------------------------
+# 2. metadata.occurred_at $exists false selects the chunk on EVERY channel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seeded_kb", ["vectorcypher", "skeleton"], indirect=True, ids=["vectorcypher", "skeleton"])
+@pytest.mark.parametrize(
+    "mode",
+    [SearchMode.VECTOR, SearchMode.KEYWORD, SearchMode.HYBRID],
+    ids=["vector", "keyword", "hybrid"],
+)
+async def test_absent_occurred_at_key_matches_across_channels(seeded_kb: tuple[Khora, UUID], mode: SearchMode) -> None:
+    """A ``metadata.occurred_at $exists false`` filter keeps the clean-blob chunk
+    identically across vector, keyword/BM25, and hybrid (graph-bearing) recall.
+
+    The chunk's ``occurred_at`` COLUMN is populated, but the blob has no such key,
+    so the filter must MATCH. VectorCypher HYBRID fires the graph channel (whose
+    in-memory post-filter reads the rebuilt blob); the SQL-pushed vector/keyword
+    channels read the stored blob directly. All must agree.
+    """
+    kb, ns = seeded_kb
+    result = await kb.recall(
+        "Marie Curie Nobel Prize",
+        namespace=ns,
+        limit=5,
+        mode=mode,
+        filter={"metadata.occurred_at": {"$exists": False}},
+    )
+    assert len(result.chunks) == 1, (
+        f"clean-blob chunk with a populated occurred_at column must survive "
+        f"'metadata.occurred_at $exists false' on mode={mode}"
+    )
+
+
+@pytest.mark.parametrize("seeded_kb", ["vectorcypher", "skeleton"], indirect=True, ids=["vectorcypher", "skeleton"])
+@pytest.mark.parametrize(
+    "mode",
+    [SearchMode.VECTOR, SearchMode.KEYWORD, SearchMode.HYBRID],
+    ids=["vector", "keyword", "hybrid"],
+)
+async def test_present_occurred_at_key_matches_nothing_across_channels(
+    seeded_kb: tuple[Khora, UUID], mode: SearchMode
+) -> None:
+    """The mirror: ``metadata.occurred_at $exists true`` selects nothing — the
+    blob carries no such key on any channel (a column-into-blob leak would make
+    the graph channel surface the chunk here)."""
+    kb, ns = seeded_kb
+    result = await kb.recall(
+        "Marie Curie Nobel Prize",
+        namespace=ns,
+        limit=5,
+        mode=mode,
+        filter={"metadata.occurred_at": {"$exists": True}},
+    )
+    assert result.chunks == [], f"no chunk should carry a 'metadata.occurred_at' key on mode={mode}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Whole-blob $eq selects the chunk (incl. the graph channel post-filter)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seeded_kb", ["vectorcypher", "skeleton"], indirect=True, ids=["vectorcypher", "skeleton"])
+@pytest.mark.parametrize(
+    "mode",
+    [SearchMode.VECTOR, SearchMode.KEYWORD, SearchMode.HYBRID],
+    ids=["vector", "keyword", "hybrid"],
+)
+async def test_whole_blob_eq_matches_across_channels(seeded_kb: tuple[Khora, UUID], mode: SearchMode) -> None:
+    """A whole-blob ``$eq`` of the exact stored blob selects the chunk on every
+    channel — the graph channel's full-AST in-memory post-filter compares against
+    the same stored blob the SQL pushdown does."""
+    kb, ns = seeded_kb
+    result = await kb.recall(
+        "Marie Curie Nobel Prize",
+        namespace=ns,
+        limit=5,
+        mode=mode,
+        filter={"metadata": dict(_STORED_BLOB)},
+    )
+    assert len(result.chunks) == 1, f"whole-blob $eq must match the stored blob on mode={mode}"

--- a/tests/integration/matrix/test_stored_blob_filter_invariant.py
+++ b/tests/integration/matrix/test_stored_blob_filter_invariant.py
@@ -22,9 +22,14 @@ time. This suite pins the user-observable consequence through a REAL recall:
    does.
 
 4. The raw ``khora_chunks`` blob is exactly what was written: user keys only, no
-   ``occurred_at`` / ``connected_entities`` / ``ppr_score`` injected. Reading the
-   stored row (rather than a recalled projection) also covers the skeleton engine
-   channel, whose rebuilt chunk is internal to the engine.
+   ``occurred_at`` / ``connected_entities`` / ``ppr_score`` injected. This asserts
+   the WRITE path stores a clean blob — the precondition every recall channel then
+   reads back. It does NOT observe the skeleton engine's rebuilt chunk: skeleton
+   drops chunk metadata into an internal ``Chunk`` that never reaches the caller
+   (``RecallChunk`` carries no metadata field), so the skeleton constructor's
+   stored-blob line is a pure dead write with no observable recall surface —
+   covered only indirectly, by this clean-write precondition plus the vector/BM25
+   recall assertions above (which skeleton also serves).
 
 Scope: sqlite_lance only — lightweight, no Docker. The embedded ``khora_chunks``
 table matches the production schema, so the write/read round-trip exercised here

--- a/tests/unit/engines/test_retriever_coverage_push.py
+++ b/tests/unit/engines/test_retriever_coverage_push.py
@@ -1579,8 +1579,13 @@ class TestFetchChunksFromEntities:
         assert chunk.document_id == doc_id
         # Score: 3 * (1 + 0.1 * 2) = 3.6
         assert score == pytest.approx(3.6)
-        assert chunk.metadata["author"] == "alice"
-        assert chunk.metadata["occurred_at"] == "2026-04-01"
+        # Recall returns the STORED metadata blob verbatim: no injected
+        # ``occurred_at`` / ``connected_entities`` keys.
+        assert chunk.metadata == {"author": "alice"}
+        # ``occurred_at`` moved to the first-class Chunk column. The record
+        # supplies a date-only string, so ``_coerce_occurred_at`` yields a naive
+        # datetime.
+        assert chunk.occurred_at == datetime(2026, 4, 1)
 
     @pytest.mark.asyncio
     async def test_no_dual_nodes_and_no_storage_returns_empty(self) -> None:
@@ -1653,8 +1658,11 @@ class TestVectorSearchChunksAndEntities:
         assert len(result) == 1
         cid, score, chunk = result[0]
         assert score == 0.7  # combined_score takes precedence
-        assert chunk.metadata["source"] == "x"
-        assert chunk.metadata["occurred_at"] == "2026-04-01T00:00:00+00:00"
+        # STORED blob verbatim: no injected ``occurred_at`` key.
+        assert chunk.metadata == {"source": "x"}
+        # ``occurred_at`` moved to the first-class Chunk column, passed through
+        # from the store result unchanged (tz-aware).
+        assert chunk.occurred_at == _dt(2026, 4, 1, tzinfo=UTC)
 
     @pytest.mark.asyncio
     async def test_vector_search_chunks_hybrid_alpha_override(self) -> None:

--- a/tests/unit/engines/test_retriever_stored_blob_metadata.py
+++ b/tests/unit/engines/test_retriever_stored_blob_metadata.py
@@ -1,0 +1,470 @@
+"""Stored-blob metadata pass-through, per recall channel.
+
+Every recall channel that produces chunks rebuilds a public ``Chunk`` from what
+its store returned. The contract these tests pin is a single invariant applied
+uniformly across the channels: the rebuilt ``chunk.metadata`` is the STORED blob
+verbatim — the channel injects NO read-time keys into it. In particular the
+first-class event-time lives on the ``occurred_at`` COLUMN, never folded back
+into the blob, and the graph/PPR bookkeeping (connected entities, the PPR mass)
+stays out of it too.
+
+The three keys a channel must never smuggle into the blob:
+
+* ``occurred_at``     — the chunk event-time is a first-class ``Chunk`` column;
+* ``connected_entities`` — graph adjacency bookkeeping;
+* ``ppr_score``       — the PageRank mass a chunk earned.
+
+Each test seeds a channel's store boundary with a CLEAN blob plus a populated
+``occurred_at`` column and asserts the rebuilt chunk keeps the blob intact and
+surfaces the event-time on the column.
+
+These are complementary to ``test_retriever_coverage_push.py`` (which already
+pins the ``_vector_search_chunks`` and the ``_fetch_chunks_from_entities``
+dual-nodes channels): the channels here are the remaining producers — the simple
+vector path, BM25, the storage graph fallback, recency, PPR, and the typed-entity
+fast path. The skeleton engine's channel and the end-to-end cross-channel filter
+behaviour are pinned in the matrix integration lane
+(``tests/integration/matrix/test_stored_blob_filter_invariant.py``), where a real
+recall exercises them.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from khora.core.models import Chunk, Entity, Relationship
+from khora.engines.vectorcypher.ppr_retrieval import ppr_retrieve_chunks
+from khora.engines.vectorcypher.retriever import (
+    RetrieverConfig,
+    VectorCypherRetriever,
+)
+from khora.engines.vectorcypher.router import QueryComplexity, RoutingDecision
+from khora.query import SearchMode
+
+pytestmark = pytest.mark.unit
+
+# The event-time carried on the first-class column throughout this module.
+_OCCURRED_AT = datetime(2026, 4, 1, tzinfo=UTC)
+
+# The keys no channel may inject into the stored blob at read time.
+_INJECTION_KEYS = ("occurred_at", "connected_entities", "ppr_score")
+
+# A representative clean stored blob: user-owned keys only, none of which is an
+# injection key. Frozen per-call via ``dict(...)`` so a channel that mutated it
+# in place would be caught by the identity-independent equality assertion.
+_CLEAN_BLOB: dict[str, Any] = {"author": "alice", "tier": "gold", "score": 3}
+
+
+def _make_retriever(
+    *,
+    config: RetrieverConfig | None = None,
+    vector_store: Any | None = None,
+    storage: Any | None = None,
+) -> VectorCypherRetriever:
+    """A retriever with mocked boundaries (mirrors the coverage-push helper)."""
+    return VectorCypherRetriever(
+        vector_store=vector_store if vector_store is not None else AsyncMock(),
+        neo4j_driver=AsyncMock(),
+        embedder=AsyncMock(),
+        config=config or RetrieverConfig(),
+        storage=storage,
+    )
+
+
+def _assert_stored_blob(chunk: Chunk) -> None:
+    """The rebuilt chunk carries the clean blob verbatim, no injected keys."""
+    assert chunk.metadata == _CLEAN_BLOB
+    for key in _INJECTION_KEYS:
+        assert key not in chunk.metadata, f"channel injected {key!r} into the stored blob"
+    # The event-time is on the first-class column, not the blob.
+    assert chunk.occurred_at == _OCCURRED_AT
+
+
+# --------------------------------------------------------------------------- #
+# vector "simple" channel — _simple_retrieve
+# --------------------------------------------------------------------------- #
+
+
+def _vector_store_result() -> MagicMock:
+    """A pgvector-shaped search result carrying a clean blob + occurred_at column."""
+    result = MagicMock()
+    result.chunk = MagicMock()
+    result.chunk.id = uuid4()
+    result.chunk.namespace_id = uuid4()
+    result.chunk.document_id = uuid4()
+    result.chunk.content = "simple vector hit"
+    result.chunk.metadata = dict(_CLEAN_BLOB)
+    result.chunk.occurred_at = _OCCURRED_AT
+    result.chunk.created_at = None
+    result.chunk.source_timestamp = None
+    result.chunk.chunker_info = {}
+    result.combined_score = 0.7
+    result.similarity = 0.6
+    return result
+
+
+class TestSimpleRetrieveChannel:
+    @pytest.mark.asyncio
+    async def test_simple_retrieve_preserves_stored_blob(self) -> None:
+        retriever = _make_retriever()
+        retriever._vector_store.search = AsyncMock(return_value=[_vector_store_result()])
+
+        routing = RoutingDecision(
+            complexity=QueryComplexity.SIMPLE,
+            use_graph=False,
+            graph_depth=0,
+            confidence=0.9,
+            reasoning="simple",
+        )
+        # VECTOR mode: pure vector store search, no BM25 fan-out or graph channel.
+        result = await retriever._simple_retrieve(
+            query="q",
+            query_embedding=[0.1, 0.2],
+            namespace_id=uuid4(),
+            temporal_filter=None,
+            limit=5,
+            routing=routing,
+            mode=SearchMode.VECTOR,
+        )
+        assert len(result.chunks) == 1
+        chunk, _score = result.chunks[0]
+        _assert_stored_blob(chunk)
+
+
+# --------------------------------------------------------------------------- #
+# BM25 channel — _bm25_search_chunks (coordinator fallback pass-through)
+# --------------------------------------------------------------------------- #
+
+
+class TestBm25Channel:
+    @pytest.mark.asyncio
+    async def test_bm25_passes_stored_blob_through(self) -> None:
+        ns = uuid4()
+        stored = Chunk(
+            id=uuid4(),
+            namespace_id=ns,
+            document_id=uuid4(),
+            content="bm25 hit",
+            metadata=dict(_CLEAN_BLOB),
+            occurred_at=_OCCURRED_AT,
+        )
+        storage = AsyncMock()
+        storage.search_fulltext_chunks = AsyncMock(return_value=[(stored, 0.9)])
+        # No temporal-store fulltext method → the coordinator fallback runs.
+        retriever = _make_retriever(storage=storage, vector_store=MagicMock(spec=[]))
+
+        result = await retriever._bm25_search_chunks(query="alpha beta", namespace_id=ns, limit=10)
+        assert len(result) == 1
+        _cid, _score, chunk = result[0]
+        _assert_stored_blob(chunk)
+
+
+# --------------------------------------------------------------------------- #
+# graph SurrealDB-fallback channel — _fetch_chunks_from_entities (no dual_nodes)
+# --------------------------------------------------------------------------- #
+
+
+class TestGraphStorageFallbackChannel:
+    @pytest.mark.asyncio
+    async def test_storage_fallback_preserves_stored_blob(self) -> None:
+        ns = uuid4()
+        stored = Chunk(
+            id=uuid4(),
+            namespace_id=ns,
+            document_id=uuid4(),
+            content="graph fallback hit",
+            metadata=dict(_CLEAN_BLOB),
+            occurred_at=_OCCURRED_AT,
+        )
+        entity = Entity(
+            id=uuid4(),
+            namespace_id=ns,
+            name="Alice",
+            entity_type="PERSON",
+            source_chunk_ids=[stored.id],
+        )
+        # SurrealDB-only shape: no graph backend (dual_nodes None), storage wired.
+        retriever = VectorCypherRetriever.__new__(VectorCypherRetriever)
+        retriever._config = RetrieverConfig()
+        retriever._dual_nodes = None
+        retriever._vector_store = MagicMock()
+        retriever._neo4j_driver = None
+        storage = MagicMock()
+        storage.get_entities_batch = AsyncMock(return_value={entity.id: entity})
+        storage.get_chunks_batch = AsyncMock(return_value={stored.id: stored})
+        retriever._storage = storage
+
+        results = await retriever._fetch_chunks_from_entities(
+            entity_ids=[entity.id],
+            namespace_id=ns,
+            temporal_filter=None,
+            limit=10,
+        )
+        assert len(results) == 1
+        _cid, _score, chunk = results[0]
+        _assert_stored_blob(chunk)
+
+
+# --------------------------------------------------------------------------- #
+# recency channel — _recency_channel_chunks
+# --------------------------------------------------------------------------- #
+
+
+class TestRecencyChannel:
+    @pytest.mark.asyncio
+    async def test_recency_preserves_stored_blob(self) -> None:
+        # A recency-store chunk carrying an embedding (so it clears the cosine
+        # gate), a clean blob, and a populated occurred_at column.
+        store_chunk = MagicMock()
+        store_chunk.id = uuid4()
+        store_chunk.namespace_id = uuid4()
+        store_chunk.document_id = uuid4()
+        store_chunk.content = "recent hit"
+        store_chunk.embedding = [1.0, 0.0, 0.0]
+        store_chunk.metadata = dict(_CLEAN_BLOB)
+        store_chunk.occurred_at = _OCCURRED_AT
+        store_chunk.created_at = None
+        store_chunk.source_timestamp = None
+        store_chunk.chunker_info = {}
+
+        vstore = MagicMock()
+        vstore.search_recent_chunks = AsyncMock(return_value=[(store_chunk, None)])
+        retriever = _make_retriever(
+            config=RetrieverConfig(temporal_query_relevance_floor=0.5),
+            vector_store=vstore,
+        )
+
+        with patch("khora._accel.batch_cosine_similarity", return_value=[(0, 0.9)]):
+            result = await retriever._recency_channel_chunks(
+                query_embedding=[1.0, 0.0, 0.0],
+                namespace_id=uuid4(),
+                temporal_filter=None,
+            )
+        assert len(result) == 1
+        _cid, _score, chunk = result[0]
+        _assert_stored_blob(chunk)
+
+
+# --------------------------------------------------------------------------- #
+# PPR channel — ppr_retrieve_chunks
+# --------------------------------------------------------------------------- #
+
+
+class TestPprChannel:
+    @pytest.mark.asyncio
+    async def test_ppr_rebuild_omits_ppr_score_and_keeps_blob(self) -> None:
+        ns = uuid4()
+        # Two chunks so the PPR ranking is non-degenerate; the seed's chunk is the
+        # one whose rebuilt blob we assert on.
+        chunk_a = Chunk(
+            id=uuid4(),
+            namespace_id=ns,
+            document_id=uuid4(),
+            content="Alice met Bob",
+            metadata=dict(_CLEAN_BLOB),
+            occurred_at=_OCCURRED_AT,
+        )
+        chunk_b = Chunk(
+            id=uuid4(),
+            namespace_id=ns,
+            document_id=uuid4(),
+            content="Bob met Carol",
+            metadata={"author": "carol"},
+            occurred_at=_OCCURRED_AT,
+        )
+        e_alice = Entity(id=uuid4(), namespace_id=ns, name="Alice", source_chunk_ids=[chunk_a.id])
+        e_bob = Entity(id=uuid4(), namespace_id=ns, name="Bob", source_chunk_ids=[chunk_a.id, chunk_b.id])
+        e_carol = Entity(id=uuid4(), namespace_id=ns, name="Carol", source_chunk_ids=[chunk_b.id])
+        rels = [
+            Relationship(
+                id=uuid4(),
+                namespace_id=ns,
+                source_entity_id=e_alice.id,
+                target_entity_id=e_bob.id,
+                relationship_type="RELATES_TO",
+                weight=1.0,
+            ),
+            Relationship(
+                id=uuid4(),
+                namespace_id=ns,
+                source_entity_id=e_bob.id,
+                target_entity_id=e_carol.id,
+                relationship_type="RELATES_TO",
+                weight=1.0,
+            ),
+        ]
+        storage = MagicMock()
+        storage.list_entities = AsyncMock(return_value=[e_alice, e_bob, e_carol])
+        storage.list_relationships = AsyncMock(return_value=rels)
+        storage.get_chunks_batch = AsyncMock(return_value={chunk_a.id: chunk_a, chunk_b.id: chunk_b})
+
+        results, _entity_scores = await ppr_retrieve_chunks(
+            storage=storage,
+            namespace_id=ns,
+            entry_entities=[(e_alice.id, 1.0)],
+            damping=0.85,
+            max_iter=50,
+            tol=1e-5,
+            top_entities=10,
+            limit=10,
+        )
+        assert results
+        rebuilt = {cid: chunk for cid, _score, chunk in results}
+        assert chunk_a.id in rebuilt
+        _assert_stored_blob(rebuilt[chunk_a.id])
+
+
+# --------------------------------------------------------------------------- #
+# typed-entity fast path — _typed_entity_recent_retrieve
+# --------------------------------------------------------------------------- #
+
+
+class TestTypedEntityFastPathChannel:
+    @pytest.mark.asyncio
+    async def test_fast_path_deserializes_stored_blob_without_injection(self) -> None:
+        retriever = _make_retriever()
+        ns = uuid4()
+        entity_id = uuid4()
+        chunk_id = uuid4()
+        doc_id = uuid4()
+
+        # The :Chunk node stores the user blob serialized as JSON; the fast path
+        # deserializes it. occurred_at is a separate node property.
+        rows = [
+            {
+                "entity": {
+                    "id": str(entity_id),
+                    "name": "Ship the prototype",
+                    "entity_type": "ACTION_ITEM",
+                    "description": "",
+                },
+                "last_mention": _OCCURRED_AT.isoformat(),
+                "evidence_chunk": {
+                    "id": str(chunk_id),
+                    "document_id": str(doc_id),
+                    "content": "Action: ship the prototype",
+                    "metadata": '{"author": "alice", "tier": "gold", "score": 3}',
+                    "occurred_at": _OCCURRED_AT.isoformat(),
+                },
+            }
+        ]
+
+        session_ctx = AsyncMock()
+        session_ctx.__aenter__.return_value = session_ctx
+        session_ctx.__aexit__.return_value = None
+        session_ctx.execute_read = AsyncMock(return_value=rows)
+        retriever._dual_nodes = MagicMock()
+        retriever._dual_nodes._session.return_value = session_ctx
+
+        routing = RoutingDecision(
+            complexity=QueryComplexity.TYPED_ENTITY_RECENT,
+            use_graph=True,
+            graph_depth=1,
+            confidence=0.9,
+            reasoning="typed",
+        )
+        result = await retriever._typed_entity_recent_retrieve(
+            query="latest action items",
+            query_embedding=[0.0],
+            namespace_id=ns,
+            temporal_filter=None,
+            graph_depth=1,
+            limit=5,
+            routing=routing,
+        )
+        assert len(result.chunks) == 1
+        chunk, _score = result.chunks[0]
+        _assert_stored_blob(chunk)
+
+
+# --------------------------------------------------------------------------- #
+# graph channel in-memory post-filter agrees with the SQL-pushdown channels
+# --------------------------------------------------------------------------- #
+
+
+class TestGraphChannelPostFilterAgreement:
+    """A graph-produced chunk clears the same filters the SQL pushdown matches.
+
+    The graph channel reads chunks from the graph store (metadata is a serialized
+    property, not push-downable), so the engine re-checks the WHOLE filter AST in
+    memory against each graph chunk with
+    ``compile_python(filter_ast, build_compile_context("Chunk", "split"))`` before
+    fusion (retriever.py graph post-filter site). Because the graph channel now
+    rebuilds ``chunk.metadata`` as the clean stored blob, that in-memory re-check
+    reaches the SAME verdict the vector/BM25 SQL pushdown reaches on the same blob
+    — the cross-channel agreement this suite exists to pin. A read-time injection
+    of ``occurred_at`` into the blob would flip ``metadata.occurred_at $exists``
+    on the graph side only, silently dropping the chunk from the graph channel
+    while the SQL channels kept it.
+    """
+
+    @staticmethod
+    def _graph_post_filter(filter_dict: dict[str, Any]):  # noqa: ANN205 - predicate callable
+        """Build the exact in-memory post-filter the graph channel applies."""
+        from khora.filter import RecallFilter
+        from khora.filter.ast import parse_to_ast
+        from khora.filter.compilers.python import compile_python
+        from khora.filter.execute import build_compile_context
+
+        ast = parse_to_ast(RecallFilter.model_validate(filter_dict))
+        return compile_python(ast, build_compile_context("Chunk", on_unsupported="split")).predicate
+
+    async def _graph_chunk(self) -> Chunk:
+        """The chunk the storage graph-fallback channel produces from a clean blob."""
+        ns = uuid4()
+        stored = Chunk(
+            id=uuid4(),
+            namespace_id=ns,
+            document_id=uuid4(),
+            content="graph hit",
+            metadata=dict(_CLEAN_BLOB),
+            occurred_at=_OCCURRED_AT,
+        )
+        entity = Entity(
+            id=uuid4(),
+            namespace_id=ns,
+            name="Alice",
+            entity_type="PERSON",
+            source_chunk_ids=[stored.id],
+        )
+        retriever = VectorCypherRetriever.__new__(VectorCypherRetriever)
+        retriever._config = RetrieverConfig()
+        retriever._dual_nodes = None
+        retriever._vector_store = MagicMock()
+        retriever._neo4j_driver = None
+        storage = MagicMock()
+        storage.get_entities_batch = AsyncMock(return_value={entity.id: entity})
+        storage.get_chunks_batch = AsyncMock(return_value={stored.id: stored})
+        retriever._storage = storage
+
+        results = await retriever._fetch_chunks_from_entities(
+            entity_ids=[entity.id],
+            namespace_id=ns,
+            temporal_filter=None,
+            limit=10,
+        )
+        assert len(results) == 1
+        return results[0][2]
+
+    @pytest.mark.asyncio
+    async def test_absent_occurred_at_key_survives_graph_post_filter(self) -> None:
+        """``metadata.occurred_at $exists false`` keeps the clean-blob graph chunk."""
+        chunk = await self._graph_chunk()
+        keep = self._graph_post_filter({"metadata.occurred_at": {"$exists": False}})
+        drop = self._graph_post_filter({"metadata.occurred_at": {"$exists": True}})
+        assert keep(chunk) is True
+        assert drop(chunk) is False
+
+    @pytest.mark.asyncio
+    async def test_whole_blob_eq_survives_graph_post_filter(self) -> None:
+        """A whole-blob ``$eq`` keeps the graph chunk whose stored blob matches."""
+        chunk = await self._graph_chunk()
+        match = self._graph_post_filter({"metadata": dict(_CLEAN_BLOB)})
+        miss = self._graph_post_filter({"metadata": {"author": "someone-else"}})
+        assert match(chunk) is True
+        assert miss(chunk) is False

--- a/tests/unit/engines/test_retriever_stored_blob_metadata.py
+++ b/tests/unit/engines/test_retriever_stored_blob_metadata.py
@@ -18,6 +18,11 @@ Each test seeds a channel's store boundary with a CLEAN blob plus a populated
 ``occurred_at`` column and asserts the rebuilt chunk keeps the blob intact and
 surfaces the event-time on the column.
 
+The contract is symmetric, so ``TestCallerStoredKeysReturnedVerbatim`` covers the
+other direction: when the caller legitimately stores those same key NAMES
+(``occurred_at`` / ``connected_entities`` / ``ppr_score``) as user data, recall
+returns them verbatim — the pass-through must not SCRUB user keys either.
+
 These are complementary to ``test_retriever_coverage_push.py`` (which already
 pins the ``_vector_search_chunks`` and the ``_fetch_chunks_from_entities``
 dual-nodes channels): the channels here are the remaining producers — the simple
@@ -59,6 +64,20 @@ _INJECTION_KEYS = ("occurred_at", "connected_entities", "ppr_score")
 # in place would be caught by the identity-independent equality assertion.
 _CLEAN_BLOB: dict[str, Any] = {"author": "alice", "tier": "gold", "score": 3}
 
+# The adversarial mirror: a stored blob whose USER keys are named exactly like
+# the read-time bookkeeping (``occurred_at`` / ``connected_entities`` /
+# ``ppr_score``) but hold caller-owned values. The blob is user data, so recall
+# must return these verbatim — never scrub or overwrite them with the first-class
+# column or graph/PPR bookkeeping. The values are deliberately un-column-like (a
+# plain string event-time, a list, a float) so a channel that folded the column
+# in would be caught by the exact-equality check.
+_CALLER_BLOB: dict[str, Any] = {
+    "author": "bob",
+    "occurred_at": "caller-owned-event-string",
+    "connected_entities": ["caller-entity-1", "caller-entity-2"],
+    "ppr_score": 0.123,
+}
+
 
 def _make_retriever(
     *,
@@ -82,6 +101,23 @@ def _assert_stored_blob(chunk: Chunk) -> None:
     for key in _INJECTION_KEYS:
         assert key not in chunk.metadata, f"channel injected {key!r} into the stored blob"
     # The event-time is on the first-class column, not the blob.
+    assert chunk.occurred_at == _OCCURRED_AT
+
+
+def _assert_caller_blob_verbatim(chunk: Chunk) -> None:
+    """The rebuilt chunk returns the caller's blob verbatim, keys and values intact.
+
+    The blob legitimately carries user keys named ``occurred_at`` /
+    ``connected_entities`` / ``ppr_score``. Recall must NOT scrub them (an
+    over-correction) nor overwrite the ``occurred_at`` key with the first-class
+    column: the caller string stays in the blob and the column is surfaced
+    separately on ``chunk.occurred_at``.
+    """
+    assert chunk.metadata == _CALLER_BLOB
+    for key in _INJECTION_KEYS:
+        assert key in chunk.metadata, f"channel scrubbed caller-owned key {key!r} from the stored blob"
+    assert chunk.metadata["occurred_at"] == "caller-owned-event-string"
+    # The caller's blob value is untouched; the real event-time is on the column.
     assert chunk.occurred_at == _OCCURRED_AT
 
 
@@ -468,3 +504,81 @@ class TestGraphChannelPostFilterAgreement:
         miss = self._graph_post_filter({"metadata": {"author": "someone-else"}})
         assert match(chunk) is True
         assert miss(chunk) is False
+
+
+# --------------------------------------------------------------------------- #
+# caller-stored keys are user data — returned verbatim, never scrubbed
+# --------------------------------------------------------------------------- #
+
+
+class TestCallerStoredKeysReturnedVerbatim:
+    """A caller-stored ``occurred_at`` / ``connected_entities`` / ``ppr_score`` in
+    the blob is USER data and comes back verbatim.
+
+    The rest of this suite asserts these keys are ABSENT — but that only guards
+    against read-time INJECTION. The stored-blob contract is symmetric: recall
+    must also not SCRUB a key the caller legitimately stored under one of those
+    names, nor overwrite the caller's ``occurred_at`` value with the first-class
+    column. An over-correction that stripped the bookkeeping names from user blobs
+    would pass every absent-key test but break this one. Covers the two changed
+    constructor sites where the risk is real: the graph fetch (where
+    ``connected_entities`` used to be injected) and the vector search.
+    """
+
+    @pytest.mark.asyncio
+    async def test_graph_fetch_returns_caller_keys_verbatim(self) -> None:
+        ns = uuid4()
+        stored = Chunk(
+            id=uuid4(),
+            namespace_id=ns,
+            document_id=uuid4(),
+            content="graph hit",
+            metadata=dict(_CALLER_BLOB),
+            occurred_at=_OCCURRED_AT,
+        )
+        entity = Entity(
+            id=uuid4(),
+            namespace_id=ns,
+            name="Alice",
+            entity_type="PERSON",
+            source_chunk_ids=[stored.id],
+        )
+        retriever = VectorCypherRetriever.__new__(VectorCypherRetriever)
+        retriever._config = RetrieverConfig()
+        retriever._dual_nodes = None
+        retriever._vector_store = MagicMock()
+        retriever._neo4j_driver = None
+        storage = MagicMock()
+        storage.get_entities_batch = AsyncMock(return_value={entity.id: entity})
+        storage.get_chunks_batch = AsyncMock(return_value={stored.id: stored})
+        retriever._storage = storage
+
+        results = await retriever._fetch_chunks_from_entities(
+            entity_ids=[entity.id],
+            namespace_id=ns,
+            temporal_filter=None,
+            limit=10,
+        )
+        assert len(results) == 1
+        _cid, _score, chunk = results[0]
+        _assert_caller_blob_verbatim(chunk)
+
+    @pytest.mark.asyncio
+    async def test_vector_search_returns_caller_keys_verbatim(self) -> None:
+        ns = uuid4()
+        result = _vector_store_result()
+        result.chunk.namespace_id = ns
+        result.chunk.metadata = dict(_CALLER_BLOB)
+        retriever = _make_retriever()
+        retriever._vector_store.search = AsyncMock(return_value=[result])
+
+        results = await retriever._vector_search_chunks(
+            query_embedding=[0.1, 0.2],
+            namespace_id=ns,
+            temporal_filter=None,
+            query_text="q",
+            limit=5,
+        )
+        assert len(results) == 1
+        _cid, _score, chunk = results[0]
+        _assert_caller_blob_verbatim(chunk)

--- a/tests/unit/filter/test_filter_fuzz.py
+++ b/tests/unit/filter/test_filter_fuzz.py
@@ -917,19 +917,25 @@ def _field_not(operand: dict[str, Any]) -> dict[str, Any]:
 # date column read consistently on the SQL-pushdown read path.
 # --------------------------------------------------------------------------- #
 #
-# The recall read paths carry the STORED metadata blob verbatim — nothing is
-# injected into ``metadata`` from the first-class ``occurred_at`` /
-# ``source_timestamp`` columns at read time. The fixed seed already models this:
-# records r07–r18 stamp a real ``occurred_at`` / ``source_timestamp`` column, yet
-# NONE of the 18 blobs carries an ``occurred_at`` KEY. So a ``metadata.occurred_at``
-# leaf reads the blob (where the key is absent) — never the column — on both the
-# oracle and the real sqlite_lance read path (the server-side prefilter that the
-# vector + BM25 recall channels share). These deterministic cases pin that
-# equivalence on the exact filters a downstream caller would use to select
-# "chunks with no event-time key in their blob" and to match a chunk by its whole
-# stored blob. They reuse the same oracle-vs-lance seam Property A drives, so a
-# future read path that reintroduced a blob injection (a column value leaking into
-# ``metadata``) would diverge here.
+# The metadata blob and the first-class ``occurred_at`` / ``source_timestamp``
+# columns are DISTINCT fields on the ``khora_chunks`` row. The fixed seed models
+# this: records r07–r18 stamp a real ``occurred_at`` / ``source_timestamp``
+# column, yet NONE of the 18 blobs carries an ``occurred_at`` KEY. So a
+# ``metadata.occurred_at`` leaf addresses the JSON blob (where the key is absent) —
+# never the column — and both the Python oracle (``compile_python`` over the
+# ``_record_mapping``) and the real sqlite_lance read path (``compile_lance`` SQL
+# prefilter ∘ ``compile_python`` post-filter over the seeded raw row) must agree on
+# that. These deterministic cases pin the COMPILER + SCHEMA invariance on the exact
+# filters a downstream caller would use to select "chunks with no event-time key in
+# their blob" and to match a chunk by its whole stored blob. They reuse the same
+# oracle-vs-lance seam Property A drives.
+#
+# SCOPE: this guards the storage/compiler layer — that ``metadata.occurred_at``
+# does not silently coalesce onto the first-class column at the schema or compile
+# level. It does NOT exercise the recall-path ``Chunk`` constructors (those build a
+# public ``Chunk`` from a store result, a step above this seam); the recall
+# constructors' stored-blob pass-through is pinned by the retriever channel tests
+# and the matrix integration lane instead.
 
 
 def _column_populated_ids() -> frozenset[str]:
@@ -942,13 +948,17 @@ def _column_populated_ids() -> frozenset[str]:
 
 
 class TestStoredBlobColumnInvariant:
-    """A populated date COLUMN never leaks into the stored metadata BLOB on read.
+    """The compiler keeps ``metadata.<key>`` addressing the blob, distinct from the
+    first-class date columns.
 
     ``metadata.occurred_at`` addresses the blob key, which is absent on every seed
     record even though many carry a populated ``occurred_at``/``source_timestamp``
-    column. The oracle and the real sqlite_lance read path (the pushdown the vector
-    + BM25 channels share) must agree on that, so a column value silently injected
-    into the blob would surface as an oracle/lance divergence here.
+    column. The Python oracle and the real sqlite_lance read path (the SQL pushdown
+    the vector + BM25 channels share) must agree the leaf reads the blob and never
+    the column — a schema/compile change that coalesced the column onto the
+    ``metadata.occurred_at`` path would surface as an oracle/lance divergence here.
+    (This is a compiler/schema-level guard over the raw row, not a check of the
+    recall-path ``Chunk`` constructors.)
     """
 
     def test_occurred_at_key_absent_matches_every_clean_blob(self) -> None:

--- a/tests/unit/filter/test_filter_fuzz.py
+++ b/tests/unit/filter/test_filter_fuzz.py
@@ -910,3 +910,93 @@ def _field_not(operand: dict[str, Any]) -> dict[str, Any]:
     """
     ((key, expr),) = operand.items()
     return {key: {"$not": expr}}
+
+
+# --------------------------------------------------------------------------- #
+# Stored-blob column invariant: a clean metadata blob + a populated first-class
+# date column read consistently on the SQL-pushdown read path.
+# --------------------------------------------------------------------------- #
+#
+# The recall read paths carry the STORED metadata blob verbatim — nothing is
+# injected into ``metadata`` from the first-class ``occurred_at`` /
+# ``source_timestamp`` columns at read time. The fixed seed already models this:
+# records r07–r18 stamp a real ``occurred_at`` / ``source_timestamp`` column, yet
+# NONE of the 18 blobs carries an ``occurred_at`` KEY. So a ``metadata.occurred_at``
+# leaf reads the blob (where the key is absent) — never the column — on both the
+# oracle and the real sqlite_lance read path (the server-side prefilter that the
+# vector + BM25 recall channels share). These deterministic cases pin that
+# equivalence on the exact filters a downstream caller would use to select
+# "chunks with no event-time key in their blob" and to match a chunk by its whole
+# stored blob. They reuse the same oracle-vs-lance seam Property A drives, so a
+# future read path that reintroduced a blob injection (a column value leaking into
+# ``metadata``) would diverge here.
+
+
+def _column_populated_ids() -> frozenset[str]:
+    """Seed ids whose first-class ``occurred_at``/``source_timestamp`` column is set.
+
+    The invariant only bites when the column is populated (an unset column can't
+    leak into the blob), so the ``$exists: false`` match MUST still include these.
+    """
+    return frozenset(r.id for r in FIXED_SEED if r.occurred_at is not None or r.source_timestamp is not None)
+
+
+class TestStoredBlobColumnInvariant:
+    """A populated date COLUMN never leaks into the stored metadata BLOB on read.
+
+    ``metadata.occurred_at`` addresses the blob key, which is absent on every seed
+    record even though many carry a populated ``occurred_at``/``source_timestamp``
+    column. The oracle and the real sqlite_lance read path (the pushdown the vector
+    + BM25 channels share) must agree on that, so a column value silently injected
+    into the blob would surface as an oracle/lance divergence here.
+    """
+
+    def test_occurred_at_key_absent_matches_every_clean_blob(self) -> None:
+        """``metadata.occurred_at $exists false`` keeps ALL 18 rows on both sides.
+
+        No seed blob carries an ``occurred_at`` key, so the leaf is universally
+        true — INCLUDING the records whose ``occurred_at`` COLUMN is populated. If a
+        read path folded the column into the blob, those column-bearing rows would
+        drop, shrinking the lance survivor set below the oracle's.
+        """
+        ast = parse_to_ast(RecallFilter.model_validate({"metadata.occurred_at": {"$exists": False}}))
+        all_ids = frozenset(r.id for r in FIXED_SEED)
+        oracle = _oracle_survivors(ast)
+        lance = _lance_survivors(ast)
+        assert oracle == all_ids, oracle
+        assert lance == oracle
+        # Non-vacuous: the column-populated records are part of the match, so the
+        # case genuinely exercises "clean blob + populated column".
+        populated = _column_populated_ids()
+        assert populated, "seed carries no column-populated records — check FIXED_SEED"
+        assert populated <= lance
+
+    def test_occurred_at_key_present_matches_nothing(self) -> None:
+        """``metadata.occurred_at $exists true`` keeps NO rows on both sides.
+
+        The mirror of the case above: because no blob carries the key, the
+        positive-existence leaf is empty. A column-into-blob leak would instead make
+        the lance side surface the column-bearing rows the oracle never sees.
+        """
+        ast = parse_to_ast(RecallFilter.model_validate({"metadata.occurred_at": {"$exists": True}}))
+        oracle = _oracle_survivors(ast)
+        lance = _lance_survivors(ast)
+        assert oracle == frozenset(), oracle
+        assert lance == oracle
+
+    def test_whole_blob_eq_matches_via_split_post_filter(self) -> None:
+        """A whole-blob ``$eq`` matches the one record whose stored blob is equal.
+
+        ``{"metadata": {<exact blob>}}`` is an object-equality compare the lance
+        compiler cannot push to SQL, so it defers the WHOLE leaf to the
+        ``compile_python`` post-filter — which reads the SAME stored blob the SQL
+        prefilter would have. r01's blob is unique in the seed, so the match is the
+        strict, non-empty subset ``{r01}`` on both sides.
+        """
+        r01_blob = {"tier": "gold", "score": 10, "tags": ["urgent", "release"]}
+        ast = parse_to_ast(RecallFilter.model_validate({"metadata": r01_blob}))
+        oracle = _oracle_survivors(ast)
+        lance = _lance_survivors(ast)
+        assert oracle == frozenset({"r01"}), oracle
+        assert lance == oracle
+        assert 0 < len(oracle) < len(FIXED_SEED)


### PR DESCRIPTION
## Summary
- Drop the engine-internal keys (`occurred_at`, `connected_entities`, `ppr_score`) that were injected into the in-memory `Chunk.metadata` at all six recall-path `Chunk` constructors (vector simple, vector full, graph entity-fetch, recency, PPR, skeleton). `Chunk.metadata` now carries the caller's stored blob, verbatim, on every retrieval channel.
- Temporal ranking and the two **production** rerank date-prefix builders (cross-encoder, LLM) already read the first-class `occurred_at`/`source_timestamp` columns (preserved on every constructor), so this is a **zero-ranking-change dead-write removal**. (The opt-in, non-production `CrossEncoderReranker(include_date_prefix=True)` experiment still reads a top-level blob key — out of scope here.)
- Restores cross-channel **filter invariance**: a given `(chunk, filter)` pair now evaluates identically whether the chunk came from the vector/BM25 SQL pushdown or the graph channel's in-memory post-filter, because the post-filter now sees the same stored blob. This is the internal `Chunk.metadata` the filter pass and rerank candidates consume — the caller-facing `RecallChunk` carries no `metadata` field, so there is no response-shape change.
- The dropped keys had zero readers (audited repo-wide): `connected_entity_ids` is a first-class `RecallChunk` field derived post-engine by inverting entity→chunk links, and the PPR score travels in the result tuple. A caller-stored `occurred_at`/`connected_entities`/`ppr_score` blob key is user data and still passes through verbatim.

## Test plan
- [x] `make format` clean, `make lint` green
- [x] Affected + new unit tests pass; full unit suite 9976 passed, 84% coverage (≥65%)
- [x] Embedded integration lane (sqlite_lance matrix): 154 passed, incl. a new cross-channel filter-invariance matrix test and a graph-channel post-filter agreement test
- [x] Postgres/Neo4j integration + e2e legs — green in CI (conformance, skeleton, vc_full)
- Added metadata-shape assertions across every channel, filter-invariant cases (`metadata.occurred_at $exists:false`, whole-blob `$eq`) proving identical evaluation via the vector, BM25, and graph channels, and a positive caller-stored-key pass-through case; tightened the two pinned-key assertions to exact stored-blob equality plus the first-class column.

Fixes #1492
Closes #1509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved stored metadata exactly as provided during recall across vector, keyword, hybrid, graph, recency, and PPR retrieval.
  * Prevented system-generated fields such as event time, connection data, and ranking scores from being added to metadata.
  * Kept event timestamps available through their dedicated fields.
  * Ensured user-provided metadata keys are returned unchanged.
* **Tests**
  * Added coverage confirming consistent metadata filtering and whole-blob matching across retrieval modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->