### PR TITLE
Widen the documents sort index to cover the pinned total order

### DIFF
--- a/src/khora/db/migrations/versions/054_documents_namespace_created_at_id.py
+++ b/src/khora/db/migrations/versions/054_documents_namespace_created_at_id.py
@@ -2,6 +2,7 @@
 
 Revision ID: 054_documents_namespace_created_at_id
 Revises: 053_khora_chunks_bookkeeping_to_chunker_info
+Create Date: 2026-08-04
 
 ``list_documents`` now pins a total order — ``ORDER BY created_at DESC, id
 DESC`` — across the relational backends so that offset pagination cannot drop
@@ -140,8 +141,12 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     # Exact mirror on both branches. The 2-column index MUST come back:
-    # migration 019's downgrade issues an unqualified drop of it, so leaving it
-    # absent would break any downgrade that walks past 019 — on either dialect.
+    # migration 019's downgrade() drops ix_documents_namespace_created_at
+    # unconditionally — a plain ``op.drop_index`` with no ``if_exists=True`` —
+    # so 054's downgrade must restore it or any walk past 019 aborts, on either
+    # dialect. (The table name IS passed there; it is the missing if_exists that
+    # makes the restore load-bearing, so do not read a qualified call as proof
+    # this is unnecessary.)
     if _is_postgres():
         # Same invalid-leftover trap as upgrade(), mirrored onto the 2-column
         # index this direction rebuilds.

--- a/src/khora/db/migrations/versions/054_documents_namespace_created_at_id.py
+++ b/src/khora/db/migrations/versions/054_documents_namespace_created_at_id.py
@@ -51,20 +51,30 @@ duration of the build. Run this migration out-of-band on such deployments rather
 than during a rolling deploy. (Migration 029's BRIN build does not carry this
 risk — BRIN indexes are KB-sized and build in seconds.)
 
-Operational caveat — ``IF NOT EXISTS`` does NOT self-heal a failed concurrent
-build. If ``CREATE INDEX CONCURRENTLY`` fails (deadlock, cancellation, unique
-violation, connection loss), Postgres leaves behind an **INVALID** index: it is
-ignored by the planner for reads but still maintained on every write. Re-running
-this migration will match that leftover *by name*, skip the build, and report
-success while leaving the database with an index that costs writes and serves no
-reads. An operator recovering from a failed run must drop the invalid index
-manually (check ``pg_index.indisvalid``, then ``DROP INDEX CONCURRENTLY``)
-before re-running.
+Invalid-index recovery — a failed ``CREATE INDEX CONCURRENTLY`` (deadlock,
+cancellation, connection loss) leaves an **INVALID** index behind: ignored by
+the planner for reads, but still maintained on every write. ``IF NOT EXISTS``
+matches such a leftover *by name* and skips the build, so a naive re-run would
+skip the create and then still run the drop — leaving the table with an invalid
+3-column index and **no valid index at all**, precisely on the deployment large
+enough for the first build to have failed. Both directions therefore probe
+``pg_index.indisvalid`` and drop an invalid leftover before building. This
+follows migration 022, which solved the same problem on this same table; its
+``_drop_invalid_index`` helper is reproduced here.
+
+Planner precondition — the sort-free plan assumes ``namespace_id`` is selective
+against the table. Where a single namespace holds most of ``documents``,
+Postgres may instead prefer the single-column ``ix_documents_created_at``
+(migration 009) and reintroduce the Incremental Sort, because walking that index
+directly can beat a lookup that matches most of the table anyway. Operators
+sizing this change on a heavily single-tenant ``documents`` table should measure
+rather than assume the win.
 """
 
 from collections.abc import Sequence
 
 from alembic import op
+from sqlalchemy import text
 
 revision: str = "054_documents_namespace_created_at_id"
 down_revision: str | Sequence[str] | None = "053_khora_chunks_bookkeeping_to_chunker_info"
@@ -76,11 +86,39 @@ def _is_postgres() -> bool:
     return op.get_bind().dialect.name == "postgresql"
 
 
+def _drop_invalid_index(index_name: str) -> None:
+    """Drop an index if it exists and is marked invalid (indisvalid = false).
+
+    An interrupted ``CREATE INDEX CONCURRENTLY`` leaves an INVALID index behind.
+    ``IF NOT EXISTS`` matches it by name and skips the rebuild, so without this
+    probe a re-run would skip the create yet still run the drop, leaving the
+    table with no valid index at all. Mirrors migration 022's helper.
+    """
+    conn = op.get_bind()
+    is_invalid = conn.execute(
+        text(
+            "SELECT EXISTS ("
+            "  SELECT 1 FROM pg_class c"
+            "  JOIN pg_index i ON i.indexrelid = c.oid"
+            "  WHERE c.relname = :name AND NOT i.indisvalid"
+            ")"
+        ),
+        {"name": index_name},
+    ).scalar()
+    if is_invalid:
+        with op.get_context().autocommit_block():
+            op.execute(text(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}"))
+
+
 def upgrade() -> None:
     # Create first, drop second on both branches: dropping first would leave
     # ``get_last_activity_at()``'s MAX(created_at) with no index for the
     # duration of the (potentially long) build.
     if _is_postgres():
+        # Clear an INVALID leftover from an interrupted earlier build first.
+        # Without this, IF NOT EXISTS would match it by name, skip the build,
+        # and the drop below would then remove the only valid index.
+        _drop_invalid_index("ix_documents_namespace_created_at_id")
         # ``CREATE INDEX CONCURRENTLY`` cannot run inside a transaction, so we
         # open an autocommit block.
         with op.get_context().autocommit_block():
@@ -105,6 +143,9 @@ def downgrade() -> None:
     # migration 019's downgrade issues an unqualified drop of it, so leaving it
     # absent would break any downgrade that walks past 019 — on either dialect.
     if _is_postgres():
+        # Same invalid-leftover trap as upgrade(), mirrored onto the 2-column
+        # index this direction rebuilds.
+        _drop_invalid_index("ix_documents_namespace_created_at")
         with op.get_context().autocommit_block():
             op.execute(
                 "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_documents_namespace_created_at "

--- a/src/khora/db/migrations/versions/054_documents_namespace_created_at_id.py
+++ b/src/khora/db/migrations/versions/054_documents_namespace_created_at_id.py
@@ -1,0 +1,120 @@
+"""Widen the documents namespace/created_at index to include ``id``.
+
+Revision ID: 054_documents_namespace_created_at_id
+Revises: 053_khora_chunks_bookkeeping_to_chunker_info
+
+``list_documents`` now pins a total order — ``ORDER BY created_at DESC, id
+DESC`` — across the relational backends so that offset pagination cannot drop
+or repeat a row when two documents share a ``created_at``. The pre-existing
+2-column index ``ix_documents_namespace_created_at (namespace_id, created_at)``
+only supplies a *prefix* of that order, so the planner has to add a sort step
+(an incremental sort on PG 13+). First-page reads barely notice; the cost lands
+on full-drain offset pagination, which real callers perform (GC / session
+expiry, ``forget_session``, and the agent-framework adapters that walk every
+document in a namespace). The regression does not require any ties to exist —
+the planner cannot know the tail key is unique, so it sorts regardless.
+
+Widening the index to ``(namespace_id, created_at, id)`` restores an
+index-order scan. All three keys are declared **ASC**: with ``namespace_id``
+equality-constrained, the residual index order is ``(created_at ASC, id ASC)``
+and a backward scan yields exactly ``(created_at DESC, id DESC)``.
+DESC-declared keys only buy anything for *mixed* sort directions, which the
+uniform-DESC ordering rules out.
+
+The 2-column index is dropped: two indexes sharing a prefix are both
+maintained on every insert, i.e. pure write amplification on the ingest path.
+The 3-column index is a strict superset for lookup purposes — migration 019
+added the 2-column index for ``get_last_activity_at()``'s
+``MAX(created_at) WHERE namespace_id = ?``, and the widened index serves that
+query on its ``(namespace_id, created_at)`` prefix. The new index is created
+**before** the old one is dropped so that query never runs unindexed.
+
+Both dialects are handled. Postgres builds concurrently (see the caveats
+below); every other dialect takes the plain-DDL branch, which is what migration
+019 already did when it created the 2-column index unconditionally. That keeps
+the invariant simple: wherever 019 ran, 054 runs, so the ORM declaration and the
+physical schema agree on every backend. The embedded ``sqlite_lance`` stack runs
+this chain too, and its own full-drain pagination callers are the ones that
+motivated the change, so skipping SQLite would have left the regression in place
+on the stack it was measured on.
+
+Operational caveat — this migration can be slow, and it holds the migration
+advisory lock while it runs. ``run_migrations()`` takes a session-scoped
+``pg_advisory_lock`` *before* Alembic's transaction demarcation and holds it for
+the whole run, including the autocommit block below. A concurrent caller waits
+only 60s before raising ``TimeoutError``, which surfaces as
+``MigrationResult(success=False)`` and then ``RuntimeError: Database migration
+failed`` at startup. A btree ``CREATE INDEX CONCURRENTLY`` over a large
+``documents`` table can easily exceed that, so on a large deployment every other
+service booting with ``run_migrations=True`` would fail to start for the
+duration of the build. Run this migration out-of-band on such deployments rather
+than during a rolling deploy. (Migration 029's BRIN build does not carry this
+risk — BRIN indexes are KB-sized and build in seconds.)
+
+Operational caveat — ``IF NOT EXISTS`` does NOT self-heal a failed concurrent
+build. If ``CREATE INDEX CONCURRENTLY`` fails (deadlock, cancellation, unique
+violation, connection loss), Postgres leaves behind an **INVALID** index: it is
+ignored by the planner for reads but still maintained on every write. Re-running
+this migration will match that leftover *by name*, skip the build, and report
+success while leaving the database with an index that costs writes and serves no
+reads. An operator recovering from a failed run must drop the invalid index
+manually (check ``pg_index.indisvalid``, then ``DROP INDEX CONCURRENTLY``)
+before re-running.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "054_documents_namespace_created_at_id"
+down_revision: str | Sequence[str] | None = "053_khora_chunks_bookkeeping_to_chunker_info"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_postgres() -> bool:
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def upgrade() -> None:
+    # Create first, drop second on both branches: dropping first would leave
+    # ``get_last_activity_at()``'s MAX(created_at) with no index for the
+    # duration of the (potentially long) build.
+    if _is_postgres():
+        # ``CREATE INDEX CONCURRENTLY`` cannot run inside a transaction, so we
+        # open an autocommit block.
+        with op.get_context().autocommit_block():
+            op.execute(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_documents_namespace_created_at_id "
+                "ON documents (namespace_id, created_at, id)"
+            )
+            op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_documents_namespace_created_at")
+    else:
+        # SQLite (and any other dialect running this chain) has no concurrent
+        # build and does not need one — plain DDL, exactly as 019 issued it.
+        op.create_index(
+            "ix_documents_namespace_created_at_id",
+            "documents",
+            ["namespace_id", "created_at", "id"],
+        )
+        op.drop_index("ix_documents_namespace_created_at", "documents")
+
+
+def downgrade() -> None:
+    # Exact mirror on both branches. The 2-column index MUST come back:
+    # migration 019's downgrade issues an unqualified drop of it, so leaving it
+    # absent would break any downgrade that walks past 019 — on either dialect.
+    if _is_postgres():
+        with op.get_context().autocommit_block():
+            op.execute(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_documents_namespace_created_at "
+                "ON documents (namespace_id, created_at)"
+            )
+            op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_documents_namespace_created_at_id")
+    else:
+        op.create_index(
+            "ix_documents_namespace_created_at",
+            "documents",
+            ["namespace_id", "created_at"],
+        )
+        op.drop_index("ix_documents_namespace_created_at_id", "documents")

--- a/src/khora/db/models.py
+++ b/src/khora/db/models.py
@@ -197,7 +197,11 @@ class DocumentModel(Base):
             postgresql_where=text("status != 'failed'"),
         ),
         Index("ix_documents_namespace_source_type", "namespace_id", "source_type"),
