### PR TITLE
Pin a total order on document listing across relational backends

### DIFF
--- a/src/khora/engines/protocol.py
+++ b/src/khora/engines/protocol.py
@@ -324,7 +324,7 @@ class MemoryEngineProtocol(Protocol):
         *,
         limit: int = 100,
     ) -> list[Document]:
-        """List documents in a namespace.
+        """List documents in a namespace, newest first, ties broken by descending id.
 
         Args:
             namespace_id: Namespace UUID

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -2883,7 +2883,7 @@ class Khora:
         namespace: str | UUID,
         limit: int = 100,
     ) -> list[Document]:
-        """List documents in a namespace.
+        """List documents in a namespace, newest first, ties broken by descending id.
 
         Args:
             namespace: Namespace UUID (as UUID or string)

--- a/src/khora/storage/backends/base.py
+++ b/src/khora/storage/backends/base.py
@@ -145,7 +145,7 @@ class RelationalBackendProtocol(Protocol):
         limit: int = 100,
         offset: int = 0,
     ) -> list[Document]:
-        """List documents in a namespace."""
+        """List documents in a namespace, newest first, ties broken by descending id."""
         ...
 
     @abstractmethod

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -477,7 +477,7 @@ class PostgreSQLBackend(AsyncSessionMixin):
         limit: int = 100,
         offset: int = 0,
     ) -> list[Document]:
-        """List documents in a namespace."""
+        """List documents in a namespace, newest first, ties broken by descending id."""
         async with self._get_session() as session:
             query = select(DocumentModel).where(DocumentModel.namespace_id == namespace_id)
             if status:

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -484,7 +484,7 @@ class PostgreSQLBackend(AsyncSessionMixin):
                 query = query.where(DocumentModel.status == status)
             if updated_before is not None:
                 query = query.where(DocumentModel.updated_at < updated_before)
-            query = query.limit(limit).offset(offset).order_by(DocumentModel.created_at.desc())
+            query = query.limit(limit).offset(offset).order_by(DocumentModel.created_at.desc(), DocumentModel.id.desc())
             result = await session.execute(query)
             return [self._document_model_to_domain(m) for m in result.scalars().all()]
 

--- a/src/khora/storage/backends/sqlite.py
+++ b/src/khora/storage/backends/sqlite.py
@@ -448,7 +448,7 @@ class SQLiteRelationalBackend:
         where = " AND ".join(conditions)
         params.extend([limit, offset])
         cursor = await self._conn.execute(
-            f"SELECT * FROM documents WHERE {where} ORDER BY created_at DESC LIMIT ? OFFSET ?",  # noqa: S608
+            f"SELECT * FROM documents WHERE {where} ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?",  # noqa: S608
             params,
         )
         rows = await cursor.fetchall()

--- a/src/khora/storage/backends/sqlite_lance/relational.py
+++ b/src/khora/storage/backends/sqlite_lance/relational.py
@@ -468,7 +468,7 @@ class SQLiteLanceRelationalAdapter(AsyncSessionMixin):
                 query = query.where(DocumentModel.status == status)
             if updated_before is not None:
                 query = query.where(DocumentModel.updated_at < updated_before)
-            query = query.limit(limit).offset(offset).order_by(DocumentModel.created_at.desc())
+            query = query.limit(limit).offset(offset).order_by(DocumentModel.created_at.desc(), DocumentModel.id.desc())
             result = await session.execute(query)
             return [self._document_model_to_domain(m) for m in result.scalars().all()]
 

--- a/src/khora/storage/backends/surrealdb/relational.py
+++ b/src/khora/storage/backends/surrealdb/relational.py
@@ -381,7 +381,7 @@ class SurrealDBRelationalAdapter:
         limit: int = 100,
         offset: int = 0,
     ) -> list[Document]:
-        """List documents in a namespace, newest first."""
+        """List documents in a namespace, newest first, ties broken by descending id."""
         ns_str = str(namespace_id)
         conditions = ["namespace_id = $ns"]
         params: dict = {"ns": ns_str, "lim": limit, "off": offset}
@@ -393,7 +393,7 @@ class SurrealDBRelationalAdapter:
             params["updated_before"] = updated_before.isoformat()
         where = " AND ".join(conditions)
         rows = await self._conn.query(
-            f"SELECT * FROM document WHERE {where} ORDER BY created_at DESC LIMIT $lim START $off",  # noqa: S608
+            f"SELECT * FROM document WHERE {where} ORDER BY created_at DESC, id DESC LIMIT $lim START $off",  # noqa: S608
             params,
         )
         return [self._row_to_document(r) for r in rows]

