### PR TITLE
Add documents-table compile contexts and relational.* compiler registry keys

### DIFF
--- a/src/khora/filter/compilers/__init__.py
+++ b/src/khora/filter/compilers/__init__.py
@@ -4,7 +4,9 @@ Each module here lowers a canonical :class:`~khora.filter.ast.FilterNode` to one
 backend's query fragment. A compiler is a stateless
 ``Callable[[FilterNode, CompileContext], CompiledFilter]`` registered against an
 ``(engine_id, storage_target)`` key on the
-:class:`~khora.filter.registry.CompilerRegistry` at engine import time.
+:class:`~khora.filter.registry.CompilerRegistry` at the registrant module's
+import time — an engine module on the recall path, a relational storage-backend
+module on the document-enumeration path.
 
 ``@internal``. Re-exported under :mod:`khora.filter.compilers` only — not from
 :mod:`khora.__init__`.

--- a/src/khora/filter/registry.py
+++ b/src/khora/filter/registry.py
@@ -13,11 +13,20 @@ document-enumeration path.
 ``@internal``. The registry is ``__all__``'d under :mod:`khora.filter` only —
 **not** :mod:`khora.__init__`. Exposing ``register()`` as a public extension
 point for third-party engine/backend authors is deferred to a future improvement
-(no current caller authors compilers; khora's five built-in compilers are the
-only consumers).
+(no current caller authors compilers; khora's own built-in compilers are the
+only consumers — seven ``compile_*`` functions ship, of which five are ever
+registered: ``compile_python`` is the in-memory oracle and ``compile_cypher``
+has no registered target).
 
-The registry is **empty at import** — khora's engines register their compilers
-at engine import time, not here. This module imports no compiler.
+Registrants are **engine and relational-storage-backend modules**, each
+registering at its own import time; this module imports no compiler. The
+registry is therefore **not** empty after a bare ``import khora``: the
+PostgreSQL and raw-SQLite backends sit on :mod:`khora.storage.backends`' eager
+import path, so their two documents-tier entries are already present. The
+sqlite_lance and SurrealDB backends are imported lazily by ``StorageFactory``,
+so their entries appear only once those backends are first constructed —
+anything enumerating :meth:`CompilerRegistry.registered_keys` for a full
+picture must import all four backend modules explicitly.
 """
 
 from __future__ import annotations

--- a/src/khora/filter/registry.py
+++ b/src/khora/filter/registry.py
@@ -5,7 +5,10 @@ stateless compiler function that lowers a :class:`~khora.filter.ast.FilterNode`
 to that backend's query fragment. It is the **second** internal seam: adding a
 backend or an alternative compiler does not require touching engine code, and
 adding an engine does not require touching compiler code — within khora's own
-codebase.
+codebase. The first key component names the query-path OWNER, which is not
+always an engine: an engine id on the recall path (``"chronicle"``,
+``"skeleton.pgvector"``), a ``relational.<dialect>`` store id on the
+document-enumeration path.
 
 ``@internal``. The registry is ``__all__``'d under :mod:`khora.filter` only —
 **not** :mod:`khora.__init__`. Exposing ``register()`` as a public extension

--- a/src/khora/storage/backends/_sqlite_capabilities.py
+++ b/src/khora/storage/backends/_sqlite_capabilities.py
@@ -1,0 +1,47 @@
+"""SQLite build-capability probes shared by the SQLite-family backends — ``@internal``.
+
+Both SQLite relational stores (the raw-SQL backend and the SQLAlchemy-over-
+aiosqlite ``sqlite_lance`` adapter) need the same answer to the same question:
+does *this process's* SQLite build have the JSON1 functions? The probe lives
+here rather than being duplicated per store because it interrogates the
+interpreter's stdlib ``sqlite3`` library, not either store's schema — the two
+stores genuinely diverge on their DDL (they disagree on the physical metadata
+column name), but they cannot disagree on this.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from functools import lru_cache
+
+__all__ = ["sqlite_has_json1"]
+
+
+@lru_cache(maxsize=1)
+def sqlite_has_json1() -> bool:
+    """Whether this process's SQLite build has the JSON1 functions.
+
+    ``compile_lance`` gates all metadata pushdown on this (``json_extract`` /
+    ``json_type`` / ``json_each``). ``json_valid`` is probed as the proxy: it is
+    a scalar function from the same JSON1 extension, so it is available exactly
+    when the others are, and unlike ``json_each`` — a table-valued function — it
+    can be tested with a bare ``SELECT``.
+
+    Probed once per process (memoized) against a throwaway in-memory database.
+    aiosqlite and SQLAlchemy's ``sqlite+aiosqlite`` driver both run on the same
+    in-process ``sqlite3`` library, so one answer serves both stores.
+
+    Returns ``False`` on any :class:`sqlite3.Error`, including a failure to open
+    the in-memory database — the conservative direction, since ``False`` only
+    routes metadata leaves to the caller's post-filter and never produces a
+    wrong row-set.
+    """
+    conn: sqlite3.Connection | None = None
+    try:
+        conn = sqlite3.connect(":memory:")
+        return conn.execute("SELECT json_valid('{}')").fetchone()[0] == 1
+    except sqlite3.Error:
+        return False
+    finally:
+        if conn is not None:
+            conn.close()

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -1048,3 +1048,59 @@ class PostgreSQLBackend(AsyncSessionMixin):
                 )
                 session.add(model)
             await session.commit()
+
+
+# --------------------------------------------------------------------------- #
+# Documents-tier recall-filter compile context + compiler registration.
+# --------------------------------------------------------------------------- #
+from khora.filter import CompileContext, CompilerRegistry  # noqa: E402
+from khora.filter.compilers.postgres import compile_postgres  # noqa: E402
+
+# The system keys this table backs with a real column — the single source of
+# truth for the documents tier. Nine of the ten ``SYSTEM_KEYS``; ``occurred_at``
+# is a recall-chunk column and has no ``documents`` counterpart (see
+# ``DocumentModel`` in ``khora/db/models.py``).
+_BACKED_SYSTEM_KEYS: frozenset[str] = frozenset(
+    {
+        "created_at",
+        "source_timestamp",
+        "source_type",
+        "source_name",
+        "source_url",
+        "external_id",
+        "content_type",
+        "source",
+        "title",
+    }
+)
+
+
+def _documents_compile_context() -> CompileContext:
+    """Build the recall-filter :class:`CompileContext` for the ``documents`` table.
+
+    ``field_mapping`` declares the nine backed system keys (identity-mapped to
+    their own columns) plus the ``metadata`` root remap to the physical
+    ``metadata`` column — ``DocumentModel`` maps the ``metadata_`` attribute to a
+    column literally named ``metadata``. ``on_unsupported="split"`` because a
+    document enumeration always has an in-memory post-filter available, so an
+    unpushable leaf is left unconsumed rather than raising.
+
+    ``occurred_at`` is deliberately absent: no ``documents`` row backs it.
+    ``compile_postgres`` does not treat the ``field_mapping`` key set as a
+    pushdown whitelist (``_col`` falls back to identity), so this context alone
+    cannot stop an ``occurred_at`` leaf from compiling to a non-existent column
+    — the caller must reject or strip it before compiling.
+    """
+    field_mapping = {key: key for key in _BACKED_SYSTEM_KEYS} | {"metadata": "metadata"}
+    return CompileContext(
+        backend_target="documents",
+        field_mapping=field_mapping,
+        on_unsupported="split",
+    )
+
+
+# Register the deterministic recall-filter compiler for this store/target at
+# import time (idempotent — same function object). Registration fires when
+# ``khora.storage.backends`` is imported, since this module is imported eagerly
+# by the package ``__init__``.
+CompilerRegistry.register("relational.postgresql", "documents", compile_postgres)

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -1088,8 +1088,11 @@ def _documents_compile_context() -> CompileContext:
     ``occurred_at`` is deliberately absent: no ``documents`` row backs it.
     ``compile_postgres`` does not treat the ``field_mapping`` key set as a
     pushdown whitelist (``_col`` falls back to identity), so this context alone
-    cannot stop an ``occurred_at`` leaf from compiling to a non-existent column
-    — the caller must reject or strip it before compiling.
+    cannot stop an ``occurred_at`` leaf from compiling to a non-existent column.
+    Worse than the resulting error: the leaf is also reported in
+    ``CompiledFilter.consumed_keys``, so the caller is told it was pushed down
+    and will not post-filter it. The caller must reject or strip the key before
+    compiling.
     """
     field_mapping = {key: key for key in _BACKED_SYSTEM_KEYS} | {"metadata": "metadata"}
     return CompileContext(

--- a/src/khora/storage/backends/sqlite.py
+++ b/src/khora/storage/backends/sqlite.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import json
 import sqlite3
 from datetime import UTC, datetime
-from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
@@ -1361,11 +1360,15 @@ class SQLiteVectorBackend:
 # --------------------------------------------------------------------------- #
 from khora.filter import CompileContext, CompilerRegistry, SchemaCapabilities  # noqa: E402
 from khora.filter.compilers.lance import compile_lance  # noqa: E402
+from khora.storage.backends._sqlite_capabilities import sqlite_has_json1  # noqa: E402
 
 # The system keys this table backs with a real column — the single source of
 # truth for the documents tier. Nine of the ten ``SYSTEM_KEYS``; ``occurred_at``
 # is a recall-chunk column and has no ``documents`` counterpart (see the
 # ``CREATE TABLE IF NOT EXISTS documents`` DDL in ``_SCHEMA_SQL`` above).
+# NOTE: ``created_at`` and ``source_timestamp`` are declared here but their
+# pushdown is NOT sound on this store — see the datetime hazard and the
+# forward-coupling alarm in ``_documents_compile_context``'s docstring below.
 _BACKED_SYSTEM_KEYS: frozenset[str] = frozenset(
     {
         "created_at",
@@ -1379,26 +1382,6 @@ _BACKED_SYSTEM_KEYS: frozenset[str] = frozenset(
         "title",
     }
 )
-
-
-@lru_cache(maxsize=1)
-def _sqlite_has_json1() -> bool:
-    """Whether this process's SQLite build has the JSON1 functions.
-
-    ``compile_lance`` gates metadata pushdown on this (``json_extract`` /
-    ``json_type`` / ``json_each``). Probed once per process against an in-memory
-    database: aiosqlite runs on the same in-process ``sqlite3`` library, so the
-    answer is process-wide. ``False`` on any error — under
-    ``on_unsupported="split"`` that only means every metadata leaf falls to the
-    caller's post-filter, never a wrong row-set.
-    """
-    conn = sqlite3.connect(":memory:")
-    try:
-        return conn.execute("SELECT json_valid('{}')").fetchone()[0] == 1
-    except sqlite3.Error:
-        return False
-    finally:
-        conn.close()
 
 
 def _documents_compile_context() -> CompileContext:
@@ -1415,20 +1398,64 @@ def _documents_compile_context() -> CompileContext:
     ``occurred_at`` is deliberately absent: no ``documents`` row backs it.
     ``compile_lance`` does not treat the ``field_mapping`` key set as a pushdown
     whitelist (``_col`` falls back to identity), so this context alone cannot
-    stop an ``occurred_at`` leaf from compiling to a non-existent column — the
-    caller must reject or strip it before compiling.
+    stop an ``occurred_at`` leaf from compiling to a non-existent column. Worse
+    than the resulting error: the leaf is also reported in
+    ``CompiledFilter.consumed_keys``, so the caller is told it was pushed down
+    and will not post-filter it. The caller must reject or strip the key before
+    compiling.
+
+    **Datetime binds on this table are not safe to push down.** Same class of
+    defect as the ``sqlite_lance`` adapter, different shape. This store writes
+    timestamps with :func:`_dt_to_str`, a bare ``dt.isoformat()`` with **no UTC
+    coercion**, into ``TEXT`` columns; ``compile_lance`` binds a datetime
+    operand as a UTC-normalized ``value.isoformat()`` and relies on
+    lexicographic ISO comparison. The two formats look compatible, which is
+    exactly why this is invisible without materializing a table — but the stored
+    string carries the *writer's* offset while the bind always carries
+    ``+00:00``, so the comparison is on wall clock, not on instant. Against a
+    ``$gte`` bound of ``'2026-01-31T12:30:00+00:00'``:
+
+    * a row stored ``'2026-01-31T13:00:00+02:00'`` — 11:00Z, ninety minutes
+      BEFORE the bound — is wrongly INCLUDED. A post-filter can remove it.
+    * a row stored ``'2026-01-31T12:30:00'`` (naive, written by a caller that
+      supplied a naive datetime) is exactly AT the bound but is wrongly
+      EXCLUDED, because the shorter string is a prefix of the bind and sorts
+      first. Since the key is reported consumed, **a post-filter can only narrow
+      and cannot recover this row.**
+
+    Reachable in practice: ``source_timestamp`` is caller-supplied with no
+    default and no timezone normalization anywhere on this write path. This
+    cannot be corrected from a compile context — a caller using this context
+    must route the date-valued system keys to its post-filter.
+
+    **When the pushdown whitelist gate lands, drop ``created_at`` and
+    ``source_timestamp`` from ``_BACKED_SYSTEM_KEYS`` above.** They are declared
+    today only because ``compile_lance`` ignores the key set — every logical key
+    falls through to identity, so declaring them changes nothing and removing
+    them would make the mapping understate what it declares. Once the compiler
+    honours the key set as a pushdown whitelist, leaving them declared *keeps*
+    pushing the broken comparison described above; removing them routes both
+    keys to the caller's post-filter instead. The test signal for that edit is
+    INVERTED — forgetting the drop leaves both keys consumed and every test
+    green, while remembering it forces a test update — so this note is the
+    alarm.
     """
     field_mapping = {key: key for key in _BACKED_SYSTEM_KEYS} | {"metadata": "metadata_"}
     return CompileContext(
         backend_target="documents",
         field_mapping=field_mapping,
-        schema_capabilities=SchemaCapabilities(sqlite_json1=_sqlite_has_json1()),
+        schema_capabilities=SchemaCapabilities(sqlite_json1=sqlite_has_json1()),
         on_unsupported="split",
     )
 
 
 # Register the deterministic recall-filter compiler for this store/target at
 # import time (idempotent — same function object). Registration fires when
