### PR TITLE
Add ungated per-type attribute-schema hints to extraction prompts

### DIFF
--- a/docs/extraction/expertise-system.md
+++ b/docs/extraction/expertise-system.md
@@ -373,6 +373,8 @@ Prompts support Jinja2 templating:
 
 Prompts render in a Jinja `ImmutableSandboxedEnvironment`; unsafe constructs (dunder/private attribute access, mutating methods) are rejected and raise `SecurityError`.
 
+Besides any keys you pass via `context`, templates can reference `{{ tool_context }}` and `{{ attribute_schema }}`. `{{ attribute_schema }}` renders the per-type attribute-key hints — each entity type's `required`/`optional` keys. The built-in prompts inject it automatically; a custom `extraction_prompt` must interpolate `{{ attribute_schema }}` explicitly to include those per-type keys.
+
 ```yaml
 system_prompt: |
   You are an expert at extracting information about {{ domain }} companies.

--- a/docs/extraction/extractors.md
+++ b/docs/extraction/extractors.md
@@ -198,6 +198,8 @@ expertise = ExpertiseConfig(
 
 Custom prompts render in a Jinja `ImmutableSandboxedEnvironment`; unsafe constructs (dunder/private attribute access, mutating methods) are rejected and raise `SecurityError`.
 
+Available variables include any keys you pass via `context` plus `{{ tool_context }}` and `{{ attribute_schema }}`. Interpolate `{{ attribute_schema }}` to include the per-type attribute-key hints (each entity type's `required`/`optional` keys); the built-in prompts add it automatically, but a custom template must reference it explicitly.
+
 ```python
 expertise = ExpertiseConfig(
     name="custom",

--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -1808,21 +1808,48 @@ class LLMEntityExtractor(EntityExtractor):
                 if key != "fields" and isinstance(values, list):
                     lines.append(f"  {key}: {', '.join(str(v) for v in values)}")
 
-        # Add attribute schema hints from entity types
-        if expertise.entity_types:
-            lines.append("\nEXPECTED ENTITY ATTRIBUTES:")
-            for et in expertise.entity_types:
-                required = et.attributes.get("required", [])
-                optional = et.attributes.get("optional", [])
-                if required or optional:
-                    parts = []
-                    if required:
-                        parts.append(f"required: {', '.join(required)}")
-                    if optional:
-                        parts.append(f"optional: {', '.join(optional)}")
-                    lines.append(f"  {et.name}: {'; '.join(parts)}")
-
         return "\n".join(lines)
+
+    def _build_attribute_schema_block(
+        self,
+        expertise: ExpertiseConfig | None,
+        entity_types: list[str] | None,
+    ) -> str:
+        """Build the per-type ATTRIBUTE SCHEMA hint block from the ontology.
+
+        For each extracted entity type that declares attributes in the
+        ExpertiseConfig, list its required/optional attribute key names so the
+        model knows which keys to populate. The keys are hints only — the model
+        prefers them but is not constrained to them, and emission still rides the
+        general ``attributes`` {"key", "value"}-pair channel.
+
+        Args:
+            expertise: Optional ExpertiseConfig carrying per-type attribute schemas.
+            entity_types: Resolved entity-type names being extracted.
+
+        Returns:
+            The schema block, or "" when there is no expertise or when no
+            extracted type declares any attributes.
+        """
+        if expertise is None or not entity_types:
+            return ""
+
+        by_name = {et.name: et for et in expertise.entity_types}
+        lines: list[str] = []
+        for type_name in entity_types:
+            et = by_name.get(type_name)
+            if et is None:
+                continue
+            required = et.attributes.get("required", [])
+            optional = et.attributes.get("optional", [])
+            if not required and not optional:
+                continue
+            lines.append(f"{et.name}: required=[{', '.join(required)}]; optional=[{', '.join(optional)}]")
+
+        if not lines:
+            return ""
+
+        return "ATTRIBUTE SCHEMA (emit these keys in attributes when present):\n" + "\n".join(lines)
 
     @staticmethod
     def _build_document_context(context: dict[str, Any] | None) -> str:
@@ -1906,6 +1933,7 @@ class LLMEntityExtractor(EntityExtractor):
                     "entity_types": entity_types,
                     "relationship_types": relationship_types,
                     "tool_context": tool_context,
+                    "attribute_schema": self._build_attribute_schema_block(expertise, entity_types),
                 }
                 return composer.render_prompt(
                     expertise.extraction_prompt,
@@ -1937,6 +1965,12 @@ class LLMEntityExtractor(EntityExtractor):
             text=text[:8000],  # Truncate very long texts
             document_context=document_context,
         )