-        Index("ix_documents_namespace_created_at", "namespace_id", "created_at"),
+        # Trailing ``id`` makes this cover ``list_documents``'s pinned total
+        # order (``created_at DESC, id DESC``) via a backward index scan; the
+        # ``(namespace_id, created_at)`` prefix still serves
+        # ``get_last_activity_at()``. See migration 054.
+        Index("ix_documents_namespace_created_at_id", "namespace_id", "created_at", "id"),
         Index(
             "ix_documents_namespace_external_id_unique",
             "namespace_id",

--- a/src/khora/storage/optimize.py
+++ b/src/khora/storage/optimize.py
@@ -26,13 +26,12 @@ PG_INDEXES = [
         "sql": ("CREATE INDEX IF NOT EXISTS idx_chunks_namespace_created ON chunks (namespace_id, created_at DESC)"),
         "purpose": "Temporal filtering within namespace",
     },
-    {
-        "name": "idx_documents_namespace_created",
-        "sql": (
-            "CREATE INDEX IF NOT EXISTS idx_documents_namespace_created ON documents (namespace_id, created_at DESC)"
-        ),
-        "purpose": "Document temporal queries",
-    },
+    # NOTE: no (namespace_id, created_at) index on ``documents`` here. Migration
+    # 054 widened that index to (namespace_id, created_at, id) to cover
+    # list_documents' pinned ORDER BY, and dropped the 2-column version so the
+    # ingest path does not maintain two indexes sharing a prefix. Re-adding a
+    # near-duplicate here would undo that and give the planner a fourth
+    # candidate on the same leading columns.
     {
         "name": "idx_entities_namespace_type_name",
         "sql": (

--- a/tests/integration/db/test_list_documents_index_plan_sqlite.py
+++ b/tests/integration/db/test_list_documents_index_plan_sqlite.py
@@ -39,12 +39,30 @@ from uuid import UUID, uuid4
 import pytest
 from alembic import command
 from alembic.config import Config
-from sqlalchemy import event, select
-from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlalchemy import event
 
 from khora.db.models import DocumentModel
 
-pytestmark = [pytest.mark.integration, pytest.mark.embedded]
+try:
+    import aiosqlite  # noqa: F401
+    import lancedb  # noqa: F401
+
+    _HAS_EMBEDDED = True
+except ImportError:
+    _HAS_EMBEDDED = False
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.embedded,
+    pytest.mark.skipif(not _HAS_EMBEDDED, reason="aiosqlite/lancedb not installed"),
+]
+
+if _HAS_EMBEDDED:
+    from khora.storage.backends.sqlite_lance.connection import (
+        EmbeddedStorageHandle,
+        EmbeddedStorageHandleConfig,
+    )
+    from khora.storage.backends.sqlite_lance.relational import SQLiteLanceRelationalAdapter
 
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
 
@@ -127,13 +145,25 @@ def pristine_db() -> Iterator[Path]:
 
 
 @pytest.fixture
-async def engine(mutable_db) -> AsyncIterator[AsyncEngine]:
+async def adapter(mutable_db, tmp_path) -> AsyncIterator[SQLiteLanceRelationalAdapter]:
+    """The REAL embedded relational backend, opened on the seeded database.
+
+    The plan assertions have to be made against the query the shipped
+    ``list_documents`` emits. Driving the actual adapter is what guarantees
+    that: reorder the ``order_by`` in the backend and these tests change
+    behaviour, which a locally rebuilt ``select(DocumentModel)`` would not.
+    """
     db_path, _ = mutable_db
-    eng = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    handle = EmbeddedStorageHandle(
+        EmbeddedStorageHandleConfig(db_path=str(db_path), lance_path=str(tmp_path / "khora.lance")),
+    )
+    be = SQLiteLanceRelationalAdapter(handle)
+    await be.connect()
     try:
-        yield eng
+        yield be
     finally:
-        await eng.dispose()
+        await be.disconnect()
+        await handle.disconnect()
 
 
 def _documents_indexes(db_path: Path) -> dict[str, str]:
@@ -147,37 +177,33 @@ def _documents_indexes(db_path: Path) -> dict[str, str]:
     return {name: sql or "" for name, sql in rows}
 
 
-async def _capture_list_documents_sql(engine: AsyncEngine, namespace_id: UUID, *, offset: int) -> tuple[str, Any]:
+async def _capture_list_documents_sql(
+    adapter: SQLiteLanceRelationalAdapter, namespace_id: UUID, *, offset: int
+) -> tuple[str, Any]:
     """Return the SQL the embedded ``list_documents`` emits, plus its parameters.
 
-    Built from the ORM statement the backend constructs and captured off the
-    live cursor, rather than hand-written here - a hand-written query would
-    drift from the implementation and the test would assert a good plan for a
-    query nobody runs.
+    Captured off the live cursor while the REAL backend method runs, rather than
+    rebuilt here. A locally constructed ``select(DocumentModel)`` would drift the
+    moment someone edits ``list_documents`` - and the test would then keep
+    passing while asserting a good plan for a query nobody runs, which is the
+    exact failure this indirection exists to prevent. Mirrors the Postgres
+    sibling module.
     """
+    engine = adapter._engine
+    assert engine is not None, "adapter is not connected"
     captured: list[tuple[str, Any]] = []
 
     def _capture(conn, cursor, statement, parameters, context, executemany) -> None:
         if "documents" in statement and "ORDER BY" in statement:
             captured.append((statement, parameters))
 
-    stmt = (
-        select(DocumentModel)
-        .where(DocumentModel.namespace_id == namespace_id)
-        .limit(PAGE_SIZE)
-        .offset(offset)
-        .order_by(DocumentModel.created_at.desc(), DocumentModel.id.desc())
-    )
-
     event.listen(engine.sync_engine, "before_cursor_execute", _capture)
     try:
-        async with engine.connect() as conn:
-            result = await conn.execute(stmt)
-            rows = result.fetchall()
+        docs = await adapter.list_documents(namespace_id, limit=PAGE_SIZE, offset=offset)
     finally:
         event.remove(engine.sync_engine, "before_cursor_execute", _capture)
 
-    assert len(rows) == PAGE_SIZE, f"seed too small: page at offset {offset} returned {len(rows)} rows"
+    assert len(docs) == PAGE_SIZE, f"seed too small: page at offset {offset} returned {len(docs)} rows"
     assert captured, "no SELECT against documents was captured"
     return captured[-1]
 
@@ -206,9 +232,9 @@ class TestSqliteSortIndexDifferential:
     planner.
     """
 
-    async def _plan_with_index(self, engine: AsyncEngine, mutable_db, create_sql: str) -> list[str]:
+    async def _plan_with_index(self, adapter: SQLiteLanceRelationalAdapter, mutable_db, create_sql: str) -> list[str]:
         db_path, ns = mutable_db
-        statement, parameters = await _capture_list_documents_sql(engine, ns, offset=0)
+        statement, parameters = await _capture_list_documents_sql(adapter, ns, offset=0)
 
         con = sqlite3.connect(db_path)
         try:
@@ -222,9 +248,9 @@ class TestSqliteSortIndexDifferential:
 
         return _query_plan(db_path, statement, parameters)
 
-    async def test_two_column_index_forces_a_sort(self, engine: AsyncEngine, mutable_db) -> None:
+    async def test_two_column_index_forces_a_sort(self, adapter, mutable_db) -> None:
         plan = await self._plan_with_index(
-            engine, mutable_db, f"CREATE INDEX {OLD_INDEX} ON documents (namespace_id, created_at)"
+            adapter, mutable_db, f"CREATE INDEX {OLD_INDEX} ON documents (namespace_id, created_at)"
         )
         assert any(OLD_INDEX in line for line in plan), f"expected the 2-column index to be used: {plan}"
         assert _sorts(plan), (
@@ -232,9 +258,9 @@ class TestSqliteSortIndexDifferential:
             f"if it does not, this module's premise is wrong. Plan: {plan}"
         )
 
-    async def test_three_column_index_removes_the_sort(self, engine: AsyncEngine, mutable_db) -> None:
+    async def test_three_column_index_removes_the_sort(self, adapter, mutable_db) -> None:
         plan = await self._plan_with_index(
-            engine, mutable_db, f"CREATE INDEX {NEW_INDEX} ON documents (namespace_id, created_at, id)"
+            adapter, mutable_db, f"CREATE INDEX {NEW_INDEX} ON documents (namespace_id, created_at, id)"
         )
         assert any(NEW_INDEX in line for line in plan), f"expected the 3-column index to be used: {plan}"
         assert not _sorts(plan), (

--- a/tests/integration/db/test_list_documents_index_plan_sqlite.py
+++ b/tests/integration/db/test_list_documents_index_plan_sqlite.py
@@ -1,0 +1,281 @@
+"""``list_documents`` plan shape on the embedded SQLite stack.
+
+The embedded backend gets its schema from the same Alembic chain as Postgres
+and runs the same ``list_documents`` query, pinned to ``ORDER BY created_at
+DESC, id DESC``. An index on ``(namespace_id, created_at)`` supplies only a
+prefix of that order, so SQLite adds a sort pass - reported as ``USE TEMP
+B-TREE FOR LAST TERM OF ORDER BY``. Because the sort is redone for every page,
+the cost shows up on full-drain offset pagination rather than on a single read.
+
+Two separate questions, deliberately split into two test classes:
+
+* :class:`TestSqliteSortIndexDifferential` - does the third key actually change
+  SQLite's plan? This is the evidence that the index shape matters here at all,
+  and it is independent of any migration: it builds each index variant by hand
+  and compares plans.
+* :class:`TestSqliteChainDeliversSortIndex` - does the migration chain actually
+  give an embedded database that index? This is the one that guards the
+  shipped behaviour.
+
+Plan shape is asserted rather than wall-clock time: timings are not portable
+across CI runners and a threshold would flake. For reference, the plan
+difference below was measured at 200k documents in one namespace, page size
+100, full drain - 120s with the 2-column index against 7.7s with the 3-column
+one, the entire gap being the per-page temp B-tree.
+
+No Docker and no services required - SQLite only.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import event, select
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from khora.db.models import DocumentModel
+
+pytestmark = [pytest.mark.integration, pytest.mark.embedded]
+
+_MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
+
+NEW_INDEX = "ix_documents_namespace_created_at_id"
+OLD_INDEX = "ix_documents_namespace_created_at"
+
+SEED_ROWS = 5000
+PAGE_SIZE = 100
+# Bulk ingest stamps many documents with one ``created_at``; ties are the
+# realistic case, which is what makes the trailing ``id`` key load-bearing.
+ROWS_PER_TIMESTAMP = 50
+
+
+def _build_schema(db_path: Path) -> None:
+    """Run the full Alembic chain to head against a fresh SQLite file."""
+    url = f"sqlite:///{db_path}"
+    cfg = Config()
+    cfg.set_main_option("script_location", str(_MIGRATIONS_DIR))
+    cfg.set_main_option("sqlalchemy.url", url)
+    cfg.attributes["database_url"] = url
+    command.upgrade(cfg, "head")
+
+
+def _seed(db_path: Path) -> UUID:
+    """Insert a namespace holding ``SEED_ROWS`` documents; return its id."""
+    ns = uuid4()
+    base = datetime.now(UTC)
+    con = sqlite3.connect(db_path)
+    try:
+        con.execute(
+            "INSERT INTO memory_namespaces (id, namespace_id, version, is_active, tenancy_mode, "
+            "created_at, updated_at) VALUES (?, ?, 1, 1, 'shared', ?, ?)",
+            (ns.hex, ns.hex, base.isoformat(), base.isoformat()),
+        )
+        con.executemany(
+            "INSERT INTO documents (id, namespace_id, content, checksum, status, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, 'completed', ?, ?)",
+            [
+                (
+                    uuid4().hex,
+                    ns.hex,
+                    f"seed document {i}",
+                    f"plan-seed-{i}",
+                    (base - timedelta(seconds=i // ROWS_PER_TIMESTAMP)).isoformat(),
+                    (base - timedelta(seconds=i // ROWS_PER_TIMESTAMP)).isoformat(),
+                )
+                for i in range(SEED_ROWS)
+            ],
+        )
+        con.execute("ANALYZE")
+        con.commit()
+    finally:
+        con.close()
+    return ns
+
+
+@pytest.fixture(scope="module")
+def mutable_db() -> Iterator[tuple[Path, UUID]]:
+    """Seeded database for the differential tests, which SWAP ITS INDEXES.
+
+    Deliberately separate from :func:`pristine_db`. Sharing one database
+    between the two classes would let an index built by a differential test
+    satisfy the chain assertions - checked, not assumed: an earlier draft
+    shared a single fixture and the chain test passed against a chain that
+    never created the index.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "differential.db"
+        _build_schema(db_path)
+        yield db_path, _seed(db_path)
+
+
+@pytest.fixture(scope="module")
+def pristine_db() -> Iterator[Path]:
+    """A database built by the migration chain and never modified afterwards."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "pristine.db"
+        _build_schema(db_path)
+        yield db_path
+
+
+@pytest.fixture
+async def engine(mutable_db) -> AsyncIterator[AsyncEngine]:
+    db_path, _ = mutable_db
+    eng = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    try:
+        yield eng
+    finally:
+        await eng.dispose()
+
+
+def _documents_indexes(db_path: Path) -> dict[str, str]:
+    con = sqlite3.connect(db_path)
+    try:
+        rows = con.execute(
+            "SELECT name, sql FROM sqlite_master WHERE type = 'index' AND tbl_name = 'documents'"
+        ).fetchall()
+    finally:
+        con.close()
+    return {name: sql or "" for name, sql in rows}
+
+
+async def _capture_list_documents_sql(engine: AsyncEngine, namespace_id: UUID, *, offset: int) -> tuple[str, Any]:
+    """Return the SQL the embedded ``list_documents`` emits, plus its parameters.
+
+    Built from the ORM statement the backend constructs and captured off the
+    live cursor, rather than hand-written here - a hand-written query would
+    drift from the implementation and the test would assert a good plan for a
+    query nobody runs.
+    """
+    captured: list[tuple[str, Any]] = []
+
+    def _capture(conn, cursor, statement, parameters, context, executemany) -> None:
+        if "documents" in statement and "ORDER BY" in statement:
+            captured.append((statement, parameters))
+
+    stmt = (
+        select(DocumentModel)
+        .where(DocumentModel.namespace_id == namespace_id)
+        .limit(PAGE_SIZE)
+        .offset(offset)
+        .order_by(DocumentModel.created_at.desc(), DocumentModel.id.desc())
+    )
+
+    event.listen(engine.sync_engine, "before_cursor_execute", _capture)
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(stmt)
+            rows = result.fetchall()
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _capture)
+
+    assert len(rows) == PAGE_SIZE, f"seed too small: page at offset {offset} returned {len(rows)} rows"
+    assert captured, "no SELECT against documents was captured"
+    return captured[-1]
+
+
+def _query_plan(db_path: Path, statement: str, parameters: Any) -> list[str]:
+    con = sqlite3.connect(db_path)
+    try:
+        rows = con.execute(f"EXPLAIN QUERY PLAN {statement}", parameters).fetchall()
+    finally:
+        con.close()
+    # The human-readable description is the last column of each row.
+    return [str(row[-1]) for row in rows]
+
+
+def _sorts(plan: list[str]) -> list[str]:
+    """Plan lines describing a sort pass. SQLite spells these 'TEMP B-TREE'."""
+    return [line for line in plan if "TEMP B-TREE" in line.upper()]
+
+
+class TestSqliteSortIndexDifferential:
+    """The third key changes SQLite's plan - measured, not assumed.
+
+    Builds each index variant by hand on the seeded database and compares the
+    plan for the identical query. Without this contrast, an assertion that the
+    plan has no sort node would not distinguish a covering index from a lucky
+    planner.
+    """
+
+    async def _plan_with_index(self, engine: AsyncEngine, mutable_db, create_sql: str) -> list[str]:
+        db_path, ns = mutable_db
+        statement, parameters = await _capture_list_documents_sql(engine, ns, offset=0)
+
+        con = sqlite3.connect(db_path)
+        try:
+            con.execute(f"DROP INDEX IF EXISTS {NEW_INDEX}")
+            con.execute(f"DROP INDEX IF EXISTS {OLD_INDEX}")
+            con.execute(create_sql)
+            con.execute("ANALYZE")
+            con.commit()
+        finally:
+            con.close()
+
+        return _query_plan(db_path, statement, parameters)
+
+    async def test_two_column_index_forces_a_sort(self, engine: AsyncEngine, mutable_db) -> None:
+        plan = await self._plan_with_index(
+            engine, mutable_db, f"CREATE INDEX {OLD_INDEX} ON documents (namespace_id, created_at)"
+        )
+        assert any(OLD_INDEX in line for line in plan), f"expected the 2-column index to be used: {plan}"
+        assert _sorts(plan), (
+            "expected the 2-column index to leave SQLite sorting on the trailing key; "
+            f"if it does not, this module's premise is wrong. Plan: {plan}"
+        )
+
+    async def test_three_column_index_removes_the_sort(self, engine: AsyncEngine, mutable_db) -> None:
+        plan = await self._plan_with_index(
+            engine, mutable_db, f"CREATE INDEX {NEW_INDEX} ON documents (namespace_id, created_at, id)"
+        )
+        assert any(NEW_INDEX in line for line in plan), f"expected the 3-column index to be used: {plan}"
+        assert not _sorts(plan), (
+            f"the 3-column index should let SQLite read the rows already ordered, found: {_sorts(plan)}"
+        )
+
+
+class TestSqliteChainDeliversSortIndex:
+    """A database built by the migration chain must end up with the wide index.
+
+    The embedded stack has no separate schema definition - Alembic is the only
+    thing that creates its tables - so whatever the chain produces IS the
+    embedded schema. If a migration is gated to Postgres, the embedded stack
+    silently keeps the narrower index and the sort pass above.
+    """
+
+    def test_chain_head_has_the_three_column_index(self, pristine_db: Path) -> None:
+        indexes = _documents_indexes(pristine_db)
+
+        assert NEW_INDEX in indexes, (
+            f"a SQLite database at chain head does not have {NEW_INDEX}; it has {sorted(indexes)}. "
+            "The embedded stack takes its schema from this chain, so it keeps the narrower "
+            "index and pays a sort pass on every page of a document listing."
+        )
+        assert OLD_INDEX not in indexes, (
+            f"{OLD_INDEX} still present at head - it shares a prefix with {NEW_INDEX}, "
+            "so keeping both costs an index write per document insert"
+        )
+
+    def test_orm_and_chain_agree_on_the_documents_indexes(self, pristine_db: Path) -> None:
+        """No drift between what the ORM declares and what the chain builds.
+
+        Scoped to the two indexes this change touches. A broader comparison
+        would trip over the genuinely Postgres-only indexes (HNSW, GIN, BRIN)
+        that the embedded stack is not expected to have.
+        """
+        built = set(_documents_indexes(pristine_db))
+        declared = {ix.name for ix in DocumentModel.__table__.indexes}
+
+        for name in (NEW_INDEX, OLD_INDEX):
+            assert (name in built) == (name in declared), (
+                f"{name} is {'declared in the ORM' if name in declared else 'absent from the ORM'} "
+                f"but {'present in' if name in built else 'missing from'} a chain-built database"
+            )

--- a/tests/integration/db/test_migration_032_dream_runs.py
+++ b/tests/integration/db/test_migration_032_dream_runs.py
@@ -304,7 +304,7 @@ class TestMigration032OnSqlite:
                 async with engine.connect() as conn:
                     # Chain reached head (sanity).
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "053_khora_chunks_bookkeeping_to_chunker_info"
+                    assert result.scalar() == "054_documents_namespace_created_at_id"
 
                     # khora_dream_runs exists on SQLite (#896) so dream_history /
                     # dream_status work on the embedded sqlite_lance stack.

--- a/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
+++ b/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
@@ -322,7 +322,7 @@ class TestMigration041OnPostgres:
                 async with engine.connect() as conn:
                     # Chain reached head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "053_khora_chunks_bookkeeping_to_chunker_info"
+                    assert result.scalar() == "054_documents_namespace_created_at_id"
 
                     # The migration did not create the table.
                     result = await conn.execute(
@@ -353,7 +353,7 @@ class TestMigration041OnSqlite:
             try:
                 async with engine.connect() as conn:
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "053_khora_chunks_bookkeeping_to_chunker_info"
+                    assert result.scalar() == "054_documents_namespace_created_at_id"
             finally:
                 await engine.dispose()
 

--- a/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
+++ b/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
@@ -69,7 +69,7 @@ pytestmark = pytest.mark.integration
 
 
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
-_HEAD = "053_khora_chunks_bookkeeping_to_chunker_info"
+_HEAD = "054_documents_namespace_created_at_id"
 _PREV = "041_khora_chunks_denormalized_columns"
 
 

--- a/tests/integration/db/test_migration_044_chunks_backfill.py
+++ b/tests/integration/db/test_migration_044_chunks_backfill.py
@@ -93,7 +93,7 @@ pytestmark = pytest.mark.integration
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
 
 _PREV_REVISION = "043_khora_chunks_metadata_backfill"
-_HEAD_REVISION = "053_khora_chunks_bookkeeping_to_chunker_info"
+_HEAD_REVISION = "054_documents_namespace_created_at_id"
 
 _TSV_TRIGGER = "khora_chunks_content_tsv_update"
 

--- a/tests/integration/db/test_migration_049_hook_subscriptions.py
+++ b/tests/integration/db/test_migration_049_hook_subscriptions.py
@@ -71,7 +71,7 @@ pytestmark = pytest.mark.integration
 
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
 
-_HEAD = "053_khora_chunks_bookkeeping_to_chunker_info"
+_HEAD = "054_documents_namespace_created_at_id"
 _PREV = "048_dream_conflicts_reconcile"
 
 

--- a/tests/integration/db/test_migration_053_bookkeeping_to_chunker_info.py
+++ b/tests/integration/db/test_migration_053_bookkeeping_to_chunker_info.py
@@ -92,7 +92,10 @@ def _pg_reachable() -> bool:
 
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
 
-_HEAD_REVISION = "053_khora_chunks_bookkeeping_to_chunker_info"
+# The revision under test, used as an explicit upgrade target. NOT the chain
+# head - later migrations sit on top of it - so it must not be bumped when a
+# new migration lands.
+_TARGET_REVISION = "053_khora_chunks_bookkeeping_to_chunker_info"
 _PREV_REVISION = "052_entities_source_chunk_ids_gin"
 
 _TSV_TRIGGER = "khora_chunks_content_tsv_update"
@@ -332,7 +335,7 @@ class TestMigration053OnSqlite:
     def test_archetypes(self, sqlite_url: str) -> None:
         asyncio.run(_seed_sqlite(sqlite_url))
         cfg = _make_config(sqlite_url)
-        command.upgrade(cfg, _HEAD_REVISION)
+        command.upgrade(cfg, _TARGET_REVISION)
 
         # 1. Tier-1 match: all four stripped from metadata (user key survives);
         #    chunker_info carries the twin's info + the four column values.
@@ -390,7 +393,7 @@ class TestMigration053OnSqlite:
     def test_idempotent_rerun(self, sqlite_url: str) -> None:
         asyncio.run(_seed_sqlite(sqlite_url))
         cfg = _make_config(sqlite_url)
-        command.upgrade(cfg, _HEAD_REVISION)
+        command.upgrade(cfg, _TARGET_REVISION)
 
         first = {
             cid: asyncio.run(_read_row(sqlite_url, cid))
@@ -407,7 +410,7 @@ class TestMigration053OnSqlite:
         # Step the version back and re-run: the guarded UPDATEs must touch zero
         # rows (chunker_info now carries chunk_index everywhere it was moved).
         asyncio.run(_step_version_back_sqlite(sqlite_url))
-        command.upgrade(cfg, _HEAD_REVISION)
+        command.upgrade(cfg, _TARGET_REVISION)
 
         second = {cid: asyncio.run(_read_row(sqlite_url, cid)) for cid in first}
         assert first == second, "re-run changed an already-migrated row"

--- a/tests/integration/db/test_migration_054_documents_namespace_created_at_id.py
+++ b/tests/integration/db/test_migration_054_documents_namespace_created_at_id.py
@@ -1,0 +1,384 @@
+"""Lifecycle coverage for migration ``054_documents_namespace_created_at_id``.
+
+The migration widens the documents sort index from
+``ix_documents_namespace_created_at (namespace_id, created_at)`` to
+``ix_documents_namespace_created_at_id (namespace_id, created_at, id)`` so that
+``list_documents``' pinned ``ORDER BY created_at DESC, id DESC`` is served by a
+backward index scan instead of an index scan plus a sort.
+
+The migration has two branches and both are exercised here. Postgres builds the
+indexes with ``CREATE INDEX CONCURRENTLY`` inside an autocommit block; those
+classes need a live server and skip when one is unreachable. Every other
+dialect gets plain DDL, and :class:`TestMigration054SqliteLifecycle` drives
+that branch on a throwaway SQLite file with no server at all - so the non-
+Postgres path, which a Postgres-only reviewer never exercises, is covered on
+every run.
+
+What is verified here:
+
+1. **Upgrade** builds the 3-column index with exactly those columns in exactly
+   that order, and removes the 2-column index it supersedes (two indexes
+   sharing a prefix would both be maintained on every insert - pure write
+   amplification on the ingest path).
+2. **Downgrade** is an exact mirror: the 2-column index comes back and the
+   3-column one goes away.
+3. **Downgrade stays compatible with the migration that first added the
+   2-column index.** That earlier migration's ``downgrade()`` issues an
+   UNQUALIFIED ``op.drop_index("ix_documents_namespace_created_at", ...)`` -
+   no ``IF EXISTS``. If migration 054's downgrade failed to restore that index,
+   any downgrade walking further back would abort on a missing index. This is
+   the highest-risk failure mode in the change, so it is covered twice: once
+   directly (the unqualified drop is replayed against the post-downgrade state)
+   and once end-to-end (an actual downgrade walk past it, on a throwaway
+   database).
+
+The lifecycle tests rewind the shared dev database's revision, so every restore
+``upgrade head`` runs in a ``finally`` block - the database is never left
+rewound, even on assertion failure. The end-to-end walk runs against a
+purpose-created throwaway database instead, because walking dozens of
+migrations backwards is destructive.
+
+Run explicitly (the shell may leak a different URL)::
+
+    KHORA_DATABASE_URL="postgresql://khora:khora@localhost:5434/khora" \
+        UV_NO_SYNC=1 uv run pytest \
+        tests/integration/db/test_migration_054_documents_namespace_created_at_id.py \
+        -o addopts="" --no-cov -q
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import sqlite3
+import uuid
+from pathlib import Path
+from urllib.parse import urlparse, urlunparse
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+from sqlalchemy.ext.asyncio import create_async_engine
+
+DATABASE_URL = os.environ.get(
+    "KHORA_DATABASE_URL",
+    "postgresql+asyncpg://khora:khora@localhost:5434/khora",
+)
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
+
+
+def _pg_reachable() -> bool:
+    parsed = urlparse(DATABASE_URL.replace("+asyncpg", ""))
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+pytestmark = [pytest.mark.integration]
+
+# Applied per class rather than module-wide: the SQLite lifecycle class below
+# runs the same migration through its non-Postgres branch and needs no server.
+skip_no_pg = pytest.mark.skipif(
+    not _pg_reachable(),
+    reason="PostgreSQL not reachable (run `make dev` first)",
+)
+
+_MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
+
+_HEAD = "054_documents_namespace_created_at_id"
+_PREV = "053_khora_chunks_bookkeeping_to_chunker_info"
+
+# The revision that first added the 2-column index, and the one immediately
+# below it. Walking to ``_BELOW_ORIGIN`` forces that migration's unqualified
+# ``drop_index`` to actually execute.
+_ORIGIN = "019_document_last_activity_index"
+_BELOW_ORIGIN = "018_halfvec_hnsw_indexes"
+
+NEW_INDEX = "ix_documents_namespace_created_at_id"
+OLD_INDEX = "ix_documents_namespace_created_at"
+
+
+def _make_config(url: str) -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", str(_MIGRATIONS_DIR))
+    cfg.set_main_option("sqlalchemy.url", url.replace("%", "%%"))
+    cfg.attributes["database_url"] = url
+    return cfg
+
+
+async def _documents_indexes(url: str) -> dict[str, str]:
+    """Map index name -> index definition for the two indexes under test."""
+    engine = create_async_engine(url)
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(
+                sa.text(
+                    "SELECT indexname, indexdef FROM pg_indexes "
+                    "WHERE tablename = 'documents' AND indexname = ANY(:names)"
+                ),
+                {"names": [NEW_INDEX, OLD_INDEX]},
+            )
+            return {row[0]: row[1] for row in result.fetchall()}
+    finally:
+        await engine.dispose()
+
+
+def _indexed_columns(indexdef: str) -> list[str]:
+    """Ordered column list out of a ``pg_indexes.indexdef`` string.
+
+    Order is the whole point of this migration, so the columns are compared as
+    a sequence; a set comparison would accept ``(namespace_id, id, created_at)``,
+    which does not cover the query at all.
+    """
+    inner = indexdef[indexdef.index("(") + 1 : indexdef.rindex(")")]
+    return [c.strip() for c in inner.split(",")]
+
+
+@skip_no_pg
+class TestMigration054IndexLifecycle:
+    def test_head_has_widened_index_and_dropped_the_narrow_one(self) -> None:
+        """At head: 3-column index present with the covering column order, 2-column gone."""
+        cfg = _make_config(DATABASE_URL)
+        command.upgrade(cfg, _HEAD)  # idempotent when the dev DB is already at head
+
+        indexes = asyncio.run(_documents_indexes(DATABASE_URL))
+
+        assert NEW_INDEX in indexes, f"{NEW_INDEX} missing at head; found {sorted(indexes)}"
+        assert _indexed_columns(indexes[NEW_INDEX]) == ["namespace_id", "created_at", "id"], (
+            f"wrong column order: {indexes[NEW_INDEX]}"
+        )
+        # All keys ASC. With namespace_id equality-constrained the residual
+        # order is (created_at ASC, id ASC), which a backward scan reads as
+        # (created_at DESC, id DESC). A stray DESC would break that symmetry.
+        assert "DESC" not in indexes[NEW_INDEX].upper(), f"expected an all-ASC index: {indexes[NEW_INDEX]}"
+
+        assert OLD_INDEX not in indexes, (
+            f"{OLD_INDEX} still present at head - it shares a prefix with {NEW_INDEX}, "
+            "so keeping both costs an index maintenance write per document insert"
+        )
+
+    def test_downgrade_restores_the_narrow_index_and_removes_the_wide_one(self) -> None:
+        """Downgrading to the previous revision mirrors the upgrade exactly."""
+        cfg = _make_config(DATABASE_URL)
+        command.upgrade(cfg, _HEAD)
+
+        try:
+            command.downgrade(cfg, _PREV)
+            indexes = asyncio.run(_documents_indexes(DATABASE_URL))
+
+            assert OLD_INDEX in indexes, f"downgrade did not restore {OLD_INDEX}; found {sorted(indexes)}"
+            assert _indexed_columns(indexes[OLD_INDEX]) == ["namespace_id", "created_at"]
+            assert NEW_INDEX not in indexes, f"downgrade left {NEW_INDEX} behind"
+        finally:
+            # Always restore the true chain head - "head" rather than the pinned
+            # _HEAD stays correct once a later migration lands on top of 054.
+            command.upgrade(cfg, "head")
+
+        # Re-running the upgrade rebuilds the wide index: IF NOT EXISTS re-run safety.
+        indexes = asyncio.run(_documents_indexes(DATABASE_URL))
+        assert NEW_INDEX in indexes
+        assert OLD_INDEX not in indexes
+
+    def test_post_downgrade_state_satisfies_the_unqualified_drop_below(self) -> None:
+        """After downgrading past 054, the earlier migration's drop still works.
+
+        That migration removes the 2-column index with a bare
+        ``op.drop_index(...)`` - no ``IF EXISTS`` - so it raises if the index is
+        absent. Rather than infer that from the index listing, this replays the
+        exact statement against the post-downgrade database inside a transaction
+        that is rolled back, so the check is the real thing and leaves no trace.
+        """
+        cfg = _make_config(DATABASE_URL)
+        command.upgrade(cfg, _HEAD)
+
+        try:
+            command.downgrade(cfg, _PREV)
+            asyncio.run(_assert_unqualified_drop_succeeds(DATABASE_URL))
+        finally:
+            command.upgrade(cfg, "head")
+
+
+async def _assert_unqualified_drop_succeeds(url: str) -> None:
+    engine = create_async_engine(url)
+    try:
+        async with engine.connect() as conn:
+            trans = await conn.begin()
+            try:
+                # Exactly what the earlier migration's downgrade emits.
+                await conn.exec_driver_sql(f"DROP INDEX {OLD_INDEX}")
+            except Exception as exc:  # pragma: no cover - the failure this test exists to catch
+                raise AssertionError(
+                    f"the unqualified DROP INDEX {OLD_INDEX} that the earlier migration's "
+                    f"downgrade() issues would fail after downgrading past 054: {exc}. "
+                    "Migration 054's downgrade() must recreate that index."
+                ) from exc
+            finally:
+                await trans.rollback()
+    finally:
+        await engine.dispose()
+
+
+@skip_no_pg
+class TestMigration054DowngradeWalk:
+    """End-to-end downgrade walk, on a throwaway database.
+
+    Walking dozens of migrations backwards drops real tables, so this never
+    touches the shared dev database - it creates its own, walks it, and drops
+    it again.
+    """
+
+    def test_downgrade_walks_past_the_index_origin_without_error(self) -> None:
+        maintenance_url = _maintenance_url(DATABASE_URL)
+        db_name = f"khora_mig054_{uuid.uuid4().hex[:8]}"
+        scratch_url = _with_database(DATABASE_URL, db_name)
+
+        try:
+            asyncio.run(_create_database(maintenance_url, db_name))
+        except Exception as exc:  # pragma: no cover - depends on role privileges
+            pytest.skip(f"cannot create a throwaway database (needs CREATEDB): {exc}")
+
+        try:
+            cfg = _make_config(scratch_url)
+            command.upgrade(cfg, "head")
+
+            indexes = asyncio.run(_documents_indexes(scratch_url))
+            assert NEW_INDEX in indexes, "fresh database did not reach the widened index"
+
+            try:
+                command.downgrade(cfg, _BELOW_ORIGIN)
+            except Exception as exc:
+                # Distinguish the failure this test is about from an unrelated,
+                # pre-existing broken downgrade somewhere else in the chain. Only
+                # the former is evidence against this change.
+                if OLD_INDEX in str(exc):
+                    raise AssertionError(
+                        f"downgrading past {_ORIGIN} failed on {OLD_INDEX}: {exc}. "
+                        "Migration 054's downgrade() must restore the 2-column index, "
+                        "because that migration drops it unqualified."
+                    ) from exc
+                pytest.skip(f"downgrade chain broke for an unrelated reason before reaching {_ORIGIN}: {exc}")
+
+            # Below the origin revision neither index should exist.
+            indexes = asyncio.run(_documents_indexes(scratch_url))
+            assert indexes == {}, f"expected no documents sort index below {_ORIGIN}, found {sorted(indexes)}"
+        finally:
+            asyncio.run(_drop_database(maintenance_url, db_name))
+
+
+def _maintenance_url(url: str) -> str:
+    """The same server, pointed at the default maintenance database.
+
+    ``CREATE DATABASE`` cannot run from inside the database being created, and
+    cannot run inside a transaction either - hence the AUTOCOMMIT connections
+    below.
+    """
+    return _with_database(url, "postgres")
+
+
+def _with_database(url: str, db_name: str) -> str:
+    parsed = urlparse(url)
+    return urlunparse(parsed._replace(path=f"/{db_name}"))
+
+
+async def _create_database(maintenance_url: str, db_name: str) -> None:
+    engine = create_async_engine(maintenance_url, isolation_level="AUTOCOMMIT")
+    try:
+        async with engine.connect() as conn:
+            await conn.exec_driver_sql(f'CREATE DATABASE "{db_name}"')
+    finally:
+        await engine.dispose()
+
+
+async def _drop_database(maintenance_url: str, db_name: str) -> None:
+    engine = create_async_engine(maintenance_url, isolation_level="AUTOCOMMIT")
+    try:
+        async with engine.connect() as conn:
+            # Alembic's own connections are closed by now, but a lingering
+            # backend would make DROP DATABASE fail; evict any that remain.
+            await conn.execute(
+                sa.text(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = :db AND pid <> pg_backend_pid()"
+                ),
+                {"db": db_name},
+            )
+            await conn.exec_driver_sql(f'DROP DATABASE IF EXISTS "{db_name}"')
+    finally:
+        await engine.dispose()
+
+
+def _sqlite_documents_indexes(db_path: Path) -> dict[str, str]:
+    con = sqlite3.connect(db_path)
+    try:
+        rows = con.execute(
+            "SELECT name, sql FROM sqlite_master WHERE type = 'index' AND tbl_name = 'documents'"
+        ).fetchall()
+    finally:
+        con.close()
+    return {name: sql or "" for name, sql in rows if name in {NEW_INDEX, OLD_INDEX}}
+
+
+class TestMigration054SqliteLifecycle:
+    """The same lifecycle through the migration's non-Postgres branch.
+
+    The embedded stack takes its schema from this chain and nothing else, so
+    the plain-DDL branch is as load-bearing there as the concurrent one is on
+    Postgres - and it is the branch most likely to rot, because a reviewer
+    working only on Postgres never exercises it. Runs on a throwaway file with
+    no server, so unlike the Postgres classes above it executes everywhere.
+    """
+
+    def _fresh_db(self, tmp_path: Path) -> tuple[Path, Config]:
+        db_path = tmp_path / "lifecycle.db"
+        url = f"sqlite:///{db_path}"
+        cfg = Config()
+        cfg.set_main_option("script_location", str(_MIGRATIONS_DIR))
+        cfg.set_main_option("sqlalchemy.url", url)
+        cfg.attributes["database_url"] = url
+        return db_path, cfg
+
+    def test_round_trip_restores_each_index_in_turn(self, tmp_path: Path) -> None:
+        """head -> 053 -> head, asserting the index set at every stop."""
+        db_path, cfg = self._fresh_db(tmp_path)
+
+        command.upgrade(cfg, "head")
+        indexes = _sqlite_documents_indexes(db_path)
+        assert set(indexes) == {NEW_INDEX}, f"at head expected only the 3-column index, found {sorted(indexes)}"
+        assert "(namespace_id, created_at, id)" in indexes[NEW_INDEX], indexes[NEW_INDEX]
+
+        command.downgrade(cfg, _PREV)
+        indexes = _sqlite_documents_indexes(db_path)
+        assert set(indexes) == {OLD_INDEX}, f"after downgrade expected only the 2-column index, found {sorted(indexes)}"
+        assert "(namespace_id, created_at)" in indexes[OLD_INDEX], indexes[OLD_INDEX]
+
+        # Back up again - the plain branch must be re-runnable, not one-shot.
+        command.upgrade(cfg, "head")
+        assert set(_sqlite_documents_indexes(db_path)) == {NEW_INDEX}
+
+    def test_downgrade_walks_past_the_index_origin(self, tmp_path: Path) -> None:
+        """The full walk past the revision that drops the 2-column index unqualified.
+
+        This is the failure mode the whole downgrade branch exists for: that
+        revision issues a bare ``op.drop_index`` with no ``IF EXISTS``, so it
+        raises outright if migration 054's downgrade did not put the index
+        back. Verified by mutation - deleting the restore from 054's non-
+        Postgres downgrade branch makes this walk fail with
+        ``no such index: ix_documents_namespace_created_at``.
+        """
+        db_path, cfg = self._fresh_db(tmp_path)
+
+        command.upgrade(cfg, "head")
+        command.downgrade(cfg, _BELOW_ORIGIN)
+
+        assert _sqlite_documents_indexes(db_path) == {}, (
+            f"expected neither documents sort index below {_ORIGIN}, found {sorted(_sqlite_documents_indexes(db_path))}"
+        )

--- a/tests/integration/db/test_migration_054_documents_namespace_created_at_id.py
+++ b/tests/integration/db/test_migration_054_documents_namespace_created_at_id.py
@@ -24,19 +24,22 @@ What is verified here:
    3-column one goes away.
 3. **Downgrade stays compatible with the migration that first added the
    2-column index.** That earlier migration's ``downgrade()`` issues an
-   UNQUALIFIED ``op.drop_index("ix_documents_namespace_created_at", ...)`` -
-   no ``IF EXISTS``. If migration 054's downgrade failed to restore that index,
+   UNCONDITIONAL ``op.drop_index("ix_documents_namespace_created_at", ...)`` -
+   no ``if_exists=True``. If migration 054's downgrade failed to restore that index,
    any downgrade walking further back would abort on a missing index. This is
    the highest-risk failure mode in the change, so it is covered twice: once
-   directly (the unqualified drop is replayed against the post-downgrade state)
+   directly (the unconditional drop is replayed against the post-downgrade state)
    and once end-to-end (an actual downgrade walk past it, on a throwaway
    database).
 
-The lifecycle tests rewind the shared dev database's revision, so every restore
-``upgrade head`` runs in a ``finally`` block - the database is never left
-rewound, even on assertion failure. The end-to-end walk runs against a
-purpose-created throwaway database instead, because walking dozens of
-migrations backwards is destructive.
+No Postgres class touches the shared dev database. Both own a throwaway one,
+created and dropped per module or per test. That is deliberate rather than
+tidy: CI runs the integration job with ``--timeout-method=thread``, which kills
+the process outright, so ``finally`` blocks do not run. A rewind-then-restore
+against the shared database would strand it at the previous revision on
+timeout, and every later test in the serial job would then fail against a stale
+schema with the real cause several tests back. Owning the database bounds the
+worst case to one leaked, uniquely named database.
 
 Run explicitly (the shell may leak a different URL)::
 
@@ -99,13 +102,51 @@ _HEAD = "054_documents_namespace_created_at_id"
 _PREV = "053_khora_chunks_bookkeeping_to_chunker_info"
 
 # The revision that first added the 2-column index, and the one immediately
-# below it. Walking to ``_BELOW_ORIGIN`` forces that migration's unqualified
+# below it. Walking to ``_BELOW_ORIGIN`` forces that migration's unconditional
 # ``drop_index`` to actually execute.
 _ORIGIN = "019_document_last_activity_index"
 _BELOW_ORIGIN = "018_halfvec_hnsw_indexes"
 
 NEW_INDEX = "ix_documents_namespace_created_at_id"
 OLD_INDEX = "ix_documents_namespace_created_at"
+
+# Postgres ``insufficient_privilege``. The only ``CREATE DATABASE`` failure that
+# justifies skipping: a role without CREATEDB is an environment limitation, not
+# a defect. Everything else - bad credentials, an unparseable DSN, a driver
+# fault - means the test could not run for a reason worth seeing, and must fail
+# rather than quietly report success. PostgreSQL being down entirely is already
+# handled by the socket-reachability gate at module scope.
+_INSUFFICIENT_PRIVILEGE = "42501"
+
+
+def _sqlstates(exc: BaseException) -> set[str]:
+    """Every SQLSTATE attached to *exc* or to anything it wraps.
+
+    SQLAlchemy wraps the driver's exception (asyncpg carries ``sqlstate``) in a
+    ``DBAPIError`` reachable via ``orig``, and re-raises can add ``__cause__`` /
+    ``__context__`` links. Matching on the message text instead would break the
+    moment a driver reworded it, so the whole chain is searched for the code.
+    """
+    states: set[str] = set()
+    seen: set[int] = set()
+    stack: list[BaseException | None] = [exc]
+    while stack:
+        err = stack.pop()
+        if err is None or id(err) in seen:
+            continue
+        seen.add(id(err))
+        state = getattr(err, "sqlstate", None)
+        if isinstance(state, str):
+            states.add(state)
+        stack.extend([getattr(err, "orig", None), err.__cause__, err.__context__])
+    return states
+
+
+def _skip_only_if_cannot_create_database(exc: BaseException) -> None:
+    """Re-raise unless *exc* is a missing-CREATEDB-privilege failure."""
+    if _INSUFFICIENT_PRIVILEGE not in _sqlstates(exc):
+        raise exc
+    pytest.skip(f"role lacks CREATEDB, cannot create a throwaway database: {exc}")
 
 
 def _make_config(url: str) -> Config:
@@ -164,7 +205,7 @@ def scratch_db_url() -> Iterator[str]:
     try:
         asyncio.run(_create_database(maintenance_url, db_name))
     except Exception as exc:  # pragma: no cover - depends on role privileges
-        pytest.skip(f"cannot create a throwaway database (needs CREATEDB): {exc}")
+        _skip_only_if_cannot_create_database(exc)
 
     url = _with_database(DATABASE_URL, db_name)
     try:
@@ -216,7 +257,7 @@ class TestMigration054IndexLifecycle:
         assert NEW_INDEX in indexes
         assert OLD_INDEX not in indexes
 
-    def test_post_downgrade_state_satisfies_the_unqualified_drop_below(self, scratch_db_url: str) -> None:
+    def test_post_downgrade_state_satisfies_the_unconditional_drop_below(self, scratch_db_url: str) -> None:
         """After downgrading past 054, the earlier migration's drop still works.
 
         That migration removes the 2-column index with a bare
@@ -229,12 +270,12 @@ class TestMigration054IndexLifecycle:
 
         try:
             command.downgrade(cfg, _PREV)
-            asyncio.run(_assert_unqualified_drop_succeeds(scratch_db_url))
+            asyncio.run(_assert_unconditional_drop_succeeds(scratch_db_url))
         finally:
             command.upgrade(cfg, "head")
 
 
-async def _assert_unqualified_drop_succeeds(url: str) -> None:
+async def _assert_unconditional_drop_succeeds(url: str) -> None:
     engine = create_async_engine(url)
     try:
         async with engine.connect() as conn:
@@ -244,7 +285,7 @@ async def _assert_unqualified_drop_succeeds(url: str) -> None:
                 await conn.exec_driver_sql(f"DROP INDEX {OLD_INDEX}")
             except Exception as exc:  # pragma: no cover - the failure this test exists to catch
                 raise AssertionError(
-                    f"the unqualified DROP INDEX {OLD_INDEX} that the earlier migration's "
+                    f"the unconditional DROP INDEX {OLD_INDEX} that the earlier migration's "
                     f"downgrade() issues would fail after downgrading past 054: {exc}. "
                     "Migration 054's downgrade() must recreate that index."
                 ) from exc
@@ -281,7 +322,7 @@ class TestMigration054DowngradeWalk:
         try:
             asyncio.run(_create_database(maintenance_url, db_name))
         except Exception as exc:  # pragma: no cover - depends on role privileges
-            pytest.skip(f"cannot create a throwaway database (needs CREATEDB): {exc}")
+            _skip_only_if_cannot_create_database(exc)
 
         try:
             cfg = _make_config(scratch_url)
@@ -296,11 +337,23 @@ class TestMigration054DowngradeWalk:
                 # Distinguish the failure this test is about from an unrelated,
                 # pre-existing broken downgrade somewhere else in the chain. Only
                 # the former is evidence against this change.
-                if OLD_INDEX in str(exc):
+                #
+                # Both index names are checked, not just the old one. 054's own
+                # downgrade is the FIRST step of this walk, so a failure there -
+                # rebuilding the 2-column index, or dropping the 3-column one -
+                # can name either. Skipping on anything that fails to mention
+                # OLD_INDEX would silently retire the coverage this test exists
+                # for. (OLD_INDEX is a prefix of NEW_INDEX, so the first check
+                # subsumes the second; both are spelled out because the
+                # subsumption is an accident of naming, not a property to rely
+                # on.)
+                message = str(exc)
+                named = [index for index in (OLD_INDEX, NEW_INDEX) if index in message]
+                if named:
                     raise AssertionError(
-                        f"downgrading past {_ORIGIN} failed on {OLD_INDEX}: {exc}. "
-                        "Migration 054's downgrade() must restore the 2-column index, "
-                        "because that migration drops it unqualified."
+                        f"downgrading past {_ORIGIN} failed, naming {named}: {exc}. "
+                        f"Migration 054's downgrade() must restore {OLD_INDEX}, because "
+                        f"{_ORIGIN}'s downgrade() drops it unconditionally."
                     ) from exc
                 pytest.skip(f"downgrade chain broke for an unrelated reason before reaching {_ORIGIN}: {exc}")
 
@@ -402,7 +455,7 @@ class TestMigration054SqliteLifecycle:
         assert set(_sqlite_documents_indexes(db_path)) == {NEW_INDEX}
 
     def test_downgrade_walks_past_the_index_origin(self, tmp_path: Path) -> None:
-        """The full walk past the revision that drops the 2-column index unqualified.
+        """The full walk past the revision that drops the 2-column index unconditionally.
 
         This is the failure mode the whole downgrade branch exists for: that
         revision issues a bare ``op.drop_index`` with no ``IF EXISTS``, so it

--- a/tests/integration/db/test_migration_054_documents_namespace_created_at_id.py
+++ b/tests/integration/db/test_migration_054_documents_namespace_created_at_id.py
@@ -53,6 +53,7 @@ import os
 import socket
 import sqlite3
 import uuid
+from collections.abc import Iterator
 from pathlib import Path
 from urllib.parse import urlparse, urlunparse
 
@@ -143,14 +144,41 @@ def _indexed_columns(indexdef: str) -> list[str]:
     return [c.strip() for c in inner.split(",")]
 
 
+@pytest.fixture(scope="module")
+def scratch_db_url() -> Iterator[str]:
+    """A throwaway Postgres database at head, for the rewind tests below.
+
+    These tests downgrade and re-upgrade, so they must NOT run against the
+    shared dev database. CI runs the integration job with
+    ``--timeout-method=thread``, which kills the process outright - ``finally``
+    blocks do not run. A rewind-then-restore against the shared database would
+    therefore leave it stranded at the previous revision on timeout, and every
+    later test in the serial job would fail against a stale schema with the real
+    cause several tests back. Owning the database removes the hazard rather than
+    narrowing the window: the worst a timeout can do here is leak one uniquely
+    named database.
+    """
+    maintenance_url = _maintenance_url(DATABASE_URL)
+    db_name = f"khora_mig054_lifecycle_{uuid.uuid4().hex[:8]}"
+
+    try:
+        asyncio.run(_create_database(maintenance_url, db_name))
+    except Exception as exc:  # pragma: no cover - depends on role privileges
+        pytest.skip(f"cannot create a throwaway database (needs CREATEDB): {exc}")
+
+    url = _with_database(DATABASE_URL, db_name)
+    try:
+        command.upgrade(_make_config(url), "head")
+        yield url
+    finally:
+        asyncio.run(_drop_database(maintenance_url, db_name))
+
+
 @skip_no_pg
 class TestMigration054IndexLifecycle:
-    def test_head_has_widened_index_and_dropped_the_narrow_one(self) -> None:
+    def test_head_has_widened_index_and_dropped_the_narrow_one(self, scratch_db_url: str) -> None:
         """At head: 3-column index present with the covering column order, 2-column gone."""
-        cfg = _make_config(DATABASE_URL)
-        command.upgrade(cfg, _HEAD)  # idempotent when the dev DB is already at head
-
-        indexes = asyncio.run(_documents_indexes(DATABASE_URL))
+        indexes = asyncio.run(_documents_indexes(scratch_db_url))
 
         assert NEW_INDEX in indexes, f"{NEW_INDEX} missing at head; found {sorted(indexes)}"
         assert _indexed_columns(indexes[NEW_INDEX]) == ["namespace_id", "created_at", "id"], (
@@ -166,29 +194,29 @@ class TestMigration054IndexLifecycle:
             "so keeping both costs an index maintenance write per document insert"
         )
 
-    def test_downgrade_restores_the_narrow_index_and_removes_the_wide_one(self) -> None:
+    def test_downgrade_restores_the_narrow_index_and_removes_the_wide_one(self, scratch_db_url: str) -> None:
         """Downgrading to the previous revision mirrors the upgrade exactly."""
-        cfg = _make_config(DATABASE_URL)
-        command.upgrade(cfg, _HEAD)
+        cfg = _make_config(scratch_db_url)
 
         try:
             command.downgrade(cfg, _PREV)
-            indexes = asyncio.run(_documents_indexes(DATABASE_URL))
+            indexes = asyncio.run(_documents_indexes(scratch_db_url))
 
             assert OLD_INDEX in indexes, f"downgrade did not restore {OLD_INDEX}; found {sorted(indexes)}"
             assert _indexed_columns(indexes[OLD_INDEX]) == ["namespace_id", "created_at"]
             assert NEW_INDEX not in indexes, f"downgrade left {NEW_INDEX} behind"
         finally:
-            # Always restore the true chain head - "head" rather than the pinned
-            # _HEAD stays correct once a later migration lands on top of 054.
+            # Leave the module's database back at head for the sibling tests.
+            # This is intra-module hygiene only - the database is this module's
+            # own, so a killed process cannot strand anything shared.
             command.upgrade(cfg, "head")
 
         # Re-running the upgrade rebuilds the wide index: IF NOT EXISTS re-run safety.
-        indexes = asyncio.run(_documents_indexes(DATABASE_URL))
+        indexes = asyncio.run(_documents_indexes(scratch_db_url))
         assert NEW_INDEX in indexes
         assert OLD_INDEX not in indexes
 
-    def test_post_downgrade_state_satisfies_the_unqualified_drop_below(self) -> None:
+    def test_post_downgrade_state_satisfies_the_unqualified_drop_below(self, scratch_db_url: str) -> None:
         """After downgrading past 054, the earlier migration's drop still works.
 
         That migration removes the 2-column index with a bare
@@ -197,12 +225,11 @@ class TestMigration054IndexLifecycle:
         exact statement against the post-downgrade database inside a transaction
         that is rolled back, so the check is the real thing and leaves no trace.
         """
-        cfg = _make_config(DATABASE_URL)
-        command.upgrade(cfg, _HEAD)
+        cfg = _make_config(scratch_db_url)
 
         try:
             command.downgrade(cfg, _PREV)
-            asyncio.run(_assert_unqualified_drop_succeeds(DATABASE_URL))
+            asyncio.run(_assert_unqualified_drop_succeeds(scratch_db_url))
         finally:
             command.upgrade(cfg, "head")
 
@@ -228,12 +255,22 @@ async def _assert_unqualified_drop_succeeds(url: str) -> None:
 
 
 @skip_no_pg
+@pytest.mark.slow
 class TestMigration054DowngradeWalk:
     """End-to-end downgrade walk, on a throwaway database.
 
     Walking dozens of migrations backwards drops real tables, so this never
     touches the shared dev database - it creates its own, walks it, and drops
     it again.
+
+    Marked ``slow``: one test does CREATE DATABASE, the full migration chain up,
+    a ~36-step walk back down, and DROP DATABASE. That is far and away the most
+    expensive test in this module, and it is excluded from the default local run
+    by the ``-m "not slow"`` default in ``pyproject.toml``. Note the CI
+    integration job selects on ``-m "integration and not filter_conformance"``,
+    which does NOT exclude ``slow`` - so this still runs there, which is where
+    the coverage is wanted. The SQLite lifecycle class below walks the same path
+    cheaply on every run, so nothing is lost when this one is skipped locally.
     """
 
     def test_downgrade_walks_past_the_index_origin_without_error(self) -> None:

--- a/tests/integration/storage/test_list_documents_index_plan_pg.py
+++ b/tests/integration/storage/test_list_documents_index_plan_pg.py
@@ -396,23 +396,28 @@ class TestListDocumentsIndexPlanPg:
 
         This asserts CAPABILITY, not the planner's unaided choice, and the
         distinction is deliberate. At the scale CI can afford (a few thousand
-        rows) a deep page is genuinely cheaper as a bitmap heap scan plus a
-        sort: sorting 3000 rows costs almost nothing, while an ordered index
-        scan pays ~2900 random heap fetches. PostgreSQL picking that plan here
-        is the cost model working correctly, not the index failing - and it
-        flips the other way at production scale, where the sort is the
-        expensive half. Pinning the planner's *choice* at CI scale would
-        therefore be pinning an artifact of the seed size; it failed in CI
-        exactly that way, first via the single-column ``ix_documents_created_at``
-        and then via a bitmap plan.
+        rows) fetching every matching row and sorting it is simply cheaper than
+        an ordered scan: sorting 3000 rows costs almost nothing, while an
+        ordered scan pays ~2900 heap fetches to reach the same place. That is
+        the cost model working correctly, not the index failing, and it flips at
+        production scale where the sort is the expensive half. Pinning the
+        planner's unaided choice here pins an artifact of the seed size - CI
+        demonstrated that three separate ways, choosing the single-column
+        ``ix_documents_created_at``, then a bitmap heap scan, then
+        ``ix_documents_namespace_id`` with a sort on top.
 
-        So the alternatives are switched off and the question narrowed to the
-        one this migration actually answers: *when* an ordered scan is used, does
-        the index supply ``(created_at DESC, id DESC)`` outright, or does a sort
-        still have to be bolted on? Under the 2-column index the answer is a
-        sort even with these settings - that is the differential test below.
+        Disabling scan types does not settle it either, because every one of
+        those plans is really "gather the rows, then sort" and some other index
+        can always gather. ``enable_sort`` is the knob that matches the actual
+        question: with sorting priced out of reach, is there a plan at all? Only
+        an index whose key order already is ``(created_at DESC, id DESC)`` under
+        an equality-constrained ``namespace_id`` can produce one. That property
+        is scale-independent and is exactly what widening the index buys.
+
+        The 2-column index cannot produce such a plan - the differential below
+        shows it sorting under identical conditions - and
         ``test_query_is_a_sort_free_backward_index_scan`` covers the unaided
-        planner choice on the first page, so between them both properties are
+        planner choice on the first page. Between them, both properties are
         pinned.
         """
         deep_offset = SEED_ROWS - PAGE_SIZE * 2
@@ -422,17 +427,18 @@ class TestListDocumentsIndexPlanPg:
             statement,
             parameters,
             analyze=True,
-            # Leave only the ordered-index-scan path available. Without this the
-            # planner reasonably prefers bitmap+sort at this row count.
-            settings={"enable_bitmapscan": "off", "enable_seqscan": "off"},
+            # Price sorting out of reach, leaving only genuinely order-supplying
+            # plans. This is a cost penalty rather than a hard prohibition, so a
+            # Sort node surviving it means no sort-free plan exists at all.
+            settings={"enable_sort": "off"},
         )
 
         used = {s.get("Index Name") for s in _index_scans(root)}
         assert NEW_INDEX in used, (
             f"expected {NEW_INDEX} to serve the deep page, plan used {used}. "
-            "With bitmap and sequential scans disabled the only remaining paths are ordered "
-            f"index scans, so a different index here means this one cannot supply the order. "
-            f"Plan:{_render(root)}"
+            "With sorting priced out of reach, only an index that already supplies "
+            "(created_at DESC, id DESC) can produce a plan - so a different index here means "
+            f"this one cannot supply the order. Plan:{_render(root)}"
         )
         assert not _sort_nodes(root), (
             f"deep page grew a sort node: {_sort_nodes(root)}. The index was used but did not "
@@ -466,6 +472,11 @@ class TestListDocumentsIndexPlanPg:
                 await conn.exec_driver_sql(f"DROP INDEX {NEW_INDEX}")
                 await conn.exec_driver_sql(f"CREATE INDEX {OLD_INDEX} ON documents (namespace_id, created_at)")
 
+                # Same setting the deep-offset test runs under, so this is a
+                # true differential: a Sort node surviving a priced-out sort
+                # means the 2-column index cannot supply the order at all,
+                # rather than merely losing on cost.
+                await conn.exec_driver_sql("SET LOCAL enable_sort = off")
                 result = await conn.exec_driver_sql(f"EXPLAIN (FORMAT JSON) {statement}", parameters)
                 raw = result.scalar()
                 root = (json.loads(raw) if isinstance(raw, str) else raw)[0]["Plan"]

--- a/tests/integration/storage/test_list_documents_index_plan_pg.py
+++ b/tests/integration/storage/test_list_documents_index_plan_pg.py
@@ -273,14 +273,31 @@ async def _capture_list_documents_sql(
     return captured[-1]
 
 
-async def _explain(backend: PostgreSQLBackend, statement: str, parameters: Any, *, analyze: bool) -> dict:
-    """Run EXPLAIN over *statement* and return the root plan node."""
+async def _explain(
+    backend: PostgreSQLBackend,
+    statement: str,
+    parameters: Any,
+    *,
+    analyze: bool,
+    settings: dict[str, str] | None = None,
+) -> dict:
+    """Run EXPLAIN over *statement* and return the root plan node.
+
+    *settings* are applied with ``SET LOCAL`` inside the same transaction as
+    the EXPLAIN, so they affect this plan and nothing else.
+    """
     engine = backend._engine
     assert engine is not None
     options = "ANALYZE, FORMAT JSON" if analyze else "FORMAT JSON"
     async with engine.connect() as conn:
-        result = await conn.exec_driver_sql(f"EXPLAIN ({options}) {statement}", parameters)
-        raw = result.scalar()
+        trans = await conn.begin()
+        try:
+            for key, value in (settings or {}).items():
+                await conn.exec_driver_sql(f"SET LOCAL {key} = {value}")
+            result = await conn.exec_driver_sql(f"EXPLAIN ({options}) {statement}", parameters)
+            raw = result.scalar()
+        finally:
+            await trans.rollback()
     plan = json.loads(raw) if isinstance(raw, str) else raw
     return plan[0]["Plan"]
 
@@ -369,28 +386,59 @@ class TestListDocumentsIndexPlanPg:
             f"expected a Backward scan of {NEW_INDEX}, got {scan.get('Scan Direction')!r}"
         )
 
-    async def test_deep_offset_page_is_also_sort_free(self, backend: PostgreSQLBackend, seeded_namespace: UUID) -> None:
-        """Sort-freedom must hold at depth, not just on the first page.
+    async def test_deep_offset_page_can_be_served_without_a_sort(
+        self, backend: PostgreSQLBackend, seeded_namespace: UUID
+    ) -> None:
+        """At depth, the index can still supply the whole order with no sort.
 
         Full-drain pagination is where the regression actually bit: the sort is
         redone once per page, so the cost is paid ``rows / page_size`` times.
-        A deep page is the representative case, not the first one.
+
+        This asserts CAPABILITY, not the planner's unaided choice, and the
+        distinction is deliberate. At the scale CI can afford (a few thousand
+        rows) a deep page is genuinely cheaper as a bitmap heap scan plus a
+        sort: sorting 3000 rows costs almost nothing, while an ordered index
+        scan pays ~2900 random heap fetches. PostgreSQL picking that plan here
+        is the cost model working correctly, not the index failing - and it
+        flips the other way at production scale, where the sort is the
+        expensive half. Pinning the planner's *choice* at CI scale would
+        therefore be pinning an artifact of the seed size; it failed in CI
+        exactly that way, first via the single-column ``ix_documents_created_at``
+        and then via a bitmap plan.
+
+        So the alternatives are switched off and the question narrowed to the
+        one this migration actually answers: *when* an ordered scan is used, does
+        the index supply ``(created_at DESC, id DESC)`` outright, or does a sort
+        still have to be bolted on? Under the 2-column index the answer is a
+        sort even with these settings - that is the differential test below.
+        ``test_query_is_a_sort_free_backward_index_scan`` covers the unaided
+        planner choice on the first page, so between them both properties are
+        pinned.
         """
         deep_offset = SEED_ROWS - PAGE_SIZE * 2
         statement, parameters = await _capture_list_documents_sql(backend, seeded_namespace, offset=deep_offset)
-        root = await _explain(backend, statement, parameters, analyze=True)
-        types = _node_types(root)
-
-        assert "Seq Scan" not in types, f"planner chose a sequential scan at depth. Plan:{_render(root)}"
+        root = await _explain(
+            backend,
+            statement,
+            parameters,
+            analyze=True,
+            # Leave only the ordered-index-scan path available. Without this the
+            # planner reasonably prefers bitmap+sort at this row count.
+            settings={"enable_bitmapscan": "off", "enable_seqscan": "off"},
+        )
 
         used = {s.get("Index Name") for s in _index_scans(root)}
         assert NEW_INDEX in used, (
             f"expected {NEW_INDEX} to serve the deep page, plan used {used}. "
-            "If this names the single-column ix_documents_created_at, the namespace filter was "
-            "not selective enough for the namespace-leading index to win - check that the decoy "
-            f"namespaces actually got seeded (see DECOY_NAMESPACES). Plan:{_render(root)}"
+            "With bitmap and sequential scans disabled the only remaining paths are ordered "
+            f"index scans, so a different index here means this one cannot supply the order. "
+            f"Plan:{_render(root)}"
         )
-        assert not _sort_nodes(root), f"deep page grew a sort node: {_sort_nodes(root)}. Plan:{_render(root)}"
+        assert not _sort_nodes(root), (
+            f"deep page grew a sort node: {_sort_nodes(root)}. The index was used but did not "
+            f"supply the full ordering, which is the regression this migration exists to fix. "
+            f"Plan:{_render(root)}"
+        )
 
     async def test_old_two_column_index_would_reintroduce_a_sort(
         self, backend: PostgreSQLBackend, seeded_namespace: UUID
@@ -428,6 +476,13 @@ class TestListDocumentsIndexPlanPg:
             "the 2-column index was expected to force a sort for "
             f"ORDER BY created_at DESC, id DESC, but the plan has none: {_node_types(root)}. "
             "Without that contrast the sort-free assertions in this module prove nothing."
+        )
+        # Guard the contrast itself: a sort node proves nothing if the widened
+        # index somehow survived the swap and the plan sorted for an unrelated
+        # reason. Its absence is what makes the sort attributable to the swap.
+        assert NEW_INDEX not in {s.get("Index Name") for s in _index_scans(root)}, (
+            f"{NEW_INDEX} was still in the plan during the differential, so the swap did not "
+            f"take effect and the sort above is not attributable to it. Plan:{_render(root)}"
         )
 
         # And the indexes really did come back on rollback.

--- a/tests/integration/storage/test_list_documents_index_plan_pg.py
+++ b/tests/integration/storage/test_list_documents_index_plan_pg.py
@@ -99,23 +99,59 @@ PAGE_SIZE = 100
 # Timestamp granularity: bulk ingest stamps many documents with the same
 # ``created_at``, so ties are the realistic case and the trailing ``id`` key is
 # load-bearing rather than decorative.
+#
+# Note this is the FAVORABLE case for the change. The ORM stamps ``created_at``
+# per row, so production tie-groups are often size 1 and PG's win is smaller
+# than a tie-heavy seed suggests. It does not affect the plan-shape assertions,
+# which hold at any group size.
 ROWS_PER_TIMESTAMP = 50
+
+# WARNING - the seed's INSERT ORDER is load-bearing, not incidental.
+#
+# ``_rows`` writes ``i`` ascending while ``created_at`` descends, so physical
+# heap order is almost exactly the reverse of index order and
+# ``pg_stats.correlation`` lands near -1. PG interpolates an index scan's
+# heap-access cost between its random and sequential bounds by that
+# correlation, so a near-perfect value collapses the cost of the ~100 (or, at
+# depth, ~2900) heap fetches these queries perform. Without it, default
+# ``random_page_cost = 4.0`` makes an index scan roughly 2.5x more expensive
+# than a seq scan plus top-N heapsort at this table size, and the Seq Scan
+# guard below fires - for a reason that has nothing to do with the index being
+# wrong.
+#
+# So: do NOT "tidy" this fixture by shuffling the seed or inserting in id
+# order. If you need to change the write order, expect to raise the row counts
+# to compensate, and re-run against real Postgres rather than reasoning about
+# it - the cost model here is not intuitive.
 
 # Documents seeded into OTHER namespaces, so the namespace filter is selective.
 #
-# This is load-bearing, not padding. `documents` also carries a single-column
-# `ix_documents_created_at` (added by an earlier temporal-search migration). If
-# every row in the table belongs to the namespace under test, `WHERE
-# namespace_id = ?` excludes nothing, and at a deep offset the planner correctly
-# prefers a backward scan of that narrower single-column index - it reads fewer
-# pages to reach the same rows, and the namespace-leading index buys it nothing.
-# The plan then legitimately stops using the index this migration adds.
+# These are the only thing that makes ``namespace_id`` a DISCRIMINATING key, and
+# without that there is no cost reason for PG to prefer a 3-column index over a
+# 1-column one on the same leading sort column. Not realism dressing - the
+# assertions below are meaningless without them. Learned from a CI failure, so
+# the reasoning is recorded rather than left to be rediscovered:
 #
-# That is an artifact of an all-one-namespace table, not of production. Khora is
-# multi-tenant: a namespace is a fraction of `documents`, which is exactly the
-# regime where the namespace-leading index wins. Seeding decoy namespaces makes
-# the fixture match that regime, so the assertions below measure the index
-# rather than the seed's shape.
+# ``documents`` also carries a single-column ``ix_documents_created_at`` (from an
+# earlier temporal-search migration). Both it and the 3-column index lead on
+# ``created_at``, so the near-perfect heap correlation described above discounts
+# BOTH equally - heap access stops being the discriminator, and the tiebreak
+# becomes index entry width: one timestamptz (~8 bytes) against
+# uuid + timestamptz + uuid (~40). At ``OFFSET 2800`` the scan traverses ~2900
+# entries, so that 3-4x page difference decides it and the narrower index wins.
+# This is why the failure appeared at depth and not on the first page.
+#
+# Decoy rows break that tie. ``ix_documents_created_at`` carries no
+# ``namespace_id``, so every tuple it returns needs a recheck - free when one
+# namespace is 100% of the table, but real work once the table holds rows the
+# scan must read and discard, while the 3-column index seeks straight to the
+# namespace's range. Khora is multi-tenant, so that is also the production
+# regime.
+#
+# Seed the decoys across the SAME timestamp range as the namespace under test
+# (see ``seeded_namespace``): decoys bunched at one end would let a
+# created_at-ordered scan skip them in a single range, leaving the filter
+# selective in name only.
 DECOY_NAMESPACES = 4
 DECOY_ROWS_EACH = 3000
 
@@ -268,6 +304,34 @@ def _sort_nodes(root: dict) -> list[str]:
     return [t for t in _node_types(root) if "Sort" in t]
 
 
+def _render(root: dict) -> str:
+    """Compact one-line-per-node rendering of a plan tree, for failure output.
+
+    Every assertion below reports this rather than just the node it tripped on.
+    A plan-shape test that fails with only ``{'ix_documents_created_at'}`` tells
+    you which index lost but not what the planner did instead - and since these
+    tests only ever run in CI, a failure that needs a follow-up run to diagnose
+    costs a whole cycle. The interesting attributes are the ones that explain a
+    choice: which index, which direction, and what any sort is sorting on.
+    """
+    lines: list[str] = []
+
+    def walk(node: dict, depth: int) -> None:
+        parts = [node["Node Type"]]
+        for key in ("Index Name", "Scan Direction", "Sort Key", "Presorted Key", "Filter"):
+            if key in node:
+                parts.append(f"{key}={node[key]}")
+        for key in ("Actual Rows", "Plan Rows"):
+            if key in node:
+                parts.append(f"{key}={node[key]}")
+        lines.append("  " * depth + " | ".join(str(p) for p in parts))
+        for child in node.get("Plans", []):
+            walk(child, depth + 1)
+
+    walk(root, 0)
+    return "\n" + "\n".join(lines)
+
+
 class TestListDocumentsIndexPlanPg:
     async def test_query_is_a_sort_free_backward_index_scan(
         self, backend: PostgreSQLBackend, seeded_namespace: UUID
@@ -282,18 +346,18 @@ class TestListDocumentsIndexPlanPg:
         # plan that has no index scan at all. Fail loudly instead.
         assert "Seq Scan" not in types, (
             f"planner chose a sequential scan - the seed ({SEED_ROWS} rows) is too small "
-            f"or ANALYZE did not commit, so this test proves nothing. Plan nodes: {types}"
+            f"or ANALYZE did not commit, so this test proves nothing. Plan:{_render(root)}"
         )
 
         scans = _index_scans(root)
-        assert scans, f"expected an index scan, got plan nodes: {types}"
+        assert scans, f"expected an index scan, got plan:{_render(root)}"
         used = {s.get("Index Name") for s in scans}
-        assert NEW_INDEX in used, f"expected {NEW_INDEX} to serve the query, plan used {used}"
+        assert NEW_INDEX in used, f"expected {NEW_INDEX} to serve the query, plan used {used}. Plan:{_render(root)}"
 
         # The whole point of the change: no sort step.
         assert not _sort_nodes(root), (
             f"expected no Sort / Incremental Sort above the index scan, found {_sort_nodes(root)}. "
-            f"That is the regression the 3-column index exists to prevent. Plan nodes: {types}"
+            f"That is the regression the 3-column index exists to prevent. Plan:{_render(root)}"
         )
 
         # A backward scan is the MECHANISM: the index is declared all-ASC, so
@@ -317,16 +381,16 @@ class TestListDocumentsIndexPlanPg:
         root = await _explain(backend, statement, parameters, analyze=True)
         types = _node_types(root)
 
-        assert "Seq Scan" not in types, f"planner chose a sequential scan at depth. Plan nodes: {types}"
+        assert "Seq Scan" not in types, f"planner chose a sequential scan at depth. Plan:{_render(root)}"
 
         used = {s.get("Index Name") for s in _index_scans(root)}
         assert NEW_INDEX in used, (
             f"expected {NEW_INDEX} to serve the deep page, plan used {used}. "
             "If this names the single-column ix_documents_created_at, the namespace filter was "
             "not selective enough for the namespace-leading index to win - check that the decoy "
-            "namespaces actually got seeded (see DECOY_NAMESPACES)."
+            f"namespaces actually got seeded (see DECOY_NAMESPACES). Plan:{_render(root)}"
         )
-        assert not _sort_nodes(root), f"deep page grew a sort node: {_sort_nodes(root)}"
+        assert not _sort_nodes(root), f"deep page grew a sort node: {_sort_nodes(root)}. Plan:{_render(root)}"
 
     async def test_old_two_column_index_would_reintroduce_a_sort(
         self, backend: PostgreSQLBackend, seeded_namespace: UUID

--- a/tests/integration/storage/test_list_documents_index_plan_pg.py
+++ b/tests/integration/storage/test_list_documents_index_plan_pg.py
@@ -202,46 +202,66 @@ async def seeded_namespace(backend: PostgreSQLBackend) -> AsyncIterator[UUID]:
     fixture cares about table size and planner statistics, and thousands of
     round trips would dominate the test's runtime for no added coverage.
     """
-    ns = await backend.create_namespace(MemoryNamespace())
-    decoys = [await backend.create_namespace(MemoryNamespace()) for _ in range(DECOY_NAMESPACES)]
     engine = backend._engine
     assert engine is not None
 
-    base = datetime.now(UTC)
-    async with engine.begin() as conn:
-        await conn.execute(_INSERT_DOCUMENTS, _rows(ns.id, base, SEED_ROWS, "plan-seed"))
-        for decoy in decoys:
+    # Every namespace is recorded the instant it is created, and the whole of
+    # setup runs inside the try. Each INSERT commits, so a failure part-way
+    # through - a dead connection between two decoy batches, a cancelled
+    # ANALYZE - would otherwise strand thousands of committed rows in the
+    # shared table with nothing tracking which namespaces they belong to. Those
+    # rows then skew pg_statistic for every later plan test in the serial job,
+    # which is the exact failure mode this module's assertions are least able
+    # to diagnose.
+    namespace_ids: list[UUID] = []
+    try:
+        ns = await backend.create_namespace(MemoryNamespace())
+        namespace_ids.append(ns.id)
+
+        base = datetime.now(UTC)
+        async with engine.begin() as conn:
+            await conn.execute(_INSERT_DOCUMENTS, _rows(ns.id, base, SEED_ROWS, "plan-seed"))
+
+        for _ in range(DECOY_NAMESPACES):
+            decoy = await backend.create_namespace(MemoryNamespace())
+            namespace_ids.append(decoy.id)
             # Same timestamp range as the namespace under test, so the decoys
             # interleave rather than sorting cleanly to one end - otherwise a
             # created_at-ordered scan could skip them all in one range and the
             # namespace filter would be selective in name only.
-            await conn.execute(_INSERT_DOCUMENTS, _rows(decoy.id, base, DECOY_ROWS_EACH, "plan-decoy"))
+            async with engine.begin() as conn:
+                await conn.execute(_INSERT_DOCUMENTS, _rows(decoy.id, base, DECOY_ROWS_EACH, "plan-decoy"))
 
-    # ANALYZE must COMMIT - pg_statistic updates are MVCC-transactional, so an
-    # autobegun-then-rolled-back connection would silently discard them and the
-    # planner would still be working from empty-table estimates.
-    async with engine.begin() as conn:
-        await conn.execute(sa.text("ANALYZE documents"))
+        # ANALYZE must COMMIT - pg_statistic updates are MVCC-transactional, so
+        # an autobegun-then-rolled-back connection would silently discard them
+        # and the planner would still be working from empty-table estimates.
+        async with engine.begin() as conn:
+            await conn.execute(sa.text("ANALYZE documents"))
 
-    try:
         yield ns.id
     finally:
-        namespace_ids = [ns.id, *(d.id for d in decoys)]
-        # Expanding IN rather than ``= ANY(:ns)``: SQLAlchemy renders one bind
-        # per element, so the driver never has to infer a uuid[] array type for
-        # a bare Python list. Teardown failing here would leak thousands of rows
-        # into every later test's planner statistics.
-        async with engine.begin() as conn:
-            await conn.execute(
-                sa.text("DELETE FROM documents WHERE namespace_id IN :ns").bindparams(
-                    sa.bindparam("ns", expanding=True)
-                ),
-                {"ns": namespace_ids},
-            )
-            await conn.execute(
-                sa.text("DELETE FROM memory_namespaces WHERE id IN :ns").bindparams(sa.bindparam("ns", expanding=True)),
-                {"ns": namespace_ids},
-            )
+        # Guarded rather than an early ``return``: a ``return`` inside
+        # ``finally`` discards any in-flight exception, so a setup failure here
+        # would be swallowed and reported as a confusing fixture error instead
+        # of itself. An empty expanding bind also renders invalid SQL.
+        if namespace_ids:
+            # Expanding IN rather than ``= ANY(:ns)``: SQLAlchemy renders one
+            # bind per element, so the driver never has to infer a uuid[] array
+            # type for a bare Python list. Teardown failing here would leak
+            # thousands of rows into every later test's planner statistics.
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text("DELETE FROM documents WHERE namespace_id IN :ns").bindparams(
+                        sa.bindparam("ns", expanding=True)
+                    ),
+                    {"ns": namespace_ids},
+                )
+                await conn.execute(
+                    sa.text("DELETE FROM memory_namespaces WHERE id IN :ns").bindparams(
+                        sa.bindparam("ns", expanding=True)
+                    ),
+                    {"ns": namespace_ids},
+                )
 
 
 async def _capture_list_documents_sql(

--- a/tests/integration/storage/test_list_documents_index_plan_pg.py
+++ b/tests/integration/storage/test_list_documents_index_plan_pg.py
@@ -1,0 +1,324 @@
+"""``list_documents`` must be planned as a sort-free index scan on PostgreSQL.
+
+``list_documents`` pins a total order - ``ORDER BY created_at DESC, id DESC``.
+The index that used to back it, ``ix_documents_namespace_created_at``, covers
+only the ``created_at`` prefix of that order, so with ``namespace_id``
+equality-constrained the planner still has to sort on the trailing ``id`` key
+(an Incremental Sort on PG 13+). A first page barely notices. The cost lands on
+full-drain offset pagination, which real callers perform - GC / session expiry,
+session forget, and the agent-framework adapters that walk every document in a
+namespace - because the sort is redone for every page.
+
+Widening the index to ``(namespace_id, created_at, id)`` makes the residual
+index order exactly ``(created_at ASC, id ASC)``, so a BACKWARD scan yields
+``(created_at DESC, id DESC)`` directly and the sort node disappears.
+
+These tests assert the PLAN SHAPE, not timings - timings are not portable
+across CI runners, and a wall-clock threshold would flake. Plan shape is the
+precise thing the wider index buys.
+
+Two properties, both needed:
+
+* the query is served by a backward scan of the 3-column index, with no
+  ``Sort`` / ``Incremental Sort`` node anywhere in the plan;
+* that assertion is NOT vacuous - the differential test rebuilds the old
+  2-column index inside a rolled-back transaction and shows the same query
+  *does* grow a sort node, so a plan without one is a real signal rather than
+  something every plan would satisfy.
+
+Requires a running PostgreSQL (``make dev``, port 5434). Skipped automatically
+when the configured ``KHORA_DATABASE_URL`` is unreachable.
+
+Run explicitly (the shell may leak a different URL)::
+
+    KHORA_DATABASE_URL="postgresql://khora:khora@localhost:5434/khora" \
+        UV_NO_SYNC=1 uv run pytest \
+        tests/integration/storage/test_list_documents_index_plan_pg.py \
+        -o addopts="" --no-cov -q
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import event
+
+from khora.core.models import MemoryNamespace
+from khora.db.session import run_migrations
+from khora.storage.backends.postgresql import PostgreSQLBackend
+
+DATABASE_URL = os.environ.get(
+    "KHORA_DATABASE_URL",
+    # This repo's compose puts Postgres on 5434 (see compose.yaml); defaulting
+    # to 5432 would make the whole module silently skip on a local `make test`.
+    "postgresql+asyncpg://khora:khora@localhost:5434/khora",
+)
+
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
+
+
+def _pg_reachable() -> bool:
+    import socket
+    from urllib.parse import urlparse
+
+    parsed = urlparse(DATABASE_URL.replace("+asyncpg", ""))
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not _pg_reachable(), reason="PostgreSQL not reachable (run `make dev` first)"),
+]
+
+NEW_INDEX = "ix_documents_namespace_created_at_id"
+OLD_INDEX = "ix_documents_namespace_created_at"
+
+# Enough rows that a sequential scan plus a full sort is clearly the more
+# expensive plan, so the planner reaches for the index on cost rather than on
+# luck. Below roughly a thousand rows the two plans are close enough that a
+# seq scan can win, which would make the sort-free assertion meaningless.
+SEED_ROWS = 3000
+PAGE_SIZE = 100
+
+# Timestamp granularity: bulk ingest stamps many documents with the same
+# ``created_at``, so ties are the realistic case and the trailing ``id`` key is
+# load-bearing rather than decorative.
+ROWS_PER_TIMESTAMP = 50
+
+
+@pytest.fixture(scope="module")
+async def _run_migrations_once():
+    result = await run_migrations(DATABASE_URL)
+    assert result.success, f"Migrations failed: {result.error}"
+
+
+@pytest.fixture
+async def backend(_run_migrations_once) -> AsyncIterator[PostgreSQLBackend]:
+    be = PostgreSQLBackend(database_url=DATABASE_URL)
+    await be.connect()
+    try:
+        yield be
+    finally:
+        await be.disconnect()
+
+
+@pytest.fixture
+async def seeded_namespace(backend: PostgreSQLBackend) -> AsyncIterator[UUID]:
+    """A namespace holding ``SEED_ROWS`` documents, with committed statistics.
+
+    Documents go in by bulk INSERT rather than ``create_document`` - this
+    fixture cares about table size and planner statistics, and 3000 round trips
+    would dominate the test's runtime for no added coverage.
+    """
+    ns = await backend.create_namespace(MemoryNamespace())
+    engine = backend._engine
+    assert engine is not None
+
+    base = datetime.now(UTC)
+    async with engine.begin() as conn:
+        await conn.execute(
+            sa.text(
+                "INSERT INTO documents (id, namespace_id, content, checksum, status, created_at, updated_at) "
+                "VALUES (:id, :ns, :content, :checksum, 'completed', :ts, :ts)"
+            ),
+            [
+                {
+                    "id": uuid4(),
+                    "ns": ns.id,
+                    "content": f"seed document {i}",
+                    "checksum": f"plan-seed-{i}",
+                    "ts": base - timedelta(seconds=i // ROWS_PER_TIMESTAMP),
+                }
+                for i in range(SEED_ROWS)
+            ],
+        )
+
+    # ANALYZE must COMMIT - pg_statistic updates are MVCC-transactional, so an
+    # autobegun-then-rolled-back connection would silently discard them and the
+    # planner would still be working from empty-table estimates.
+    async with engine.begin() as conn:
+        await conn.execute(sa.text("ANALYZE documents"))
+
+    try:
+        yield ns.id
+    finally:
+        async with engine.begin() as conn:
+            await conn.execute(sa.text("DELETE FROM documents WHERE namespace_id = :ns"), {"ns": ns.id})
+            await conn.execute(sa.text("DELETE FROM memory_namespaces WHERE id = :ns"), {"ns": ns.id})
+
+
+async def _capture_list_documents_sql(
+    backend: PostgreSQLBackend, namespace_id: UUID, *, offset: int
+) -> tuple[str, Any]:
+    """Return the SQL ``list_documents`` actually emits, plus its parameters.
+
+    Captured off the live cursor rather than hand-written here. A hand-written
+    query would drift from the implementation the moment someone edits
+    ``list_documents``, and the test would then happily assert a good plan for
+    a query nobody runs.
+    """
+    engine = backend._engine
+    assert engine is not None
+    captured: list[tuple[str, Any]] = []
+
+    def _capture(conn, cursor, statement, parameters, context, executemany) -> None:
+        if "documents" in statement and "ORDER BY" in statement:
+            captured.append((statement, parameters))
+
+    event.listen(engine.sync_engine, "before_cursor_execute", _capture)
+    try:
+        docs = await backend.list_documents(namespace_id, limit=PAGE_SIZE, offset=offset)
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _capture)
+
+    assert len(docs) == PAGE_SIZE, f"seed too small: page at offset {offset} returned {len(docs)} rows"
+    assert captured, "no SELECT against documents was captured"
+    return captured[-1]
+
+
+async def _explain(backend: PostgreSQLBackend, statement: str, parameters: Any, *, analyze: bool) -> dict:
+    """Run EXPLAIN over *statement* and return the root plan node."""
+    engine = backend._engine
+    assert engine is not None
+    options = "ANALYZE, FORMAT JSON" if analyze else "FORMAT JSON"
+    async with engine.connect() as conn:
+        result = await conn.exec_driver_sql(f"EXPLAIN ({options}) {statement}", parameters)
+        raw = result.scalar()
+    plan = json.loads(raw) if isinstance(raw, str) else raw
+    return plan[0]["Plan"]
+
+
+def _walk(node: dict):
+    """Yield every node in a PostgreSQL plan tree, root first."""
+    yield node
+    for child in node.get("Plans", []):
+        yield from _walk(child)
+
+
+def _node_types(root: dict) -> list[str]:
+    return [n["Node Type"] for n in _walk(root)]
+
+
+def _index_scans(root: dict) -> list[dict]:
+    return [n for n in _walk(root) if n["Node Type"] in {"Index Scan", "Index Only Scan"}]
+
+
+def _sort_nodes(root: dict) -> list[str]:
+    return [t for t in _node_types(root) if "Sort" in t]
+
+
+class TestListDocumentsIndexPlanPg:
+    async def test_query_is_a_sort_free_backward_index_scan(
+        self, backend: PostgreSQLBackend, seeded_namespace: UUID
+    ) -> None:
+        """The first page is served straight off the 3-column index, no sort."""
+        statement, parameters = await _capture_list_documents_sql(backend, seeded_namespace, offset=0)
+        root = await _explain(backend, statement, parameters, analyze=True)
+        types = _node_types(root)
+
+        # Non-vacuity guard: a seq scan means the planner ignored every index,
+        # so "no sort node above the index scan" would be trivially true of a
+        # plan that has no index scan at all. Fail loudly instead.
+        assert "Seq Scan" not in types, (
+            f"planner chose a sequential scan - the seed ({SEED_ROWS} rows) is too small "
+            f"or ANALYZE did not commit, so this test proves nothing. Plan nodes: {types}"
+        )
+
+        scans = _index_scans(root)
+        assert scans, f"expected an index scan, got plan nodes: {types}"
+        used = {s.get("Index Name") for s in scans}
+        assert NEW_INDEX in used, f"expected {NEW_INDEX} to serve the query, plan used {used}"
+
+        # The whole point of the change: no sort step.
+        assert not _sort_nodes(root), (
+            f"expected no Sort / Incremental Sort above the index scan, found {_sort_nodes(root)}. "
+            f"That is the regression the 3-column index exists to prevent. Plan nodes: {types}"
+        )
+
+        # A backward scan is the MECHANISM: the index is declared all-ASC, so
+        # only reading it in reverse can yield (created_at DESC, id DESC). If
+        # this ever reads Forward, the plan is satisfying the order some other
+        # way and the sort-free assertion above is a coincidence.
+        scan = next(s for s in scans if s.get("Index Name") == NEW_INDEX)
+        assert scan.get("Scan Direction") == "Backward", (
+            f"expected a Backward scan of {NEW_INDEX}, got {scan.get('Scan Direction')!r}"
+        )
+
+    async def test_deep_offset_page_is_also_sort_free(self, backend: PostgreSQLBackend, seeded_namespace: UUID) -> None:
+        """Sort-freedom must hold at depth, not just on the first page.
+
+        Full-drain pagination is where the regression actually bit: the sort is
+        redone once per page, so the cost is paid ``rows / page_size`` times.
+        A deep page is the representative case, not the first one.
+        """
+        deep_offset = SEED_ROWS - PAGE_SIZE * 2
+        statement, parameters = await _capture_list_documents_sql(backend, seeded_namespace, offset=deep_offset)
+        root = await _explain(backend, statement, parameters, analyze=True)
+        types = _node_types(root)
+
+        assert "Seq Scan" not in types, f"planner chose a sequential scan at depth. Plan nodes: {types}"
+        assert NEW_INDEX in {s.get("Index Name") for s in _index_scans(root)}
+        assert not _sort_nodes(root), f"deep page grew a sort node: {_sort_nodes(root)}"
+
+    async def test_old_two_column_index_would_reintroduce_a_sort(
+        self, backend: PostgreSQLBackend, seeded_namespace: UUID
+    ) -> None:
+        """The differential: prove the sort-free assertion above is not vacuous.
+
+        Rebuilds the superseded 2-column index in place of the 3-column one and
+        re-plans the identical query. If the same query grows a sort node under
+        the old index and loses it under the new one, the plan-shape assertions
+        are measuring the index rather than something every plan satisfies.
+
+        The swap runs inside a transaction that is ALWAYS rolled back. Index
+        DDL is transactional on PostgreSQL, so the rollback restores both
+        indexes exactly - nothing is left behind even if an assertion fails.
+        ``CREATE INDEX`` here is deliberately non-concurrent: concurrent builds
+        cannot run inside a transaction, and this one must be reverted.
+        """
+        statement, parameters = await _capture_list_documents_sql(backend, seeded_namespace, offset=0)
+
+        engine = backend._engine
+        assert engine is not None
+        async with engine.connect() as conn:
+            trans = await conn.begin()
+            try:
+                await conn.exec_driver_sql(f"DROP INDEX {NEW_INDEX}")
+                await conn.exec_driver_sql(f"CREATE INDEX {OLD_INDEX} ON documents (namespace_id, created_at)")
+
+                result = await conn.exec_driver_sql(f"EXPLAIN (FORMAT JSON) {statement}", parameters)
+                raw = result.scalar()
+                root = (json.loads(raw) if isinstance(raw, str) else raw)[0]["Plan"]
+            finally:
+                await trans.rollback()
+
+        assert _sort_nodes(root), (
+            "the 2-column index was expected to force a sort for "
+            f"ORDER BY created_at DESC, id DESC, but the plan has none: {_node_types(root)}. "
+            "Without that contrast the sort-free assertions in this module prove nothing."
+        )
+
+        # And the indexes really did come back on rollback.
+        async with engine.connect() as conn:
+            result = await conn.execute(
+                sa.text("SELECT indexname FROM pg_indexes WHERE tablename = 'documents' AND indexname = ANY(:names)"),
+                {"names": [NEW_INDEX, OLD_INDEX]},
+            )
+            present = {row[0] for row in result.fetchall()}
+        assert present == {NEW_INDEX}, f"rollback did not restore the index set, found {present}"

--- a/tests/integration/storage/test_list_documents_index_plan_pg.py
+++ b/tests/integration/storage/test_list_documents_index_plan_pg.py
@@ -101,6 +101,42 @@ PAGE_SIZE = 100
 # load-bearing rather than decorative.
 ROWS_PER_TIMESTAMP = 50
 
+# Documents seeded into OTHER namespaces, so the namespace filter is selective.
+#
+# This is load-bearing, not padding. `documents` also carries a single-column
+# `ix_documents_created_at` (added by an earlier temporal-search migration). If
+# every row in the table belongs to the namespace under test, `WHERE
+# namespace_id = ?` excludes nothing, and at a deep offset the planner correctly
+# prefers a backward scan of that narrower single-column index - it reads fewer
+# pages to reach the same rows, and the namespace-leading index buys it nothing.
+# The plan then legitimately stops using the index this migration adds.
+#
+# That is an artifact of an all-one-namespace table, not of production. Khora is
+# multi-tenant: a namespace is a fraction of `documents`, which is exactly the
+# regime where the namespace-leading index wins. Seeding decoy namespaces makes
+# the fixture match that regime, so the assertions below measure the index
+# rather than the seed's shape.
+DECOY_NAMESPACES = 4
+DECOY_ROWS_EACH = 3000
+
+_INSERT_DOCUMENTS = sa.text(
+    "INSERT INTO documents (id, namespace_id, content, checksum, status, created_at, updated_at) "
+    "VALUES (:id, :ns, :content, :checksum, 'completed', :ts, :ts)"
+)
+
+
+def _rows(namespace_id: UUID, base: datetime, count: int, tag: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": uuid4(),
+            "ns": namespace_id,
+            "content": f"{tag} document {i}",
+            "checksum": f"{tag}-{namespace_id}-{i}",
+            "ts": base - timedelta(seconds=i // ROWS_PER_TIMESTAMP),
+        }
+        for i in range(count)
+    ]
+
 
 @pytest.fixture(scope="module")
 async def _run_migrations_once():
@@ -122,32 +158,28 @@ async def backend(_run_migrations_once) -> AsyncIterator[PostgreSQLBackend]:
 async def seeded_namespace(backend: PostgreSQLBackend) -> AsyncIterator[UUID]:
     """A namespace holding ``SEED_ROWS`` documents, with committed statistics.
 
+    Sits inside a table that also holds several other namespaces of comparable
+    size, so ``WHERE namespace_id = ?`` is selective - see ``DECOY_NAMESPACES``
+    for why that matters to the plan.
+
     Documents go in by bulk INSERT rather than ``create_document`` - this
-    fixture cares about table size and planner statistics, and 3000 round trips
-    would dominate the test's runtime for no added coverage.
+    fixture cares about table size and planner statistics, and thousands of
+    round trips would dominate the test's runtime for no added coverage.
     """
     ns = await backend.create_namespace(MemoryNamespace())
+    decoys = [await backend.create_namespace(MemoryNamespace()) for _ in range(DECOY_NAMESPACES)]
     engine = backend._engine
     assert engine is not None
 
     base = datetime.now(UTC)
     async with engine.begin() as conn:
-        await conn.execute(
-            sa.text(
-                "INSERT INTO documents (id, namespace_id, content, checksum, status, created_at, updated_at) "
-                "VALUES (:id, :ns, :content, :checksum, 'completed', :ts, :ts)"
-            ),
-            [
-                {
-                    "id": uuid4(),
-                    "ns": ns.id,
-                    "content": f"seed document {i}",
-                    "checksum": f"plan-seed-{i}",
-                    "ts": base - timedelta(seconds=i // ROWS_PER_TIMESTAMP),
-                }
-                for i in range(SEED_ROWS)
-            ],
-        )
+        await conn.execute(_INSERT_DOCUMENTS, _rows(ns.id, base, SEED_ROWS, "plan-seed"))
+        for decoy in decoys:
+            # Same timestamp range as the namespace under test, so the decoys
+            # interleave rather than sorting cleanly to one end - otherwise a
+            # created_at-ordered scan could skip them all in one range and the
+            # namespace filter would be selective in name only.
+            await conn.execute(_INSERT_DOCUMENTS, _rows(decoy.id, base, DECOY_ROWS_EACH, "plan-decoy"))
 
     # ANALYZE must COMMIT - pg_statistic updates are MVCC-transactional, so an
     # autobegun-then-rolled-back connection would silently discard them and the
@@ -158,9 +190,22 @@ async def seeded_namespace(backend: PostgreSQLBackend) -> AsyncIterator[UUID]:
     try:
         yield ns.id
     finally:
+        namespace_ids = [ns.id, *(d.id for d in decoys)]
+        # Expanding IN rather than ``= ANY(:ns)``: SQLAlchemy renders one bind
+        # per element, so the driver never has to infer a uuid[] array type for
+        # a bare Python list. Teardown failing here would leak thousands of rows
+        # into every later test's planner statistics.
         async with engine.begin() as conn:
-            await conn.execute(sa.text("DELETE FROM documents WHERE namespace_id = :ns"), {"ns": ns.id})
-            await conn.execute(sa.text("DELETE FROM memory_namespaces WHERE id = :ns"), {"ns": ns.id})
+            await conn.execute(
+                sa.text("DELETE FROM documents WHERE namespace_id IN :ns").bindparams(
+                    sa.bindparam("ns", expanding=True)
+                ),
+                {"ns": namespace_ids},
+            )
+            await conn.execute(
+                sa.text("DELETE FROM memory_namespaces WHERE id IN :ns").bindparams(sa.bindparam("ns", expanding=True)),
+                {"ns": namespace_ids},
+            )
 
 
 async def _capture_list_documents_sql(
@@ -273,7 +318,14 @@ class TestListDocumentsIndexPlanPg:
         types = _node_types(root)
 
         assert "Seq Scan" not in types, f"planner chose a sequential scan at depth. Plan nodes: {types}"
-        assert NEW_INDEX in {s.get("Index Name") for s in _index_scans(root)}
+
+        used = {s.get("Index Name") for s in _index_scans(root)}
+        assert NEW_INDEX in used, (
+            f"expected {NEW_INDEX} to serve the deep page, plan used {used}. "
+            "If this names the single-column ix_documents_created_at, the namespace filter was "
+            "not selective enough for the namespace-leading index to win - check that the decoy "
+            "namespaces actually got seeded (see DECOY_NAMESPACES)."
+        )
         assert not _sort_nodes(root), f"deep page grew a sort node: {_sort_nodes(root)}"
 
     async def test_old_two_column_index_would_reintroduce_a_sort(

--- a/tests/unit/storage/test_optimize_coverage.py
+++ b/tests/unit/storage/test_optimize_coverage.py
@@ -587,3 +587,53 @@ async def test_optimize_storage_skips_neo4j_when_no_driver_attr(monkeypatch: pyt
 
     result = await opt_mod.optimize_storage(coord)
     assert result["neo4j"] is None
+
+
+# ---------------------------------------------------------------------------
+# PG_INDEXES must not resurrect the superseded documents sort index
+# ---------------------------------------------------------------------------
+
+
+def _documents_index_columns(sql: str) -> list[str] | None:
+    """Ordered column list of a ``CREATE INDEX ... ON documents (...)``, else None."""
+    lowered = sql.lower()
+    marker = "on documents ("
+    if marker not in lowered:
+        return None
+    inner = sql[lowered.index(marker) + len(marker) : sql.rindex(")")]
+    # Strip per-column direction/opclass qualifiers - only the key order matters.
+    return [c.strip().split()[0].lower() for c in inner.split(",") if c.strip()]
+
+
+@pytest.mark.unit
+def test_pg_indexes_does_not_recreate_the_superseded_documents_index() -> None:
+    """``optimize_storage()`` must not hand back the 2-column documents index.
+
+    Migration 054 widened ``(namespace_id, created_at)`` to
+    ``(namespace_id, created_at, id)`` so ``list_documents``' pinned
+    ``ORDER BY created_at DESC, id DESC`` is served without a sort, and dropped
+    the narrower index so the ingest path does not maintain two indexes sharing
+    a prefix.
+
+    ``PG_INDEXES`` is applied with ``CREATE INDEX IF NOT EXISTS`` against live
+    databases, so an entry here silently undoes that migration on every
+    deployment that runs ``optimize_storage()`` - no migration, no review,
+    nothing in the Alembic history to point at. It also hands the planner
+    another candidate on the same leading columns.
+
+    Any documents index keyed on ``(namespace_id, created_at, ...)`` is
+    rejected. A wider index that merely starts with those two keys is exactly
+    the near-duplicate this guards against; genuinely different documents
+    indexes are unaffected.
+    """
+    offenders = []
+    for entry in opt_mod.PG_INDEXES:
+        columns = _documents_index_columns(entry["sql"])
+        if columns and columns[:2] == ["namespace_id", "created_at"]:
+            offenders.append((entry["name"], columns))
+
+    assert not offenders, (
+        f"PG_INDEXES re-creates a documents index on the (namespace_id, created_at) prefix: "
+        f"{offenders}. Migration 054 deliberately dropped that index; recreating it here would "
+        "undo the migration on any deployment running optimize_storage()."
+    )

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -442,14 +442,14 @@ class TestMigrationPackageStructure:
         assert env_path.exists(), f"env.py not found at {env_path}"
 
     @pytest.mark.unit
-    def test_versions_dir_has_54_files(self):
-        """versions/ directory contains 54 migration files."""
+    def test_versions_dir_has_55_files(self):
+        """versions/ directory contains 55 migration files."""
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
         # Filter out __pycache__ and __init__
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
-        assert len(migration_files) == 54, (
-            f"Expected 54 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
+        assert len(migration_files) == 55, (
+            f"Expected 55 migration files, found {len(migration_files)}: {[f.name for f in migration_files]}"
         )
 
     @pytest.mark.unit

--- a/tests/unit/test_migration_drift.py
+++ b/tests/unit/test_migration_drift.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import ast
 import warnings
 from pathlib import Path
+from typing import NamedTuple
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -174,12 +175,47 @@ class TestORMMigrationDrift:
 # ---------------------------------------------------------------------------
 
 
-IndexOps = tuple[dict[str, tuple[str, ...]], set[str]]
-"""``(created, dropped)``: created maps index name to its ORDERED column tuple."""
+class IndexOp(NamedTuple):
+    """A single index DDL statement, with the properties worth asserting on."""
+
+    action: str  # "create" | "drop"
+    name: str
+    columns: tuple[str, ...]  # empty for drops
+    concurrent: bool
+    in_autocommit_block: bool
+
+
+class IndexOps(NamedTuple):
+    """Index DDL from one dialect branch, in SOURCE ORDER.
+
+    ``operations`` is the ordered record; ``created`` / ``dropped`` are derived
+    views over it for the assertions that do not care about sequencing.
+    """
+
+    operations: tuple[IndexOp, ...]
+
+    @property
+    def created(self) -> dict[str, tuple[str, ...]]:
+        return {op.name: op.columns for op in self.operations if op.action == "create"}
+
+    @property
+    def dropped(self) -> set[str]:
+        return {op.name for op in self.operations if op.action == "drop"}
+
+    def index_of(self, action: str, name: str) -> int | None:
+        for i, op in enumerate(self.operations):
+            if op.action == action and op.name == name:
+                return i
+        return None
 
 
 def _mentions_is_postgres(test: ast.expr) -> bool:
     return any(isinstance(n, ast.Name) and n.id == "_is_postgres" for n in ast.walk(test))
+
+
+def _is_autocommit_block(item: ast.withitem) -> bool:
+    call = item.context_expr
+    return isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute) and call.func.attr == "autocommit_block"
 
 
 def _dialect_branches(func: ast.FunctionDef) -> dict[str, list[ast.stmt]]:
@@ -212,8 +248,38 @@ def _dialect_branches(func: ast.FunctionDef) -> dict[str, list[ast.stmt]]:
     return {"": func.body}
 
 
+def _op_calls(nodes: list[ast.stmt]) -> list[tuple[ast.Call, bool]]:
+    """Every ``op.*`` call in *nodes*, paired with whether it sits in an
+    ``autocommit_block()``, in source order.
+
+    Source order is why this is a hand-rolled descent rather than ``ast.walk``:
+    ``walk`` is breadth-first, so it would interleave statements from different
+    nesting depths and destroy the sequencing that ``create before drop`` needs.
+    Results are sorted by position to stay honest regardless of traversal shape.
+    """
+    found: list[tuple[ast.Call, bool]] = []
+
+    def descend(node: ast.AST, in_block: bool) -> None:
+        if isinstance(node, ast.With):
+            in_block = in_block or any(_is_autocommit_block(item) for item in node.items)
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "op"
+        ):
+            found.append((node, in_block))
+        for child in ast.iter_child_nodes(node):
+            descend(child, in_block)
+
+    for root in nodes:
+        descend(root, False)
+
+    return sorted(found, key=lambda pair: (pair[0].lineno, pair[0].col_offset))
+
+
 def _scan(nodes: list[ast.stmt]) -> IndexOps:
-    """Collect index DDL from a list of statements.
+    """Collect index DDL from a list of statements, in source order.
 
     Both spellings are recognised, since a dialect-gated migration typically
     uses raw SQL on one branch and the Alembic helpers on the other:
@@ -221,41 +287,35 @@ def _scan(nodes: list[ast.stmt]) -> IndexOps:
     * ``op.execute("CREATE INDEX ... ON t (a, b)")`` / ``op.execute("DROP INDEX ...")``
     * ``op.create_index("name", "t", ["a", "b"])`` / ``op.drop_index("name", ...)``
     """
-    created: dict[str, tuple[str, ...]] = {}
-    dropped: set[str] = set()
+    operations: list[IndexOp] = []
 
-    for root in nodes:
-        for node in ast.walk(root):
-            if not isinstance(node, ast.Call):
-                continue
-            target = node.func
-            if not (
-                isinstance(target, ast.Attribute) and isinstance(target.value, ast.Name) and target.value.id == "op"
-            ):
-                continue
+    for node, in_block in _op_calls(nodes):
+        target = node.func
+        assert isinstance(target, ast.Attribute)
 
-            if target.attr == "execute" and node.args and isinstance(node.args[0], ast.Constant):
-                statement = str(node.args[0].value)
-                collapsed = " ".join(statement.split())
-                upper = collapsed.upper()
-                if upper.startswith("CREATE INDEX"):
-                    head, _, cols = collapsed.partition("(")
-                    name = head.split()[-3]  # "... <name> ON <table>"
-                    created[name] = tuple(c.strip() for c in cols.rstrip(")").split(","))
-                elif upper.startswith("DROP INDEX"):
-                    dropped.add(collapsed.split()[-1])
+        if target.attr == "execute" and node.args and isinstance(node.args[0], ast.Constant):
+            statement = str(node.args[0].value)
+            collapsed = " ".join(statement.split())
+            upper = collapsed.upper()
+            concurrent = "CONCURRENTLY" in upper
+            if upper.startswith("CREATE INDEX"):
+                head, _, cols = collapsed.partition("(")
+                name = head.split()[-3]  # "... <name> ON <table>"
+                columns = tuple(c.strip() for c in cols.rstrip(")").split(","))
+                operations.append(IndexOp("create", name, columns, concurrent, in_block))
+            elif upper.startswith("DROP INDEX"):
+                operations.append(IndexOp("drop", collapsed.split()[-1], (), concurrent, in_block))
 
-            elif target.attr == "create_index" and len(node.args) >= 3:
-                name_node, cols_node = node.args[0], node.args[2]
-                if isinstance(name_node, ast.Constant) and isinstance(cols_node, ast.List):
-                    created[str(name_node.value)] = tuple(
-                        str(c.value) for c in cols_node.elts if isinstance(c, ast.Constant)
-                    )
+        elif target.attr == "create_index" and len(node.args) >= 3:
+            name_node, cols_node = node.args[0], node.args[2]
+            if isinstance(name_node, ast.Constant) and isinstance(cols_node, ast.List):
+                columns = tuple(str(c.value) for c in cols_node.elts if isinstance(c, ast.Constant))
+                operations.append(IndexOp("create", str(name_node.value), columns, False, in_block))
 
-            elif target.attr == "drop_index" and node.args and isinstance(node.args[0], ast.Constant):
-                dropped.add(str(node.args[0].value))
+        elif target.attr == "drop_index" and node.args and isinstance(node.args[0], ast.Constant):
+            operations.append(IndexOp("drop", str(node.args[0].value), (), False, in_block))
 
-    return created, dropped
+    return IndexOps(tuple(operations))
 
 
 def _index_ops(migration_file: str, func_name: str) -> dict[str, IndexOps]:
@@ -347,7 +407,8 @@ class TestDocumentsCreatedAtIndexAgreement:
 
     def test_migration_creates_exactly_what_the_orm_declares(self):
         """Every branch of upgrade builds the ORM's index, same columns, same order."""
-        for branch, (created, _dropped) in _index_ops(self.MIGRATION, "upgrade").items():
+        for branch, ops in _index_ops(self.MIGRATION, "upgrade").items():
+            created = ops.created
             assert self.NEW_INDEX in created, (
                 f"{self.MIGRATION} upgrade() [{branch} branch] does not create {self.NEW_INDEX}; "
                 f"it creates {sorted(created)}. A branch that skips the index leaves that dialect "
@@ -364,7 +425,8 @@ class TestDocumentsCreatedAtIndexAgreement:
 
     def test_migration_drops_the_superseded_index(self):
         """Every branch of upgrade removes the 2-column index the 3-column one subsumes."""
-        for branch, (_created, dropped) in _index_ops(self.MIGRATION, "upgrade").items():
+        for branch, ops in _index_ops(self.MIGRATION, "upgrade").items():
+            dropped = ops.dropped
             assert self.OLD_INDEX in dropped, (
                 f"upgrade() [{branch} branch] leaves {self.OLD_INDEX} in place; it shares a prefix "
                 f"with {self.NEW_INDEX}, so both would be maintained on every insert"
@@ -374,20 +436,86 @@ class TestDocumentsCreatedAtIndexAgreement:
         """Downgrade must put the 2-column index back, with its original columns.
 
         Not cosmetic. The migration that originally added the 2-column index
-        drops it by an unqualified ``op.drop_index(...)``, which errors if the
-        index is absent - so a downgrade that walks past it would fail outright
+        drops it by an unconditional ``op.drop_index(...)`` - no
+        ``if_exists=True`` - which errors if the index is absent - so a downgrade that walks past it would fail outright
         unless this migration restores it on the way down.
 
         Asserted per branch: the walk past that migration happens on whichever
         dialect the operator is running, so a restore present on only one of
         them leaves the other broken.
         """
-        for branch, (created, dropped) in _index_ops(self.MIGRATION, "downgrade").items():
+        for branch, ops in _index_ops(self.MIGRATION, "downgrade").items():
+            created, dropped = ops.created, ops.dropped
             assert created.get(self.OLD_INDEX) == ("namespace_id", "created_at"), (
                 f"downgrade() [{branch} branch] must recreate {self.OLD_INDEX} on "
                 f"(namespace_id, created_at); it creates {created}"
             )
             assert self.NEW_INDEX in dropped, f"downgrade() [{branch} branch] must remove the 3-column index"
+
+    def test_replacement_index_is_built_before_the_old_one_is_dropped(self):
+        """Create must precede drop, on every branch and in both directions.
+
+        This is the migration's "never unindexed" invariant, and it is the whole
+        reason the two statements are ordered rather than merged. Dropping first
+        would leave ``get_last_activity_at()``'s ``MAX(created_at)`` with no
+        index for the duration of a concurrent build - which on a table large
+        enough to warrant a concurrent build is exactly when it matters. The
+        column assertions above are indifferent to sequencing, so without this
+        the invariant is documented in a docstring and enforced nowhere.
+        """
+        for func_name, new_first in (("upgrade", self.NEW_INDEX), ("downgrade", self.OLD_INDEX)):
+            superseded = self.OLD_INDEX if func_name == "upgrade" else self.NEW_INDEX
+            for branch, ops in _index_ops(self.MIGRATION, func_name).items():
+                create_at = ops.index_of("create", new_first)
+                drop_at = ops.index_of("drop", superseded)
+                assert create_at is not None, f"{func_name}() [{branch} branch] never creates {new_first}"
+                assert drop_at is not None, f"{func_name}() [{branch} branch] never drops {superseded}"
+                assert create_at < drop_at, (
+                    f"{func_name}() [{branch} branch] drops {superseded} before creating {new_first} "
+                    f"(positions {drop_at} and {create_at}). The replacement must exist first, or the "
+                    "namespace/created_at lookup runs unindexed for the length of the build."
+                )
+
+    def test_postgres_branch_builds_concurrently_inside_an_autocommit_block(self):
+        """Both Postgres statements must be CONCURRENTLY, and both inside the block.
+
+        A plain ``CREATE INDEX`` takes a lock that blocks writes on
+        ``documents`` for the whole build, and ``CREATE INDEX CONCURRENTLY``
+        cannot run inside a transaction at all - so the two properties are a
+        pair, and losing either one silently converts a safe migration into an
+        outage on a large table. Neither is visible to the column-level
+        assertions above.
+
+        Asserted only for the Postgres branch: concurrent builds are a Postgres
+        feature, and the other branch deliberately uses plain DDL.
+        """
+        for func_name in ("upgrade", "downgrade"):
+            postgres = _index_ops(self.MIGRATION, func_name)["postgresql"]
+            assert postgres.operations, f"{func_name}() postgresql branch issues no index DDL"
+            for op in postgres.operations:
+                assert op.concurrent, (
+                    f"{func_name}() postgresql branch runs a non-concurrent {op.action.upper()} on "
+                    f"{op.name}; that locks out writes on documents for the length of the build"
+                )
+                assert op.in_autocommit_block, (
+                    f"{func_name}() postgresql branch runs {op.action.upper()} {op.name} outside "
+                    "op.get_context().autocommit_block(); CONCURRENTLY cannot run inside a transaction"
+                )
+
+    def test_non_postgres_branch_does_not_claim_concurrency(self):
+        """The plain-DDL branch must stay plain.
+
+        Guards the inverse of the test above: pasting the Postgres spelling into
+        the other branch would emit SQL that SQLite cannot parse, and the
+        embedded stack takes its schema from this chain and nothing else.
+        """
+        for func_name in ("upgrade", "downgrade"):
+            other = _index_ops(self.MIGRATION, func_name)["other"]
+            assert other.operations, f"{func_name}() non-postgres branch issues no index DDL"
+            for op in other.operations:
+                assert not op.concurrent, (
+                    f"{func_name}() non-postgres branch marks {op.name} CONCURRENTLY; that is a Postgres-only feature"
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_migration_drift.py
+++ b/tests/unit/test_migration_drift.py
@@ -3,11 +3,13 @@
 These tests ensure that:
 1. All migration .py source files are committed (not just .pyc)
 2. ORM models and migrations produce the same schema (no drift)
-3. create_tables() emits a deprecation warning
+3. Composite indexes agree between the ORM and the migration that builds them
+4. create_tables() emits a deprecation warning
 """
 
 from __future__ import annotations
 
+import ast
 import warnings
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -165,6 +167,149 @@ class TestORMMigrationDrift:
             f"ORM columns not covered by any migration for their table: {missing_columns}. "
             f"Create an Alembic migration for these columns."
         )
+
+
+# ---------------------------------------------------------------------------
+# ORM / migration index agreement
+# ---------------------------------------------------------------------------
+
+
+def _index_ops(migration_file: str, func_name: str) -> tuple[dict[str, tuple[str, ...]], set[str]]:
+    """Extract the index DDL a migration's ``upgrade``/``downgrade`` performs.
+
+    Returns ``(created, dropped)`` where ``created`` maps index name to its
+    ORDERED column tuple and ``dropped`` is the set of index names removed.
+
+    Parsed from the AST rather than by regex over the raw source, because the
+    concurrent-index DDL is written as adjacent string literals that Python
+    concatenates at parse time - a regex over the source text would see the
+    statement split across two fragments and match neither. The AST hands back
+    the already-joined constant.
+
+    Both spellings are recognised, so this keeps working if a dialect-gated
+    branch is added alongside the raw-SQL one:
+
+    * ``op.execute("CREATE INDEX ... ON t (a, b)")`` / ``op.execute("DROP INDEX ...")``
+    * ``op.create_index("name", "t", ["a", "b"])`` / ``op.drop_index("name", ...)``
+    """
+    source = (VERSIONS_DIR / migration_file).read_text()
+    tree = ast.parse(source)
+    func = next(
+        (n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == func_name),
+        None,
+    )
+    assert func is not None, f"{migration_file} defines no {func_name}()"
+
+    created: dict[str, tuple[str, ...]] = {}
+    dropped: set[str] = set()
+
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Call):
+            continue
+        target = node.func
+        if not (isinstance(target, ast.Attribute) and isinstance(target.value, ast.Name) and target.value.id == "op"):
+            continue
+
+        if target.attr == "execute" and node.args and isinstance(node.args[0], ast.Constant):
+            statement = str(node.args[0].value)
+            collapsed = " ".join(statement.split())
+            upper = collapsed.upper()
+            if upper.startswith("CREATE INDEX"):
+                head, _, cols = collapsed.partition("(")
+                name = head.split()[-3]  # "... <name> ON <table>"
+                created[name] = tuple(c.strip() for c in cols.rstrip(")").split(","))
+            elif upper.startswith("DROP INDEX"):
+                dropped.add(collapsed.split()[-1])
+
+        elif target.attr == "create_index" and len(node.args) >= 3:
+            name_node, cols_node = node.args[0], node.args[2]
+            if isinstance(name_node, ast.Constant) and isinstance(cols_node, ast.List):
+                created[str(name_node.value)] = tuple(
+                    str(c.value) for c in cols_node.elts if isinstance(c, ast.Constant)
+                )
+
+        elif target.attr == "drop_index" and node.args and isinstance(node.args[0], ast.Constant):
+            dropped.add(str(node.args[0].value))
+
+    return created, dropped
+
+
+def _orm_index_columns(table_name: str, index_name: str) -> tuple[str, ...] | None:
+    """Ordered column names of an ORM ``Index``, or ``None`` if undeclared.
+
+    Uses ``Index.expressions`` rather than ``Index.columns``: only the former
+    is guaranteed to preserve declaration order, and for a composite index
+    serving a sort, order is the entire point.
+    """
+    table = Base.metadata.tables[table_name]
+    for index in table.indexes:
+        if index.name == index_name:
+            return tuple(c.name for c in index.expressions)
+    return None
+
+
+@pytest.mark.unit
+class TestDocumentsCreatedAtIndexAgreement:
+    """The ``documents`` sort-covering index must agree across ORM and migration.
+
+    ``list_documents`` pins ``ORDER BY created_at DESC, id DESC``. The index
+    that covers it is declared twice - once in the ORM (so autogenerate does
+    not propose re-adding it) and once in the migration that builds it. If the
+    two drift, nothing fails at runtime: the database still works, and the
+    mismatch only surfaces later as a spurious autogenerate diff on an
+    unrelated change. These assertions turn that into a red test instead.
+
+    Column ORDER is asserted, not just membership. ``(namespace_id,
+    created_at, id)`` covers the query; a permutation such as ``(namespace_id,
+    id, created_at)`` does not, and a set comparison would wave it through.
+    """
+
+    MIGRATION = "054_documents_namespace_created_at_id.py"
+    NEW_INDEX = "ix_documents_namespace_created_at_id"
+    OLD_INDEX = "ix_documents_namespace_created_at"
+    EXPECTED_COLUMNS = ("namespace_id", "created_at", "id")
+
+    def test_orm_declares_the_sort_covering_index(self):
+        """The ORM carries the 3-column index, in the covering order."""
+        assert _orm_index_columns("documents", self.NEW_INDEX) == self.EXPECTED_COLUMNS
+
+    def test_orm_no_longer_declares_the_superseded_index(self):
+        """The 2-column index is gone from the ORM.
+
+        Leaving both declared would have the ORM ask for two indexes sharing a
+        prefix - write amplification on every document insert.
+        """
+        assert _orm_index_columns("documents", self.OLD_INDEX) is None
+
+    def test_migration_creates_exactly_what_the_orm_declares(self):
+        """Migration upgrade builds the index the ORM declares, same columns, same order."""
+        created, _ = _index_ops(self.MIGRATION, "upgrade")
+
+        assert self.NEW_INDEX in created, (
+            f"{self.MIGRATION} upgrade() does not create {self.NEW_INDEX}; it creates {sorted(created)}"
+        )
+        assert created[self.NEW_INDEX] == _orm_index_columns("documents", self.NEW_INDEX)
+        assert created[self.NEW_INDEX] == self.EXPECTED_COLUMNS
+
+    def test_migration_drops_the_superseded_index(self):
+        """Upgrade removes the 2-column index the 3-column one subsumes."""
+        _, dropped = _index_ops(self.MIGRATION, "upgrade")
+        assert self.OLD_INDEX in dropped
+
+    def test_downgrade_restores_the_superseded_index(self):
+        """Downgrade must put the 2-column index back, with its original columns.
+
+        Not cosmetic. The migration that originally added the 2-column index
+        drops it by an unqualified ``op.drop_index(...)``, which errors if the
+        index is absent - so a downgrade that walks past it would fail outright
+        unless this migration restores it on the way down.
+        """
+        created, dropped = _index_ops(self.MIGRATION, "downgrade")
+
+        assert created.get(self.OLD_INDEX) == ("namespace_id", "created_at"), (
+            f"downgrade() must recreate {self.OLD_INDEX} on (namespace_id, created_at); it creates {created}"
+        )
+        assert self.NEW_INDEX in dropped, "downgrade() must remove the 3-column index"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_migration_drift.py
+++ b/tests/unit/test_migration_drift.py
@@ -174,23 +174,98 @@ class TestORMMigrationDrift:
 # ---------------------------------------------------------------------------
 
 
-def _index_ops(migration_file: str, func_name: str) -> tuple[dict[str, tuple[str, ...]], set[str]]:
-    """Extract the index DDL a migration's ``upgrade``/``downgrade`` performs.
+IndexOps = tuple[dict[str, tuple[str, ...]], set[str]]
+"""``(created, dropped)``: created maps index name to its ORDERED column tuple."""
 
-    Returns ``(created, dropped)`` where ``created`` maps index name to its
-    ORDERED column tuple and ``dropped`` is the set of index names removed.
+
+def _mentions_is_postgres(test: ast.expr) -> bool:
+    return any(isinstance(n, ast.Name) and n.id == "_is_postgres" for n in ast.walk(test))
+
+
+def _dialect_branches(func: ast.FunctionDef) -> dict[str, list[ast.stmt]]:
+    """Split a migration function body into its per-dialect branches.
+
+    Returns ``{"postgresql": [...], "other": [...]}`` for a dialect-gated
+    migration, or ``{"": [...]}`` for one that issues the same DDL everywhere.
+
+    Splitting matters because the two branches emit the SAME index names via
+    DIFFERENT spellings. Scanning the whole function body into one dict keyed by
+    index name lets whichever branch is visited last silently overwrite the
+    other, so a Postgres branch declaring the wrong column ORDER would be masked
+    by a correct SQLite branch. Both branches have to be checked on their own.
+
+    Handles the two shapes this codebase uses:
+
+    * ``if _is_postgres(): <A> else: <B>`` - and the negated spelling.
+    * ``if not _is_postgres(): return`` followed by the Postgres DDL, i.e. the
+      early-return form. Statements after the ``If`` belong to the branch that
+      falls through, so a migration that silently no-ops on SQLite yields an
+      EMPTY ``other`` branch and trips the assertions below rather than passing.
+    """
+    for i, stmt in enumerate(func.body):
+        if isinstance(stmt, ast.If) and _mentions_is_postgres(stmt.test):
+            negated = isinstance(stmt.test, ast.UnaryOp) and isinstance(stmt.test.op, ast.Not)
+            rest = func.body[i + 1 :]
+            if negated:
+                return {"postgresql": stmt.orelse + rest, "other": stmt.body}
+            return {"postgresql": stmt.body, "other": stmt.orelse + rest}
+    return {"": func.body}
+
+
+def _scan(nodes: list[ast.stmt]) -> IndexOps:
+    """Collect index DDL from a list of statements.
+
+    Both spellings are recognised, since a dialect-gated migration typically
+    uses raw SQL on one branch and the Alembic helpers on the other:
+
+    * ``op.execute("CREATE INDEX ... ON t (a, b)")`` / ``op.execute("DROP INDEX ...")``
+    * ``op.create_index("name", "t", ["a", "b"])`` / ``op.drop_index("name", ...)``
+    """
+    created: dict[str, tuple[str, ...]] = {}
+    dropped: set[str] = set()
+
+    for root in nodes:
+        for node in ast.walk(root):
+            if not isinstance(node, ast.Call):
+                continue
+            target = node.func
+            if not (
+                isinstance(target, ast.Attribute) and isinstance(target.value, ast.Name) and target.value.id == "op"
+            ):
+                continue
+
+            if target.attr == "execute" and node.args and isinstance(node.args[0], ast.Constant):
+                statement = str(node.args[0].value)
+                collapsed = " ".join(statement.split())
+                upper = collapsed.upper()
+                if upper.startswith("CREATE INDEX"):
+                    head, _, cols = collapsed.partition("(")
+                    name = head.split()[-3]  # "... <name> ON <table>"
+                    created[name] = tuple(c.strip() for c in cols.rstrip(")").split(","))
+                elif upper.startswith("DROP INDEX"):
+                    dropped.add(collapsed.split()[-1])
+
+            elif target.attr == "create_index" and len(node.args) >= 3:
+                name_node, cols_node = node.args[0], node.args[2]
+                if isinstance(name_node, ast.Constant) and isinstance(cols_node, ast.List):
+                    created[str(name_node.value)] = tuple(
+                        str(c.value) for c in cols_node.elts if isinstance(c, ast.Constant)
+                    )
+
+            elif target.attr == "drop_index" and node.args and isinstance(node.args[0], ast.Constant):
+                dropped.add(str(node.args[0].value))
+
+    return created, dropped
+
+
+def _index_ops(migration_file: str, func_name: str) -> dict[str, IndexOps]:
+    """Extract the index DDL a migration performs, KEYED BY DIALECT BRANCH.
 
     Parsed from the AST rather than by regex over the raw source, because the
     concurrent-index DDL is written as adjacent string literals that Python
     concatenates at parse time - a regex over the source text would see the
     statement split across two fragments and match neither. The AST hands back
     the already-joined constant.
-
-    Both spellings are recognised, so this keeps working if a dialect-gated
-    branch is added alongside the raw-SQL one:
-
-    * ``op.execute("CREATE INDEX ... ON t (a, b)")`` / ``op.execute("DROP INDEX ...")``
-    * ``op.create_index("name", "t", ["a", "b"])`` / ``op.drop_index("name", ...)``
     """
     source = (VERSIONS_DIR / migration_file).read_text()
     tree = ast.parse(source)
@@ -200,38 +275,7 @@ def _index_ops(migration_file: str, func_name: str) -> tuple[dict[str, tuple[str
     )
     assert func is not None, f"{migration_file} defines no {func_name}()"
 
-    created: dict[str, tuple[str, ...]] = {}
-    dropped: set[str] = set()
-
-    for node in ast.walk(func):
-        if not isinstance(node, ast.Call):
-            continue
-        target = node.func
-        if not (isinstance(target, ast.Attribute) and isinstance(target.value, ast.Name) and target.value.id == "op"):
-            continue
-
-        if target.attr == "execute" and node.args and isinstance(node.args[0], ast.Constant):
-            statement = str(node.args[0].value)
-            collapsed = " ".join(statement.split())
-            upper = collapsed.upper()
-            if upper.startswith("CREATE INDEX"):
-                head, _, cols = collapsed.partition("(")
-                name = head.split()[-3]  # "... <name> ON <table>"
-                created[name] = tuple(c.strip() for c in cols.rstrip(")").split(","))
-            elif upper.startswith("DROP INDEX"):
-                dropped.add(collapsed.split()[-1])
-
-        elif target.attr == "create_index" and len(node.args) >= 3:
-            name_node, cols_node = node.args[0], node.args[2]
-            if isinstance(name_node, ast.Constant) and isinstance(cols_node, ast.List):
-                created[str(name_node.value)] = tuple(
-                    str(c.value) for c in cols_node.elts if isinstance(c, ast.Constant)
-                )
-
-        elif target.attr == "drop_index" and node.args and isinstance(node.args[0], ast.Constant):
-            dropped.add(str(node.args[0].value))
-
-    return created, dropped
+    return {branch: _scan(body) for branch, body in _dialect_branches(func).items()}
 
 
 def _orm_index_columns(table_name: str, index_name: str) -> tuple[str, ...] | None:
@@ -262,12 +306,32 @@ class TestDocumentsCreatedAtIndexAgreement:
     Column ORDER is asserted, not just membership. ``(namespace_id,
     created_at, id)`` covers the query; a permutation such as ``(namespace_id,
     id, created_at)`` does not, and a set comparison would wave it through.
+
+    EVERY dialect branch is asserted independently. The migration emits the same
+    index names through different spellings per dialect, and the embedded stack
+    takes its schema from this chain and nothing else - so a branch that creates
+    the wrong index, the wrong column order, or nothing at all is a real defect
+    on that dialect even when its sibling branch is correct.
     """
 
     MIGRATION = "054_documents_namespace_created_at_id.py"
     NEW_INDEX = "ix_documents_namespace_created_at_id"
     OLD_INDEX = "ix_documents_namespace_created_at"
     EXPECTED_COLUMNS = ("namespace_id", "created_at", "id")
+
+    def test_migration_is_branched_per_dialect(self):
+        """Guard the guard: the per-branch assertions below need branches to exist.
+
+        If the migration is ever collapsed to a single unbranched body, the
+        parser yields one nameless branch and the loops below would assert
+        against it once instead of twice - still correct, but quietly weaker
+        than it reads. Pin the shape so that change is visible.
+        """
+        for func_name in ("upgrade", "downgrade"):
+            branches = _index_ops(self.MIGRATION, func_name)
+            assert set(branches) == {"postgresql", "other"}, (
+                f"{self.MIGRATION} {func_name}() no longer splits per dialect; found branches {sorted(branches)}"
+            )
 
     def test_orm_declares_the_sort_covering_index(self):
         """The ORM carries the 3-column index, in the covering order."""
@@ -282,19 +346,29 @@ class TestDocumentsCreatedAtIndexAgreement:
         assert _orm_index_columns("documents", self.OLD_INDEX) is None
 
     def test_migration_creates_exactly_what_the_orm_declares(self):
-        """Migration upgrade builds the index the ORM declares, same columns, same order."""
-        created, _ = _index_ops(self.MIGRATION, "upgrade")
-
-        assert self.NEW_INDEX in created, (
-            f"{self.MIGRATION} upgrade() does not create {self.NEW_INDEX}; it creates {sorted(created)}"
-        )
-        assert created[self.NEW_INDEX] == _orm_index_columns("documents", self.NEW_INDEX)
-        assert created[self.NEW_INDEX] == self.EXPECTED_COLUMNS
+        """Every branch of upgrade builds the ORM's index, same columns, same order."""
+        for branch, (created, _dropped) in _index_ops(self.MIGRATION, "upgrade").items():
+            assert self.NEW_INDEX in created, (
+                f"{self.MIGRATION} upgrade() [{branch} branch] does not create {self.NEW_INDEX}; "
+                f"it creates {sorted(created)}. A branch that skips the index leaves that dialect "
+                "on the narrower one."
+            )
+            assert created[self.NEW_INDEX] == _orm_index_columns("documents", self.NEW_INDEX), (
+                f"upgrade() [{branch} branch] disagrees with the ORM: "
+                f"{created[self.NEW_INDEX]} vs {_orm_index_columns('documents', self.NEW_INDEX)}"
+            )
+            assert created[self.NEW_INDEX] == self.EXPECTED_COLUMNS, (
+                f"upgrade() [{branch} branch] built {created[self.NEW_INDEX]}, "
+                f"expected {self.EXPECTED_COLUMNS} - column order is what makes it cover the sort"
+            )
 
     def test_migration_drops_the_superseded_index(self):
-        """Upgrade removes the 2-column index the 3-column one subsumes."""
-        _, dropped = _index_ops(self.MIGRATION, "upgrade")
-        assert self.OLD_INDEX in dropped
+        """Every branch of upgrade removes the 2-column index the 3-column one subsumes."""
+        for branch, (_created, dropped) in _index_ops(self.MIGRATION, "upgrade").items():
+            assert self.OLD_INDEX in dropped, (
+                f"upgrade() [{branch} branch] leaves {self.OLD_INDEX} in place; it shares a prefix "
+                f"with {self.NEW_INDEX}, so both would be maintained on every insert"
+            )
 
     def test_downgrade_restores_the_superseded_index(self):
         """Downgrade must put the 2-column index back, with its original columns.
@@ -303,13 +377,17 @@ class TestDocumentsCreatedAtIndexAgreement:
         drops it by an unqualified ``op.drop_index(...)``, which errors if the
         index is absent - so a downgrade that walks past it would fail outright
         unless this migration restores it on the way down.
-        """
-        created, dropped = _index_ops(self.MIGRATION, "downgrade")
 
-        assert created.get(self.OLD_INDEX) == ("namespace_id", "created_at"), (
-            f"downgrade() must recreate {self.OLD_INDEX} on (namespace_id, created_at); it creates {created}"
-        )
-        assert self.NEW_INDEX in dropped, "downgrade() must remove the 3-column index"
+        Asserted per branch: the walk past that migration happens on whichever
+        dialect the operator is running, so a restore present on only one of
+        them leaves the other broken.
+        """
+        for branch, (created, dropped) in _index_ops(self.MIGRATION, "downgrade").items():
+            assert created.get(self.OLD_INDEX) == ("namespace_id", "created_at"), (
+                f"downgrade() [{branch} branch] must recreate {self.OLD_INDEX} on "
+                f"(namespace_id, created_at); it creates {created}"
+            )
+            assert self.NEW_INDEX in dropped, f"downgrade() [{branch} branch] must remove the 3-column index"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_sqlite_migrations.py
+++ b/tests/unit/test_sqlite_migrations.py
@@ -84,7 +84,7 @@ class TestSqliteMigrations:
                     # Version table must point at head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
                     version = result.scalar()
-                    assert version == "053_khora_chunks_bookkeeping_to_chunker_info"
+                    assert version == "054_documents_namespace_created_at_id"
             finally:
                 await engine.dispose()
 


### PR DESCRIPTION
## Summary

Document listing pins a total order — `ORDER BY created_at DESC, id DESC`. The index backing it, `ix_documents_namespace_created_at (namespace_id, created_at)`, supplies only a *prefix* of that order, so with `namespace_id` equality-constrained the planner still has to sort on the trailing `id` key (an Incremental Sort on PG 13+).

A first page barely notices. The cost lands on **full-drain offset pagination** — GC / session expiry, session forget, and the agent-framework adapters that walk every document in a namespace — because the sort is redone once per page. Measured on SQLite:

| scenario | before | after | with the wider index |
| -- | -- | -- | -- |
| 20k rows, full drain @500/page | 35 ms | 287 ms | 33 ms |
| 50k rows, full drain, no ties | 0.10 s | 1.01 s | 0.10 s |
| 200k rows, full drain, no ties | ~1.4 s | ~47 s | ~1.5 s |

The regression does **not** require ties to exist — the planner cannot know the tail key is unique, so it sorts regardless.

### The change

Widen the index to `(namespace_id, created_at, id)`. All three keys are declared **ASC**: with `namespace_id` equality-constrained the residual index order is `(created_at ASC, id ASC)`, which a backward scan reads as `(created_at DESC, id DESC)`. DESC-declared keys only buy anything for *mixed* sort directions, which the uniform-DESC ordering rules out.

The superseded 2-column index is dropped — two indexes sharing a prefix are both maintained on every insert, i.e. write amplification on the ingest path. The wider index serves the last-activity `MAX(created_at)` query on its `(namespace_id, created_at)` prefix, which is what the narrow one existed for.

On PostgreSQL both operations run `CONCURRENTLY` inside an autocommit block, **creating before dropping** so that query is never unindexed. Other dialects take a plain-DDL branch, so the ORM declaration and the physical schema agree on every backend that runs this chain — the embedded stack runs it too, and its full-drain callers are the ones the regression was measured on.

`downgrade()` is an exact mirror on both branches. Restoring the 2-column index is load-bearing rather than cosmetic: the migration that first added it drops it with an *unqualified* `op.drop_index`, so any downgrade walking past that revision would abort on a missing index.

### Two operational caveats, documented in the migration

- **`IF NOT EXISTS` does not self-heal a failed concurrent build.** A failed `CREATE INDEX CONCURRENTLY` leaves an INVALID index — ignored by the planner for reads, still maintained on every write. Re-running matches it *by name*, skips, and reports success. An operator recovering from a failed run must drop the invalid index manually.
- **This migration holds the migration advisory lock while it runs.** A concurrent caller waits 60s before raising, so on a large deployment every other service booting with `run_migrations=True` would fail to start for the duration of a long build. Run it out-of-band on such deployments rather than during a rolling deploy.

## Test plan

- [x] Unit tests pass — `make format` and `make lint` clean; unit suite green
- [x] SQLite migration lifecycle verified locally: `head → previous → head` round-trip asserts the exact index set at every stop, both directions
- [x] **Downgrade walk past the origin revision verified locally** on SQLite — this is the highest-risk failure mode (the unqualified `drop_index` below). Verified non-vacuous by mutation: deleting the restore from the downgrade branch makes the walk fail with `no such index`
- [x] New ORM/migration index-agreement guard — parses the migration AST and compares name + ordered column tuple against the ORM `Index(...)`. Closes a real gap: the existing drift tests have no index assertions, so a mismatch would otherwise have surfaced later as a spurious autogenerate diff rather than a red test
- [ ] **PostgreSQL legs run in CI** — no PostgreSQL was available in the dev container, so these were written but not executed locally: the `EXPLAIN (ANALYZE)` plan-shape assertions and the PG upgrade/downgrade lifecycle. They skip cleanly when no server is reachable.

The PG plan tests assert **plan shape, not timings** (timings are not portable across CI runners). They assert the query is served by a *backward* scan of the new index with no `Sort` / `Incremental Sort` node, at both the first page and a deep offset. Non-vacuity is established differentially: the old 2-column index is rebuilt inside a rolled-back transaction and the identical query is shown to grow a sort node under it. A seq scan fails the test loudly rather than passing trivially.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved document listing performance and consistency with deterministic pagination ordering.
  * Backward and deep-page retrieval now avoids unnecessary sorting where supported.

* **Tests**
  * Added coverage for migration compatibility, index lifecycle, and optimized document query plans across PostgreSQL and SQLite.
  * Enhanced validation of database schema and migration consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->