### PR TITLE
Render prompt templates in a Jinja sandboxed environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 
 ## [Unreleased]
 
+### Security
+
+- **Prompt templates now render in a Jinja `ImmutableSandboxedEnvironment`**, closing an SSTI -> RCE vector: extraction/expertise prompts (`ExpertiseComposer.render_prompt`) and persona chat prompts (`PromptGenerator`) previously rendered through a raw, non-sandboxed `jinja2.Template`. Templates that attempt unsafe constructs now raise `jinja2.exceptions.SecurityError` instead of failing open and returning the raw template string. The LLM extractor prompt-render call sites fail closed on `SecurityError` (propagate rather than silently degrading to the default prompt), while genuine non-security render errors keep their existing fallback behavior.
+
 ## [0.22.2] - recall-quality correctness, HNSW index-backed search, durable reconcilers
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 
 ## [Unreleased]
 
-### Security
-
-- **Prompt templates now render in a Jinja `ImmutableSandboxedEnvironment`**, closing an SSTI -> RCE vector: extraction/expertise prompts (`ExpertiseComposer.render_prompt`) and persona chat prompts (`PromptGenerator`) previously rendered through a raw, non-sandboxed `jinja2.Template`. Templates that attempt unsafe constructs now raise `jinja2.exceptions.SecurityError` instead of failing open and returning the raw template string. The LLM extractor prompt-render call sites fail closed on `SecurityError` (propagate rather than silently degrading to the default prompt), while genuine non-security render errors keep their existing fallback behavior.
-
 ## [0.22.2] - recall-quality correctness, HNSW index-backed search, durable reconcilers
 
 ### Added

--- a/docs/extraction/expertise-system.md
+++ b/docs/extraction/expertise-system.md
@@ -371,6 +371,8 @@ inference_rules:
 
 Prompts support Jinja2 templating:
 
