### PR TITLE
Emit entity attributes on the strict structured-output path

### DIFF
--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -209,6 +209,7 @@ Extract entities, relationships, and temporal information from the following tex
 {document_context}
 Entity types to extract: {entity_types}
 Relationship types to use: {relationship_types}
+For each entity, emit "attributes" as an array of {{"key": ..., "value": ...}} string pairs drawn from its salient fields (identifiers, emails, state, urls, dates, etc.).
 
 Text:
 {text}"""
@@ -745,8 +746,27 @@ class LLMEntityExtractor(EntityExtractor):
                                                 {"type": "null"},
                                             ],
                                         },
+                                        "attributes": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "key": {"type": "string"},
+                                                    "value": {"type": "string"},
+                                                },
+                                                "required": ["key", "value"],
+                                                "additionalProperties": False,
+                                            },
+                                        },
                                     },
-                                    "required": ["name", "entity_type", "description", "aliases", "temporal"],
+                                    "required": [
+                                        "name",
+                                        "entity_type",
+                                        "description",
+                                        "aliases",
+                                        "temporal",
+                                        "attributes",
+                                    ],
                                     "additionalProperties": False,
                                 },
                             },
@@ -843,8 +863,20 @@ class LLMEntityExtractor(EntityExtractor):
                                         {"type": "null"},
                                     ],
                                 },
+                                "attributes": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "key": {"type": "string"},
+                                            "value": {"type": "string"},
+                                        },
+                                        "required": ["key", "value"],
+                                        "additionalProperties": False,
+                                    },
+                                },
                             },
-                            "required": ["name", "entity_type", "description", "aliases", "temporal"],
+                            "required": ["name", "entity_type", "description", "aliases", "temporal", "attributes"],
                             "additionalProperties": False,
                         },
                     },
@@ -2770,9 +2802,23 @@ Return ONLY valid JSON, no other text."""
                             valid_until=t.get("valid_until"),
                         )
 
-                # Ensure attributes is a dict (LLM sometimes returns a list)
-                attrs = e.get("attributes", {})
-                if not isinstance(attrs, dict):
+                # Normalize attributes to a dict. The strict schema emits a list
+                # of {"key": ..., "value": ...} pairs; other paths may return a
+                # dict directly. Anything else collapses to an empty dict.
+                raw_attrs = e.get("attributes", {})
+                if isinstance(raw_attrs, dict):
+                    attrs = raw_attrs
+                elif isinstance(raw_attrs, list):
+                    attrs = {}
+                    for pair in raw_attrs:
+                        if not isinstance(pair, dict):
+                            continue
+                        key = pair.get("key")
+                        if not isinstance(key, str):
+                            continue
+                        value = pair.get("value")
+                        attrs[key] = str(value) if value is not None else ""
+                else:
                     attrs = {}
 
                 # QUALITY FIX: Use heuristic confidence instead of hardcoded 0.9

--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -190,7 +190,7 @@ Guidelines:
 - Use canonical entity names (e.g., "Jennifer Walsh" not "Jenny", "Acme Corporation" not "Acme Corp")
 - Include aliases for entities that have multiple names/abbreviations
 - Extract temporal information when dates, times, or relative time references appear
-- For STATE_CHANGE detection: when text indicates transitions ("switched from X to Y", "no longer X", "used to X", "previously X but now Y"), extract a STATE_CHANGE entity with these required attributes: {"entity_affected": "name of entity whose state changed", "previous_state": "old value", "new_state": "new value", "attribute_changed": "what changed (e.g. job_title, location, instrument)", "transition_date": "ISO date or null"}. Set valid_from to the transition date. Use INVOLVES to link it to the affected entity
+- For STATE_CHANGE detection: when text indicates transitions ("switched from X to Y", "no longer X", "used to X", "previously X but now Y"), extract a STATE_CHANGE entity whose attributes carry these keys as {"key", "value"} pairs: entity_affected (name of entity whose state changed), previous_state (old value), new_state (new value), attribute_changed (what changed, e.g. job_title, location, instrument), transition_date (ISO date or null). Set valid_from to the transition date. Use INVOLVES to link it to the affected entity
 - For EVENT detection: when text describes specific occurrences, extract the event with date, participants, and location when available
 - Use temporal relationships (PRECEDES, FOLLOWS, INVOLVES) to connect events and state changes to other entities
 - Ensure relationship source/target names match extracted entity names exactly
@@ -2361,7 +2361,8 @@ Return a JSON object with a "sections" array, one object per input section:
     {"entities": [...], "relationships": [...], "events": [...]},
     ...
 ]}