+        # Per-type attribute keys: names which keys to emit on top of the
+        # general attributes nudge baked into the template. Prepended alongside
+        # tool_context so both lead the prompt rather than trail the text.
+        attribute_schema = self._build_attribute_schema_block(expertise, entity_types)
+        if attribute_schema:
+            prompt = attribute_schema + "\n\n" + prompt
         if tool_context:
             prompt = tool_context + "\n\n" + prompt
         return prompt
@@ -2345,6 +2379,12 @@ class LLMEntityExtractor(EntityExtractor):
 
         sections = "\n".join(f"=== SECTION {i + 1} ===\n{text[:4000]}" for i, text in enumerate(texts))
 
+        # Per-type attribute keys: computed once from the original expertise.
+        # Delivered to the custom multi-section builder as the {{ attribute_schema }}
+        # template variable (mirroring tool_context), and placed adjacent to the
+        # general attributes nudge in the hardcoded fallback builder.
+        attribute_schema = self._build_attribute_schema_block(expertise, entity_types)
+
         # If expertise has custom extraction prompt, use it with multi-section adaptation
         if expertise and expertise.extraction_prompt:
             from khora.extraction.skills.composer import ExpertiseComposer
@@ -2371,6 +2411,7 @@ For each entity, emit "attributes" as an array of {"key": ..., "value": ...} str
                 "entity_types": entity_types,
                 "relationship_types": relationship_types,
                 "tool_context": tool_context or "",
