### PR TITLE
chore: release v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ Format: versions match git tags (`git tag vX.Y.Z`). Versions before 0.5.1 were i
 
 ## [Unreleased]
 
+## [0.23.0] - recall-quality seeding/fusion pack, recall & ingest performance, namespace deletion
+
+### Added
+
+- **Namespace cascade-delete** (#1523, #1460): new public `Khora.delete_namespace(namespace)` deletes a namespace and reclaims its storage across all backends (documents, chunks, entities, relationships, graph nodes, vector rows). The relational cascade is gated on satellite-purge success, and the LanceDB namespace delete is always attempted even if `count_rows` fails. Previously the only lifecycle op below `create` was `deactivate_namespace`, which orphaned the data (unreadable and unremovable).
+- **Graph-channel seeding upgrades, default-OFF** (#1520, #1473): three independently-flagged upgrades to graph-channel seed quality - reverse-seeding graph entry entities from top vector chunks, per-mention diversified seeding, and an evidence-based graph channel gate - each with telemetry for downstream A/B validation. No defaults flipped.
+- **Typed/weighted graph expansion + query-aware chunk scoring** (#1519, #1474): `relationship.weight` is now stamped from per-pair co-mention frequency at ingest (always on, additive - a previously-inert column is populated); typed/confidence-weighted graph expansion and seed-relevance-weighted graph-chunk scoring land flag-gated.
+- **Score-calibrated convex fusion + gate/confidence calibration** (#1517, #1475): an opt-in magnitude-aware fusion alternative to rank-only weighted RRF (a lone strong-cosine hit is no longer buried below weak chunks that merely co-occur across channels), plus fixes to two latent mis-calibrations in the LLM-rerank gate and confidence formula.
+- **HippoRAG-2 recognition-filtered PPR seeding** (#1515, #1476): gated behind `enable_ppr_retrieval`, A/B-pending.
+- **Adaptive expansion depth from a cached degree histogram** (#1506, #1477): traversal depth is chosen against a BFS frontier *budget* predicted from a per-namespace degree histogram (epoch-invalidated cache, single-flighted build, config knobs), replacing the seed-count step function that went deeper exactly when hub seeds made the frontier explode.
+- **Policy-gated per-namespace partial HNSW promotion** (#1502, #1470): mechanism + promotion policy + tenant-count ceiling for promoting a hot namespace to its own partial HNSW index. Everything default-OFF; nothing auto-creates indexes on the write path.
+- **Opt-in recall result cache** (#1503, #1469): epoch-invalidated result cache at the engine boundary with a config fingerprint in the cache key. Default OFF.
+- **Golden-set retrieval rank-regression tests + shadow-scoring A/B harness** (#1504, #1479): a hermetic CI safety net (sqlite_lance + deterministic embeddings, zero network/LLM) guarding retrieval ranking, plus an observe-only shadow-scoring harness.
+
+### Changed
+
+- **Chunk bookkeeping relocated from `metadata` to `chunker_info`** (#1495, #1493, #1498, #1512): `chunk_index` / `start_char` / `end_char` / `token_count` are no longer written into chunk `metadata` - they live in `chunker_info` at all six persisting writer sites, round-trip through the weaviate and turbopuffer temporal stores (previously silently dropped), and data migration 053 backfills existing rows. The reader has **no metadata fallback** - run `alembic upgrade head` when upgrading.
+- **Recall-time metadata injections removed** (#1516, #1510, #1513): the engine-internal keys (`occurred_at`, `connected_entities`, `ppr_score`) are no longer injected into `Chunk.metadata` on any recall channel - `Chunk.metadata` now carries the caller's stored blob verbatim. Temporal ranking and the rerank date-prefix builders read the first-class `Chunk.occurred_at` / `source_timestamp` columns, which every recall-path constructor now populates from its authoritative source. Callers reading those injected metadata keys must switch to the first-class fields.
+- **Prompt templates render in a Jinja sandbox** (#1525): extraction/expertise and persona chat prompts render through an `ImmutableSandboxedEnvironment`, closing a server-side-template-injection → in-process-RCE path. Fail-closed behavior change: a blocked construct raises `jinja2.exceptions.SecurityError`.
+- **Shared recall projection seam + isolated scoring pipeline** (#1505, #1480): the entity/relationship/doc-stub projection duplicated between VectorCypher and Chronicle moved to `khora.core.recall_projection`, and scoring was extracted into `_score_and_rank` - behavior-parity refactor backed by a parity harness.
+- **pgvector upsert commit granularity is configurable** (#1514, #1471): default is per-batch (single transaction); per-sub-batch commit remains available for high-contention multi-writer namespaces.
+
+### Fixed
+
+- **Provenance-filtered graph recall** (#1481, #1487, #1496): under a caller filter, the VectorCypher graph path and Chronicle's entity channel no longer leak entities/relationships the chunk-side filter never touched - both enforce the same compiled predicate existentially over each entity's provenance chunks, and the provenance record view is document-key aware so filters on the seven denormalized document keys don't over-drop.
+- **Filter report `unenforced_keys` computed from result surfaces** (#1462): a non-empty result surface not covered by the filter's channels forces the filter's leaves into `unenforced_keys`, keeping the pushed/post-filtered/unenforced partition honest.
+- **MMR uses post-boost/rerank relevance, not raw cosine** (#1485, #1497, #1463): diversity selection no longer discards the cross-encoder/LLM rerankers and recency/coherence boosts; also fixes reranking being inert on the default recall path.
+- **Crash-abandoned half-ingested documents are re-ingested** (#1486, #1464): a document left `PENDING` with chunks committed but no entities/relationships no longer blocks re-ingest by checksum.
+- **Per-symbol khora-accel import** (#1483, #1465): one drifted/missing Rust symbol no longer silently disables the entire Rust acceleration layer.
+- **VectorCypher chunk counts read from the temporal store** (#1522, #1459): `Khora.stats(ns).chunks` / `count_chunks(ns)` no longer return 0 for a fully-recallable namespace.
+- **Neo4j `valid_until` stored as native ZONED DATETIME** (#1500, #1472): the bi-temporal recall traversals are now sargable, so the composite `entity_ns_valid_until` index does a range `IndexSeek` instead of a per-row `datetime()` cast filter; includes a hardened native-datetime backfill.
+- **Hermes namespace derived from stable identity, not session** (#1484, #1466): the adapter no longer mints a fresh namespace per session, restoring cross-session entity dedup and continuity.
+- **Session fan-out channel failures record an ADR-001 `Degradation`** (#1482, #1467) instead of being silently dropped from the merge.
+
+### Performance
+
+- **Recall front-matter overlap** (#1503, #1469): the query embedding launches at t0 (overlapping temporal-detect/route) and HyDE runs speculatively so its LLM call overlaps the baseline retrieve.
+- **PPR affordability pack** (#1515, #1476): top-k rank-stability early-stop for the power iteration (Rust + Python lockstep), CSR power-iteration kernel, and an epoch-keyed PPR graph-slice cache - all inert unless `enable_ppr_retrieval` is on.
+- **Batch write-path** (#1501, #1471): namespace advisory lock released between sub-batches (concurrent same-namespace ingests interleave), stage-6 hook dispatch gathered, window pipelining prefetches next-window embeddings, and chunk embeddings are released after persist.
+- **Recall's sequential Neo4j reads share one session** (#1499, #1468): the expand → version-filter → chunk-fetch chain uses `DualNodeManager.bind_session()` instead of 2-3 pool acquisitions per recall.
+
 ## [0.22.2] - recall-quality correctness, HNSW index-backed search, durable reconcilers
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ nlp = ["spacy>=3.8.0"]
 # LOCKSTEP: this pin must match rust/khora-accel/Cargo.toml's version exactly.
 # Bump both in the same PR. See CLAUDE.md → Version Bumps.
 rust = [
-    "khora-accel==0.22.2",
+    "khora-accel==0.23.0",
 ]
 # SurrealDB unified backend (graph + vector + relational in one DB)
 surrealdb = ["surrealdb>=2.0.0,<3.0"]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -82,18 +82,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "khora-accel"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "aho-corasick",
  "criterion",
@@ -305,9 +305,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -560,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -572,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -665,9 +665,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -787,18 +787,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -807,6 +807,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/rust/khora-accel/Cargo.toml
+++ b/rust/khora-accel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khora-accel"
-version = "0.22.2"
+version = "0.23.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Rust-accelerated operations for Khora"


### PR DESCRIPTION
Release prep for **v0.23.0** (minor bump from v0.22.2 — 33 merged PRs, feature-heavy and largely flag-gated).

Linear: DYT-5476

Per the CLAUDE.md release procedure, all four lockstep changes in one PR:

- `rust/khora-accel/Cargo.toml` → `version = "0.23.0"`
- `pyproject.toml` `rust` extra pin → `khora-accel==0.23.0`
- `rust/Cargo.lock` regenerated via `cargo generate-lockfile` (khora-accel 0.23.0 + compatible dep refreshes)
- `CHANGELOG.md` → new `## [0.23.0]` entry covering the graph-seeding/fusion recall-quality pack (#1473/#1474/#1475), PPR affordability + HippoRAG-2 seeding (#1476), adaptive traversal depth (#1477), golden-set/shadow harness (#1479/#1480), recall result cache + front-matter overlap (#1469), namespace cascade-delete (#1460), partial HNSW promotion (#1470), batch write-path perf (#1471), chunker_info relocation + migration 053, provenance-filtered graph recall, and the Jinja sandbox (#1525)

## Verification

- `make format` clean
- Full `make test` green locally: 10105 unit passed, 676 integration passed, coverage 87% (gate 77%)
- Note: the local venv's khora-accel wheel was a stale 0.18.2 and was uninstalled (23 Rust-parity failures were from that stale wheel, present on `main` too); CI's rust job builds the extension fresh from source

## After merge

```
git tag v0.23.0 && git push origin v0.23.0
```
`release.yml` publishes khora + khora-accel 0.23.0 to PyPI and creates the GitHub release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added namespace cascade deletion through the public API.
  * Added optional score-calibrated fusion, adaptive traversal depth, and recall result caching.
  * Improved graph seeding, expansion, and relevance scoring.
  * Added configurable chunk timestamp handling and enhanced recall/ingestion workflows.

* **Bug Fixes**
  * Improved filtering, relevance ranking, crash recovery, statistics, and namespace identity consistency.
  * Added safer prompt template handling and more reliable behavior when graph channels fail.

* **Performance**
  * Improved embedding, ingestion, batch writing, graph reads, and traversal efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->