-# ``khora.storage.backends`` is imported (this module is imported eagerly by the
-# package ``__init__``).
+# ``khora.storage.backends`` is imported, which imports this module eagerly —
+# but inside a ``try``/``except ImportError`` that sets the backend to ``None``
+# (unlike the PostgreSQL backend, which is imported unconditionally). Two
+# consequences: without the optional SQLite dependencies this key never
+# registers at all, and an ``ImportError`` raised anywhere in the filter imports
+# above would be swallowed there, silently disabling this whole backend rather
+# than surfacing. Keep those imports to ``khora.filter`` (stdlib-only deps).
 CompilerRegistry.register("relational.sqlite", "documents", compile_lance)

--- a/src/khora/storage/backends/sqlite.py
+++ b/src/khora/storage/backends/sqlite.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from datetime import UTC, datetime
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
@@ -1353,3 +1354,81 @@ class SQLiteVectorBackend:
             created_at=_parse_dt(row["created_at"]) or datetime.now(UTC),
             updated_at=_parse_dt(row["updated_at"]) or datetime.now(UTC),
         )
+
+
+# --------------------------------------------------------------------------- #
+# Documents-tier recall-filter compile context + compiler registration.
+# --------------------------------------------------------------------------- #
+from khora.filter import CompileContext, CompilerRegistry, SchemaCapabilities  # noqa: E402
+from khora.filter.compilers.lance import compile_lance  # noqa: E402
+
+# The system keys this table backs with a real column — the single source of
+# truth for the documents tier. Nine of the ten ``SYSTEM_KEYS``; ``occurred_at``
+# is a recall-chunk column and has no ``documents`` counterpart (see the
+# ``CREATE TABLE IF NOT EXISTS documents`` DDL in ``_SCHEMA_SQL`` above).
+_BACKED_SYSTEM_KEYS: frozenset[str] = frozenset(
+    {
+        "created_at",
+        "source_timestamp",
+        "source_type",
+        "source_name",
+        "source_url",
+        "external_id",
+        "content_type",
+        "source",
+        "title",
+    }
+)
+
+
+@lru_cache(maxsize=1)
+def _sqlite_has_json1() -> bool:
+    """Whether this process's SQLite build has the JSON1 functions.
+
+    ``compile_lance`` gates metadata pushdown on this (``json_extract`` /
+    ``json_type`` / ``json_each``). Probed once per process against an in-memory
+    database: aiosqlite runs on the same in-process ``sqlite3`` library, so the
+    answer is process-wide. ``False`` on any error — under
+    ``on_unsupported="split"`` that only means every metadata leaf falls to the
+    caller's post-filter, never a wrong row-set.
+    """
+    conn = sqlite3.connect(":memory:")
+    try:
+        return conn.execute("SELECT json_valid('{}')").fetchone()[0] == 1
+    except sqlite3.Error:
+        return False
+    finally:
+        conn.close()
+
+
+def _documents_compile_context() -> CompileContext:
+    """Build the recall-filter :class:`CompileContext` for the ``documents`` table.
+
+    ``field_mapping`` declares the nine backed system keys (identity-mapped to
+    their bare columns) plus the ``metadata`` root remap to the physical
+    ``metadata_`` column — this backend's raw DDL diverges from the shared
+    SQLAlchemy model, which names the same column ``metadata``.
+    ``on_unsupported="split"`` because a document enumeration always has an
+    in-memory post-filter available, so an unpushable leaf is left unconsumed
+    rather than raising.
+
+    ``occurred_at`` is deliberately absent: no ``documents`` row backs it.
+    ``compile_lance`` does not treat the ``field_mapping`` key set as a pushdown
+    whitelist (``_col`` falls back to identity), so this context alone cannot
+    stop an ``occurred_at`` leaf from compiling to a non-existent column — the
+    caller must reject or strip it before compiling.
+    """
+    field_mapping = {key: key for key in _BACKED_SYSTEM_KEYS} | {"metadata": "metadata_"}
+    return CompileContext(
+        backend_target="documents",
+        field_mapping=field_mapping,
+        schema_capabilities=SchemaCapabilities(sqlite_json1=_sqlite_has_json1()),
+        on_unsupported="split",
+    )
+
+
+# Register the deterministic recall-filter compiler for this store/target at
+# import time (idempotent — same function object). Registration fires when
+# ``khora.storage.backends`` is imported (this module is imported eagerly by the
+# package ``__init__``).
+CompilerRegistry.register("relational.sqlite", "documents", compile_lance)

--- a/src/khora/storage/backends/sqlite_lance/relational.py
+++ b/src/khora/storage/backends/sqlite_lance/relational.py
@@ -13,9 +13,7 @@ this adapter assumes tables already exist.
 
 from __future__ import annotations
 
-import sqlite3
 from datetime import UTC, datetime
-from functools import lru_cache
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
@@ -1088,11 +1086,15 @@ def _row_to_memory_fact(row: object) -> MemoryFact:
 # --------------------------------------------------------------------------- #
 from khora.filter import CompileContext, CompilerRegistry, SchemaCapabilities  # noqa: E402
 from khora.filter.compilers.lance import compile_lance  # noqa: E402
+from khora.storage.backends._sqlite_capabilities import sqlite_has_json1  # noqa: E402
 
 # The system keys this table backs with a real column — the single source of
 # truth for the documents tier. Nine of the ten ``SYSTEM_KEYS``; ``occurred_at``
 # is a recall-chunk column and has no ``documents`` counterpart (this adapter
 # reuses ``DocumentModel`` from ``khora/db/models.py``).
