### PR TITLE
Make split-mode filter compilation sound on the relational documents targets

### DIFF
--- a/src/khora/filter/compilers/_split.py
+++ b/src/khora/filter/compilers/_split.py
@@ -18,13 +18,16 @@ post-filter. An ``AND`` still handles each child independently.
 
 **2. The reported consumed slice is the pruned tree, not the emission trace.**
 :func:`consumed_subtree` reconstructs exactly the sub-AST that reached the
-backend, so a cache key can be derived from it (:func:`consumed_slice_hash`)
-instead of from the whole filter — two filters that differ only in a deferred
-subtree compile to the same predicate and must share a key. It is also what makes
-``consumed_keys`` honest per *occurrence*: a dotted path is only fully pushed when
-**every** one of its occurrences landed in the slice, so a key pushed in one
-branch and deferred in another is reported via :func:`deferred_paths` and stays
-post-filtered.
+backend. Hashing it (:func:`consumed_slice_hash`) yields a **plan-identity hash**:
+two filters that differ only in a deferred subtree compile to the same predicate
+and therefore share it. That is emphatically **not** a result-cache key — the
+deferred remainder still narrows the result set through the caller's post-filter,
+so two filters sharing this hash routinely return different rows. Key a result
+cache on ``canonical_hash(filter_ast)`` over the *whole* AST instead. The slice is
+also what makes ``consumed_keys`` honest per *occurrence*: a dotted path is only
+fully pushed when **every** one of its occurrences landed in the slice, so a key
+pushed in one branch and deferred in another is reported via
+:func:`deferred_paths` and stays post-filtered.
 
 **3. ``field_mapping is None`` means identity, NOT an empty whitelist.** A
 compiler MAY read a *non-``None``* ``field_mapping``'s key set as the backend's
@@ -32,19 +35,29 @@ declared+pushable system-key whitelist (:func:`system_key_declared`), but ``None
 is the documented identity mapping — every chunk-tier postgres / lance context
 passes ``None``, so folding it into "nothing is declared" would defer every
 system-key pushdown on the hot recall path. Only a backend that must fail *closed*
-(surrealdb: a missing field on a SCHEMAFULL table reads ``NONE`` and total-false
-drops every row) reads an absent mapping as an empty whitelist, and it does that
-with its own ``dict(ctx.field_mapping or {})`` rather than this helper.
+reads an absent mapping as an empty whitelist — surrealdb (a missing field on a
+SCHEMAFULL table reads ``NONE`` and total-false drops every row) and weaviate —
+and both do it with their own ``dict(ctx.field_mapping or {})`` rather than this
+helper.
 
 These helpers are pure: no bind allocation, no ``consumed`` mutation, no
-telemetry. A compiler supplies a :data:`ClauseConsumable` predicate mirroring its
-own leaf dispatch, and the gate does the rest.
+telemetry. A compiler supplies a ``ClauseConsumable`` predicate mirroring its own
+leaf dispatch, and the gate does the rest.
+
+**Memoization.** The gate is consulted once per ``OR`` / ``NOT`` node during the
+emission walk and again while pruning, so without memoization a leaf is re-tested
+once per enclosing level — O(depth x leaves). Every entry point therefore accepts
+a ``memo`` dict that a compiler creates once per compile pass and threads through,
+making the whole gate O(n). The memo is keyed on ``id(node)``, which is sound only
+because the AST is held alive by the caller for the pass's duration; it MUST NOT
+outlive the compile.
 """
 
 from __future__ import annotations
 
 from collections import Counter
 from collections.abc import Callable, Iterator
+from typing import Literal
 
 from khora.filter import CompileContext
 from khora.filter.ast import (
@@ -56,11 +69,11 @@ from khora.filter.ast import (
 from khora.filter.model import Op
 
 __all__ = [
-    "ClauseConsumable",
     "consumed_slice_hash",
     "consumed_subtree",
     "deferred_paths",
     "node_consumable",
+    "split_report",
     "system_key_declared",
 ]
 
@@ -71,6 +84,9 @@ __all__ = [
 # modes (e.g. surrealdb's unsafe-identifier check) — those are injection guards,
 # not capability gaps, and swallowing them here would silently drop the error.
 ClauseConsumable = Callable[[FilterClause], bool]
+
+# Per-compile-pass memo for :func:`node_consumable`, keyed on ``id(node)``.
+ConsumableMemo = dict[int, bool]
 
 
 def system_key_declared(ctx: CompileContext, key: str) -> bool:
@@ -85,18 +101,37 @@ def system_key_declared(ctx: CompileContext, key: str) -> bool:
     return ctx.field_mapping is None or key in ctx.field_mapping
 
 
-def node_consumable(node: FilterNode | FilterClause, ok: ClauseConsumable) -> bool:
+def node_consumable(
+    node: FilterNode | FilterClause,
+    ok: ClauseConsumable,
+    memo: ConsumableMemo | None = None,
+) -> bool:
     """True iff ``node``'s whole subtree compiles (nothing falls to the placeholder).
 
     A logical node is consumable iff every child is; a leaf is consumable iff
     ``ok`` says so. This is the all-or-nothing gate for ``OR`` / ``NOT`` (rule 1).
+
+    Pass the compile pass's ``memo`` to make repeated consultations O(1) per node
+    (see the module docstring); omitting it is correct but re-walks the subtree.
     """
+    if memo is None:
+        memo = {}
+    cached = memo.get(id(node))
+    if cached is not None:
+        return cached
     if isinstance(node, FilterClause):
-        return ok(node)
-    return all(node_consumable(child, ok) for child in node.children)
+        result = ok(node)
+    else:
+        result = all(node_consumable(child, ok, memo) for child in node.children)
+    memo[id(node)] = result
+    return result
 
 
-def consumed_subtree(node: FilterNode | FilterClause, ok: ClauseConsumable) -> FilterNode:
+def consumed_subtree(
+    node: FilterNode | FilterClause,
+    ok: ClauseConsumable,
+    memo: ConsumableMemo | None = None,
+) -> FilterNode:
     """Reconstruct the sub-AST that actually reaches the backend under ``"split"``.
 
     Mirrors the emission walk exactly: an ``AND`` keeps its consumable children
@@ -108,7 +143,7 @@ def consumed_subtree(node: FilterNode | FilterClause, ok: ClauseConsumable) -> F
     single-child wrapper would hash differently from the identical filter written
     without the deferred sibling.
     """
-    pruned = _prune(node, ok)
+    pruned = _prune(node, ok, memo if memo is not None else {})
     if pruned is None:
         # Everything deferred — the compiler emitted the match-all placeholder,
         # whose AST equivalent is the empty (match-everything) AND.
@@ -121,41 +156,87 @@ def consumed_subtree(node: FilterNode | FilterClause, ok: ClauseConsumable) -> F
     return normalized
 
 
-def consumed_slice_hash(node: FilterNode | FilterClause, ok: ClauseConsumable) -> str:
-    """The canonical hash of the consumed slice — the compiler's cache-key source.
+def consumed_slice_hash(
+    node: FilterNode | FilterClause,
+    ok: ClauseConsumable,
+    memo: ConsumableMemo | None = None,
+) -> str:
+    """Plan-identity hash over the consumed slice — **never** a result-cache key.
+
+    Identifies the predicate the backend actually received, so two filters
+    differing only in a deferred subtree share it. Their *result sets* still
+    differ, because the deferred remainder is enforced by the caller's
+    post-filter — see rule 2 in the module docstring.
 
     In ``on_unsupported="raise"`` mode every leaf that reaches emission is
     consumable (an unconsumable one raises instead of returning), so the slice is
     the whole tree and the hash is identical to ``canonical_hash(node)``.
     """
-    return canonical_hash(consumed_subtree(node, ok))
+    return canonical_hash(consumed_subtree(node, ok, memo))
 
 
-def deferred_paths(node: FilterNode | FilterClause, ok: ClauseConsumable) -> frozenset[str]:
+def deferred_paths(
+    node: FilterNode | FilterClause,
+    ok: ClauseConsumable,
+    memo: ConsumableMemo | None = None,
+) -> frozenset[str]:
     """Dotted paths with at least one leaf occurrence NOT in the consumed slice.
 
     ``consumed_keys`` is a set of dotted paths, but a path can occur many times in
     one AST — pushed in a conjunctive leaf and deferred inside an ``$or`` / ``$not``
-    the gate defers wholesale. Reporting it consumed would tell a caller that
-    differences ``leaf_keys - consumed_keys`` that the deferred occurrence is
+    the gate defers wholesale. Reporting such a path consumed would tell a caller
+    differencing ``leaf_keys - consumed_keys`` that the deferred occurrence is
     already enforced, so it would never be post-filtered and the query would
     return rows the filter excludes. Subtracting this set from the emission
     accumulator leaves exactly the paths **every** occurrence of which was pushed.
     """
-    kept = Counter(_leaf_paths(consumed_subtree(node, ok)))
+    return _deferred_from_slice(node, consumed_subtree(node, ok, memo))
+
+
+def split_report(
+    node: FilterNode,
+    ok: ClauseConsumable,
+    *,
+    on_unsupported: Literal["raise", "split"],
+    memo: ConsumableMemo | None = None,
+) -> tuple[frozenset[str], str]:
+    """``(deferred_paths, consumed_slice_hash)`` from a single pruned-tree build.
+
+    The two outputs share one :func:`consumed_subtree` reconstruction — computing
+    them separately prunes and re-normalizes the whole AST twice per compile.
+
+    Under ``"raise"`` the result is fixed by construction and skips the walk
+    entirely: if compilation returned at all then no leaf hit the unsupported
+    path, so nothing was deferred and the slice IS the whole tree. This is the
+    live recall path for the raise-mode chunk-tier contexts, where the pruning
+    work would be pure waste.
+    """
+    if on_unsupported == "raise":
+        return frozenset(), canonical_hash(node)
+    slice_ = consumed_subtree(node, ok, memo)
+    return _deferred_from_slice(node, slice_), canonical_hash(slice_)
+
+
+def _deferred_from_slice(node: FilterNode | FilterClause, slice_: FilterNode) -> frozenset[str]:
+    """Paths occurring more often in ``node`` than in its consumed ``slice_``."""
+    kept = Counter(_leaf_paths(slice_))
     return frozenset(path for path, count in Counter(_leaf_paths(node)).items() if count > kept[path])
 
 
-def _prune(node: FilterNode | FilterClause, ok: ClauseConsumable) -> FilterNode | FilterClause | None:
+def _prune(
+    node: FilterNode | FilterClause,
+    ok: ClauseConsumable,
+    memo: ConsumableMemo,
+) -> FilterNode | FilterClause | None:
     """The consumed-slice walk: ``None`` for a subtree the compiler defers whole."""
     if isinstance(node, FilterClause):
-        return node if ok(node) else None
+        return node if node_consumable(node, ok, memo) else None
     if node.op == Op.AND:
-        kept = tuple(p for p in (_prune(child, ok) for child in node.children) if p is not None)
+        kept = tuple(p for p in (_prune(child, ok, memo) for child in node.children) if p is not None)
         return FilterNode(op=Op.AND, children=kept)
     # OR / NOT — all-or-nothing (rule 1): never recursed into, so a leaf under a
     # deferred node is deferred with it.
-    return node if node_consumable(node, ok) else None
+    return node if node_consumable(node, ok, memo) else None
 
 
 def _leaf_paths(node: FilterNode | FilterClause) -> Iterator[str]:

--- a/src/khora/filter/compilers/_split.py
+++ b/src/khora/filter/compilers/_split.py
@@ -1,0 +1,172 @@
+"""Split-mode pushdown soundness — the shared gate every SQL-ish compiler uses.
+
+``@internal``. One home for the three rules a compiler running under
+``CompileContext.on_unsupported == "split"`` must obey, so the postgres / lance /
+surrealdb compilers cannot drift from each other (or from the invariants their
+callers' post-filters rely on).
+
+**1. AND distributes; OR / NOT are all-or-nothing.** The match-all placeholder an
+unconsumable leaf emits under ``"split"`` (``sa.true()`` / ``"1"`` / ``"true"``)
+is superset-safe only in *positive* position: ``A AND <match-all>`` ≡ ``A`` (still
+narrows correctly), but ``NOT (A OR <match-all>)`` ≡ ``NOT <match-all>`` ≡
+match-nothing — which would *drop every row the filter keeps*, breaking the
+superset invariant (a ``compile_python`` post-filter only narrows; it cannot add
+a wrongly-excluded row back). So an ``OR`` / ``NOT`` node is pushed down only when
+its **entire** subtree is consumable (:func:`node_consumable`); otherwise the whole
+node emits the placeholder and consumes nothing, deferring it wholesale to the
+post-filter. An ``AND`` still handles each child independently.
+
+**2. The reported consumed slice is the pruned tree, not the emission trace.**
+:func:`consumed_subtree` reconstructs exactly the sub-AST that reached the
+backend, so a cache key can be derived from it (:func:`consumed_slice_hash`)
+instead of from the whole filter — two filters that differ only in a deferred
+subtree compile to the same predicate and must share a key. It is also what makes
+``consumed_keys`` honest per *occurrence*: a dotted path is only fully pushed when
+**every** one of its occurrences landed in the slice, so a key pushed in one
+branch and deferred in another is reported via :func:`deferred_paths` and stays
+post-filtered.
+
+**3. ``field_mapping is None`` means identity, NOT an empty whitelist.** A
+compiler MAY read a *non-``None``* ``field_mapping``'s key set as the backend's
+declared+pushable system-key whitelist (:func:`system_key_declared`), but ``None``
+is the documented identity mapping — every chunk-tier postgres / lance context
+passes ``None``, so folding it into "nothing is declared" would defer every
+system-key pushdown on the hot recall path. Only a backend that must fail *closed*
+(surrealdb: a missing field on a SCHEMAFULL table reads ``NONE`` and total-false
+drops every row) reads an absent mapping as an empty whitelist, and it does that
+with its own ``dict(ctx.field_mapping or {})`` rather than this helper.
+
+These helpers are pure: no bind allocation, no ``consumed`` mutation, no
+telemetry. A compiler supplies a :data:`ClauseConsumable` predicate mirroring its
+own leaf dispatch, and the gate does the rest.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable, Iterator
+
+from khora.filter import CompileContext
+from khora.filter.ast import (
+    FilterClause,
+    FilterNode,
+    _normalize,
+    canonical_hash,
+)
+from khora.filter.model import Op
+
+__all__ = [
+    "ClauseConsumable",
+    "consumed_slice_hash",
+    "consumed_subtree",
+    "deferred_paths",
+    "node_consumable",
+    "system_key_declared",
+]
+
+
+# A compiler's own leaf-dispatch mirror: ``True`` iff this leaf compiles to a real
+# backend predicate (rather than the match-all placeholder). It must be a pure
+# predicate over the clause, and it must NOT consider guards that raise in both
+# modes (e.g. surrealdb's unsafe-identifier check) — those are injection guards,
+# not capability gaps, and swallowing them here would silently drop the error.
+ClauseConsumable = Callable[[FilterClause], bool]
+
+
+def system_key_declared(ctx: CompileContext, key: str) -> bool:
+    """Whether ``ctx`` declares a real backend column for system ``key``.
+
+    ``field_mapping is None`` is the **identity mapping** — no whitelist, so every
+    system key is declared (the chunk-tier contract; see the module docstring).
+    A non-``None`` mapping IS the declared+pushable whitelist: a system key it
+    omits is not backed by a column this compiler may push to, so the leaf is
+    unconsumable and falls to the caller's post-filter.
+    """
+    return ctx.field_mapping is None or key in ctx.field_mapping
+
+
+def node_consumable(node: FilterNode | FilterClause, ok: ClauseConsumable) -> bool:
+    """True iff ``node``'s whole subtree compiles (nothing falls to the placeholder).
+
+    A logical node is consumable iff every child is; a leaf is consumable iff
+    ``ok`` says so. This is the all-or-nothing gate for ``OR`` / ``NOT`` (rule 1).
+    """
+    if isinstance(node, FilterClause):
+        return ok(node)
+    return all(node_consumable(child, ok) for child in node.children)
+
+
+def consumed_subtree(node: FilterNode | FilterClause, ok: ClauseConsumable) -> FilterNode:
+    """Reconstruct the sub-AST that actually reaches the backend under ``"split"``.
+
+    Mirrors the emission walk exactly: an ``AND`` keeps its consumable children
+    (possibly none — the empty ``AND`` is match-everything, the placeholder's
+    meaning); an ``OR`` / ``NOT`` is kept whole iff :func:`node_consumable`, else
+    dropped entirely. The pruned tree is run back through the AST's own
+    normalization so it is in the same canonical form
+    :func:`~khora.filter.ast.parse_to_ast` produces — otherwise a pruned
+    single-child wrapper would hash differently from the identical filter written
+    without the deferred sibling.
+    """
+    pruned = _prune(node, ok)
+    if pruned is None:
+        # Everything deferred — the compiler emitted the match-all placeholder,
+        # whose AST equivalent is the empty (match-everything) AND.
+        return FilterNode(op=Op.AND, children=())
+    if isinstance(pruned, FilterClause):
+        # Keep the root a FilterNode (the compiler-boundary contract).
+        pruned = FilterNode(op=Op.AND, children=(pruned,))
+    normalized = _normalize(pruned)
+    assert isinstance(normalized, FilterNode)  # noqa: S101 - root-shape invariant (ast._normalize rule 2)
+    return normalized
+
+
+def consumed_slice_hash(node: FilterNode | FilterClause, ok: ClauseConsumable) -> str:
+    """The canonical hash of the consumed slice — the compiler's cache-key source.
+
+    In ``on_unsupported="raise"`` mode every leaf that reaches emission is
+    consumable (an unconsumable one raises instead of returning), so the slice is
+    the whole tree and the hash is identical to ``canonical_hash(node)``.
+    """
+    return canonical_hash(consumed_subtree(node, ok))
+
+
+def deferred_paths(node: FilterNode | FilterClause, ok: ClauseConsumable) -> frozenset[str]:
+    """Dotted paths with at least one leaf occurrence NOT in the consumed slice.
+
+    ``consumed_keys`` is a set of dotted paths, but a path can occur many times in
+    one AST — pushed in a conjunctive leaf and deferred inside an ``$or`` / ``$not``
+    the gate defers wholesale. Reporting it consumed would tell a caller that
+    differences ``leaf_keys - consumed_keys`` that the deferred occurrence is
+    already enforced, so it would never be post-filtered and the query would
+    return rows the filter excludes. Subtracting this set from the emission
+    accumulator leaves exactly the paths **every** occurrence of which was pushed.
+    """
+    kept = Counter(_leaf_paths(consumed_subtree(node, ok)))
+    return frozenset(path for path, count in Counter(_leaf_paths(node)).items() if count > kept[path])
+
+
+def _prune(node: FilterNode | FilterClause, ok: ClauseConsumable) -> FilterNode | FilterClause | None:
+    """The consumed-slice walk: ``None`` for a subtree the compiler defers whole."""
+    if isinstance(node, FilterClause):
+        return node if ok(node) else None
+    if node.op == Op.AND:
+        kept = tuple(p for p in (_prune(child, ok) for child in node.children) if p is not None)
+        return FilterNode(op=Op.AND, children=kept)
+    # OR / NOT — all-or-nothing (rule 1): never recursed into, so a leaf under a
+    # deferred node is deferred with it.
+    return node if node_consumable(node, ok) else None
+
+
+def _leaf_paths(node: FilterNode | FilterClause) -> Iterator[str]:
+    """Yield the dotted key of every leaf occurrence (duplicates preserved).
+
+    Same traversal as ``khora.filter.execute.iter_leaf_clauses`` / the compilers'
+    ``_path_str``; inlined so this module stays a dependency-free leaf of the
+    filter package.
+    """
+    if isinstance(node, FilterClause):
+        yield ".".join(node.path)
+        return
+    for child in node.children:
+        yield from _leaf_paths(child)

--- a/src/khora/filter/compilers/chronicle.py
+++ b/src/khora/filter/compilers/chronicle.py
@@ -166,7 +166,7 @@ def compile_chronicle(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[Ch
         predicate=ChronicleDateBound(created_after=lower, created_before=upper),
         params={},
         consumed_keys=frozenset(consumed),
-        canonical_hash=canonical_hash(ast),
+        consumed_slice_hash=canonical_hash(ast),
     )
 
 

--- a/src/khora/filter/compilers/cypher.py
+++ b/src/khora/filter/compilers/cypher.py
@@ -113,11 +113,14 @@ def compile_cypher(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[str]:
         predicate=predicate,
         params=builder.params,
         consumed_keys=frozenset(consumed),
-        # canonical_hash over the whole AST. In on_unsupported="raise" mode (the
-        # only mode used today) every leaf is consumed, so the whole tree == the
-        # consumed slice. When split-mode is implemented, hash the reconstructed
-        # consumed sub-AST instead, not the whole tree.
-        canonical_hash=canonical_hash(ast),
+        # Whole-AST hash as a CONSERVATIVE plan identity: equal hash implies equal
+        # AST, hence equal consumed slice, so it can only over-distinguish two
+        # identical plans — never conflate two different ones. Switching to the
+        # reconstructed slice (as postgres / lance / surrealdb do) would be a
+        # tightening, not a fix, and it is only worth doing together with this
+        # compiler's per-occurrence ``consumed_keys``, which still over-claims a
+        # path deferred inside a gated OR/NOT. Both are tracked as follow-ups.
+        consumed_slice_hash=canonical_hash(ast),
     )
 
 

--- a/src/khora/filter/compilers/lance.py
+++ b/src/khora/filter/compilers/lance.py
@@ -99,9 +99,9 @@ from khora.filter.ast import (
     FilterNode,
 )
 from khora.filter.compilers._split import (
-    consumed_slice_hash,
-    deferred_paths,
+    ConsumableMemo,
     node_consumable,
+    split_report,
     system_key_declared,
 )
 from khora.filter.model import SYSTEM_KEYS, Op
@@ -155,20 +155,29 @@ def compile_lance(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[str]:
     consumed: set[str] = set()
     builder = _Builder(ctx=ctx, consumed=consumed)
     predicate = builder.compile_node(ast)
+    # One pruned-tree reconstruction feeds both outputs; under "raise" the walk is
+    # skipped entirely (nothing can have been deferred).
+    deferred, slice_hash = split_report(
+        ast,
+        builder._clause_consumable,
+        on_unsupported=ctx.on_unsupported,
+        memo=builder._consumable_memo,
+    )
     return CompiledFilter(
         predicate=predicate,
         params={"args": builder.args},
         # A dotted path is only reported consumed when EVERY occurrence of it was
         # pushed: the emission accumulator records the leaves that emitted real
-        # SQL, and ``deferred_paths`` removes any path that ALSO occurs inside a
+        # SQL, and the deferred set removes any path that ALSO occurs inside a
         # subtree the split gate deferred (else a caller differencing
         # ``leaf_keys - consumed_keys`` would never re-check that occurrence).
-        consumed_keys=frozenset(consumed) - deferred_paths(ast, builder._clause_consumable),
-        # The hash covers the CONSUMED SLICE, not the whole AST — two filters that
-        # differ only in a deferred subtree compile to the same WHERE and must
-        # share a cache key. In on_unsupported="raise" mode every leaf is
-        # consumable, so the slice IS the whole tree and the hash is unchanged.
-        canonical_hash=consumed_slice_hash(ast, builder._clause_consumable),
+        consumed_keys=frozenset(consumed) - deferred,
+        # Plan identity over the CONSUMED SLICE, not the whole AST: two filters
+        # differing only in a deferred subtree emit the same WHERE and share this.
+        # They do NOT share a result set — the deferred remainder is enforced by
+        # the caller's post-filter — so this is never a result-cache key. In
+        # on_unsupported="raise" mode the slice IS the whole tree.
+        consumed_slice_hash=slice_hash,
     )
 
 
@@ -209,6 +218,10 @@ class _Builder:
     def __init__(self, *, ctx: CompileContext, consumed: set[str]) -> None:
         self._ctx = ctx
         self._consumed = consumed
+        # One memo per compile pass so the all-or-nothing gate is O(n) rather
+        # than re-testing each leaf once per enclosing OR/NOT level. Keyed on
+        # id(node) — sound only for this pass's lifetime, which is its scope.
+        self._consumable_memo: ConsumableMemo = {}
         self._qualifier = ctx.table_alias or ctx.backend_target
         self.args: list[Any] = []
 
@@ -261,7 +274,9 @@ class _Builder:
             if not node.children:
                 # The validator forbids an empty $or; guard defensively.
                 return "0"
-            if self._ctx.on_unsupported == "split" and not node_consumable(node, self._clause_consumable):
+            if self._ctx.on_unsupported == "split" and not node_consumable(
+                node, self._clause_consumable, self._consumable_memo
+            ):
                 # A non-consumable disjunct would compile to "1", making the whole
                 # OR match-all here while the post-filter still narrows — safe in
                 # positive position but it under-pushes silently AND becomes a
@@ -274,7 +289,9 @@ class _Builder:
         # polarities, so the negation is sound); otherwise defer the whole NOT
         # (in "split" mode). In "raise" mode we descend so the offending leaf
         # raises rather than being silently swallowed by the all-or-nothing gate.
-        if self._ctx.on_unsupported == "split" and not node_consumable(node, self._clause_consumable):
+        if self._ctx.on_unsupported == "split" and not node_consumable(
+            node, self._clause_consumable, self._consumable_memo
+        ):
             return "1"
         return f"(NOT ({self.compile_node(node.children[0])}))"
 

--- a/src/khora/filter/compilers/lance.py
+++ b/src/khora/filter/compilers/lance.py
@@ -97,7 +97,12 @@ from khora.filter.ast import (
     DateLiteral,
     FilterClause,
     FilterNode,
-    canonical_hash,
+)
+from khora.filter.compilers._split import (
+    consumed_slice_hash,
+    deferred_paths,
+    node_consumable,
+    system_key_declared,
 )
 from khora.filter.model import SYSTEM_KEYS, Op
 
@@ -134,7 +139,9 @@ def compile_lance(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[str]:
     the aliased FTS-join path, ``khora_chunks.occurred_at`` on the unaliased
     vector post-fetch path), and ``field_mapping`` remaps a logical key to its
     physical column name (identity when ``None``), so the compiler embeds no
-    engine schema.
+    engine schema. A **non-``None``** ``field_mapping`` is additionally the
+    declared+pushable system-key whitelist — a system key it omits is unsupported
+    (``None`` stays the plain identity mapping, whitelisting nothing away).
 
     Honors ``ctx.on_unsupported``: on a clause this backend cannot express,
     ``"raise"`` raises :class:`RecallFilterUnsupportedError`; ``"split"`` omits it
@@ -151,12 +158,17 @@ def compile_lance(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[str]:
     return CompiledFilter(
         predicate=predicate,
         params={"args": builder.args},
-        consumed_keys=frozenset(consumed),
-        # canonical_hash over the whole AST. In on_unsupported="raise" mode every
-        # leaf is consumed, so the whole tree == the consumed slice. When
-        # split-mode is implemented end-to-end, hash the reconstructed consumed
-        # sub-AST instead, not the whole tree.
-        canonical_hash=canonical_hash(ast),
+        # A dotted path is only reported consumed when EVERY occurrence of it was
+        # pushed: the emission accumulator records the leaves that emitted real
+        # SQL, and ``deferred_paths`` removes any path that ALSO occurs inside a
+        # subtree the split gate deferred (else a caller differencing
+        # ``leaf_keys - consumed_keys`` would never re-check that occurrence).
+        consumed_keys=frozenset(consumed) - deferred_paths(ast, builder._clause_consumable),
+        # The hash covers the CONSUMED SLICE, not the whole AST — two filters that
+        # differ only in a deferred subtree compile to the same WHERE and must
+        # share a cache key. In on_unsupported="raise" mode every leaf is
+        # consumable, so the slice IS the whole tree and the hash is unchanged.
+        canonical_hash=consumed_slice_hash(ast, builder._clause_consumable),
     )
 
 
@@ -249,7 +261,7 @@ class _Builder:
             if not node.children:
                 # The validator forbids an empty $or; guard defensively.
                 return "0"
-            if self._ctx.on_unsupported == "split" and not self._consumable(node):
+            if self._ctx.on_unsupported == "split" and not node_consumable(node, self._clause_consumable):
                 # A non-consumable disjunct would compile to "1", making the whole
                 # OR match-all here while the post-filter still narrows — safe in
                 # positive position but it under-pushes silently AND becomes a
@@ -262,38 +274,35 @@ class _Builder:
         # polarities, so the negation is sound); otherwise defer the whole NOT
         # (in "split" mode). In "raise" mode we descend so the offending leaf
         # raises rather than being silently swallowed by the all-or-nothing gate.
-        if self._ctx.on_unsupported == "split" and not self._consumable(node):
+        if self._ctx.on_unsupported == "split" and not node_consumable(node, self._clause_consumable):
             return "1"
         return f"(NOT ({self.compile_node(node.children[0])}))"
 
-    def _consumable(self, node: FilterNode | FilterClause) -> bool:
-        """True iff ``node``'s whole subtree compiles to SQL (no ``"1"`` deferral).
+    def _clause_consumable(self, clause: FilterClause) -> bool:
+        """True iff this leaf compiles to real SQL — the :mod:`_split` gate predicate.
 
-        A pure predicate — no bind allocation, no ``consumed`` mutation, no
-        telemetry. A logical node is consumable iff every child is; a leaf is
-        consumable iff it is a system key or a pushdownable metadata predicate
-        (mirrors :meth:`_clause_unconsumable`). Used to keep an ``OR`` / ``NOT``
-        all-or-nothing: a node is pushed only when nothing inside it would fall to
-        the ``"1"`` placeholder.
+        The pure mirror of :meth:`compile_clause`'s dispatch (no bind allocation,
+        no ``consumed`` mutation), so the all-or-nothing ``OR`` / ``NOT`` gate and
+        the consumed-slice reconstruction both see exactly what emission does.
         """
