### PR TITLE
Make entity attribute validation additive-safe

### DIFF
--- a/src/khora/core/models/entity.py
+++ b/src/khora/core/models/entity.py
@@ -75,8 +75,8 @@ class Entity:
         """Validate and clean attributes using the registered schema for this entity type.
 
         Note: intentionally NOT called on the ingest path. ``validate_attributes``
-        is additive-safe (it never drops ontology attribute keys), so calling this
-        is optional cleanup rather than a required write-path step.
+        is additive-safe (it never drops non-None ontology attribute keys), so
+        calling this is optional cleanup rather than a required write-path step.
         """
         from khora.core.models.schemas import validate_attributes
 

--- a/src/khora/core/models/entity.py
+++ b/src/khora/core/models/entity.py
@@ -72,7 +72,12 @@ class Entity:
             self.source_tool = ""
 
     def validate(self) -> None:
-        """Validate and clean attributes using the registered schema for this entity type."""
+        """Validate and clean attributes using the registered schema for this entity type.
+
+        Note: intentionally NOT called on the ingest path. ``validate_attributes``
+        is additive-safe (it never drops ontology attribute keys), so calling this
+        is optional cleanup rather than a required write-path step.
+        """
         from khora.core.models.schemas import validate_attributes
 
         self.attributes = validate_attributes(self.entity_type, self.attributes)