+                "attribute_schema": attribute_schema,
             }
             try:
                 prompt = composer.render_prompt(
@@ -2390,6 +2431,7 @@ For each entity, emit "attributes" as an array of {"key": ..., "value": ...} str
         # Fallback to hardcoded prompt (existing behavior)
         if not expertise or not expertise.extraction_prompt:
             tool_prefix = f"{tool_context}\n\n" if tool_context else ""
+            attr_schema_section = f"\n\n{attribute_schema}" if attribute_schema else ""
             prompt = f"""{tool_prefix}Extract entities, relationships, and events from each text section below.
 
 Entity types to find: {", ".join(entity_types)}
@@ -2404,7 +2446,7 @@ Return a JSON object with a "sections" array, one object per section:
 ]}}
 
 Each section follows the same entity/relationship/event format.
-For each entity, emit "attributes" as an array of {{"key": ..., "value": ...}} string pairs drawn from its salient fields (identifiers, emails, state, urls, dates, etc.).
+For each entity, emit "attributes" as an array of {{"key": ..., "value": ...}} string pairs drawn from its salient fields (identifiers, emails, state, urls, dates, etc.).{attr_schema_section}
 Return ONLY valid JSON, no other text."""
 
         try:

--- a/src/khora/extraction/extractors/llm.py
+++ b/src/khora/extraction/extractors/llm.py
@@ -1840,8 +1840,10 @@ class LLMEntityExtractor(EntityExtractor):
             et = by_name.get(type_name)
             if et is None:
                 continue
-            required = et.attributes.get("required", [])
-            optional = et.attributes.get("optional", [])
+            # Coerce present-but-None sides: an empty YAML scalar ("required:")
+            # parses to None, which would blow up the ", ".join below.
+            required = et.attributes.get("required") or []
+            optional = et.attributes.get("optional") or []
             if not required and not optional:
                 continue
             lines.append(f"{et.name}: required=[{', '.join(required)}]; optional=[{', '.join(optional)}]")

--- a/src/khora/extraction/skills/composer.py
+++ b/src/khora/extraction/skills/composer.py
@@ -137,7 +137,16 @@ class ExpertiseComposer:
         - tool_schemas: Tool schema dict
         - tools: List of tool names
         - parent_prompt: Parent's system prompt (for inheritance)
-        - context: Any additional context passed in
+        - source_tool: Name of the source tool for the content, if any
+        - tool_context: Source/tool field-context block ("" when absent)
+        - attribute_schema: Per-type ATTRIBUTE SCHEMA block naming each entity
+          type's required/optional attribute keys, supplied on the extraction
+          path. A custom ``extraction_prompt`` must interpolate
+          ``{{ attribute_schema }}`` to surface these per-type keys — unlike the
+          general "emit attributes" nudge, which is baked into the built-in
+          prompt text and is always present. Renders "" when no extracted type
+          declares attributes.
+        - context: Any additional context passed in (e.g. ``text``)
 
         Args:
             template: Jinja2 template string

--- a/tests/unit/test_extraction_llm.py
+++ b/tests/unit/test_extraction_llm.py
@@ -417,6 +417,212 @@ class TestRenderPrompts:
         assert len(prompt) < 20000
 
 
+class TestAttributeSchemaBlock:
+    """Tests for the ontology-driven ATTRIBUTE SCHEMA block (per-type keys)."""
+
+    _HEADER = "ATTRIBUTE SCHEMA (emit these keys in attributes when present):"
+
+    @staticmethod
+    def _expertise():
+        from khora.extraction.skills.base import EntityTypeConfig, ExpertiseConfig
+
+        return ExpertiseConfig(
+            name="support",
+            entity_types=[
+                EntityTypeConfig(
+                    name="PERSON",
+                    attributes={"required": ["email"], "optional": ["title", "department"]},
+                ),
+                # optional side omitted → must render as optional=[]
+                EntityTypeConfig(name="TICKET", attributes={"required": ["identifier", "status"]}),
+                # required side omitted → must render as required=[]
+                EntityTypeConfig(name="ORGANIZATION", attributes={"optional": ["industry"]}),
+                # declares no attributes at all → excluded entirely
+                EntityTypeConfig(name="CONCEPT"),
+            ],
+        )
+
+    def test_block_lists_declaring_types(self) -> None:
+        """Header plus one line per declaring type, using the ontology key names."""
+        extractor = LLMEntityExtractor(model="test")
+        block = extractor._build_attribute_schema_block(
+            self._expertise(), ["PERSON", "TICKET", "ORGANIZATION", "CONCEPT"]
+        )
+        assert block.startswith(self._HEADER)
+        assert "PERSON: required=[email]; optional=[title, department]" in block
+        assert "TICKET: required=[identifier, status]; optional=[]" in block
+        assert "ORGANIZATION: required=[]; optional=[industry]" in block
+        # CONCEPT declares no attributes → no line
+        assert "CONCEPT" not in block
+
+    def test_only_resolved_types_included(self) -> None:
+        """A declared type absent from the resolved entity_types list is excluded."""
+        extractor = LLMEntityExtractor(model="test")
+        block = extractor._build_attribute_schema_block(self._expertise(), ["TICKET"])
+        assert "TICKET: required=[identifier, status]; optional=[]" in block
+        assert "PERSON" not in block
+        assert "ORGANIZATION" not in block
+
+    def test_empty_when_no_expertise(self) -> None:
+        extractor = LLMEntityExtractor(model="test")
+        assert extractor._build_attribute_schema_block(None, ["PERSON"]) == ""
+
+    def test_empty_when_no_declaring_types(self) -> None:
+        from khora.extraction.skills.base import EntityTypeConfig, ExpertiseConfig
+
+        extractor = LLMEntityExtractor(model="test")
+        expertise = ExpertiseConfig(name="x", entity_types=[EntityTypeConfig(name="CONCEPT")])
+        assert extractor._build_attribute_schema_block(expertise, ["CONCEPT"]) == ""
+
+    def test_empty_when_no_entity_types(self) -> None:
+        extractor = LLMEntityExtractor(model="test")
+        expertise = self._expertise()
+        assert extractor._build_attribute_schema_block(expertise, None) == ""
+        assert extractor._build_attribute_schema_block(expertise, []) == ""
+
+    def test_block_in_single_prompt_structured_ungated(self) -> None:
+        """Block appears in the single-doc structured prompt with context=None.
+
+        context=None proves the block is NOT gated on source_tool / tool_schemas.
+        """
+        extractor = LLMEntityExtractor(model="gpt-4o")  # structured-output path
+        prompt = extractor._render_extraction_prompt(
+            "Alice emailed the team.",
+            ["PERSON", "TICKET"],
+            self._expertise(),
+            None,
+            relationship_types=["KNOWS"],
+        )
+        assert self._HEADER in prompt
+        assert "PERSON: required=[email]; optional=[title, department]" in prompt
+        assert "TICKET: required=[identifier, status]; optional=[]" in prompt
+
+    def test_block_in_single_prompt_custom(self) -> None:
+        """A custom extraction_prompt receives attribute_schema via prompt_context."""
+        from khora.extraction.skills.base import EntityTypeConfig, ExpertiseConfig
+
+        extractor = LLMEntityExtractor(model="gpt-4o")
+        expertise = ExpertiseConfig(
+            name="custom",
+            extraction_prompt="Extract from: {{ text }}\n{{ attribute_schema }}",
+            entity_types=[
+                EntityTypeConfig(name="PERSON", attributes={"required": ["email"], "optional": ["title"]}),
+            ],
+        )
+        prompt = extractor._render_extraction_prompt("Alice", ["PERSON"], expertise, None, relationship_types=["KNOWS"])
+        assert self._HEADER in prompt
+        assert "PERSON: required=[email]; optional=[title]" in prompt
+
+    def test_block_absent_single_prompt_no_expertise(self) -> None:
+        extractor = LLMEntityExtractor(model="gpt-4o")
+        prompt = extractor._render_extraction_prompt("Alice", ["PERSON"], None, None, relationship_types=["KNOWS"])
+        assert "ATTRIBUTE SCHEMA" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_block_in_batch_prompt_ungated(self) -> None:
+        """Block appears in the batch (fallback) prompt with context=None.
+
+        Captures the user message sent to litellm to assert on the assembled
+        prompt without a live LLM.
+        """
+        import litellm
+
+        extractor = LLMEntityExtractor(model="gpt-4o", max_retries=1)
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps({"sections": [{"entities": [], "relationships": []}]})
+        mock_response.choices[0].finish_reason = "stop"
+        mock_response.usage = MagicMock(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+
+        captured: dict[str, object] = {}
+
+        async def fake_acompletion(*args, **kwargs):
+            captured["messages"] = kwargs["messages"]
+            return mock_response
+
+        with (
+            patch("litellm.acompletion", new_callable=AsyncMock, side_effect=fake_acompletion),
+            patch("khora.telemetry.get_collector") as mock_telem,
+        ):
+            mock_telem.return_value.record_llm_call = MagicMock()
+            await extractor._extract_multi_batch(
+                ["Alice emailed the team."],
+                ["PERSON", "TICKET"],
+                litellm,
+                expertise=self._expertise(),
+                context=None,
+                relationship_types=["KNOWS"],
+            )
+
+        user_msg = captured["messages"][1]["content"]
+        assert self._HEADER in user_msg
+        assert "PERSON: required=[email]; optional=[title, department]" in user_msg
+        assert "TICKET: required=[identifier, status]; optional=[]" in user_msg
+
+    @pytest.mark.asyncio
+    async def test_block_in_batch_prompt_custom_multi_section(self) -> None:
+        """Block appears in the batch custom multi-section path (expertise.extraction_prompt).
+
+        The fallback batch path is covered above; this exercises the other batch
+        injection site. Delivery is symmetric with the single custom path: the
+        schema arrives as the {{ attribute_schema }} template variable (mirroring
+        tool_context), so the custom template references it explicitly.
+        context=None keeps it ungated.
+        """
+        import litellm
+
+        from khora.extraction.skills.base import EntityTypeConfig, ExpertiseConfig
+
+        expertise = ExpertiseConfig(
+            name="support",
+            extraction_prompt="Extract entities from the sections:\n{{ text }}\n{{ attribute_schema }}",
+            entity_types=[
+                EntityTypeConfig(
+                    name="PERSON",
+                    attributes={"required": ["email"], "optional": ["title", "department"]},
+                ),
+                EntityTypeConfig(name="TICKET", attributes={"required": ["identifier", "status"]}),
+            ],
+        )
+
+        extractor = LLMEntityExtractor(model="gpt-4o", max_retries=1)
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps({"sections": [{"entities": [], "relationships": []}]})
+        mock_response.choices[0].finish_reason = "stop"
+        mock_response.usage = MagicMock(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+
+        captured: dict[str, object] = {}
+
+        async def fake_acompletion(*args, **kwargs):
+            captured["messages"] = kwargs["messages"]
+            return mock_response
+
+        with (
+            patch("litellm.acompletion", new_callable=AsyncMock, side_effect=fake_acompletion),
+            patch("khora.telemetry.get_collector") as mock_telem,
+        ):
+            mock_telem.return_value.record_llm_call = MagicMock()
+            await extractor._extract_multi_batch(
+                ["Alice emailed the team."],
+                ["PERSON", "TICKET"],
+                litellm,
+                expertise=expertise,
+                context=None,
+                relationship_types=["KNOWS"],
+            )
+
+        user_msg = captured["messages"][1]["content"]
+        # The custom template literal proves the custom branch rendered rather than
+        # silently falling through to the hardcoded fallback (which also emits the block).
+        assert "Extract entities from the sections:" in user_msg
+        assert self._HEADER in user_msg
+        assert "PERSON: required=[email]; optional=[title, department]" in user_msg
+        assert "TICKET: required=[identifier, status]; optional=[]" in user_msg
+
+
 class TestExtract:
     """Tests for the extract method."""
 

--- a/tests/unit/test_extraction_llm.py
+++ b/tests/unit/test_extraction_llm.py
@@ -480,6 +480,37 @@ class TestAttributeSchemaBlock:
         assert extractor._build_attribute_schema_block(expertise, None) == ""
         assert extractor._build_attribute_schema_block(expertise, []) == ""
 
+    def test_present_but_none_attribute_side_coerced(self) -> None:
+        """An empty YAML scalar ("optional:") parses to None; must not crash.
+
+        Built through ExpertiseConfig.from_dict (the real YAML load path), which
+        passes attributes straight through, so either side can be present-but-None.
+        The block coerces None -> [] rather than raising TypeError in the ", ".join.
+        """
+        from khora.extraction.skills.base import ExpertiseConfig
+
+        extractor = LLMEntityExtractor(model="test")
+        # Shape mirrors `yaml.safe_load` output: an empty scalar becomes None.
+        expertise = ExpertiseConfig.from_dict(
+            {
+                "name": "yaml_edge",
+                "entity_types": [
+                    # optional side present-but-None, required a real list
+                    {"name": "NAME", "attributes": {"required": ["name"], "optional": None}},
+                    # required side present-but-None, optional a real list
+                    {"name": "FOO", "attributes": {"required": None, "optional": ["x"]}},
+                    # both sides present-but-None → declares nothing → omitted
+                    {"name": "BAZ", "attributes": {"required": None, "optional": None}},
+                ],
+            }
+        )
+        # Must not raise, and each None side renders as [].
+        block = extractor._build_attribute_schema_block(expertise, ["NAME", "FOO", "BAZ"])
+        assert "NAME: required=[name]; optional=[]" in block
+        assert "FOO: required=[]; optional=[x]" in block
+        # BAZ declares no usable attributes → no line
+        assert "BAZ" not in block
+
     def test_block_in_single_prompt_structured_ungated(self) -> None:
         """Block appears in the single-doc structured prompt with context=None.
 

--- a/tests/unit/test_extraction_llm_coverage.py
+++ b/tests/unit/test_extraction_llm_coverage.py
@@ -247,7 +247,9 @@ class TestBuildContexts:
         assert "author" in out
         assert "labels" in out
 
-    def test_tool_context_with_entity_attribute_hints(self) -> None:
+    def test_tool_context_omits_entity_attribute_hints(self) -> None:
+        """Per-type attribute keys no longer live in tool context (moved to the
+        ungated ATTRIBUTE SCHEMA block); tool fields still render."""
         ex = LLMEntityExtractor()
         et = MagicMock()
         et.name = "PERSON"
@@ -258,8 +260,10 @@ class TestBuildContexts:
         expertise.entity_types = [et]
 
         out = ex._build_tool_context(expertise, {"source_tool": "slack"})
-        assert "PERSON" in out
-        assert "required: name" in out
+        assert "EXPECTED ENTITY ATTRIBUTES" not in out
+        assert "required: name" not in out
+        # SOURCE CONTEXT tool-field output stays intact.
+        assert "author" in out
 
     def test_document_context_empty(self) -> None:
         assert LLMEntityExtractor._build_document_context(None) == ""

--- a/tests/unit/test_saas_extraction.py
+++ b/tests/unit/test_saas_extraction.py
@@ -56,8 +56,13 @@ class TestToolSchemaContext:
         result = extractor._build_tool_context(expertise, None)
         assert result == ""
 
-    def test_build_tool_context_includes_attribute_hints(self):
-        """_build_tool_context includes attribute schema hints from entity types."""
+    def test_build_tool_context_omits_attribute_hints(self):
+        """_build_tool_context no longer emits the EXPECTED ENTITY ATTRIBUTES block.
+
+        Per-type attribute keys moved to _build_attribute_schema_block (ungated,
+        injected directly into the prompt) so they are no longer double-listed
+        here. The SOURCE CONTEXT tool-field output must stay intact.
+        """
         from khora.extraction.skills.base import EntityTypeConfig
 
         extractor = LLMEntityExtractor(model="test")
@@ -69,14 +74,17 @@ class TestToolSchemaContext:
                     attributes={"required": ["identifier", "title", "status"], "optional": ["priority"]},
                 )
             ],
-            tool_schemas={"linear": {"issue": {"fields": ["identifier"]}}},
+            tool_schemas={"linear": {"issue": {"fields": ["identifier", "title"]}}},
         )
         context = {"source_tool": "linear"}
 
         result = extractor._build_tool_context(expertise, context)
-        assert "EXPECTED ENTITY ATTRIBUTES" in result
-        assert "TICKET" in result
-        assert "identifier" in result
+        # The attribute-schema block is gone from tool context.
+        assert "EXPECTED ENTITY ATTRIBUTES" not in result
+        # SOURCE CONTEXT tool-field output is unchanged.
+        assert "SOURCE CONTEXT" in result
+        assert "linear" in result
+        assert "issue fields: identifier, title" in result
 
 
 class TestExtractedEntitySourceTool:


### PR DESCRIPTION
## Summary
- Add `_build_attribute_schema_block`, which lists each extracted entity type's declared `required`/`optional` attribute keys so the model knows which attribute keys to populate on extracted entities.
- The block is built from the **resolved** entity types and is **ungated** — no longer tied to tool schemas or source-tool context — so it reaches both the single-document (`_render_extraction_prompt`) and batch (`_extract_multi_batch`) prompt paths, including when no source-tool context is present.
- Default/structured and hardcoded-fallback templates inject the block directly (adjacent to the existing general "emit attributes" nudge, without duplicating it); custom `extraction_prompt` templates receive it as a template variable on both single and batch paths, mirroring how tool-context is delivered.
- Remove the now-redundant per-type attribute listing from the tool-context builder to avoid double-listing; its source/tool-field output is unchanged.

## Test plan
- [x] Unit tests pass (extraction suite: 287 passed)
- [ ] Integration tests pass (run in CI)
- [x] Block present on single + batch prompts incl. no-source-tool-context case; absent when no expertise / no declaring type; tool-context builder no longer double-lists (its field output intact)

Fixes #1543

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an ontology-driven **ATTRIBUTE SCHEMA** prompt block for LLM entity extraction, listing required/optional attribute keys per entity type.
  * Included the attribute schema in single-document and batch/multi-section extraction prompts, including custom templates via `{{ attribute_schema }}`.

* **Bug Fixes**
  * Removed inline “expected entity attributes” hinting from the tool context so extraction guidance uses the standalone schema block.
  * Omitted schema details when expertise or attribute declarations are missing.

* **Documentation**
  * Updated extraction docs to explain `{{ tool_context }}` and `{{ attribute_schema }}` usage in custom prompts.

* **Tests**
  * Expanded unit coverage for attribute-schema rendering and prompt injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->