+Prompts render in a Jinja `ImmutableSandboxedEnvironment`; unsafe constructs (dunder/private attribute access, mutating methods) are rejected and raise `SecurityError`.
+
 ```yaml
 system_prompt: |
   You are an expert at extracting information about {{ domain }} companies.

--- a/docs/extraction/extractors.md
+++ b/docs/extraction/extractors.md
@@ -196,6 +196,8 @@ expertise = ExpertiseConfig(
 
 ### Custom Extraction Prompt (Jinja2)
 
+Custom prompts render in a Jinja `ImmutableSandboxedEnvironment`; unsafe constructs (dunder/private attribute access, mutating methods) are rejected and raise `SecurityError`.
+
 ```python
 expertise = ExpertiseConfig(
     name="custom",

--- a/src/khora/chat/prompt.py
+++ b/src/khora/chat/prompt.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from jinja2 import Template
+from jinja2.sandbox import ImmutableSandboxedEnvironment
 
 if TYPE_CHECKING:
     from .history import ChatMessage
     from .persona import PersonaConfig
+
+# Shared sandboxed environment for rendering persona-supplied templates.
+# ImmutableSandboxedEnvironment blocks the SSTI -> RCE surface of raw
+# ``jinja2.Template``; a blocked construct raises SecurityError at render time.
+_SANDBOX_ENV = ImmutableSandboxedEnvironment()
 
 
 class PromptGenerator:
@@ -37,7 +42,7 @@ Previous conversation context:
         """
         self.persona = persona
         template_str = persona.chat.system_prompt_template or self.DEFAULT_SYSTEM_TEMPLATE
-        self._system_template = Template(template_str)
+        self._system_template = _SANDBOX_ENV.from_string(template_str)
 
     def build_system_prompt(self, history_summary: str = "") -> str:
         """Build the system prompt with persona and history context.

--- a/src/khora/chat/prompt.py
+++ b/src/khora/chat/prompt.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from jinja2.exceptions import SecurityError
 from jinja2.sandbox import ImmutableSandboxedEnvironment
+from loguru import logger
 
 if TYPE_CHECKING:
     from .history import ChatMessage
@@ -53,10 +55,15 @@ Previous conversation context:
         Returns:
             System prompt string
         """
-        return self._system_template.render(
-            persona=self.persona,
-            history_summary=history_summary,
-        )
+        try:
+            return self._system_template.render(
+                persona=self.persona,
+                history_summary=history_summary,
+            )
+        except SecurityError as e:
+            # Fail closed: never render a blocked SSTI construct; surface loudly.
+            logger.warning(f"Blocked unsafe construct in persona prompt template: {e}")
+            raise
 
     def build_messages(
         self,

--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -9,6 +9,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
+from jinja2.exceptions import SecurityError
 from loguru import logger
 from tenacity import (
     AsyncRetrying,
@@ -1731,6 +1732,10 @@ class LLMEntityExtractor(EntityExtractor):
                 expertise=expertise,
                 context=context,
             )
+        except SecurityError as e:
+            # Fail closed: never downgrade a blocked SSTI attempt to a fallback prompt.
+            logger.warning(f"Blocked unsafe construct in expertise system prompt: {e}")
+            raise
         except Exception as e:
             logger.warning(f"Failed to render system prompt: {e}")
             return expertise.system_prompt or DEFAULT_SYSTEM_PROMPT
@@ -1875,6 +1880,10 @@ class LLMEntityExtractor(EntityExtractor):
                     expertise=expertise,
                     context=prompt_context,
                 )
+            except SecurityError as e:
+                # Fail closed: never downgrade a blocked SSTI attempt to the default prompt.
+                logger.warning(f"Blocked unsafe construct in expertise extraction prompt: {e}")
+                raise
             except Exception as e:
                 logger.warning(f"Failed to render extraction prompt: {e}")
 
@@ -2336,6 +2345,10 @@ Each section follows the entity/relationship format from the instructions above.
                     expertise=expertise,
                     context=prompt_context,
                 )
+            except SecurityError as e:
+                # Fail closed: never downgrade a blocked SSTI attempt to the default prompt.
+                logger.warning(f"Blocked unsafe construct in expertise extraction prompt: {e}")
+                raise
             except Exception as e:
                 logger.warning(f"Failed to render extraction prompt for batch: {e}")
                 # Fall through to default prompt below

--- a/src/khora/extraction/skills/composer.py
+++ b/src/khora/extraction/skills/composer.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from jinja2.exceptions import SecurityError
+from jinja2.sandbox import ImmutableSandboxedEnvironment
 from loguru import logger
 
 from .base import (
@@ -21,6 +23,11 @@ from .base import (
 
 if TYPE_CHECKING:
     from .loader import ExpertiseLoader
+
+# Shared sandboxed environment for rendering untrusted prompt templates.
+# ImmutableSandboxedEnvironment blocks attribute access to dunders / mutating
+# operations, closing the SSTI -> RCE surface of raw ``jinja2.Template``.
+_SANDBOX_ENV = ImmutableSandboxedEnvironment()
 
 
 class ExpertiseComposer:
@@ -144,29 +151,27 @@ class ExpertiseComposer:
         if not template:
             return ""
 
+        user_ctx = context or {}
+        ctx = {
+            "expertise": expertise,
+            "entity_types": expertise.entity_types if expertise else [],
+            "relationship_types": expertise.relationship_types if expertise else [],
+            "tool_schemas": expertise.tool_schemas if expertise else {},
+            "tools": list(expertise.tool_schemas.keys()) if expertise else [],
+            "parent_prompt": parent_prompt or "",
+            "source_tool": user_ctx.get("source_tool", ""),
+            "tool_context": user_ctx.get("tool_context", ""),
+            **user_ctx,
+        }
+
         try:
-            from jinja2 import Template
+            return _SANDBOX_ENV.from_string(template).render(**ctx)
 
-            user_ctx = context or {}
-            ctx = {
-                "expertise": expertise,
-                "entity_types": expertise.entity_types if expertise else [],
-                "relationship_types": expertise.relationship_types if expertise else [],
-                "tool_schemas": expertise.tool_schemas if expertise else {},
-                "tools": list(expertise.tool_schemas.keys()) if expertise else [],
-                "parent_prompt": parent_prompt or "",
-                "source_tool": user_ctx.get("source_tool", ""),
-                "tool_context": user_ctx.get("tool_context", ""),
-                **user_ctx,
-            }
-
-            jinja_template = Template(template)
-            return jinja_template.render(**ctx)
-
-        except ImportError:
-            # Jinja2 not installed, return template as-is
-            logger.debug("Jinja2 not installed, returning template without rendering")
-            return template
+        except SecurityError as e:
+            # Sandbox blocked an unsafe construct (SSTI attempt) - never fail
+            # open by returning the raw template; surface the attempt loudly.
+            logger.warning(f"Blocked unsafe construct in prompt template: {e}")
+            raise
 
         except Exception as e:
             logger.warning(f"Failed to render prompt template: {e}")

--- a/tests/unit/test_prompt_sandbox.py
+++ b/tests/unit/test_prompt_sandbox.py
@@ -162,3 +162,29 @@ class TestExtractorFailsClosed:
         extractor = LLMEntityExtractor(model="test-model")
         with pytest.raises(SecurityError):
             extractor._render_system_prompt(expertise, None)
+
+    def test_render_extraction_prompt_propagates_security_error(self) -> None:
+        """An SSTI payload in expertise.extraction_prompt raises, not fallback."""
+        expertise = ExpertiseConfig(
+            name="malicious",
+            extraction_prompt=_SSTI_PAYLOAD,
+        )
+        extractor = LLMEntityExtractor(model="test-model")
+        with pytest.raises(SecurityError):
+            extractor._render_extraction_prompt("some text", ["PERSON"], expertise, None)
+
+    async def test_extract_multi_batch_propagates_security_error(self) -> None:
+        """A poisoned extraction_prompt fails closed on the batch path too."""
+        expertise = ExpertiseConfig(
+            name="malicious",
+            extraction_prompt=_SSTI_PAYLOAD,
+        )
+        extractor = LLMEntityExtractor(model="test-model")
+        # SecurityError surfaces during prompt render, before any LLM call.
+        with pytest.raises(SecurityError):
+            await extractor._extract_multi_batch(
+                ["some text"],
+                ["PERSON"],
+                None,
+                expertise=expertise,
+            )

--- a/tests/unit/test_prompt_sandbox.py
+++ b/tests/unit/test_prompt_sandbox.py
@@ -1,0 +1,164 @@
+"""Sandbox-rendering tests for prompt templates (SSTI -> RCE hardening).
+
+Extraction/expertise prompts (``ExpertiseComposer.render_prompt``) and persona
+chat prompts (``PromptGenerator``) render through a Jinja
+``ImmutableSandboxedEnvironment``. Unsafe constructs must raise
+``jinja2.exceptions.SecurityError`` rather than failing open.
+"""
+
+from __future__ import annotations
+
+import pytest
+from jinja2.exceptions import SecurityError
+
+from khora.chat.persona import ChatConfig, PersonaConfig
+from khora.chat.prompt import PromptGenerator
+from khora.extraction.extractors.llm import LLMEntityExtractor
+from khora.extraction.skills import (
+    EntityTypeConfig,
+    ExpertiseConfig,
+    ExpertiseLoader,
+)
+from khora.extraction.skills.composer import ExpertiseComposer
+
+# ---------------------------------------------------------------------------
+# 1 + 4. Unsafe constructs are blocked (raise, never fail open)
+# ---------------------------------------------------------------------------
+
+_SSTI_PAYLOAD = "UID=={{ cycler.__init__.__globals__.os.popen('id -u').read().strip() }}"
+
+
+class TestSandboxBlocksSSTI:
+    def test_render_prompt_raises_security_error_on_ssti(self) -> None:
+        """A dunder-traversal SSTI payload raises SecurityError."""
+        composer = ExpertiseComposer()
+        with pytest.raises(SecurityError):
+            composer.render_prompt(_SSTI_PAYLOAD)
+
+    def test_render_prompt_does_not_return_interpolated_output(self) -> None:
+        """The blocked payload never fails open by returning the raw template."""
+        composer = ExpertiseComposer()
+        try:
+            result = composer.render_prompt(_SSTI_PAYLOAD)
+        except SecurityError:
+            # Expected: raised rather than returning anything.
+            return
+        # If it somehow did not raise, it must NOT have returned the payload
+        # string (a fail-open regression) nor command output.
+        pytest.fail(f"expected SecurityError, got a returned value: {result!r}")
+
+
+# ---------------------------------------------------------------------------
+# 2. Legitimate expertise templates render identically under the sandbox
+# ---------------------------------------------------------------------------
+
+
+class TestLegitimateExpertiseRendering:
+    def test_for_loop_and_join_filter_render(self) -> None:
+        """A normal loop + ``| join`` filter renders to the expected string."""
+        expertise = ExpertiseConfig(
+            name="test",
+            entity_types=[
+                EntityTypeConfig(name="PERSON", description="A human individual"),
+                EntityTypeConfig(name="ORG", description="An organization"),
+            ],
+            tool_schemas={"web_search": {}, "calculator": {}},
+        )
+        template = (
+            "{% for e in entity_types %}{{ e.name }}: {{ e.description }}\n{% endfor %}Tools: {{ tools | join(', ') }}"
+        )
+        expected = "PERSON: A human individual\nORG: An organization\nTools: web_search, calculator"
+
+        composer = ExpertiseComposer()
+        assert composer.render_prompt(template, expertise=expertise) == expected
+
+    def test_non_security_render_error_fails_open(self) -> None:
+        """A benign template error still warns + returns the raw template."""
+        composer = ExpertiseComposer()
+        # Unclosed block -> TemplateSyntaxError (not a SecurityError).
+        template = "{% for x in %}"
+        assert composer.render_prompt(template) == template
+
+
+# ---------------------------------------------------------------------------
+# 3. Persona chat template renders correctly under the sandbox
+# ---------------------------------------------------------------------------
+
+
+def _make_persona() -> PersonaConfig:
+    return PersonaConfig(
+        name="Jane Doe",
+        title="VP Engineering",
+        company="Acme Inc",
+        background="Experienced engineering leader.",
+        chat=ChatConfig(system_prompt_template=""),
+    )
+
+
+class TestPersonaChatRendering:
+    def test_default_template_without_history(self) -> None:
+        gen = PromptGenerator(_make_persona())
+        prompt = gen.build_system_prompt()
+        assert "Jane Doe" in prompt
+        assert "VP Engineering" in prompt
+        assert "Acme Inc" in prompt
+        assert "Previous conversation context" not in prompt
+
+    def test_default_template_with_history(self) -> None:
+        gen = PromptGenerator(_make_persona())
+        prompt = gen.build_system_prompt(history_summary="We discussed roadmap.")
+        assert "Previous conversation context" in prompt
+        assert "We discussed roadmap." in prompt
+
+    def test_persona_template_rejects_ssti(self) -> None:
+        """A persona template carrying an SSTI payload raises at render time."""
+        persona = PersonaConfig(
+            name="Jane Doe",
+            title="VP",
+            company="Acme",
+            background="bg",
+            chat=ChatConfig(system_prompt_template=("{{ cycler.__init__.__globals__.os.popen('id').read() }}")),
+        )
+        gen = PromptGenerator(persona)
+        with pytest.raises(SecurityError):
+            gen.build_system_prompt()
+
+
+# ---------------------------------------------------------------------------
+# 5. All builtin expertise skills render without error and stably
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinExpertiseRendering:
+    @pytest.mark.parametrize("builtin_name", ["general", "meetings", "slack"])
+    def test_builtin_prompts_render_without_raising(self, builtin_name: str) -> None:
+        loader = ExpertiseLoader()
+        config = loader.load_builtin(builtin_name)
+        composer = ExpertiseComposer()
+
+        for template in (config.system_prompt, config.extraction_prompt):
+            first = composer.render_prompt(template, expertise=config)
+            second = composer.render_prompt(template, expertise=config)
+            # Stable / idempotent under the sandbox.
+            assert first == second
+
+        # The system prompt is non-empty for every builtin.
+        assert composer.render_prompt(config.system_prompt, expertise=config).strip()
+
+
+# ---------------------------------------------------------------------------
+# Caller-level regression guard: SecurityError must propagate through the
+# LLM extractor rather than silently downgrading to a fallback prompt.
+# ---------------------------------------------------------------------------
+
+
+class TestExtractorFailsClosed:
+    def test_render_system_prompt_propagates_security_error(self) -> None:
+        """An SSTI payload in expertise.system_prompt raises, not fallback."""
+        expertise = ExpertiseConfig(
+            name="malicious",
+            system_prompt=_SSTI_PAYLOAD,
+        )
+        extractor = LLMEntityExtractor(model="test-model")
+        with pytest.raises(SecurityError):
+            extractor._render_system_prompt(expertise, None)


### PR DESCRIPTION
## Summary
- Extraction/expertise prompts (`ExpertiseComposer.render_prompt`) and persona chat prompts (`PromptGenerator`) previously rendered through a raw, non-sandboxed `jinja2.Template`. Any caller able to influence a prompt string could execute arbitrary code in-process on the host (server-side template injection → RCE).
- Both sinks now render through a shared module-level `jinja2.sandbox.ImmutableSandboxedEnvironment`. Loops, filters, conditionals, and normal attribute access on data render identically; only dunder-traversal / code-execution gadgets are refused.
- **Behavior change (fail closed):** a blocked construct now raises `jinja2.exceptions.SecurityError` instead of the previous fail-open path that logged a warning and returned the raw, un-rendered template. The composer and all three extractor render call sites re-raise `SecurityError` so a malicious or malformed prompt fails loudly rather than silently degrading to a default/un-rendered prompt. Non-security render errors keep their existing fallback behavior.
- Dropped a now-dead `ImportError` fallback in the composer (jinja2 is a hard dependency).

## Test plan
- [x] Unit tests pass (`tests/unit/test_prompt_sandbox.py`, 11 tests): SSTI proof payload raises `SecurityError` and returns no interpolated output; legit `{% for %}` + `| join` prompt renders byte-identically; persona `{% if history_summary %}` renders with and without history; `SecurityError` propagates and is not downgraded to the raw template (composer- and extractor-caller level); all three builtin expertise skills render without error and idempotently.
- [x] Regression suites pass (`test_chat_prompt`, `test_expertise`, `test_extraction_llm`, persona/passthrough): 124 passed combined.
- [x] `ruff check` / `ruff format` clean on touched files.
- [ ] CI full suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Prompt templates are now rendered in a hardened Jinja sandbox to block unsafe expressions and mitigate SSTI-to-RCE risks.
  - When unsafe constructs are detected, processing fails closed by raising `SecurityError` instead of falling back to a default/less-restricted prompt.
  - Safe, legitimate prompt features and prior handling for non-security rendering errors remain supported.
- **Tests**
  - Added unit coverage to verify `SecurityError` propagation and correct rendering for persona, expertise, and extractor prompt flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->