+# NOTE: ``created_at`` and ``source_timestamp`` are declared here but their
+# pushdown is NOT sound on this store — see the datetime hazard and the
+# forward-coupling alarm in ``_documents_compile_context``'s docstring below.
 _BACKED_SYSTEM_KEYS: frozenset[str] = frozenset(
     {
         "created_at",
@@ -1106,26 +1108,6 @@ _BACKED_SYSTEM_KEYS: frozenset[str] = frozenset(
         "title",
     }
 )
-
-
-@lru_cache(maxsize=1)
-def _sqlite_has_json1() -> bool:
-    """Whether this process's SQLite build has the JSON1 functions.
-
-    ``compile_lance`` gates metadata pushdown on this (``json_extract`` /
-    ``json_type`` / ``json_each``). Probed once per process against an in-memory
-    database: aiosqlite and SQLAlchemy's ``sqlite+aiosqlite`` both run on the
-    same in-process ``sqlite3`` library, so the answer is process-wide.
-    ``False`` on any error — under ``on_unsupported="split"`` that only means
-    every metadata leaf falls to the caller's post-filter, never a wrong row-set.
-    """
-    conn = sqlite3.connect(":memory:")
-    try:
-        return conn.execute("SELECT json_valid('{}')").fetchone()[0] == 1
-    except sqlite3.Error:
-        return False
-    finally:
-        conn.close()
 
 
 def _documents_compile_context() -> CompileContext:
@@ -1142,30 +1124,44 @@ def _documents_compile_context() -> CompileContext:
     ``occurred_at`` is deliberately absent: no ``documents`` row backs it.
     ``compile_lance`` does not treat the ``field_mapping`` key set as a pushdown
     whitelist (``_col`` falls back to identity), so this context alone cannot
-    stop an ``occurred_at`` leaf from compiling to a non-existent column — the
-    caller must reject or strip it before compiling.
+    stop an ``occurred_at`` leaf from compiling to a non-existent column. Worse
+    than the resulting error: the leaf is also reported in
+    ``CompiledFilter.consumed_keys``, so the caller is told it was pushed down
+    and will not post-filter it. The caller must reject or strip the key before
+    compiling.
 
-    **Datetime binds on this table are not yet safe to push down.** The
-    ``documents`` rows are written through SQLAlchemy's SQLite ``DATETIME``
-    type, which stores ``'2026-01-31 12:30:00.000000'`` — a SPACE separator and
-    no UTC offset. ``compile_lance`` binds a datetime operand as
-    ``value.isoformat()`` (``'T'`` separator, offset included) and relies on
-    lexicographic ISO comparison, so the two forms do not line up: ``' '``
-    (0x20) sorts before ``'T'`` (0x54), which means a ``$gte`` bound excludes
-    rows from the bound's own day. A pushed-down ``created_at`` /
-    ``source_timestamp`` comparison therefore returns silently wrong rows. This
-    cannot be corrected from a compile context. Until the bind format is fixed
-    upstream, a caller using this context must normalize its datetime binds to
-    the stored format or route the date-valued system keys to its post-filter.
+    **Datetime binds on this table are not safe to push down.** The ``documents``
+    rows are written through SQLAlchemy's SQLite ``DATETIME`` type, which stores
+    ``'2026-01-31 12:30:00.000000'`` — a SPACE separator and no UTC offset.
+    ``compile_lance`` binds a datetime operand as ``value.isoformat()`` (``'T'``
+    separator, offset included) and relies on lexicographic ISO comparison, so
+    the two forms do not line up: ``' '`` (0x20) sorts before ``'T'`` (0x54).
+    Both bound directions are wrong, in opposite ways — a ``$gte`` bound
+    EXCLUDES rows from the bound's own day, while a ``$lte`` bound INCLUDES
+    every row from that day. A pushed-down ``created_at`` / ``source_timestamp``
+    comparison therefore returns silently wrong rows.
+
+    **The only sound remedy is the post-filter.** Normalizing the caller's binds
+    to the stored format cannot work: SQLAlchemy's ``DATETIME`` discards the
+    offset at write time without converting to UTC, so the column holds
+    writer-local wall clock. Two rows at the same instant — ``12:30+00:00`` and
+    ``14:30+02:00`` — store as ``'...12:30:00.000000'`` and
+    ``'...14:30:00.000000'`` and sort two hours apart. The information needed to
+    recover an instant ordering is already gone by the time any bind is built,
+    so no bind format can be correct for every row. A caller using this context
+    must route the date-valued system keys to its post-filter and accept the
+    full-namespace scan that implies — an intentional trade, since silently
+    wrong rows are worse than slow ones.
 
     **When the pushdown whitelist gate lands, drop ``created_at`` and
     ``source_timestamp`` from ``_BACKED_SYSTEM_KEYS`` above.** They are declared
     today only because ``compile_lance`` ignores the key set — every logical key
-    falls through to identity, so declaring them changes nothing. Once the
-    compiler honours the key set as a pushdown whitelist, leaving them declared
-    starts pushing the broken comparison described above; removing them routes
-    both keys to the caller's post-filter instead. The test signal for that edit
-    is INVERTED — forgetting the drop leaves both keys consumed and every test
+    falls through to identity, so declaring them changes nothing and removing
+    them would make the mapping understate what it declares. Once the compiler
+    honours the key set as a pushdown whitelist, leaving them declared *keeps*
+    pushing the broken comparison described above; removing them routes both
+    keys to the caller's post-filter instead. The test signal for that edit is
+    INVERTED — forgetting the drop leaves both keys consumed and every test
     green, while remembering it forces a test update — so this note is the alarm.
     """
     field_mapping = {key: key for key in _BACKED_SYSTEM_KEYS} | {"metadata": "metadata"}
@@ -1173,7 +1169,7 @@ def _documents_compile_context() -> CompileContext:
         backend_target="documents",
         field_mapping=field_mapping,
         on_unsupported="split",
-        schema_capabilities=SchemaCapabilities(sqlite_json1=_sqlite_has_json1()),
+        schema_capabilities=SchemaCapabilities(sqlite_json1=sqlite_has_json1()),
     )
 
 

--- a/src/khora/storage/backends/sqlite_lance/relational.py
+++ b/src/khora/storage/backends/sqlite_lance/relational.py
@@ -13,7 +13,9 @@ this adapter assumes tables already exist.
 
 from __future__ import annotations
 
+import sqlite3
 from datetime import UTC, datetime
+from functools import lru_cache
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
@@ -1079,3 +1081,104 @@ def _row_to_memory_fact(row: object) -> MemoryFact:
         created_at=row.created_at,
         updated_at=row.updated_at,
     )
+
+
+# --------------------------------------------------------------------------- #
+# Documents-tier recall-filter compile context + compiler registration.
+# --------------------------------------------------------------------------- #
+from khora.filter import CompileContext, CompilerRegistry, SchemaCapabilities  # noqa: E402
+from khora.filter.compilers.lance import compile_lance  # noqa: E402
+
+# The system keys this table backs with a real column — the single source of
+# truth for the documents tier. Nine of the ten ``SYSTEM_KEYS``; ``occurred_at``
+# is a recall-chunk column and has no ``documents`` counterpart (this adapter
+# reuses ``DocumentModel`` from ``khora/db/models.py``).
+_BACKED_SYSTEM_KEYS: frozenset[str] = frozenset(
+    {
+        "created_at",
+        "source_timestamp",
+        "source_type",
+        "source_name",
+        "source_url",
+        "external_id",
+        "content_type",
+        "source",
+        "title",
+    }
+)
+
+
+@lru_cache(maxsize=1)
+def _sqlite_has_json1() -> bool:
+    """Whether this process's SQLite build has the JSON1 functions.
+
+    ``compile_lance`` gates metadata pushdown on this (``json_extract`` /
+    ``json_type`` / ``json_each``). Probed once per process against an in-memory
+    database: aiosqlite and SQLAlchemy's ``sqlite+aiosqlite`` both run on the
+    same in-process ``sqlite3`` library, so the answer is process-wide.
+    ``False`` on any error — under ``on_unsupported="split"`` that only means
+    every metadata leaf falls to the caller's post-filter, never a wrong row-set.
+    """
+    conn = sqlite3.connect(":memory:")
+    try:
+        return conn.execute("SELECT json_valid('{}')").fetchone()[0] == 1
+    except sqlite3.Error:
+        return False
+    finally:
+        conn.close()
+
+
+def _documents_compile_context() -> CompileContext:
+    """Build the recall-filter :class:`CompileContext` for the ``documents`` table.
+
+    ``field_mapping`` declares the nine backed system keys (identity-mapped to
+    their own columns) plus the ``metadata`` root remap to the physical
+    ``metadata`` column — this adapter reuses ``DocumentModel``, which maps the
+    ``metadata_`` attribute to a column literally named ``metadata`` (the raw
+    SQLite backend's own DDL differs here). ``on_unsupported="split"`` because a
+    document enumeration always has an in-memory post-filter available, so an
+    unpushable leaf is left unconsumed rather than raising.
+
+    ``occurred_at`` is deliberately absent: no ``documents`` row backs it.
+    ``compile_lance`` does not treat the ``field_mapping`` key set as a pushdown
+    whitelist (``_col`` falls back to identity), so this context alone cannot
+    stop an ``occurred_at`` leaf from compiling to a non-existent column — the
+    caller must reject or strip it before compiling.
+
+    **Datetime binds on this table are not yet safe to push down.** The
+    ``documents`` rows are written through SQLAlchemy's SQLite ``DATETIME``
+    type, which stores ``'2026-01-31 12:30:00.000000'`` — a SPACE separator and
+    no UTC offset. ``compile_lance`` binds a datetime operand as
+    ``value.isoformat()`` (``'T'`` separator, offset included) and relies on
+    lexicographic ISO comparison, so the two forms do not line up: ``' '``
+    (0x20) sorts before ``'T'`` (0x54), which means a ``$gte`` bound excludes
+    rows from the bound's own day. A pushed-down ``created_at`` /
+    ``source_timestamp`` comparison therefore returns silently wrong rows. This
+    cannot be corrected from a compile context. Until the bind format is fixed
+    upstream, a caller using this context must normalize its datetime binds to
+    the stored format or route the date-valued system keys to its post-filter.
+
+    **When the pushdown whitelist gate lands, drop ``created_at`` and
+    ``source_timestamp`` from ``_BACKED_SYSTEM_KEYS`` above.** They are declared
+    today only because ``compile_lance`` ignores the key set — every logical key
+    falls through to identity, so declaring them changes nothing. Once the
+    compiler honours the key set as a pushdown whitelist, leaving them declared
+    starts pushing the broken comparison described above; removing them routes
+    both keys to the caller's post-filter instead. The test signal for that edit
+    is INVERTED — forgetting the drop leaves both keys consumed and every test
+    green, while remembering it forces a test update — so this note is the alarm.
+    """
+    field_mapping = {key: key for key in _BACKED_SYSTEM_KEYS} | {"metadata": "metadata"}
+    return CompileContext(
+        backend_target="documents",
+        field_mapping=field_mapping,
+        on_unsupported="split",
+        schema_capabilities=SchemaCapabilities(sqlite_json1=_sqlite_has_json1()),
+    )
+
+
+# Register the deterministic recall-filter compiler for this store/target at
+# import time (idempotent — same function object). This module is imported
+# lazily by ``StorageFactory``, so registration happens when the backend is
+# first constructed.
+CompilerRegistry.register("relational.sqlite_lance", "documents", compile_lance)

--- a/src/khora/storage/backends/surrealdb/relational.py
+++ b/src/khora/storage/backends/surrealdb/relational.py
@@ -1135,3 +1135,79 @@ def _row_to_memory_fact(row: dict[str, Any]) -> _MemoryFactRow:
         created_at=_parse_dt(row.get("created_at")),
         updated_at=_parse_dt(row.get("updated_at")),
     )
+
+
+# --------------------------------------------------------------------------- #
+# Documents-tier recall-filter compile context + compiler registration.
+# --------------------------------------------------------------------------- #
+from khora.filter import CompileContext, CompilerRegistry  # noqa: E402
+from khora.filter.compilers.surrealdb import compile_surrealdb  # noqa: E402
+
+# The system keys this table backs with a real field — the single source of
+# truth for the documents tier. Nine of the ten ``SYSTEM_KEYS``; ``occurred_at``
+# is a recall-chunk field and has no ``document`` counterpart (see the
+# ``DEFINE FIELD ... ON document`` block in ``surrealdb/schema.py``).
+_BACKED_SYSTEM_KEYS: frozenset[str] = frozenset(
+    {
+        "created_at",
+        "source_timestamp",
+        "source_type",
+        "source_name",
+        "source_url",
+        "external_id",
+        "content_type",
+        "source",
+        "title",
+    }
+)
+
+
+def _documents_compile_context() -> CompileContext:
+    """Build the recall-filter :class:`CompileContext` for the ``document`` table.
+
+    ``field_mapping`` declares the nine backed system keys (identity-mapped to
+    their bare fields) plus the ``metadata`` root remap to the physical
+    ``metadata_`` field. ``on_unsupported="split"`` because a document
+    enumeration always has an in-memory post-filter available, so an unpushable
+    leaf is left unconsumed rather than raising — unlike the chunk-tier context
+    in ``khora/storage/temporal/surrealdb.py``, whose engine has no post-filter
+    path and therefore uses ``"raise"``.
+
+    ``occurred_at`` is deliberately absent: no ``document`` row backs it.
+    ``compile_surrealdb`` treats the ``field_mapping`` key set as the backend's
+    declared+pushable whitelist, so an undeclared system key is left out of
+    ``consumed_keys`` and routed to the caller's post-filter instead of emitting
+    a predicate against a missing field — the only documents backend where the
+    omission has that effect.
+
+    **The placeholder is not inert under a negation.** ``compile_surrealdb`` has
+    no all-or-nothing split gate (the one ``compile_lance`` documents at
+    ``_consumable``), so an undeclared leaf emits the literal ``true`` in place,
+    whatever its position in the tree. That is safe in positive position
+    (``A AND true`` is ``A``) but not under ``$not`` / ``$or``: a filter such as
+    ``{"$not": {"$or": [{"title": "x"}, {"occurred_at": {"$gt": ...}}]}}``
+    compiles to ``!((((title = $f_0)) OR (true)))``, which is ``!true`` — it
+    matches ZERO rows, silently, while ``consumed_keys`` reports ``occurred_at``
+    as still needing a post-filter that can only narrow further. A caller must
+    reject an undeclared system key rather than rely on the post-filter to
+    recover it.
+
+    ``backend_target`` is the SINGULAR ``document``, the real physical table name
+    (``surrealdb/schema.py``), not the plural registry key. ``compile_surrealdb``
+    never reads ``backend_target``, so the value is inert today; it names the
+    physical table (house precedent) so the eventual enumeration caller reads the
+    truth rather than a plausible-looking wrong table.
+    """
+    field_mapping = {key: key for key in _BACKED_SYSTEM_KEYS} | {"metadata": "metadata_"}
+    return CompileContext(
+        backend_target="document",
+        field_mapping=field_mapping,
+        on_unsupported="split",
+    )
+
+
+# Register the deterministic recall-filter compiler for this store/target at
+# import time (idempotent — same function object). This module is imported
+# lazily by ``StorageFactory``, so registration happens when the backend is
+# first constructed.
+CompilerRegistry.register("relational.surrealdb", "documents", compile_surrealdb)

--- a/src/khora/storage/backends/surrealdb/relational.py
+++ b/src/khora/storage/backends/surrealdb/relational.py
@@ -1167,30 +1167,48 @@ def _documents_compile_context() -> CompileContext:
 
     ``field_mapping`` declares the nine backed system keys (identity-mapped to
     their bare fields) plus the ``metadata`` root remap to the physical
-    ``metadata_`` field. ``on_unsupported="split"`` because a document
-    enumeration always has an in-memory post-filter available, so an unpushable
-    leaf is left unconsumed rather than raising — unlike the chunk-tier context
-    in ``khora/storage/temporal/surrealdb.py``, whose engine has no post-filter
-    path and therefore uses ``"raise"``.
+    ``metadata_`` field.
+
+    **``on_unsupported="raise"`` is an interim posture, not the end state.** The
+    enumeration contract specifies split semantics — an unpushable leaf is left
+    unconsumed for the caller's post-filter rather than raising — and this
+    context will use ``"split"`` once the compiler is sound under it. It is not
+    sound today, for the reason below, and the staged raise-then-split rollout
+    is explicitly permitted: raising is a strictly narrower behaviour that a
+    later loosening can widen without breaking a caller. Nothing consumes this
+    context yet, so the interim posture costs nothing and removes both live
+    hazards. The soundness gate flips it back.
 
     ``occurred_at`` is deliberately absent: no ``document`` row backs it.
     ``compile_surrealdb`` treats the ``field_mapping`` key set as the backend's
-    declared+pushable whitelist, so an undeclared system key is left out of
-    ``consumed_keys`` and routed to the caller's post-filter instead of emitting
-    a predicate against a missing field — the only documents backend where the
-    omission has that effect.
+    declared+pushable whitelist, so an undeclared system key never emits a
+    predicate against a missing field — the only documents backend where the
+    omission has that effect. Under ``"raise"`` such a leaf now surfaces as a
+    :class:`~khora.filter.model.RecallFilterUnsupportedError` instead of being
+    silently absorbed.
 
-    **The placeholder is not inert under a negation.** ``compile_surrealdb`` has
-    no all-or-nothing split gate (the one ``compile_lance`` documents at
-    ``_consumable``), so an undeclared leaf emits the literal ``true`` in place,
-    whatever its position in the tree. That is safe in positive position
-    (``A AND true`` is ``A``) but not under ``$not`` / ``$or``: a filter such as
+    **Why ``"split"`` is unsafe here until the gate lands.**
+    ``compile_surrealdb`` has no all-or-nothing split gate (the one
+    ``compile_lance`` documents at ``_consumable``), so under ``"split"`` an
+    undeclared leaf emits the literal ``true`` in place, whatever its position
+    in the tree. That is harmless in positive position (``A AND true`` is
+    ``A``) but not under ``$not`` / ``$or``: a filter such as
     ``{"$not": {"$or": [{"title": "x"}, {"occurred_at": {"$gt": ...}}]}}``
     compiles to ``!((((title = $f_0)) OR (true)))``, which is ``!true`` — it
     matches ZERO rows, silently, while ``consumed_keys`` reports ``occurred_at``
-    as still needing a post-filter that can only narrow further. A caller must
-    reject an undeclared system key rather than rely on the post-filter to
-    recover it.
+    as still needing a post-filter that can only narrow further. The
+    known-gap test pins this against an explicitly split-mode copy of this
+    context, so the defect stays documented while the shipped context avoids it.
+
+    **A third gap survives both modes.** ``compile_surrealdb`` raises the
+    internal ``CompileError`` on an unsafe (non-identifier) metadata path
+    segment — a hyphenated key such as ``metadata.due-date`` is legal JSON and
+    common in the wild — and it does so regardless of ``on_unsupported``, since
+    that is a guard rather than a capability gap. ``CompileError`` is documented
+    as "a bug, not a capability gap", so it would escape as an internal error;
+    the documents scan path is obliged to catch it and re-raise it as
+    ``RecallFilterUnsupportedError`` so it surfaces as a structured rejection.
+    That mapping belongs to the scan path and cannot be implemented from here.
 
     ``backend_target`` is the SINGULAR ``document``, the real physical table name
     (``surrealdb/schema.py``), not the plural registry key. ``compile_surrealdb``
@@ -1202,7 +1220,13 @@ def _documents_compile_context() -> CompileContext:
     return CompileContext(
         backend_target="document",
         field_mapping=field_mapping,
-        on_unsupported="split",
+        # Interim posture — see the docstring. The contract specifies "split";
+        # this compiler is not sound under it (an unsupported leaf emits a bare
+        # ``true`` that inverts under ``$not``/``$or``), and the staged
+        # raise-then-split rollout is permitted precisely so a context can ship
+        # narrow and widen later. Flip back to "split" with the compiler
+        # soundness gate.
+        on_unsupported="raise",
     )
 
 

--- a/tests/integration/matrix/test_compiler_registry_keys.py
+++ b/tests/integration/matrix/test_compiler_registry_keys.py
@@ -27,6 +27,10 @@ import pytest
 # Importing these modules fires their module-level ``CompilerRegistry.register``
 # calls (the registry is empty until an engine/backend module imports).
 import khora.engines.chronicle.engine  # noqa: F401
+import khora.storage.backends.postgresql  # noqa: F401
+import khora.storage.backends.sqlite  # noqa: F401
+import khora.storage.backends.sqlite_lance.relational  # noqa: F401
+import khora.storage.backends.surrealdb.relational  # noqa: F401
 import khora.storage.temporal.pgvector  # noqa: F401
 import khora.storage.temporal.sqlite_lance  # noqa: F401
 import khora.storage.temporal.surrealdb  # noqa: F401
@@ -43,9 +47,16 @@ pytestmark = [pytest.mark.filter_conformance]
 # ``test_registry_holds_exactly_expected_keys`` fails until you do, so a new
 # registration can no longer be silently excluded from the conformance matrix.
 # Currently registered: chronicle, skeleton.pgvector, skeleton.sqlite_lance,
-# skeleton.surrealdb, skeleton.weaviate.
+# skeleton.surrealdb, skeleton.weaviate (chunk tier), and relational.postgresql,
+# relational.sqlite, relational.sqlite_lance, relational.surrealdb (documents
+# tier — the first key component names the query-path owner, which on the
+# document-enumeration path is a store id rather than an engine id).
 EXPECTED_KEYS: tuple[tuple[str, str], ...] = (
     ("chronicle", "chunks"),
+    ("relational.postgresql", "documents"),
+    ("relational.sqlite", "documents"),
+    ("relational.sqlite_lance", "documents"),
+    ("relational.surrealdb", "documents"),
     ("skeleton.pgvector", "khora_chunks"),
     ("skeleton.sqlite_lance", "khora_chunks"),
     ("skeleton.surrealdb", "temporal_chunk"),

--- a/tests/integration/matrix/test_documents_compiler_identity.py
+++ b/tests/integration/matrix/test_documents_compiler_identity.py
@@ -1,0 +1,86 @@
+"""Compiler-identity guard for the four ``documents``-tier registrations.
+
+The sibling drift guard (``test_compiler_registry_keys.py``) asserts WHICH
+``(engine_id, storage_target)`` keys the registry holds. It cannot see what each
+key is bound TO: a documents key wired to the wrong backend's compiler resolves
+to a perfectly callable function and passes it. This module closes that half —
+it asserts the compiler FUNCTION OBJECT behind each documents key, so a
+copy-paste registration (the plausible mistake, since three of the four blocks
+are near-identical and two legitimately share ``compile_lance``) fails here.
+
+Deliberately NOT a second exact-key-set assertion: two copies of that assertion
+would drift apart, and the sibling guard already owns it.
+
+**Why this lives in the integration session and not next to the unit tests for
+these contexts.** The registry is process-wide class state, and the unit suite
+contains a module whose autouse fixture clears it around every test
+(``tests/recall/test_compiler_registry.py``). Registration is an import-time
+side effect, so once a module is in ``sys.modules`` a later import cannot re-fire
+it — a registry read scheduled after that fixture sees an empty registry. The
+unit job runs those tests in the same session under ``xdist``, which makes the
+ordering nondeterministic; the integration job never collects them. Same reason
+the sibling guard sits in a session of its own.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Importing these modules fires their module-level ``CompilerRegistry.register``
+# calls — two are on ``import khora``'s eager path, two are imported lazily by
+# ``StorageFactory``, so all four are named explicitly rather than assumed.
+import khora.storage.backends.postgresql  # noqa: F401
+import khora.storage.backends.sqlite  # noqa: F401
+import khora.storage.backends.sqlite_lance.relational  # noqa: F401
+import khora.storage.backends.surrealdb.relational  # noqa: F401
+from khora.filter.compilers.lance import compile_lance
+from khora.filter.compilers.postgres import compile_postgres
+from khora.filter.compilers.surrealdb import compile_surrealdb
+from khora.filter.registry import CompilerFn, CompilerRegistry
+
+pytestmark = [pytest.mark.integration]
+
+
+# Each documents-tier registry key and the compiler its store module must bind
+# it to. Verified at the ``CompilerRegistry.register(...)`` call-site in each
+# backend module imported above. The two SQLite dialects share ``compile_lance``
+# by design — they differ in their compile context, not their compiler.
+EXPECTED_DOCUMENTS_COMPILERS: tuple[tuple[str, str, CompilerFn], ...] = (
+    ("relational.postgresql", "documents", compile_postgres),
+    ("relational.sqlite", "documents", compile_lance),
+    ("relational.sqlite_lance", "documents", compile_lance),
+    ("relational.surrealdb", "documents", compile_surrealdb),
+)
+
+
+@pytest.mark.parametrize(
+    ("engine_id", "storage_target", "expected"),
+    EXPECTED_DOCUMENTS_COMPILERS,
+    ids=[f"{key}" for key, _target, _fn in EXPECTED_DOCUMENTS_COMPILERS],
+)
+def test_documents_key_resolves_to_its_own_compiler(
+    engine_id: str,
+    storage_target: str,
+    expected: CompilerFn,
+) -> None:
+    """Identity, not callability — the wrong compiler is also callable."""
+    assert CompilerRegistry.get(engine_id, storage_target) is expected
+
+
+def test_documents_keys_are_not_all_bound_to_one_compiler() -> None:
+    """Three distinct compilers back the four documents keys.
+
+    A registration block copy-pasted across the four store modules without
+    swapping the compiler import would still satisfy every per-key assertion in
+    isolation if the expectations were derived from the registry. This pins the
+    shape of the mapping itself: three distinct functions, with the SQLite pair
+    sharing one and the other two standing alone.
+    """
+    resolved = [CompilerRegistry.get(key, target) for key, target, _fn in EXPECTED_DOCUMENTS_COMPILERS]
+    assert len({id(fn) for fn in resolved}) == 3
+    assert CompilerRegistry.get("relational.sqlite", "documents") is CompilerRegistry.get(
+        "relational.sqlite_lance", "documents"
+    )
+    assert CompilerRegistry.get("relational.postgresql", "documents") is not CompilerRegistry.get(
+        "relational.surrealdb", "documents"
+    )

--- a/tests/unit/filter/test_documents_compile_contexts.py
+++ b/tests/unit/filter/test_documents_compile_contexts.py
@@ -1,0 +1,699 @@
+"""Unit tests for the four ``documents``-tier recall-filter compile contexts.
+
+``@internal``. Each relational store module builds the
+:class:`~khora.filter.context.CompileContext` that the document-enumeration path
+hands to its backend compiler. The context is the ONLY place the physical
+``documents`` schema is declared, so these tests pin what a compiler emits when
+it is driven by that context: the physical table qualifier, the physical metadata
+column, the pushdown/residual split, and the two known gaps a caller must defend
+against.
+
+Truth table these tests lock (verified against the four shipped builders):
+
+===============  ================  ==================  ==================
+context          backend_target    metadata column     compiler
+===============  ================  ==================  ==================
+postgresql       ``documents``     ``metadata``        ``compile_postgres``
+sqlite (raw)     ``documents``     ``metadata_``       ``compile_lance``
+sqlite_lance     ``documents``     ``metadata``        ``compile_lance``
+surrealdb        ``document``      ``metadata_``       ``compile_surrealdb``
+===============  ================  ==================  ==================
+
+**Why every metadata assertion goes through a delimited matcher.** ``metadata``
+is a PREFIX of ``metadata_``, so the obvious ``"documents.metadata" in sql``
+passes against BOTH spellings — it would stay green against exactly the defect
+this module exists to catch (a context wired to the other backend's column), and
+its mirror image ``"metadata" not in sql`` is unsatisfiable where ``metadata_``
+is the correct spelling. Every column assertion therefore uses
+:func:`_emits_column`, whose trailing ``\\b`` refuses to match a longer
+identifier, and every test asserts the OPPOSITE spelling is absent through the
+same matcher. :func:`test_metadata_column_matcher_rejects_the_swapped_mapping`
+is the standing proof that the matcher discriminates: it runs the shipped
+assertion against a deliberately swapped mapping and requires it to fail there.
+
+**Why the SQLite metadata tests build a local context.** Both SQLite builders
+derive ``sqlite_json1`` from a runtime probe of the host's ``sqlite3`` build.
+``compile_lance`` gates ALL metadata pushdown on that flag, so on a build without
+JSON1 the shipped context emits no metadata column at all and a column assertion
+against it would fail for a reason that has nothing to do with the mapping. The
+column tests therefore build a local ``sqlite_json1=True`` context carrying the
+shipped ``field_mapping``; the probe-driven behaviour of the shipped context is
+pinned separately, in a form that is self-consistent under either probe answer.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql.elements import ColumnElement
+
+from khora.filter import RecallFilter
+from khora.filter.ast import FilterNode, parse_to_ast
+from khora.filter.compilers.lance import compile_lance
+from khora.filter.compilers.postgres import compile_postgres
+from khora.filter.compilers.surrealdb import compile_surrealdb
+from khora.filter.context import CompileContext, SchemaCapabilities
+from khora.filter.model import SYSTEM_KEYS
+from khora.filter.registry import CompiledFilter
+from khora.storage.backends.postgresql import _documents_compile_context as postgres_context
+from khora.storage.backends.sqlite import _documents_compile_context as sqlite_context
+from khora.storage.backends.sqlite import _sqlite_has_json1 as sqlite_has_json1
+from khora.storage.backends.sqlite_lance.relational import _documents_compile_context as sqlite_lance_context
+from khora.storage.backends.sqlite_lance.relational import _sqlite_has_json1 as sqlite_lance_has_json1
+from khora.storage.backends.surrealdb.relational import _documents_compile_context as surrealdb_context
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+_DT = datetime(2026, 1, 31, 12, 30, tzinfo=UTC)
+
+# The nine system keys a ``documents`` row backs with a real column, restated
+# here independently of the store modules' own ``_BACKED_SYSTEM_KEYS`` — a test
+# that imported the constant under test would assert nothing.
+_BACKED_KEYS: frozenset[str] = frozenset(
+    {
+        "created_at",
+        "source_timestamp",
+        "source_type",
+        "source_name",
+        "source_url",
+        "external_id",
+        "content_type",
+        "source",
+        "title",
+    }
+)
+
+
+def _ast(wire: dict) -> FilterNode:
+    """Validate a wire-form filter and lower it to the canonical AST."""
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+def _norm(sql: str) -> str:
+    """Collapse whitespace and lowercase for resilient matching."""
+    return " ".join(sql.split()).lower()
+
+
+def _postgres_sql(wire: dict, ctx: CompileContext) -> str:
+    """Compile with ``compile_postgres`` and render the predicate as inline SQL."""
+    predicate = compile_postgres(_ast(wire), ctx).predicate
+    assert isinstance(predicate, ColumnElement), f"not a SQLAlchemy element: {type(predicate)!r}"
+    return _norm(str(predicate.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})))
+
+
+def _lance_sql(wire: dict, ctx: CompileContext) -> str:
+    return _norm(compile_lance(_ast(wire), ctx).predicate)
+
+
+def _surrealdb_sql(wire: dict, ctx: CompileContext) -> str:
+    return _norm(compile_surrealdb(_ast(wire), ctx).predicate)
+
+
+def _emits_column(sql: str, column: str) -> bool:
+    """Whether ``sql`` references exactly ``column`` — never a longer identifier.
+
+    The trailing ``\\b`` is the whole point: ``metadata`` is a prefix of
+    ``metadata_``, so a plain substring test cannot tell the two physical columns
+    apart and would pass against a context wired to the wrong one. ``_`` is a
+    word character, so ``metadata\\b`` does not match inside ``metadata_``.
+    """
+    return re.search(rf"\b{re.escape(column)}\b", sql) is not None
+
+
+def _json1_variant(ctx: CompileContext) -> CompileContext:
+    """The same context with JSON1 forced on, so metadata pushdown is exercised.
+
+    The shipped SQLite contexts derive ``sqlite_json1`` from a runtime probe.
+    Column-mapping tests must not depend on the host's SQLite build, so they run
+    against this local variant, which carries the shipped ``field_mapping``
+    verbatim and only pins the capability flag.
+    """
+    return CompileContext(
+        backend_target=ctx.backend_target,
+        table_alias=ctx.table_alias,
+        param_namespace=ctx.param_namespace,
+        field_mapping=ctx.field_mapping,
+        schema_capabilities=SchemaCapabilities(sqlite_json1=True),
+        on_unsupported=ctx.on_unsupported,
+    )
+
+
+# Every context builder, with its expected physical target/metadata column, and
+# the SQL-rendering helper for the compiler it is registered against.
+_ALL_CONTEXTS: tuple[tuple[str, Callable[[], CompileContext], str, str], ...] = (
+    ("postgresql", postgres_context, "documents", "metadata"),
+    ("sqlite", sqlite_context, "documents", "metadata_"),
+    ("sqlite_lance", sqlite_lance_context, "documents", "metadata"),
+    ("surrealdb", surrealdb_context, "document", "metadata_"),
+)
+
+# The two ``compile_lance``-driven contexts, which share every behaviour that
+# depends on the JSON1 capability flag.
+_SQLITE_CONTEXTS: tuple[tuple[str, Callable[[], CompileContext], str], ...] = (
+    ("sqlite", sqlite_context, "metadata_"),
+    ("sqlite_lance", sqlite_lance_context, "metadata"),
+)
+
+
+# ===========================================================================
+# Context shape.
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    ("name", "builder", "target", "metadata_column"),
+    _ALL_CONTEXTS,
+    ids=[case[0] for case in _ALL_CONTEXTS],
+)
+def test_context_declares_the_physical_schema(
+    name: str,
+    builder: Callable[[], CompileContext],
+    target: str,
+    metadata_column: str,
+) -> None:
+    ctx = builder()
+    # ``backend_target`` is the PHYSICAL table name, which is the singular
+    # ``document`` on SurrealDB even though the registry key is plural.
+    assert ctx.backend_target == target
+    # No documents read path aliases the table, so the qualifier comes from
+    # ``backend_target`` alone.
+    assert ctx.table_alias is None
+    assert ctx.param_namespace == "f"
+    # A document enumeration always has an in-memory post-filter available, so an
+    # unpushable leaf is left unconsumed rather than raising.
+    assert ctx.on_unsupported == "split"
+
+    mapping = ctx.field_mapping
+    assert mapping is not None
+    # Exactly the nine backed system keys plus the ``metadata`` root — the
+    # ``metadata`` entry must be present even where it is identity, because
+    # ``compile_postgres`` resolves it eagerly.
+    assert set(mapping) == set(_BACKED_KEYS) | {"metadata"}
+    assert all(mapping[key] == key for key in _BACKED_KEYS)
+    assert mapping["metadata"] == metadata_column
+
+
+@pytest.mark.parametrize(
+    ("name", "builder"),
+    [(case[0], case[1]) for case in _ALL_CONTEXTS],
+    ids=[case[0] for case in _ALL_CONTEXTS],
+)
+def test_occurred_at_is_absent_from_every_documents_mapping(
+    name: str,
+    builder: Callable[[], CompileContext],
+) -> None:
+    mapping = builder().field_mapping
+    assert mapping is not None
+    assert "occurred_at" not in mapping
+    # The omission is only meaningful because ``occurred_at`` IS a filterable
+    # system key: it can reach a compiler as an AST leaf, it just has no
+    # ``documents`` column behind it.
+    assert "occurred_at" in SYSTEM_KEYS
+    assert set(_BACKED_KEYS) | {"occurred_at"} == set(SYSTEM_KEYS)
+
+
+def test_only_the_sqlite_contexts_declare_a_capability() -> None:
+    # Neither ``compile_postgres`` nor ``compile_surrealdb`` reads
+    # ``schema_capabilities``, so their contexts leave it at the conservative
+    # all-False default.
+    assert postgres_context().schema_capabilities == SchemaCapabilities.DEFAULTS
+    assert surrealdb_context().schema_capabilities == SchemaCapabilities.DEFAULTS
+
+    # The two ``compile_lance`` contexts declare exactly one capability —
+    # ``sqlite_json1``, whose value comes from a runtime probe of the host's
+    # SQLite build and is therefore asserted as a bool, not as a fixed answer.
+    for _name, builder, _column in _SQLITE_CONTEXTS:
+        capabilities = builder().schema_capabilities
+        assert isinstance(capabilities.sqlite_json1, bool)
+        assert not capabilities.jsonb_path_query
+        assert not capabilities.full_text
+        assert not capabilities.native_map_metadata
+
+
+# ===========================================================================
+# System-key leaves — the physical table qualifier.
+# ===========================================================================
+
+
+def test_postgres_system_key_is_qualified_by_the_documents_table() -> None:
+    sql = _postgres_sql({"source_type": "email"}, postgres_context())
+    assert _emits_column(sql, "documents.source_type")
+
+
+@pytest.mark.parametrize(
+    ("name", "builder", "metadata_column"),
+    _SQLITE_CONTEXTS,
+    ids=[case[0] for case in _SQLITE_CONTEXTS],
+)
+def test_sqlite_system_key_is_qualified_by_the_documents_table(
+    name: str,
+    builder: Callable[[], CompileContext],
+    metadata_column: str,
+) -> None:
+    sql = _lance_sql({"source_type": "email"}, builder())
+    assert _emits_column(sql, "documents.source_type")
+    # Positional binds, not named — ``compile_lance`` returns an ordered arg list.
+    compiled = compile_lance(_ast({"source_type": "email"}), builder())
+    assert compiled.params == {"args": ["email"]}
+
+
+def test_surrealdb_system_key_is_a_bare_field() -> None:
+    ctx = surrealdb_context()
+    compiled = compile_surrealdb(_ast({"source_type": "email"}), ctx)
+    sql = _norm(compiled.predicate)
+    # SurrealQL selects from the table directly, so fields are unqualified —
+    # a ``document.`` / ``documents.`` prefix here would be a syntax error.
+    assert _emits_column(sql, "source_type")
+    assert "document." not in sql
+    assert "documents." not in sql
+    # Named binds under the context's ``param_namespace``.
+    assert compiled.params == {"f_0": "email"}
+    assert "$f_0" in sql
+
+
+# ===========================================================================
+# Metadata leaves — the physical metadata column (delimited matcher).
+# ===========================================================================
+
+
+def test_postgres_metadata_leaf_addresses_the_metadata_column() -> None:
+    sql = _postgres_sql({"metadata.tier": {"$eq": "gold"}}, postgres_context())
+    assert _emits_column(sql, "documents.metadata")
+    # ...and NOT the raw-SQLite spelling. Both spellings render distinguishably;
+    # only a delimited matcher keeps that information.
+    assert not _emits_column(sql, "documents.metadata_")
+
+
+@pytest.mark.parametrize(
+    ("name", "builder", "metadata_column"),
+    _SQLITE_CONTEXTS,
+    ids=[case[0] for case in _SQLITE_CONTEXTS],
+)
+def test_sqlite_metadata_leaf_addresses_its_own_metadata_column(
+    name: str,
+    builder: Callable[[], CompileContext],
+    metadata_column: str,
+) -> None:
+    # Local JSON1 context: the shipped flag is probe-derived, and with JSON1 off
+    # there is no metadata column in the fragment at all (pinned separately).
+    ctx = _json1_variant(builder())
+    sql = _lance_sql({"metadata.tier": {"$eq": "gold"}}, ctx)
+    other = "metadata" if metadata_column == "metadata_" else "metadata_"
+    assert _emits_column(sql, f"documents.{metadata_column}")
+    assert not _emits_column(sql, f"documents.{other}")
+    # The JSON path is bound, not interpolated.
+    assert "json_each(" in sql
+
+
+def test_surrealdb_metadata_leaf_addresses_the_metadata_underscore_field() -> None:
+    sql = _surrealdb_sql({"metadata.tier": {"$eq": "gold"}}, surrealdb_context())
+    assert _emits_column(sql, "metadata_.tier")
+    assert not _emits_column(sql, "metadata.tier")
+
+
+def test_metadata_column_matcher_rejects_the_swapped_mapping() -> None:
+    """The column assertions above must FAIL against the defect they guard.
+
+    ``metadata`` is a prefix of ``metadata_``, so a substring assertion stays
+    green when a context is wired to the other backend's column. This test runs
+    each backend's shipped assertion against a context whose metadata mapping has
+    been deliberately swapped to the wrong spelling and requires it to reject —
+    if this ever passes trivially, every metadata assertion above is worthless.
+    """
+
+    def _swapped(ctx: CompileContext, wrong_column: str) -> CompileContext:
+        mapping = dict(ctx.field_mapping or {}) | {"metadata": wrong_column}
+        return CompileContext(
+            backend_target=ctx.backend_target,
+            table_alias=ctx.table_alias,
+            param_namespace=ctx.param_namespace,
+            field_mapping=mapping,
+            schema_capabilities=ctx.schema_capabilities,
+            on_unsupported=ctx.on_unsupported,
+        )
+
+    wire = {"metadata.tier": {"$eq": "gold"}}
+
+    # Postgres: shipped column is ``metadata``; swap it to ``metadata_``.
+    sql = _postgres_sql(wire, _swapped(postgres_context(), "metadata_"))
+    assert not _emits_column(sql, "documents.metadata")
+    assert _emits_column(sql, "documents.metadata_")
+
+    # Raw SQLite: shipped column is ``metadata_``; swap it to ``metadata``.
+    sql = _lance_sql(wire, _swapped(_json1_variant(sqlite_context()), "metadata"))
+    assert not _emits_column(sql, "documents.metadata_")
+    assert _emits_column(sql, "documents.metadata")
+
+    # sqlite_lance: shipped column is ``metadata``; swap it to ``metadata_``.
+    sql = _lance_sql(wire, _swapped(_json1_variant(sqlite_lance_context()), "metadata_"))
+    assert not _emits_column(sql, "documents.metadata")
+    assert _emits_column(sql, "documents.metadata_")
+
+    # SurrealDB: shipped field is ``metadata_``; swap it to ``metadata``.
+    sql = _surrealdb_sql(wire, _swapped(surrealdb_context(), "metadata"))
+    assert not _emits_column(sql, "metadata_.tier")
+    assert _emits_column(sql, "metadata.tier")
+
+
+# ===========================================================================
+# Pushdown / residual split.
+# ===========================================================================
+
+
+# Both wire spellings of a ``$date`` metadata comparison that the validator
+# accepts: ``$date`` as the operator key over a scalar operand (the form the
+# existing compiler suite uses), and a ``$date``-wrapped OPERAND under a range
+# operator. Both are inexpressible in SQLite and must split the same way. The
+# third conceivable spelling — an operator nested INSIDE ``$date``
+# (``{"$date": {"$gt": ...}}``) — is rejected by the validator, so it can never
+# reach a compiler and is not a compiler concern.
+_DATE_METADATA_WIRES: tuple[tuple[str, dict], ...] = (
+    ("date-as-operator", {"metadata.due": {"$date": "2026-01-01T00:00:00Z"}}),
+    ("date-wrapped-operand", {"metadata.due": {"$gt": {"$date": "2026-01-01T00:00:00Z"}}}),
+)
+
+
+@pytest.mark.parametrize(
+    ("name", "builder", "metadata_column"),
+    _SQLITE_CONTEXTS,
+    ids=[case[0] for case in _SQLITE_CONTEXTS],
+)
+@pytest.mark.parametrize(
+    ("wire_id", "date_wire"),
+    _DATE_METADATA_WIRES,
+    ids=[case[0] for case in _DATE_METADATA_WIRES],
+)
+def test_sqlite_date_metadata_compare_is_a_residual_not_a_raise(
+    wire_id: str,
+    date_wire: dict,
+    name: str,
+    builder: Callable[[], CompileContext],
+    metadata_column: str,
+) -> None:
+    """A ``$date`` metadata compare is inexpressible in SQLite and must split.
+
+    Run against a local JSON1 context so the contrast is real: with JSON1 on, a
+    plain metadata ``$eq`` IS consumed, while the ``$date`` compare on the very
+    same column is not. Against the shipped probe-derived context this pair could
+    both be residuals for the unrelated reason that the host has no JSON1, which
+    would prove nothing about ``$date`` — the control is what makes the residual
+    assertion mean something.
+    """
+    ctx = _json1_variant(builder())
+
+    # CONTROL — a plain metadata leaf on the same column DOES push down here.
+    consumed_leaf = compile_lance(_ast({"metadata.tier": {"$eq": "gold"}}), ctx)
+    assert consumed_leaf.consumed_keys == frozenset({"metadata.tier"})
+    assert _emits_column(_norm(consumed_leaf.predicate), f"documents.{metadata_column}")
+
+    # ``on_unsupported="split"`` — the unsupported leaf comes back as a residual,
+    # never as a ``RecallFilterUnsupportedError``.
+    residual = compile_lance(_ast(date_wire), ctx)
+    assert residual.consumed_keys == frozenset()
+    # Non-constraining placeholder: the caller's post-filter re-checks the leaf.
+    assert residual.predicate.strip() == "(1)"
+    assert residual.params == {"args": []}
+    # No column is addressed at all — nothing to get wrong, and nothing pushed.
+    assert not _emits_column(_norm(residual.predicate), f"documents.{metadata_column}")
+
+    # Both leaves in one filter: the split is per-leaf, not per-filter.
+    both = compile_lance(_ast({"metadata.tier": {"$eq": "gold"}} | date_wire), ctx)
+    assert both.consumed_keys == frozenset({"metadata.tier"})
+    assert _emits_column(_norm(both.predicate), f"documents.{metadata_column}")
+
+
+@pytest.mark.parametrize(
+    ("name", "builder", "metadata_column"),
+    _SQLITE_CONTEXTS,
+    ids=[case[0] for case in _SQLITE_CONTEXTS],
+)
+def test_shipped_sqlite_context_is_self_consistent_under_either_json1_answer(
+    name: str,
+    builder: Callable[[], CompileContext],
+    metadata_column: str,
+) -> None:
+    """The shipped context's metadata behaviour matches its own probe result.
+
+    ``sqlite_json1`` is probed from the host's SQLite build, so this asserts the
+    IMPLICATION rather than a fixed outcome: JSON1 on ⇒ the metadata leaf pushes
+    down to this backend's column; JSON1 off ⇒ every metadata leaf is a residual
+    the caller post-filters. Green on a host either way; a mapping or gating
+    regression still fails it.
+    """
+    ctx = builder()
+    compiled: CompiledFilter[Any] = compile_lance(_ast({"metadata.tier": {"$eq": "gold"}}), ctx)
+    sql = _norm(compiled.predicate)
+
+    if ctx.schema_capabilities.sqlite_json1:
+        assert compiled.consumed_keys == frozenset({"metadata.tier"})
+        assert _emits_column(sql, f"documents.{metadata_column}")
+    else:
+        assert compiled.consumed_keys == frozenset()
+        assert sql.strip() == "(1)"
+        assert not _emits_column(sql, "documents.metadata")
+        assert not _emits_column(sql, "documents.metadata_")
+
+    # A system key pushes down either way — the capability gates metadata only.
+    system = compile_lance(_ast({"source_type": "email"}), ctx)
+    assert system.consumed_keys == frozenset({"source_type"})
+
+
+# ===========================================================================
+# The JSON1 probe — the only new runtime logic behind these contexts.
+# ===========================================================================
+
+# Both SQLite store modules carry their own copy of the probe (their schemas
+# genuinely diverge, so they share no code); both are covered.
+_JSON1_PROBES: tuple[tuple[str, Callable[[], bool]], ...] = (
+    ("sqlite", sqlite_has_json1),
+    ("sqlite_lance", sqlite_lance_has_json1),
+)
+
+
+def _direct_json1_probe() -> bool:
+    """Ask this interpreter's ``sqlite3`` build about JSON1, independently."""
+    conn = sqlite3.connect(":memory:")
+    try:
+        return conn.execute("SELECT json_valid('{}')").fetchone()[0] == 1
+    except sqlite3.Error:
+        return False
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize(("name", "probe"), _JSON1_PROBES, ids=[case[0] for case in _JSON1_PROBES])
+def test_json1_probe_agrees_with_the_hosts_sqlite_build(name: str, probe: Callable[[], bool]) -> None:
+    """The probe reports what this host's SQLite actually supports.
+
+    Asserted against an independent probe rather than a hardcoded ``True``, so
+    the test states the contract (the flag tracks the runtime) instead of the
+    accident of which SQLite this host shipped. ``aiosqlite`` and SQLAlchemy's
+    ``sqlite+aiosqlite`` both run on this same in-process library, which is what
+    makes a process-wide answer correct.
+    """
+    result = probe()
+    assert isinstance(result, bool)
+    assert result is _direct_json1_probe()
+
+
+@pytest.mark.parametrize(("name", "probe"), _JSON1_PROBES, ids=[case[0] for case in _JSON1_PROBES])
+def test_json1_probe_is_stable_across_calls(name: str, probe: Callable[[], bool]) -> None:
+    # Memoized: the answer cannot change within a process, and a context built
+    # twice must not disagree with itself.
+    assert probe() is probe()
+
+
+@pytest.mark.parametrize(("name", "probe"), _JSON1_PROBES, ids=[case[0] for case in _JSON1_PROBES])
+def test_json1_probe_fails_closed_when_the_query_errors(
+    name: str,
+    probe: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed probe reports NO JSON1 — the conservative answer.
+
+    This is the branch that decides what happens on a SQLite build without the
+    JSON1 functions, and it is unreachable on a host that has them, so it is
+    driven here with a connection whose query raises. ``False`` is the only safe
+    answer: under ``on_unsupported="split"`` it sends every metadata leaf to the
+    caller's post-filter (less pushdown, same rows), whereas a wrong ``True``
+    would emit ``json_extract`` against a build that cannot run it.
+
+    Without this case the probe tests could not distinguish a real probe from a
+    hardcoded ``True`` on a JSON1-enabled host.
+    """
+
+    class _FailingConnection:
+        def execute(self, _sql: str) -> object:
+            raise sqlite3.Error("no such function: json_valid")
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(sqlite3, "connect", lambda *_args, **_kwargs: _FailingConnection())
+    # The probe is memoized, so the real answer must be evicted before and after
+    # this case or the fake result would leak into the rest of the session.
+    probe.cache_clear()
+    try:
+        assert probe() is False
+    finally:
+        probe.cache_clear()
+
+    monkeypatch.undo()
+    # Back to the host's real answer for every later test in this process.
+    assert probe() is _direct_json1_probe()
+
+
+def test_both_sqlite_probes_reach_the_same_answer() -> None:
+    # Two independent copies of the same probe against the same in-process
+    # library — a divergence would mean one of them stopped probing.
+    assert sqlite_has_json1() is sqlite_lance_has_json1()
+
+
+@pytest.mark.parametrize(
+    ("name", "builder", "metadata_column"),
+    _SQLITE_CONTEXTS,
+    ids=[case[0] for case in _SQLITE_CONTEXTS],
+)
+def test_context_capability_carries_the_probe_result(
+    name: str,
+    builder: Callable[[], CompileContext],
+    metadata_column: str,
+) -> None:
+    # The probe is only meaningful because the context hands its answer to the
+    # compiler — this is the wire between the two.
+    assert builder().schema_capabilities.sqlite_json1 is _direct_json1_probe()
+
+
+# ===========================================================================
+# KNOWN GAPS — pinned as they behave today, NOT as they should behave.
+# ===========================================================================
+
+
+def test_occurred_at_is_defended_on_surrealdb() -> None:
+    # ``compile_surrealdb`` treats the ``field_mapping`` key set as its
+    # declared+pushable whitelist, so the undeclared ``occurred_at`` leaf never
+    # reaches the query: it emits the non-constraining literal and is left out of
+    # ``consumed_keys`` for the caller to post-filter. This is the one backend
+    # where the context alone prevents the bad predicate.
+    ctx = surrealdb_context()
+    compiled = compile_surrealdb(_ast({"occurred_at": {"$gte": _DT}}), ctx)
+    assert compiled.predicate.strip() == "(true)"
+    assert compiled.consumed_keys == frozenset()
+    assert compiled.params == {}
+
+
+def test_occurred_at_is_not_defended_on_sql_backends() -> None:
+    """KNOWN GAP — pins today's behaviour so the caller contract is written down.
+
+    ``compile_postgres`` and ``compile_lance`` fall back to identity for a key
+    that is absent from ``field_mapping``, so an ``occurred_at`` leaf compiles to
+    a column that does not exist on ``documents`` AND is reported in
+    ``consumed_keys`` — the caller is told the leaf was pushed down and will not
+    post-filter it, while the statement itself fails at execute time. Nothing
+    expressible in a compile context prevents this; until the compilers honour
+    the key set as a whitelist, the enumeration caller MUST strip ``occurred_at``
+    before compiling. These assertions encode the gap, not the desired behaviour.
+
+    **This expectation INVERTS when the pushdown whitelist gate lands.**
+    ``consumed_keys`` becomes ``frozenset()`` and no ``documents.occurred_at``
+    column is emitted at all, matching what ``compile_surrealdb`` already does
+    (see the test above) — that is the fix landing, not a regression. Update the
+    assertions; do NOT restore green by declaring ``occurred_at`` in the
+    ``field_mapping``, which would point the leaf at a column no ``documents``
+    table has.
+    """
+    wire = {"occurred_at": {"$gte": _DT}}
+
+    sql = _postgres_sql(wire, postgres_context())
+    assert _emits_column(sql, "documents.occurred_at")
+    assert compile_postgres(_ast(wire), postgres_context()).consumed_keys == frozenset({"occurred_at"})
+
+    for _name, builder, _column in _SQLITE_CONTEXTS:
+        compiled = compile_lance(_ast(wire), builder())
+        assert _emits_column(_norm(compiled.predicate), "documents.occurred_at")
+        assert compiled.consumed_keys == frozenset({"occurred_at"})
+
+
+def test_surrealdb_placeholder_inverts_under_a_negated_or() -> None:
+    """KNOWN GAP — an undeclared key under ``$not``/``$or`` matches nothing.
+
+    The placeholder ``compile_surrealdb`` emits for an unsupported leaf is the
+    literal ``true``, which is non-constraining only inside a positive
+    conjunction. Under a negated OR it inverts: ``!(... OR true)`` is always
+    false, so the query silently returns no rows while ``consumed_keys`` still
+    reports the leaf as the caller's to post-filter — and post-filtering can only
+    narrow, never recover the dropped rows. Pinned as it behaves today; the fix
+    is a soundness gate in the compiler, not in this context.
+
+    **This expectation INVERTS when that soundness gate lands.** A gated
+    ``compile_surrealdb`` defers the whole ``OR`` node rather than letting a
+    match-all placeholder invert, so ``or (true)`` disappears from the emitted
+    predicate and ``title`` stops being consumed — that is the fix landing, not a
+    regression. Update the assertions to the deferred shape; do NOT restore green
+    by relaxing them back to accepting an inverted placeholder.
+    """
+    compiled = compile_surrealdb(
+        _ast({"$not": {"$or": [{"title": "x"}, {"occurred_at": {"$gt": _DT}}]}}),
+        surrealdb_context(),
+    )
+    sql = _norm(compiled.predicate)
+    assert sql.startswith("!(")
+    assert "or (true)" in sql
+    assert compiled.consumed_keys == frozenset({"title"})
+
+
+def test_sqlite_lance_datetime_bind_does_not_match_the_stored_format() -> None:
+    """KNOWN GAP — the pushed-down bind format differs from the stored format.
+
+    ``documents`` rows on this stack are written through SQLAlchemy's SQLite
+    ``DATETIME`` type, which stores ``'2026-01-31 12:30:00.000000'`` (SPACE
+    separator, no offset), while ``compile_lance`` binds a datetime operand as
+    ``.isoformat()`` (``'T'`` separator, offset included) and relies on
+    lexicographic ISO comparison. ``' '`` (0x20) sorts before ``'T'`` (0x54), so a
+    pushed-down ``created_at`` / ``source_timestamp`` bound silently excludes rows
+    from its own day. The bind value is pinned here so the mismatch is visible in
+    a test rather than only in a docstring; the caller must strip the date-valued
+    system keys until the bind format is fixed upstream.
+
+    **This expectation INVERTS when the pushdown whitelist gate lands.**
+    ``consumed_keys`` becomes ``frozenset()`` once ``compile_lance`` honours the
+    ``field_mapping`` key set and the two date keys are dropped from the
+    sqlite_lance mapping — that is the fix landing, not a regression. Update the
+    assertion; do NOT restore green by re-declaring ``created_at`` in the
+    mapping, which would reinstate the silent mismatch this test documents.
+    """
+    compiled = compile_lance(_ast({"created_at": {"$gte": _DT}}), sqlite_lance_context())
+    assert compiled.params == {"args": ["2026-01-31T12:30:00+00:00"]}
+    # Stored form for the same instant, which the bind above does NOT equal.
+    assert "2026-01-31 12:30:00.000000" != compiled.params["args"][0]
+    assert compiled.consumed_keys == frozenset({"created_at"})
+
+
+# ===========================================================================
+# Field-mapping typing sanity (cheap, catches a Mapping/str mix-up).
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    ("name", "builder"),
+    [(case[0], case[1]) for case in _ALL_CONTEXTS],
+    ids=[case[0] for case in _ALL_CONTEXTS],
+)
+def test_field_mapping_is_a_plain_string_to_string_mapping(
+    name: str,
+    builder: Callable[[], CompileContext],
+) -> None:
+    mapping = builder().field_mapping
+    assert isinstance(mapping, Mapping)
+    assert all(isinstance(key, str) and isinstance(value, str) for key, value in mapping.items())

--- a/tests/unit/filter/test_documents_compile_contexts.py
+++ b/tests/unit/filter/test_documents_compile_contexts.py
@@ -43,29 +43,32 @@ pinned separately, in a form that is self-consistent under either probe answer.
 
 from __future__ import annotations
 
+import dataclasses
 import re
 import sqlite3
 from collections.abc import Callable, Mapping
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 import pytest
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.sql.elements import ColumnElement
 
+from khora.db.models import DocumentModel
 from khora.filter import RecallFilter
 from khora.filter.ast import FilterNode, parse_to_ast
 from khora.filter.compilers.lance import compile_lance
 from khora.filter.compilers.postgres import compile_postgres
 from khora.filter.compilers.surrealdb import compile_surrealdb
 from khora.filter.context import CompileContext, SchemaCapabilities
-from khora.filter.model import SYSTEM_KEYS
+from khora.filter.model import SYSTEM_KEYS, RecallFilterUnsupportedError
 from khora.filter.registry import CompiledFilter
+from khora.storage.backends._sqlite_capabilities import sqlite_has_json1
 from khora.storage.backends.postgresql import _documents_compile_context as postgres_context
+from khora.storage.backends.sqlite import _SCHEMA_SQL
 from khora.storage.backends.sqlite import _documents_compile_context as sqlite_context
-from khora.storage.backends.sqlite import _sqlite_has_json1 as sqlite_has_json1
 from khora.storage.backends.sqlite_lance.relational import _documents_compile_context as sqlite_lance_context
-from khora.storage.backends.sqlite_lance.relational import _sqlite_has_json1 as sqlite_lance_has_json1
 from khora.storage.backends.surrealdb.relational import _documents_compile_context as surrealdb_context
 
 pytestmark = pytest.mark.unit
@@ -138,15 +141,12 @@ def _json1_variant(ctx: CompileContext) -> CompileContext:
     Column-mapping tests must not depend on the host's SQLite build, so they run
     against this local variant, which carries the shipped ``field_mapping``
     verbatim and only pins the capability flag.
+
+    ``dataclasses.replace`` rather than a field-by-field rebuild: a new field on
+    :class:`CompileContext` would otherwise be silently dropped from every test
+    routed through this helper, with nothing to flag it.
     """
-    return CompileContext(
-        backend_target=ctx.backend_target,
-        table_alias=ctx.table_alias,
-        param_namespace=ctx.param_namespace,
-        field_mapping=ctx.field_mapping,
-        schema_capabilities=SchemaCapabilities(sqlite_json1=True),
-        on_unsupported=ctx.on_unsupported,
-    )
+    return dataclasses.replace(ctx, schema_capabilities=SchemaCapabilities(sqlite_json1=True))
 
 
 # Every context builder, with its expected physical target/metadata column, and
@@ -157,6 +157,19 @@ _ALL_CONTEXTS: tuple[tuple[str, Callable[[], CompileContext], str, str], ...] = 
     ("sqlite_lance", sqlite_lance_context, "documents", "metadata"),
     ("surrealdb", surrealdb_context, "document", "metadata_"),
 )
+
+# The enumeration contract specifies ``"split"`` everywhere. The SurrealDB
+# context ships ``"raise"`` as an interim posture because ``compile_surrealdb``
+# is not sound under split — its unsupported-leaf placeholder inverts under
+# ``$not``/``$or`` (pinned in the known-gap section below). Raising is strictly
+# narrower, so widening it back to ``"split"`` with the compiler soundness gate
+# is not a breaking change for a caller.
+_EXPECTED_UNSUPPORTED_MODE: Mapping[str, str] = {
+    "postgresql": "split",
+    "sqlite": "split",
+    "sqlite_lance": "split",
+    "surrealdb": "raise",
+}
 
 # The two ``compile_lance``-driven contexts, which share every behaviour that
 # depends on the JSON1 capability flag.
@@ -191,8 +204,9 @@ def test_context_declares_the_physical_schema(
     assert ctx.table_alias is None
     assert ctx.param_namespace == "f"
     # A document enumeration always has an in-memory post-filter available, so an
-    # unpushable leaf is left unconsumed rather than raising.
-    assert ctx.on_unsupported == "split"
+    # unpushable leaf is normally left unconsumed rather than raising — except on
+    # SurrealDB, whose compiler is not yet sound under split (see the map above).
+    assert ctx.on_unsupported == _EXPECTED_UNSUPPORTED_MODE[name]
 
     mapping = ctx.field_mapping
     assert mapping is not None
@@ -221,6 +235,78 @@ def test_occurred_at_is_absent_from_every_documents_mapping(
     # ``documents`` column behind it.
     assert "occurred_at" in SYSTEM_KEYS
     assert set(_BACKED_KEYS) | {"occurred_at"} == set(SYSTEM_KEYS)
+
+
+def _real_columns(name: str) -> frozenset[str]:
+    """The physical column/field names each store's own schema actually defines.
+
+    Read from each store's schema artifact rather than restated here, so this is
+    a genuine cross-check of the mappings instead of a comparison against a copy
+    of them. Needs no database server and no fixtures.
+    """
+    if name in {"postgresql", "sqlite_lance"}:
+        # Both reuse the shared declarative model. ``.c`` is keyed by PHYSICAL
+        # column name, so the metadata column reads as ``metadata`` even though
+        # the mapped attribute is ``metadata_``.
+        return frozenset(DocumentModel.__table__.c.keys())
+    if name == "sqlite":
+        conn = sqlite3.connect(":memory:")
+        try:
+            conn.executescript(_SCHEMA_SQL)
+            return frozenset(row[1] for row in conn.execute("PRAGMA table_info(documents)"))
+        finally:
+            conn.close()
+    if name == "surrealdb":
+        schema = Path(
+            str(__import__("khora.storage.backends.surrealdb.schema", fromlist=["__file__"]).__file__)
+        ).read_text()
+        return frozenset(re.findall(r"DEFINE FIELD (?:IF NOT EXISTS )?(\w+) ON document\b", schema))
+    raise AssertionError(f"unknown store {name!r}")
+
+
+@pytest.mark.parametrize(
+    ("name", "builder", "target", "metadata_column"),
+    _ALL_CONTEXTS,
+    ids=[case[0] for case in _ALL_CONTEXTS],
+)
+def test_field_mapping_matches_the_real_physical_columns(
+    name: str,
+    builder: Callable[[], CompileContext],
+    target: str,
+    metadata_column: str,
+) -> None:
+    """Every declared physical name must exist in the store's own schema.
+
+    The other context assertions compare the mapping to literals restated in
+    this module, so they would happily agree with a mapping that names a column
+    no table has. This one reads each store's real schema and is the guard that
+    actually fails when a column is renamed or dropped underneath a context —
+    the exact drift this whole module exists to prevent.
+    """
+    columns = _real_columns(name)
+    assert columns, f"failed to read any columns for {name}"
+
+    mapping = builder().field_mapping
+    assert mapping is not None
+    missing = set(mapping.values()) - columns
+    assert not missing, f"{name} maps to columns its schema does not define: {sorted(missing)}"
+
+
+@pytest.mark.parametrize(
+    ("name", "builder", "target", "metadata_column"),
+    _ALL_CONTEXTS,
+    ids=[case[0] for case in _ALL_CONTEXTS],
+)
+def test_occurred_at_is_absent_from_every_real_documents_schema(
+    name: str,
+    builder: Callable[[], CompileContext],
+    target: str,
+    metadata_column: str,
+) -> None:
+    # The reason ``occurred_at`` is excluded from every mapping, asserted against
+    # the schemas themselves rather than left as prose: it is chunk event-time
+    # and no documents table has a column for it on any backend.
+    assert "occurred_at" not in _real_columns(name)
 
 
 def test_only_the_sqlite_contexts_declare_a_capability() -> None:
@@ -323,25 +409,24 @@ def test_surrealdb_metadata_leaf_addresses_the_metadata_underscore_field() -> No
 
 
 def test_metadata_column_matcher_rejects_the_swapped_mapping() -> None:
-    """The column assertions above must FAIL against the defect they guard.
+    """``_emits_column`` must DISCRIMINATE the two physical spellings.
 
-    ``metadata`` is a prefix of ``metadata_``, so a substring assertion stays
-    green when a context is wired to the other backend's column. This test runs
-    each backend's shipped assertion against a context whose metadata mapping has
-    been deliberately swapped to the wrong spelling and requires it to reject —
-    if this ever passes trivially, every metadata assertion above is worthless.
+    ``metadata`` is a prefix of ``metadata_``, so a plain substring assertion is
+    green for both and cannot fail against the defect this module exists to
+    guard. This case pins that the word-boundary matcher tells them apart:
+    compile through a context whose metadata mapping is the wrong spelling and
+    require the shipped-column assertion to reject it.
+
+    Scope, stated precisely: both the shipped and the wrong spelling are
+    hardcoded here, so this proves the MATCHER discriminates — not that any
+    shipped mapping is correct. The mapping itself is guarded by
+    :func:`test_field_mapping_matches_the_real_physical_columns` (against each
+    store's real schema) and by ``test_context_declares_the_physical_schema``.
     """
 
     def _swapped(ctx: CompileContext, wrong_column: str) -> CompileContext:
         mapping = dict(ctx.field_mapping or {}) | {"metadata": wrong_column}
-        return CompileContext(
-            backend_target=ctx.backend_target,
-            table_alias=ctx.table_alias,
-            param_namespace=ctx.param_namespace,
-            field_mapping=mapping,
-            schema_capabilities=ctx.schema_capabilities,
-            on_unsupported=ctx.on_unsupported,
-        )
+        return dataclasses.replace(ctx, field_mapping=mapping)
 
     wire = {"metadata.tier": {"$eq": "gold"}}
 
@@ -473,14 +558,9 @@ def test_shipped_sqlite_context_is_self_consistent_under_either_json1_answer(
 # The JSON1 probe — the only new runtime logic behind these contexts.
 # ===========================================================================
 
-# Both SQLite store modules carry their own copy of the probe (their schemas
-# genuinely diverge, so they share no code); both are covered.
-_JSON1_PROBES: tuple[tuple[str, Callable[[], bool]], ...] = (
-    ("sqlite", sqlite_has_json1),
-    ("sqlite_lance", sqlite_lance_has_json1),
-)
 
-
+# Both SQLite stores share ONE probe: it interrogates the process's stdlib
+# ``sqlite3`` build, not either store's schema, so the two cannot disagree.
 def _direct_json1_probe() -> bool:
     """Ask this interpreter's ``sqlite3`` build about JSON1, independently."""
     conn = sqlite3.connect(":memory:")
@@ -492,32 +572,71 @@ def _direct_json1_probe() -> bool:
         conn.close()
 
 
-@pytest.mark.parametrize(("name", "probe"), _JSON1_PROBES, ids=[case[0] for case in _JSON1_PROBES])
-def test_json1_probe_agrees_with_the_hosts_sqlite_build(name: str, probe: Callable[[], bool]) -> None:
+def test_json1_probe_agrees_with_the_hosts_sqlite_build() -> None:
     """The probe reports what this host's SQLite actually supports.
 
     Asserted against an independent probe rather than a hardcoded ``True``, so
     the test states the contract (the flag tracks the runtime) instead of the
     accident of which SQLite this host shipped. ``aiosqlite`` and SQLAlchemy's
     ``sqlite+aiosqlite`` both run on this same in-process library, which is what
-    makes a process-wide answer correct.
+    makes a single process-wide answer correct for both stores.
     """
-    result = probe()
+    result = sqlite_has_json1()
     assert isinstance(result, bool)
     assert result is _direct_json1_probe()
 
 
-@pytest.mark.parametrize(("name", "probe"), _JSON1_PROBES, ids=[case[0] for case in _JSON1_PROBES])
-def test_json1_probe_is_stable_across_calls(name: str, probe: Callable[[], bool]) -> None:
+def test_json1_probe_is_stable_across_calls() -> None:
     # Memoized: the answer cannot change within a process, and a context built
     # twice must not disagree with itself.
-    assert probe() is probe()
+    assert sqlite_has_json1() is sqlite_has_json1()
 
 
-@pytest.mark.parametrize(("name", "probe"), _JSON1_PROBES, ids=[case[0] for case in _JSON1_PROBES])
+def test_json1_probe_interrogates_json1_specifically(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The probe must ask about JSON1 — not merely run *some* query successfully.
+
+    Without this, a probe rewritten to ``SELECT 1`` passes every other case on a
+    JSON1-enabled host: the fail-closed case below drives its negative branch
+    with a connection that raises for ANY SQL, so it cannot tell the two apart.
+    A ``SELECT 1`` probe would report ``True`` on a build lacking JSON1 and
+    ``compile_lance`` would then emit ``json_extract`` / ``json_each`` against a
+    build that cannot run them — exactly what the probe exists to prevent.
+
+    Orthogonal to :func:`test_context_reads_the_probe_rather_than_hardcoding_it`:
+    that one pins the context→probe wire, this one pins what the probe asks.
+    Fixing either leaves the other's mutant alive.
+    """
+    executed: list[str] = []
+    # Bind the real factory before patching, or the wrapper below re-enters the
+    # patched one and recurses.
+    real_connect = sqlite3.connect
+
+    class _RecordingConnection:
+        def __init__(self) -> None:
+            self._conn = real_connect(":memory:")
+
+        def execute(self, sql: str) -> object:
+            executed.append(sql)
+            return self._conn.execute(sql)
+
+        def close(self) -> None:
+            self._conn.close()
+
+    monkeypatch.setattr(sqlite3, "connect", lambda *_a, **_k: _RecordingConnection())
+    sqlite_has_json1.cache_clear()
+    try:
+        sqlite_has_json1()
+    finally:
+        sqlite_has_json1.cache_clear()
+    monkeypatch.undo()
+
+    assert executed, "the probe ran no query at all"
+    assert any("json_valid" in sql for sql in executed), f"probe must interrogate a JSON1 function, but ran: {executed}"
+    # Restore the host's real answer for every later test in this process.
+    assert sqlite_has_json1() is _direct_json1_probe()
+
+
 def test_json1_probe_fails_closed_when_the_query_errors(
-    name: str,
-    probe: Any,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A failed probe reports NO JSON1 — the conservative answer.
@@ -543,21 +662,15 @@ def test_json1_probe_fails_closed_when_the_query_errors(
     monkeypatch.setattr(sqlite3, "connect", lambda *_args, **_kwargs: _FailingConnection())
     # The probe is memoized, so the real answer must be evicted before and after
     # this case or the fake result would leak into the rest of the session.
-    probe.cache_clear()
+    sqlite_has_json1.cache_clear()
     try:
-        assert probe() is False
+        assert sqlite_has_json1() is False
     finally:
-        probe.cache_clear()
+        sqlite_has_json1.cache_clear()
 
     monkeypatch.undo()
     # Back to the host's real answer for every later test in this process.
-    assert probe() is _direct_json1_probe()
-
-
-def test_both_sqlite_probes_reach_the_same_answer() -> None:
-    # Two independent copies of the same probe against the same in-process
-    # library — a divergence would mean one of them stopped probing.
-    assert sqlite_has_json1() is sqlite_lance_has_json1()
+    assert sqlite_has_json1() is _direct_json1_probe()
 
 
 @pytest.mark.parametrize(
@@ -575,22 +688,65 @@ def test_context_capability_carries_the_probe_result(
     assert builder().schema_capabilities.sqlite_json1 is _direct_json1_probe()
 
 
+@pytest.mark.parametrize(
+    ("name", "builder", "metadata_column"),
+    _SQLITE_CONTEXTS,
+    ids=[case[0] for case in _SQLITE_CONTEXTS],
+)
+def test_context_reads_the_probe_rather_than_hardcoding_it(
+    name: str,
+    builder: Callable[[], CompileContext],
+    metadata_column: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A context that hardcoded ``sqlite_json1=True`` must fail here.
+
+    The case above compares the context's flag to a live probe, so on a
+    JSON1-enabled host both sides are ``True`` and it cannot distinguish "reads
+    the probe" from "hardcoded". Forcing the probe to the opposite answer is
+    what makes the wire observable.
+    """
+    # Patch the name in the STORE module, not in ``_sqlite_capabilities``: each
+    # store does ``from ... import sqlite_has_json1``, which binds the function
+    # object into its own namespace at import time, so patching the source
+    # module would not be observed here.
+    store_module = builder.__module__
+    for forced in (False, True):
+        monkeypatch.setattr(f"{store_module}.sqlite_has_json1", lambda _v=forced: _v)
+        try:
+            assert builder().schema_capabilities.sqlite_json1 is forced
+        finally:
+            monkeypatch.undo()
+
+    # The real probe is memoized and was never displaced, but assert the host's
+    # answer is intact so nothing leaks into later tests.
+    assert builder().schema_capabilities.sqlite_json1 is _direct_json1_probe()
+
+
 # ===========================================================================
 # KNOWN GAPS — pinned as they behave today, NOT as they should behave.
 # ===========================================================================
 
 
 def test_occurred_at_is_defended_on_surrealdb() -> None:
-    # ``compile_surrealdb`` treats the ``field_mapping`` key set as its
-    # declared+pushable whitelist, so the undeclared ``occurred_at`` leaf never
-    # reaches the query: it emits the non-constraining literal and is left out of
-    # ``consumed_keys`` for the caller to post-filter. This is the one backend
-    # where the context alone prevents the bad predicate.
+    """The shipped SurrealDB context REJECTS an undeclared system key.
+
+    ``compile_surrealdb`` treats the ``field_mapping`` key set as its
+    declared+pushable whitelist, so the undeclared ``occurred_at`` leaf never
+    reaches the query. Under the shipped ``on_unsupported="raise"`` that surfaces
+    as a structured error rather than a silent placeholder — the interim posture
+    that keeps the inversion below unreachable until the compiler soundness gate
+    lands. This is the one backend where the context alone prevents the bad
+    predicate; the three SQL backends cannot (see the case below).
+
+    When the context flips back to ``"split"``, this expectation changes to the
+    placeholder shape — ``predicate == "(true)"`` with empty ``consumed_keys`` —
+    which is only safe once the compiler defers rather than emitting a
+    match-all in place.
+    """
     ctx = surrealdb_context()
-    compiled = compile_surrealdb(_ast({"occurred_at": {"$gte": _DT}}), ctx)
-    assert compiled.predicate.strip() == "(true)"
-    assert compiled.consumed_keys == frozenset()
-    assert compiled.params == {}
+    with pytest.raises(RecallFilterUnsupportedError):
+        compile_surrealdb(_ast({"occurred_at": {"$gte": _DT}}), ctx)
 
 
 def test_occurred_at_is_not_defended_on_sql_backends() -> None:
@@ -636,6 +792,12 @@ def test_surrealdb_placeholder_inverts_under_a_negated_or() -> None:
     narrow, never recover the dropped rows. Pinned as it behaves today; the fix
     is a soundness gate in the compiler, not in this context.
 
+    The SHIPPED context now uses ``on_unsupported="raise"`` precisely to keep
+    this unreachable, so the defect is pinned here against an explicitly
+    split-mode copy of it. That keeps the compiler bug documented and guarded
+    while no caller can trip it — and it is why this case must build its own
+    context rather than using the shipped one.
+
     **This expectation INVERTS when that soundness gate lands.** A gated
     ``compile_surrealdb`` defers the whole ``OR`` node rather than letting a
     match-all placeholder invert, so ``or (true)`` disappears from the emitted
@@ -643,9 +805,10 @@ def test_surrealdb_placeholder_inverts_under_a_negated_or() -> None:
     regression. Update the assertions to the deferred shape; do NOT restore green
     by relaxing them back to accepting an inverted placeholder.
     """
+    split_ctx = dataclasses.replace(surrealdb_context(), on_unsupported="split")
     compiled = compile_surrealdb(
         _ast({"$not": {"$or": [{"title": "x"}, {"occurred_at": {"$gt": _DT}}]}}),
-        surrealdb_context(),
+        split_ctx,
     )
     sql = _norm(compiled.predicate)
     assert sql.startswith("!(")


### PR DESCRIPTION
## Summary

Adds one documents-table `CompileContext` per relational backend and registers the **existing** dialect compilers under four new registry keys. No compiler is written or modified, and the five chunk-tier registrations are byte-identical.

| Registry key | Compiler (reused as-is) |
| --- | --- |
| `("relational.postgresql", "documents")` | `compile_postgres` |
| `("relational.sqlite", "documents")` | `compile_lance` |
| `("relational.sqlite_lance", "documents")` | `compile_lance` |
| `("relational.surrealdb", "documents")` | `compile_surrealdb` |

Each context declares the nine system keys the documents table actually backs, plus the `metadata` root remap, and uses `on_unsupported="split"`.

- **The physical metadata column diverges across stores**, and each mapping is derived from that store's own DDL rather than assumed: `metadata` on postgresql and sqlite_lance (which share the ORM model), `metadata_` on raw sqlite and surrealdb. A context wired with the wrong column fails at query time — or, on a permissive engine, silently matches nothing.
- `updated_at` and `status` are deliberately **not** mapped: neither is a system filter key, so neither can ever appear as an AST leaf.
- The surrealdb context targets the singular `document` table, its real physical name. That compiler never reads `backend_target`, so the value is inert today — which is exactly why it names the truth rather than a plausible-looking wrong table.
- The registry drift guard grows to nine keys **and** gains explicit imports of all four backend modules, so the key set cannot vary by worker under xdist.

The contexts have no caller yet — the enumeration scan path is separate work. That is intended, not an oversight.

## Known gaps: documented and test-pinned, not fixed

This change is the first thing in the codebase to select `on_unsupported="split"` on the postgres and surrealdb compilers, which surfaced three pre-existing compiler-layer defects. Fixing them means editing conformance-proven compilers, so they are documented in the context docstrings and pinned by tests that state they encode a known gap rather than desired behaviour. Each has a tracked follow-up.

1. **`occurred_at` has no documents column**, and `compile_postgres` / `compile_lance` fall back to identity for unmapped keys — so such a leaf compiles to a non-existent column *and* is reported as consumed, meaning a caller would not post-filter it. Rejection belongs at the caller. `compile_surrealdb`'s whitelist does prevent it.
2. **`compile_surrealdb`'s split placeholder is the literal `true`**, which inverts under `$not`/`$or`: `!(x OR true)` is `false`, so the query silently matches zero rows.
3. **sqlite_lance stores documents datetimes via SQLAlchemy `DATETIME`** (space separator, no offset) while `compile_lance` binds `isoformat()` — so a pushed-down date compare can silently exclude the bound's own day.

## Test plan

- [x] Unit tests pass — `tests/unit/filter`: 1457 passed (baseline 1416; +41)
- [x] Integration tests pass — compiler-identity guard 5 passed; registry drift guard 10 passed under `-m filter_conformance`
- [x] Full suite green, coverage 85.39% against the 77% gate
- [x] `ruff format --check` and `ruff check` clean; `ty` reports the same 107 diagnostics with and without the change (zero new)
- [x] **Mutation-verified, not just passing.** `metadata` is a prefix substring of `metadata_`, so the obvious `"documents.metadata" in sql` assertion passes against the exact defect this change exists to prevent. Every metadata assertion goes through a word-boundary matcher instead, and sabotaging each context's mapping was confirmed to fail the shipped assertions (2/5/5/2 across the four backends). The swap experiment is preserved as a standing test.
- [x] The registry-identity and split-residual assertions were mutation-checked the same way, as was the JSON1 probe (a hardcoded `True` fails the fail-closed case)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added document-level recall-filter support for PostgreSQL, SQLite, SQLite-Lance, and SurrealDB.
  * Added backend-specific metadata mapping and handling for unsupported filter conditions.
  * Added SQLite JSON capability detection for metadata filtering.

* **Documentation**
  * Clarified query-path ownership and compiler registration behavior.

* **Tests**
  * Added comprehensive coverage for document filtering, backend mappings, capabilities, parameters, and compiler registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->