### PR TITLE
Guard entity upsert against empty attributes overwriting populated ones

### DIFF
--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -1781,7 +1781,7 @@ class Neo4jBackend(GraphBackendBase):
             MATCH (e:Entity {id: $id, namespace_id: $namespace_id})
             SET e.name = $name,
                 e.description = $description,
-                e.attributes = $attributes,
+                e.attributes = CASE WHEN $attributes IS NULL OR $attributes = '{}' OR $attributes = '' THEN e.attributes ELSE $attributes END,
                 e.source_document_ids = $source_document_ids,
                 e.source_chunk_ids = $source_chunk_ids,
                 e.mention_count = $mention_count,
@@ -1941,7 +1941,7 @@ class Neo4jBackend(GraphBackendBase):
                 e.confidence = CASE WHEN row.confidence > e.confidence THEN row.confidence ELSE e.confidence END,
                 e.updated_at = row.updated_at,
                 e.version_valid_from = coalesce(e.version_valid_from, row.version_valid_from),
-                e.attributes = row.attributes
+                e.attributes = CASE WHEN row.attributes IS NULL OR row.attributes = '{}' OR row.attributes = '' THEN e.attributes ELSE row.attributes END
             RETURN e.id AS id, e.name AS name, row.id AS input_id,
                    CASE WHEN e.id = row.id THEN true ELSE false END AS is_new
         """

--- a/src/khora/storage/backends/neo4j.py
+++ b/src/khora/storage/backends/neo4j.py
@@ -2145,8 +2145,13 @@ class Neo4jBackend(GraphBackendBase):
                     if not pre:
                         continue
 
-                    # Compare serialized attributes to detect real changes
-                    if pre["attributes"] == input_row["attributes"]:
+                    # Compare serialized attributes to detect real changes.
+                    # An empty/NULL incoming attributes is treated as no change,
+                    # mirroring the ON MATCH SET guard above so an empty re-upsert
+                    # of a populated entity does not append a phantom version_row.
+                    incoming_attrs = input_row["attributes"]
+                    incoming_is_empty = incoming_attrs is None or incoming_attrs == "{}" or incoming_attrs == ""
+                    if incoming_is_empty or pre["attributes"] == incoming_attrs:
                         continue
 
                     version_rows.append(

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -1087,13 +1087,17 @@ class PgVectorBackend(AsyncSessionMixin):
                 constraint="uq_entities_namespace_name_type",
                 set_={
                     "description": stmt.excluded.description,
-                    # An incoming empty ({}) or NULL attributes must not clobber a
-                    # stored populated attributes; keep the existing value in that
-                    # case, otherwise overwrite with the incoming value.
+                    # An incoming empty ({}), SQL NULL, or json ``null`` attributes
+                    # must not clobber a stored populated attributes; keep the
+                    # existing value in that case, otherwise overwrite with the
+                    # incoming value. JSONB has ``none_as_null=False``, so a Python
+                    # None binds as ``'null'::jsonb`` (not SQL NULL) — the
+                    # jsonb_typeof check catches that path.
                     "attributes": sa.case(
                         (
                             sa.or_(
                                 stmt.excluded.attributes.is_(None),
+                                sa.func.jsonb_typeof(stmt.excluded.attributes) == "null",
                                 stmt.excluded.attributes == sa.cast("{}", JSONB),
                             ),
                             EntityModel.attributes,

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -1054,7 +1054,7 @@ class PgVectorBackend(AsyncSessionMixin):
         Acquires a namespace-scoped advisory lock to prevent deadlocks
         when concurrent coroutines upsert entities in the same namespace.
         """
-        from sqlalchemy.dialects.postgresql import insert
+        from sqlalchemy.dialects.postgresql import JSONB, insert
 
         async with self._get_session() as session:
             # Advisory lock prevents deadlocks with concurrent upserts
