### PR TITLE
Fix NUL byte crashes during ingestion

### DIFF
--- a/src/khora/core/models/document.py
+++ b/src/khora/core/models/document.py
@@ -13,6 +13,19 @@ from typing import Any
 from uuid import UUID, uuid4
 
 
+def _strip_nul_bytes(value: Any) -> Any:
+    """Remove PostgreSQL-incompatible NUL bytes from text and JSON-like values."""
+    if isinstance(value, str):
+        return value.replace("\x00", "")
+    if isinstance(value, dict):
+        return {_strip_nul_bytes(key): _strip_nul_bytes(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_strip_nul_bytes(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_strip_nul_bytes(item) for item in value)
+    return value
+
+
 class DocumentStatus(str, Enum):
     """Document processing status."""
 
@@ -114,6 +127,14 @@ class Document:
     orphan_prior_status: str | None = field(default=None, init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
+        self.content = _strip_nul_bytes(self.content)
+        self.title = _strip_nul_bytes(self.title)
+        self.source = _strip_nul_bytes(self.source)
+        self.source_name = _strip_nul_bytes(self.source_name)
+        self.source_url = _strip_nul_bytes(self.source_url)
+        self.author = _strip_nul_bytes(self.author)
+        self.metadata = _strip_nul_bytes(self.metadata)
+        self.extraction_params = _strip_nul_bytes(self.extraction_params)
         if self.external_id is not None:
             if not self.external_id.strip():
                 raise ValueError("external_id must be None or a non-blank string")
@@ -194,6 +215,11 @@ class Chunk:
 
     # Populated by Khora when include_sources=True
     source_document: DocumentSource | None = None
+
+    def __post_init__(self) -> None:
+        self.content = _strip_nul_bytes(self.content)
+        self.metadata = _strip_nul_bytes(self.metadata)
+        self.chunker_info = _strip_nul_bytes(self.chunker_info)
 
     @property
     def has_embedding(self) -> bool:

--- a/src/khora/core/models/entity.py
+++ b/src/khora/core/models/entity.py
@@ -11,6 +11,8 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
+from khora.core.models.document import _strip_nul_bytes
+
 if TYPE_CHECKING:
     from khora.core.models.document import DocumentSource
 
@@ -70,6 +72,12 @@ class Entity:
             self.description = ""
         if self.source_tool is None:
             self.source_tool = ""
+        self.name = _strip_nul_bytes(self.name)
+        self.entity_type = _strip_nul_bytes(self.entity_type)
+        self.description = _strip_nul_bytes(self.description)
+        self.attributes = _strip_nul_bytes(self.attributes)
+        self.source_tool = _strip_nul_bytes(self.source_tool)
+        self.metadata = _strip_nul_bytes(self.metadata)
 
     def validate(self) -> None:
         """Validate and clean attributes using the registered schema for this entity type."""
@@ -148,6 +156,14 @@ class Relationship:
     metadata: dict[str, Any] = field(default_factory=dict)
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def __post_init__(self) -> None:
+        self.relationship_type = _strip_nul_bytes(self.relationship_type)
+        self.description = _strip_nul_bytes(self.description)
+        self.source_entity_name = _strip_nul_bytes(self.source_entity_name)
+        self.target_entity_name = _strip_nul_bytes(self.target_entity_name)
+        self.properties = _strip_nul_bytes(self.properties)
+        self.metadata = _strip_nul_bytes(self.metadata)
 
 
 @dataclass(slots=True)

--- a/tests/unit/core/test_nul_sanitization.py
+++ b/tests/unit/core/test_nul_sanitization.py
@@ -1,0 +1,29 @@
+"""Regression tests for PostgreSQL-incompatible NUL bytes in stored models."""
+
+from khora.core.models import Chunk, Document, Entity, Relationship
+
+
+def test_storage_models_strip_nul_bytes_from_text_and_json_fields() -> None:
+    document = Document(content="before\x00after", metadata={"nested\x00key": ["value\x00"]})
+    chunk = Chunk(content="chunk\x00text", metadata={"value": "nul\x00"})
+    entity = Entity(
+        name="Acme\x00 Corp",
+        description="entity\x00description",
+        attributes={"nested": {"value": "nul\x00"}},
+    )
+    relationship = Relationship(
+        relationship_type="WORKS\x00_FOR",
+        description="relationship\x00description",
+        properties={"nested": ["nul\x00"]},
+    )
+
+    assert document.content == "beforeafter"
+    assert document.metadata == {"nestedkey": ["value"]}
+    assert chunk.content == "chunktext"
+    assert chunk.metadata == {"value": "nul"}
+    assert entity.name == "Acme Corp"
+    assert entity.description == "entitydescription"
+    assert entity.attributes == {"nested": {"value": "nul"}}
+    assert relationship.relationship_type == "WORKS_FOR"
+    assert relationship.description == "relationshipdescription"
+    assert relationship.properties == {"nested": ["nul"]}


### PR DESCRIPTION
PostgreSQL rejects NUL bytes in text and JSONB values. This strips them recursively from document, chunk, entity, and relationship model fields before storage.

Fixes #1528

Test: NUL sanitization regression (failed before, passed after); Ruff check/format and Python compilation passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unsupported NUL characters from document, chunk, entity, and relationship text fields before storage.
  * Applied sanitization to nested metadata and other structured values, preventing storage failures caused by invalid characters.

* **Tests**
  * Added coverage verifying NUL characters are removed from text, nested values, and JSON-like keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->