--- a/src/khora/core/models/schemas.py
+++ b/src/khora/core/models/schemas.py
@@ -149,25 +149,31 @@ def register_attribute_schema(
 
 
 def validate_attributes(entity_type: str, attributes: dict[str, Any]) -> dict[str, Any]:
-    """Validate and coerce attributes using the registered schema.
+    """Validate and coerce attributes using the registered schema (additive-safe).
 
-    Falls back to passthrough if no schema is registered for the entity type
-    or if validation fails (graceful degradation).
+    Coerces the fields the registered schema knows about while preserving any
+    unknown keys with non-None values (e.g. ontology-specific attributes)
+    rather than dropping them. Falls back to passthrough if no schema is
+    registered for the entity type or if validation fails (graceful
+    degradation).
 
     Args:
         entity_type: The entity type name (e.g. "PERSON", "TICKET")
         attributes: Raw attributes dict to validate
 
     Returns:
-        Cleaned attributes dict with None values excluded
+        On the validated path: schema-known fields coerced and all non-None
+        unknown keys preserved, with None-valued keys excluded (unchanged from
+        prior behavior). On the degraded paths (unregistered type or
+        ValidationError) the original attributes are returned unchanged.
     """
     schema = ATTRIBUTE_SCHEMAS.get(entity_type.upper())
     if not schema:
         return attributes
 
     try:
-        validated = schema.model_validate(attributes)
-        return validated.model_dump(exclude_none=True)
+        validated = schema.model_validate(attributes).model_dump(exclude_none=True)
+        return {**{k: v for k, v in attributes.items() if v is not None}, **validated}
     except ValidationError:
         # Graceful degradation: return original attributes if validation fails
         return attributes

--- a/tests/unit/test_attribute_schemas.py
+++ b/tests/unit/test_attribute_schemas.py
@@ -84,6 +84,11 @@ class TestValidateAttributes:
         result = validate_attributes("PERSON", attrs)
         assert result == {"name": "X", "slack_user_id": "U1"}
 
+    def test_none_unknown_key_dropped_on_validated_path(self):
+        """A None-valued unknown key is excluded on the validated path (base-dict filter)."""
+        result = validate_attributes("PERSON", {"name": "X", "foo": None})
+        assert result == {"name": "X"}
+
     def test_unregistered_type_returned_unchanged(self):
         """An unregistered entity type is returned unchanged."""
         attrs = {"identifier": "ENG-123", "title": "Fix bug", "state": "open"}

--- a/tests/unit/test_attribute_schemas.py
+++ b/tests/unit/test_attribute_schemas.py
@@ -62,13 +62,46 @@ class TestValidateAttributes:
         result = validate_attributes("UNKNOWN_TYPE", attrs)
         assert result == attrs
 
-    def test_extra_fields_ignored(self):
-        """Extra fields not in schema are silently dropped."""
+    def test_extra_fields_preserved(self):
+        """Extra fields not in the schema are preserved (additive-safe)."""
         attrs = {"name": "Alice", "unknown_field": "value"}
         result = validate_attributes("PERSON", attrs)
-        assert "name" in result
-        # Pydantic by default ignores extra fields
-        assert "unknown_field" not in result
+        assert result["name"] == "Alice"
+        # Unknown/ontology keys survive validation rather than being dropped.
+        assert result["unknown_field"] == "value"
+
+    def test_unknown_keys_preserved_additive(self):
+        """Unknown ontology keys survive alongside known coerced fields."""
+        attrs = {"name": "X", "slack_user_id": "U1", "timezone": "CET"}
+        result = validate_attributes("PERSON", attrs)
+        assert result["name"] == "X"
+        assert result["slack_user_id"] == "U1"
+        assert result["timezone"] == "CET"
+
+    def test_none_known_field_stripped_while_unknown_key_preserved(self):
+        """Known None fields are stripped even as unknown ontology keys survive."""
+        attrs = {"name": "X", "title": None, "slack_user_id": "U1"}
+        result = validate_attributes("PERSON", attrs)
+        assert result == {"name": "X", "slack_user_id": "U1"}
+
+    def test_unregistered_type_returned_unchanged(self):
+        """An unregistered entity type is returned unchanged."""
+        attrs = {"identifier": "ENG-123", "title": "Fix bug", "state": "open"}
+        result = validate_attributes("LINEAR_ISSUE", attrs)
+        assert result == attrs
+
+    def test_known_fields_coerced_for_registered_type(self):
+        """Registered-schema fields are still coerced (coercion wins over raw input)."""
+        attrs = {"name": "AI", "related_concepts": ("ML", "DL")}
+        result = validate_attributes("CONCEPT", attrs)
+        assert isinstance(result["related_concepts"], list)
+        assert result["related_concepts"] == ["ML", "DL"]
+
+    def test_validation_error_returns_original_attributes(self):
+        """A ValidationError degrades gracefully, returning original attributes unchanged."""
+        attrs = {"title": "Engineer", "slack_user_id": "U1"}  # missing required name
+        result = validate_attributes("PERSON", attrs)
+        assert result == attrs
 
     def test_case_insensitive_type_lookup(self):
         """Entity type lookup should be case-insensitive."""


### PR DESCRIPTION
## Summary
- `validate_attributes` previously returned `model_dump(exclude_none=True)` from the matched attribute schema, which silently dropped any attribute key not declared on the hardcoded model (e.g. a PERSON's `slack_user_id` / `timezone`).
- It now merges the schema-coerced known fields *over* the caller's non-None attributes, so known keys are still coerced/normalized while unknown (e.g. ontology-defined) keys are preserved.
- Unregistered entity types and `ValidationError` cases still pass the original attributes through unchanged (graceful degradation preserved).
- Added a note on `Entity.validate()` clarifying it is intentionally not wired into the ingest path and that `validate_attributes` is additive-safe. This is latent-hazard hardening — no ingest-path behavior changes today.

## Test plan
- [x] Unit tests pass (`tests/unit/test_attribute_schemas.py` — 17 passed): unknown keys preserved, unregistered type unchanged, known-field coercion still applies, `ValidationError` returns original attributes, and the None-known-field-stripped-while-unknown-key-preserved intersection case.
- [ ] Integration tests pass (CI — Docker not available in local sandbox)
- [x] Manual verification: additive merge confirmed via pydantic coercion probes; no new call sites added, `Entity.validate()` remains uncalled in `src/`.

Fixes #1546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved additional entity attributes during validation instead of silently removing them.
  * Continued converting recognized fields to their expected formats.
  * Retained original attributes when validation fails or no schema is registered.
  * Removed fields with empty (`None`) values while preserving other attributes.

* **Tests**
  * Added coverage for attribute preservation, coercion, and validation-failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->