--- a/tests/integration/storage/backends/surrealdb/test_list_documents_order.py
+++ b/tests/integration/storage/backends/surrealdb/test_list_documents_order.py
@@ -1,0 +1,111 @@
+"""``SurrealDBRelationalAdapter.list_documents`` total-order tests.
+
+``list_documents`` sorts on ``(created_at DESC, id DESC)``. Bulk ingest stamps
+many documents with the same ``created_at``; on that seed ``created_at`` alone
+leaves the sort under-determined and row positions are not addressable.
+
+The SurrealDB leg is worth its own coverage because ``id`` is not a plain UUID
+column here - it is a ``RecordID`` (``document:<uuid>``), so the SurrealQL
+``ORDER BY id DESC`` sorts record ids rather than UUIDs. These tests pin that
+the resulting sequence is a strict total order and that it agrees with
+descending UUID order, which is what a later keyset cursor would rely on.
+
+See :mod:`tests.test_helpers.document_order` for why the seed is non-vacuous.
+
+Runs against an in-memory SurrealDB (``mode="memory"``) - no docker required.
+Skipped when the ``surrealdb`` extra is not installed.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("surrealdb")
+
+from khora.core.models import Document, MemoryNamespace, TenancyMode  # noqa: E402
+from khora.storage.backends.surrealdb.connection import SurrealDBConnection  # noqa: E402
+from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter  # noqa: E402
+from tests.test_helpers.document_order import (  # noqa: E402
+    id_ladder,
+    seed_order,
+    walk_pages,
+)
+
+pytestmark = pytest.mark.integration
+
+SEED_SIZE = 12
+
+
+@pytest.fixture
+async def adapter():
+    conn = SurrealDBConnection(mode="memory", namespace="khora_test", database="doc_order")
+    await conn.connect()
+    adapter = SurrealDBRelationalAdapter(conn)
+    try:
+        yield adapter
+    finally:
+        await conn.disconnect()
+
+
+@pytest.fixture
+async def namespace(adapter):
+    nid = uuid4()
+    ns = MemoryNamespace(id=nid, namespace_id=nid, tenancy_mode=TenancyMode.SHARED)
+    return await adapter.create_namespace(ns)
+
+
+async def _seed_tied_documents(adapter, namespace) -> list:
+    """Seed ``SEED_SIZE`` documents sharing one ``created_at``.
+
+    Rows are written in ``seed_order`` (non-monotonic by id) so that neither
+    insertion order nor its reverse can coincide with the expected sequence.
+    """
+    shared_created_at = datetime.now(UTC)
+    ids = id_ladder(SEED_SIZE)
+    for i, doc_id in enumerate(seed_order(ids)):
+        await adapter.create_document(
+            Document(
+                id=doc_id,
+                namespace_id=namespace.id,
+                content="tied content",
+                checksum=f"sum-{i}",
+                created_at=shared_created_at,
+                updated_at=shared_created_at,
+            )
+        )
+    return ids
+
+
+async def test_ties_break_on_id_desc_and_repeat_identically(adapter, namespace) -> None:
+    ids = await _seed_tied_documents(adapter, namespace)
+
+    docs = await adapter.list_documents(namespace.id)
+
+    # The tie is real: if these differed, ``created_at`` alone would decide the
+    # order and the id tie-break would never be exercised.
+    assert len({d.created_at for d in docs}) == 1
+    # RecordID ordering agrees with descending UUID order.
+    assert [d.id for d in docs] == sorted(ids, reverse=True)
+
+    # Same query, same answer - the order is a property of the query, not of
+    # whatever the scan happened to produce on the first call.
+    for _ in range(2):
+        assert [d.id for d in await adapter.list_documents(namespace.id)] == [d.id for d in docs]
+
+
+async def test_offset_pagination_is_exhaustive_and_non_overlapping(adapter, namespace) -> None:
+    ids = await _seed_tied_documents(adapter, namespace)
+    expected = sorted(ids, reverse=True)
+
+    # Page size deliberately does not divide the seed size, so the final page is
+    # short and an off-by-one at the boundary shows up.
+    pages = await walk_pages(adapter.list_documents, namespace.id, page_size=5)
+    seen = [d.id for page in pages for d in page]
+
+    assert [len(p) for p in pages] == [5, 5, 2]
+    assert len(seen) == len(set(seen))  # no document served twice
+    assert set(seen) == set(expected)  # every document served
+    assert seen == expected  # and in the same order as the unpaged read

--- a/tests/integration/storage/backends/surrealdb/test_list_documents_order.py
+++ b/tests/integration/storage/backends/surrealdb/test_list_documents_order.py
@@ -18,7 +18,6 @@ Skipped when the ``surrealdb`` extra is not installed.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
@@ -29,8 +28,8 @@ from khora.core.models import Document, MemoryNamespace, TenancyMode  # noqa: E4
 from khora.storage.backends.surrealdb.connection import SurrealDBConnection  # noqa: E402
 from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter  # noqa: E402
 from tests.test_helpers.document_order import (  # noqa: E402
-    id_ladder,
-    seed_order,
+    OrderSeed,
+    order_seed,
     walk_pages,
 )
 
@@ -57,38 +56,43 @@ async def namespace(adapter):
     return await adapter.create_namespace(ns)
 
 
-async def _seed_tied_documents(adapter, namespace) -> list:
-    """Seed ``SEED_SIZE`` documents sharing one ``created_at``.
+async def _seed_ordered_documents(adapter, namespace) -> OrderSeed:
+    """Seed ``SEED_SIZE`` documents pinning both sort keys.
 
     Rows are written in ``seed_order`` (non-monotonic by id) so that neither
     insertion order nor its reverse can coincide with the expected sequence.
     """
-    shared_created_at = datetime.now(UTC)
-    ids = id_ladder(SEED_SIZE)
-    for i, doc_id in enumerate(seed_order(ids)):
+    seed = order_seed(SEED_SIZE)
+    for i, (doc_id, created_at) in enumerate(seed.writes):
         await adapter.create_document(
             Document(
                 id=doc_id,
                 namespace_id=namespace.id,
                 content="tied content",
                 checksum=f"sum-{i}",
-                created_at=shared_created_at,
-                updated_at=shared_created_at,
+                created_at=created_at,
+                updated_at=created_at,
             )
         )
-    return ids
+    return seed
 
 
-async def test_ties_break_on_id_desc_and_repeat_identically(adapter, namespace) -> None:
-    ids = await _seed_tied_documents(adapter, namespace)
+async def test_orders_by_created_at_then_id_desc_and_repeats_identically(adapter, namespace) -> None:
+    seed = await _seed_ordered_documents(adapter, namespace)
 
     docs = await adapter.list_documents(namespace.id)
 
     # The tie is real: if these differed, ``created_at`` alone would decide the
     # order and the id tie-break would never be exercised.
-    assert len({d.created_at for d in docs}) == 1
+    assert len({d.created_at for d in docs if d.id in seed.tied_ids}) == 1
+
+    # ``created_at`` leads: these two rows carry the id that would put them at
+    # the opposite end, so only a leading ``created_at`` lands them here.
+    assert docs[0].id == seed.newest_id
+    assert docs[-1].id == seed.oldest_id
+
     # RecordID ordering agrees with descending UUID order.
-    assert [d.id for d in docs] == sorted(ids, reverse=True)
+    assert [d.id for d in docs] == seed.expected
 
     # Same query, same answer - the order is a property of the query, not of
     # whatever the scan happened to produce on the first call.
@@ -97,8 +101,8 @@ async def test_ties_break_on_id_desc_and_repeat_identically(adapter, namespace) 
 
 
 async def test_offset_pagination_is_exhaustive_and_non_overlapping(adapter, namespace) -> None:
-    ids = await _seed_tied_documents(adapter, namespace)
-    expected = sorted(ids, reverse=True)
+    seed = await _seed_ordered_documents(adapter, namespace)
+    expected = seed.expected
 
     # Page size deliberately does not divide the seed size, so the final page is
     # short and an off-by-one at the boundary shows up.