-        if isinstance(node, FilterClause):
-            return not self._clause_unconsumable(node)
-        return all(self._consumable(c) for c in node.children)
+        return not self._clause_unconsumable(clause)
 
     def _clause_unconsumable(self, clause: FilterClause) -> bool:
         """True iff this leaf cannot be pushed to SQL (would emit ``"1"``).
 
         Mirrors the leaf dispatch in :meth:`compile_clause` /
-        :meth:`_compile_metadata_clause` without side effects: a system key always
-        pushes; a metadata leaf is unconsumable when JSON1 is unavailable, or when
-        it is one of the shapes that cannot match the oracle in SQL — the bare-blob
-        ``$eq``, an ``object_equal`` (dict-operand) ``$eq`` / ``$ne``, a ``$date``
-        compare, or a ``$in`` / ``$nin`` carrying a dict (object_equal) or ``None``
-        (JSON-null member) element. Any non-system, non-metadata path is unconsumable.
+        :meth:`_compile_metadata_clause` without side effects: a system key pushes
+        when ``ctx`` declares it (:func:`~khora.filter.compilers._split.system_key_declared`
+        — every key when ``field_mapping`` is the identity ``None``); a metadata
+        leaf is unconsumable when JSON1 is unavailable, or when it is one of the
+        shapes that cannot match the oracle in SQL — the bare-blob ``$eq``, an
+        ``object_equal`` (dict-operand) ``$eq`` / ``$ne``, a ``$date`` compare, or a
+        ``$in`` / ``$nin`` carrying a dict (object_equal) or ``None`` (JSON-null
+        member) element. Any non-system, non-metadata path is unconsumable.
         """
         path = clause.path
         if len(path) == 1 and path[0] in SYSTEM_KEYS:
-            return False
+            return not system_key_declared(self._ctx, path[0])
         if not (path and path[0] == "metadata"):
             return True
         if not self._ctx.schema_capabilities.sqlite_json1:
@@ -320,6 +329,19 @@ class _Builder:
         """Dispatch a leaf on key-kind (system key vs metadata path)."""
         path = clause.path
         if len(path) == 1 and path[0] in SYSTEM_KEYS:
+            # A non-``None`` ``field_mapping`` IS the declared+pushable whitelist, so
+            # a store DROPPING a key from it is load-bearing: that is how a table
+            # whose column cannot be compared soundly (a SQLite ``DATETIME`` column
+            # storing a space-separated, offset-less string that does not order
+            # lexicographically against this compiler's ISO-8601 binds) keeps the
+            # leaf out of the WHERE and routes it to the caller's post-filter. The
+            # per-key reasoning lives with the mapping, in the
+            # ``_documents_compile_context`` docstrings of
+            # ``storage/backends/sqlite_lance/relational.py`` and
+            # ``storage/backends/sqlite.py``. ``field_mapping is None`` is the
+            # identity mapping (no whitelist) — every chunk-tier context passes it.
+            if not system_key_declared(self._ctx, path[0]):
+                return self._unsupported(clause, "the backend does not declare a column for this system key")
             expr = self._compile_system_clause(clause)
         elif path and path[0] == "metadata":
             if not self._ctx.schema_capabilities.sqlite_json1:

--- a/src/khora/filter/compilers/postgres.py
+++ b/src/khora/filter/compilers/postgres.py
@@ -56,7 +56,12 @@ from khora.filter.ast import (
     DateLiteral,
     FilterClause,
     FilterNode,
-    canonical_hash,
+)
+from khora.filter.compilers._split import (
+    consumed_slice_hash,
+    deferred_paths,
+    node_consumable,
+    system_key_declared,
 )
 from khora.filter.model import SYSTEM_KEYS, Op
 
@@ -104,10 +109,12 @@ def compile_postgres(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[Col
 
     Column references are derived from ``ctx`` alone (``backend_target`` /
     ``table_alias`` qualify, ``field_mapping`` remaps) via :func:`_col`, so the
-    compiler embeds no engine schema. Honors ``ctx.on_unsupported``: on a clause
-    this backend cannot express (should not happen post-validation), ``"raise"``
-    raises :class:`RecallFilterUnsupportedError`; ``"split"`` omits it from
-    ``consumed_keys`` and emits a non-constraining placeholder.
+    compiler embeds no engine schema. A **non-``None``** ``field_mapping`` is
+    additionally the declared+pushable system-key whitelist — a system key it
+    omits is unsupported (``None`` stays the plain identity mapping, whitelisting
+    nothing away). Honors ``ctx.on_unsupported``: on a clause this backend cannot
+    express, ``"raise"`` raises :class:`RecallFilterUnsupportedError`; ``"split"``
+    omits it from ``consumed_keys`` and emits a non-constraining placeholder.
     """
     consumed: set[str] = set()
     builder = _Builder(ctx=ctx, consumed=consumed)
@@ -115,12 +122,17 @@ def compile_postgres(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[Col
     return CompiledFilter(
         predicate=predicate,
         params={},
-        consumed_keys=frozenset(consumed),
-        # canonical_hash over the whole AST. In on_unsupported="raise" mode (the
-        # only mode used today) every leaf is consumed, so the whole tree == the
-        # consumed slice. When split-mode is implemented, hash the reconstructed
-        # consumed sub-AST instead, not the whole tree.
-        canonical_hash=canonical_hash(ast),
+        # A dotted path is only reported consumed when EVERY occurrence of it was
+        # pushed: the emission accumulator records the leaves that emitted real
+        # SQL, and ``deferred_paths`` removes any path that ALSO occurs inside a
+        # subtree the split gate deferred (else a caller differencing
+        # ``leaf_keys - consumed_keys`` would never re-check that occurrence).
+        consumed_keys=frozenset(consumed) - deferred_paths(ast, builder._clause_consumable),
+        # The hash covers the CONSUMED SLICE, not the whole AST — two filters that
+        # differ only in a deferred subtree compile to the same WHERE and must
+        # share a cache key. In on_unsupported="raise" mode every leaf is
+        # consumable, so the slice IS the whole tree and the hash is unchanged.
+        canonical_hash=consumed_slice_hash(ast, builder._clause_consumable),
     )
 
 
@@ -152,7 +164,21 @@ class _Builder:
     # ----- logical node walk ---------------------------------------------- #
 
     def compile_node(self, node: FilterNode | FilterClause) -> ColumnElement[bool]:
-        """Compile a logical node or leaf to a boolean expression."""
+        """Compile a logical node or leaf to a boolean expression.
+
+        **Split-mode soundness — "AND distributes; OR/NOT are all-or-nothing."**
+        The match-all placeholder ``sa.true()`` an unsupported leaf emits under
+        ``on_unsupported="split"`` is superset-safe only in *positive* position:
+        ``A AND TRUE`` ≡ ``A`` (still narrows correctly), but ``NOT (A OR TRUE)``
+        ≡ ``NOT TRUE`` ≡ ``FALSE`` — which would *drop every row the filter keeps*,
+        breaking the superset invariant (the caller's post-filter only narrows; it
+        cannot add a wrongly-excluded row back). So an ``OR`` / ``NOT`` node is
+        pushed down only when its **entire** subtree is consumable; otherwise the
+        whole node emits ``sa.true()`` and consumes nothing, deferring it wholesale
+        to the post-filter. An ``AND`` still handles each child independently — a
+        non-consumable child becomes ``sa.true()`` and the consumable siblings
+        still narrow. See :mod:`khora.filter.compilers._split`.
+        """
         if isinstance(node, FilterClause):
             return self.compile_clause(node)
         if node.op == Op.AND:
@@ -164,10 +190,40 @@ class _Builder:
             if not node.children:
                 # The validator forbids an empty $or; guard defensively.
                 return sa.false()
+            if self._ctx.on_unsupported == "split" and not node_consumable(node, self._clause_consumable):
+                # A non-consumable disjunct would compile to TRUE, making the whole
+                # OR match-all here while the post-filter still narrows — safe in
+                # positive position but it under-pushes silently AND becomes a
+                # false-exclude if a parent NOT wraps it. Defer the whole OR. In
+                # "raise" mode we instead descend so the offending leaf raises.
+                return sa.true()
             return sa.or_(*(self.compile_node(c) for c in node.children))
         # Op.NOT — exactly one child per the AST contract. Leaves are built total
-        # (never NULL) so this negation flips absent rows correctly.
+        # (never NULL) so this negation flips absent rows correctly. Pushed only
+        # when the child is fully consumable; otherwise defer the whole NOT (in
+        # "split" mode). In "raise" mode we descend so the offending leaf raises
+        # rather than being silently swallowed by the all-or-nothing gate.
+        if self._ctx.on_unsupported == "split" and not node_consumable(node, self._clause_consumable):
+            return sa.true()
         return sa.not_(self.compile_node(node.children[0]))
+
+    def _clause_consumable(self, clause: FilterClause) -> bool:
+        """True iff this leaf compiles to a real predicate — the gate predicate.
+
+        The pure mirror of :meth:`compile_clause`'s dispatch (no bind allocation,
+        no ``consumed`` mutation), so the all-or-nothing ``OR`` / ``NOT`` gate and
+        the consumed-slice reconstruction both see exactly what emission does: a
+        system key pushes when ``ctx`` declares a column for it
+        (:func:`~khora.filter.compilers._split.system_key_declared` — every key
+        when ``field_mapping`` is the identity ``None``); a metadata leaf pushes
+        except the bare blob under a non-``$eq`` operator; nothing else pushes.
+        """
+        path = clause.path
+        if len(path) == 1 and path[0] in SYSTEM_KEYS:
+            return system_key_declared(self._ctx, path[0])
+        if path and path[0] == "metadata":
+            return len(path) > 1 or clause.op == Op.EQ
+        return False
 
     # ----- leaf key-kind split -------------------------------------------- #
 
@@ -175,9 +231,25 @@ class _Builder:
         """Dispatch a leaf on key-kind (system key vs metadata path)."""
         path = clause.path
         if len(path) == 1 and path[0] in SYSTEM_KEYS:
+            # A non-``None`` ``field_mapping`` IS the declared+pushable whitelist:
+            # a system key it omits is not backed by a column on this table, so
+            # pushing it would compile a predicate against a column that does not
+            # exist. Dropping a key from the mapping is therefore load-bearing —
+            # the per-key reasoning lives with the mapping, in the backends'
+            # ``_documents_compile_context`` docstrings. ``field_mapping is None``
+            # is the identity mapping (no whitelist), which is what every
+            # chunk-tier context passes.
+            if not system_key_declared(self._ctx, path[0]):
+                return self._unsupported(clause, "the backend does not declare a column for this system key")
             expr = self._compile_system_clause(clause)
         elif path and path[0] == "metadata":
-            expr = self._compile_metadata_clause(clause)
+            compiled = self._compile_metadata_clause(clause)
+            if compiled is None:
+                # Unsupported metadata shape — route it BEFORE the ``consumed``
+                # add below, so the emit path and :meth:`_clause_consumable` agree
+                # on what was actually pushed.
+                return self._unsupported(clause, "only $eq is defined on the bare metadata blob")
+            expr = compiled
         else:
             return self._unsupported(clause, "path is neither a system key nor a metadata path")
         self._consumed.add(_path_str(path))
@@ -242,7 +314,13 @@ class _Builder:
 
     # ----- metadata leaves (JSONB) ---------------------------------------- #
 
-    def _compile_metadata_clause(self, clause: FilterClause) -> ColumnElement[bool]:
+    def _compile_metadata_clause(self, clause: FilterClause) -> ColumnElement[bool] | None:
+        """Compile a metadata leaf, or ``None`` if this backend cannot express it.
+
+        Returning ``None`` (rather than calling ``_unsupported`` here) keeps the
+        unsupported leaf out of ``consumed`` — the caller routes it per
+        ``on_unsupported`` before recording anything.
+        """
         path = clause.path
         op = clause.op
         operand = clause.operand
@@ -253,7 +331,9 @@ class _Builder:
         # the empty object, so a wrapping $not includes it.
         if len(path) == 1:
             if op != Op.EQ:
-                return self._unsupported(clause, "only $eq is defined on the bare metadata blob")
+                # Only $eq is defined on the bare blob — unsupported (the caller
+                # turns this into the ``on_unsupported`` handling).
+                return None
             return self._md == _jsonb_literal(operand)
 
         segs = path[1:]  # drop the leading "metadata" root

--- a/src/khora/filter/compilers/postgres.py
+++ b/src/khora/filter/compilers/postgres.py
@@ -58,9 +58,9 @@ from khora.filter.ast import (
     FilterNode,
 )
 from khora.filter.compilers._split import (
-    consumed_slice_hash,
-    deferred_paths,
+    ConsumableMemo,
     node_consumable,
+    split_report,
     system_key_declared,
 )
 from khora.filter.model import SYSTEM_KEYS, Op
@@ -119,20 +119,29 @@ def compile_postgres(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[Col
     consumed: set[str] = set()
     builder = _Builder(ctx=ctx, consumed=consumed)
     predicate = builder.compile_node(ast)
+    # One pruned-tree reconstruction feeds both outputs; under "raise" the walk is
+    # skipped entirely (nothing can have been deferred).
+    deferred, slice_hash = split_report(
+        ast,
+        builder._clause_consumable,
+        on_unsupported=ctx.on_unsupported,
+        memo=builder._consumable_memo,
+    )
     return CompiledFilter(
         predicate=predicate,
         params={},
         # A dotted path is only reported consumed when EVERY occurrence of it was
         # pushed: the emission accumulator records the leaves that emitted real
-        # SQL, and ``deferred_paths`` removes any path that ALSO occurs inside a
+        # SQL, and the deferred set removes any path that ALSO occurs inside a
         # subtree the split gate deferred (else a caller differencing
         # ``leaf_keys - consumed_keys`` would never re-check that occurrence).
-        consumed_keys=frozenset(consumed) - deferred_paths(ast, builder._clause_consumable),
-        # The hash covers the CONSUMED SLICE, not the whole AST — two filters that
-        # differ only in a deferred subtree compile to the same WHERE and must
-        # share a cache key. In on_unsupported="raise" mode every leaf is
-        # consumable, so the slice IS the whole tree and the hash is unchanged.
-        canonical_hash=consumed_slice_hash(ast, builder._clause_consumable),
+        consumed_keys=frozenset(consumed) - deferred,
+        # Plan identity over the CONSUMED SLICE, not the whole AST: two filters
+        # differing only in a deferred subtree emit the same WHERE and share this.
+        # They do NOT share a result set — the deferred remainder is enforced by
+        # the caller's post-filter — so this is never a result-cache key. In
+        # on_unsupported="raise" mode the slice IS the whole tree.
+        consumed_slice_hash=slice_hash,
     )
 
 
@@ -153,6 +162,10 @@ class _Builder:
     def __init__(self, *, ctx: CompileContext, consumed: set[str]) -> None:
         self._ctx = ctx
         self._consumed = consumed
+        # One memo per compile pass so the all-or-nothing gate is O(n) rather
+        # than re-testing each leaf once per enclosing OR/NOT level. Keyed on
+        # id(node) — sound only for this pass's lifetime, which is its scope.
+        self._consumable_memo: ConsumableMemo = {}
         # The metadata column is nullable. Coalesce a NULL blob to an empty JSONB
         # object once here so every downstream operator (`?`, `@>`, `#>`, `=`) is
         # total against a NULL row: `'{}' ? k` / `'{}' @> x` return FALSE (not
@@ -190,7 +203,9 @@ class _Builder:
             if not node.children:
                 # The validator forbids an empty $or; guard defensively.
                 return sa.false()
-            if self._ctx.on_unsupported == "split" and not node_consumable(node, self._clause_consumable):
+            if self._ctx.on_unsupported == "split" and not node_consumable(
+                node, self._clause_consumable, self._consumable_memo
+            ):
                 # A non-consumable disjunct would compile to TRUE, making the whole
                 # OR match-all here while the post-filter still narrows — safe in
                 # positive position but it under-pushes silently AND becomes a
@@ -203,7 +218,9 @@ class _Builder:
         # when the child is fully consumable; otherwise defer the whole NOT (in
         # "split" mode). In "raise" mode we descend so the offending leaf raises
         # rather than being silently swallowed by the all-or-nothing gate.
-        if self._ctx.on_unsupported == "split" and not node_consumable(node, self._clause_consumable):
+        if self._ctx.on_unsupported == "split" and not node_consumable(
+            node, self._clause_consumable, self._consumable_memo
+        ):
             return sa.true()
         return sa.not_(self.compile_node(node.children[0]))
 

--- a/src/khora/filter/compilers/python.py
+++ b/src/khora/filter/compilers/python.py
@@ -124,7 +124,7 @@ def compile_python(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[Calla
         predicate=predicate,
         params={},
         consumed_keys=frozenset(consumed),
-        canonical_hash=canonical_hash(ast),
+        consumed_slice_hash=canonical_hash(ast),
     )
 
 

--- a/src/khora/filter/compilers/surrealdb.py
+++ b/src/khora/filter/compilers/surrealdb.py
@@ -103,7 +103,11 @@ from khora.filter.ast import (
     DateLiteral,
     FilterClause,
     FilterNode,
-    canonical_hash,
+)
+from khora.filter.compilers._split import (
+    consumed_slice_hash,
+    deferred_paths,
+    node_consumable,
 )
 from khora.filter.context import CompileError
 from khora.filter.model import SYSTEM_KEYS, Op
@@ -123,7 +127,10 @@ _RANGE_OP = {
 # underscore, then alphanumerics / underscores. Stricter than the storage-layer
 # ``_sanitize_field_name`` (no dots — each AST path segment is already a single
 # field name) and kept self-contained so the compiler embeds no storage import.
-_SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+# Anchored with ``\Z``, NOT ``$``: ``$`` also matches just before a trailing
+# newline, so ``"tier\n"`` would pass a ``^...$`` guard and be interpolated
+# verbatim into the predicate string. ``\Z`` is the absolute end of the string.
+_SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*\Z")
 
 
 def compile_surrealdb(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[str]:
@@ -153,11 +160,17 @@ def compile_surrealdb(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[st
     return CompiledFilter(
         predicate=predicate,
         params=builder.params,
-        consumed_keys=frozenset(consumed),
-        # canonical_hash over the whole AST. In on_unsupported="raise" mode (the
-        # only mode the skeleton engine uses) every leaf is consumed, so the whole
-        # tree == the consumed slice.
-        canonical_hash=canonical_hash(ast),
+        # A dotted path is only reported consumed when EVERY occurrence of it was
+        # pushed: the emission accumulator records the leaves that emitted real
+        # SurrealQL, and ``deferred_paths`` removes any path that ALSO occurs
+        # inside a subtree the split gate deferred (else a caller differencing
+        # ``leaf_keys - consumed_keys`` would never re-check that occurrence).
+        consumed_keys=frozenset(consumed) - deferred_paths(ast, builder._clause_consumable),
+        # The hash covers the CONSUMED SLICE, not the whole AST — two filters that
+        # differ only in a deferred subtree compile to the same WHERE and must
+        # share a cache key. In on_unsupported="raise" mode every leaf is
+        # consumable, so the slice IS the whole tree and the hash is unchanged.
+        canonical_hash=consumed_slice_hash(ast, builder._clause_consumable),
     )
 
 
@@ -187,7 +200,11 @@ class _Builder:
         # undeclared — the backend does not back it with a column, so the
         # system-key branch of :meth:`compile_clause` routes it to ``_unsupported``.
         # The ``metadata`` root is keyed separately, so the metadata branch never
-        # consults this set.
+        # consults this set. ``or {}`` means a ``None`` ``field_mapping`` declares
+        # NOTHING here — deliberately stricter than
+        # ``_split.system_key_declared``'s identity reading, which postgres/lance
+        # use. Do not "unify" the two: see :meth:`_clause_consumable` for why a
+        # backend that cannot fail loud must fail closed.
         self._declared: dict[str, str] = dict(ctx.field_mapping or {})
 
     # ----- bind allocation ------------------------------------------------ #
@@ -234,7 +251,21 @@ class _Builder:
     # ----- logical node walk ---------------------------------------------- #
 
     def compile_node(self, node: FilterNode | FilterClause) -> str:
-        """Compile a logical node or leaf to a SurrealQL boolean string."""
+        """Compile a logical node or leaf to a SurrealQL boolean string.
+
+        **Split-mode soundness — "AND distributes; OR/NOT are all-or-nothing."**
+        The match-all placeholder ``"true"`` an unsupported leaf emits under
+        ``on_unsupported="split"`` is superset-safe only in *positive* position:
+        ``A AND true`` ≡ ``A`` (still narrows correctly), but ``!(A OR true)`` ≡
+        ``!true`` ≡ ``false`` — which would *drop every row the filter keeps*,
+        breaking the superset invariant (the caller's post-filter only narrows; it
+        cannot add a wrongly-excluded row back). So an ``OR`` / ``NOT`` node is
+        pushed down only when its **entire** subtree is consumable; otherwise the
+        whole node emits ``"true"`` and consumes nothing, deferring it wholesale to
+        the post-filter. An ``AND`` still handles each child independently — a
+        non-consumable child becomes ``"true"`` and the consumable siblings still
+        narrow. See :mod:`khora.filter.compilers._split`.
+        """
         if isinstance(node, FilterClause):
             return self.compile_clause(node)
         if node.op == Op.AND:
@@ -246,11 +277,60 @@ class _Builder:
             if not node.children:
                 # The validator forbids an empty $or; guard defensively.
                 return "false"
+            if self._ctx.on_unsupported == "split" and not node_consumable(node, self._clause_consumable):
+                # A non-consumable disjunct would compile to "true", making the
+                # whole OR match-all here while the post-filter still narrows —
+                # safe in positive position but it under-pushes silently AND
+                # becomes a false-exclude if a parent NOT wraps it. Defer the whole
+                # OR. In "raise" mode we instead descend so the offending leaf
+                # raises.
+                return "true"
             return "(" + " OR ".join(self.compile_node(c) for c in node.children) + ")"
         # Op.NOT — exactly one child per the AST contract. SurrealQL's NONE-boolean
         # algebra makes every leaf total, so this negation flips absent rows
-        # correctly without a coalesce wrapper.
+        # correctly without a coalesce wrapper. Pushed only when the child is fully
+        # consumable; otherwise defer the whole NOT (in "split" mode). In "raise"
+        # mode we descend so the offending leaf raises rather than being silently
+        # swallowed by the all-or-nothing gate.
+        if self._ctx.on_unsupported == "split" and not node_consumable(node, self._clause_consumable):
+            return "true"
         return f"!({self.compile_node(node.children[0])})"
+
+    def _clause_consumable(self, clause: FilterClause) -> bool:
+        """True iff this leaf compiles to real SurrealQL — the gate predicate.
+
+        The pure mirror of :meth:`compile_clause`'s dispatch (no bind allocation,
+        no ``consumed`` mutation), so the all-or-nothing ``OR`` / ``NOT`` gate and
+        the consumed-slice reconstruction both see exactly what emission does.
+
+        **Deliberately asymmetric with postgres / lance on the system-key gate.**
+        Those two read a ``None`` ``field_mapping`` as the identity mapping (no
+        whitelist, every system key pushes) via
+        :func:`~khora.filter.compilers._split.system_key_declared`; this compiler
+        instead consults ``self._declared`` — ``dict(ctx.field_mapping or {})`` — so
+        an absent mapping declares *nothing*. The asymmetry is the point: SQL fails
+        LOUD on a missing column (the query errors), whereas on a SCHEMAFULL
+        SurrealDB table a missing field reads ``NONE`` and SurrealQL's total-false
+        absent-compare (``NONE = x`` → ``false``) would silently drop every row. A
+        backend that cannot fail loud must fail closed.
+
+        It deliberately does NOT consider :data:`_SAFE_SEGMENT_RE` safety, because
+        it mirrors the emit path and the emit path is not mode-dependent there:
+        :meth:`_metadata_path` raises :class:`CompileError` on an unsafe segment
+        under BOTH modes (it is an injection guard, not a capability gap), so such
+        a leaf is never deferred. Reporting it unconsumable *here alone* would
+        desynchronize the gate from emission — the enclosing subtree would defer,
+        :meth:`_metadata_path` would never run, and the guard would not fire at
+        all. If the guard is ever turned into a real split-mode capability gap
+        (routing to :meth:`_unsupported` instead of raising), this branch must
+        become mode-aware in the same change.
+        """
+        path = clause.path
+        if len(path) == 1 and path[0] in SYSTEM_KEYS:
+            return path[0] in self._declared
+        if path and path[0] == "metadata":
+            return len(path) > 1 or clause.op == Op.EQ
+        return False
 
     # ----- leaf key-kind split -------------------------------------------- #
 
@@ -274,7 +354,13 @@ class _Builder:
                 )
             expr = self._compile_system_clause(clause)
         elif path and path[0] == "metadata":
-            expr = self._compile_metadata_clause(clause)
+            compiled = self._compile_metadata_clause(clause)
+            if compiled is None:
+                # Unsupported metadata shape — route it BEFORE the ``consumed`` add
+                # below, so the emit path and :meth:`_clause_consumable` agree on
+                # what was actually pushed.
+                return self._unsupported(clause, "only $eq is defined on the bare metadata blob")
+            expr = compiled
         else:
             return self._unsupported(clause, "path is neither a system key nor a metadata path")
         self._consumed.add(_path_str(path))
@@ -343,7 +429,13 @@ class _Builder:
 
     # ----- metadata leaves (native object descent) ------------------------ #
 
-    def _compile_metadata_clause(self, clause: FilterClause) -> str:
+    def _compile_metadata_clause(self, clause: FilterClause) -> str | None:
+        """Compile a metadata leaf, or ``None`` if this backend cannot express it.
+
+        Returning ``None`` (rather than calling ``_unsupported`` here) keeps the
+        unsupported leaf out of ``consumed`` — the caller routes it per
+        ``on_unsupported`` before recording anything.
+        """
         path = clause.path
         op = clause.op
         operand = clause.operand
@@ -352,7 +444,9 @@ class _Builder:
         # equality is structural / key-order-insensitive.
         if len(path) == 1:
             if op != Op.EQ:
-                return self._unsupported(clause, "only $eq is defined on the bare metadata blob")
+                # Only $eq is defined on the bare blob — unsupported (the caller
+                # turns this into the ``on_unsupported`` handling).
+                return None
             root = (self._ctx.field_mapping or {}).get("metadata", "metadata")
             return f"({root} = {self._bind(operand)})"
 

--- a/src/khora/filter/compilers/surrealdb.py
+++ b/src/khora/filter/compilers/surrealdb.py
@@ -105,9 +105,9 @@ from khora.filter.ast import (
     FilterNode,
 )
 from khora.filter.compilers._split import (
-    consumed_slice_hash,
-    deferred_paths,
+    ConsumableMemo,
     node_consumable,
+    split_report,
 )
 from khora.filter.context import CompileError
 from khora.filter.model import SYSTEM_KEYS, Op
@@ -157,20 +157,29 @@ def compile_surrealdb(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[st
     consumed: set[str] = set()
     builder = _Builder(ctx=ctx, consumed=consumed)
     predicate = builder.compile_node(ast)
+    # One pruned-tree reconstruction feeds both outputs; under "raise" the walk is
+    # skipped entirely (nothing can have been deferred).
+    deferred, slice_hash = split_report(
+        ast,
+        builder._clause_consumable,
+        on_unsupported=ctx.on_unsupported,
+        memo=builder._consumable_memo,
+    )
     return CompiledFilter(
         predicate=predicate,
         params=builder.params,
         # A dotted path is only reported consumed when EVERY occurrence of it was
         # pushed: the emission accumulator records the leaves that emitted real
-        # SurrealQL, and ``deferred_paths`` removes any path that ALSO occurs
+        # SurrealQL, and the deferred set removes any path that ALSO occurs
         # inside a subtree the split gate deferred (else a caller differencing
         # ``leaf_keys - consumed_keys`` would never re-check that occurrence).
-        consumed_keys=frozenset(consumed) - deferred_paths(ast, builder._clause_consumable),
-        # The hash covers the CONSUMED SLICE, not the whole AST — two filters that
-        # differ only in a deferred subtree compile to the same WHERE and must
-        # share a cache key. In on_unsupported="raise" mode every leaf is
-        # consumable, so the slice IS the whole tree and the hash is unchanged.
-        canonical_hash=consumed_slice_hash(ast, builder._clause_consumable),
+        consumed_keys=frozenset(consumed) - deferred,
+        # Plan identity over the CONSUMED SLICE, not the whole AST: two filters
+        # differing only in a deferred subtree emit the same predicate and share
+        # this. They do NOT share a result set — the deferred remainder is enforced
+        # by the caller's post-filter — so this is never a result-cache key. In
+        # on_unsupported="raise" mode the slice IS the whole tree.
+        consumed_slice_hash=slice_hash,
     )
 
 
@@ -192,6 +201,10 @@ class _Builder:
     def __init__(self, *, ctx: CompileContext, consumed: set[str]) -> None:
         self._ctx = ctx
         self._consumed = consumed
+        # One memo per compile pass so the all-or-nothing gate is O(n) rather
+        # than re-testing each leaf once per enclosing OR/NOT level. Keyed on
+        # id(node) — sound only for this pass's lifetime, which is its scope.
+        self._consumable_memo: ConsumableMemo = {}
         self._alias = ctx.table_alias
         self.params: dict[str, Any] = {}
         self._counter = 0
@@ -277,7 +290,9 @@ class _Builder:
             if not node.children:
                 # The validator forbids an empty $or; guard defensively.
                 return "false"
-            if self._ctx.on_unsupported == "split" and not node_consumable(node, self._clause_consumable):
+            if self._ctx.on_unsupported == "split" and not node_consumable(
+                node, self._clause_consumable, self._consumable_memo
+            ):
                 # A non-consumable disjunct would compile to "true", making the
                 # whole OR match-all here while the post-filter still narrows —
                 # safe in positive position but it under-pushes silently AND
@@ -292,7 +307,9 @@ class _Builder:
         # consumable; otherwise defer the whole NOT (in "split" mode). In "raise"
         # mode we descend so the offending leaf raises rather than being silently
         # swallowed by the all-or-nothing gate.
-        if self._ctx.on_unsupported == "split" and not node_consumable(node, self._clause_consumable):
+        if self._ctx.on_unsupported == "split" and not node_consumable(
+            node, self._clause_consumable, self._consumable_memo
+        ):
             return "true"
         return f"!({self.compile_node(node.children[0])})"
 
@@ -317,13 +334,25 @@ class _Builder:
         It deliberately does NOT consider :data:`_SAFE_SEGMENT_RE` safety, because
         it mirrors the emit path and the emit path is not mode-dependent there:
         :meth:`_metadata_path` raises :class:`CompileError` on an unsafe segment
-        under BOTH modes (it is an injection guard, not a capability gap), so such
-        a leaf is never deferred. Reporting it unconsumable *here alone* would
-        desynchronize the gate from emission — the enclosing subtree would defer,
+        under BOTH modes (it is an injection guard, not a capability gap).
+        Reporting such a leaf unconsumable *here alone* would desynchronize the
+        gate from emission — the enclosing subtree would defer,
         :meth:`_metadata_path` would never run, and the guard would not fire at
         all. If the guard is ever turned into a real split-mode capability gap
         (routing to :meth:`_unsupported` instead of raising), this branch must
         become mode-aware in the same change.
+
+        **The guard's firing is nevertheless sibling-dependent, and a caller must
+        not assume otherwise.** An unsafe segment raises when the emit walk reaches
+        it, which it does not when the leaf sits inside an ``$or`` / ``$not`` that
+        the all-or-nothing gate defers for an *unrelated* reason — say an
+        undeclared system key elsewhere in the same disjunction. That subtree emits
+        the placeholder and the leaf reaches ``compile_python`` instead, which
+        handles hyphenated keys correctly, so the rows are right either way and
+        nothing unsafe is interpolated. But a scan path that maps
+        :class:`CompileError` onto the public unsupported-filter error MUST treat
+        that mapping as best-effort: the same filter can raise or not depending on
+        what else is in the enclosing subtree.
         """
         path = clause.path
         if len(path) == 1 and path[0] in SYSTEM_KEYS:

--- a/src/khora/filter/compilers/weaviate.py
+++ b/src/khora/filter/compilers/weaviate.py
@@ -125,10 +125,12 @@ def compile_weaviate(ast: FilterNode, ctx: CompileContext) -> CompiledFilter[Any
         predicate=predicate,
         params={},
         consumed_keys=frozenset(consumed),
-        # canonical_hash over the whole AST — the engine re-checks the whole AST in
-        # its post-filter (the pushed-down filter is only a superset prefilter), so
-        # the cache key is keyed on the full predicate, not the pushed slice.
-        canonical_hash=canonical_hash(ast),
+        # Whole-AST hash — the engine re-checks the whole AST in its post-filter
+        # (the pushed-down filter is only a superset prefilter), so identifying the
+        # full predicate rather than the pushed slice is the useful granularity
+        # here. It is also a conservative plan identity: equal hash implies equal
+        # AST, hence equal slice, so it can only over-distinguish, never conflate.
+        consumed_slice_hash=canonical_hash(ast),
     )
 
 

--- a/src/khora/filter/conformance.py
+++ b/src/khora/filter/conformance.py
@@ -852,7 +852,7 @@ _OP_BACKENDS: frozenset[str] = _INMEM_BACKENDS | _LIVE_BACKENDS
 # metadata path segment surrealdb can safely interpolate. A segment that fails this
 # (e.g. a ``$``-prefixed key) makes the surrealdb compiler raise ``CompileError``, so
 # the case is pruned from the surrealdb leg only — every other backend binds the path.
-_SURREAL_SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SURREAL_SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*\Z")
 
 
 def _surreal_excluded(filter_: dict[str, Any] | RecallFilter, seed: tuple[SeedRecord, ...]) -> bool:

--- a/src/khora/filter/context.py
+++ b/src/khora/filter/context.py
@@ -118,15 +118,22 @@ class CompileContext:
       Lets one compiler serve a different schema (e.g. the legacy
       ``chunks``/``documents`` tables) without per-engine branching. ``None`` =
       identity mapping (system key name == column name) and **no whitelist** —
-      every system key is declared. A **non-``None``** mapping's KEY SET is
-      additionally the backend's declared+pushable property whitelist: a system key
-      it omits is "undeclared" and is not pushed down (it falls to the caller's
-      post-filter under ``"split"``, or raises under ``"raise"``). ``postgres`` /
-      ``lance`` read it that way via
-      :func:`~khora.filter.compilers._split.system_key_declared`;
-      ``weaviate`` / ``surrealdb`` are stricter — they read an absent mapping as
-      declaring *nothing*, because a missing property there silently matches no
-      rows instead of failing loud.
+      every system key is declared. A compiler **MAY** additionally treat a
+      *non-``None``* mapping's KEY SET as the backend's declared+pushable property
+      whitelist: a system key it omits is then "undeclared" and is not pushed down
+      (it falls to the caller's post-filter under ``"split"``, or raises under
+      ``"raise"``). Who does what today:
+
+      - ``postgres`` / ``lance`` read it as a whitelist via
+        :func:`~khora.filter.compilers._split.system_key_declared`, which preserves
+        ``field_mapping is None`` as identity-with-no-whitelist.
+      - ``weaviate`` / ``surrealdb`` are stricter: they read ``field_mapping``
+        being ``None`` as declaring *nothing*, because a missing property there
+        silently matches no rows instead of failing loud.
+      - ``cypher`` / ``python`` do **not** read it as a whitelist at all — they
+        fall back to identity for an undeclared key (``cypher.py`` and
+        ``python.py``, in each ``_col``-equivalent lookup). Neither is handed a
+        partial mapping today, so the distinction is latent rather than live.
     * ``schema_capabilities`` — what the backend can do natively
       (:class:`SchemaCapabilities`).
     * ``on_unsupported`` — ``"raise"`` stops on the first node the backend cannot

--- a/src/khora/filter/context.py
+++ b/src/khora/filter/context.py
@@ -117,11 +117,16 @@ class CompileContext:
     * ``field_mapping`` — optional system-key → backend column/property name map.
       Lets one compiler serve a different schema (e.g. the legacy
       ``chunks``/``documents`` tables) without per-engine branching. ``None`` =
-      identity mapping (system key name == column name). A compiler MAY also treat
-      the KEY SET as the backend's declared+pushable property whitelist — a key
-      absent from ``field_mapping`` is then "undeclared" and not pushed down (as
-      :func:`~khora.filter.compilers.weaviate.compile_weaviate` does, leaving
-      undeclared keys to the post-filter).
+      identity mapping (system key name == column name) and **no whitelist** —
+      every system key is declared. A **non-``None``** mapping's KEY SET is
+      additionally the backend's declared+pushable property whitelist: a system key
+      it omits is "undeclared" and is not pushed down (it falls to the caller's
+      post-filter under ``"split"``, or raises under ``"raise"``). ``postgres`` /
+      ``lance`` read it that way via
+      :func:`~khora.filter.compilers._split.system_key_declared`;
+      ``weaviate`` / ``surrealdb`` are stricter — they read an absent mapping as
+      declaring *nothing*, because a missing property there silently matches no
+      rows instead of failing loud.
     * ``schema_capabilities`` — what the backend can do natively
       (:class:`SchemaCapabilities`).
     * ``on_unsupported`` — ``"raise"`` stops on the first node the backend cannot

--- a/src/khora/filter/registry.py
+++ b/src/khora/filter/registry.py
@@ -69,8 +69,19 @@ class CompiledFilter(Generic[T]):
     * ``consumed_keys`` — the AST leaves this compiler handled, for partial
       pushdown: when ``CompileContext.on_unsupported == "split"`` the engine
       post-filters whatever is *not* in this set.
-    * ``canonical_hash`` — the stable hash of the consumed slice, the engine's
-      cache-key source.
+    * ``canonical_hash`` — a stable hash identifying the predicate this compiler
+      emitted. Compilers that reconstruct the consumed slice (postgres / lance /
+      surrealdb) hash that slice, so in ``"split"`` mode two filters that push the
+      same predicate share a hash while their result sets differ; **for those it
+      is not a recall-result cache key** — the deferred remainder still narrows
+      the result set through the engine's post-filter. Compilers that hash the
+      whole AST (cypher / weaviate / python / chronicle) do not have that property
+      — equal hash there implies equal AST, hence equal result set;
+      ``compile_weaviate`` explains its choice at the construction site. In
+      ``"raise"`` mode the slice IS the whole AST and the two rules coincide, so
+      raise-mode callers are unaffected. Key a result cache on
+      ``canonical_hash(filter_ast)`` over the full AST regardless, as
+      ``engines/vectorcypher/recall_cache.py`` does.
     """
 
     predicate: T

--- a/src/khora/filter/registry.py
+++ b/src/khora/filter/registry.py
@@ -66,28 +66,36 @@ class CompiledFilter(Generic[T]):
     * ``predicate`` — the compiled backend predicate (typed ``T``).
     * ``params`` — bind parameters for backends that bind (Postgres, Cypher);
       empty for backends that inline literals.
-    * ``consumed_keys`` — the AST leaves this compiler handled, for partial
-      pushdown: when ``CompileContext.on_unsupported == "split"`` the engine
-      post-filters whatever is *not* in this set.
-    * ``canonical_hash`` — a stable hash identifying the predicate this compiler
-      emitted. Compilers that reconstruct the consumed slice (postgres / lance /
-      surrealdb) hash that slice, so in ``"split"`` mode two filters that push the
-      same predicate share a hash while their result sets differ; **for those it
-      is not a recall-result cache key** — the deferred remainder still narrows
-      the result set through the engine's post-filter. Compilers that hash the
-      whole AST (cypher / weaviate / python / chronicle) do not have that property
-      — equal hash there implies equal AST, hence equal result set;
-      ``compile_weaviate`` explains its choice at the construction site. In
-      ``"raise"`` mode the slice IS the whole AST and the two rules coincide, so
-      raise-mode callers are unaffected. Key a result cache on
-      ``canonical_hash(filter_ast)`` over the full AST regardless, as
-      ``engines/vectorcypher/recall_cache.py`` does.
+    * ``consumed_keys`` — the dotted paths this compiler fully handled, for
+      partial pushdown: when ``CompileContext.on_unsupported == "split"`` the
+      engine post-filters whatever is *not* in this set. Membership is per
+      **occurrence**, not per leaf: a path counts as consumed only when EVERY one
+      of its occurrences in the AST was pushed, so a key pushed in a conjunctive
+      leaf but deferred inside an ``$or`` / ``$not`` the gate deferred wholesale is
+      reported *absent* and stays post-filtered. Erring the other way would tell a
+      caller differencing ``leaf_keys - consumed_keys`` that a deferred occurrence
+      was already enforced, and the query would return rows the filter excludes.
+    * ``consumed_slice_hash`` — a stable **plan-identity** hash: it identifies the
+      predicate the backend actually received, not the filter the caller asked
+      for. Under ``"split"`` two filters differing only in a deferred subtree emit
+      the same predicate and therefore share this hash **while returning different
+      rows**, because the deferred remainder is still enforced by the engine's
+      post-filter. It is consequently **never a result-cache key** — key those on
+      ``canonical_hash(filter_ast)`` over the whole AST, as
+      ``engines/vectorcypher/recall_cache.py`` does. Postgres / lance / surrealdb
+      derive it from the reconstructed slice; cypher / weaviate / python /
+      chronicle currently supply the whole-AST hash, which is a *conservative*
+      plan identity (equal hash there implies equal AST, hence equal slice — it
+      can only over-distinguish two identical plans, never conflate two different
+      ones), and ``compile_weaviate`` explains its choice at the construction
+      site. In ``"raise"`` mode the slice IS the whole AST, so every compiler
+      agrees and raise-mode callers see no difference.
     """
 
     predicate: T
     params: dict[str, Any]
     consumed_keys: frozenset[str]
-    canonical_hash: str
+    consumed_slice_hash: str
 
 
 # A compiler is a stateless function of ``(ast, ctx)``.

--- a/src/khora/filter/report.py
+++ b/src/khora/filter/report.py
@@ -61,12 +61,20 @@ class FilterChannelReport(BaseModel):
     dotted constraint-leaf keys (``".".join(clause.path)``) that this channel's
     compiler pushed into its backend query versus the ones it re-checked in
     memory. Both lists are sorted for deterministic, JSON-stable output.
+
+    Membership is per **occurrence**, not per leaf: a key appears in
+    ``pushed_keys`` only when EVERY occurrence of it in the AST was pushed. A key
+    can therefore appear in the emitted query and still be reported post-filtered,
+    when a second occurrence sat inside an ``$or`` / ``$not`` the backend's
+    all-or-nothing split gate deferred wholesale. That direction is the honest one
+    — the post-filter does re-check it — and the reverse would tell a caller a
+    deferred occurrence was already enforced.
     """
 
     model_config = ConfigDict(frozen=True)
 
     pushed_keys: list[str] = Field(default_factory=list)
-    """Constraint-leaf keys this channel pushed into its backend query (sorted)."""
+    """Keys fully pushed into this channel's backend query — every occurrence (sorted)."""
 
     post_filtered_keys: list[str] = Field(default_factory=list)
     """Constraint-leaf keys this channel re-checked with an in-memory predicate (sorted)."""

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -1086,13 +1086,30 @@ def _documents_compile_context() -> CompileContext:
     unpushable leaf is left unconsumed rather than raising.
 
     ``occurred_at`` is deliberately absent: no ``documents`` row backs it.
-    ``compile_postgres`` does not treat the ``field_mapping`` key set as a
-    pushdown whitelist (``_col`` falls back to identity), so this context alone
-    cannot stop an ``occurred_at`` leaf from compiling to a non-existent column.
-    Worse than the resulting error: the leaf is also reported in
-    ``CompiledFilter.consumed_keys``, so the caller is told it was pushed down
-    and will not post-filter it. The caller must reject or strip the key before
-    compiling.
+    ``compile_postgres`` treats the ``field_mapping`` key set as the pushdown
+    whitelist, so the omission is enforced rather than advisory — an
+    ``occurred_at`` leaf never compiles to a predicate against a non-existent
+    column. Under this context's ``"split"`` mode it emits the match-all
+    placeholder, stays out of ``CompiledFilter.consumed_keys``, and reaches the
+    caller's post-filter; the caller no longer has to strip the key first.
+
+    All nine backed keys stay declared here, including the two date-valued ones.
+    Unlike the SQLite-backed documents adapters — where timestamps live in
+    ``TEXT`` columns compared lexicographically against a string bind — this
+    table's ``created_at`` and ``source_timestamp`` are real ``timestamptz``
+    columns and ``compile_postgres`` binds a datetime object, so the comparison
+    is on instants and both pushdowns are sound.
+
+    **The enumeration post-filter must evaluate the FULL filter AST
+    unconditionally.** Everything the compiler pushes is a superset filter, but
+    that rests on a specific property rather than being a free-standing
+    guarantee: the all-or-nothing ``$or`` / ``$not`` gate defers a whole subtree
+    it cannot fully express, rather than leaving a match-all placeholder inside
+    it that would invert under negation and wrongly EXCLUDE rows. Given that,
+    re-running every leaf in memory can only narrow. Treat
+    ``consumed_keys`` as a reporting and overfetch-sizing signal, not as
+    permission to skip the leaves it names; that keeps caller correctness
+    independent of how precisely the compiler tracks partial pushdown.
     """
     field_mapping = {key: key for key in _BACKED_SYSTEM_KEYS} | {"metadata": "metadata"}
     return CompileContext(

--- a/src/khora/storage/backends/sqlite.py
+++ b/src/khora/storage/backends/sqlite.py
@@ -1362,17 +1362,16 @@ from khora.filter import CompileContext, CompilerRegistry, SchemaCapabilities  #
 from khora.filter.compilers.lance import compile_lance  # noqa: E402
 from khora.storage.backends._sqlite_capabilities import sqlite_has_json1  # noqa: E402
 
-# The system keys this table backs with a real column — the single source of
-# truth for the documents tier. Nine of the ten ``SYSTEM_KEYS``; ``occurred_at``
-# is a recall-chunk column and has no ``documents`` counterpart (see the
-# ``CREATE TABLE IF NOT EXISTS documents`` DDL in ``_SCHEMA_SQL`` above).
-# NOTE: ``created_at`` and ``source_timestamp`` are declared here but their
-# pushdown is NOT sound on this store — see the datetime hazard and the
-# forward-coupling alarm in ``_documents_compile_context``'s docstring below.
+# The system keys this table backs with a real column AND can push down soundly
+# — the single source of truth for the documents tier, and the pushdown
+# whitelist the compiler enforces. Seven of the ten ``SYSTEM_KEYS``.
+# ``occurred_at`` is a recall-chunk column and has no ``documents`` counterpart
+# (see the ``CREATE TABLE IF NOT EXISTS documents`` DDL in ``_SCHEMA_SQL``
+# above). ``created_at`` and ``source_timestamp`` are real columns but are
+# withheld on purpose: their stored format makes a pushed comparison silently
+# wrong — see the datetime hazard in ``_documents_compile_context``'s docstring.
 _BACKED_SYSTEM_KEYS: frozenset[str] = frozenset(
     {
-        "created_at",
-        "source_timestamp",
         "source_type",
         "source_name",
         "source_url",
@@ -1387,31 +1386,33 @@ _BACKED_SYSTEM_KEYS: frozenset[str] = frozenset(
 def _documents_compile_context() -> CompileContext:
     """Build the recall-filter :class:`CompileContext` for the ``documents`` table.
 
-    ``field_mapping`` declares the nine backed system keys (identity-mapped to
-    their bare columns) plus the ``metadata`` root remap to the physical
-    ``metadata_`` column — this backend's raw DDL diverges from the shared
-    SQLAlchemy model, which names the same column ``metadata``.
-    ``on_unsupported="split"`` because a document enumeration always has an
-    in-memory post-filter available, so an unpushable leaf is left unconsumed
-    rather than raising.
+    ``field_mapping`` declares the seven system keys this table both backs and
+    can push down soundly (identity-mapped to their bare columns) plus the
+    ``metadata`` root remap to the physical ``metadata_`` column — this backend's
+    raw DDL diverges from the shared SQLAlchemy model, which names the same
+    column ``metadata``. ``on_unsupported="split"`` because a document
+    enumeration always has an in-memory post-filter available, so an unpushable
+    leaf is left unconsumed rather than raising.
 
-    ``occurred_at`` is deliberately absent: no ``documents`` row backs it.
-    ``compile_lance`` does not treat the ``field_mapping`` key set as a pushdown
-    whitelist (``_col`` falls back to identity), so this context alone cannot
-    stop an ``occurred_at`` leaf from compiling to a non-existent column. Worse
-    than the resulting error: the leaf is also reported in
-    ``CompiledFilter.consumed_keys``, so the caller is told it was pushed down
-    and will not post-filter it. The caller must reject or strip the key before
-    compiling.
+    **The declared key set IS the pushdown whitelist.** ``compile_lance`` treats
+    a system key this mapping does not declare as unpushable: the leaf emits the
+    match-all placeholder, is kept out of ``CompiledFilter.consumed_keys``, and
+    reaches the caller's post-filter. Three of the ten system keys are withheld,
+    each for its own reason — the omissions are load-bearing, not oversights.
 
-    **Datetime binds on this table are not safe to push down.** Same class of
-    defect as the ``sqlite_lance`` adapter, different shape. This store writes
-    timestamps with :func:`_dt_to_str`, a bare ``dt.isoformat()`` with **no UTC
-    coercion**, into ``TEXT`` columns; ``compile_lance`` binds a datetime
-    operand as a UTC-normalized ``value.isoformat()`` and relies on
-    lexicographic ISO comparison. The two formats look compatible, which is
-    exactly why this is invisible without materializing a table — but the stored
-    string carries the *writer's* offset while the bind always carries
+    ``occurred_at`` is withheld because no ``documents`` row backs it: pushing it
+    would compile a predicate against a column that does not exist.
+
+    ``created_at`` and ``source_timestamp`` are withheld even though both are
+    real columns, because **datetime binds on this table are not safe to push
+    down.** Same class of defect as the ``sqlite_lance`` adapter, different
+    shape. This store writes timestamps with :func:`_dt_to_str`, a bare
+    ``dt.isoformat()`` with **no UTC coercion**, into ``TEXT`` columns;
+    ``compile_lance`` binds a datetime operand as a UTC-normalized
+    ``value.isoformat()`` and relies on lexicographic ISO comparison. The two
+    formats look compatible, which is exactly why this is invisible without
+    materializing a table — but the stored string carries the *writer's* offset
+    while the bind always carries
     ``+00:00``, so the comparison is on wall clock, not on instant. Against a
     ``$gte`` bound of ``'2026-01-31T12:30:00+00:00'``:
 
@@ -1425,20 +1426,41 @@ def _documents_compile_context() -> CompileContext:
 
     Reachable in practice: ``source_timestamp`` is caller-supplied with no
     default and no timezone normalization anywhere on this write path. This
-    cannot be corrected from a compile context — a caller using this context
-    must route the date-valued system keys to its post-filter.
+    cannot be corrected from a compile context — the date-valued system keys
+    have to reach the caller's post-filter, and withholding them from the
+    mapping is what sends them there.
 
-    **When the pushdown whitelist gate lands, drop ``created_at`` and
-    ``source_timestamp`` from ``_BACKED_SYSTEM_KEYS`` above.** They are declared
-    today only because ``compile_lance`` ignores the key set — every logical key
-    falls through to identity, so declaring them changes nothing and removing
-    them would make the mapping understate what it declares. Once the compiler
-    honours the key set as a pushdown whitelist, leaving them declared *keeps*
-    pushing the broken comparison described above; removing them routes both
-    keys to the caller's post-filter instead. The test signal for that edit is
-    INVERTED — forgetting the drop leaves both keys consumed and every test
-    green, while remembering it forces a test update — so this note is the
-    alarm.
+    **Withholding the two keys is what enforces that remedy.** While the
+    compiler still fell back to identity for an undeclared key, declaring them
+    was free and dropping them would only have understated the mapping. Now that
+    the key set is honoured as a whitelist, declaring them would *keep* pushing
+    the broken comparison above; leaving them out routes both to the post-filter.
+    Re-adding either key to ``_BACKED_SYSTEM_KEYS`` re-opens the silent
+    wrong-rows defect — including the unrecoverable false-exclude, which no
+    post-filter can undo — and the compiler cannot catch that for you: the
+    mapping is the only place the constraint lives.
+
+    **The same write shape reaches the chunk rows** — :func:`_dt_to_str` also
+    writes ``chunks.created_at`` / ``chunks.source_timestamp`` — but nothing is
+    broken there today, because ``documents`` is this backend's only registered
+    compile target and no chunk-tier context exists to push a date predicate.
+    Adding one would reintroduce the hazard on the chunk tier; that context
+    would have to withhold the same two keys, or the write path would have to
+    UTC-coerce first (:func:`khora.storage.temporal.sqlite_lance._dt_to_iso` is
+    the correct shape) plus backfill the existing rows.
+
+    **The enumeration post-filter must evaluate the FULL filter AST
+    unconditionally.** Everything the compiler pushes is a superset filter, but
+    only because of two specific properties — it is not a free-standing
+    guarantee. The all-or-nothing ``$or`` / ``$not`` gate defers a whole subtree
+    it cannot fully express, rather than leaving a match-all placeholder inside
+    it that would invert under negation and wrongly EXCLUDE rows; and keys whose
+    stored format does not order against this compiler's binds are kept out of
+    the declared mapping entirely, per the paragraphs above. Given both,
+    re-running every leaf in memory can only narrow. Treat ``consumed_keys`` as a
+    reporting and overfetch-sizing signal, not as permission to skip the leaves
+    it names; that keeps caller correctness independent of how precisely the
+    compiler tracks partial pushdown.
     """
     field_mapping = {key: key for key in _BACKED_SYSTEM_KEYS} | {"metadata": "metadata_"}
     return CompileContext(

--- a/src/khora/storage/backends/sqlite.py
+++ b/src/khora/storage/backends/sqlite.py
@@ -1370,7 +1370,7 @@ from khora.storage.backends._sqlite_capabilities import sqlite_has_json1  # noqa
 # above). ``created_at`` and ``source_timestamp`` are real columns but are
 # withheld on purpose: their stored format makes a pushed comparison silently
 # wrong — see the datetime hazard in ``_documents_compile_context``'s docstring.
-_BACKED_SYSTEM_KEYS: frozenset[str] = frozenset(
+_PUSHABLE_SYSTEM_KEYS: frozenset[str] = frozenset(
     {
         "source_type",
         "source_name",
@@ -1435,10 +1435,15 @@ def _documents_compile_context() -> CompileContext:
     was free and dropping them would only have understated the mapping. Now that
     the key set is honoured as a whitelist, declaring them would *keep* pushing
     the broken comparison above; leaving them out routes both to the post-filter.
-    Re-adding either key to ``_BACKED_SYSTEM_KEYS`` re-opens the silent
+    Re-adding either key to ``_PUSHABLE_SYSTEM_KEYS`` re-opens the silent
     wrong-rows defect — including the unrecoverable false-exclude, which no
     post-filter can undo — and the compiler cannot catch that for you: the
-    mapping is the only place the constraint lives.
+    mapping is the only place the constraint lives. That caveat holds **unless
+    the write path is UTC-normalized first**: unlike the shared-model store,
+    which discards the offset at write and so cannot recover the instant for
+    existing rows, this store's :func:`_dt_to_str` preserves the writer's offset,
+    so its data is lossless and a coercing write path (plus a backfill of the
+    naive and non-UTC rows) would make these keys soundly pushable again.
 
     **The same write shape reaches the chunk rows** — :func:`_dt_to_str` also
     writes ``chunks.created_at`` / ``chunks.source_timestamp`` — but nothing is
@@ -1462,7 +1467,7 @@ def _documents_compile_context() -> CompileContext:
     it names; that keeps caller correctness independent of how precisely the
     compiler tracks partial pushdown.
     """