-Each section follows the entity/relationship format from the instructions above."""
+Each section follows the entity/relationship format from the instructions above.
+For each entity, emit "attributes" as an array of {"key": ..., "value": ...} string pairs drawn from its salient fields (identifiers, emails, state, urls, dates, etc.)."""
             )
 
             prompt_context = {
@@ -2403,6 +2404,7 @@ Return a JSON object with a "sections" array, one object per section:
 ]}}
 
 Each section follows the same entity/relationship/event format.
+For each entity, emit "attributes" as an array of {{"key": ..., "value": ...}} string pairs drawn from its salient fields (identifiers, emails, state, urls, dates, etc.).
 Return ONLY valid JSON, no other text."""
 
         try:

--- a/tests/unit/test_extraction_llm.py
+++ b/tests/unit/test_extraction_llm.py
@@ -1182,3 +1182,164 @@ class TestBisectionOnTruncation:
 
         assert results == []
         mock_multi.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Entity attributes: strict-schema emission and pair-form parsing
+# ---------------------------------------------------------------------------
+
+# Strict structured output cannot express an open-ended {string: string} map
+# (additionalProperties must be False), so attributes are emitted as an array of
+# {"key": ..., "value": ...} pairs. This is the expected schema for each pair.
+_ATTRIBUTES_PAIR_ITEM = {
+    "type": "object",
+    "properties": {
+        "key": {"type": "string"},
+        "value": {"type": "string"},
+    },
+    "required": ["key", "value"],
+    "additionalProperties": False,
+}
+
+
+class TestAttributesSchema:
+    """The strict json_schema entity item carries an `attributes` pairs array."""
+
+    def _make_extractor(self) -> LLMEntityExtractor:
+        # gpt-4o-mini is on MODELS_REQUIRING_JSON_SCHEMA, so the strict
+        # json_schema branch (not the loose json_object fallback) is exercised.
+        return LLMEntityExtractor(model="gpt-4o-mini")
+
+    @staticmethod
+    def _assert_entity_item_strict(item: dict) -> None:
+        """The entity item stays strict-valid with attributes present."""
+        # attributes is a pairs array on the item.
+        assert "attributes" in item["properties"]
+        assert item["properties"]["attributes"]["type"] == "array"
+        assert item["properties"]["attributes"]["items"] == _ATTRIBUTES_PAIR_ITEM
+        # attributes is required.
+        assert "attributes" in item["required"]
+        # Strict-valid: every property is required and the item is closed.
+        assert set(item["required"]) == set(item["properties"])
+        assert item["additionalProperties"] is False
+
+    def test_response_format_entity_item(self) -> None:
+        """_get_response_format: entity item includes the attributes pairs array."""
+        fmt = self._make_extractor()._get_response_format()
+        assert fmt["json_schema"]["strict"] is True
+        item = fmt["json_schema"]["schema"]["properties"]["entities"]["items"]
+        self._assert_entity_item_strict(item)
+
+    def test_multi_response_format_entity_item(self) -> None:
+        """_get_multi_response_format: section entity item includes the pairs array."""
+        fmt = self._make_extractor()._get_multi_response_format()
+        assert fmt["json_schema"]["strict"] is True
+        item = fmt["json_schema"]["schema"]["properties"]["sections"]["items"]["properties"]["entities"]["items"]
+        self._assert_entity_item_strict(item)
+
+
+class TestAttributesParsing:
+    """_parse_response folds pair-form attributes into a dict."""
+
+    def _make_extractor(self) -> LLMEntityExtractor:
+        return LLMEntityExtractor(model="test-model")
+
+    def test_pairs_fold_to_dict(self) -> None:
+        """A list of {key, value} pairs folds into a {key: value} dict."""
+        extractor = self._make_extractor()
+        data = {
+            "entities": [
+                {
+                    "name": "Alice",
+                    "entity_type": "PERSON",
+                    "attributes": [
+                        {"key": "email", "value": "alice@example.com"},
+                        {"key": "role", "value": "engineer"},
+                    ],
+                }
+            ],
+            "relationships": [],
+        }
+        result = extractor._parse_response(json.dumps(data))
+        assert result.entities[0].attributes == {
+            "email": "alice@example.com",
+            "role": "engineer",
+        }
+
+    def test_dict_passes_through(self) -> None:
+        """An already-dict attributes value passes through unchanged."""
+        extractor = self._make_extractor()
+        data = {
+            "entities": [
+                {
+                    "name": "Alice",
+                    "entity_type": "PERSON",
+                    "attributes": {"email": "alice@example.com", "role": "engineer"},
+                }
+            ],
+            "relationships": [],
+        }
+        result = extractor._parse_response(json.dumps(data))
+        assert result.entities[0].attributes == {
+            "email": "alice@example.com",
+            "role": "engineer",
+        }
+
+    def test_empty_absent_or_scalar_yield_empty_dict(self) -> None:
+        """Empty list, absent attributes, and a scalar value all collapse to {}."""
+        extractor = self._make_extractor()
+        data = {
+            "entities": [
+                {"name": "EmptyList", "entity_type": "CONCEPT", "attributes": []},
+                {"name": "Absent", "entity_type": "CONCEPT"},
+                {"name": "Scalar", "entity_type": "CONCEPT", "attributes": "not-a-mapping"},
+            ],
+            "relationships": [],
+        }
+        result = extractor._parse_response(json.dumps(data))
+        by_name = {e.name: e for e in result.entities}
+        assert by_name["EmptyList"].attributes == {}
+        assert by_name["Absent"].attributes == {}
+        assert by_name["Scalar"].attributes == {}
+
+    @pytest.mark.asyncio
+    async def test_extract_round_trip_folds_pair_attributes(self) -> None:
+        """A mocked LLM returning pair-form attributes yields a populated dict."""
+        extractor = LLMEntityExtractor(model="test-model", max_retries=1)
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps(
+            {
+                "entities": [
+                    {
+                        "name": "Alice",
+                        "entity_type": "PERSON",
+                        "description": "A person",
+                        "attributes": [
+                            {"key": "email", "value": "alice@example.com"},
+                            {"key": "team", "value": "platform"},
+                        ],
+                    }
+                ],
+                "relationships": [],
+            }
+        )
+        mock_response.usage = MagicMock(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+
+        with (
+            patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_response),
+            patch("khora.telemetry.get_collector") as mock_telem,
+        ):
+            mock_telem.return_value.record_llm_call = MagicMock()
+            result = await extractor.extract(
+                "Alice works at Acme Corp",
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR"],
+            )
+
+        assert len(result.entities) == 1
+        assert result.entities[0].attributes == {
+            "email": "alice@example.com",
+            "team": "platform",
+        }

--- a/tests/unit/test_extraction_llm.py
+++ b/tests/unit/test_extraction_llm.py
@@ -1386,3 +1386,58 @@ class TestAttributesParsing:
             "email": "alice@example.com",
             "team": "platform",
         }
+
+    @pytest.mark.asyncio
+    async def test_extract_multi_round_trip_folds_pair_attributes(self) -> None:
+        """The batch (production) path also folds pair-form attributes into a dict.
+
+        Guards the extract_multi -> _extract_multi_batch path against a future
+        refactor that gives the batch path its own parse and silently drops
+        attributes in production.
+        """
+        extractor = LLMEntityExtractor(model="test-model", max_retries=1)
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps(
+            {
+                "sections": [
+                    {
+                        "entities": [
+                            {
+                                "name": "Alice",
+                                "entity_type": "PERSON",
+                                "description": "A person",
+                                "attributes": [
+                                    {"key": "email", "value": "alice@example.com"},
+                                    {"key": "team", "value": "platform"},
+                                ],
+                            }
+                        ],
+                        "relationships": [],
+                        "events": [],
+                    }
+                ]
+            }
+        )
+        mock_response.choices[0].finish_reason = "stop"
+        mock_response.usage = MagicMock(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+
+        with (
+            patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_response),
+            patch("khora.telemetry.get_collector") as mock_telem,
+        ):
+            mock_telem.return_value.record_llm_call = MagicMock()
+            results = await extractor.extract_multi(
+                ["Alice works at Acme Corp"],
+                batch_size=5,
+                entity_types=["PERSON", "ORGANIZATION"],
+                relationship_types=["WORKS_FOR"],
+                tiered_extraction=False,
+            )
+
+        assert len(results) == 1
+        assert results[0].entities[0].attributes == {
+            "email": "alice@example.com",
+            "team": "platform",
+        }

--- a/tests/unit/test_extraction_llm.py
+++ b/tests/unit/test_extraction_llm.py
@@ -1302,6 +1302,49 @@ class TestAttributesParsing:
         assert by_name["Absent"].attributes == {}
         assert by_name["Scalar"].attributes == {}
 
+    def test_pair_value_coercion_and_malformed_items(self) -> None:
+        """Pair values are string-coerced; missing/None values and malformed items are handled."""
+        extractor = self._make_extractor()
+        data = {
+            "entities": [
+                # Non-string value is coerced to str; missing and None values -> "".
+                {
+                    "name": "Coerce",
+                    "entity_type": "CONCEPT",
+                    "attributes": [
+                        {"key": "age", "value": 30},
+                        {"key": "no_value"},
+                        {"key": "null_value", "value": None},
+                    ],
+                },
+                # Duplicate keys: last value wins.
+                {
+                    "name": "Dup",
+                    "entity_type": "CONCEPT",
+                    "attributes": [
+                        {"key": "state", "value": "old"},
+                        {"key": "state", "value": "new"},
+                    ],
+                },
+                # Malformed items (non-dict item, non-string key) are skipped; valid pair kept.
+                {
+                    "name": "Malformed",
+                    "entity_type": "CONCEPT",
+                    "attributes": [
+                        "not-a-dict",
+                        {"key": 123, "value": "dropped"},
+                        {"key": "ok", "value": "kept"},
+                    ],
+                },
+            ],
+            "relationships": [],
+        }
+        result = extractor._parse_response(json.dumps(data))
+        by_name = {e.name: e for e in result.entities}
+        assert by_name["Coerce"].attributes == {"age": "30", "no_value": "", "null_value": ""}
+        assert by_name["Dup"].attributes == {"state": "new"}
+        assert by_name["Malformed"].attributes == {"ok": "kept"}
+
     @pytest.mark.asyncio
     async def test_extract_round_trip_folds_pair_attributes(self) -> None:
         """A mocked LLM returning pair-form attributes yields a populated dict."""


### PR DESCRIPTION
## Summary
- On the strict `json_schema` extraction path (used by models like the default `gpt-4o-mini`), the response schema omitted `attributes` and the structured prompt never asked for them, so every directly-extracted entity was persisted with empty attributes.
- Add an `attributes` field to the entity item in **both** the single-doc (`_get_response_format`) and multi-section (`_get_multi_response_format`) strict response schemas. Because open maps are illegal under `strict`, attributes are modeled as an array of `{key, value}` string pairs; the field is added to the item's `required` list so the schema stays strict-valid (every property required, `additionalProperties: false`).
- Add one line to the structured extraction prompt instructing the model to emit `attributes` as `{key, value}` pairs from an entity's salient fields (identifiers, emails, state, urls, dates).
- Fold the pairs back into a dict on parse, while still accepting the legacy dict shape and collapsing anything else to `{}`.
- The non-structured prompt (dict-example) is unchanged.

Fixes #1542

## Behavior change (reviewer awareness)
Before this change, strict-schema models always produced `attributes == {}`, which left the downstream `STATE_CHANGE` handler (`pipelines/tasks/extract.py`) effectively dormant for those models. Now that entities can carry attributes (e.g. `entity_affected` / `new_state` / `transition_date`), that handler activates on the strict path and can drive bi-temporal `SUPERSEDES` version creation. This is the intended benefit of populating attributes, but it is a behavior change beyond "just emit attributes." The `attributes` public type (`dict[str, Any]`) is unchanged, so no public API contract is affected.

## Follow-ups (out of scope here)
- Attribute-value **grounding**: the prompt currently nudges the model to fill attributes from salient fields but does not constrain values to text explicitly present. Tightening this to reduce fabrication (and feeding the ontology's per-type attribute keys into the prompt) is tracked separately as khora#1543.

## Test plan
- [x] Unit tests pass (`tests/unit/test_extraction_llm.py`): both strict response formats carry the `attributes` pairs array in `properties` + `required` and stay strict-valid; parser folds pairs → dict, passes an already-dict through, collapses empty/absent/scalar → `{}`, coerces non-string/None pair values, drops malformed items, and last-wins on duplicate keys; async round-trip yields populated `.attributes`.
- [x] Adjacent extractor suites green (`test_extraction_llm_coverage.py`, `test_extraction_second_pass_batch.py`, `test_parameterized_extraction.py`).
- [x] `ruff format` / `ruff check` / typecheck clean.
- [ ] Full integration + e2e suite — validated in CI (requires Postgres/Neo4j).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated entity extraction to emit `attributes` as an array of `{key, value}` pairs for structured outputs.
  * Strengthened strict JSON schema support to require `attributes` in `{key, value}` pair form across single and multi-part extraction.
  * Added normalization so extracted `attributes` are consistently returned as a key/value dictionary, with safe handling of missing data.
* **Bug Fixes**
  * Improved robustness for empty, malformed, or non-standard `attributes` inputs (invalid entries are ignored; duplicate keys keep the last value).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->