--- a/tests/integration/storage/test_list_documents_order_pg.py
+++ b/tests/integration/storage/test_list_documents_order_pg.py
@@ -15,14 +15,13 @@ configured ``KHORA_DATABASE_URL`` is unreachable.
 from __future__ import annotations
 
 import os
-from datetime import UTC, datetime
 
 import pytest
 
 from khora.core.models import Document, MemoryNamespace
 from khora.db.session import run_migrations
 from khora.storage.backends.postgresql import PostgreSQLBackend
-from tests.test_helpers.document_order import id_ladder, seed_order, walk_pages
+from tests.test_helpers.document_order import order_seed, walk_pages
 
 DATABASE_URL = os.environ.get(
     "KHORA_DATABASE_URL",
@@ -80,39 +79,46 @@ async def backend(_run_migrations_once):
 
 @pytest.fixture
 async def seeded(backend: PostgreSQLBackend):
-    """A fresh namespace holding ``SEED_SIZE`` documents that share ``created_at``.
+    """A fresh namespace holding ``SEED_SIZE`` documents pinning both sort keys.
 
     Rows are written in ``seed_order`` (non-monotonic by id) so that neither
     insertion order nor its reverse can coincide with the expected sequence.
     """
     ns = await backend.create_namespace(MemoryNamespace())
-    shared_created_at = datetime.now(UTC)
-    ids = id_ladder(SEED_SIZE)
-    for i, doc_id in enumerate(seed_order(ids)):
+    seed = order_seed(SEED_SIZE)
+    for i, (doc_id, created_at) in enumerate(seed.writes):
         await backend.create_document(
             Document(
                 id=doc_id,
                 namespace_id=ns.id,
                 content="tied content",
                 checksum=f"sum-{i}",
-                created_at=shared_created_at,
-                updated_at=shared_created_at,
+                created_at=created_at,
+                updated_at=created_at,
             )
         )
-    return ns, ids
+    return ns, seed
 
 
 @skip_no_pg
 class TestListDocumentsTotalOrderPg:
-    async def test_ties_break_on_id_desc_and_repeat_identically(self, backend: PostgreSQLBackend, seeded) -> None:
-        ns, ids = seeded
+    async def test_orders_by_created_at_then_id_desc_and_repeats_identically(
+        self, backend: PostgreSQLBackend, seeded
+    ) -> None:
+        ns, seed = seeded
 
         docs = await backend.list_documents(ns.id)
 
         # The tie is real: if these differed, ``created_at`` alone would decide
         # the order and the id tie-break would never be exercised.
-        assert len({d.created_at for d in docs}) == 1
-        assert [d.id for d in docs] == sorted(ids, reverse=True)
+        assert len({d.created_at for d in docs if d.id in seed.tied_ids}) == 1
+
+        # ``created_at`` leads: these two rows carry the id that would put them
+        # at the opposite end, so only a leading ``created_at`` lands them here.
+        assert docs[0].id == seed.newest_id
+        assert docs[-1].id == seed.oldest_id
+
+        assert [d.id for d in docs] == seed.expected
 
         # Same query, same answer - the order is a property of the query, not
         # of whatever the scan happened to produce on the first call.
@@ -122,8 +128,8 @@ class TestListDocumentsTotalOrderPg:
     async def test_offset_pagination_is_exhaustive_and_non_overlapping(
         self, backend: PostgreSQLBackend, seeded
     ) -> None:
-        ns, ids = seeded
-        expected = sorted(ids, reverse=True)
+        ns, seed = seeded
+        expected = seed.expected
 
         # Page size deliberately does not divide the seed size, so the final
         # page is short and an off-by-one at the boundary shows up.

--- a/tests/integration/storage/test_list_documents_order_pg.py
+++ b/tests/integration/storage/test_list_documents_order_pg.py
@@ -1,0 +1,134 @@
+"""``PostgreSQLBackend.list_documents`` total-order tests.
+
+``list_documents`` sorts on ``(created_at DESC, id DESC)``. Bulk ingest stamps
+many documents with the same ``created_at``; on that seed ``created_at`` alone
+leaves the sort under-determined - Postgres is free to return tied rows in any
+order, and its sort is not stable, so row positions are not addressable and
+offset paging can serve the same document twice or skip one.
+
+See :mod:`tests.test_helpers.document_order` for why the seed is non-vacuous.
+
+Requires a running PostgreSQL (``make dev``). Skipped automatically when the
+configured ``KHORA_DATABASE_URL`` is unreachable.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+
+import pytest
+
+from khora.core.models import Document, MemoryNamespace
+from khora.db.session import run_migrations
+from khora.storage.backends.postgresql import PostgreSQLBackend
+from tests.test_helpers.document_order import id_ladder, seed_order, walk_pages
+
+DATABASE_URL = os.environ.get(
+    "KHORA_DATABASE_URL",
+    "postgresql+asyncpg://khora:khora@localhost:5432/khora",
+)
+
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
+
+
+pytestmark = [pytest.mark.integration]
+
+SEED_SIZE = 12
+
+
+def _pg_reachable() -> bool:
+    import socket
+    from urllib.parse import urlparse
+
+    parsed = urlparse(DATABASE_URL.replace("+asyncpg", ""))
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+skip_no_pg = pytest.mark.skipif(
+    not _pg_reachable(),
+    reason="PostgreSQL not reachable (run `make dev` first)",
+)
+
+
+@pytest.fixture(scope="module")
+async def _run_migrations_once():
+    result = await run_migrations(DATABASE_URL)
+    assert result.success, f"Migrations failed: {result.error}"
+
+
+@pytest.fixture
+async def backend(_run_migrations_once):
+    be = PostgreSQLBackend(database_url=DATABASE_URL)
+    await be.connect()
+    try:
+        yield be
+    finally:
+        await be.disconnect()
+
+
+@pytest.fixture
+async def seeded(backend: PostgreSQLBackend):
+    """A fresh namespace holding ``SEED_SIZE`` documents that share ``created_at``.
+
+    Rows are written in ``seed_order`` (non-monotonic by id) so that neither
+    insertion order nor its reverse can coincide with the expected sequence.
+    """
+    ns = await backend.create_namespace(MemoryNamespace())
+    shared_created_at = datetime.now(UTC)
+    ids = id_ladder(SEED_SIZE)
+    for i, doc_id in enumerate(seed_order(ids)):
+        await backend.create_document(
+            Document(
+                id=doc_id,
+                namespace_id=ns.id,
+                content="tied content",
+                checksum=f"sum-{i}",
+                created_at=shared_created_at,
+                updated_at=shared_created_at,
+            )
+        )
+    return ns, ids
+
+
+@skip_no_pg
+class TestListDocumentsTotalOrderPg:
+    async def test_ties_break_on_id_desc_and_repeat_identically(self, backend: PostgreSQLBackend, seeded) -> None:
+        ns, ids = seeded
+
+        docs = await backend.list_documents(ns.id)
+
+        # The tie is real: if these differed, ``created_at`` alone would decide
+        # the order and the id tie-break would never be exercised.
+        assert len({d.created_at for d in docs}) == 1
+        assert [d.id for d in docs] == sorted(ids, reverse=True)
+
+        # Same query, same answer - the order is a property of the query, not
+        # of whatever the scan happened to produce on the first call.
+        for _ in range(2):
+            assert [d.id for d in await backend.list_documents(ns.id)] == [d.id for d in docs]
+
+    async def test_offset_pagination_is_exhaustive_and_non_overlapping(
+        self, backend: PostgreSQLBackend, seeded
+    ) -> None:
+        ns, ids = seeded
+        expected = sorted(ids, reverse=True)
+
+        # Page size deliberately does not divide the seed size, so the final
+        # page is short and an off-by-one at the boundary shows up.
+        pages = await walk_pages(backend.list_documents, ns.id, page_size=5)
+        seen = [d.id for page in pages for d in page]
+
+        assert [len(p) for p in pages] == [5, 5, 2]
+        assert len(seen) == len(set(seen))  # no document served twice
+        assert set(seen) == set(expected)  # every document served
+        assert seen == expected  # and in the same order as the unpaged read

--- a/tests/integration/storage/test_list_documents_order_pg.py
+++ b/tests/integration/storage/test_list_documents_order_pg.py
@@ -26,7 +26,9 @@ from tests.test_helpers.document_order import id_ladder, seed_order, walk_pages
 
 DATABASE_URL = os.environ.get(
     "KHORA_DATABASE_URL",
-    "postgresql+asyncpg://khora:khora@localhost:5432/khora",
+    # This repo's compose puts Postgres on 5434 (see compose.yaml); defaulting to
+    # 5432 would make the whole class silently skip on a local `make test`.
+    "postgresql+asyncpg://khora:khora@localhost:5434/khora",
 )
 
 if DATABASE_URL.startswith("postgresql://"):

--- a/tests/test_helpers/document_order.py
+++ b/tests/test_helpers/document_order.py
@@ -1,9 +1,12 @@
-"""Seed + paging helpers for the ``list_documents`` tie-break ordering tests.
+"""Seed + paging helpers for the ``list_documents`` ordering tests.
 
-``list_documents`` sorts on ``(created_at DESC, id DESC)``. Proving the
-``id DESC`` leg requires a seed where ``created_at`` alone cannot decide the
-order, and an expected sequence that is fixed by construction rather than by
-chance - hence :func:`id_ladder` and :func:`seed_order`.
+``list_documents`` sorts on ``(created_at DESC, id DESC)``, and each key needs
+its own witness. Proving the ``id DESC`` leg requires rows where ``created_at``
+alone cannot decide the order, and an expected sequence that is fixed by
+construction rather than by chance - hence :func:`id_ladder` and
+:func:`seed_order`. Proving that ``created_at`` LEADS requires rows outside that
+tie block whose timestamp and id disagree. :func:`order_seed` builds both halves
+in one seed.
 
 Shared by the four backend test modules (postgresql, raw sqlite, sqlite_lance,
 surrealdb) so the "why this seed is not vacuous" reasoning lives in one place.
@@ -12,6 +15,8 @@ surrealdb) so the "why this seed is not vacuous" reasoning lives in one place.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
 
 
@@ -66,6 +71,61 @@ def seed_order(ids: Sequence[UUID]) -> list[UUID]:
     return out
 
 