@@ -1087,7 +1087,19 @@ class PgVectorBackend(AsyncSessionMixin):
                 constraint="uq_entities_namespace_name_type",
                 set_={
                     "description": stmt.excluded.description,
-                    "attributes": stmt.excluded.attributes,
+                    # An incoming empty ({}) or NULL attributes must not clobber a
+                    # stored populated attributes; keep the existing value in that
+                    # case, otherwise overwrite with the incoming value.
+                    "attributes": sa.case(
+                        (
+                            sa.or_(
+                                stmt.excluded.attributes.is_(None),
+                                stmt.excluded.attributes == sa.cast("{}", JSONB),
+                            ),
+                            EntityModel.attributes,
+                        ),
+                        else_=stmt.excluded.attributes,
+                    ),
                     "source_document_ids": _accumulate_source_ids_sql("source_document_ids"),
                     "source_chunk_ids": _accumulate_source_ids_sql("source_chunk_ids"),
                     "mention_count": stmt.excluded.mention_count,

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -1092,13 +1092,16 @@ class PgVectorBackend(AsyncSessionMixin):
                     # existing value in that case, otherwise overwrite with the
                     # incoming value. JSONB has ``none_as_null=False``, so a Python
                     # None binds as ``'null'::jsonb`` (not SQL NULL) — the
-                    # jsonb_typeof check catches that path.
+                    # jsonb_typeof check catches that path. The empty-object check
+                    # uses ``type_coerce({}, JSONB)`` (binds the dict -> ``'{}'``)
+                    # rather than ``cast("{}", JSONB)``, which would JSON-encode the
+                    # string to ``'"{}"'`` and never match a real empty object.
                     "attributes": sa.case(
                         (
                             sa.or_(
                                 stmt.excluded.attributes.is_(None),
                                 sa.func.jsonb_typeof(stmt.excluded.attributes) == "null",
-                                stmt.excluded.attributes == sa.cast("{}", JSONB),
+                                stmt.excluded.attributes == sa.type_coerce({}, JSONB),
                             ),
                             EntityModel.attributes,
                         ),

--- a/src/khora/storage/backends/pgvector.py
+++ b/src/khora/storage/backends/pgvector.py
@@ -1317,7 +1317,7 @@ class PgVectorBackend(AsyncSessionMixin):
             return []
 
         async def _do_upsert():
-            from sqlalchemy.dialects.postgresql import insert
+            from sqlalchemy.dialects.postgresql import JSONB, insert
 
             # Sort by (namespace_id, name, entity_type) to ensure consistent lock ordering
             sorted_entities = sorted(entities, key=lambda e: (str(e.namespace_id), e.name, str(e.entity_type)))
@@ -1365,7 +1365,27 @@ class PgVectorBackend(AsyncSessionMixin):
                     constraint="uq_entities_namespace_name_type",
                     set_={
                         "description": stmt.excluded.description,
-                        "attributes": stmt.excluded.attributes,
+                        # An incoming empty ({}), SQL NULL, or json ``null`` attributes
+                        # must not clobber a stored populated attributes; keep the
+                        # existing value in that case, otherwise overwrite with the
+                        # incoming value. JSONB has ``none_as_null=False``, so a Python
+                        # None binds as ``'null'::jsonb`` (not SQL NULL) — the
+                        # jsonb_typeof check catches that path. The empty-object check
+                        # uses ``type_coerce({}, JSONB)`` (binds the dict -> ``'{}'``)
+                        # rather than ``cast("{}", JSONB)``, which would JSON-encode the
+                        # string to ``'"{}"'`` and never match a real empty object.
+                        # Mirrors the single-entity guard in ``_upsert_entity``.
+                        "attributes": sa.case(
+                            (
+                                sa.or_(
+                                    stmt.excluded.attributes.is_(None),
+                                    sa.func.jsonb_typeof(stmt.excluded.attributes) == "null",
+                                    stmt.excluded.attributes == sa.type_coerce({}, JSONB),
+                                ),
+                                EntityModel.attributes,
+                            ),
+                            else_=stmt.excluded.attributes,
+                        ),
                         "source_document_ids": _accumulate_source_ids_sql("source_document_ids"),
                         "source_chunk_ids": _accumulate_source_ids_sql("source_chunk_ids"),
                         "mention_count": stmt.excluded.mention_count,

--- a/tests/integration/test_neo4j_entity_attributes_guard.py
+++ b/tests/integration/test_neo4j_entity_attributes_guard.py
@@ -1,0 +1,140 @@
+"""Real-Neo4j integration test for the empty-attributes upsert guard.
+
+On entity upsert, an incoming EMPTY (``{}``) or NULL ``attributes`` must not
+clobber a stored, populated ``attributes``. A non-empty incoming value
+overwrites the stored dict wholesale (no key-union merge). The guard lives in
+``Neo4jBackend`` as the ``ON MATCH SET`` clause of ``_UPSERT_CYPHER``
+(``upsert_entities_batch``):
+
+    e.attributes = CASE WHEN row.attributes IS NULL OR row.attributes = '{}'
+        OR row.attributes = '' THEN e.attributes ELSE row.attributes END
+
+``attributes`` is persisted as a JSON *string* (``serialize_dict``), so ``{}``
+serializes to ``'{}'`` and ``None`` serializes to a Cypher NULL — the two
+branches the guard fences.
+
+Why this is gated by ``NEO4J_INTEGRATION_TEST=1``:
+
+    Khora's CI does NOT provision a Neo4j instance, so real-Neo4j coverage
+    lives behind an opt-in env var (matching the sibling
+    ``test_neo4j_get_entity_relationships_integration.py``). Local developers
+    running ``make dev`` can exercise it.
+
+How to run locally::
+
+    make dev  # starts postgres + neo4j via docker compose
+    NEO4J_INTEGRATION_TEST=1 uv run pytest \
+        tests/integration/test_neo4j_entity_attributes_guard.py -v
+
+Connection parameters are read from env vars with defaults matching the
+``make dev`` compose stack::
+
+    KHORA_NEO4J_URL       (default: bolt://localhost:7687)
+    KHORA_NEO4J_USERNAME  (default: neo4j)
+    KHORA_NEO4J_PASSWORD  (default: password)
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from uuid import uuid4
+
+import pytest
+
+from khora.core.models.entity import Entity
+from khora.storage.backends.neo4j import Neo4jBackend
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("NEO4J_INTEGRATION_TEST"),
+        reason="set NEO4J_INTEGRATION_TEST=1 to run against real Neo4j (requires make dev)",
+    ),
+]
+
+
+@pytest.fixture
+async def backend() -> AsyncIterator[Neo4jBackend]:
+    url = os.environ.get("KHORA_NEO4J_URL", "bolt://localhost:7687")
+    user = os.environ.get("KHORA_NEO4J_USERNAME", "neo4j")
+    password = os.environ.get("KHORA_NEO4J_PASSWORD", "password")
+
+    be = Neo4jBackend(url, user=user, password=password)
+    await be.connect()
+    try:
+        yield be
+    finally:
+        await be.disconnect()
+
+
+def _entity(ns_id, name: str, attributes, entity_type: str = "PERSON") -> Entity:
+    """Build a fresh Entity with a new candidate id — mirrors the LLM-ingestion
+    shape where each extraction gets a throwaway id and storage dedupes by
+    (namespace, name, entity_type).
+
+    ``attributes`` is passed verbatim (including ``None``): the Entity
+    dataclass does not coerce ``None`` -> ``{}``, so a ``None`` here serializes
+    to a Cypher NULL and exercises the ``row.attributes IS NULL`` branch of the
+    guard.
+    """
+    return Entity(
+        id=uuid4(),
+        namespace_id=ns_id,
+        name=name,
+        entity_type=entity_type,
+        attributes=attributes,
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_attributes_does_not_overwrite_populated(backend: Neo4jBackend) -> None:
+    """Upsert ``{"a": 1}`` then the same key with ``{}`` — the stored
+    attributes must stay ``{"a": 1}`` (empty incoming does not clobber)."""
+    ns = uuid4()
+    name = f"guard-empty-{uuid4().hex[:8]}"
+
+    await backend.upsert_entities_batch(ns, [_entity(ns, name, {"a": 1})])
+    await backend.upsert_entities_batch(ns, [_entity(ns, name, {})])
+
+    got = await backend.get_entity_by_name(ns, name, "PERSON")
+    assert got is not None
+    assert got.attributes == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_null_attributes_does_not_overwrite_populated(backend: Neo4jBackend) -> None:
+    """Upsert ``{"a": 1}`` then the same key with NULL (``None``) attributes —
+    the stored attributes must stay ``{"a": 1}``.
+
+    Distinct from the empty-dict case: ``None`` serializes to a Cypher NULL and
+    hits the ``row.attributes IS NULL`` branch rather than ``= '{}'``."""
+    ns = uuid4()
+    name = f"guard-null-{uuid4().hex[:8]}"
+
+    await backend.upsert_entities_batch(ns, [_entity(ns, name, {"a": 1})])
+    await backend.upsert_entities_batch(ns, [_entity(ns, name, None)])
+
+    got = await backend.get_entity_by_name(ns, name, "PERSON")
+    assert got is not None
+    assert got.attributes == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_nonempty_attributes_overwrites_without_key_union(backend: Neo4jBackend) -> None:
+    """Upsert ``{"a": 1}`` then the same key with ``{"b": 2}`` — the stored
+    attributes must become EXACTLY ``{"b": 2}``.
+
+    The guard only protects against empty/NULL incoming values; a non-empty
+    incoming dict replaces the stored one wholesale. Key-union merge
+    (``{"a": 1, "b": 2}``) is intentionally OUT OF SCOPE."""
+    ns = uuid4()
+    name = f"guard-overwrite-{uuid4().hex[:8]}"
+
+    await backend.upsert_entities_batch(ns, [_entity(ns, name, {"a": 1})])
+    await backend.upsert_entities_batch(ns, [_entity(ns, name, {"b": 2})])
+
+    got = await backend.get_entity_by_name(ns, name, "PERSON")
+    assert got is not None
+    assert got.attributes == {"b": 2}
+    assert "a" not in got.attributes

--- a/tests/integration/test_neo4j_entity_attributes_guard.py
+++ b/tests/integration/test_neo4j_entity_attributes_guard.py
@@ -20,6 +20,10 @@ one. ``upsert_entities_batch`` only snapshots when attributes actually change,
 and the Phase-2 change-detector mirrors the ON MATCH SET guard by treating an
 empty/NULL incoming value as "no change".
 
+The single-entity ``update_entity`` query carries a twin of the guard; the
+``test_update_entity_*`` cases below exercise that direct-update path (used by
+the expansion/coordinator route), which the batch tests do not touch.
+
 Why this is gated by ``NEO4J_INTEGRATION_TEST=1``:
 
     The integration job in ``.github/workflows/ci.yml`` provisions a Neo4j
@@ -228,3 +232,70 @@ async def test_genuine_change_creates_single_version(backend: Neo4jBackend) -> N
     got = await backend.get_entity_by_name(ns, name, "PERSON")
     assert got is not None
     assert got.attributes == {"b": 2}
+
+
+@pytest.mark.asyncio
+async def test_update_entity_empty_attributes_does_not_overwrite_populated(backend: Neo4jBackend) -> None:
+    """Single-entity path (``update_entity``): seed ``{"a": 1}`` then update the
+    same node with ``{}`` — stored attributes must stay ``{"a": 1}``.
+
+    ``update_entity`` is the direct single-node write (the expansion/coordinator
+    update route) and carries its own guard, separate from ``_UPSERT_CYPHER``'s
+    ``ON MATCH SET`` — so it needs coverage the batch tests don't provide."""
+    ns = uuid4()
+    name = f"guard-update-empty-{uuid4().hex[:8]}"
+
+    seed = _entity(ns, name, {"a": 1})
+    await backend.upsert_entities_batch(ns, [seed])
+
+    # update_entity MATCHes by id, so target the stored node.
+    update = _entity(ns, name, {})
+    update.id = seed.id
+    await backend.update_entity(update, namespace_id=ns)
+
+    got = await backend.get_entity_by_name(ns, name, "PERSON")
+    assert got is not None
+    assert got.attributes == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_update_entity_null_attributes_does_not_overwrite_populated(backend: Neo4jBackend) -> None:
+    """Single-entity path: seed ``{"a": 1}`` then ``update_entity`` with NULL
+    (``None``) attributes — stored attributes must stay ``{"a": 1}`` (hits the
+    ``$attributes IS NULL`` branch)."""
+    ns = uuid4()
+    name = f"guard-update-null-{uuid4().hex[:8]}"
+
+    seed = _entity(ns, name, {"a": 1})
+    await backend.upsert_entities_batch(ns, [seed])
+
+    update = _entity(ns, name, None)
+    update.id = seed.id
+    await backend.update_entity(update, namespace_id=ns)
+
+    got = await backend.get_entity_by_name(ns, name, "PERSON")
+    assert got is not None
+    assert got.attributes == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_update_entity_nonempty_attributes_overwrites_without_key_union(backend: Neo4jBackend) -> None:
+    """Single-entity path: seed ``{"a": 1}`` then ``update_entity`` with
+    ``{"b": 2}`` — stored attributes must become EXACTLY ``{"b": 2}``.
+
+    A non-empty incoming value overwrites wholesale; key-union merge
+    (``{"a": 1, "b": 2}``) is intentionally OUT OF SCOPE."""
+    ns = uuid4()
+    name = f"guard-update-overwrite-{uuid4().hex[:8]}"
+
+    seed = _entity(ns, name, {"a": 1})
+    await backend.upsert_entities_batch(ns, [seed])
+
+    update = _entity(ns, name, {"b": 2})
+    update.id = seed.id
+    await backend.update_entity(update, namespace_id=ns)
+
+    got = await backend.get_entity_by_name(ns, name, "PERSON")
+    assert got is not None
+    assert got.attributes == {"b": 2}
+    assert "a" not in got.attributes

--- a/tests/integration/test_neo4j_entity_attributes_guard.py
+++ b/tests/integration/test_neo4j_entity_attributes_guard.py
@@ -13,12 +13,21 @@ overwrites the stored dict wholesale (no key-union merge). The guard lives in
 serializes to ``'{}'`` and ``None`` serializes to a Cypher NULL — the two
 branches the guard fences.
 
+This module also pins the version-chain side of the guard: a guard-preserved
+(empty/NULL) re-upsert must NOT append a phantom ``:EntityVersion`` snapshot or
+``[:SUPERSEDES]`` edge, while a genuine attribute change still creates exactly
+one. ``upsert_entities_batch`` only snapshots when attributes actually change,
+and the Phase-2 change-detector mirrors the ON MATCH SET guard by treating an
+empty/NULL incoming value as "no change".
+
 Why this is gated by ``NEO4J_INTEGRATION_TEST=1``:
 
-    Khora's CI does NOT provision a Neo4j instance, so real-Neo4j coverage
-    lives behind an opt-in env var (matching the sibling
-    ``test_neo4j_get_entity_relationships_integration.py``). Local developers
-    running ``make dev`` can exercise it.
+    The integration job in ``.github/workflows/ci.yml`` provisions a Neo4j
+    service and sets ``NEO4J_INTEGRATION_TEST=1``, so these tests run for real
+    in CI. The env-var gate keeps them opt-in everywhere else: a local box
+    without ``make dev`` (or any run that has not started Neo4j) skips them
+    cleanly instead of erroring on an unreachable bolt port. It matches the
+    sibling ``test_neo4j_get_entity_relationships_integration.py``.
 
 How to run locally::
 
@@ -138,3 +147,84 @@ async def test_nonempty_attributes_overwrites_without_key_union(backend: Neo4jBa
     assert got is not None
     assert got.attributes == {"b": 2}
     assert "a" not in got.attributes
+
+
+async def _count_versions(backend: Neo4jBackend, ns_id, name: str, entity_type: str) -> tuple[int, int]:
+    """Count ``:EntityVersion`` snapshots and ``[:SUPERSEDES]`` edges for one
+    entity identity.
+
+    The namespace is unique per test (fresh ``uuid4``), so matching on
+    (namespace_id, name, entity_type) uniquely identifies this entity's version
+    chain without needing the canonical node id. ``upsert_entities_batch``
+    stamps those three properties onto every snapshot node it creates.
+    """
+
+    async def _query(tx) -> tuple[int, int]:
+        ev_result = await tx.run(
+            "MATCH (ev:EntityVersion {namespace_id: $ns, name: $name, entity_type: $etype}) RETURN count(ev) AS c",
+            ns=str(ns_id),
+            name=name,
+            etype=entity_type,
+        )
+        ev_record = await ev_result.single()
+        edge_result = await tx.run(
+            "MATCH (:Entity {namespace_id: $ns, name: $name, entity_type: $etype})"
+            "-[s:SUPERSEDES]->(:EntityVersion) RETURN count(s) AS c",
+            ns=str(ns_id),
+            name=name,
+            etype=entity_type,
+        )
+        edge_record = await edge_result.single()
+        return ev_record["c"], edge_record["c"]
+
+    async with backend._session() as session:
+        return await session.execute_read(_query)
+
+
+@pytest.mark.asyncio
+async def test_empty_reupsert_creates_no_phantom_version(backend: Neo4jBackend) -> None:
+    """Guard-preserved re-upsert must not append a phantom version snapshot.
+
+    Seeding ``{"a": 1}`` then re-upserting the same key with ``{}`` and ``None``
+    leaves the stored attributes unchanged (the ON MATCH SET guard), so the
+    Phase-2 change-detector must treat it as "no change" and create NO
+    ``:EntityVersion`` node and NO ``[:SUPERSEDES]`` edge (H2 regression)."""
+    ns = uuid4()
+    name = f"guard-noversion-{uuid4().hex[:8]}"
+
+    await backend.upsert_entities_batch(ns, [_entity(ns, name, {"a": 1})])
+    await backend.upsert_entities_batch(ns, [_entity(ns, name, {})])
+    await backend.upsert_entities_batch(ns, [_entity(ns, name, None)])
+
+    ev_count, supersedes_count = await _count_versions(backend, ns, name, "PERSON")
+    assert ev_count == 0, f"empty/NULL re-upsert must not snapshot a version, got {ev_count}"
+    assert supersedes_count == 0, f"empty/NULL re-upsert must not create a SUPERSEDES edge, got {supersedes_count}"
+
+    # The current node still carries the seeded attributes (guard held).
+    got = await backend.get_entity_by_name(ns, name, "PERSON")
+    assert got is not None
+    assert got.attributes == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_genuine_change_creates_single_version(backend: Neo4jBackend) -> None:
+    """Positive control: a real attribute change still snapshots exactly one
+    version.
+
+    Seeding ``{"a": 1}`` then upserting ``{"b": 2}`` is a genuine change, so
+    Phase-2 must create exactly one ``:EntityVersion`` node and one
+    ``[:SUPERSEDES]`` edge — proving the H2 fix suppresses only the phantom
+    (empty/NULL) case, not legitimate versioning."""
+    ns = uuid4()
+    name = f"guard-oneversion-{uuid4().hex[:8]}"
+
+    await backend.upsert_entities_batch(ns, [_entity(ns, name, {"a": 1})])
+    await backend.upsert_entities_batch(ns, [_entity(ns, name, {"b": 2})])
+
+    ev_count, supersedes_count = await _count_versions(backend, ns, name, "PERSON")
+    assert ev_count == 1, f"genuine change must snapshot exactly one version, got {ev_count}"
+    assert supersedes_count == 1, f"genuine change must create exactly one SUPERSEDES edge, got {supersedes_count}"
+
+    got = await backend.get_entity_by_name(ns, name, "PERSON")
+    assert got is not None
+    assert got.attributes == {"b": 2}

--- a/tests/integration/test_pgvector_entity_attributes_guard.py
+++ b/tests/integration/test_pgvector_entity_attributes_guard.py
@@ -1,0 +1,166 @@
+"""Integration test for the empty-attributes upsert guard on the pgvector
+entity backend.
+
+On entity upsert, an incoming EMPTY (``{}``) or NULL ``attributes`` must not
+clobber a stored, populated ``attributes``. A non-empty incoming value
+overwrites the stored dict wholesale (no key-union merge). The guard lives in
+``PgVectorBackend._upsert_entity`` as a ``CASE`` on the
+``on_conflict_do_update`` set-clause and is reached through the single-entity
+``create_entity`` / ``update_entity`` path.
+
+Gated by ``KHORA_DATABASE_URL`` (defaults to the ``make dev`` Postgres on port
+5432). The guard is a SQL ``CASE`` over ``excluded.attributes`` vs the stored
+column, so it can only be exercised against real Postgres — a SQLite mock
+cannot reproduce the ``ON CONFLICT DO UPDATE`` semantics.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from khora.core.models import Entity
+from khora.storage.backends.pgvector import PgVectorBackend
+
+# Match the schema's pgvector column dimension (Vector(1536)).
+EMBED_DIM = 1536
+
+
+def _pg_reachable() -> bool:
+    import socket
+    from urllib.parse import urlparse
+
+    url = os.environ.get(
+        "KHORA_DATABASE_URL",
+        "postgresql+asyncpg://khora:khora@localhost:5432/khora",
+    )
+    parsed = urlparse(url.replace("+asyncpg", ""))
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not _pg_reachable(), reason="PostgreSQL not reachable (run `make dev`)"),
+]
+
+
+@pytest.fixture
+async def backend() -> AsyncIterator[PgVectorBackend]:
+    database_url = os.environ.get(
+        "KHORA_DATABASE_URL",
+        "postgresql+asyncpg://khora:khora@localhost:5432/khora",
+    )
+    be = PgVectorBackend(database_url=database_url, embedding_dimension=EMBED_DIM)
+    await be.connect()
+    try:
+        yield be
+    finally:
+        await be.disconnect()
+
+
+@pytest.fixture
+async def namespace_id(backend: PgVectorBackend) -> AsyncIterator[UUID]:
+    """Create a fresh namespace row directly so the test owns its tear-down
+    surface and doesn't depend on the Khora façade."""
+    ns_id = uuid4()
+    engine = create_async_engine(backend._database_url)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                sa.text(
+                    "INSERT INTO memory_namespaces (id, namespace_id, version, "
+                    "is_active, tenancy_mode, created_at, updated_at) "
+                    "VALUES (:id, :nsid, 1, true, 'shared', NOW(), NOW())"
+                ),
+                {"id": ns_id, "nsid": ns_id},
+            )
+        yield ns_id
+        async with engine.begin() as conn:
+            await conn.execute(sa.text("DELETE FROM entities WHERE namespace_id = :id"), {"id": ns_id})
+            await conn.execute(sa.text("DELETE FROM memory_namespaces WHERE id = :id"), {"id": ns_id})
+    finally:
+        await engine.dispose()
+
+
+def _entity(ns_id: UUID, entity_id: UUID, name: str, attributes, entity_type: str = "PERSON") -> Entity:
+    """Build an Entity with a caller-controlled ``id`` so re-upserts of the
+    same logical entity read back deterministically by id.
+
+    ``attributes`` is passed verbatim (including ``None``): the Entity
+    dataclass does not coerce ``None`` -> ``{}`` in ``__post_init__``, so a
+    ``None`` here reaches the backend as a genuine SQL NULL and exercises the
+    ``excluded.attributes IS NULL`` branch of the guard.
+    """
+    return Entity(
+        id=entity_id,
+        namespace_id=ns_id,
+        name=name,
+        entity_type=entity_type,
+        attributes=attributes,
+        embedding=[0.1] * EMBED_DIM,
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_attributes_does_not_overwrite_populated(backend: PgVectorBackend, namespace_id: UUID) -> None:
+    """Upsert ``{"a": 1}`` then the same key with ``{}`` — the stored
+    attributes must stay ``{"a": 1}`` (empty incoming does not clobber)."""
+    eid = uuid4()
+    name = f"guard-empty-{uuid4()}"
+
+    await backend.create_entity(_entity(namespace_id, eid, name, {"a": 1}))
+    await backend.create_entity(_entity(namespace_id, eid, name, {}))
+
+    got = await backend.get_entity(eid, namespace_id=namespace_id)
+    assert got is not None
+    assert got.attributes == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_null_attributes_does_not_overwrite_populated(backend: PgVectorBackend, namespace_id: UUID) -> None:
+    """Upsert ``{"a": 1}`` then the same key with NULL (``None``) attributes —
+    the stored attributes must stay ``{"a": 1}``.
+
+    Distinct from the empty-dict case: ``None`` reaches the guard's
+    ``excluded.attributes.is_(None)`` branch rather than the ``== '{}'``
+    branch."""
+    eid = uuid4()
+    name = f"guard-null-{uuid4()}"
+
+    await backend.create_entity(_entity(namespace_id, eid, name, {"a": 1}))
+    await backend.create_entity(_entity(namespace_id, eid, name, None))
+
+    got = await backend.get_entity(eid, namespace_id=namespace_id)
+    assert got is not None
+    assert got.attributes == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_nonempty_attributes_overwrites_without_key_union(backend: PgVectorBackend, namespace_id: UUID) -> None:
+    """Upsert ``{"a": 1}`` then the same key with ``{"b": 2}`` — the stored
+    attributes must become EXACTLY ``{"b": 2}``.
+
+    The guard only protects against empty/NULL incoming values; a non-empty
+    incoming dict replaces the stored one wholesale. Key-union merge
+    (``{"a": 1, "b": 2}``) is intentionally OUT OF SCOPE."""
+    eid = uuid4()
+    name = f"guard-overwrite-{uuid4()}"
+
+    await backend.create_entity(_entity(namespace_id, eid, name, {"a": 1}))
+    await backend.create_entity(_entity(namespace_id, eid, name, {"b": 2}))
+
+    got = await backend.get_entity(eid, namespace_id=namespace_id)
+    assert got is not None
+    assert got.attributes == {"b": 2}
+    assert "a" not in got.attributes

--- a/tests/integration/test_pgvector_entity_attributes_guard.py
+++ b/tests/integration/test_pgvector_entity_attributes_guard.py
@@ -98,9 +98,10 @@ def _entity(ns_id: UUID, entity_id: UUID, name: str, attributes, entity_type: st
     same logical entity read back deterministically by id.
 
     ``attributes`` is passed verbatim (including ``None``): the Entity
-    dataclass does not coerce ``None`` -> ``{}`` in ``__post_init__``, so a
-    ``None`` here reaches the backend as a genuine SQL NULL and exercises the
-    ``excluded.attributes IS NULL`` branch of the guard.
+    dataclass does not coerce ``None`` -> ``{}`` in ``__post_init__``. The ORM
+    column is ``JSONB`` with ``none_as_null=False``, so a ``None`` binds as
+    ``'null'::jsonb`` (not a SQL NULL) and is caught by the guard's
+    ``jsonb_typeof(excluded.attributes) = 'null'`` branch.
     """
     return Entity(
         id=entity_id,
@@ -132,9 +133,9 @@ async def test_null_attributes_does_not_overwrite_populated(backend: PgVectorBac
     """Upsert ``{"a": 1}`` then the same key with NULL (``None``) attributes —
     the stored attributes must stay ``{"a": 1}``.
 
-    Distinct from the empty-dict case: ``None`` reaches the guard's
-    ``excluded.attributes.is_(None)`` branch rather than the ``== '{}'``
-    branch."""
+    Distinct from the empty-dict case: ``None`` binds as ``'null'::jsonb``
+    (JSONB ``none_as_null=False``), so it is caught by the guard's
+    ``jsonb_typeof(...) = 'null'`` branch rather than the ``== '{}'`` branch."""
     eid = uuid4()
     name = f"guard-null-{uuid4()}"
 

--- a/tests/integration/test_pgvector_entity_attributes_guard.py
+++ b/tests/integration/test_pgvector_entity_attributes_guard.py
@@ -165,3 +165,65 @@ async def test_nonempty_attributes_overwrites_without_key_union(backend: PgVecto
     assert got is not None
     assert got.attributes == {"b": 2}
     assert "a" not in got.attributes
+
+
+@pytest.mark.asyncio
+async def test_batch_empty_attributes_does_not_overwrite_populated(
+    backend: PgVectorBackend, namespace_id: UUID
+) -> None:
+    """Batch path (``upsert_entities_batch``): upsert ``{"a": 1}`` then the
+    same key with ``{}`` — the stored attributes must stay ``{"a": 1}``.
+
+    The batch multi-row ``INSERT ... ON CONFLICT DO UPDATE`` carries the same
+    ``CASE`` guard as the single ``create_entity`` path; this exercises it via
+    ``upsert_entities_batch`` rather than ``_upsert_entity``."""
+    eid = uuid4()
+    name = f"guard-batch-empty-{uuid4()}"
+
+    await backend.upsert_entities_batch(namespace_id, [_entity(namespace_id, eid, name, {"a": 1})])
+    await backend.upsert_entities_batch(namespace_id, [_entity(namespace_id, eid, name, {})])
+
+    got = await backend.get_entity(eid, namespace_id=namespace_id)
+    assert got is not None
+    assert got.attributes == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_batch_null_attributes_does_not_overwrite_populated(backend: PgVectorBackend, namespace_id: UUID) -> None:
+    """Batch path: upsert ``{"a": 1}`` then the same key with NULL (``None``)
+    attributes — the stored attributes must stay ``{"a": 1}``.
+
+    Distinct from the empty-dict case: ``None`` binds as ``'null'::jsonb``
+    (JSONB ``none_as_null=False``), so it is caught by the guard's
+    ``jsonb_typeof(...) = 'null'`` branch rather than the ``== '{}'`` branch."""
+    eid = uuid4()
+    name = f"guard-batch-null-{uuid4()}"
+
+    await backend.upsert_entities_batch(namespace_id, [_entity(namespace_id, eid, name, {"a": 1})])
+    await backend.upsert_entities_batch(namespace_id, [_entity(namespace_id, eid, name, None)])
+
+    got = await backend.get_entity(eid, namespace_id=namespace_id)
+    assert got is not None
+    assert got.attributes == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_batch_nonempty_attributes_overwrites_without_key_union(
+    backend: PgVectorBackend, namespace_id: UUID
+) -> None:
+    """Batch path: upsert ``{"a": 1}`` then the same key with ``{"b": 2}`` —
+    the stored attributes must become EXACTLY ``{"b": 2}``.
+
+    The guard only protects against empty/NULL incoming values; a non-empty
+    incoming dict replaces the stored one wholesale. Key-union merge
+    (``{"a": 1, "b": 2}``) is intentionally OUT OF SCOPE."""
+    eid = uuid4()
+    name = f"guard-batch-overwrite-{uuid4()}"
+
+    await backend.upsert_entities_batch(namespace_id, [_entity(namespace_id, eid, name, {"a": 1})])
+    await backend.upsert_entities_batch(namespace_id, [_entity(namespace_id, eid, name, {"b": 2})])
+
+    got = await backend.get_entity(eid, namespace_id=namespace_id)
+    assert got is not None
+    assert got.attributes == {"b": 2}
+    assert "a" not in got.attributes


### PR DESCRIPTION
## Summary
- On entity upsert, an incoming **empty** (`{}`) or `NULL` `attributes` no longer overwrites a stored, populated `attributes`. The same entity recurs across batches within a single ingest, so a later empty-attribute batch previously wiped earlier-captured attributes — this stops that data loss, even in a clean namespace.
- **Neo4j** (`attributes` stored as a JSON string): the `ON MATCH SET` clause of the batch upsert (`_UPSERT_CYPHER`) and the single-entity `update_entity` path now keep the existing value when the incoming string is `NULL`, `'{}'`, or empty, via `CASE WHEN ... THEN e.attributes ELSE row.attributes END`.
- **pgvector** (`attributes` stored as JSONB): the `ON CONFLICT DO UPDATE` set-clause keeps the existing column when the incoming value is SQL `NULL` or `{}`::jsonb, via a `CASE`. The `NULL` branch uses an explicit `IS NULL` check (since `NULL = '{}'::jsonb` is `NULL`, not false).
- A **non-empty** incoming value still overwrites the stored dict wholesale. Deep key-union merge of old + new keys is intentionally **out of scope** (filed separately if wanted).

## Test plan
- [x] Unit tests: no regressions introduced by this change
- [ ] Integration tests (both Neo4j and pgvector lanes) — added under `tests/integration/`, exercised in CI (require live Postgres/Neo4j)
- [x] Manual verification: confirmed the guard matches the serializer — an empty dict serializes to `'{}'` and `None` to a `NULL`, so every empty representation is fenced; a non-empty dict overwrites and is asserted to replace (not union) the stored value

Fixes #1545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated entity upsert behavior across Neo4j and PostgreSQL/pgvector to preserve existing `attributes` when the incoming payload is `null` or empty; non-empty payloads still fully overwrite.
  - Prevented creation of unintended `EntityVersion` snapshots and `SUPERSEDES` edges during no-op (empty/NULL) re-upserts.
- **Tests**
  - Expanded Neo4j integration tests to verify overwrite vs no-overwrite behavior and assert correct version-chain/edge creation.
  - Added pgvector integration tests covering the same empty/NULL/non-empty semantics for both single and batch upserts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->