### PR TITLE
docs: fix 404 README links to the ADK and OpenAI Agents guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Opt-in adapters for the major agentic frameworks. Each adapter is in its own ext
 |---|---|---|
 | [CrewAI](https://docs.deyta.ai/khora/integrations/crewai) | `uv add khora[crewai]` | `KhoraMemory` - drop-in storage backend for CrewAI's unified `Memory`. |
 | [LangGraph](https://docs.deyta.ai/khora/integrations/langgraph) | `uv add khora[langgraph]` | `KhoraStore` - `BaseStore` implementation for `StateGraph` semantic long-term memory. |
-| [Google ADK](https://docs.deyta.ai/khora/integrations/google_adk) | `uv add khora[google-adk]` | `KhoraMemoryService` - `BaseMemoryService` drop-in for ADK `Runner`. |
-| [OpenAI Agents SDK](https://docs.deyta.ai/khora/integrations/openai_agents) | `uv add khora[openai-agents]` | `KhoraSession`, `khora_recall_tool`, `KhoraMemoryHooks`. |
+| [Google ADK](https://docs.deyta.ai/khora/integrations/google-adk) | `uv add khora[google-adk]` | `KhoraMemoryService` - `BaseMemoryService` drop-in for ADK `Runner`. |
+| [OpenAI Agents SDK](https://docs.deyta.ai/khora/integrations/openai-agents) | `uv add khora[openai-agents]` | `KhoraSession`, `khora_recall_tool`, `KhoraMemoryHooks`. |
 | [LlamaIndex](https://docs.deyta.ai/khora/integrations/llamaindex) | `uv add khora[llamaindex]` | `KhoraRetriever`, `KhoraMemoryBlock`. |
 
 See the [docs](https://docs.deyta.ai/khora) for per-adapter guides and the "write your own" Protocol surface.


### PR DESCRIPTION
## What

Two integration links in `README.md` use underscore slugs, but the docs site normalizes to hyphens, so both 404:

| Line | Before | After |
|---|---|---|
| 92 | `/khora/integrations/google_adk` (404) | `/khora/integrations/google-adk` (200) |
| 93 | `/khora/integrations/openai_agents` (404) | `/khora/integrations/openai-agents` (200) |

The underscores are leftovers from the old in-repo filenames (`docs/integrations/google_adk.md`).

## Why now

`README.md` renders on both the GitHub repo page and the PyPI project page, so these are the most visible links in the project.

## Verification

Checked every `docs.deyta.ai` URL in `README.md`, not just the two changed — all six return 200:

```
200  https://docs.deyta.ai/khora
200  https://docs.deyta.ai/khora/integrations/crewai
200  https://docs.deyta.ai/khora/integrations/google-adk
200  https://docs.deyta.ai/khora/integrations/langgraph
200  https://docs.deyta.ai/khora/integrations/llamaindex
200  https://docs.deyta.ai/khora/integrations/openai-agents
```

These were the only two underscore occurrences in the repo (`git grep -nE 'docs\.deyta\.ai/khora/integrations/[a-z]+_[a-z]+'` matches nothing else).

`ruff format --check` and `ruff check` pass. I did not run `make test`: the diff is two markdown URL strings, and no test reads `README.md` (the `README` hits under `tests/` are a comment in `test_claudemd_structure.py`, which reads CLAUDE.md, and a docstring pointing at the golden-set directory's own README). CI covers it regardless.

Independent of #1536 — different lines, no conflict in either merge order.

Fixes #1571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated integration documentation links for the Google ADK and OpenAI Agents SDK adapters.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->