-    field_mapping = {key: key for key in _BACKED_SYSTEM_KEYS} | {"metadata": "metadata_"}
+    field_mapping = {key: key for key in _PUSHABLE_SYSTEM_KEYS} | {"metadata": "metadata_"}
     return CompileContext(
         backend_target="documents",
         field_mapping=field_mapping,

--- a/src/khora/storage/backends/sqlite_lance/relational.py
+++ b/src/khora/storage/backends/sqlite_lance/relational.py
@@ -1096,7 +1096,7 @@ from khora.storage.backends._sqlite_capabilities import sqlite_has_json1  # noqa
 # ``created_at`` and ``source_timestamp`` are real columns but are withheld on
 # purpose: their stored format makes a pushed comparison silently wrong — see
 # the datetime hazard in ``_documents_compile_context``'s docstring below.
-_BACKED_SYSTEM_KEYS: frozenset[str] = frozenset(
+_PUSHABLE_SYSTEM_KEYS: frozenset[str] = frozenset(
     {
         "source_type",
         "source_name",
@@ -1160,7 +1160,7 @@ def _documents_compile_context() -> CompileContext:
     was free and dropping them would only have understated the mapping. Now that
     the key set is honoured as a whitelist, declaring them would *keep* pushing
     the broken comparison above; leaving them out routes both to the post-filter.
-    Re-adding either key to ``_BACKED_SYSTEM_KEYS`` re-opens the silent
+    Re-adding either key to ``_PUSHABLE_SYSTEM_KEYS`` re-opens the silent
     wrong-rows defect, and the compiler cannot catch that for you — the mapping
     is the only place the constraint lives.
 
@@ -1177,7 +1177,7 @@ def _documents_compile_context() -> CompileContext:
     it names; that keeps caller correctness independent of how precisely the
     compiler tracks partial pushdown.
     """
-    field_mapping = {key: key for key in _BACKED_SYSTEM_KEYS} | {"metadata": "metadata"}
+    field_mapping = {key: key for key in _PUSHABLE_SYSTEM_KEYS} | {"metadata": "metadata"}
     return CompileContext(
         backend_target="documents",
         field_mapping=field_mapping,

--- a/src/khora/storage/backends/sqlite_lance/relational.py
+++ b/src/khora/storage/backends/sqlite_lance/relational.py
@@ -1088,17 +1088,16 @@ from khora.filter import CompileContext, CompilerRegistry, SchemaCapabilities  #
 from khora.filter.compilers.lance import compile_lance  # noqa: E402
 from khora.storage.backends._sqlite_capabilities import sqlite_has_json1  # noqa: E402
 
-# The system keys this table backs with a real column — the single source of
-# truth for the documents tier. Nine of the ten ``SYSTEM_KEYS``; ``occurred_at``
-# is a recall-chunk column and has no ``documents`` counterpart (this adapter
-# reuses ``DocumentModel`` from ``khora/db/models.py``).
-# NOTE: ``created_at`` and ``source_timestamp`` are declared here but their
-# pushdown is NOT sound on this store — see the datetime hazard and the
-# forward-coupling alarm in ``_documents_compile_context``'s docstring below.
+# The system keys this table backs with a real column AND can push down soundly
+# — the single source of truth for the documents tier, and the pushdown
+# whitelist the compiler enforces. Seven of the ten ``SYSTEM_KEYS``.
+# ``occurred_at`` is a recall-chunk column and has no ``documents`` counterpart
+# (this adapter reuses ``DocumentModel`` from ``khora/db/models.py``).
+# ``created_at`` and ``source_timestamp`` are real columns but are withheld on
+# purpose: their stored format makes a pushed comparison silently wrong — see
+# the datetime hazard in ``_documents_compile_context``'s docstring below.
 _BACKED_SYSTEM_KEYS: frozenset[str] = frozenset(
     {
-        "created_at",
-        "source_timestamp",
         "source_type",
         "source_name",
         "source_url",
@@ -1113,26 +1112,29 @@ _BACKED_SYSTEM_KEYS: frozenset[str] = frozenset(
 def _documents_compile_context() -> CompileContext:
     """Build the recall-filter :class:`CompileContext` for the ``documents`` table.
 
-    ``field_mapping`` declares the nine backed system keys (identity-mapped to
-    their own columns) plus the ``metadata`` root remap to the physical
-    ``metadata`` column — this adapter reuses ``DocumentModel``, which maps the
-    ``metadata_`` attribute to a column literally named ``metadata`` (the raw
-    SQLite backend's own DDL differs here). ``on_unsupported="split"`` because a
-    document enumeration always has an in-memory post-filter available, so an
-    unpushable leaf is left unconsumed rather than raising.
+    ``field_mapping`` declares the seven system keys this table both backs and
+    can push down soundly (identity-mapped to their own columns) plus the
+    ``metadata`` root remap to the physical ``metadata`` column — this adapter
+    reuses ``DocumentModel``, which maps the ``metadata_`` attribute to a column
+    literally named ``metadata`` (the raw SQLite backend's own DDL differs here).
+    ``on_unsupported="split"`` because a document enumeration always has an
+    in-memory post-filter available, so an unpushable leaf is left unconsumed
+    rather than raising.
 
-    ``occurred_at`` is deliberately absent: no ``documents`` row backs it.
-    ``compile_lance`` does not treat the ``field_mapping`` key set as a pushdown
-    whitelist (``_col`` falls back to identity), so this context alone cannot
-    stop an ``occurred_at`` leaf from compiling to a non-existent column. Worse
-    than the resulting error: the leaf is also reported in
-    ``CompiledFilter.consumed_keys``, so the caller is told it was pushed down
-    and will not post-filter it. The caller must reject or strip the key before
-    compiling.
+    **The declared key set IS the pushdown whitelist.** ``compile_lance`` treats
+    a system key this mapping does not declare as unpushable: the leaf emits the
+    match-all placeholder, is kept out of ``CompiledFilter.consumed_keys``, and
+    reaches the caller's post-filter. Three of the ten system keys are withheld,
+    each for its own reason — the omissions are load-bearing, not oversights.
 
-    **Datetime binds on this table are not safe to push down.** The ``documents``
-    rows are written through SQLAlchemy's SQLite ``DATETIME`` type, which stores
-    ``'2026-01-31 12:30:00.000000'`` — a SPACE separator and no UTC offset.
+    ``occurred_at`` is withheld because no ``documents`` row backs it: pushing it
+    would compile a predicate against a column that does not exist.
+
+    ``created_at`` and ``source_timestamp`` are withheld even though both are
+    real columns, because **datetime binds on this table are not safe to push
+    down.** The ``documents`` rows are written through SQLAlchemy's SQLite
+    ``DATETIME`` type, which stores ``'2026-01-31 12:30:00.000000'`` — a SPACE
+    separator and no UTC offset.
     ``compile_lance`` binds a datetime operand as ``value.isoformat()`` (``'T'``
     separator, offset included) and relies on lexicographic ISO comparison, so
     the two forms do not line up: ``' '`` (0x20) sorts before ``'T'`` (0x54).
@@ -1153,16 +1155,27 @@ def _documents_compile_context() -> CompileContext:
     full-namespace scan that implies — an intentional trade, since silently
     wrong rows are worse than slow ones.
 
-    **When the pushdown whitelist gate lands, drop ``created_at`` and
-    ``source_timestamp`` from ``_BACKED_SYSTEM_KEYS`` above.** They are declared
-    today only because ``compile_lance`` ignores the key set — every logical key
-    falls through to identity, so declaring them changes nothing and removing
-    them would make the mapping understate what it declares. Once the compiler
-    honours the key set as a pushdown whitelist, leaving them declared *keeps*
-    pushing the broken comparison described above; removing them routes both
-    keys to the caller's post-filter instead. The test signal for that edit is
-    INVERTED — forgetting the drop leaves both keys consumed and every test
-    green, while remembering it forces a test update — so this note is the alarm.
+    **Withholding the two keys is what enforces that remedy.** While the
+    compiler still fell back to identity for an undeclared key, declaring them
+    was free and dropping them would only have understated the mapping. Now that
+    the key set is honoured as a whitelist, declaring them would *keep* pushing
+    the broken comparison above; leaving them out routes both to the post-filter.
+    Re-adding either key to ``_BACKED_SYSTEM_KEYS`` re-opens the silent
+    wrong-rows defect, and the compiler cannot catch that for you — the mapping
+    is the only place the constraint lives.
+
+    **The enumeration post-filter must evaluate the FULL filter AST
+    unconditionally.** Everything the compiler pushes is a superset filter, but
+    only because of two specific properties — it is not a free-standing
+    guarantee. The all-or-nothing ``$or`` / ``$not`` gate defers a whole subtree
+    it cannot fully express, rather than leaving a match-all placeholder inside
+    it that would invert under negation and wrongly EXCLUDE rows; and keys whose
+    stored format does not order against this compiler's binds are kept out of
+    the declared mapping entirely, per the paragraphs above. Given both,
+    re-running every leaf in memory can only narrow. Treat ``consumed_keys`` as a
+    reporting and overfetch-sizing signal, not as permission to skip the leaves
+    it names; that keeps caller correctness independent of how precisely the
+    compiler tracks partial pushdown.
     """
     field_mapping = {key: key for key in _BACKED_SYSTEM_KEYS} | {"metadata": "metadata"}
     return CompileContext(

--- a/src/khora/storage/backends/surrealdb/relational.py
+++ b/src/khora/storage/backends/surrealdb/relational.py
@@ -1167,40 +1167,40 @@ def _documents_compile_context() -> CompileContext:
 
     ``field_mapping`` declares the nine backed system keys (identity-mapped to
     their bare fields) plus the ``metadata`` root remap to the physical
-    ``metadata_`` field.
-
-    **``on_unsupported="raise"`` is an interim posture, not the end state.** The
-    enumeration contract specifies split semantics — an unpushable leaf is left
-    unconsumed for the caller's post-filter rather than raising — and this
-    context will use ``"split"`` once the compiler is sound under it. It is not
-    sound today, for the reason below, and the staged raise-then-split rollout
-    is explicitly permitted: raising is a strictly narrower behaviour that a
-    later loosening can widen without breaking a caller. Nothing consumes this
-    context yet, so the interim posture costs nothing and removes both live
-    hazards. The soundness gate flips it back.
+    ``metadata_`` field. ``on_unsupported="split"`` per the enumeration
+    contract: a document enumeration always has an in-memory post-filter
+    available, so an unpushable leaf is left unconsumed rather than raising.
 
     ``occurred_at`` is deliberately absent: no ``document`` row backs it.
     ``compile_surrealdb`` treats the ``field_mapping`` key set as the backend's
     declared+pushable whitelist, so an undeclared system key never emits a
-    predicate against a missing field — the only documents backend where the
-    omission has that effect. Under ``"raise"`` such a leaf now surfaces as a
-    :class:`~khora.filter.model.RecallFilterUnsupportedError` instead of being
-    silently absorbed.
+    predicate against a missing field. Under ``"split"`` such a leaf emits the
+    match-all placeholder, stays out of ``CompiledFilter.consumed_keys``, and
+    reaches the caller's post-filter.
 
-    **Why ``"split"`` is unsafe here until the gate lands.**
-    ``compile_surrealdb`` has no all-or-nothing split gate (the one
-    ``compile_lance`` documents at ``_consumable``), so under ``"split"`` an
-    undeclared leaf emits the literal ``true`` in place, whatever its position
-    in the tree. That is harmless in positive position (``A AND true`` is
-    ``A``) but not under ``$not`` / ``$or``: a filter such as
-    ``{"$not": {"$or": [{"title": "x"}, {"occurred_at": {"$gt": ...}}]}}``
-    compiles to ``!((((title = $f_0)) OR (true)))``, which is ``!true`` — it
-    matches ZERO rows, silently, while ``consumed_keys`` reports ``occurred_at``
-    as still needing a post-filter that can only narrow further. The
-    known-gap test pins this against an explicitly split-mode copy of this
-    context, so the defect stays documented while the shipped context avoids it.
+    That whitelist matters more here than on the SQL backends. Were such a
+    predicate emitted, SQL would ERROR on a column that does not exist — loud,
+    and impossible to mistake for a result — whereas on the SCHEMAFULL
+    ``document`` table a missing field reads ``NONE`` and SurrealQL's
+    total-false absent-compare would return an empty result set that looks
+    exactly like a legitimate no-match. ``compile_surrealdb`` is correspondingly
+    stricter about what counts as declared; see its own gate for the difference.
 
-    **A third gap survives both modes.** ``compile_surrealdb`` raises the
+    **``"split"`` is sound here only because of the all-or-nothing gate.** The
+    ``true`` placeholder an unpushable leaf emits is superset-safe in positive
+    position (``A AND true`` is ``A``) but inverts under ``$not`` / ``$or``:
+    ``{"$not": {"$or": [{"title": "x"}, {"occurred_at": {"$gt": ...}}]}}`` would
+    compile to ``!((((title = $f_0)) OR (true)))`` — ``!true``, matching ZERO
+    rows silently, while ``consumed_keys`` reported ``title`` as pushed and left
+    the caller a post-filter that can only narrow further. ``compile_surrealdb``
+    therefore pushes an ``OR`` / ``NOT`` node only when its ENTIRE subtree is
+    pushable; otherwise the whole node defers to the post-filter, consuming
+    nothing. The filter above now compiles to a bare ``true`` with empty
+    ``consumed_keys``. This context's ``"split"`` posture depends on that gate:
+    relaxing it re-opens the zero-row defect above.
+    ``tests/unit/filter/test_documents_compile_contexts.py`` pins the behaviour.
+
+    **A separate gap survives both modes.** ``compile_surrealdb`` raises the
     internal ``CompileError`` on an unsafe (non-identifier) metadata path
     segment — a hyphenated key such as ``metadata.due-date`` is legal JSON and
     common in the wild — and it does so regardless of ``on_unsupported``, since
@@ -1209,6 +1209,26 @@ def _documents_compile_context() -> CompileContext:
     the documents scan path is obliged to catch it and re-raise it as
     ``RecallFilterUnsupportedError`` so it surfaces as a structured rejection.
     That mapping belongs to the scan path and cannot be implemented from here.
+    The cleaner long-term remedy is compiler-side and deliberately not done in
+    this change: under ``"split"``, "I cannot render this segment as a SurrealQL
+    identifier" is a capability gap, not an internal fault, so the leaf belongs
+    on the unsupported path (placeholder, unconsumed, post-filtered) with
+    ``CompileError`` reserved for ``"raise"``. That has to move the emit path and
+    the gate predicate together — changing only one would make them disagree —
+    which is why it is a follow-up rather than a line here.
+
+    **The enumeration post-filter must evaluate the FULL filter AST
+    unconditionally.** Everything the compiler pushes is a superset filter, but
+    only because of two specific properties — it is not a free-standing
+    guarantee. The all-or-nothing gate above defers a whole subtree it cannot
+    fully express, rather than leaving a ``true`` placeholder inside it that
+    would invert under negation and wrongly EXCLUDE rows; and an undeclared
+    system key defers its own leaf rather than compiling to a ``NONE`` compare
+    that would drop every row. Given both, re-running every leaf in memory can
+    only narrow. Treat ``consumed_keys`` as a reporting and
+    overfetch-sizing signal, not as permission to skip the leaves it names; that
+    keeps caller correctness independent of how precisely the compiler tracks
+    partial pushdown.
 
     ``backend_target`` is the SINGULAR ``document``, the real physical table name
     (``surrealdb/schema.py``), not the plural registry key. ``compile_surrealdb``
@@ -1220,13 +1240,11 @@ def _documents_compile_context() -> CompileContext:
     return CompileContext(
         backend_target="document",
         field_mapping=field_mapping,
-        # Interim posture — see the docstring. The contract specifies "split";
-        # this compiler is not sound under it (an unsupported leaf emits a bare
-        # ``true`` that inverts under ``$not``/``$or``), and the staged
-        # raise-then-split rollout is permitted precisely so a context can ship
-        # narrow and widen later. Flip back to "split" with the compiler
-        # soundness gate.
-        on_unsupported="raise",
+        # The enumeration contract's mode. Safe only because ``compile_surrealdb``
+        # keeps an ``OR`` / ``NOT`` node all-or-nothing — see the docstring; a bare
+        # ``true`` placeholder inside a negated subtree would otherwise match zero
+        # rows silently.
+        on_unsupported="split",
     )
 
 

--- a/src/khora/storage/temporal/sqlite_lance.py
+++ b/src/khora/storage/temporal/sqlite_lance.py
@@ -485,13 +485,13 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         # flag can never be added to one path and silently missed by the other — the
         # report can't drift from the executed WHERE. consumed_keys is
         # alias-independent (``_clause_unconsumable`` reads only clause.path /
-        # SYSTEM_KEYS / sqlite_json1 / operand shape, never table_alias) and
-        # compile_lance is deterministic, so this alias=None compile reports the same
-        # keys the per-pass alias="c"/None WHERE compiles emit. NO-DEMOTE: a consumed
-        # leaf stays in pushed_keys even though the always-on compile_python
-        # post-filter re-checks the full AST (defensive_recheck=True). The plan is
-        # handed back per-call via ``filter_plan_out`` (no mutable instance state —
-        # race-free under concurrent recalls on a shared store).
+        # SYSTEM_KEYS / sqlite_json1 / field_mapping / operand shape, never
+        # table_alias) and compile_lance is deterministic, so this alias=None compile
+        # reports the same keys the per-pass alias="c"/None WHERE compiles emit.
+        # NO-DEMOTE: a consumed leaf stays in pushed_keys even though the always-on
+        # compile_python post-filter re-checks the full AST (defensive_recheck=True).
+        # The plan is handed back per-call via ``filter_plan_out`` (no mutable
+        # instance state — race-free under concurrent recalls on a shared store).
         if filter_ast is not None and filter_ast.children:
             from khora.filter.compilers.lance import compile_lance
             from khora.filter.execute import filter_leaf_keys

--- a/tests/recall/test_compile_chronicle.py
+++ b/tests/recall/test_compile_chronicle.py
@@ -354,4 +354,4 @@ def test_carries_canonical_hash() -> None:
 
     node = _ast({_PUSHED_KEY: {"$gte": _LB}})
     compiled = compile_chronicle(node, _CTX)
-    assert compiled.canonical_hash == canonical_hash(node)
+    assert compiled.consumed_slice_hash == canonical_hash(node)

--- a/tests/recall/test_compile_python.py
+++ b/tests/recall/test_compile_python.py
@@ -657,7 +657,7 @@ def test_compiled_filter_carries_canonical_hash() -> None:
 
     node = _ast({"source_name": "linear"})
     compiled = compile_python(node, _CTX)
-    assert compiled.canonical_hash == canonical_hash(node)
+    assert compiled.consumed_slice_hash == canonical_hash(node)
 
 
 # ===========================================================================

--- a/tests/recall/test_compiler_registry.py
+++ b/tests/recall/test_compiler_registry.py
@@ -42,11 +42,11 @@ def _clean_registry() -> None:
 
 
 def _fake_compiler(ast: FilterNode, ctx: CompileContext) -> CompiledFilter:
-    return CompiledFilter(predicate="WHERE 1=1", params={}, consumed_keys=frozenset(), canonical_hash="abc")
+    return CompiledFilter(predicate="WHERE 1=1", params={}, consumed_keys=frozenset(), consumed_slice_hash="abc")
 
 
 def _other_compiler(ast: FilterNode, ctx: CompileContext) -> CompiledFilter:
-    return CompiledFilter(predicate="WHERE 2=2", params={}, consumed_keys=frozenset(), canonical_hash="def")
+    return CompiledFilter(predicate="WHERE 2=2", params={}, consumed_keys=frozenset(), consumed_slice_hash="def")
 
 
 # ---------------------------------------------------------------------------
@@ -234,16 +234,16 @@ def test_compiled_filter_fields() -> None:
         predicate="WHERE x = :f_0",
         params={"f_0": 1},
         consumed_keys=frozenset({"source_name"}),
-        canonical_hash="deadbeef",
+        consumed_slice_hash="deadbeef",
     )
     assert cf.predicate == "WHERE x = :f_0"
     assert cf.params == {"f_0": 1}
     assert cf.consumed_keys == frozenset({"source_name"})
-    assert cf.canonical_hash == "deadbeef"
+    assert cf.consumed_slice_hash == "deadbeef"
 
 
 def test_compiled_filter_is_frozen() -> None:
-    cf = CompiledFilter(predicate=1, params={}, consumed_keys=frozenset(), canonical_hash="h")
+    cf = CompiledFilter(predicate=1, params={}, consumed_keys=frozenset(), consumed_slice_hash="h")
     with pytest.raises((AttributeError, TypeError)):
         cf.predicate = 2  # type: ignore[misc]
 
@@ -258,7 +258,7 @@ def test_compiled_filter_predicate_type_is_generic() -> None:
         predicate=_callable_predicate,
         params={},
         consumed_keys=frozenset({"source_name", "title"}),
-        canonical_hash="h",
+        consumed_slice_hash="h",
     )
     assert cf.predicate is _callable_predicate
     assert cf.consumed_keys == frozenset({"source_name", "title"})
@@ -269,7 +269,7 @@ def test_compiled_filter_consumed_keys_is_frozenset() -> None:
         predicate="p",
         params={"f_0": 1},
         consumed_keys=frozenset({"a"}),
-        canonical_hash="h",
+        consumed_slice_hash="h",
     )
     assert isinstance(cf.consumed_keys, frozenset)
 

--- a/tests/unit/filter/test_compile_cypher.py
+++ b/tests/unit/filter/test_compile_cypher.py
@@ -598,7 +598,7 @@ def test_compiled_filter_carries_canonical_hash() -> None:
     compiled = compile_cypher(node, _CTX)
     from khora.filter.ast import canonical_hash
 
-    assert compiled.canonical_hash == canonical_hash(node)
+    assert compiled.consumed_slice_hash == canonical_hash(node)
 
 
 def test_compiled_filter_consumed_keys_is_frozenset() -> None:

--- a/tests/unit/filter/test_compile_lance.py
+++ b/tests/unit/filter/test_compile_lance.py
@@ -574,7 +574,7 @@ def test_compiled_filter_carries_canonical_hash() -> None:
 
     node = _ast({"source_name": "linear"})
     compiled = compile_lance(node, _CTX)
-    assert compiled.canonical_hash == canonical_hash(node)
+    assert compiled.consumed_slice_hash == canonical_hash(node)
 
 
 def test_compiled_filter_consumed_keys_is_frozenset() -> None:

--- a/tests/unit/filter/test_compile_postgres.py
+++ b/tests/unit/filter/test_compile_postgres.py
@@ -580,7 +580,7 @@ def test_compiled_filter_carries_canonical_hash() -> None:
     compiled = compile_postgres(node, _CTX)
     from khora.filter.ast import canonical_hash
 
-    assert compiled.canonical_hash == canonical_hash(node)
+    assert compiled.consumed_slice_hash == canonical_hash(node)
 
 
 def test_compiled_filter_consumed_keys_is_frozenset() -> None:

--- a/tests/unit/filter/test_compile_surrealdb.py
+++ b/tests/unit/filter/test_compile_surrealdb.py
@@ -697,7 +697,7 @@ def test_composition_binds_are_distinct_per_clause() -> None:
 def test_compiled_filter_carries_canonical_hash() -> None:
     node = _ast({"occurred_at": _DT})
     compiled = compile_surrealdb(node, _CTX)
-    assert compiled.canonical_hash == canonical_hash(node)
+    assert compiled.consumed_slice_hash == canonical_hash(node)
 
 
 def test_compiled_filter_consumed_keys_is_frozenset() -> None:

--- a/tests/unit/filter/test_compile_weaviate.py
+++ b/tests/unit/filter/test_compile_weaviate.py
@@ -521,7 +521,7 @@ def test_no_field_mapping_pushes_nothing() -> None:
 def test_compiled_filter_carries_canonical_hash() -> None:
     node = _ast({"occurred_at": "2026-02-03T00:00:00Z"})
     compiled = compile_weaviate(node, _CTX)
-    assert compiled.canonical_hash == canonical_hash(node)
+    assert compiled.consumed_slice_hash == canonical_hash(node)
 
 
 def test_params_always_empty() -> None:

--- a/tests/unit/filter/test_documents_compile_contexts.py
+++ b/tests/unit/filter/test_documents_compile_contexts.py
@@ -52,6 +52,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -60,9 +61,11 @@ from khora.filter import RecallFilter
 from khora.filter.ast import FilterNode, parse_to_ast
 from khora.filter.compilers.lance import compile_lance
 from khora.filter.compilers.postgres import compile_postgres
+from khora.filter.compilers.python import compile_python
 from khora.filter.compilers.surrealdb import compile_surrealdb
 from khora.filter.context import CompileContext, SchemaCapabilities
-from khora.filter.model import SYSTEM_KEYS, RecallFilterUnsupportedError
+from khora.filter.execute import build_compile_context
+from khora.filter.model import SYSTEM_KEYS
 from khora.filter.registry import CompiledFilter
 from khora.storage.backends._sqlite_capabilities import sqlite_has_json1
 from khora.storage.backends.postgresql import _documents_compile_context as postgres_context
@@ -96,6 +99,29 @@ _BACKED_KEYS: frozenset[str] = frozenset(
         "title",
     }
 )
+
+# Backed by a column but deliberately NOT declared, per context. Since the
+# compilers honour a non-``None`` ``field_mapping`` key set as the pushdown
+# whitelist, an omission is now enforced rather than advisory — so "which keys
+# are withheld" is a behavioural claim, not bookkeeping.
+#
+# Both SQLite-backed stores withhold the two date-valued keys: they write
+# timestamps as strings whose format does not order lexicographically against
+# the ISO-8601 bind ``compile_lance`` emits, so a pushed comparison silently
+# returns wrong rows (pinned below, and proved against a real table in
+# :func:`test_sqlite_lance_date_predicate_survives_the_day_boundary`). Postgres
+# and SurrealDB compare real timestamp values and withhold nothing.
+_WITHHELD_KEYS: Mapping[str, frozenset[str]] = {
+    "postgresql": frozenset(),
+    "sqlite": frozenset({"created_at", "source_timestamp"}),
+    "sqlite_lance": frozenset({"created_at", "source_timestamp"}),
+    "surrealdb": frozenset(),
+}
+
+
+def _declared_keys(name: str) -> frozenset[str]:
+    """The system keys ``name``'s context declares — backed minus withheld."""
+    return _BACKED_KEYS - _WITHHELD_KEYS[name]
 
 
 def _ast(wire: dict) -> FilterNode:
@@ -158,17 +184,17 @@ _ALL_CONTEXTS: tuple[tuple[str, Callable[[], CompileContext], str, str], ...] = 
     ("surrealdb", surrealdb_context, "document", "metadata_"),
 )
 
-# The enumeration contract specifies ``"split"`` everywhere. The SurrealDB
-# context ships ``"raise"`` as an interim posture because ``compile_surrealdb``
-# is not sound under split — its unsupported-leaf placeholder inverts under
-# ``$not``/``$or`` (pinned in the known-gap section below). Raising is strictly
-# narrower, so widening it back to ``"split"`` with the compiler soundness gate
-# is not a breaking change for a caller.
+# The enumeration contract specifies ``"split"`` everywhere, and every context
+# now ships it. SurrealDB previously shipped ``"raise"`` as an interim posture,
+# because ``compile_surrealdb``'s unsupported-leaf placeholder inverted under
+# ``$not``/``$or``; the all-or-nothing gate in
+# :mod:`khora.filter.compilers._split` closed that, so the context is back on
+# ``"split"`` with the rest.
 _EXPECTED_UNSUPPORTED_MODE: Mapping[str, str] = {
     "postgresql": "split",
     "sqlite": "split",
     "sqlite_lance": "split",
-    "surrealdb": "raise",
+    "surrealdb": "split",
 }
 
 # The two ``compile_lance``-driven contexts, which share every behaviour that
@@ -210,12 +236,16 @@ def test_context_declares_the_physical_schema(
 
     mapping = ctx.field_mapping
     assert mapping is not None
-    # Exactly the nine backed system keys plus the ``metadata`` root — the
+    # Exactly the declared system keys plus the ``metadata`` root — the
     # ``metadata`` entry must be present even where it is identity, because
     # ``compile_postgres`` resolves it eagerly.
-    assert set(mapping) == set(_BACKED_KEYS) | {"metadata"}
-    assert all(mapping[key] == key for key in _BACKED_KEYS)
+    declared = _declared_keys(name)
+    assert set(mapping) == set(declared) | {"metadata"}
+    assert all(mapping[key] == key for key in declared)
     assert mapping["metadata"] == metadata_column
+    # The withheld keys are absent — and that omission is what routes them to
+    # the caller's post-filter, since the key set IS the pushdown whitelist.
+    assert not set(mapping) & _WITHHELD_KEYS[name]
 
 
 @pytest.mark.parametrize(
@@ -307,6 +337,34 @@ def test_occurred_at_is_absent_from_every_real_documents_schema(
     # the schemas themselves rather than left as prose: it is chunk event-time
     # and no documents table has a column for it on any backend.
     assert "occurred_at" not in _real_columns(name)
+
+
+@pytest.mark.parametrize(
+    ("name", "builder", "target", "metadata_column"),
+    _ALL_CONTEXTS,
+    ids=[case[0] for case in _ALL_CONTEXTS],
+)
+def test_withheld_keys_are_real_columns_withheld_for_soundness(
+    name: str,
+    builder: Callable[[], CompileContext],
+    target: str,
+    metadata_column: str,
+) -> None:
+    """The withheld keys DO have columns — they are held back, not missing.
+
+    This is what separates the two reasons a key can be undeclared, which the
+    mapping alone cannot distinguish. ``occurred_at`` is undeclared because no
+    ``documents`` table has the column; ``created_at`` / ``source_timestamp`` on
+    the two SQLite stores are undeclared even though the columns exist, because
+    the stored string format does not order against this compiler's binds.
+    Asserting the columns are real is what keeps the second reason from being
+    quietly re-read as the first — and what would fail if someone "fixed" a
+    withheld key by deleting the column instead of the pushdown.
+    """
+    columns = _real_columns(name)
+    assert columns, f"failed to read any columns for {name}"
+    for key in _WITHHELD_KEYS[name]:
+        assert key in columns, f"{name} withholds {key!r}, which is not even a column"
 
 
 def test_only_the_sqlite_contexts_declare_a_capability() -> None:
@@ -724,100 +782,95 @@ def test_context_reads_the_probe_rather_than_hardcoding_it(
 
 
 # ===========================================================================
-# KNOWN GAPS — pinned as they behave today, NOT as they should behave.
+# The undeclared-key defences — each of these INVERTED a pin from the previous
+# revision, where the same shape was recorded as a known gap.
 # ===========================================================================
 
 
 def test_occurred_at_is_defended_on_surrealdb() -> None:
-    """The shipped SurrealDB context REJECTS an undeclared system key.
+    """The shipped SurrealDB context DEFERS an undeclared system key.
 
     ``compile_surrealdb`` treats the ``field_mapping`` key set as its
     declared+pushable whitelist, so the undeclared ``occurred_at`` leaf never
-    reaches the query. Under the shipped ``on_unsupported="raise"`` that surfaces
-    as a structured error rather than a silent placeholder — the interim posture
-    that keeps the inversion below unreachable until the compiler soundness gate
-    lands. This is the one backend where the context alone prevents the bad
-    predicate; the three SQL backends cannot (see the case below).
-
-    When the context flips back to ``"split"``, this expectation changes to the
-    placeholder shape — ``predicate == "(true)"`` with empty ``consumed_keys`` —
-    which is only safe once the compiler defers rather than emitting a
-    match-all in place.
+    reaches the query. This used to surface as a ``RecallFilterUnsupportedError``
+    because the context shipped ``on_unsupported="raise"`` — an interim posture
+    that existed only to keep the placeholder inversion below unreachable. With
+    the all-or-nothing gate in :mod:`khora.filter.compilers._split` closing that,
+    the context is back on ``"split"`` and the leaf takes the ordinary residual
+    path: a match-all placeholder, nothing consumed, the caller's post-filter
+    enforces it.
     """
-    ctx = surrealdb_context()
-    with pytest.raises(RecallFilterUnsupportedError):
-        compile_surrealdb(_ast({"occurred_at": {"$gte": _DT}}), ctx)
+    compiled = compile_surrealdb(_ast({"occurred_at": {"$gte": _DT}}), surrealdb_context())
+    # Non-constraining placeholder, not a predicate against a field the
+    # ``document`` table does not have.
+    assert compiled.predicate.strip() == "(true)"
+    assert compiled.params == {}
+    assert compiled.consumed_keys == frozenset()
+    assert not _emits_column(_norm(compiled.predicate), "occurred_at")
 
 
-def test_occurred_at_is_not_defended_on_sql_backends() -> None:
-    """KNOWN GAP — pins today's behaviour so the caller contract is written down.
+def test_occurred_at_is_defended_on_sql_backends() -> None:
+    """The three SQL contexts defer ``occurred_at`` instead of inventing a column.
 
-    ``compile_postgres`` and ``compile_lance`` fall back to identity for a key
-    that is absent from ``field_mapping``, so an ``occurred_at`` leaf compiles to
-    a column that does not exist on ``documents`` AND is reported in
-    ``consumed_keys`` — the caller is told the leaf was pushed down and will not
-    post-filter it, while the statement itself fails at execute time. Nothing
-    expressible in a compile context prevents this; until the compilers honour
-    the key set as a whitelist, the enumeration caller MUST strip ``occurred_at``
-    before compiling. These assertions encode the gap, not the desired behaviour.
+    Previously ``compile_postgres`` / ``compile_lance`` fell back to identity for
+    a key absent from ``field_mapping``, so this leaf compiled to
+    ``documents.occurred_at`` — a column no ``documents`` table has — AND was
+    reported in ``consumed_keys``, telling the caller it had been pushed while
+    the statement itself would fail at execute time. Both compilers now honour a
+    non-``None`` key set as the pushdown whitelist, so the undeclared key emits
+    the match-all placeholder and stays a residual.
 
-    **This expectation INVERTS when the pushdown whitelist gate lands.**
-    ``consumed_keys`` becomes ``frozenset()`` and no ``documents.occurred_at``
-    column is emitted at all, matching what ``compile_surrealdb`` already does
-    (see the test above) — that is the fix landing, not a regression. Update the
-    assertions; do NOT restore green by declaring ``occurred_at`` in the
-    ``field_mapping``, which would point the leaf at a column no ``documents``
-    table has.
+    Do NOT restore green here by declaring ``occurred_at`` in a ``field_mapping``
+    — that points the leaf back at a column that does not exist.
     """
     wire = {"occurred_at": {"$gte": _DT}}
 
     sql = _postgres_sql(wire, postgres_context())
-    assert _emits_column(sql, "documents.occurred_at")
-    assert compile_postgres(_ast(wire), postgres_context()).consumed_keys == frozenset({"occurred_at"})
+    assert not _emits_column(sql, "documents.occurred_at")
+    assert compile_postgres(_ast(wire), postgres_context()).consumed_keys == frozenset()
 
     for _name, builder, _column in _SQLITE_CONTEXTS:
         compiled = compile_lance(_ast(wire), builder())
-        assert _emits_column(_norm(compiled.predicate), "documents.occurred_at")
-        assert compiled.consumed_keys == frozenset({"occurred_at"})
+        assert not _emits_column(_norm(compiled.predicate), "documents.occurred_at")
+        assert compiled.predicate.strip() == "(1)"
+        assert compiled.consumed_keys == frozenset()
 
 
-def test_surrealdb_placeholder_inverts_under_a_negated_or() -> None:
-    """KNOWN GAP — an undeclared key under ``$not``/``$or`` matches nothing.
+def test_surrealdb_defers_a_negated_or_rather_than_inverting_a_placeholder() -> None:
+    """An undeclared key under ``$not``/``$or`` defers the node, it does not invert.
 
     The placeholder ``compile_surrealdb`` emits for an unsupported leaf is the
     literal ``true``, which is non-constraining only inside a positive
-    conjunction. Under a negated OR it inverts: ``!(... OR true)`` is always
-    false, so the query silently returns no rows while ``consumed_keys`` still
-    reports the leaf as the caller's to post-filter — and post-filtering can only
-    narrow, never recover the dropped rows. Pinned as it behaves today; the fix
-    is a soundness gate in the compiler, not in this context.
+    conjunction. Under a negated OR it used to invert: ``!(... OR true)`` is
+    always false, so the query silently returned NO rows while ``consumed_keys``
+    still reported ``title`` as pushed — and a post-filter only narrows, so the
+    wrongly-excluded rows were unrecoverable. The gate now defers the whole
+    ``$not`` subtree instead, emitting the bare match-all and consuming nothing.
 
-    The SHIPPED context now uses ``on_unsupported="raise"`` precisely to keep
-    this unreachable, so the defect is pinned here against an explicitly
-    split-mode copy of it. That keeps the compiler bug documented and guarded
-    while no caller can trip it — and it is why this case must build its own
-    context rather than using the shipped one.
-
-    **This expectation INVERTS when that soundness gate lands.** A gated
-    ``compile_surrealdb`` defers the whole ``OR`` node rather than letting a
-    match-all placeholder invert, so ``or (true)`` disappears from the emitted
-    predicate and ``title`` stops being consumed — that is the fix landing, not a
-    regression. Update the assertions to the deferred shape; do NOT restore green
-    by relaxing them back to accepting an inverted placeholder.
+    Run against the SHIPPED context, not a split-mode copy of it. The previous
+    revision had to build its own context because the shipped one was
+    ``"raise"``; asserting against the real one is what makes this the alarm for
+    a future ``"split"`` flip landing without the gate.
     """
-    split_ctx = dataclasses.replace(surrealdb_context(), on_unsupported="split")
     compiled = compile_surrealdb(
         _ast({"$not": {"$or": [{"title": "x"}, {"occurred_at": {"$gt": _DT}}]}}),
-        split_ctx,
+        surrealdb_context(),
     )
     sql = _norm(compiled.predicate)
-    assert sql.startswith("!(")
-    assert "or (true)" in sql
-    assert compiled.consumed_keys == frozenset({"title"})
+    # The whole negation is deferred: the bare placeholder, with no negation and
+    # no inverted disjunct left in the fragment at all.
+    assert sql.strip() == "true"
+    assert "!(" not in sql
+    assert "or" not in sql
+    assert compiled.params == {}
+    # ``title`` IS declared and would push on its own — it is unconsumed here
+    # only because the gate deferred the subtree containing it.
+    assert compiled.consumed_keys == frozenset()
+    assert compile_surrealdb(_ast({"title": "x"}), surrealdb_context()).consumed_keys == frozenset({"title"})
 
 
 def test_sqlite_lance_datetime_bind_does_not_match_the_stored_format() -> None:
-    """KNOWN GAP — the pushed-down bind format differs from the stored format.
+    """The date-valued keys are withheld, so the mismatched bind never ships.
 
     ``documents`` rows on this stack are written through SQLAlchemy's SQLite
     ``DATETIME`` type, which stores ``'2026-01-31 12:30:00.000000'`` (SPACE
@@ -825,22 +878,256 @@ def test_sqlite_lance_datetime_bind_does_not_match_the_stored_format() -> None:
     ``.isoformat()`` (``'T'`` separator, offset included) and relies on
     lexicographic ISO comparison. ``' '`` (0x20) sorts before ``'T'`` (0x54), so a
     pushed-down ``created_at`` / ``source_timestamp`` bound silently excludes rows
-    from its own day. The bind value is pinned here so the mismatch is visible in
-    a test rather than only in a docstring; the caller must strip the date-valued
-    system keys until the bind format is fixed upstream.
+    from its own day.
 
-    **This expectation INVERTS when the pushdown whitelist gate lands.**
-    ``consumed_keys`` becomes ``frozenset()`` once ``compile_lance`` honours the
-    ``field_mapping`` key set and the two date keys are dropped from the
-    sqlite_lance mapping — that is the fix landing, not a regression. Update the
-    assertion; do NOT restore green by re-declaring ``created_at`` in the
-    mapping, which would reinstate the silent mismatch this test documents.
+    The previous revision pinned ``consumed_keys == {"created_at"}`` here,
+    because the mapping declared the key and ``compile_lance`` ignored the key
+    set anyway. Dropping the two date keys from ``_BACKED_SYSTEM_KEYS`` is what
+    makes that assertion fail, and the inverted assertion below — the key is a
+    RESIDUAL — is the standing guard that the drop stays dropped. Do NOT restore
+    green by re-declaring ``created_at``: that reinstates the silent mismatch.
+
+    The second half compiles the same leaf through a context that DOES declare
+    the key, so the defective bind is still visible in a test rather than only in
+    a docstring. That is what keeps the withholding legible as load-bearing —
+    without it, nothing here shows what re-declaring the key would cost.
     """
     compiled = compile_lance(_ast({"created_at": {"$gte": _DT}}), sqlite_lance_context())
-    assert compiled.params == {"args": ["2026-01-31T12:30:00+00:00"]}
+    assert compiled.consumed_keys == frozenset()
+    assert compiled.predicate.strip() == "(1)"
+    assert compiled.params == {"args": []}
+    assert not _emits_column(_norm(compiled.predicate), "documents.created_at")
+
+    # What re-declaring the key would emit: the ``'T'``-separated, offset-bearing
+    # bind that does not compare against the stored ``' '``-separated form.
+    ctx = sqlite_lance_context()
+    redeclared = dataclasses.replace(ctx, field_mapping=dict(ctx.field_mapping or {}) | {"created_at": "created_at"})
+    pushed = compile_lance(_ast({"created_at": {"$gte": _DT}}), redeclared)
+    assert pushed.consumed_keys == frozenset({"created_at"})
+    assert pushed.params == {"args": ["2026-01-31T12:30:00+00:00"]}
     # Stored form for the same instant, which the bind above does NOT equal.
-    assert "2026-01-31 12:30:00.000000" != compiled.params["args"][0]
-    assert compiled.consumed_keys == frozenset({"created_at"})
+    assert "2026-01-31 12:30:00.000000" != pushed.params["args"][0]
+
+
+def test_sqlite_lance_date_predicate_survives_the_day_boundary() -> None:
+    """A same-day row survives a ``$gte`` on midnight — against a REAL table.
+
+    The end-to-end form of the mismatch above, which is the only form that shows
+    the consequence rather than the bind string. A row written at 09:00 on the
+    filter's own day is materialized through the SAME SQLAlchemy column type the
+    ``documents`` model declares, so the stored spelling is authentic rather than
+    restated here; then the compiled fragment is executed as the ``WHERE`` clause
+    it would be in production.
+
+    The CONTROL is what makes this a proof: compiled through a context that
+    re-declares ``created_at`` — i.e. the mapping as it shipped before the two
+    date keys were withheld — the very same row is EXCLUDED, because
+    ``'2026-08-04 09:00:00.000000' >= '2026-08-04T00:00:00+00:00'`` is false
+    lexicographically (``' '`` 0x20 sorts before ``'T'`` 0x54). Under the shipped
+    mapping the leaf is not pushed at all, the row reaches the caller, and the
+    full-AST post-filter keeps it.
+
+    Deliberately not a lancedb test: only the relational half is in play, so this
+    stays a hermetic in-memory SQLite case with no optional extra required.
+    """
+    row_at = datetime(2026, 8, 4, 9, 0, tzinfo=UTC)
+    # A two-column stand-in, but ``created_at`` carries the model's OWN type
+    # object — the stored format is decided by that type plus the SQLite
+    # dialect, so reusing it is what keeps this faithful. Building the full
+    # ``DocumentModel`` table is not possible here: its ``JSONB`` columns have no
+    # SQLite DDL rendering outside the migration chain, and none of them matter
+    # to a datetime comparison.
+    metadata = sa.MetaData()
+    documents = sa.Table(
+        "documents",
+        metadata,
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("created_at", DocumentModel.__table__.c.created_at.type, nullable=False),
+    )
+    engine = sa.create_engine("sqlite://")
+    try:
+        metadata.create_all(engine)
+        with engine.begin() as conn:
+            conn.execute(sa.insert(documents).values(id="doc-1", created_at=row_at))
+            stored = conn.exec_driver_sql("SELECT created_at FROM documents").scalar_one()
+        # The stored spelling, read back from the table rather than asserted from
+        # memory: space-separated, no offset.
+        assert stored == "2026-08-04 09:00:00.000000"
+
+        ast = _ast({"created_at": {"$gte": "2026-08-04T00:00:00+00:00"}})
+
+        def _survivors(ctx: CompileContext) -> list[str]:
+            compiled = compile_lance(ast, ctx)
+            with engine.begin() as conn:
+                rows = conn.exec_driver_sql(
+                    f"SELECT id FROM documents WHERE {compiled.predicate}",  # noqa: S608 - compiled fragment, binds are parameterized
+                    tuple(compiled.params["args"]),
+                ).fetchall()
+            return [row[0] for row in rows]
+
+        ctx = sqlite_lance_context()
+        # SHIPPED: the leaf is withheld, so the prefilter does not narrow and the
+        # row reaches the caller.
+        assert _survivors(ctx) == ["doc-1"]
+
+        # CONTROL: re-declare the key and the same row disappears — the defect
+        # this withholding exists to prevent, executed rather than described.
+        redeclared = dataclasses.replace(
+            ctx, field_mapping=dict(ctx.field_mapping or {}) | {"created_at": "created_at"}
+        )
+        assert _survivors(redeclared) == []
+    finally:
+        engine.dispose()
+
+    # The caller's post-filter evaluates the FULL AST and keeps the row, so the
+    # shipped path returns it — correct rows across the day boundary.
+    post_filter = compile_python(ast, build_compile_context("documents", on_unsupported="split")).predicate
+    assert post_filter({"id": "doc-1", "created_at": row_at}) is True
+
+
+# ===========================================================================
+# Split-mode soundness — the all-or-nothing OR/NOT gate, per documents context.
+# ===========================================================================
+
+
+# The unconsumable leaf every documents context agrees on: ``occurred_at`` is a
+# system key (so it reaches a compiler as an AST leaf) that no documents mapping
+# declares. Using one shape across all four keeps the gate the only variable.
+_UNDECLARED_LEAF: dict = {"occurred_at": {"$gt": _DT}}
+
+# ``(compiler, context builder, the match-all placeholder that compiler emits)``.
+_SPLIT_TARGETS: tuple[tuple[str, Callable, Callable[[], CompileContext], str], ...] = (
+    ("postgresql", compile_postgres, postgres_context, "true"),
+    ("sqlite", compile_lance, sqlite_context, "1"),
+    ("sqlite_lance", compile_lance, sqlite_lance_context, "1"),
+    ("surrealdb", compile_surrealdb, surrealdb_context, "true"),
+)
+
+
+def _rendered(name: str, compiled: CompiledFilter[Any]) -> str:
+    """The emitted fragment as a string, rendering SQLAlchemy elements inline.
+
+    ``literal_binds`` matters here rather than being cosmetic: SQLAlchemy folds
+    ``or_(x, true())`` down to ``true`` during compilation, so whether the gate
+    fired is only observable AFTER rendering. Reading ``str(element)`` would show
+    an un-short-circuited tree and hide it.
+    """
+    if name == "postgresql":
+        predicate = compiled.predicate
+        assert isinstance(predicate, ColumnElement), f"not a SQLAlchemy element: {type(predicate)!r}"
+        return _norm(str(predicate.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})))
+    return _norm(compiled.predicate)
+
+
+@pytest.mark.parametrize(
+    ("name", "compiler", "builder", "placeholder"),
+    _SPLIT_TARGETS,
+    ids=[case[0] for case in _SPLIT_TARGETS],
+)
+def test_negated_or_defers_whole_rather_than_inverting(
+    name: str,
+    compiler: Callable,
+    builder: Callable[[], CompileContext],
+    placeholder: str,
+) -> None:
+    """``$not`` over an ``$or`` holding an undeclared key defers the WHOLE node.
+
+    The soundness property behind every documents context, stated per compiler.
+    A match-all placeholder is superset-safe only in positive position: under a
+    negation it inverts to match-NOTHING, which empties the result set — and a
+    post-filter only narrows, so those rows are unrecoverable. The gate therefore
+    refuses to push an ``$or`` / ``$not`` unless its entire subtree is
+    consumable.
+
+    The assertion is on the RENDERED fragment: it must be the bare match-all, not
+    a negation and not a ``false``. ``title`` is declared on every documents
+    mapping and pushes on its own, so its absence from ``consumed_keys`` here is
+    the gate deferring the subtree — not the key being unsupported.
+    """
+    ctx = builder()
+    assert ctx.on_unsupported == "split", "this case only means anything under split"
+
+    compiled = compiler(_ast({"$not": {"$or": [{"title": "x"}, _UNDECLARED_LEAF]}}), ctx)
+    sql = _rendered(name, compiled)
+
+    # The bare match-all placeholder — the whole negation deferred.
+    assert sql.strip() == placeholder
+    # Nothing that could empty the result set survived into the fragment.
+    assert "not" not in sql
+    assert "!(" not in sql
+    assert " or " not in sql
+    assert "false" not in sql
+    assert "0" not in sql.replace(placeholder, "")
+    assert compiled.consumed_keys == frozenset()
+
+    # CONTROL — ``title`` alone DOES push here, so the empty ``consumed_keys``
+    # above is the gate firing rather than a uniformly unsupported leaf.
+    assert compiler(_ast({"title": "x"}), ctx).consumed_keys == frozenset({"title"})
+
+
+@pytest.mark.parametrize(
+    ("name", "compiler", "builder", "placeholder"),
+    _SPLIT_TARGETS,
+    ids=[case[0] for case in _SPLIT_TARGETS],
+)
+def test_key_in_both_a_pushed_leaf_and_a_deferred_subtree_is_not_consumed(
+    name: str,
+    compiler: Callable,
+    builder: Callable[[], CompileContext],
+    placeholder: str,
+) -> None:
+    """A path pushed in one branch and deferred in another is NOT reported consumed.
+
+    ``consumed_keys`` is a set of dotted paths, but a path can occur many times
+    in one AST. Here the same key sits in a conjunctive leaf that IS pushed and
+    again inside a ``$not`` the gate defers wholesale. Reporting it consumed
+    would tell a caller differencing ``leaf_keys - consumed_keys`` that the
+    deferred occurrence is already enforced, so it would never be post-filtered
+    and the query would return rows the filter excludes.
+
+    Both halves of the emitted fragment are asserted, because the interesting
+    failure is not "nothing was pushed": the conjunctive leaf SHOULD still push
+    (that is the pushdown being preserved) while the key is still reported as a
+    residual. A test that only checked ``consumed_keys`` would pass against a
+    compiler that had simply stopped pushing anything.
+    """
+    ctx = builder()
+    key, pushed_leaf, deferred_leaf = _repeated_key_case(name)
+
+    compiled = compiler(
+        _ast({"$and": [pushed_leaf, {"$not": {"$or": [deferred_leaf, _UNDECLARED_LEAF]}}]}),
+        ctx,
+    )
+    sql = _rendered(name, compiled)
+
+    # The conjunctive occurrence still pushed — pushdown is preserved.
+    assert key in sql, f"expected the conjunctive {key!r} leaf to still push: {sql}"
+    # ...and the key is nonetheless a residual, because its other occurrence was
+    # deferred with the ``$not``.
+    assert key not in compiled.consumed_keys
+    assert compiled.consumed_keys == frozenset()
+
+    # CONTROL — the same key with only the conjunctive occurrence IS consumed,
+    # so the exclusion above is per-occurrence accounting and not the key being
+    # unpushable on this context.
+    assert compiler(_ast(pushed_leaf), ctx).consumed_keys == frozenset({key})
+
+
+def _repeated_key_case(name: str) -> tuple[str, dict, dict]:
+    """A declared key plus two leaves on it, for the repeated-path case above.
+
+    The key has to be one the context actually declares, or the case degenerates
+    to "nothing was pushed" and proves nothing. The two SQLite contexts withhold
+    both date-valued keys, so they use a string key and equality leaves instead
+    of a range.
+    """
+    if name in {"sqlite", "sqlite_lance"}:
+        return "source_type", {"source_type": "email"}, {"source_type": "web"}
+    return (
+        "created_at",
+        {"created_at": {"$gte": "2026-01-01T00:00:00+00:00"}},
+        {"created_at": {"$lt": "2026-02-01T00:00:00+00:00"}},
+    )
 
 
 # ===========================================================================

--- a/tests/unit/filter/test_documents_compile_contexts.py
+++ b/tests/unit/filter/test_documents_compile_contexts.py
@@ -84,7 +84,7 @@ pytestmark = pytest.mark.unit
 _DT = datetime(2026, 1, 31, 12, 30, tzinfo=UTC)
 
 # The nine system keys a ``documents`` row backs with a real column, restated
-# here independently of the store modules' own ``_BACKED_SYSTEM_KEYS`` — a test
+# here independently of the store modules' own ``_PUSHABLE_SYSTEM_KEYS`` — a test
 # that imported the constant under test would assert nothing.
 _BACKED_KEYS: frozenset[str] = frozenset(
     {
@@ -882,7 +882,7 @@ def test_sqlite_lance_datetime_bind_does_not_match_the_stored_format() -> None:
 
     The previous revision pinned ``consumed_keys == {"created_at"}`` here,
     because the mapping declared the key and ``compile_lance`` ignored the key
-    set anyway. Dropping the two date keys from ``_BACKED_SYSTEM_KEYS`` is what
+    set anyway. Dropping the two date keys from ``_PUSHABLE_SYSTEM_KEYS`` is what
     makes that assertion fail, and the inverted assertion below — the key is a
     RESIDUAL — is the standing guard that the drop stays dropped. Do NOT restore
     green by re-declaring ``created_at``: that reinstates the silent mismatch.

--- a/tests/unit/filter/test_report.py
+++ b/tests/unit/filter/test_report.py
@@ -445,7 +445,14 @@ def test_model_json_schema_snapshot() -> None:
                     "One entry per retrieval channel that saw the filter. The two lists name the\n"
                     'dotted constraint-leaf keys (``".".join(clause.path)``) that this channel\'s\n'
                     "compiler pushed into its backend query versus the ones it re-checked in\n"
-                    "memory. Both lists are sorted for deterministic, JSON-stable output."
+                    "memory. Both lists are sorted for deterministic, JSON-stable output.\n\n"
+                    "Membership is per **occurrence**, not per leaf: a key appears in\n"
+                    "``pushed_keys`` only when EVERY occurrence of it in the AST was pushed. A key\n"
+                    "can therefore appear in the emitted query and still be reported post-filtered,\n"
+                    "when a second occurrence sat inside an ``$or`` / ``$not`` the backend's\n"
+                    "all-or-nothing split gate deferred wholesale. That direction is the honest one\n"
+                    "— the post-filter does re-check it — and the reverse would tell a caller a\n"
+                    "deferred occurrence was already enforced."
                 ),
                 "properties": {
                     "pushed_keys": {

--- a/tests/unit/filter/test_split_mode_soundness.py
+++ b/tests/unit/filter/test_split_mode_soundness.py
@@ -781,12 +781,13 @@ def test_surrealdb_reads_an_absent_mapping_as_declaring_nothing() -> None:
 
 
 def test_two_different_splits_of_one_filter_hash_differently() -> None:
-    """The same AST that splits differently must NOT share a cache key.
+    """The same AST that splits differently must NOT share a plan-identity hash.
 
     Two contexts differing ONLY in ``sqlite_json1``: with JSON1 the metadata leaf
     is pushed, without it the leaf is deferred and the backend receives a
-    match-all. Those are different queries and must not collide. Hashing the
-    whole AST — what the compilers did before — gave them the same key.
+    match-all. Those are different queries, so the hash identifying the emitted
+    plan must distinguish them. Hashing the whole AST — what the compilers did
+    before — gave them the same value.
     """
     ast = _ast({"metadata.tier": "gold"})
     on = CompileContext(backend_target="khora_chunks", on_unsupported="split", schema_capabilities=_JSON1_ON)
@@ -797,15 +798,16 @@ def test_two_different_splits_of_one_filter_hash_differently() -> None:
 
     assert pushed.consumed_keys == frozenset({"metadata.tier"})
     assert deferred.consumed_keys == frozenset()
-    assert pushed.canonical_hash != deferred.canonical_hash
+    assert pushed.consumed_slice_hash != deferred.consumed_slice_hash
 
     # The pushed side consumed everything, so its slice IS the whole AST.
-    assert pushed.canonical_hash == canonical_hash(ast)
+    assert pushed.consumed_slice_hash == canonical_hash(ast)
     # The deferred side pushed nothing, so its slice is the match-everything AST
-    # — and any other fully-deferred filter shares that key, correctly, because
-    # they send the backend the identical query.
-    assert deferred.canonical_hash == canonical_hash(FilterNode(op=Op.AND, children=()))
-    assert deferred.canonical_hash == compile_lance(_ast({"metadata.other": "x"}), off).canonical_hash
+    # — and any other fully-deferred filter shares that hash, correctly, because
+    # they send the backend the identical query. That collision is also exactly
+    # why this value is NOT a result-cache key: these two keep different rows.
+    assert deferred.consumed_slice_hash == canonical_hash(FilterNode(op=Op.AND, children=()))
+    assert deferred.consumed_slice_hash == compile_lance(_ast({"metadata.other": "x"}), off).consumed_slice_hash
 
 
 @pytest.mark.parametrize(("name", "compiler", "builder_cls", "ctx"), _GATED_TARGETS, ids=_GATED_IDS)
@@ -815,11 +817,12 @@ def test_equal_hash_implies_equal_emitted_predicate(
     builder_cls: Any,
     ctx: CompileContext,
 ) -> None:
-    """The cache-key contract: same ``canonical_hash`` ⟹ same emitted predicate.
+    """The plan-identity contract: equal hash ⟹ equal emitted predicate.
 
-    ``CompiledFilter.canonical_hash`` is documented as identifying *the predicate
-    this compiler emitted*, so anything keying a prepared-statement or plan cache
-    on it needs this implication to hold. It is what the OR branch of the gate
+    ``CompiledFilter.consumed_slice_hash`` identifies *the predicate this compiler
+    emitted*, so anything keying a prepared-statement or plan cache on it needs
+    this implication to hold. A *result* cache must NOT key on it — the deferred
+    remainder still narrows the rows; see the field's docstring. It is what the OR branch of the gate
     actually buys, and it is why that branch is correctness rather than tidiness.
 
     Two filters differing ONLY in a bind inside a deferred ``$or`` both prune to
@@ -840,7 +843,7 @@ def test_equal_hash_implies_equal_emitted_predicate(
 
     # Non-vacuity: the two filters really are different, and really do collide.
     assert consumable_leaf != other
-    assert first.canonical_hash == second.canonical_hash
+    assert first.consumed_slice_hash == second.consumed_slice_hash
     assert _render(first.predicate) == _render(second.predicate)
 
 
@@ -860,7 +863,7 @@ def test_raise_mode_canonical_hash_is_unchanged_over_the_corpus(
 ) -> None:
     """In ``"raise"`` mode the hash still equals ``canonical_hash(ast)``.
 
-    Chunk-tier cache keys must not move. In raise mode every leaf that reaches
+    Chunk-tier plan-identity hashes must not move. In raise mode every leaf that reaches
     emission is consumable (an unconsumable one raises instead), so the consumed
     slice IS the whole tree and hashing the slice is hashing the AST. Asserted
     over the whole corpus rather than a sample, because "the keys did not move"
@@ -871,7 +874,7 @@ def test_raise_mode_canonical_hash_is_unchanged_over_the_corpus(
             compiled = compiler(ast, ctx)
         except (RecallFilterUnsupportedError, CompileError):
             continue
-        assert compiled.canonical_hash == canonical_hash(ast), f"{name} {case}: cache key moved"
+        assert compiled.consumed_slice_hash == canonical_hash(ast), f"{name} {case}: plan hash moved"
         assert compiled.consumed_keys == filter_leaf_keys(ast), f"{name} {case}: raise mode left a residual"
 
 
@@ -1248,6 +1251,22 @@ def test_clause_consumable_mirrors_what_emission_did(
     That UNDER-claim direction costs pushdown rather than rows, so it is the
     cheaper failure — but do not read an all-green mirror as proof that predicate
     and emission agree in both directions. Invariant (a) carries that half.
+
+    **One known, documented under-claim exists today.** ``compile_lance``'s
+    ``_clause_unconsumable`` tests ``isinstance(operand, (DateLiteral, dict))``
+    *before* dispatching on the operator, while ``_compile_metadata_clause`` only
+    consults the operand type for ``$eq`` / ``$ne`` / range. So for ``$exists``,
+    and for range / ``$in`` / ``$nin`` carrying a dict operand, the predicate
+    reports unconsumable while emission pushes the leaf. It is validator-reachable
+    (``{"metadata.tier": {"$gt": {"a": 1}}}`` validates), and it is in the SAFE
+    direction — the leaf stays post-filtered, so no row is dropped. Its one visible
+    consequence is that ``consumed_slice_hash`` prunes a leaf the WHERE still
+    contains, which makes the equal-hash-implies-equal-predicate property
+    (:func:`test_equal_hash_implies_equal_emitted_predicate`) hold with this single
+    documented exception. The line pre-dates the split machinery; narrowing it to
+    mirror the emit path's op dispatch is a tracked follow-up, deliberately not
+    done here because it changes pre-existing pushdown behaviour and needs its own
+    corpus case.
 
     Each leaf runs in ISOLATION (``FilterNode(AND, (leaf,))``), which is the
     right shape: ``_clause_consumable`` is per-leaf by definition, and

--- a/tests/unit/filter/test_split_mode_soundness.py
+++ b/tests/unit/filter/test_split_mode_soundness.py
@@ -1,0 +1,1281 @@
+"""Unit tests for the split-mode pushdown gate the SQL-ish compilers share.
+
+``@internal``. :mod:`khora.filter.compilers._split` is the one place the
+postgres / lance / surrealdb compilers agree on what ``on_unsupported="split"``
+means, and its three rules are what every caller's post-filter contract rests
+on:
+
+1. **AND distributes; OR / NOT are all-or-nothing.** The match-all placeholder
+   an unconsumable leaf emits is superset-safe only in positive position — under
+   a negation it inverts to match-NOTHING, dropping rows a post-filter can never
+   add back. So an ``OR`` / ``NOT`` is pushed only when its ENTIRE subtree is
+   consumable.
+2. **``consumed_keys`` is per-occurrence honest.** A dotted path pushed in one
+   branch and deferred in another is NOT reported consumed, or a caller
+   differencing ``leaf_keys - consumed_keys`` would skip the occurrence that
+   never reached the backend.
+3. **``field_mapping is None`` is the identity mapping, not an empty
+   whitelist.** Every chunk-tier context passes ``None``; reading it as "nothing
+   is declared" would defer every system-key pushdown on the hot recall path.
+
+**What the conformance corpus does NOT cover, and why the hand-written cases
+below are load-bearing.** Measured over all 209 corpus ASTs against the real
+chunk-tier contexts: the OR/NOT gate changes the outcome for 1 of them, and the
+key-in-both-positions shape of rule 2 has ZERO corpus coverage. The corpus is
+excellent at operator semantics and useless at these two shapes, so
+:func:`test_negated_or_over_an_unconsumable_leaf_defers_the_whole_node` and
+:func:`test_key_pushed_in_one_branch_and_deferred_in_another_is_not_consumed`
+are explicit and must not be traded for corpus-driven assertions.
+
+**The corpus IS the right tool for the two structural invariants**, which is
+what :func:`test_clause_consumable_mirrors_what_emission_did` (the per-leaf
+mirror) and :func:`test_raise_mode_raises_exactly_when_a_leaf_is_unconsumable`
+(the raise-mode biconditional) use it for. Those encode relationships rather
+than expected outputs, so a new corpus case strengthens them without edits.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import pytest
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql.elements import ColumnElement
+
+from khora.filter import RecallFilter
+from khora.filter.ast import FilterClause, FilterNode, canonical_hash, parse_to_ast
+from khora.filter.compilers import lance as lance_module
+from khora.filter.compilers import postgres as postgres_module
+from khora.filter.compilers import surrealdb as surrealdb_module
+from khora.filter.compilers._split import consumed_subtree
+from khora.filter.compilers.lance import compile_lance
+from khora.filter.compilers.postgres import compile_postgres
+from khora.filter.compilers.surrealdb import compile_surrealdb
+from khora.filter.conformance import (
+    _resolve_ast,
+    f_array_cases,
+    f_coerce_cases,
+    f_dates_cases,
+    f_dotkey_cases,
+    f_exists_cases,
+    f_impossible_cases,
+    f_logic_cases,
+    f_nullval_cases,
+    f_objeq_cases,
+    f_op_cases,
+    f_polarity_cases,
+    f_sel_cases,
+    f_sugar_cases,
+    f_unsup_cases,
+)
+from khora.filter.context import CompileContext, CompileError, SchemaCapabilities
+from khora.filter.execute import build_compile_context, filter_leaf_keys
+from khora.filter.model import SYSTEM_KEYS, Op, RecallFilterUnsupportedError
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Corpus + context fixtures.
+# ---------------------------------------------------------------------------
+
+# The same 14 family generators the conformance catalog enumerates, listed here
+# rather than imported as a collection so a new family shows up as an explicit
+# edit in both places.
+_FAMILY_GENERATORS = (
+    f_op_cases,
+    f_sugar_cases,
+    f_impossible_cases,
+    f_exists_cases,
+    f_coerce_cases,
+    f_polarity_cases,
+    f_objeq_cases,
+    f_dotkey_cases,
+    f_array_cases,
+    f_logic_cases,
+    f_dates_cases,
+    f_nullval_cases,
+    f_sel_cases,
+    f_unsup_cases,
+)
+
+_D1 = "2026-01-01T00:00:00+00:00"
+_D2 = "2026-02-01T00:00:00+00:00"
+_D3 = "2026-03-01T00:00:00+00:00"
+
+_JSON1_ON = SchemaCapabilities(sqlite_json1=True)
+_JSON1_OFF = SchemaCapabilities(sqlite_json1=False)
+
+# The nine system keys a ``documents`` row backs, restated independently of the
+# store modules (a test that imported the constant under test asserts nothing).
+_DOCUMENT_KEYS = frozenset(SYSTEM_KEYS) - {"occurred_at"}
+
+# The SurrealDB chunk-tier whitelist, mirroring ``storage/temporal/surrealdb.py``.
+_SURREAL_CHUNK_MAPPING = {"occurred_at": "occurred_at", "created_at": "created_at", "metadata": "metadata_"}
+
+# The date-typed system keys. The validator gives them a range grammar and no
+# ``$exists``, so operator-shape helpers have to branch on this.
+_DATE_KEYS = frozenset({"created_at", "source_timestamp", "occurred_at"})
+
+
+def _corpus() -> list[tuple[str, FilterNode]]:
+    """Every conformance case, lowered through the real validator + ``parse_to_ast``."""
+    cases: list[tuple[str, FilterNode]] = []
+    for generator in _FAMILY_GENERATORS:
+        for index, case in enumerate(generator()):
+            cases.append((f"{generator.__name__}[{index}]", _resolve_ast(case.filter)))
+    return cases
+
+
+def _distinct_corpus_leaves() -> list[FilterClause]:
+    """Every structurally distinct leaf clause anywhere in the corpus."""
+    leaves: list[FilterClause] = []
+    seen: set[tuple[Any, ...]] = set()
+    for _name, ast in _corpus():
+        for leaf in _iter_leaves(ast):
+            key = (leaf.path, leaf.op, repr(leaf.operand))
+            if key not in seen:
+                seen.add(key)
+                leaves.append(leaf)
+    return leaves
+
+
+def _iter_leaves(node: FilterNode | FilterClause) -> Iterator[FilterClause]:
+    """Yield every leaf OCCURRENCE, duplicates preserved."""
+    if isinstance(node, FilterClause):
+        yield node
+        return
+    for child in node.children:
+        yield from _iter_leaves(child)
+
+
+def _ast(wire: dict) -> FilterNode:
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+def _norm(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+def _render(predicate: Any) -> str:
+    """The emitted fragment as a string, rendering SQLAlchemy elements inline.
+
+    ``literal_binds`` is load-bearing, not cosmetic: SQLAlchemy folds
+    ``or_(x, true())`` to ``true`` during compilation, so whether the gate fired
+    is only observable after rendering. ``str(element)`` shows the
+    un-short-circuited tree and would hide it.
+    """
+    if isinstance(predicate, ColumnElement):
+        return _norm(str(predicate.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})))
+    return _norm(str(predicate))
+
+
+# ``(id, compile fn, builder module, context)`` for every compiler/context pair
+# the gate runs under. Both tiers are present on purpose: the chunk tier is where
+# the gate is LIVE on the embedded read path, the documents tier is where the
+# whitelist actually withholds keys.
+def _split_targets() -> tuple[tuple[str, Callable, Any, CompileContext], ...]:
+    return (
+        (
+            "lance/chunk",
+            compile_lance,
+            lance_module._Builder,
+            CompileContext(backend_target="khora_chunks", on_unsupported="split", schema_capabilities=_JSON1_ON),
+        ),
+        (
+            "lance/documents",
+            compile_lance,
+            lance_module._Builder,
+            CompileContext(
+                backend_target="documents",
+                field_mapping={k: k for k in _DOCUMENT_KEYS - {"created_at", "source_timestamp"}}
+                | {"metadata": "metadata"},
+                on_unsupported="split",
+                schema_capabilities=_JSON1_ON,
+            ),
+        ),
+        (
+            "postgres/chunk",
+            compile_postgres,
+            postgres_module._Builder,
+            CompileContext(backend_target="khora_chunks", on_unsupported="split"),
+        ),
+        (
+            "postgres/documents",
+            compile_postgres,
+            postgres_module._Builder,
+            CompileContext(
+                backend_target="documents",
+                field_mapping={k: k for k in _DOCUMENT_KEYS} | {"metadata": "metadata"},
+                on_unsupported="split",
+            ),
+        ),
+        (
+            "surreal/chunk",
+            compile_surrealdb,
+            surrealdb_module._Builder,
+            CompileContext(
+                backend_target="temporal_chunk", field_mapping=_SURREAL_CHUNK_MAPPING, on_unsupported="split"
+            ),
+        ),
+        (
+            "surreal/documents",
+            compile_surrealdb,
+            surrealdb_module._Builder,
+            CompileContext(
+                backend_target="document",
+                field_mapping={k: k for k in _DOCUMENT_KEYS} | {"metadata": "metadata_"},
+                on_unsupported="split",
+            ),
+        ),
+    )
+
+
+# The two chunk-tier contexts that ship ``on_unsupported="raise"``, copied from
+# their production call sites (``storage/temporal/pgvector.py`` and
+# ``storage/temporal/surrealdb.py``). The remaining chunk-tier stores —
+# sqlite_lance and weaviate — are SPLIT and live.
+def _raise_targets() -> tuple[tuple[str, Callable, Any, CompileContext], ...]:
+    return (
+        (
+            "postgres/chunk",
+            compile_postgres,
+            postgres_module._Builder,
+            build_compile_context("khora_chunks", on_unsupported="raise"),
+        ),
+        (
+            "surreal/chunk",
+            compile_surrealdb,
+            surrealdb_module._Builder,
+            CompileContext(
+                backend_target="temporal_chunk", field_mapping=_SURREAL_CHUNK_MAPPING, on_unsupported="raise"
+            ),
+        ),
+    )
+
+
+_SPLIT_IDS = [target[0] for target in _split_targets()]
+_RAISE_IDS = [target[0] for target in _raise_targets()]
+
+# The targets whose gate cases below can be driven from an ORDINARY wire form —
+# a system key the context withholds, or a metadata shape the backend cannot
+# express. ``postgres/chunk`` is absent because neither exists there:
+# ``field_mapping=None`` declares every system key, every dotted metadata path is
+# pushable, and every bare-``metadata`` wire form folds to ``$eq``
+# (:func:`test_every_bare_metadata_wire_form_folds_to_eq`).
+#
+# That is NOT the same as "no unconsumable leaf exists" for that context. One
+# does — any path that is neither a system key nor ``metadata.*`` — and it is
+# reachable, so the guard rejecting it is live rather than dead code. It is
+# covered by :func:`test_an_undeclared_path_never_reaches_a_column_token` and by
+# the raise-mode biconditional's non-vacuity branch, both of which run against
+# the shipped ``postgres/chunk`` context.
+_GATED_TARGETS = tuple(target for target in _split_targets() if target[0] != "postgres/chunk")
+_GATED_IDS = [target[0] for target in _GATED_TARGETS]
+
+
+# ===========================================================================
+# Rule 1 — AND distributes; OR / NOT are all-or-nothing.
+# ===========================================================================
+
+
+@pytest.mark.parametrize(("name", "compiler", "builder_cls", "ctx"), _GATED_TARGETS, ids=_GATED_IDS)
+def test_negated_or_over_an_unconsumable_leaf_defers_the_whole_node(
+    name: str,
+    compiler: Callable,
+    builder_cls: Any,
+    ctx: CompileContext,
+) -> None:
+    """``$not`` over an ``$or`` holding an unconsumable leaf defers the WHOLE node.
+
+    The shape the corpus does not cover and the reason the gate exists. Without
+    it the unconsumable disjunct emits a match-all, the enclosing ``$or`` becomes
+    match-all, and the ``$not`` inverts it to match-NOTHING — the query returns
+    ZERO rows while ``consumed_keys`` still names the consumable sibling, so the
+    caller post-filters a set the backend already emptied. A post-filter only
+    narrows, so those rows are gone.
+
+    Asserted on the RENDERED fragment (see :func:`_render`) and stated as "the
+    bare match-all", not "does not contain ``false``": an emitted ``NOT (...)``
+    over a placeholder is equally wrong even where it does not literally spell
+    ``false``.
+    """
+    consumable_leaf, unconsumable_leaf = _leaf_pair(name)
+    compiled = compiler(_ast({"$not": {"$or": [consumable_leaf, unconsumable_leaf]}}), ctx)
+    sql = _render(compiled.predicate)
+
+    assert sql.strip() in {"true", "1"}, f"expected the bare match-all placeholder, got: {sql}"
+    assert compiled.consumed_keys == frozenset()
+
+    # CONTROLS — without these the assertion above is satisfied by a compiler
+    # that pushes nothing at all on this context.
+    consumable_key = next(iter(filter_leaf_keys(_ast(consumable_leaf))))
+    assert compiler(_ast(consumable_leaf), ctx).consumed_keys == frozenset({consumable_key})
+    assert compiler(_ast(unconsumable_leaf), ctx).consumed_keys == frozenset()
+
+
+@pytest.mark.parametrize(("name", "compiler", "builder_cls", "ctx"), _GATED_TARGETS, ids=_GATED_IDS)
+def test_bare_or_over_an_unconsumable_leaf_also_defers_whole(
+    name: str,
+    compiler: Callable,
+    builder_cls: Any,
+    ctx: CompileContext,
+) -> None:
+    """An ``$or`` in POSITIVE position defers too — the readable half of a real invariant.
+
+    Worth its own case because ``consumed_keys`` cannot tell the two apart: the
+    deferred-path subtraction reports the same empty set whether or not the OR
+    branch of the gate ran, since it derives from ``consumed_subtree`` rather
+    than from emission. Only the emitted fragment differs — with the gate it is
+    the bare placeholder, without it the compilers emit
+    ``<pushed leaf> OR <placeholder>``.
+
+    This is NOT merely emission hygiene. ``A OR <match-all>`` is indeed
+    equivalent to ``<match-all>``, so no rows move — but the pruned slice says
+    NOTHING was pushed while emission pushed a real leaf, which breaks the
+    ``canonical_hash`` contract. That consequence is pinned separately and
+    formatting-independently in
+    :func:`test_equal_hash_implies_equal_emitted_predicate`; this case exists for
+    the readable failure message, and that one for the property that will not rot
+    when the emitted SQL is reformatted.
+    """
+    consumable_leaf, unconsumable_leaf = _leaf_pair(name)
+    compiled = compiler(_ast({"$or": [consumable_leaf, unconsumable_leaf]}), ctx)
+    sql = _render(compiled.predicate)
+
+    assert sql.strip() in {"true", "1"}, f"expected the bare placeholder, got: {sql}"
+    assert " or " not in sql.lower()
+    assert compiled.consumed_keys == frozenset()
+
+
+@pytest.mark.parametrize(("name", "compiler", "builder_cls", "ctx"), _GATED_TARGETS, ids=_GATED_IDS)
+def test_and_still_distributes_over_an_unconsumable_sibling(
+    name: str,
+    compiler: Callable,
+    builder_cls: Any,
+    ctx: CompileContext,
+) -> None:
+    """``AND`` is NOT all-or-nothing — the consumable sibling still narrows.
+
+    The other half of rule 1, and the one that would silently disappear if the
+    gate were applied uniformly to every logical node. Losing it costs no
+    correctness (an under-pushed filter is still a superset) but it would move
+    every conjunctive pushdown to the post-filter, which is why it is pinned
+    rather than left implied by the OR/NOT case above.
+    """
+    consumable_leaf, unconsumable_leaf = _leaf_pair(name)
+    consumable_key = next(iter(filter_leaf_keys(_ast(consumable_leaf))))
+
+    compiled = compiler(_ast({"$and": [consumable_leaf, unconsumable_leaf]}), ctx)
+    assert compiled.consumed_keys == frozenset({consumable_key})
+    assert consumable_key in _render(compiled.predicate)
+
+
+def _leaf_pair(name: str) -> tuple[dict, dict]:
+    """A ``(consumable, unconsumable)`` leaf pair for the given target.
+
+    Picked per target because "unconsumable" has a different cause on each: an
+    undeclared system key where a whitelist withholds one, and a ``$date``
+    metadata compare on the chunk-tier contexts that declare everything.
+    """
+    if name == "lance/chunk":
+        # ``field_mapping=None`` declares every system key, so the unconsumable
+        # leaf has to be a shape SQLite cannot express.
+        return {"source_type": "email"}, {"metadata.when": {"$date": _D3}}
+    if name == "surreal/chunk":
+        # Only occurred_at / created_at / metadata are declared here.
+        return {"created_at": {"$gte": _D1}}, {"source_type": "email"}
+    # Both documents tiers withhold ``occurred_at``.
+    return {"title": "x"}, {"occurred_at": {"$gt": _D1}}
+
+
+# ===========================================================================
+# Rule 2 — ``consumed_keys`` is per-occurrence honest.
+# ===========================================================================
+
+
+def test_key_pushed_in_one_branch_and_deferred_in_another_is_not_consumed() -> None:
+    """The exact repro, on the LIVE embedded chunk path.
+
+    ``storage/temporal/sqlite_lance.py`` compiles with ``on_unsupported="split"``,
+    so this shape was reachable in production, not merely theoretical. Before the
+    fix this AST compiled to ``(coalesce(khora_chunks.created_at >= ?, 0) AND 1)``
+    with ``consumed_keys == {"created_at"}`` — the ``$not`` half deferred to the
+    placeholder while the report claimed the key had been fully pushed, so a
+    caller differencing ``leaf_keys - consumed_keys`` never re-checked it and the
+    query returned rows the filter excludes.
+
+    The emitted SQL is UNCHANGED by the fix and is asserted here to say so: the
+    defect was in the report, not the predicate. That is also why a test that
+    only checked ``consumed_keys`` would be weak — it would pass against a
+    compiler that had simply stopped pushing the conjunctive leaf.
+    """
+    ctx = CompileContext(backend_target="khora_chunks", on_unsupported="split", schema_capabilities=_JSON1_ON)
+    ast = _ast(
+        {
+            "$and": [
+                {"created_at": {"$gte": _D1}},
+                {"$not": {"$or": [{"created_at": {"$lt": _D2}}, {"metadata.when": {"$date": _D3}}]}},
+            ]
+        }
+    )
+    compiled = compile_lance(ast, ctx)
+
+    # The conjunctive occurrence still pushes; the ``$not`` is the placeholder.
+    assert _render(compiled.predicate) == "(coalesce(khora_chunks.created_at >= ?, 0) AND 1)"
+    # ...and ``created_at`` is nonetheless a residual, so the caller re-checks it.
+    assert compiled.consumed_keys == frozenset()
+    assert "created_at" in filter_leaf_keys(ast) - compiled.consumed_keys
+
+    # CONTROL — the same key WITHOUT the deferred second occurrence is consumed,
+    # so the exclusion above is per-occurrence accounting, not the key being
+    # unpushable on this context.
+    assert compile_lance(_ast({"created_at": {"$gte": _D1}}), ctx).consumed_keys == frozenset({"created_at"})
+
+
+@pytest.mark.parametrize(("name", "compiler", "builder_cls", "ctx"), _GATED_TARGETS, ids=_GATED_IDS)
+def test_repeated_path_accounting_holds_on_every_compiler(
+    name: str,
+    compiler: Callable,
+    builder_cls: Any,
+    ctx: CompileContext,
+) -> None:
+    """The same per-occurrence rule, across all three compilers and both tiers.
+
+    The case above pins the production repro verbatim; this one pins that the
+    rule is shared rather than a property of ``compile_lance``.
+    """
+    consumable_leaf, unconsumable_leaf = _leaf_pair(name)
+    key = next(iter(filter_leaf_keys(_ast(consumable_leaf))))
+
+    compiled = compiler(
+        _ast({"$and": [consumable_leaf, {"$not": {"$or": [consumable_leaf, unconsumable_leaf]}}]}),
+        ctx,
+    )
+    assert key not in compiled.consumed_keys
+    assert compiler(_ast(consumable_leaf), ctx).consumed_keys == frozenset({key})
+
+
+# ===========================================================================
+# The two accounting invariants — DELIBERATELY DIFFERENT ARTIFACTS.
+# ===========================================================================
+
+
+def _oracle_split(
+    node: FilterNode | FilterClause,
+    consumable: Callable[[FilterClause], bool],
+) -> tuple[list[FilterClause], list[FilterNode | FilterClause]]:
+    """An independent re-derivation of the gate: ``(kept leaves, deferred nodes)``.
+
+    Written straight from the three rules rather than by calling into
+    :mod:`khora.filter.compilers._split`, so the invariants below compare the
+    shipped walk against a second implementation instead of against itself.
+    """
+    if isinstance(node, FilterClause):
+        return ([node], []) if consumable(node) else ([], [node])
+    if node.op == Op.AND:
+        kept: list[FilterClause] = []
+        deferred: list[FilterNode | FilterClause] = []
+        for child in node.children:
+            child_kept, child_deferred = _oracle_split(child, consumable)
+            kept.extend(child_kept)
+            deferred.extend(child_deferred)
+        return kept, deferred
+    # OR / NOT — all-or-nothing, never recursed into.
+    if all(consumable(leaf) for leaf in _iter_leaves(node)):
+        return list(_iter_leaves(node)), []
+    return [], [node]
+
+
+@pytest.mark.parametrize(("name", "compiler", "builder_cls", "ctx"), _split_targets(), ids=_SPLIT_IDS)
+def test_the_two_accounting_invariants_over_the_corpus(
+    name: str,
+    compiler: Callable,
+    builder_cls: Any,
+    ctx: CompileContext,
+) -> None:
+    """Two SEPARATE invariants over every corpus AST. They are not the same set.
+
+    (a) The RAW emission accumulator — what ``compile_clause`` recorded, before
+        the deferred-path subtraction — equals the dotted paths of the leaves in
+        the pruned slice. This is the per-occurrence, structural artifact, and it
+        is what the cache key hashes.
+
+    (b) ``consumed_keys`` equals that set MINUS the paths under every deferred
+        node. This is the per-path CONSERVATIVE artifact, and it is what the
+        caller's post-filter contract reads.
+
+    **The tempting single assertion ``leaf_keys(slice) == consumed_keys`` is
+    wrong and must not replace these.** It is SATISFIED BY the very defect this
+    change fixes — a key pushed in one branch and deferred in another appears in
+    the slice AND was reported consumed, so the equality held while the key was
+    only half-enforced — and it is FAILED BY the correct behaviour. The two sets
+    are different on purpose; collapsing them re-opens the gap.
+    """
+    for case, ast in _corpus():
+        builder = builder_cls(ctx=ctx, consumed=set())
+        try:
+            compiled = compiler(ast, ctx)
+        except CompileError:
+            # Injection guard, orthogonal to consumability — see the raise-mode
+            # biconditional below for why these are excluded rather than accepted.
+            continue
+
+        kept, deferred = _oracle_split(ast, builder._clause_consumable)
+
+        # (a) the raw accumulator == the pruned slice's leaf paths, per occurrence.
+        raw = _replay_raw_consumed(compiler, builder_cls, ctx, ast)
+        assert raw == {_dotted(leaf) for leaf in kept}, f"{name} {case}: raw accumulator diverged from the slice"
+        assert raw == set(filter_leaf_keys(consumed_subtree(ast, builder._clause_consumable))), (
+            f"{name} {case}: shipped slice diverged from the oracle slice"
+        )
+
+        # (b) consumed_keys == (a) minus every path under a deferred node.
+        deferred_paths = {_dotted(leaf) for node in deferred for leaf in _iter_leaves(node)}
+        assert compiled.consumed_keys == frozenset(raw - deferred_paths), (
+            f"{name} {case}: consumed_keys is not the slice minus the deferred paths"
+        )
+
+
+def _replay_raw_consumed(
+    compiler: Callable,
+    builder_cls: Any,
+    ctx: CompileContext,
+    ast: FilterNode,
+) -> set[str]:
+    """The emission accumulator BEFORE the deferred-path subtraction.
+
+    ``CompiledFilter`` only exposes the post-subtraction set, so the raw one is
+    read by driving the builder the way ``compiler`` does. That is white-box, and
+    intentionally so: invariant (a) is a statement about the emission walk, which
+    is not otherwise observable.
+    """
+    consumed: set[str] = set()
+    builder_cls(ctx=ctx, consumed=consumed).compile_node(ast)
+    return consumed
+
+
+def _dotted(leaf: FilterClause) -> str:
+    return ".".join(leaf.path)
+
+
+def test_the_slice_and_consumed_keys_are_deliberately_different_sets() -> None:
+    """A worked case where the two artifacts DISAGREE — the point of keeping both.
+
+    Without this, "the slice and ``consumed_keys`` are different artifacts" is
+    only a claim in a docstring. Here ``created_at`` IS in the consumed slice
+    (its conjunctive occurrence really was pushed, and the cache key must reflect
+    that) and is NOT in ``consumed_keys`` (its other occurrence was deferred, so
+    the post-filter must still enforce it).
+    """
+    ctx = CompileContext(backend_target="khora_chunks", on_unsupported="split", schema_capabilities=_JSON1_ON)
+    ast = _ast(
+        {
+            "$and": [
+                {"created_at": {"$gte": _D1}},
+                {"$not": {"$or": [{"created_at": {"$lt": _D2}}, {"metadata.when": {"$date": _D3}}]}},
+            ]
+        }
+    )
+    builder = lance_module._Builder(ctx=ctx, consumed=set())
+    slice_keys = filter_leaf_keys(consumed_subtree(ast, builder._clause_consumable))
+
+    assert "created_at" in slice_keys
+    assert "created_at" not in compile_lance(ast, ctx).consumed_keys
+
+
+# ===========================================================================
+# Rule 3 — ``field_mapping is None`` is identity, NOT an empty whitelist.
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    ("name", "compiler", "ctx"),
+    (
+        ("postgres", compile_postgres, CompileContext(backend_target="khora_chunks", on_unsupported="split")),
+        (
+            "lance",
+            compile_lance,
+            CompileContext(backend_target="khora_chunks", on_unsupported="split", schema_capabilities=_JSON1_ON),
+        ),
+    ),
+    ids=["postgres", "lance"],
+)
+def test_identity_field_mapping_still_pushes_every_system_key(
+    name: str,
+    compiler: Callable,
+    ctx: CompileContext,
+) -> None:
+    """THE OUTAGE GUARD for the whitelist gate.
+
+    Every chunk-tier postgres / lance context passes ``field_mapping=None``. If
+    the gate had been written as a plain membership test, ``None`` would fold to
+    "nothing is declared" and EVERY system-key pushdown on the default recall
+    path would move to the post-filter — a silent, total pushdown outage that no
+    correctness test would catch, because an under-pushed filter still returns
+    the right rows (just after fetching far more of them).
+
+    So: with the identity mapping, all ten system keys must still push and still
+    be consumed. Parametrized over the operator too, since the gate sits on the
+    leaf dispatch and a shape-specific regression would slip past a single ``$eq``.
+    """
+    assert ctx.field_mapping is None, "the whole point of this case is the identity mapping"
+
+    for key in sorted(SYSTEM_KEYS):
+        for wire in _system_key_wires(key):
+            compiled = compiler(_ast(wire), ctx)
+            assert compiled.consumed_keys == frozenset({key}), f"{name}: {key} not pushed for {wire}"
+            # The column must appear in the fragment too, so "consumed" is not
+            # satisfied by a match-all that consumed the key without narrowing.
+            # ``$exists`` is the documented exception: every system key is a real
+            # NOT NULL column, so existence is statically true and BOTH compilers
+            # fold it to the placeholder while still (correctly) consuming the key.
+            assert key in _render(compiled.predicate), f"{name}: {key} absent from the fragment for {wire}"
+
+    # ``$exists`` is only in the validator's grammar for the string-typed keys.
+    for key in sorted(SYSTEM_KEYS - _DATE_KEYS):
+        exists = compiler(_ast({key: {"$exists": True}}), ctx)
+        assert exists.consumed_keys == frozenset({key}), f"{name}: {key} $exists not consumed"
+        assert _render(exists.predicate).strip() in {"true", "(1)"}
+
+
+def _system_key_wires(key: str) -> tuple[dict, ...]:
+    """Narrowing operator shapes per system key, with operands the validator accepts.
+
+    ``$exists`` is handled separately by the caller — it is statically true on a
+    NOT NULL column and folds to the placeholder, so it cannot carry the
+    "column appears in the fragment" half of the assertion.
+    """
+    if key in _DATE_KEYS:
+        return ({key: {"$gte": _D1}}, {key: {"$lt": _D2}})
+    return ({key: "x"}, {key: {"$in": ["x", "y"]}})
+
+
+def test_a_declared_whitelist_does_withhold_an_undeclared_key() -> None:
+    """The other side of rule 3 — a NON-``None`` mapping really is a whitelist.
+
+    Paired with the case above so neither reading can be satisfied vacuously: the
+    identity mapping must whitelist nothing away, and a real mapping must.
+    """
+    ctx = CompileContext(
+        backend_target="documents",
+        field_mapping={"title": "title", "metadata": "metadata"},
+        on_unsupported="split",
+    )
+    assert compile_postgres(_ast({"title": "x"}), ctx).consumed_keys == frozenset({"title"})
+    assert compile_postgres(_ast({"source_type": "email"}), ctx).consumed_keys == frozenset()
+
+
+def test_surrealdb_reads_an_absent_mapping_as_declaring_nothing() -> None:
+    """SurrealDB is DELIBERATELY asymmetric with postgres / lance here.
+
+    SQL fails loud on a missing column — the statement errors. On a SCHEMAFULL
+    SurrealDB table a missing field reads ``NONE`` and SurrealQL's total-false
+    absent-compare silently drops every row, so this compiler must fail CLOSED:
+    ``field_mapping=None`` declares nothing rather than everything. Pinned so the
+    asymmetry is not "unified away" as an inconsistency.
+    """
+    ctx = CompileContext(backend_target="temporal_chunk", on_unsupported="split")
+    assert ctx.field_mapping is None
+    compiled = compile_surrealdb(_ast({"source_type": "email"}), ctx)
+    assert compiled.consumed_keys == frozenset()
+    assert compiled.predicate.strip() == "(true)"
+
+
+# ===========================================================================
+# The cache key — ``canonical_hash`` over the consumed slice.
+# ===========================================================================
+
+
+def test_two_different_splits_of_one_filter_hash_differently() -> None:
+    """The same AST that splits differently must NOT share a cache key.
+
+    Two contexts differing ONLY in ``sqlite_json1``: with JSON1 the metadata leaf
+    is pushed, without it the leaf is deferred and the backend receives a
+    match-all. Those are different queries and must not collide. Hashing the
+    whole AST — what the compilers did before — gave them the same key.
+    """
+    ast = _ast({"metadata.tier": "gold"})
+    on = CompileContext(backend_target="khora_chunks", on_unsupported="split", schema_capabilities=_JSON1_ON)
+    off = dataclasses.replace(on, schema_capabilities=_JSON1_OFF)
+
+    pushed = compile_lance(ast, on)
+    deferred = compile_lance(ast, off)
+
+    assert pushed.consumed_keys == frozenset({"metadata.tier"})
+    assert deferred.consumed_keys == frozenset()
+    assert pushed.canonical_hash != deferred.canonical_hash
+
+    # The pushed side consumed everything, so its slice IS the whole AST.
+    assert pushed.canonical_hash == canonical_hash(ast)
+    # The deferred side pushed nothing, so its slice is the match-everything AST
+    # — and any other fully-deferred filter shares that key, correctly, because
+    # they send the backend the identical query.
+    assert deferred.canonical_hash == canonical_hash(FilterNode(op=Op.AND, children=()))
+    assert deferred.canonical_hash == compile_lance(_ast({"metadata.other": "x"}), off).canonical_hash
+
+
+@pytest.mark.parametrize(("name", "compiler", "builder_cls", "ctx"), _GATED_TARGETS, ids=_GATED_IDS)
+def test_equal_hash_implies_equal_emitted_predicate(
+    name: str,
+    compiler: Callable,
+    builder_cls: Any,
+    ctx: CompileContext,
+) -> None:
+    """The cache-key contract: same ``canonical_hash`` ⟹ same emitted predicate.
+
+    ``CompiledFilter.canonical_hash`` is documented as identifying *the predicate
+    this compiler emitted*, so anything keying a prepared-statement or plan cache
+    on it needs this implication to hold. It is what the OR branch of the gate
+    actually buys, and it is why that branch is correctness rather than tidiness.
+
+    Two filters differing ONLY in a bind inside a deferred ``$or`` both prune to
+    the empty AND — ``consumed_subtree`` applies the all-or-nothing OR rule
+    regardless of the gate — so they share a hash by construction. Without the OR
+    branch, emission would still push the consumable disjunct, and the two would
+    emit DIFFERENT SQL under one key.
+
+    Preferred over an exact-fragment assertion because it survives any harmless
+    reformatting of the emitted SQL while still failing if the gate is removed.
+    """
+    consumable_leaf, unconsumable_leaf = _leaf_pair(name)
+    key = next(iter(filter_leaf_keys(_ast(consumable_leaf))))
+    other = _second_operand(name, key)
+
+    first = compiler(_ast({"$or": [consumable_leaf, unconsumable_leaf]}), ctx)
+    second = compiler(_ast({"$or": [other, unconsumable_leaf]}), ctx)
+
+    # Non-vacuity: the two filters really are different, and really do collide.
+    assert consumable_leaf != other
+    assert first.canonical_hash == second.canonical_hash
+    assert _render(first.predicate) == _render(second.predicate)
+
+
+def _second_operand(name: str, key: str) -> dict:
+    """A second leaf on the same key with a DIFFERENT operand."""
+    if key in _DATE_KEYS:
+        return {key: {"$gte": _D2}}
+    return {key: "a-different-value"}
+
+
+@pytest.mark.parametrize(("name", "compiler", "builder_cls", "ctx"), _raise_targets(), ids=_RAISE_IDS)
+def test_raise_mode_canonical_hash_is_unchanged_over_the_corpus(
+    name: str,
+    compiler: Callable,
+    builder_cls: Any,
+    ctx: CompileContext,
+) -> None:
+    """In ``"raise"`` mode the hash still equals ``canonical_hash(ast)``.
+
+    Chunk-tier cache keys must not move. In raise mode every leaf that reaches
+    emission is consumable (an unconsumable one raises instead), so the consumed
+    slice IS the whole tree and hashing the slice is hashing the AST. Asserted
+    over the whole corpus rather than a sample, because "the keys did not move"
+    is the kind of claim a handful of cases can pass while a real one shifts.
+    """
+    for case, ast in _corpus():
+        try:
+            compiled = compiler(ast, ctx)
+        except (RecallFilterUnsupportedError, CompileError):
+            continue
+        assert compiled.canonical_hash == canonical_hash(ast), f"{name} {case}: cache key moved"
+        assert compiled.consumed_keys == filter_leaf_keys(ast), f"{name} {case}: raise mode left a residual"
+
+
+# ===========================================================================
+# Raise-mode inertness — the gate must contribute NOTHING when it cannot fire.
+# ===========================================================================
+
+# Emissions captured from the compilers as they stood BEFORE the split gate
+# landed (commit dc313e60), for the two chunk-tier contexts that ship
+# ``on_unsupported="raise"``. Measured, not hand-written. The full measurement
+# covered all 209 corpus ASTs across six contexts (1254 records) and found every
+# predicate and every bind byte-identical; this table is the standing guard that
+# keeps a representative slice of that result checked on every run.
+#
+# The shapes are chosen for what the gate COULD have touched — ``$or``, ``$not``,
+# and a ``$not`` over an ``$or`` with a mixed subtree — plus ordinary leaves as
+# controls. If a legitimate change to the emitted SQL lands, update these strings
+# and say so; do not delete the table.
+_RAISES = object()
+
+_PG_RAISE_PINS: tuple[tuple[str, dict, Any], ...] = (
+    ("bare", {}, "true"),
+    (
+        "sys_range",
+        {"created_at": {"$gte": _D1}},
+        "coalesce(khora_chunks.created_at >= '2026-01-01 00:00:00+00:00', false)",
+    ),
+    ("sys_exists", {"source_url": {"$exists": True}}, "true"),
+    (
+        "or_sys",
+        {"$or": [{"occurred_at": {"$gte": _D1}}, {"created_at": {"$lt": _D2}}]},
+        "coalesce(khora_chunks.occurred_at >= '2026-01-01 00:00:00+00:00', false) "
+        "OR coalesce(khora_chunks.created_at < '2026-02-01 00:00:00+00:00', false)",
+    ),
+    (
+        "not_sys",
+        {"$not": {"created_at": {"$gte": _D1}}},
+        "NOT coalesce(khora_chunks.created_at >= '2026-01-01 00:00:00+00:00', false)",
+    ),
+    (
+        "not_or_mixed",
+        {"$not": {"$or": [{"metadata.tier": "gold"}, {"created_at": {"$lt": _D2}}]}},
+        "NOT ((coalesce(khora_chunks.metadata, CAST('{}' AS JSONB)) @> CAST('{\"tier\": \"gold\"}' AS JSONB)) "
+        "OR (coalesce(khora_chunks.metadata, CAST('{}' AS JSONB)) @> CAST('{\"tier\": [\"gold\"]}' AS JSONB)) "
+        "OR coalesce(khora_chunks.created_at < '2026-02-01 00:00:00+00:00', false))",
+    ),
+    (
+        "mixed_and",
+        {"$and": [{"created_at": {"$gte": _D1}}, {"metadata.tier": "gold"}]},
+        "coalesce(khora_chunks.created_at >= '2026-01-01 00:00:00+00:00', false) "
+        "AND ((coalesce(khora_chunks.metadata, CAST('{}' AS JSONB)) @> CAST('{\"tier\": \"gold\"}' AS JSONB)) "
+        "OR (coalesce(khora_chunks.metadata, CAST('{}' AS JSONB)) @> CAST('{\"tier\": [\"gold\"]}' AS JSONB)))",
+    ),
+)
+
+_SURREAL_RAISE_PINS: tuple[tuple[str, dict, Any], ...] = (
+    ("bare", {}, "true"),
+    ("sys_range", {"created_at": {"$gte": _D1}}, "((created_at IS NOT NONE AND created_at >= $f_0))"),
+    # Undeclared on this whitelist — raising is the pre-existing behaviour and
+    # the gate must not have widened it into a placeholder.
+    ("undeclared_sys", {"source_type": "email"}, _RAISES),
+    ("undeclared_exists", {"source_url": {"$exists": True}}, _RAISES),
+    (
+        "or_sys",
+        {"$or": [{"occurred_at": {"$gte": _D1}}, {"created_at": {"$lt": _D2}}]},
+        "(((occurred_at IS NOT NONE AND occurred_at >= $f_0)) OR ((created_at IS NOT NONE AND created_at < $f_1)))",
+    ),
+    ("not_sys", {"$not": {"created_at": {"$gte": _D1}}}, "!(((created_at IS NOT NONE AND created_at >= $f_0)))"),
+    (
+        "not_or_mixed",
+        {"$not": {"$or": [{"metadata.tier": "gold"}, {"created_at": {"$lt": _D2}}]}},
+        "!((((metadata_.tier = $f_0 OR (type::is::array(metadata_.tier) AND metadata_.tier CONTAINS $f_0))) "
+        "OR ((created_at IS NOT NONE AND created_at < $f_1))))",
+    ),
+    (
+        "mixed_and",
+        {"$and": [{"created_at": {"$gte": _D1}}, {"metadata.tier": "gold"}]},
+        "((created_at IS NOT NONE AND created_at >= $f_0) "
+        "AND (metadata_.tier = $f_1 OR (type::is::array(metadata_.tier) AND metadata_.tier CONTAINS $f_1)))",
+    ),
+)
+
+
+@pytest.mark.parametrize(("case", "wire", "expected"), _PG_RAISE_PINS, ids=[pin[0] for pin in _PG_RAISE_PINS])
+def test_postgres_raise_mode_emission_is_byte_identical(case: str, wire: dict, expected: Any) -> None:
+    """The pgvector chunk-tier context emits exactly what it emitted before.
+
+    ``storage/temporal/pgvector.py`` is the hottest compile path in the library
+    and it runs ``on_unsupported="raise"``, where the gate is unreachable by
+    construction: an unconsumable leaf raises before any OR/NOT node can defer.
+    "Unreachable by construction" is an argument, though, and this is the
+    measurement.
+    """
+    ctx = build_compile_context("khora_chunks", on_unsupported="raise")
+    if expected is _RAISES:
+        with pytest.raises(RecallFilterUnsupportedError):
+            compile_postgres(_ast(wire), ctx)
+        return
+    assert _render(compile_postgres(_ast(wire), ctx).predicate) == expected
+
+
+@pytest.mark.parametrize(("case", "wire", "expected"), _SURREAL_RAISE_PINS, ids=[pin[0] for pin in _SURREAL_RAISE_PINS])
+def test_surrealdb_raise_mode_emission_is_byte_identical(case: str, wire: dict, expected: Any) -> None:
+    """The SurrealDB chunk-tier context emits exactly what it emitted before."""
+    ctx = CompileContext(backend_target="temporal_chunk", field_mapping=_SURREAL_CHUNK_MAPPING, on_unsupported="raise")
+    if expected is _RAISES:
+        with pytest.raises(RecallFilterUnsupportedError):
+            compile_surrealdb(_ast(wire), ctx)
+        return
+    assert _render(compile_surrealdb(_ast(wire), ctx).predicate) == expected
+
+
+@pytest.mark.parametrize(("name", "compiler", "builder_cls", "ctx"), _raise_targets(), ids=_RAISE_IDS)
+def test_raise_mode_raises_exactly_when_a_leaf_is_unconsumable(
+    name: str,
+    compiler: Callable,
+    builder_cls: Any,
+    ctx: CompileContext,
+) -> None:
+    """BICONDITIONAL over the corpus: raises ⇔ some leaf is not consumable.
+
+    The structural reason raise-mode emission cannot have moved: the gate is
+    consulted only under ``"split"``, so in ``"raise"`` mode the ONLY thing
+    ``_clause_consumable`` can correspond to is whether the compile raised. Both
+    directions matter — a compile that raised on a fully-consumable AST would
+    mean the gate had started rejecting things, and one that succeeded with an
+    unconsumable leaf would mean an unsupported leaf had slipped through as a
+    placeholder.
+
+    The left-hand side is specifically ``RecallFilterUnsupportedError``, NOT "any
+    exception". :class:`CompileError` (an unsafe metadata identifier — one corpus
+    case, ``f_dotkey_cases`` ``{'metadata.$ref': 'x'}``) is an injection guard,
+    orthogonal to consumability: the predicate legitimately stays ``True`` while
+    the compile raises. Those cases are EXCLUDED. Accepting "either error" would
+    make the test vacuously pass on exactly the cases it should ignore.
+    """
+    excluded = 0
+    for case, ast in _corpus():
+        builder = builder_cls(ctx=ctx, consumed=set())
+        predicted = any(not builder._clause_consumable(leaf) for leaf in _iter_leaves(ast))
+        try:
+            compiler(ast, ctx)
+            actual = False
+        except RecallFilterUnsupportedError:
+            actual = True
+        except CompileError:
+            excluded += 1
+            continue
+        assert predicted == actual, f"{name} {case}: predicted_raise={predicted} actually_raised={actual}"
+
+    assert excluded <= 1, f"{name}: unexpected number of CompileError cases ({excluded})"
+
+    # Non-vacuity. A biconditional is trivially true when one side is constant,
+    # so both branches have to be reachable SOMEWHERE — but the honest statement
+    # differs per target, and flattening the two would hide which is which.
+    assert compiler(_ast({"created_at": {"$gte": _D1}}), ctx).consumed_keys == frozenset({"created_at"})
+    if name == "postgres/chunk":
+        # No CORPUS case raises here: ``field_mapping=None`` declares every
+        # system key and every dotted metadata path is pushable, so every leaf
+        # the corpus contains is consumable. That is a fact about the corpus, NOT
+        # about the context — an unconsumable leaf does exist for this context
+        # (a path that is neither a system key nor ``metadata.*``), and the
+        # raising branch is exercised with one below on the SHIPPED context
+        # rather than on a whitelisted variant of it.
+        assert all(not _raises(compile_postgres, ast, ctx) for _case, ast in _corpus())
+        with pytest.raises(RecallFilterUnsupportedError):
+            compile_postgres(FilterNode(op=Op.AND, children=(FilterClause(path=("a",), op=Op.EQ, operand=1),)), ctx)
+        return
+
+    # SurrealDB's chunk whitelist withholds most system keys, so the corpus
+    # itself exercises both branches.
+    outcomes = {_raises(compiler, ast, ctx) for _case, ast in _corpus()} - {None}
+    assert outcomes == {True, False}, f"{name}: corpus no longer exercises both branches ({outcomes})"
+
+
+def _raises(compiler: Callable, ast: FilterNode, ctx: CompileContext) -> bool | None:
+    """``True``/``False`` for raised-or-not; ``None`` for an excluded CompileError."""
+    try:
+        compiler(ast, ctx)
+    except RecallFilterUnsupportedError:
+        return True
+    except CompileError:
+        return None
+    return False
+
+
+@pytest.mark.parametrize(
+    "wire",
+    (
+        {"metadata": {"a": 1}},
+        {"metadata": {"$ne": {"a": 1}}},
+        {"metadata": {"$gt": {"a": 1}}},
+        {"metadata": {"$gte": {"a": 1}}},
+        {"metadata": {"$lt": {"a": 1}}},
+        {"metadata": {"$lte": {"a": 1}}},
+        {"metadata": {"$in": [{"a": 1}]}},
+        {"metadata": {"$nin": [{"a": 1}]}},
+        {"metadata": {"$exists": True}},
+        {"metadata": {}},
+    ),
+    ids=lambda w: str(next(iter(w.values()))),
+)
+def test_every_bare_metadata_wire_form_folds_to_eq(wire: dict) -> None:
+    """The bare ``metadata`` blob always lowers to ``$eq`` over a literal operand.
+
+    This is the genuinely validator-guaranteed property, and it is what makes
+    ``_clause_consumable``'s bare-metadata branch (``len(path) > 1 or op ==
+    Op.EQ``) agree with emission in practice: the ``op != Op.EQ`` half is not
+    reachable through a ``metadata`` wire form, because every operator-looking
+    key is read as part of the literal blob rather than as an operator.
+
+    Pinned per form rather than as prose because the whole bare-metadata
+    consumability branch rests on it — if the validator ever grows real operator
+    parsing on the bare blob, these are the cases that say so.
+    """
+    leaves = list(_iter_leaves(_ast(wire)))
+    assert [leaf.path for leaf in leaves] == [("metadata",)]
+    assert [leaf.op for leaf in leaves] == [Op.EQ]
+
+
+# ``(id, compiler, AND-wrapped placeholder, bare placeholder)``. The two spellings
+# differ on ``compile_lance`` and are NOT interchangeable: an AND root wraps its
+# single child, so a lone deferred leaf renders ``(1)``, whereas a deferred
+# ``$not`` returns the placeholder from the NOT node itself with no wrapper and
+# renders a bare ``1``. ``compile_postgres`` collapses both to ``true`` because
+# SQLAlchemy folds the wrapper away. Asserting the exact spelling per position
+# rather than "contains a placeholder" is what keeps the two positions distinct.
+_PLACEHOLDER_SHAPES: tuple[tuple[str, Callable, str, str], ...] = (
+    ("postgres", compile_postgres, "true", "true"),
+    ("lance", compile_lance, "(1)", "1"),
+)
+
+
+@pytest.mark.parametrize(
+    ("name", "compiler", "placeholder", "bare_placeholder"),
+    _PLACEHOLDER_SHAPES,
+    ids=[case[0] for case in _PLACEHOLDER_SHAPES],
+)
+def test_an_undeclared_path_never_reaches_a_column_token(
+    name: str,
+    compiler: Callable,
+    placeholder: str,
+    bare_placeholder: str,
+) -> None:
+    """A path that is neither a system key nor ``metadata.*`` is DEFERRED, never emitted.
+
+    This pins ``compile_clause``'s final ``else`` branch as LIVE. That branch is
+    the only thing between an arbitrary path and ``_col``, which builds its
+    column token with ``sa.literal_column(f"{qualifier}.{physical}")`` — raw SQL
+    text, not a bind — and on every chunk-tier context ``field_mapping is None``,
+    so ``physical`` would be the path segment verbatim.
+
+    ``_col``'s own docstring says ``logical_name`` "is always a controlled token
+    … never free user text". That is true only BECAUSE this branch rejects
+    everything else first: it is a property maintained upstream, not a property
+    of the input. So without this test, the branch reads as dead code and the
+    docstring reads as a standing guarantee — two mutually reinforcing reasons to
+    delete a live guard.
+
+    The clause is constructed DIRECTLY rather than through
+    :meth:`RecallFilter.model_validate`, deliberately. This asserts compiler
+    behaviour, which is what the guard is; routing it through the validator would
+    couple the test to whichever wire forms happen to reach a compiler today, and
+    it would start erroring rather than passing if that ever narrows.
+    """
+    ctx = CompileContext(backend_target="khora_chunks", on_unsupported="split", schema_capabilities=_JSON1_ON)
+    payload = 'evil" OR 1=1--'
+    ast = FilterNode(op=Op.AND, children=(FilterClause(path=(payload,), op=Op.EQ, operand=1),))
+
+    compiled = compiler(ast, ctx)
+    assert _render(compiled.predicate).strip() == placeholder
+    assert compiled.consumed_keys == frozenset()
+    # THE ASSERTION THAT ACTUALLY PROVES CONTAINMENT. "the leaf is unconsumable"
+    # would still pass if a future refactor routed the path into the column token
+    # by some other route; the absence of the payload from the rendered SQL is
+    # what says it did not. Rendering is via ``_render``, i.e. ``literal_binds``
+    # for SQLAlchemy, so this sees the real statement text rather than ``:param_1``.
+    assert payload not in _render(compiled.predicate)
+
+    # UNDER A NEGATION — the gate must refuse to push it there too. Emitting a
+    # placeholder inside a ``$not`` would invert it to match-nothing, which is
+    # the unrecoverable direction, and it is a separate branch of the gate from
+    # the positive case above. The expected shape is ``bare_placeholder``, not
+    # ``placeholder``: the NOT branch returns the gate's placeholder directly,
+    # whereas the positive case above reaches it through the AND branch, which
+    # parenthesizes its joined children. On postgres the two coincide; on lance
+    # they are ``1`` and ``(1)``, so asserting the AND-wrapped form here would
+    # pin a shape the NOT branch never emits.
+    negated = FilterNode(op=Op.NOT, children=(ast,))
+    negated_compiled = compiler(negated, ctx)
+    assert _render(negated_compiled.predicate).strip() == bare_placeholder
+    assert negated_compiled.consumed_keys == frozenset()
+    assert payload not in _render(negated_compiled.predicate)
+
+    # Same leaf under "raise" is a structured error, not a silent placeholder —
+    # in both positions.
+    raising = dataclasses.replace(ctx, on_unsupported="raise")
+    with pytest.raises(RecallFilterUnsupportedError):
+        compiler(ast, raising)
+    with pytest.raises(RecallFilterUnsupportedError):
+        compiler(negated, raising)
+
+
+# ===========================================================================
+# THE MIRROR — the only check standing between the gate predicate and a silent
+# row-drop. Rank it above everything else in this module.
+# ===========================================================================
+
+
+@pytest.mark.parametrize(("name", "compiler", "builder_cls", "ctx"), _split_targets(), ids=_SPLIT_IDS)
+def test_clause_consumable_mirrors_what_emission_did(
+    name: str,
+    compiler: Callable,
+    builder_cls: Any,
+    ctx: CompileContext,
+) -> None:
+    """``_clause_consumable`` must agree with what ``compile_clause`` ACTUALLY did.
+
+    **This is the load-bearing test of the module.** The gate defers an ``OR`` /
+    ``NOT`` based on ``_clause_consumable``, and the shipped implementation
+    RE-DERIVES the deferred set from that same predicate rather than recording
+    what emission chose. So if the predicate ever drifts from the emit path — a
+    new unsupported metadata shape handled in ``compile_clause`` but not mirrored
+    in ``_clause_consumable``, say — the gate would judge a subtree consumable,
+    push it, and let a match-all placeholder invert under a negation. That is a
+    silent row-drop, and the deferred-path subtraction cannot catch it: the
+    subtraction guards the REPORT, only this guards the PREDICATE.
+
+    Each leaf runs in ISOLATION (``FilterNode(AND, (leaf,))``), which is the
+    right shape: ``_clause_consumable`` is per-leaf by definition, and
+    composition is the gate's job — covered by the biconditional and the
+    accounting invariants above.
+
+    :class:`CompileError` cases are excluded (see the biconditional's docstring).
+    """
+    checked = 0
+    for leaf in _distinct_corpus_leaves():
+        builder = builder_cls(ctx=ctx, consumed=set())
+        predicted = builder._clause_consumable(leaf)
+        try:
+            compiled = compiler(FilterNode(op=Op.AND, children=(leaf,)), ctx)
+        except CompileError:
+            continue
+        actual = bool(compiled.consumed_keys)
+        assert predicted == actual, (
+            f"{name}: {_dotted(leaf)} {leaf.op} — _clause_consumable said {predicted}, emission consumed {actual}"
+        )
+        checked += 1
+    assert checked > 100, f"{name}: only {checked} leaves reached the mirror; the corpus shrank"
+
+
+# The whitelist branch must actually rule some leaves unconsumable, or the mirror
+# above is green for a compiler that never exercises it. Measured counts, of the
+# 182 distinct corpus leaves. If a corpus change drops one of these to zero the
+# mirror has gone vacuous on that target and the test must be FIXED, not deleted.
+_WHITELIST_REJECTION_COUNTS: tuple[tuple[str, int, frozenset[str]], ...] = (
+    ("postgres/documents", 16, frozenset({"occurred_at"})),
+    ("lance/documents", 37, frozenset({"created_at", "occurred_at", "source_timestamp"})),
+    (
+        "surreal/chunk",
+        77,
+        frozenset(
+            {
+                "content_type",
+                "external_id",
+                "source",
+                "source_name",
+                "source_timestamp",
+                "source_type",
+                "source_url",
+                "title",
+            }
+        ),
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("target", "expected_count", "expected_keys"),
+    _WHITELIST_REJECTION_COUNTS,
+    ids=[case[0] for case in _WHITELIST_REJECTION_COUNTS],
+)
+def test_the_mirror_is_not_vacuous_on_the_whitelist_branch(
+    target: str,
+    expected_count: int,
+    expected_keys: frozenset[str],
+) -> None:
+    """The whitelist branch is REACHED — without this, an all-green mirror proves nothing.
+
+    A mirror test passes trivially if every leaf is consumable on every context:
+    ``_clause_consumable`` returning a constant ``True`` would satisfy it. These
+    counts are the proof that the interesting branch runs, and the key sets say
+    WHICH keys each context withholds, so a mapping change that silently stops
+    withholding one shows up here rather than as a quiet loss of coverage.
+    """
+    by_name = {name: (builder_cls, ctx) for name, _fn, builder_cls, ctx in _split_targets()}
+    builder_cls, ctx = by_name[target]
+    builder = builder_cls(ctx=ctx, consumed=set())
+
+    system_leaves = [leaf for leaf in _distinct_corpus_leaves() if len(leaf.path) == 1 and leaf.path[0] in SYSTEM_KEYS]
+    rejected = [leaf for leaf in system_leaves if not builder._clause_consumable(leaf)]
+
+    assert rejected, f"{target}: the whitelist branch rules NOTHING unconsumable — the mirror is vacuous here"
+    assert {leaf.path[0] for leaf in rejected} == expected_keys
+    assert len(rejected) == expected_count
+
+
+# ===========================================================================
+# The metadata-identifier guard.
+# ===========================================================================
+
+
+def test_safe_segment_pattern_rejects_a_trailing_newline() -> None:
+    """``"tier\\n"`` must NOT be accepted as a metadata path segment.
+
+    A WRONG-FIELD bug before an injection one. The pattern was anchored with
+    ``$``, which in Python also matches just before a trailing newline, so
+    ``"tier\\n"`` passed the guard and was interpolated verbatim into the
+    predicate string — addressing ``metadata_.tier\\n``, a field name no document
+    has, which on a SCHEMAFULL table reads ``NONE`` and silently matches no rows.
+    ``\\Z`` is the absolute end of the string.
+    """
+    for pattern in (surrealdb_module._SAFE_SEGMENT_RE, _conformance_segment_re()):
+        assert pattern.match("tier") is not None
+        assert pattern.match("tier\n") is None
+        # The anchor is the fix; a segment containing an interior newline was
+        # already rejected by the character class and proves nothing on its own.
+        assert pattern.match("tier\nother") is None
+        assert re.search(r"\\Z", pattern.pattern), f"{pattern.pattern!r} is not \\Z-anchored"
+
+
+def _conformance_segment_re() -> re.Pattern[str]:
+    """The conformance harness's mirror of the compiler's pattern.
+
+    Imported through the module rather than at file scope to keep the two copies
+    visibly separate — they are duplicated on purpose (the harness must decide
+    what SurrealDB will reject without importing the compiler), and a fix to one
+    that misses the other is exactly what this test exists to catch.
+    """
+    from khora.filter import conformance
+
+    return conformance._SURREAL_SAFE_SEGMENT_RE
+
+
+def test_the_two_segment_patterns_have_not_drifted() -> None:
+    # The mirror is only a mirror while the patterns agree; the previous
+    # revision's bug was present in both and had to be fixed in both.
+    assert surrealdb_module._SAFE_SEGMENT_RE.pattern == _conformance_segment_re().pattern
+
+
+@pytest.mark.parametrize("mode", ("split", "raise"))
+def test_an_unsafe_metadata_segment_raises_in_both_modes(mode: str) -> None:
+    """KNOWN GAP, pinned as it behaves — the guard is not a split-mode capability gap.
+
+    ``compile_surrealdb`` raises :class:`CompileError` on a non-identifier
+    metadata segment under BOTH modes, rather than routing it to the
+    unsupported-leaf path where ``"split"`` would defer it. That is deliberate
+    today: it is an injection guard, and ``_clause_consumable`` therefore does
+    NOT consider segment safety — reporting such a leaf unconsumable would let
+    the enclosing subtree defer, the guard would never run, and the error would
+    vanish rather than surface.
+
+    Pinned as current behaviour, not endorsed. If the guard is ever turned into a
+    real capability gap, ``_clause_consumable`` must become mode-aware in the
+    same change or the mirror above will start failing.
+    """
+    ctx = CompileContext(
+        backend_target="document",
+        field_mapping={"title": "title", "metadata": "metadata_"},
+        on_unsupported=mode,
+    )
+    with pytest.raises(CompileError):
+        compile_surrealdb(_ast({"metadata.$ref": "x"}), ctx)
+
+
+# ===========================================================================
+# Scope note — the compilers deliberately NOT fixed here.
+# ===========================================================================
+
+
+def test_the_split_helpers_are_only_wired_into_the_three_sql_compilers() -> None:
+    """``compile_cypher`` / ``compile_weaviate`` / ``compile_chronicle`` are OUT of scope.
+
+    They share the same over-claiming ``consumed_keys`` shape and are
+    deliberately left alone in this change, so their cache-key pins stay green.
+    Asserted as an import fact rather than as behaviour: if one of them is fixed
+    later, this is the line that says "update the scope note too".
+    """
+    from khora.filter.compilers import _split, chronicle, cypher, weaviate
+
+    def _uses_split(module: Any) -> bool:
+        """Whether ``module`` bound any name exported by :mod:`._split`."""
+        return any(getattr(module, name, None) is getattr(_split, name) for name in _split.__all__)
+
+    candidates = (lance_module, postgres_module, surrealdb_module, cypher, weaviate, chronicle)
+    wired = {module.__name__.rsplit(".", 1)[-1] for module in candidates if _uses_split(module)}
+    assert wired == {"lance", "postgres", "surrealdb"}

--- a/tests/unit/filter/test_split_mode_soundness.py
+++ b/tests/unit/filter/test_split_mode_soundness.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import dataclasses
 import re
 from collections.abc import Callable, Iterator
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -349,6 +350,95 @@ def test_bare_or_over_an_unconsumable_leaf_also_defers_whole(
     assert sql.strip() in {"true", "1"}, f"expected the bare placeholder, got: {sql}"
     assert " or " not in sql.lower()
     assert compiled.consumed_keys == frozenset()
+
+
+@pytest.mark.parametrize(("name", "compiler", "builder_cls", "ctx"), _GATED_TARGETS, ids=_GATED_IDS)
+def test_bare_not_over_an_unconsumable_leaf_defers(
+    name: str,
+    compiler: Callable,
+    builder_cls: Any,
+    ctx: CompileContext,
+) -> None:
+    """A ``$not`` directly over an unconsumable LEAF — the NOT branch on its own.
+
+    Separated from the ``$not($or)`` case deliberately. ``OR`` and ``NOT`` are
+    different branches of :meth:`compile_node`, and ``$not($or)`` exercises both
+    at once, so a bug confined to the plain ``NOT``-over-leaf path can hide
+    behind the OR branch handling it first. This is the shape with no ``$or``
+    anywhere in it.
+    """
+    _consumable_leaf, unconsumable_leaf = _leaf_pair(name)
+    compiled = compiler(_ast({"$not": unconsumable_leaf}), ctx)
+    sql = _render(compiled.predicate)
+
+    assert sql.strip() in {"true", "1"}, f"expected the bare match-all placeholder, got: {sql}"
+    assert "not" not in sql.lower()
+    assert "!(" not in sql
+    assert compiled.consumed_keys == frozenset()
+
+
+# ``(id, shape builder)`` — the three logical shapes the gate can defer, built
+# from two leaves. Used for the over-deferral controls below.
+_LOGICAL_SHAPES: tuple[tuple[str, Callable[[dict, dict], dict]], ...] = (
+    ("or", lambda a, b: {"$or": [a, b]}),
+    ("not", lambda a, _b: {"$not": a}),
+    ("not_or", lambda a, b: {"$not": {"$or": [a, b]}}),
+)
+
+
+# NOTE this one runs over ALL split targets, not just the gated ones: it needs
+# no unconsumable leaf, only two consumable ones. ``postgres/chunk`` is excluded
+# elsewhere for lack of an ordinary unconsumable leaf, but it is precisely where
+# an over-deferral regression would hurt most — it is the pgvector recall path.
+@pytest.mark.parametrize(("name", "compiler", "builder_cls", "ctx"), _split_targets(), ids=_SPLIT_IDS)
+@pytest.mark.parametrize(("shape", "build"), _LOGICAL_SHAPES, ids=[case[0] for case in _LOGICAL_SHAPES])
+def test_a_fully_consumable_or_not_is_still_pushed(
+    shape: str,
+    build: Callable[[dict, dict], dict],
+    name: str,
+    compiler: Callable,
+    builder_cls: Any,
+    ctx: CompileContext,
+) -> None:
+    """OVER-DEFERRAL CONTROL — the gate must defer correctly, not defer everything.
+
+    Every other gate case in this module asserts that something IS deferred, so
+    all of them pass against a compiler that simply never pushes an ``$or`` /
+    ``$not`` at all. Measured, not assumed: forcing both gate branches to defer
+    unconditionally leaves every dedicated gate test in this file GREEN, and is
+    caught only incidentally by
+    :func:`test_the_two_accounting_invariants_over_the_corpus`, whose failure
+    message says nothing about over-deferral.
+
+    So this is the other direction, stated per shape: with EVERY leaf consumable,
+    the node is pushed and both keys are consumed. Losing this costs no
+    correctness — an under-pushed filter still returns the right rows — which is
+    exactly why nothing else would notice it, and why a silent collapse of all
+    disjunctive pushdown needs its own guard.
+    """
+    first, second = _consumable_pair(name)
+    keys = filter_leaf_keys(_ast(first)) | filter_leaf_keys(_ast(second))
+
+    compiled = compiler(_ast(build(first, second)), ctx)
+    sql = _render(compiled.predicate)
+
+    assert sql.strip() not in {"true", "1"}, f"{shape} was deferred despite being fully consumable: {sql}"
+    expected = filter_leaf_keys(_ast(first)) if shape == "not" else keys
+    assert compiled.consumed_keys == expected
+    # The negation / disjunction really is in the emitted fragment, rather than
+    # the leaves having been flattened into a bare conjunction.
+    assert ("!(" in sql or "not" in sql.lower()) if shape.startswith("not") else (" or " in sql.lower())
+
+
+def _consumable_pair(name: str) -> tuple[dict, dict]:
+    """Two leaves on DIFFERENT keys that the given target can both push."""
+    if name == "surreal/chunk":
+        # Only occurred_at / created_at / metadata are declared here.
+        return {"created_at": {"$gte": _D1}}, {"occurred_at": {"$gte": _D1}}
+    if name == "lance/chunk":
+        return {"source_type": "email"}, {"source_name": "linear"}
+    # Both documents tiers declare these two.
+    return {"title": "x"}, {"source_type": "email"}
 
 
 @pytest.mark.parametrize(("name", "compiler", "builder_cls", "ctx"), _GATED_TARGETS, ids=_GATED_IDS)
@@ -837,30 +927,49 @@ _PG_RAISE_PINS: tuple[tuple[str, dict, Any], ...] = (
     ),
 )
 
-_SURREAL_RAISE_PINS: tuple[tuple[str, dict, Any], ...] = (
-    ("bare", {}, "true"),
-    ("sys_range", {"created_at": {"$gte": _D1}}, "((created_at IS NOT NONE AND created_at >= $f_0))"),
+# The bind values the ``$f_N`` placeholders below refer to, as real objects —
+# ``compile_surrealdb`` carries datetimes through verbatim rather than
+# stringifying them, which is itself part of what these pins protect.
+_DT1 = datetime(2026, 1, 1, tzinfo=UTC)
+_DT2 = datetime(2026, 2, 1, tzinfo=UTC)
+
+_SURREAL_RAISE_PINS: tuple[tuple[str, dict, Any, dict], ...] = (
+    ("bare", {}, "true", {}),
+    (
+        "sys_range",
+        {"created_at": {"$gte": _D1}},
+        "((created_at IS NOT NONE AND created_at >= $f_0))",
+        {"f_0": _DT1},
+    ),
     # Undeclared on this whitelist — raising is the pre-existing behaviour and
     # the gate must not have widened it into a placeholder.
-    ("undeclared_sys", {"source_type": "email"}, _RAISES),
-    ("undeclared_exists", {"source_url": {"$exists": True}}, _RAISES),
+    ("undeclared_sys", {"source_type": "email"}, _RAISES, {}),
+    ("undeclared_exists", {"source_url": {"$exists": True}}, _RAISES, {}),
     (
         "or_sys",
         {"$or": [{"occurred_at": {"$gte": _D1}}, {"created_at": {"$lt": _D2}}]},
         "(((occurred_at IS NOT NONE AND occurred_at >= $f_0)) OR ((created_at IS NOT NONE AND created_at < $f_1)))",
+        {"f_0": _DT1, "f_1": _DT2},
     ),
-    ("not_sys", {"$not": {"created_at": {"$gte": _D1}}}, "!(((created_at IS NOT NONE AND created_at >= $f_0)))"),
+    (
+        "not_sys",
+        {"$not": {"created_at": {"$gte": _D1}}},
+        "!(((created_at IS NOT NONE AND created_at >= $f_0)))",
+        {"f_0": _DT1},
+    ),
     (
         "not_or_mixed",
         {"$not": {"$or": [{"metadata.tier": "gold"}, {"created_at": {"$lt": _D2}}]}},
         "!((((metadata_.tier = $f_0 OR (type::is::array(metadata_.tier) AND metadata_.tier CONTAINS $f_0))) "
         "OR ((created_at IS NOT NONE AND created_at < $f_1))))",
+        {"f_0": "gold", "f_1": _DT2},
     ),
     (
         "mixed_and",
         {"$and": [{"created_at": {"$gte": _D1}}, {"metadata.tier": "gold"}]},
         "((created_at IS NOT NONE AND created_at >= $f_0) "
         "AND (metadata_.tier = $f_1 OR (type::is::array(metadata_.tier) AND metadata_.tier CONTAINS $f_1)))",
+        {"f_0": _DT1, "f_1": "gold"},
     ),
 )
 
@@ -883,15 +992,30 @@ def test_postgres_raise_mode_emission_is_byte_identical(case: str, wire: dict, e
     assert _render(compile_postgres(_ast(wire), ctx).predicate) == expected
 
 
-@pytest.mark.parametrize(("case", "wire", "expected"), _SURREAL_RAISE_PINS, ids=[pin[0] for pin in _SURREAL_RAISE_PINS])
-def test_surrealdb_raise_mode_emission_is_byte_identical(case: str, wire: dict, expected: Any) -> None:
-    """The SurrealDB chunk-tier context emits exactly what it emitted before."""
+@pytest.mark.parametrize(
+    ("case", "wire", "expected", "expected_params"),
+    _SURREAL_RAISE_PINS,
+    ids=[pin[0] for pin in _SURREAL_RAISE_PINS],
+)
+def test_surrealdb_raise_mode_emission_is_byte_identical(
+    case: str, wire: dict, expected: Any, expected_params: dict
+) -> None:
+    """The SurrealDB chunk-tier context emits exactly what it emitted before.
+
+    Both halves are pinned: the predicate string AND the bind values it refers
+    to. ``compile_surrealdb`` emits NAMED placeholders (``$f_0``), so — unlike
+    the postgres table, where ``literal_binds`` inlines operands into the string
+    — the predicate alone would leave every operand unasserted, and "predicate
+    and binds unchanged" would only be half-checked.
+    """
     ctx = CompileContext(backend_target="temporal_chunk", field_mapping=_SURREAL_CHUNK_MAPPING, on_unsupported="raise")
     if expected is _RAISES:
         with pytest.raises(RecallFilterUnsupportedError):
             compile_surrealdb(_ast(wire), ctx)
         return
-    assert _render(compile_surrealdb(_ast(wire), ctx).predicate) == expected
+    compiled = compile_surrealdb(_ast(wire), ctx)
+    assert _render(compiled.predicate) == expected
+    assert compiled.params == expected_params
 
 
 @pytest.mark.parametrize(("name", "compiler", "builder_cls", "ctx"), _raise_targets(), ids=_RAISE_IDS)
@@ -1100,15 +1224,30 @@ def test_clause_consumable_mirrors_what_emission_did(
 ) -> None:
     """``_clause_consumable`` must agree with what ``compile_clause`` ACTUALLY did.
 
-    **This is the load-bearing test of the module.** The gate defers an ``OR`` /
-    ``NOT`` based on ``_clause_consumable``, and the shipped implementation
-    RE-DERIVES the deferred set from that same predicate rather than recording
-    what emission chose. So if the predicate ever drifts from the emit path — a
+    **This is the load-bearing test for the DANGEROUS direction.** The gate
+    defers an ``OR`` / ``NOT`` based on ``_clause_consumable``, and the shipped
+    implementation RE-DERIVES the deferred set from that same predicate rather
+    than recording what emission chose. So if the predicate ever OVER-claims — a
     new unsupported metadata shape handled in ``compile_clause`` but not mirrored
-    in ``_clause_consumable``, say — the gate would judge a subtree consumable,
-    push it, and let a match-all placeholder invert under a negation. That is a
-    silent row-drop, and the deferred-path subtraction cannot catch it: the
-    subtraction guards the REPORT, only this guards the PREDICATE.
+    in ``_clause_consumable`` — the gate would judge a subtree consumable, push
+    it, and let a match-all placeholder invert under a negation. That is a silent
+    row-drop, and the deferred-path subtraction cannot catch it: the subtraction
+    guards the REPORT, only this guards the PREDICATE.
+
+    **It is one-directional, and deliberately not the whole story.** It reads
+    ``actual = bool(compiled.consumed_keys)``, and ``consumed_keys`` is itself
+    derived from ``_clause_consumable`` via ``deferred_paths`` — so when the
+    predicate says *unconsumable*, the subtraction forces ``consumed_keys`` empty
+    no matter what emission did, and the assertion becomes self-satisfying.
+    Measured: making the postgres metadata branch return ``False`` while emission
+    still pushes those leaves leaves this test GREEN on all six targets, and is
+    caught only by invariant (a) in
+    :func:`test_the_two_accounting_invariants_over_the_corpus`, which compares
+    the raw emission accumulator against an independently-derived slice.
+
+    That UNDER-claim direction costs pushdown rather than rows, so it is the
+    cheaper failure — but do not read an all-green mirror as proof that predicate
+    and emission agree in both directions. Invariant (a) carries that half.
 
     Each leaf runs in ISOLATION (``FilterNode(AND, (leaf,))``), which is the
     right shape: ``_clause_consumable`` is per-leaf by definition, and


### PR DESCRIPTION
## Summary

The documents-table compile contexts registered previously are driven in **split mode**, which the SQL and SurrealQL compilers were never built for. Every defect below produces a **silently wrong result** rather than an error, so they land together, before anything executes those contexts.

**Nothing in this PR executes today.** `_documents_compile_context()` is defined in all four backends and called from nowhere in `src/` — only tests import it, and no `list_documents` signature takes a `filter_ast`. Separately, no live `compile_postgres` / `compile_lance` caller passes a non-`None` `field_mapping`. This is contract-hardening ahead of a caller, not a change to running behaviour; the live blast radius is confined to the embedded chunk tier's pushdown *report*, described under "Live effects" below.

- **OR/NOT is now all-or-nothing in `compile_postgres` and `compile_surrealdb`.** An unsupported leaf emits a match-all placeholder — superset-safe under `AND`, but under a negation `!(x OR true)` is `false`, dropping every row with no error and no residual signal. Both compilers now defer a whole `OR`/`NOT` subtree unless all of it is expressible, mirroring the rule `compile_lance` already applied. The gate is **split-mode only**. Shared logic lives in a new `filter/compilers/_split.py`.
- **A non-`None` `field_mapping` is now a pushdown whitelist in `compile_postgres` and `compile_lance`.** Both previously fell back to *identity* for any unmapped system key, so an `occurred_at` leaf compiled against a nonexistent `documents.occurred_at` column **while being reported consumed**. A `None` mapping still means identity-with-no-whitelist — every chunk-tier context passes `None`, so folding `None` into "empty whitelist" would have been a total recall outage.
- **`consumed_keys` no longer over-claims a path that also occurs inside a deferred subtree.** It was a set of dotted paths with no per-occurrence notion, so a key pushed in one position and deferred in another was reported fully pushed, and a caller post-filtering `leaf_keys - consumed_keys` would not enforce the deferred half. This shape is *created* by the gate above, so it could not be deferred to a follow-up: shipping the gate alone would introduce a new report-lie on two compilers that previously had no way to produce one.
- **`created_at` and `source_timestamp` are withheld from both SQLite documents mappings.** Neither store writes a datetime `compile_lance`'s lexicographic ISO compare can read: the SQLAlchemy store writes a space separator with the offset dropped, and the raw store writes `isoformat()` with no UTC coercion. Postgres keeps both keys; they are real `timestamptz` columns bound as datetimes.
- Smaller, same family: a leaf routed to the unsupported path is no longer marked consumed; `canonical_hash` derives from the consumed slice, and the registry docstring that called it a cache-key source is corrected; metadata path segments match with `fullmatch`, since `$` also matched before a trailing newline. The SurrealDB documents context returns to split mode now that its compiler is gated.

### Rejected alternatives for the SQLite date keys

Normalizing the write paths would be correct *and* fast. It was rejected because **for the SQLAlchemy-backed store it is not merely expensive, it is impossible for existing rows**: SQLite `DateTime(timezone=True)` discards the offset at write, so `12:30+05:00` and `12:30+00:00` are byte-identical on disk and the instant is unrecoverable. Withholding is forced there, not chosen. A third option — normalizing both sides in SQL via SQLite's `datetime()` — needs no migration and would rescue the *raw* store (SQLite normalizes ISO-8601 offsets correctly), but it cannot help the lossy store, it needs a new capability flag so compilers don't branch per-store, and it defeats the index. So the drop is needed regardless.

Cost, stated precisely: date-predicated document listing becomes a full-namespace scan on the two embedded stores; other system keys still push. Measured on the SQLAlchemy store, 1% selectivity: 87x at 1k docs, 118x at 10k, 146x at 100k. That cost is **prospective** — no caller exists — and the fast path it replaces returned wrong rows, so it is not a baseline that could be regressed from. The raw store never had a `created_at` index, so it loses only row transport.

### Deliberately not in this change

The same per-occurrence `consumed_keys` shape exists in the cypher, weaviate, chronicle, and python compilers. All are pre-existing and none is a regression here. Harm is confined to the pushdown report **and overfetch sizing** — `engines/vectorcypher/retriever.py:1928` feeds the cypher compiler's `consumed_keys` into `has_residual_metadata(...)`, so over-claiming there under-sizes graph overfetch, a recall-completeness effect rather than a purely cosmetic one.

One further item — treating an unrenderable metadata path segment as a split-mode capability gap rather than an internal error — was **cut for scope**: the emit path and the gate predicate have to move together or they desynchronize. It is not cut for unsoundness, and not for unreachability (the triggering shape, a hyphenated metadata key, is legal JSON and common). An unsafe segment still raises from the emit path in both modes, which is correct for an injection guard.

## Live effects

The only currently-executing path this touches is the embedded chunk tier (the one live split-mode `compile_lance` context). There, the per-occurrence accounting can shrink `ChannelPlan.pushed_keys` for the key-in-both-positions shape — a correctness improvement to the honesty surface — and `canonical_hash` moves on the 19 of 195 corpus cases that defer a residual. Nothing reads `CompiledFilter.canonical_hash` in `src/`; the recall cache keys on `canonical_hash(filter_ast)` over the full AST.

## Test plan

- [x] Unit tests pass — 10440 passed, 35 skipped; 84% coverage (gate 77%)
- [x] `make lint` clean; `make format` clean
- [x] **Raise-mode `canonical_hash` and `consumed_keys` pinned corpus-wide** (209 ASTs × both raise-mode contexts), plus the raise/consumable biconditional. Emitted predicate text and binds are pinned on a representative 8-shape sample per compiler. Full byte-identity across all 209 ASTs × 6 contexts (1254 records: predicate, params, `consumed_keys`, `canonical_hash`) was verified once against the base commit and reproduced independently by two reviewers — that comparison is a one-off measurement, not a standing CI gate.
- [x] Hand-written coverage for both fixed shapes, because the corpus does not reach them: it fires the new gate on **1 of 209** ASTs under the realistic embedded config and has **zero** coverage of the key-in-both-positions shape.
- [x] A mirror test pins that each compiler's consumable predicate agrees with what its emit path did. It is one-directional by construction — it catches the row-dropping direction (over-claim), while the under-claim direction is caught by the corpus accounting invariant. The docstring says so.
- [x] Over-deferral controls across all six split targets. Added after measurement showed every existing gate test stayed green against a compiler that never pushes an `$or`/`$not` at all.
- [x] Mutation-tested: 21 of 22 mutants caught, including re-adding either withheld key. The one survivor is a shape unreachable through the validator, with a tripwire test if that changes.
- [ ] **Integration tests not run locally** — no container runtime in the dev environment (verified: no docker/podman binary, no socket, ports refused). Covered by CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter handling across supported storage backends, especially for unsupported fields and complex `AND`, `OR`, and `NOT` expressions.
  * Prevented incorrect result exclusions by deferring unsupported conditions for complete post-filter evaluation.
  * Improved handling of repeated fields, metadata paths, date-based filters, and array comparisons.

* **Documentation**
  * Clarified filter pushdown, post-filtering, consumed-key reporting, and filter-plan identity behavior.

* **API Changes**
  * Renamed the compiled-filter hash field to `consumed_slice_hash`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->