### PR TITLE
docs: document reranking config (query.* / KHORA_QUERY_RERANKING_*)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -210,7 +210,7 @@ result: RecallResult = await kb.recall(
 - `mode` - one of `SearchMode.VECTOR`, `GRAPH`, `HYBRID`, `ALL`, or `KEYWORD`.
 - `min_similarity` - a hard cosine floor honored by every mode (VECTOR / GRAPH / HYBRID / ALL / KEYWORD) as of #1438/#1445: candidates below the floor are dropped before fusion. BM25/keyword evidence can still boost a chunk that clears the floor, but cannot rescue one below it. Default `0.0` disables the floor (falling back to the configured `min_chunk_similarity`, itself `0.0` by default). See [Recall semantics](query-engine/recall-semantics.md).
 - `start_time` / `end_time` - **Deprecated.** Explicit temporal filter; bypasses NLP temporal detection. Both-naive or both-aware datetimes are required. Honored on all three engines (chronicle, vectorcypher, skeleton). Prefer the `filter` form: `filter={"occurred_at": {"$gte": ..., "$lt": ...}}`. Cannot be combined with `filter=`.
-- To skip LLM-side work (reranking, HyDE expansion), set the config flags `enable_llm_reranking=False` and `enable_hyde="never"` on `KhoraConfig.query` (env: `KHORA_QUERY_ENABLE_LLM_RERANKING`, `KHORA_QUERY_ENABLE_HYDE`).
+- To skip LLM-side work: LLM listwise reranking is off by default (enable via `query.enable_llm_reranking=True` / `KHORA_QUERY_ENABLE_LLM_RERANKING`), and set `enable_hyde="never"` on `KhoraConfig.query` (env: `KHORA_QUERY_ENABLE_HYDE`) to disable HyDE expansion. Note the cross-encoder reranker is on by default and runs locally (not an LLM call); disable it with `KHORA_QUERY_ENABLE_RERANKING=false`.
 
 ### `context_text`
 

--- a/docs/architecture/performance-optimization.md
+++ b/docs/architecture/performance-optimization.md
@@ -404,7 +404,7 @@ config = RetrieverConfig(
 )
 ```
 
-`bigram_coherence_score()` checks function-word transitions (articles → content words, prepositions → noun phrases). The score is blended into the RRF score via `apply_coherence_boost()`. This adds negligible latency (pure Python string analysis, no LLM calls) while improving confounder rejection when LLM reranking is disabled (`KHORA_QUERY_ENABLE_LLM_RERANKING=false`).
+`bigram_coherence_score()` checks function-word transitions (articles → content words, prepositions → noun phrases). The score is blended into the RRF score via `apply_coherence_boost()`. This adds negligible latency (pure Python string analysis, no LLM calls) while improving confounder rejection when LLM reranking is disabled (the default).
 
 ## Phase 9: Neo4j Write Contention Elimination
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -275,7 +275,14 @@ Prefix: `KHORA_QUERY_`. See [query-engine/retrieval-tuning.md](query-engine/retr
 | `KHORA_QUERY_HYDE_NUM_HYPOTHETICALS` | `1` | Number of hypothetical documents to generate (1–5). |
 | `KHORA_QUERY_ENABLE_HYDE_CYPHER` | `false` | **Currently inert.** The `khora.query.hyde_cypher` module (LLM-picked parameterized Cypher templates) exists but is not yet wired into the retrieval pipeline - no code reads this flag, so setting it has no effect on `recall()`. |
 | `KHORA_QUERY_HYDE_CYPHER_LIMIT` | `20` | **Currently inert** - see `KHORA_QUERY_ENABLE_HYDE_CYPHER`. |
-| `KHORA_QUERY_ENABLE_RERANKING` | `true` | Cross-encoder reranking of top candidates. |
+| `KHORA_QUERY_ENABLE_RERANKING` | `true` | Cross-encoder reranking; **on by default**. With the defaults the first `recall()` loads `BAAI/bge-reranker-v2-m3` (~2.3 GB, GPU-preferred). Set `false` to disable. |
+| `KHORA_QUERY_RERANKING_MODEL` | `BAAI/bge-reranker-v2-m3` | Any model loadable by `CrossEncoder(name)`; e.g. `cross-encoder/ms-marco-MiniLM-L-6-v2` for a light CPU default. |
+| `KHORA_QUERY_RERANKING_TOP_N` | `50` | Candidates fed to the reranker. |
+| `KHORA_QUERY_RERANKING_BLEND_WEIGHT` | `0.7` | Reranker-score weight when blending with the original fused score (`0.7` = 70 % reranker / 30 % original). |
+| `KHORA_QUERY_ENABLE_LLM_RERANKING` | `false` | **Opt-in.** LLM listwise reranking after the cross-encoder stage (temporal queries). |
+| `KHORA_QUERY_LLM_RERANKING_MODEL` | `gpt-4o-mini` | Model for LLM listwise reranking. |
+| `KHORA_QUERY_LLM_RERANKING_TOP_N` | `10` | Top candidates sent to the LLM reranker. |
+| `KHORA_QUERY_LLM_RERANKING_CONFIDENCE_THRESHOLD` | `0.1` | Trigger LLM reranking only when the cross-encoder's rank-1-vs-rank-2 score gap is below this. |
 | `KHORA_QUERY_TEMPORAL_SQL_PUSHDOWN` | `true` | Push relative-date filters into SQL WHERE clauses. |
 | `KHORA_QUERY_METADATA_OVERFETCH_MULTIPLIER` | `3` | Over-fetch multiplier (2–10) for the VectorCypher graph chunk channel when a caller filter has a metadata predicate that can't push down to Cypher and must be post-filtered in memory. The graph fetch widens to `min(limit * multiplier, 200)` so fusion still has candidates after filtering; no effect for no-filter or system-key-only filters. |
 | `KHORA_QUERY_ENABLE_BM25_CHANNEL` | `false` | **Opt-in.** Add an independent BM25 lexical channel to fusion (alongside vector + graph), so exact keyword matches surface even when semantic similarity is weak. |
@@ -286,6 +293,8 @@ Prefix: `KHORA_QUERY_`. See [query-engine/retrieval-tuning.md](query-engine/retr
 | `KHORA_QUERY_SHADOW_SCORING_STRATEGY` | `score_sort` | Candidate ordering for the shadow harness: `score_sort` (re-order by descending `RecallChunk.score` - the #1433/#1463 divergence class) or `identity` (no-op self-check). Only consulted when `KHORA_QUERY_SHADOW_SCORING=true`. |
 
 > **Default-path fusion is vector + graph only.** On the default `kb.recall()` (VectorCypher) engine only the vector and graph channels fuse by default (weights 0.6 / 0.4). The lexical/BM25 channel is opt-in via `KHORA_QUERY_ENABLE_BM25_CHANNEL=true`; when enabled it fuses at `KHORA_QUERY_KEYWORD_WEIGHT` (0.3). The legacy 3-way HYBRID with an always-on keyword channel applies to the older `HybridQueryEngine`, not the default recall path.
+
+> **Reranking knobs apply to the default VectorCypher engine** (the engine reconciles the `query.reranking_*` family onto its config). `KHORA_QUERY_RERANKING_METHOD` and `KHORA_QUERY_RERANKING_FINAL_K` are the exception — they have no `VectorCypherConfig` equivalent and affect only the separate `HybridQueryEngine`. For per-engine overrides and model selection, see [retrieval-tuning.md](query-engine/retrieval-tuning.md#reranking).
 
 ### Abstention signals
 

--- a/docs/engines/vectorcypher-engine.md
+++ b/docs/engines/vectorcypher-engine.md
@@ -673,7 +673,7 @@ uv run alembic upgrade head
 
 ## Recent Improvements
 
-**Cross-encoder reranking.** After the initial vector + Cypher retrieval, an optional cross-encoder model rescores the top candidates for precision. The model is cached across queries to avoid reload overhead, and inference runs in `asyncio.to_thread` to keep the event loop free. Enable/disable via `KHORA_QUERY_ENABLE_RERANKING`.
+**Cross-encoder reranking.** After the initial vector + Cypher retrieval, an optional cross-encoder model rescores the top candidates for precision. The model is cached across queries to avoid reload overhead, and inference runs in `asyncio.to_thread` to keep the event loop free. Reranking is **on by default** (model `BAAI/bge-reranker-v2-m3`, ~2.3 GB, GPU-preferred) and configured via `KHORA_QUERY_RERANKING_*` / `config.query.reranking_*`, or a `VectorCypherConfig` for per-engine overrides. Disable with `KHORA_QUERY_ENABLE_RERANKING=false`. See [retrieval tuning → Reranking](../query-engine/retrieval-tuning.md#reranking).
 
 **Independent BM25 channel (opt-in).** When `KHORA_QUERY_ENABLE_BM25_CHANNEL=true` is set, VectorCypher runs BM25 full-text search as a separate retrieval channel alongside vector and Cypher graph traversal. Results are fused via RRF, giving keyword-exact matches a dedicated signal path rather than relying solely on embedding similarity. Default is OFF; keyword matching in HYBRID mode uses the `enable_keyword_search` path inside `HybridQueryEngine`, not this channel.
 

--- a/docs/query-engine/overview.md
+++ b/docs/query-engine/overview.md
@@ -235,7 +235,7 @@ For higher precision, a neural reranker can reorder the top results:
 config = QueryConfig(enable_reranking=True)
 ```
 
-This uses a cross-encoder model that looks at query-document pairs together, catching nuances that initial retrieval might miss.
+This uses a cross-encoder model that looks at query-document pairs together, catching nuances that initial retrieval might miss. On the default VectorCypher engine reranking is **on by default** (model `BAAI/bge-reranker-v2-m3`) and configured via `KHORA_QUERY_RERANKING_*` / `config.query.reranking_*` — or a `VectorCypherConfig` for per-engine overrides. See [Reranking](retrieval-tuning.md#reranking) for the knobs, model selection, and how to disable or pick a lighter model.
 
 **Optional date-prefix experiment (opt-in).** `CrossEncoderReranker(include_date_prefix=True)` (or the `include_date_prefix=True` kwarg on `create_reranker`) prepends `[YYYY-MM-DD] ` to each candidate's content before scoring. Off-the-shelf cross-encoders tokenize ISO dates fine, so this gives them an explicit recency signal at negligible token cost. Date source priority: `metadata.custom.occurred_at` → `metadata.custom.sent_at` → `metadata.created_at`. Default **OFF** pending an A/B run on the corporate-shape benchmark (Issue #594, Phase D5).
 

--- a/docs/query-engine/retrieval-tuning.md
+++ b/docs/query-engine/retrieval-tuning.md
@@ -205,7 +205,7 @@ KHORA_QUERY_DIVERSITY_LAMBDA=0.5    # default
 
 ### Coherence Scoring
 
-The VectorCypher retriever applies a lightweight text coherence signal after RRF fusion to penalize word-shuffled confounders. This is particularly effective when LLM reranking is disabled (`KHORA_QUERY_ENABLE_LLM_RERANKING=false`), where confounders would otherwise rank alongside genuine results.
+The VectorCypher retriever applies a lightweight text coherence signal after RRF fusion to penalize word-shuffled confounders. This is particularly effective when LLM reranking is disabled (the default), where confounders would otherwise rank alongside genuine results.
 
 **How it works:** `bigram_coherence_score()` checks function-word transitions (articles → content words, prepositions → noun phrases). Genuine text has predictable bigram patterns; word-shuffled text does not. The score is blended into the RRF score via `apply_coherence_boost()`.
 
@@ -226,6 +226,73 @@ config = RetrieverConfig(
 Coherence scoring complements, but does not replace, MMR diversity selection. MMR removes same-document dominance; coherence scoring removes incoherent text. Both can be enabled simultaneously (the default).
 
 > **Note:** Coherence scoring only applies to the VectorCypher retriever pipeline.
+
+### Reranking
+
+After RRF fusion, an optional neural reranker rescores the top candidates as query–document *pairs* (a cross-encoder, unlike the bi-encoder used for the initial embedding search). The reranker is cached across queries and runs in `asyncio.to_thread`, and it [skips small result sets](#reranking-skip-for-small-result-sets-p1) (<5 chunks).
+
+On the default **VectorCypher** engine, reranking is **on by default**: `query.enable_reranking` defaults to `True`, and the engine reconciles the `query.reranking_*` family — and the matching `KHORA_QUERY_RERANKING_*` env vars — onto its config. So the simplest way to configure it is through `KhoraConfig.query` / env vars:
+
+```bash
+KHORA_QUERY_ENABLE_RERANKING=true                      # default
+KHORA_QUERY_RERANKING_MODEL=BAAI/bge-reranker-v2-m3    # default
+KHORA_QUERY_RERANKING_TOP_N=50                         # default
+KHORA_QUERY_RERANKING_BLEND_WEIGHT=0.7                 # default
+```
+
+| Env var (`KHORA_QUERY_…`) / `query.*` field | Default | Notes |
+|---|---|---|
+| `ENABLE_RERANKING` / `enable_reranking` | `true` | Master on/off. **On by default.** |
+| `RERANKING_MODEL` / `reranking_model` | `BAAI/bge-reranker-v2-m3` | Any model loadable by `CrossEncoder(name)`. |
+| `RERANKING_TOP_N` / `reranking_top_n` | `50` | Candidates fed to the reranker. |
+| `RERANKING_BLEND_WEIGHT` / `reranking_blend_weight` | `0.7` | Reranker-score weight when blending with the original fused score (`0.7` = 70 % reranker / 30 % original). |
+
+> **Heads-up — reranking is on by default and loads a ~2.3 GB model.** With the defaults, the first `recall()` downloads and loads `BAAI/bge-reranker-v2-m3` (best on GPU). To disable it set `KHORA_QUERY_ENABLE_RERANKING=false` (or `query.enable_reranking=False`); to keep reranking but cut the footprint, pick a lighter `reranking_model` (see below).
+
+**The default reranker.** The default is **[`BAAI/bge-reranker-v2-m3`](https://huggingface.co/BAAI/bge-reranker-v2-m3)** — a 568M-parameter multilingual (XLM-RoBERTa-large) reranker chosen for its markedly stronger discrimination than the legacy MS MARCO MiniLM cross-encoders (on GraphRAG-Bench it lifted medium-difficulty accuracy from ~0.796 to ~0.82). The trade-off is weight: it downloads **~2.3 GB** and is best run on a **GPU** (the reranker auto-detects the device). It emits relevance logits rather than 0–1 scores; the default `reranking_blend_weight=0.7` handles that fine.
+
+**Choosing a lighter model (CPU-only / latency-sensitive).** On CPU-only deployments, or when the ~2.3 GB download and per-query cost of bge are too much, switch to a small MS MARCO MiniLM cross-encoder. The `L-N` suffix is the number of transformer layers ([sentence-transformers pretrained models](https://www.sbert.net/docs/cross_encoder/pretrained_models.html)) — more layers means more accurate but slower:
+
+| Model | Notes |
+|---|---|
+| `BAAI/bge-reranker-v2-m3` (default) | Strongest relevance; ~2.3 GB; GPU recommended. |
+| `cross-encoder/ms-marco-MiniLM-L-12-v2` | Lightweight; ~74.3 NDCG@10 on TREC-DL. |
+| `cross-encoder/ms-marco-MiniLM-L-6-v2` | Lightest; near-identical quality to L-12, ~2× faster. Best CPU default. |
+
+Because the reranker is cached by `(model, include_date_prefix)`, switching the model is a one-line config change:
+
+```bash
+KHORA_QUERY_RERANKING_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2   # lighter, CPU-friendly
+```
+
+**Per-engine overrides with `VectorCypherConfig`.** For finer control you can pass a `VectorCypherConfig` via `engine_kwargs`. Any field you set there explicitly wins over `query.*`, which in turn wins over the `VectorCypherConfig` defaults:
+
+```python
+from khora import Khora
+from khora.engines.vectorcypher import VectorCypherConfig
+
+kb = Khora(
+    config,
+    engine="vectorcypher",
+    engine_kwargs={"vectorcypher_config": VectorCypherConfig(reranking_top_n=100)},
+)
+```
+
+> **Precedence:** explicit `vectorcypher_config` field > `query.*` / `KHORA_QUERY_RERANKING_*` > `VectorCypherConfig` default. One edge case: a `vectorcypher_config` field set *to its own dataclass default* can't be distinguished from "unset", so `query.*` wins for that field — configure those via `query.*` instead.
+
+**LLM listwise reranking (opt-in).** For temporal queries you can chain an LLM reranker *after* the cross-encoder stage. It only fires when the cross-encoder is *not* already confident — i.e. when the rank-1-vs-rank-2 score gap is below the confidence threshold — so most queries never pay the extra LLM call:
+
+| Env var (`KHORA_QUERY_…`) / `query.*` field | Default | Notes |
+|---|---|---|
+| `ENABLE_LLM_RERANKING` / `enable_llm_reranking` | `false` | Opt-in; runs after the cross-encoder, temporal queries only. |
+| `LLM_RERANKING_MODEL` / `llm_reranking_model` | `gpt-4o-mini` | Model for the listwise pass. |
+| `LLM_RERANKING_TOP_N` / `llm_reranking_top_n` | `10` | Top candidates sent to the LLM. |
+| `LLM_RERANKING_CONFIDENCE_THRESHOLD` / `llm_reranking_confidence_threshold` | `0.1` | Trigger only when the cross-encoder rank-1/rank-2 gap is below this. |
+| `llm_reranking_mode` (`VectorCypherConfig` only) | `"auto"` | `"auto"` gates the LLM step on version metadata; `"always"` forces it on every temporal query. |
+
+> **Note:** `KHORA_QUERY_RERANKING_METHOD` and `KHORA_QUERY_RERANKING_FINAL_K` exist on `QuerySettings` but have no `VectorCypherConfig` equivalent, so they are **not** applied on the VectorCypher (`recall()`) path — they affect the separate `HybridQueryEngine` only.
+
+See also the opt-in [cross-encoder date-prefix experiment](#whats-next) below, which prepends `[YYYY-MM-DD]` to each candidate before scoring.
 
 ## What's Next
 


### PR DESCRIPTION
## What

Documents Khora's reranking configuration, which had no docs beyond an on/off mention. Reranking is on by default on the default VectorCypher engine, and the full `query.reranking_*` family is reconciled onto the engine so `query.*` / `KHORA_QUERY_RERANKING_*` take effect on the `recall()` path.

## Current behavior documented

- Reranking is **on by default** on the default VectorCypher engine and loads **`BAAI/bge-reranker-v2-m3`** (~2.3 GB, GPU-preferred).
- Configure via `KHORA_QUERY_RERANKING_*` / `config.query.reranking_*`, or a `VectorCypherConfig` for per-engine overrides.
- **Precedence:** explicit `vectorcypher_config` field > `query.*` / env > `VectorCypherConfig` default.
- `KHORA_QUERY_RERANKING_METHOD` / `KHORA_QUERY_RERANKING_FINAL_K` have no `VectorCypherConfig` equivalent — they affect only the separate `HybridQueryEngine`, not the `recall()` path.

## Changes

- **`configuration.md`** — added the `KHORA_QUERY_RERANKING_*` + LLM-reranker env-var rows with current defaults; note that `RERANKING_METHOD` / `RERANKING_FINAL_K` are `HybridQueryEngine`-only.
- **`query-engine/retrieval-tuning.md`** — new `### Reranking` subsection: knob tables, on-by-default + ~2.3 GB/GPU heads-up and how to disable, bge default rationale, lighter MiniLM (L-6/L-12) guidance, `VectorCypherConfig` overrides + precedence, LLM listwise reranking.
- **`overview.md` / `engines/vectorcypher-engine.md`** — Step 6 / reranking note updated to default-on + env-var/`VectorCypherConfig` configuration.
- **`api-reference.md` / `architecture/performance-optimization.md`** — corrected LLM-reranking-disabled references (LLM listwise is off by default; the cross-encoder reranker is on by default and runs locally).

## Verification

Verified behaviorally against current `main`: instantiated `KhoraConfig` / `VectorCypherEngine` and confirmed on the real `recall()` path — documented defaults match `QuerySettings`; the reconciliation flips reranking on (dataclass `False` → `True`) and pulls the bge model; the `explicit vectorcypher_config > query.* > VectorCypherConfig default` precedence holds (including the set-to-default edge case); `KHORA_QUERY_ENABLE_RERANKING=false` disables and `KHORA_QUERY_RERANKING_MODEL` switches the model; and `reranking_method` / `reranking_final_k` genuinely have no `VectorCypherConfig` field.

Docs-only — no code or test changes.

Supersedes the stale, conflicting docs branch for the same content (rebased onto current `main`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that cross-encoder reranking is enabled by default for the VectorCypher engine.
  * Documented reranking configuration options, model selection, candidate limits, blending, and engine-specific overrides.
  * Explained how to disable reranking, HyDE, and optional LLM listwise reranking.
  * Added details on reranking behavior, performance considerations, precedence rules, and confidence thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->