### PR TITLE
Merge entity attributes across chunks in pipeline dedup

### DIFF
--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -375,6 +375,14 @@ async def stream_extract_and_embed_entities(
                         _vu = _parse_temporal_date(_t.valid_until) if _t else None
                         if _vu and (not existing.valid_until or _vu > existing.valid_until):
                             existing.valid_until = _vu
+                        # Union attributes across chunks: prefer existing, fill missing, skip empty (#1544)
+                        existing_attrs = existing.attributes if isinstance(existing.attributes, dict) else {}
+                        incoming_attrs = extracted.attributes if isinstance(extracted.attributes, dict) else {}
+                        for _k, _v in incoming_attrs.items():
+                            if _v in (None, ""):
+                                continue
+                            existing_attrs.setdefault(_k, _v)
+                        existing.attributes = existing_attrs
                     else:
                         entity_type = extracted.entity_type or "CONCEPT"
 

--- a/src/khora/pipelines/flows/ingest.py
+++ b/src/khora/pipelines/flows/ingest.py
@@ -375,13 +375,15 @@ async def stream_extract_and_embed_entities(
                         _vu = _parse_temporal_date(_t.valid_until) if _t else None
                         if _vu and (not existing.valid_until or _vu > existing.valid_until):
                             existing.valid_until = _vu
-                        # Union attributes across chunks: prefer existing, fill missing, skip empty (#1544)
+                        # Union attributes across chunks: prefer existing non-empty, fill
+                        # missing or empty from later chunks, skip None/empty incoming (#1544)
                         existing_attrs = existing.attributes if isinstance(existing.attributes, dict) else {}
                         incoming_attrs = extracted.attributes if isinstance(extracted.attributes, dict) else {}
                         for _k, _v in incoming_attrs.items():
                             if _v in (None, ""):
                                 continue
-                            existing_attrs.setdefault(_k, _v)
+                            if existing_attrs.get(_k) in (None, ""):
+                                existing_attrs[_k] = _v
                         existing.attributes = existing_attrs
                     else:
                         entity_type = extracted.entity_type or "CONCEPT"

--- a/src/khora/pipelines/tasks/extract.py
+++ b/src/khora/pipelines/tasks/extract.py
@@ -326,6 +326,14 @@ async def extract_entities(
                     merge_valid_from = chunk.source_timestamp
                 if existing.valid_from and merge_valid_from is not None and merge_valid_from < existing.valid_from:
                     existing.valid_from = merge_valid_from
+                # Union attributes across chunks: prefer existing, fill missing, skip empty (#1544)
+                existing_attrs = existing.attributes if isinstance(existing.attributes, dict) else {}
+                incoming_attrs = extracted.attributes if isinstance(extracted.attributes, dict) else {}
+                for _k, _v in incoming_attrs.items():
+                    if _v in (None, ""):
+                        continue
+                    existing_attrs.setdefault(_k, _v)
+                existing.attributes = existing_attrs
             else:
                 # Create new entity — preserve original type string from LLM
                 entity_type = extracted.entity_type or "CONCEPT"

--- a/src/khora/pipelines/tasks/extract.py
+++ b/src/khora/pipelines/tasks/extract.py
@@ -326,13 +326,15 @@ async def extract_entities(
                     merge_valid_from = chunk.source_timestamp
                 if existing.valid_from and merge_valid_from is not None and merge_valid_from < existing.valid_from:
                     existing.valid_from = merge_valid_from
-                # Union attributes across chunks: prefer existing, fill missing, skip empty (#1544)
+                # Union attributes across chunks: prefer existing non-empty, fill
+                # missing or empty from later chunks, skip None/empty incoming (#1544)
                 existing_attrs = existing.attributes if isinstance(existing.attributes, dict) else {}
                 incoming_attrs = extracted.attributes if isinstance(extracted.attributes, dict) else {}
                 for _k, _v in incoming_attrs.items():
                     if _v in (None, ""):
                         continue
-                    existing_attrs.setdefault(_k, _v)
+                    if existing_attrs.get(_k) in (None, ""):
+                        existing_attrs[_k] = _v
                 existing.attributes = existing_attrs
             else:
                 # Create new entity — preserve original type string from LLM

--- a/tests/unit/pipelines/test_attribute_merge_dedup_1544.py
+++ b/tests/unit/pipelines/test_attribute_merge_dedup_1544.py
@@ -1,0 +1,153 @@
+"""In-pipeline dedup must union entity attributes across chunks (#1544).
+
+Both dedup call sites — ``extract_entities`` (tasks/extract.py) and
+``stream_extract_and_embed_entities`` (flows/ingest.py) — previously kept the
+first chunk's ``attributes`` and discarded later chunks' attributes when the
+same (name, entity_type) recurred. These tests drive the real dedup path for
+each site and assert the union semantics: existing-preferred, add-missing,
+skip-None-or-empty-string.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from khora.core.models import Chunk
+from khora.extraction.extractors.base import ExtractedEntity, ExtractionResult
+from khora.pipelines.tasks.extract import extract_entities
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_chunk(
+    content: str,
+    *,
+    namespace_id: UUID,
+    document_id: UUID | None = None,
+) -> Chunk:
+    return Chunk(
+        id=uuid4(),
+        namespace_id=namespace_id,
+        document_id=document_id or uuid4(),
+        content=content,
+        created_at=datetime.now(UTC),
+    )
+
+
+# Attribute sets shared by both call sites — chunk1 wins on the shared "role"
+# key, "title" is filled from chunk2, and the empty/None values are skipped.
+_CHUNK1_ATTRS = {"email": "a@example.com", "role": "existing"}
+_CHUNK2_ATTRS = {"title": "Engineer", "role": "incoming", "blank": "", "none_val": None}
+
+
+def _assert_union(attrs: dict[str, Any]) -> None:
+    assert attrs["email"] == "a@example.com"  # kept from chunk1
+    assert attrs["title"] == "Engineer"  # added from chunk2 (missing key)
+    assert attrs["role"] == "existing"  # existing (chunk1) wins on shared key
+    assert "blank" not in attrs  # empty string skipped
+    assert "none_val" not in attrs  # None skipped
+
+
+# ---------------------------------------------------------------------------
+# Site 1: extract_entities (tasks/extract.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_extract_dedup_unions_attributes() -> None:
+    ns = uuid4()
+    c1 = _make_chunk("Alice is an engineer.", namespace_id=ns)
+    c2 = _make_chunk("Alice again.", namespace_id=ns)
+
+    r1 = ExtractionResult(
+        entities=[
+            ExtractedEntity(
+                name="Alice",
+                entity_type="PERSON",
+                confidence=0.9,
+                attributes=dict(_CHUNK1_ATTRS),
+            )
+        ],
+    )
+    r2 = ExtractionResult(
+        entities=[
+            ExtractedEntity(
+                name="Alice",
+                entity_type="PERSON",
+                confidence=0.9,
+                attributes=dict(_CHUNK2_ATTRS),
+            )
+        ],
+    )
+
+    extractor = AsyncMock()
+    extractor.extract_multi = AsyncMock(return_value=[r1, r2])
+
+    entities, _ = await extract_entities(
+        [c1, c2],
+        entity_types=["PERSON"],
+        relationship_types=[],
+        selective_extraction=False,
+        shared_extractor=extractor,
+    )
+
+    assert len(entities) == 1
+    _assert_union(entities[0].attributes)
+
+
+# ---------------------------------------------------------------------------
+# Site 2: stream_extract_and_embed_entities (flows/ingest.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_dedup_unions_attributes() -> None:
+    from khora.pipelines.flows.ingest import stream_extract_and_embed_entities
+
+    ns = uuid4()
+    c1 = _make_chunk("Alice is an engineer.", namespace_id=ns)
+    c2 = _make_chunk("Alice again.", namespace_id=ns)
+
+    r1 = ExtractionResult(
+        entities=[
+            ExtractedEntity(
+                name="Alice",
+                entity_type="PERSON",
+                confidence=0.9,
+                attributes=dict(_CHUNK1_ATTRS),
+            )
+        ],
+    )
+    r2 = ExtractionResult(
+        entities=[
+            ExtractedEntity(
+                name="Alice",
+                entity_type="PERSON",
+                confidence=0.9,
+                attributes=dict(_CHUNK2_ATTRS),
+            )
+        ],
+    )
+
+    extractor = MagicMock()
+    extractor.extract_multi = AsyncMock(return_value=[r1, r2])
+    embedder = MagicMock(embed_batch=AsyncMock(side_effect=lambda texts: [[0.1] for _ in texts]))
+
+    with patch("khora.extraction.extractors.LLMEntityExtractor", return_value=extractor):
+        entities, _ = await stream_extract_and_embed_entities(
+            [c1, c2],
+            embedder,
+            entity_types=["PERSON"],
+            relationship_types=[],
+        )
+
+    assert len(entities) == 1
+    _assert_union(entities[0].attributes)

--- a/tests/unit/pipelines/test_attribute_merge_dedup_1544.py
+++ b/tests/unit/pipelines/test_attribute_merge_dedup_1544.py
@@ -44,7 +44,13 @@ def _make_chunk(
 # Attribute sets shared by both call sites — chunk1 wins on the shared "role"
 # key, "title" is filled from chunk2, and the empty/None values are skipped.
 _CHUNK1_ATTRS = {"email": "a@example.com", "role": "existing"}
-_CHUNK2_ATTRS = {"title": "Engineer", "role": "incoming", "blank": "", "none_val": None}
+_CHUNK2_ATTRS = {
+    "title": "Engineer",
+    "role": "incoming",
+    "blank": "",
+    "none_val": None,
+    "count": 0,
+}
 
 
 def _assert_union(attrs: dict[str, Any]) -> None:
@@ -53,6 +59,9 @@ def _assert_union(attrs: dict[str, Any]) -> None:
     assert attrs["role"] == "existing"  # existing (chunk1) wins on shared key
     assert "blank" not in attrs  # empty string skipped
     assert "none_val" not in attrs  # None skipped
+    # A legit falsy value must survive: the skip guard is `in (None, "")`, not
+    # `if not _v`, so 0/0.0/False are added, not dropped. Guards a future refactor.
+    assert attrs["count"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/pipelines/test_attribute_merge_dedup_1544.py
+++ b/tests/unit/pipelines/test_attribute_merge_dedup_1544.py
@@ -41,27 +41,33 @@ def _make_chunk(
     )
 
 
-# Attribute sets shared by both call sites — chunk1 wins on the shared "role"
-# key, "title" is filled from chunk2, and the empty/None values are skipped.
-_CHUNK1_ATTRS = {"email": "a@example.com", "role": "existing"}
+# Attribute sets shared by both call sites: chunk1's non-empty "role" wins,
+# "title" is filled as a missing key, chunk1's empty "phone"/"fax" are upgraded
+# from chunk2's non-empty values, and chunk2's own empty/None values are skipped.
+_CHUNK1_ATTRS = {"email": "a@example.com", "role": "existing", "phone": "", "fax": None}
 _CHUNK2_ATTRS = {
     "title": "Engineer",
     "role": "incoming",
     "blank": "",
     "none_val": None,
     "count": 0,
+    "phone": "555-0100",
+    "fax": "555-0199",
 }
 
 
 def _assert_union(attrs: dict[str, Any]) -> None:
     assert attrs["email"] == "a@example.com"  # kept from chunk1
     assert attrs["title"] == "Engineer"  # added from chunk2 (missing key)
-    assert attrs["role"] == "existing"  # existing (chunk1) wins on shared key
-    assert "blank" not in attrs  # empty string skipped
-    assert "none_val" not in attrs  # None skipped
+    assert attrs["role"] == "existing"  # existing (chunk1) non-empty wins on shared key
+    assert "blank" not in attrs  # empty string incoming skipped
+    assert "none_val" not in attrs  # None incoming skipped
     # A legit falsy value must survive: the skip guard is `in (None, "")`, not
     # `if not _v`, so 0/0.0/False are added, not dropped. Guards a future refactor.
     assert attrs["count"] == 0
+    # An existing EMPTY value is upgraded by a later chunk's non-empty value (#1544).
+    assert attrs["phone"] == "555-0100"  # chunk1 "" -> chunk2 non-empty
+    assert attrs["fax"] == "555-0199"  # chunk1 None -> chunk2 non-empty
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- When the same `(name, entity_type)` entity recurs across chunks, the in-pipeline dedup updated mention counts and source ids but **discarded later chunks' `attributes`** — the first chunk's attributes won and any attributes found in later chunks were lost.
- Union attributes inline at both dedup call sites (`extract_entities` in `pipelines/tasks/extract.py` and `stream_extract_and_embed_entities` in `pipelines/flows/ingest.py`) with **existing-preferred / add-missing / skip-None-or-empty-string** semantics: a key already present keeps its existing value, missing keys are filled from later chunks, and `None`/empty-string incoming values are skipped.
- Kept the merge surgical and inline — deliberately did not reuse the broader `Entity.merge_with` (it also merges aliases and other fields, out of scope here).

## Test plan
- [x] Unit tests pass — new `tests/unit/pipelines/test_attribute_merge_dedup_1544.py` drives the real dedup path at **both** call sites and asserts: union (both keys present), existing value wins on a shared key, and `None`/empty-string incoming values are skipped.
- [x] `make format` clean; `make lint` passes (ruff clean, no new type findings in changed files).
- [ ] Full `make test` (unit + integration + e2e, coverage gate) — validated in CI (requires `lancedb` + Docker Postgres/Neo4j not available in the dev sandbox).

Fixes #1544

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entity deduplication by merging attributes across extraction chunks when multiple mentions resolve to the same entity.
  * Preserves already-known attribute values and fills only missing keys from later chunks.
  * Skips attributes that are `None` or empty strings while keeping other falsy-but-valid values (e.g., `0`).

* **Tests**
  * Added unit coverage to verify attribute-union behavior in both extraction and ingest pipelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->