+@dataclass(frozen=True)
+class OrderSeed:
+    """A seed plan: the rows to write, and the one order they must come back in."""
+
+    writes: list[tuple[UUID, datetime]]
+    """``(id, created_at)`` pairs, in the order the rows must be written."""
+
+    expected: list[UUID]
+    """The single correct result of an unfiltered ``list_documents``."""
+
+    tied_ids: set[UUID]
+    """The ids of the rows sharing one ``created_at``."""
+
+    newest_id: UUID
+    """Newest ``created_at``, lowest id - must sort FIRST."""
+
+    oldest_id: UUID
+    """Oldest ``created_at``, highest id - must sort LAST."""
+
+
+def order_seed(total: int) -> OrderSeed:
+    """Build a seed of ``total`` documents that pins both sort keys.
+
+    ``total - 2`` rows share one ``created_at``, so only the ``id DESC`` leg can
+    decide their order. The other two sit outside that tie block with timestamp
+    and id deliberately in conflict: the newest row carries the LOWEST id and
+    the oldest row the HIGHEST. An implementation that sorts on ``id`` first
+    therefore parks them at exactly the wrong ends, so a swapped-key
+    ``ORDER BY id DESC, created_at DESC`` cannot reproduce :attr:`expected`.
+
+    Without those two rows the whole seed ties on ``created_at`` and the two
+    orderings are byte-identical - checked, not assumed: a key swap in the
+    SQLite backend left every one of these tests passing.
+    """
+    if total < 4:
+        raise ValueError(f"total must leave a tie block of at least 2 rows, got {total}")
+
+    ids = id_ladder(total)
+    newest_id, oldest_id = ids[0], ids[-1]
+    tied = ids[1:-1]
+
+    shared = datetime.now(UTC)
+    stamps = dict.fromkeys(tied, shared)
+    stamps[newest_id] = shared + timedelta(seconds=1)
+    stamps[oldest_id] = shared - timedelta(seconds=1)
+
+    return OrderSeed(
+        writes=[(doc_id, stamps[doc_id]) for doc_id in seed_order(ids)],
+        expected=[newest_id, *reversed(tied), oldest_id],
+        tied_ids=set(tied),
+        newest_id=newest_id,
+        oldest_id=oldest_id,
+    )
+
+
 async def walk_pages(
     list_documents: Callable[..., Awaitable[Sequence]],
     namespace_id: UUID,
@@ -92,4 +152,4 @@ async def walk_pages(
     raise AssertionError(f"list_documents did not drain within {max_pages} pages of {page_size}")
 
 
-__all__ = ["id_ladder", "seed_order", "walk_pages"]
+__all__ = ["OrderSeed", "id_ladder", "order_seed", "seed_order", "walk_pages"]

--- a/tests/test_helpers/document_order.py
+++ b/tests/test_helpers/document_order.py
@@ -1,0 +1,95 @@
+"""Seed + paging helpers for the ``list_documents`` tie-break ordering tests.
+
+``list_documents`` sorts on ``(created_at DESC, id DESC)``. Proving the
+``id DESC`` leg requires a seed where ``created_at`` alone cannot decide the
+order, and an expected sequence that is fixed by construction rather than by
+chance - hence :func:`id_ladder` and :func:`seed_order`.
+
+Shared by the four backend test modules (postgresql, raw sqlite, sqlite_lance,
+surrealdb) so the "why this seed is not vacuous" reasoning lives in one place.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+from uuid import UUID, uuid4
+
+
+def id_ladder(n: int) -> list[UUID]:
+    """Return ``n`` document ids in strictly ASCENDING order.
+
+    Each id is a shared random 96-bit prefix plus an 8-hex-digit counter, so
+    ``ids[i] < ids[j]`` exactly when ``i < j``: the expected ``id DESC`` result
+    is ``list(reversed(ids))``, known up front rather than sampled.
+
+    Why not plain ``uuid4`` ids: with random ids the expected order is whatever
+    the sort happens to produce, so a backend that ignores the ``id`` tie-break
+    can still match by luck (with two rows, half the time). Seeding a ladder
+    removes luck from the assertion entirely - there is exactly one correct
+    answer and an implementation that drops the ``id`` key cannot produce it.
+
+    The random prefix keeps the ids unique across runs, so the tests are safe
+    against a persistent database that is not truncated between runs.
+
+    Seed rows through :func:`seed_order` rather than in ladder order - see that
+    function for why ladder order is not safe to seed in.
+    """
+    prefix = uuid4().hex[:24]
+    return [UUID(f"{prefix}{i:08x}") for i in range(n)]
+
+
+def seed_order(ids: Sequence[UUID]) -> list[UUID]:
+    """Reorder ``ids`` into the fixed, non-monotonic order rows are written in.
+
+    Interleaves the ladder from both ends (``ids[0], ids[-1], ids[1], ...``), so
+    the write order is neither ascending nor descending by id.
+
+    This matters. When every ``created_at`` ties, a backend that ignores the id
+    key returns rows in whatever order the scan produced - and the observed
+    fallbacks go BOTH ways: raw SQLite sorts stably and yields insertion order,
+    while the SQLAlchemy/SQLite path walks the ``(namespace_id, created_at)``
+    index backwards and yields REVERSE insertion order. Seeding in ladder order
+    therefore makes the second backend return exactly the expected descending
+    sequence for the wrong reason - checked, not assumed: an earlier draft of
+    these tests seeded in ladder order and passed against the pre-tie-break
+    implementation. A non-monotonic write order cannot coincide with descending
+    id order in either direction.
+    """
+    out: list[UUID] = []
+    lo, hi = 0, len(ids) - 1
+    while lo <= hi:
+        out.append(ids[lo])
+        if lo != hi:
+            out.append(ids[hi])
+        lo += 1
+        hi -= 1
+    return out
+
+
+async def walk_pages(
+    list_documents: Callable[..., Awaitable[Sequence]],
+    namespace_id: UUID,
+    *,
+    page_size: int,
+    max_pages: int = 100,
+) -> list[list]:
+    """Page through ``list_documents`` with ``limit``/``offset`` until drained.
+
+    Returns the pages in request order; the caller asserts on their
+    concatenation (order + exhaustiveness) and on their union (no overlap).
+
+    ``max_pages`` is a safety valve: a backend that ignored ``offset`` would
+    otherwise loop forever, and a guardrail test should fail rather than hang.
+    """
+    pages: list[list] = []
+    offset = 0
+    while len(pages) < max_pages:
+        page = list(await list_documents(namespace_id, limit=page_size, offset=offset))
+        if not page:
+            return pages
+        pages.append(page)
+        offset += page_size
+    raise AssertionError(f"list_documents did not drain within {max_pages} pages of {page_size}")
+
+
+__all__ = ["id_ladder", "seed_order", "walk_pages"]

--- a/tests/test_helpers/document_order.py
+++ b/tests/test_helpers/document_order.py
@@ -59,7 +59,14 @@ def seed_order(ids: Sequence[UUID]) -> list[UUID]:
     these tests seeded in ladder order and passed against the pre-tie-break
     implementation. A non-monotonic write order cannot coincide with descending
     id order in either direction.
+
+    Fewer than three ids cannot satisfy that contract: two ids interleave to
+    ``[ids[0], ids[1]]``, which is just ascending insertion order, so the
+    guarantee this helper exists to provide would silently not hold.
     """
+    if len(ids) < 3:
+        raise ValueError(f"seed_order requires at least 3 ids to produce a non-monotonic write order, got {len(ids)}")
+
     out: list[UUID] = []
     lo, hi = 0, len(ids) - 1
     while lo <= hi:

--- a/tests/unit/storage/backends/sqlite_lance/test_relational.py
+++ b/tests/unit/storage/backends/sqlite_lance/test_relational.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
@@ -17,6 +17,7 @@ except ImportError:
 
 from khora.core.models import Document, MemoryNamespace, TenancyMode
 from khora.core.models.document import DocumentStatus
+from tests.test_helpers.document_order import id_ladder, seed_order, walk_pages
 
 pytestmark = pytest.mark.skipif(not _HAS_EMBEDDED, reason="aiosqlite/lancedb not installed")
 
@@ -308,6 +309,66 @@ async def test_dedup_excludes_failed_documents(adapter, namespace):
     await adapter.create_document(failed)
 
     assert await adapter.get_document_by_checksum(namespace.id, "same") is None
+
+
+# ---------------------------------------------------------------------------
+# list_documents total order
+# ---------------------------------------------------------------------------
+#
+# ``list_documents`` sorts on ``(created_at DESC, id DESC)``. Bulk ingest stamps
+# many documents with the same ``created_at``; on that seed ``created_at`` alone
+# leaves the sort under-determined and row positions are not addressable. See
+# ``tests.test_helpers.document_order`` for why the seed below is non-vacuous.
+
+_ORDER_SEED_SIZE = 12
+
+
+async def _seed_tied_documents(adapter, namespace) -> list:
+    """Seed ``_ORDER_SEED_SIZE`` documents sharing one ``created_at``.
+
+    Rows are written in ``seed_order`` (non-monotonic by id) so that neither
+    insertion order nor its reverse can coincide with the expected sequence.
+    """
+    shared_created_at = datetime.now(UTC)
+    ids = id_ladder(_ORDER_SEED_SIZE)
+    for i, doc_id in enumerate(seed_order(ids)):
+        doc = _make_document(namespace.id, checksum=f"sum-{i}")
+        doc.id = doc_id
+        doc.created_at = shared_created_at
+        doc.updated_at = shared_created_at
+        await adapter.create_document(doc)
+    return ids
+
+
+async def test_list_documents_ties_break_on_id_desc_and_repeat_identically(adapter, namespace):
+    ids = await _seed_tied_documents(adapter, namespace)
+
+    docs = await adapter.list_documents(namespace.id)
+
+    # The tie is real: if these differed, ``created_at`` alone would decide the
+    # order and the id tie-break would never be exercised.
+    assert len({d.created_at for d in docs}) == 1
+    assert [d.id for d in docs] == sorted(ids, reverse=True)
+
+    # Same query, same answer - the order is a property of the query, not of
+    # whatever the scan happened to produce on the first call.
+    for _ in range(2):
+        assert [d.id for d in await adapter.list_documents(namespace.id)] == [d.id for d in docs]
+
+
+async def test_list_documents_offset_pagination_is_exhaustive_and_non_overlapping(adapter, namespace):
+    ids = await _seed_tied_documents(adapter, namespace)
+    expected = sorted(ids, reverse=True)
+
+    # Page size deliberately does not divide the seed size, so the final page is
+    # short and an off-by-one at the boundary shows up.
+    pages = await walk_pages(adapter.list_documents, namespace.id, page_size=5)
+    seen = [d.id for page in pages for d in page]
+
+    assert [len(p) for p in pages] == [5, 5, 2]
+    assert len(seen) == len(set(seen))  # no document served twice
+    assert set(seen) == set(expected)  # every document served
+    assert seen == expected  # and in the same order as the unpaged read
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/storage/backends/sqlite_lance/test_relational.py
+++ b/tests/unit/storage/backends/sqlite_lance/test_relational.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime
 from uuid import uuid4
 
 import pytest
@@ -17,7 +17,7 @@ except ImportError:
 
 from khora.core.models import Document, MemoryNamespace, TenancyMode
 from khora.core.models.document import DocumentStatus
-from tests.test_helpers.document_order import id_ladder, seed_order, walk_pages
+from tests.test_helpers.document_order import OrderSeed, order_seed, walk_pages
 
 pytestmark = pytest.mark.skipif(not _HAS_EMBEDDED, reason="aiosqlite/lancedb not installed")
 
@@ -323,32 +323,37 @@ async def test_dedup_excludes_failed_documents(adapter, namespace):
 _ORDER_SEED_SIZE = 12
 
 
-async def _seed_tied_documents(adapter, namespace) -> list:
-    """Seed ``_ORDER_SEED_SIZE`` documents sharing one ``created_at``.
+async def _seed_ordered_documents(adapter, namespace) -> OrderSeed:
+    """Seed ``_ORDER_SEED_SIZE`` documents pinning both sort keys.
 
     Rows are written in ``seed_order`` (non-monotonic by id) so that neither
     insertion order nor its reverse can coincide with the expected sequence.
     """
-    shared_created_at = datetime.now(UTC)
-    ids = id_ladder(_ORDER_SEED_SIZE)
-    for i, doc_id in enumerate(seed_order(ids)):
+    seed = order_seed(_ORDER_SEED_SIZE)
+    for i, (doc_id, created_at) in enumerate(seed.writes):
         doc = _make_document(namespace.id, checksum=f"sum-{i}")
         doc.id = doc_id
-        doc.created_at = shared_created_at
-        doc.updated_at = shared_created_at
+        doc.created_at = created_at
+        doc.updated_at = created_at
         await adapter.create_document(doc)
-    return ids
+    return seed
 
 
-async def test_list_documents_ties_break_on_id_desc_and_repeat_identically(adapter, namespace):
-    ids = await _seed_tied_documents(adapter, namespace)
+async def test_list_documents_orders_by_created_at_then_id_desc_and_repeats_identically(adapter, namespace):
+    seed = await _seed_ordered_documents(adapter, namespace)
 
     docs = await adapter.list_documents(namespace.id)
 
     # The tie is real: if these differed, ``created_at`` alone would decide the
     # order and the id tie-break would never be exercised.
-    assert len({d.created_at for d in docs}) == 1
-    assert [d.id for d in docs] == sorted(ids, reverse=True)
+    assert len({d.created_at for d in docs if d.id in seed.tied_ids}) == 1
+
+    # ``created_at`` leads: these two rows carry the id that would put them at
+    # the opposite end, so only a leading ``created_at`` lands them here.
+    assert docs[0].id == seed.newest_id
+    assert docs[-1].id == seed.oldest_id
+
+    assert [d.id for d in docs] == seed.expected
 
     # Same query, same answer - the order is a property of the query, not of
     # whatever the scan happened to produce on the first call.
@@ -357,8 +362,8 @@ async def test_list_documents_ties_break_on_id_desc_and_repeat_identically(adapt
 
 
 async def test_list_documents_offset_pagination_is_exhaustive_and_non_overlapping(adapter, namespace):
-    ids = await _seed_tied_documents(adapter, namespace)
-    expected = sorted(ids, reverse=True)
+    seed = await _seed_ordered_documents(adapter, namespace)
+    expected = seed.expected
 
     # Page size deliberately does not divide the seed size, so the final page is
     # short and an off-by-one at the boundary shows up.

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -12,6 +12,7 @@ from khora.core.models.document import DocumentStatus
 from khora.core.models.entity import Entity
 from khora.core.models.tenancy import TenancyMode
 from khora.storage.backends.sqlite import SQLiteRelationalBackend, SQLiteVectorBackend
+from tests.test_helpers.document_order import id_ladder, seed_order, walk_pages
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -383,6 +384,70 @@ class TestDocumentCRUD:
         sources = await relational.get_document_sources_batch([doc.id], namespace_id=ns.id)
         assert len(sources) == 1
         assert sources[doc.id].title == "Test Document"
+
+
+# ---------------------------------------------------------------------------
+# list_documents total order
+# ---------------------------------------------------------------------------
+
+
+class TestListDocumentsTotalOrder:
+    """``created_at`` ties are broken by ``id DESC``, so row positions are stable.
+
+    Bulk ingest stamps many documents with the same ``created_at``; on that seed
+    ``created_at`` alone leaves the sort under-determined and row positions are
+    not addressable. See :mod:`tests.test_helpers.document_order` for why the
+    seed makes these assertions non-vacuous.
+    """
+
+    SEED_SIZE = 12
+
+    async def _seed(self, relational: SQLiteRelationalBackend) -> tuple[MemoryNamespace, list]:
+        ns = _make_namespace()
+        await relational.create_namespace(ns)
+
+        shared_created_at = datetime.now(UTC)
+        ids = id_ladder(self.SEED_SIZE)
+        for i, doc_id in enumerate(seed_order(ids)):
+            await relational.create_document(
+                _make_document(
+                    ns.id,
+                    id=doc_id,
+                    checksum=f"sum-{i}",
+                    created_at=shared_created_at,
+                    updated_at=shared_created_at,
+                )
+            )
+        return ns, ids
+
+    async def test_ties_break_on_id_desc_and_repeat_identically(self, relational: SQLiteRelationalBackend):
+        ns, ids = await self._seed(relational)
+
+        docs = await relational.list_documents(ns.id)
+
+        # The tie is real: if these differed, ``created_at`` alone would decide
+        # the order and the id tie-break would never be exercised.
+        assert len({d.created_at for d in docs}) == 1
+        assert [d.id for d in docs] == sorted(ids, reverse=True)
+
+        # Same query, same answer - the order is a property of the query, not
+        # of whatever the scan happened to produce on the first call.
+        for _ in range(2):
+            assert [d.id for d in await relational.list_documents(ns.id)] == [d.id for d in docs]
+
+    async def test_offset_pagination_is_exhaustive_and_non_overlapping(self, relational: SQLiteRelationalBackend):
+        ns, ids = await self._seed(relational)
+        expected = sorted(ids, reverse=True)
+
+        # Page size deliberately does not divide the seed size, so the final
+        # page is short and an off-by-one at the boundary shows up.
+        pages = await walk_pages(relational.list_documents, ns.id, page_size=5)
+        seen = [d.id for page in pages for d in page]
+
+        assert [len(p) for p in pages] == [5, 5, 2]
+        assert len(seen) == len(set(seen))  # no document served twice
+        assert set(seen) == set(expected)  # every document served
+        assert seen == expected  # and in the same order as the unpaged read
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -12,7 +12,7 @@ from khora.core.models.document import DocumentStatus
 from khora.core.models.entity import Entity
 from khora.core.models.tenancy import TenancyMode
 from khora.storage.backends.sqlite import SQLiteRelationalBackend, SQLiteVectorBackend
-from tests.test_helpers.document_order import id_ladder, seed_order, walk_pages
+from tests.test_helpers.document_order import OrderSeed, order_seed, walk_pages
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -392,7 +392,7 @@ class TestDocumentCRUD:
 
 
 class TestListDocumentsTotalOrder:
-    """``created_at`` ties are broken by ``id DESC``, so row positions are stable.
+    """Documents come back newest first, ties broken by ``id DESC``.
 
     Bulk ingest stamps many documents with the same ``created_at``; on that seed
     ``created_at`` alone leaves the sort under-determined and row positions are
@@ -402,33 +402,38 @@ class TestListDocumentsTotalOrder:
 
     SEED_SIZE = 12
 
-    async def _seed(self, relational: SQLiteRelationalBackend) -> tuple[MemoryNamespace, list]:
+    async def _seed(self, relational: SQLiteRelationalBackend) -> tuple[MemoryNamespace, OrderSeed]:
         ns = _make_namespace()
         await relational.create_namespace(ns)
 
-        shared_created_at = datetime.now(UTC)
-        ids = id_ladder(self.SEED_SIZE)
-        for i, doc_id in enumerate(seed_order(ids)):
+        seed = order_seed(self.SEED_SIZE)
+        for i, (doc_id, created_at) in enumerate(seed.writes):
             await relational.create_document(
                 _make_document(
                     ns.id,
                     id=doc_id,
                     checksum=f"sum-{i}",
-                    created_at=shared_created_at,
-                    updated_at=shared_created_at,
+                    created_at=created_at,
+                    updated_at=created_at,
                 )
             )
-        return ns, ids
+        return ns, seed
 
-    async def test_ties_break_on_id_desc_and_repeat_identically(self, relational: SQLiteRelationalBackend):
-        ns, ids = await self._seed(relational)
+    async def test_orders_by_created_at_then_id_desc_and_repeats_identically(self, relational: SQLiteRelationalBackend):
+        ns, seed = await self._seed(relational)
 
         docs = await relational.list_documents(ns.id)
 
         # The tie is real: if these differed, ``created_at`` alone would decide
         # the order and the id tie-break would never be exercised.
-        assert len({d.created_at for d in docs}) == 1
-        assert [d.id for d in docs] == sorted(ids, reverse=True)
+        assert len({d.created_at for d in docs if d.id in seed.tied_ids}) == 1
+
+        # ``created_at`` leads: these two rows carry the id that would put them
+        # at the opposite end, so only a leading ``created_at`` lands them here.
+        assert docs[0].id == seed.newest_id
+        assert docs[-1].id == seed.oldest_id
+
+        assert [d.id for d in docs] == seed.expected
 
         # Same query, same answer - the order is a property of the query, not
         # of whatever the scan happened to produce on the first call.
@@ -436,8 +441,8 @@ class TestListDocumentsTotalOrder:
             assert [d.id for d in await relational.list_documents(ns.id)] == [d.id for d in docs]
 
     async def test_offset_pagination_is_exhaustive_and_non_overlapping(self, relational: SQLiteRelationalBackend):
-        ns, ids = await self._seed(relational)
-        expected = sorted(ids, reverse=True)
+        ns, seed = await self._seed(relational)
+        expected = seed.expected
 
         # Page size deliberately does not divide the seed size, so the final
         # page is short and an off-by-one at the boundary shows up.


### PR DESCRIPTION
## Summary

- `list_documents` ordered by `created_at DESC` alone on every relational backend, leaving the sort under-determined whenever timestamps tie. Tied rows could come back in any order, so row positions were not addressable and offset paging over a tied set could serve the same document twice or skip one.
- Adds `id DESC` as a tie-break on all four relational backends, giving `list_documents` a total order:
  - `postgresql.py` and `sqlite_lance/relational.py` (SQLAlchemy) — `.order_by(DocumentModel.created_at.desc(), DocumentModel.id.desc())`
  - `sqlite.py` (raw SQL) — `ORDER BY created_at DESC, id DESC`
  - `surrealdb/relational.py` (SurrealQL) — `ORDER BY created_at DESC, id DESC`
- Uniformly descending on **both** keys, deliberately. A future keyset cursor over this surface is a single row-value comparison `(created_at, id) < (:ts, :id)`; mixing sort directions would force an OR-expansion of that predicate in every backend.
- States the ordering guarantee on the `RelationalBackendProtocol.list_documents` docstring, so the contract lives with the protocol that all four backends jointly implement rather than only in four separate SQL strings.
- No API change, no schema change, no migrations, no new indexes, and no recall-path changes. Ordering is the only altered query semantic.

The bug is real, not theoretical. Reverting only the SurrealDB `ORDER BY` line and re-running its test makes offset paging return 12 rows containing just 10 distinct documents — two served twice, two skipped.

### Scope note: what this does and does not fix

This delivers a deterministic total order over a **static** dataset. It does **not** make offset pagination exhaustive under concurrent inserts or deletes — no caller holds a snapshot across pages, so that hazard remains until keyset pagination lands. The value here is the prerequisite total order, not general pagination correctness.

### Performance: a real regression on deep pagination, and the index that fixes it

Worth stating plainly rather than burying. Adding the second sort key demotes `ix_documents_namespace_created_at (namespace_id, created_at)` from supplying the whole sort to supplying only a prefix, so the engine adds a sort step (`USE TEMP B-TREE FOR LAST TERM OF ORDER BY` on SQLite; incremental sort on PG 13+).

For the shape users actually issue — a first page, `LIMIT 100 OFFSET 0` — the cost is unmeasurable (0.07 ms → 0.08 ms on SQLite at 20k rows). The regression shows up in **full-drain offset pagination**, where a caller loops over every page; `gc.py`, `forget_session`, and the CrewAI / OpenAI-Agents / LangGraph adapters all do this. Independent measurements on SQLite disagreed on magnitude but agreed on direction and on the fix:

| scenario | before | after | after + 3-col index |
| -- | -- | -- | -- |
| 20k rows, full drain @500/page | 35 ms | 287 ms | 33 ms |
| 50k rows, full drain, no ties | 0.10 s | 1.01 s | 0.10 s |
| 200k rows, full drain, no ties | ~1.4 s | ~47 s | ~1.5 s |

Notably the regression does **not** require ties — it appears with entirely distinct timestamps, and worsens as tie groups grow.

The fix is a single **all-ASC** index, `(namespace_id, created_at, id)`: with `namespace_id` equality-constrained the residual index order is `(created_at ASC, id ASC)`, and a backward scan yields exactly `(created_at DESC, id DESC)`, so DESC-declared keys buy nothing. It restores baseline in every regime and leaves existing `ORDER BY created_at DESC` callers untouched. It is also the index the planned keyset cursor needs.

That index is **deliberately not in this PR** — this change is scoped to ordering with no schema change, and the index is tracked as a separate follow-up. Reviewers who would rather not merge the ordering change without it should say so; the measurements above are the input to that call. Note also that the raw `sqlite.py` backend manages its own DDL and never runs Alembic, so an Alembic index would cover PostgreSQL and `sqlite_lance` only.

All numbers above are SQLite. PostgreSQL's incremental-sort behavior is analogous by the same backward-scan argument, but the constants are unmeasured — no `EXPLAIN (ANALYZE)` was captured.

### Unrelated fix carried along

`pip-audit` began flagging `aiohttp` 3.14.1 (CVE-2026-69244) after this branch opened, failing the `security` job on any PR including this one. The constraint floor moves to 3.14.3, following the existing convention in that block.

## Test plan

- [x] Unit tests pass — full unit suite: 9766 passed, 35 skipped, coverage 80.99% (threshold 77%)
- [x] `make format` clean; `make lint` exits 0
- [x] CI `test-unit` and `test-integration` both green
- [x] **SurrealDB leg verified live** — reverting only its `ORDER BY` makes both its tests fail, the paging one on `len(seen) == len(set(seen))` → `12 == 10`
- [x] **Guardrail verified non-vacuous** — with the source change stashed, all four new unit-level tests fail; they pass with it restored
- [ ] PostgreSQL leg — runs in CI; its red state was not demonstrated locally (no Docker in the dev container). Non-vacuous by construction, per the seed argument below.

New tests seed documents sharing a single `created_at` and assert a fixed descending-id sequence, that repeated calls return the identical order, and that offset paging is non-overlapping and exhaustive.

**What makes the seed non-vacuous is the write order, not the ids.** This is worth spelling out because the obvious reading is wrong: an earlier draft used a deterministic *ascending* id ladder and still passed against the old implementation on `sqlite_lance`. The two SQLite backends' fallback orderings point in opposite directions — raw sqlite full-sorts and yields insertion order, while `sqlite_lance` backward-scans the existing index and yields *reverse* insertion order — so any monotonic seed is guaranteed vacuous on one of them. `seed_order` therefore interleaves the ladder from both ends, producing a write order that neither insertion order, its reverse, nor heap order can coincide with. Deterministic ids alone would not have caught this; the helper's docstring records the trap so a later "simplification" back to ladder order does not silently reintroduce it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Document listing now enforces deterministic ordering (newest documents first, descending ID as tie-breaker) across all storage backends for consistent pagination results.

* **Documentation**
  * Updated API documentation to specify document ordering behavior.

* **Tests**
  * Added comprehensive integration and unit tests verifying deterministic ordering and pagination consistency across storage backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->