### PR TITLE
Give the documents sort index to the two self-managed backends

### DIFF
--- a/src/khora/storage/backends/sqlite.py
+++ b/src/khora/storage/backends/sqlite.py
@@ -78,11 +78,41 @@ CREATE TABLE IF NOT EXISTS documents (
     source_timestamp TEXT,
     external_id TEXT
 );
-CREATE INDEX IF NOT EXISTS idx_docs_ns ON documents(namespace_id);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_docs_checksum
     ON documents(namespace_id, checksum) WHERE checksum != '';
 CREATE INDEX IF NOT EXISTS idx_docs_ns_external_id
     ON documents(namespace_id, external_id) WHERE external_id IS NOT NULL;
+-- Sort index for ``list_documents``, which pins the total order
+-- ``ORDER BY created_at DESC, id DESC``. All three keys are ASC, which a
+-- backward scan reads as that DESC order. Without the trailing ``id`` key
+-- SQLite adds a per-page ``USE TEMP B-TREE FOR ORDER BY`` — invisible on a
+-- first page, dominant on a full drain. The ``status`` / ``updated_at``
+-- predicates are residual filters on top of the scan and do not defeat it.
+-- Mirrors ``db/migrations/versions/054_documents_namespace_created_at_id.py``,
+-- which does not reach this store and carries the full argument.
+--
+-- ``idx_docs_ns`` is dropped as a now-redundant strict prefix, mirroring the
+-- other half of that migration. The namespace aggregates all re-plan onto
+-- this index as covering scans: ``get_last_activity_at``'s ``MAX(created_at)``
+-- stops reading the table altogether, ``get_document_stats`` follows it down,
+-- and bare ``count_documents`` pays slightly more for the wider index
+-- entries. Ratios are omitted on purpose — they scale with rows per
+-- namespace. The partial ``idx_docs_checksum`` / ``idx_docs_ns_external_id``
+-- also lead with ``namespace_id`` but are NOT redundant — their ``WHERE``
+-- clauses make them a different index.
+--
+-- Created before the drop so no connect ever observes the table with neither
+-- index. Both re-run on every ``connect()`` and are a no-op once converged, so
+-- an existing database converts on its next open, paying one inline index
+-- build of order 60 ms per 100k rows — WAL keeps readers going, other writers
+-- wait.
+--
+-- Keep this comment free of semicolons — ``_create_schema`` splits this blob
+-- on the semicolon, so one inside a ``--`` comment would cut the comment in
+-- half and feed the remainder to SQLite as a statement.
+CREATE INDEX IF NOT EXISTS idx_docs_ns_created_id
+    ON documents(namespace_id, created_at, id);
+DROP INDEX IF EXISTS idx_docs_ns;
 
 CREATE TABLE IF NOT EXISTS chunks (
     id TEXT PRIMARY KEY,

--- a/src/khora/storage/backends/sqlite.py
+++ b/src/khora/storage/backends/sqlite.py
@@ -85,27 +85,41 @@ CREATE INDEX IF NOT EXISTS idx_docs_ns_external_id
 -- Sort index for ``list_documents``, which pins the total order
 -- ``ORDER BY created_at DESC, id DESC``. All three keys are ASC, which a
 -- backward scan reads as that DESC order. Without the trailing ``id`` key
--- SQLite adds a per-page ``USE TEMP B-TREE FOR ORDER BY`` — invisible on a
--- first page, dominant on a full drain. The ``status`` / ``updated_at``
--- predicates are residual filters on top of the scan and do not defeat it.
--- Mirrors ``db/migrations/versions/054_documents_namespace_created_at_id.py``,
--- which does not reach this store and carries the full argument.
+-- SQLite satisfies the leading term off the index and adds a per-page
+-- ``USE TEMP B-TREE FOR LAST TERM OF ORDER BY`` for the tiebreak — invisible
+-- on a first page, dominant on a full drain. The legacy 1-key index cannot
+-- satisfy either term and spells it ``USE TEMP B-TREE FOR ORDER BY``. The
+-- ``status`` / ``updated_at`` predicates are residual filters on top of the
+-- scan and do not defeat it. Mirrors
+-- ``db/migrations/versions/054_documents_namespace_created_at_id.py``, which
+-- does not reach this store and carries the full argument.
 --
 -- ``idx_docs_ns`` is dropped as a now-redundant strict prefix, mirroring the
--- other half of that migration. The namespace aggregates all re-plan onto
--- this index as covering scans: ``get_last_activity_at``'s ``MAX(created_at)``
--- stops reading the table altogether, ``get_document_stats`` follows it down,
--- and bare ``count_documents`` pays slightly more for the wider index
--- entries. Ratios are omitted on purpose — they scale with rows per
--- namespace. The partial ``idx_docs_checksum`` / ``idx_docs_ns_external_id``
--- also lead with ``namespace_id`` but are NOT redundant — their ``WHERE``
--- clauses make them a different index.
+-- other half of that migration. The namespace aggregates all re-plan onto this
+-- index as covering scans: ``MAX(created_at)`` stops reading the table
+-- altogether and ``get_document_stats`` follows it down, while bare
+-- ``count_documents`` pays for the wider entries — roughly 1.3-1.7x, climbing
+-- with namespace size, still a covering scan and never a table scan. The
+-- partial ``idx_docs_checksum`` / ``idx_docs_ns_external_id`` also lead with
+-- ``namespace_id`` but are NOT redundant — their ``WHERE`` clauses make them a
+-- different index.
 --
 -- Created before the drop so no connect ever observes the table with neither
 -- index. Both re-run on every ``connect()`` and are a no-op once converged, so
--- an existing database converts on its next open, paying one inline index
--- build of order 60 ms per 100k rows — WAL keeps readers going, other writers
--- wait.
+-- an existing database converts on its next open, paying one inline index build
+-- of order 60-110 ms per 100k rows depending on row width. Two consequences of
+-- putting real work in this blob, both new:
+-- 1. That converting connect is the first real writer the blob has ever
+--    contained, and ``_create_schema`` catches ``OperationalError`` only around
+--    the ``ALTER TABLE``. A writer holding the lock past sqlite3's default 5000
+--    ms ``busy_timeout`` therefore makes the build raise ``database is locked``
+--    out of ``connect()``, where it previously could not fail. A retry once the
+--    lock clears heals it.
+-- 2. The ``DROP`` is the first destructive statement here. While the blob was
+--    purely additive, mixed khora versions sharing one file converged. They no
+--    longer do — an older version re-creates ``idx_docs_ns`` and this one drops
+--    it again, a full index build per old-version connect. Self-correcting once
+--    every process on the file is on this version.
 --
 -- Keep this comment free of semicolons — ``_create_schema`` splits this blob
 -- on the semicolon, so one inside a ``--`` comment would cut the comment in

--- a/src/khora/storage/backends/surrealdb/schema.py
+++ b/src/khora/storage/backends/surrealdb/schema.py
@@ -84,7 +84,6 @@ DEFINE FIELD IF NOT EXISTS processed_at ON document TYPE option<datetime>;
 DEFINE FIELD IF NOT EXISTS source_timestamp ON document TYPE option<datetime>;
 DEFINE FIELD IF NOT EXISTS external_id ON document TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS session_id ON document TYPE option<string>;
-DEFINE INDEX IF NOT EXISTS idx_document_namespace ON document FIELDS namespace_id;
 DEFINE INDEX IF NOT EXISTS idx_document_ns_session ON document FIELDS namespace_id, session_id;
 -- Note: SurrealDB does not support partial indexes; full index used for dedup queries
 DEFINE INDEX IF NOT EXISTS idx_document_ns_checksum ON document FIELDS namespace_id, checksum;
@@ -93,30 +92,53 @@ DEFINE INDEX IF NOT EXISTS idx_document_ns_external_id ON document FIELDS namesp
 -- Sort index backing ``list_documents``' pinned ``ORDER BY created_at DESC,
 -- id DESC``, mirroring the relational backends' index from
 -- ``db/migrations/versions/054_documents_namespace_created_at_id.py``.
--- Two fields, not three: ``id`` is the record identifier rather than an
--- ordinary field, so naming it in ``FIELDS`` fails to define on this
--- SCHEMAFULL table unless a ``DEFINE FIELD id`` is added first — and since
--- ``DEFINE FIELD IF NOT EXISTS`` is append-only that would type ``id`` on
--- fresh databases only, diverging them permanently from existing ones.
--- It is also unnecessary: a non-unique index carries the record id as its
--- trailing key component, so a backward scan of ``(namespace_id,
--- created_at)`` already yields exactly ``created_at DESC, id DESC``.
--- Measured over ``ws://``, on the exact versions named — nothing between
--- 2.6.5 and 3.0.5 was run, so treat the boundary as unknown rather than
--- assuming it is the major bump. Servers 3.0.5 and 3.2.0 drop the sort
--- entirely and push LIMIT/START into a backward index scan (first page
--- 8-23x faster at 4k rows, full drain 1.6-5.1x). Server 2.6.5 does not:
--- the plan is byte-identical with and without this index because that
--- engine sorts in memory unconditionally, so there the index buys nothing
--- and costs only write-side maintenance (~6% on a batched 4k-row insert).
--- The embedded engine (``memory://`` / ``surrealkv://``) reports
--- ``surrealdb-2.0.0`` and behaves like 2.6.5 — embedded gets the write cost
--- and none of the benefit. The benefit is also latent everywhere for now:
--- the ``FLEXIBLE TYPE`` clauses elsewhere in this DDL do not parse on either
--- 3.x server (they require ``TYPE ... FLEXIBLE``, and reject FLEXIBLE on
--- non-object types), so schema init cannot currently reach a server that
--- would use this index.
+-- Four things a future editor should not undo:
+-- 1. Two fields, not three. ``id`` is the record identifier rather than an
+--    ordinary field, so naming it in ``FIELDS`` fails to define on this
+--    SCHEMAFULL table. Adding a ``DEFINE FIELD id`` to make it legal is
+--    worse: ``DEFINE FIELD IF NOT EXISTS`` is append-only, so it would type
+--    ``id`` on fresh databases only and diverge them permanently from
+--    existing ones.
+-- 2. Omitting ``id`` rests on a non-unique index carrying the record id as
+--    its trailing key component. That holds on embedded 2.0.0, where the
+--    scan order matches ``ORDER BY id`` across a tie block — but the row
+--    order of an unsorted scan is not a contractual ordering, and it is
+--    unverified on 3.x, the engine that would actually rely on it. If the
+--    two orders ever diverge, a planner that drops the sort returns ties in
+--    index-key order and ``START`` paging silently drops or repeats rows.
+--    Gate this behind a ``ws://`` pagination test before anything depends
+--    on it.
+-- 3. Not ``CONCURRENTLY``. That build is asynchronous and the planner
+--    routes queries through the index before it is populated, so counts
+--    come back short for the length of the build with no error. A one-time
+--    upgrade stall beats a window of silently wrong reads.
+-- 4. This index is NOT selected on any engine khora can currently reach.
+--    2.6.5 and embedded 2.0.0 sort in memory unconditionally; 3.0.5 / 3.2.0
+--    do push LIMIT/START into a backward index scan, but the ``FLEXIBLE
+--    TYPE`` clauses elsewhere in this DDL do not parse there, so schema
+--    init cannot reach such a server at all (#1584). Treat the 3.x read win
+--    as unconfirmed under the real index set until #1584 lands: on the
+--    engines that can be measured, the planner picks among equally eligible
+--    ``(namespace_id, …)`` composites by index NAME, and
+--    ``idx_document_ns_checksum`` sorts ahead of this one.
 DEFINE INDEX IF NOT EXISTS idx_document_ns_created ON document FIELDS namespace_id, created_at;
+-- ``idx_document_namespace``, this blob's former one-field namespace index,
+-- is a strict prefix of the index just created. Its ``DEFINE`` is gone from
+-- the block above and existing databases drop it here — the two had to move
+-- together, since side by side they would rebuild and destroy the index on
+-- every ``connect()``. Created before dropped, so a connect dying between
+-- the two leaves more index coverage than needed rather than less. Same
+-- ordering rationale as the raw-SQLite blob's ``idx_docs_ns`` drop.
+-- The drop is safe but does NOT promote the index above: the planner
+-- prefix-matches a bare ``WHERE namespace_id = $ns`` onto a two-field
+-- composite, so no query shape falls back to a table scan, but the one it
+-- picks is ``idx_document_ns_checksum`` (see 4). This drop stands on write
+-- cost alone — it returns inserts to parity with today rather than making
+-- them cheaper. Checked for row loss rather than assumed safe, because the
+-- composite that takes over has a nullable second column and SurrealDB does
+-- index NONE: rows with and without a checksum all come back under every
+-- index set.
+REMOVE INDEX IF EXISTS idx_document_namespace ON document;
 
 -- Chunk (with HNSW vector index and BM25 full-text index)
 DEFINE TABLE IF NOT EXISTS chunk SCHEMAFULL;

--- a/src/khora/storage/backends/surrealdb/schema.py
+++ b/src/khora/storage/backends/surrealdb/schema.py
@@ -90,6 +90,33 @@ DEFINE INDEX IF NOT EXISTS idx_document_ns_session ON document FIELDS namespace_
 DEFINE INDEX IF NOT EXISTS idx_document_ns_checksum ON document FIELDS namespace_id, checksum;
 DEFINE INDEX IF NOT EXISTS idx_document_ns_status ON document FIELDS namespace_id, status;
 DEFINE INDEX IF NOT EXISTS idx_document_ns_external_id ON document FIELDS namespace_id, external_id;
+-- Sort index backing ``list_documents``' pinned ``ORDER BY created_at DESC,
+-- id DESC``, mirroring the relational backends' index from
+-- ``db/migrations/versions/054_documents_namespace_created_at_id.py``.
+-- Two fields, not three: ``id`` is the record identifier rather than an
+-- ordinary field, so naming it in ``FIELDS`` fails to define on this
+-- SCHEMAFULL table unless a ``DEFINE FIELD id`` is added first — and since
+-- ``DEFINE FIELD IF NOT EXISTS`` is append-only that would type ``id`` on
+-- fresh databases only, diverging them permanently from existing ones.
+-- It is also unnecessary: a non-unique index carries the record id as its
+-- trailing key component, so a backward scan of ``(namespace_id,
+-- created_at)`` already yields exactly ``created_at DESC, id DESC``.
+-- Measured over ``ws://``, on the exact versions named — nothing between
+-- 2.6.5 and 3.0.5 was run, so treat the boundary as unknown rather than
+-- assuming it is the major bump. Servers 3.0.5 and 3.2.0 drop the sort
+-- entirely and push LIMIT/START into a backward index scan (first page
+-- 8-23x faster at 4k rows, full drain 1.6-5.1x). Server 2.6.5 does not:
+-- the plan is byte-identical with and without this index because that
+-- engine sorts in memory unconditionally, so there the index buys nothing
+-- and costs only write-side maintenance (~6% on a batched 4k-row insert).
+-- The embedded engine (``memory://`` / ``surrealkv://``) reports
+-- ``surrealdb-2.0.0`` and behaves like 2.6.5 — embedded gets the write cost
+-- and none of the benefit. The benefit is also latent everywhere for now:
+-- the ``FLEXIBLE TYPE`` clauses elsewhere in this DDL do not parse on either
+-- 3.x server (they require ``TYPE ... FLEXIBLE``, and reject FLEXIBLE on
+-- non-object types), so schema init cannot currently reach a server that
+-- would use this index.
+DEFINE INDEX IF NOT EXISTS idx_document_ns_created ON document FIELDS namespace_id, created_at;
 
 -- Chunk (with HNSW vector index and BM25 full-text index)
 DEFINE TABLE IF NOT EXISTS chunk SCHEMAFULL;

--- a/tests/unit/storage/backends/surrealdb/test_document_sort_index.py
+++ b/tests/unit/storage/backends/surrealdb/test_document_sort_index.py
@@ -1,0 +1,191 @@
+"""Regression tests for the ``document`` sort index DDL (PR #1581).
+
+The SurrealDB half of that change is two lines of DDL inside
+``_TABLE_DEFINITIONS``: it defines ``idx_document_ns_created`` on
+``(namespace_id, created_at)`` and removes ``idx_document_namespace``, the
+one-field index that is a strict prefix of it.
+
+Nothing caught either statement failing. ``initialize_schema`` hands the whole
+multi-statement blob to ``conn.execute()``, which does not surface a
+per-statement DDL error: a ``DEFINE`` that never applies still leaves
+``SurrealDB schema initialized successfully`` in the log. These tests assert
+the two indexes' *actual* post-init state via ``INFO FOR TABLE document``, so
+a statement that stops parsing (the fate of the ``FLEXIBLE TYPE`` clauses on
+3.x servers, #1584) fails here instead of silently degrading a deployment.
+
+Read the scope honestly: these are *existence* assertions, not *selection*
+assertions. ``idx_document_ns_created`` is **not selected by any planner
+reachable from this repo**. On embedded 2.0.0 a bare ``WHERE namespace_id =
+$ns`` prefix-matches whichever ``(namespace_id, …)`` composite sorts first by
+name, which is ``idx_document_ns_checksum``. A test pinning the sort index as
+the chosen plan fails today, on this branch. So a green run here means the DDL
+applied — it does not mean the index earns its write cost. The selection test
+becomes meaningful only on a server that can parse this DDL (#1584); it is
+deliberately not written as one now, because pinning the current winner would
+harden an undocumented, name-ordered planner tie-break into a test.
+
+They run against ``memory://`` — no server, no API key.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+pytest.importorskip("surrealdb")
+
+from khora.storage.backends.surrealdb.connection import SurrealDBConnection  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+SORT_INDEX = "idx_document_ns_created"
+LEGACY_INDEX = "idx_document_namespace"
+
+
+async def _document_indexes(conn: SurrealDBConnection) -> dict[str, str]:
+    """Return ``{index_name: definition}`` for the ``document`` table."""
+    info: Any = await conn.query_one("INFO FOR TABLE document")
+    return dict(info["indexes"])
+
+
+async def _connected() -> SurrealDBConnection:
+    """A ``memory://`` connection with khora's real schema applied."""
+    conn = SurrealDBConnection(mode="memory", sync_data=False)
+    await conn.connect()
+    return conn
+
+
+async def test_sort_index_is_actually_defined() -> None:
+    """``idx_document_ns_created`` exists on ``(namespace_id, created_at)``."""
+    conn = await _connected()
+    try:
+        indexes = await _document_indexes(conn)
+        assert SORT_INDEX in indexes, (
+            f"{SORT_INDEX} missing after schema init; document indexes are "
+            f"{sorted(indexes)}. initialize_schema swallows per-statement DDL "
+            "errors, so a non-parsing DEFINE looks like success in the log."
+        )
+        definition = indexes[SORT_INDEX]
+        assert "namespace_id" in definition and "created_at" in definition, definition
+    finally:
+        await conn.disconnect()
+
+
+async def test_legacy_prefix_index_is_removed() -> None:
+    """The one-field ``idx_document_namespace`` is gone after schema init.
+
+    It is a strict prefix of the sort index. Leaving it in place costs write
+    maintenance for no read benefit, and it is the finding the raw-SQLite half
+    of #1581 closes by dropping its own equivalent.
+
+    Weak by construction: on a *fresh* database the index was never defined,
+    so this passes whether or not the ``REMOVE`` statement is present — it was
+    confirmed to survive deleting that statement. It guards only against the
+    ``DEFINE`` coming back. The load-bearing checks are
+    ``test_existing_database_drops_the_legacy_index_on_connect`` (behavioural)
+    and ``test_ddl_creates_before_it_drops_and_keeps_no_stale_define``
+    (source-level).
+    """
+    conn = await _connected()
+    try:
+        indexes = await _document_indexes(conn)
+        assert LEGACY_INDEX not in indexes, (
+            f"{LEGACY_INDEX} still defined after schema init; document indexes are {sorted(indexes)}"
+        )
+    finally:
+        await conn.disconnect()
+
+
+async def test_existing_database_drops_the_legacy_index_on_connect() -> None:
+    """An older database that already carries the legacy index converges.
+
+    The blob re-executes on every ``connect()``, so an upgrade path is the
+    normal path here: the pre-existing index must be removed, and the rows it
+    used to serve must all still be reachable afterwards.
+    """
+    conn = await _connected()
+    try:
+        # Recreate the pre-#1581 state on a database that already holds rows.
+        await conn.execute(f"DEFINE INDEX IF NOT EXISTS {LEGACY_INDEX} ON document FIELDS namespace_id")
+        assert LEGACY_INDEX in await _document_indexes(conn)
+        for i in range(20):
+            await conn.execute(
+                "CREATE type::thing('document', $id) SET namespace_id = $ns, title = $t, created_at = time::now()",
+                {"id": f"doc{i:03d}", "ns": "ns-a", "t": f"t{i}"},
+            )
+
+        # Re-run schema init the way a later connect() would.
+        from khora.storage.backends.surrealdb.schema import initialize_schema
+
+        await initialize_schema(conn)
+
+        indexes = await _document_indexes(conn)
+        assert LEGACY_INDEX not in indexes, sorted(indexes)
+        assert SORT_INDEX in indexes, sorted(indexes)
+
+        rows = await conn.query(
+            "SELECT id, created_at FROM document WHERE namespace_id = $ns ORDER BY created_at DESC, id DESC",
+            {"ns": "ns-a"},
+        )
+        assert len(rows) == 20, f"rows lost after dropping {LEGACY_INDEX}: {len(rows)}/20"
+    finally:
+        await conn.disconnect()
+
+
+def test_ddl_creates_before_it_drops_and_keeps_no_stale_define() -> None:
+    """Source-level guard on statement order and on the removed ``DEFINE``.
+
+    ``INFO FOR TABLE`` cannot see either of these: both a swapped
+    create/drop order and a legacy ``DEFINE`` left beside the ``REMOVE``
+    converge on the same final index set. The order matters because a
+    connect that dies between the two statements should leave more index
+    coverage than needed, not less; the stale ``DEFINE`` matters because the
+    blob re-executes on every ``connect()``, so side by side the pair would
+    rebuild and destroy the index each time.
+    """
+    from khora.storage.backends.surrealdb.schema import _TABLE_DEFINITIONS
+
+    statements = [s.strip() for s in _TABLE_DEFINITIONS.split("\n") if s.strip() and not s.strip().startswith("--")]
+    defines = [i for i, s in enumerate(statements) if re.match(rf"DEFINE INDEX (IF NOT EXISTS )?{SORT_INDEX}\b", s)]
+    removes = [i for i, s in enumerate(statements) if re.match(rf"REMOVE INDEX (IF EXISTS )?{LEGACY_INDEX}\b", s)]
+    stale = [s for s in statements if re.match(rf"DEFINE INDEX .*\b{LEGACY_INDEX}\b", s)]
+
+    assert len(defines) == 1, f"expected exactly one DEFINE of {SORT_INDEX}, got {defines}"
+    assert len(removes) == 1, f"expected exactly one REMOVE of {LEGACY_INDEX}, got {removes}"
+    assert not stale, f"legacy DEFINE left beside the REMOVE: {stale}"
+    assert defines[0] < removes[0], (
+        f"{SORT_INDEX} must be defined before {LEGACY_INDEX} is removed "
+        f"(define at {defines[0]}, remove at {removes[0]})"
+    )
+
+
+async def test_namespace_only_query_still_uses_an_index() -> None:
+    """A bare ``namespace_id`` filter must not fall back to a table scan.
+
+    Dropping the one-field index only works because the planner prefix-matches
+    the leading column of a two-field composite. This is the guard on that: if
+    a future engine stops prefix-matching, ``list_documents`` silently becomes
+    a full table scan, and this test is what says so.
+    """
+    conn = await _connected()
+    try:
+        for i in range(20):
+            await conn.execute(
+                "CREATE type::thing('document', $id) SET namespace_id = $ns, created_at = time::now()",
+                {"id": f"doc{i:03d}", "ns": "ns-a"},
+            )
+        plan: Any = await conn.query(
+            "SELECT * FROM document WHERE namespace_id = $ns ORDER BY created_at DESC, id DESC LIMIT 5 START 0 EXPLAIN",
+            {"ns": "ns-a"},
+        )
+        iterate = plan[0]
+        assert iterate["operation"] == "Iterate Index", (
+            f"namespace-only document listing no longer uses an index: {plan}"
+        )
+        # Which composite wins is chosen by index name on the engines reachable
+        # today, so this deliberately does not pin the specific index.
+        assert iterate["detail"]["plan"]["index"].startswith("idx_document_ns"), plan
+    finally:
+        await conn.disconnect()

--- a/tests/unit/storage/backends/surrealdb/test_document_sort_index.py
+++ b/tests/unit/storage/backends/surrealdb/test_document_sort_index.py
@@ -50,6 +50,23 @@ async def _document_indexes(conn: SurrealDBConnection) -> dict[str, str]:
     return dict(info["indexes"])
 
 
+async def _document_fields(conn: SurrealDBConnection) -> dict[str, str]:
+    """Return ``{field_name: definition}`` for the ``document`` table."""
+    info: Any = await conn.query_one("INFO FOR TABLE document")
+    return dict(info["fields"])
+
+
+def _index_fields(definition: str) -> list[str]:
+    """The ordered key list of a ``DEFINE INDEX ... FIELDS a, b`` definition.
+
+    Order is the whole point: ``(created_at, namespace_id)`` would satisfy a
+    membership check and be useless for a ``namespace_id``-equality lookup.
+    """
+    match = re.search(r"\bFIELDS\s+(.+?)(?:\s+(?:UNIQUE|SEARCH|MTREE|HNSW|COMMENT|CONCURRENTLY)\b|$)", definition)
+    assert match, f"could not parse FIELDS out of {definition!r}"
+    return [f.strip() for f in match.group(1).split(",")]
+
+
 async def _connected() -> SurrealDBConnection:
     """A ``memory://`` connection with khora's real schema applied."""
     conn = SurrealDBConnection(mode="memory", sync_data=False)
@@ -58,7 +75,7 @@ async def _connected() -> SurrealDBConnection:
 
 
 async def test_sort_index_is_actually_defined() -> None:
-    """``idx_document_ns_created`` exists on ``(namespace_id, created_at)``."""
+    """``idx_document_ns_created`` exists on exactly ``(namespace_id, created_at)``."""
     conn = await _connected()
     try:
         indexes = await _document_indexes(conn)
@@ -68,7 +85,46 @@ async def test_sort_index_is_actually_defined() -> None:
             "errors, so a non-parsing DEFINE looks like success in the log."
         )
         definition = indexes[SORT_INDEX]
-        assert "namespace_id" in definition and "created_at" in definition, definition
+        assert _index_fields(definition) == ["namespace_id", "created_at"], (
+            f"{SORT_INDEX} must be keyed on (namespace_id, created_at) in that order, got {definition!r}"
+        )
+    finally:
+        await conn.disconnect()
+
+
+async def test_flexible_fields_survive_schema_init() -> None:
+    """Every ``FLEXIBLE``-declared ``document`` field actually materializes.
+
+    ``FLEXIBLE TYPE x`` is the 2.x clause order and is what the engine echoes
+    back in ``INFO FOR TABLE`` even when handed ``TYPE x FLEXIBLE``, so both
+    spellings parse on the pinned SDK. This test does not encode a preference
+    between them — it pins the outcome: because ``initialize_schema`` submits
+    the whole blob through one ``execute`` and per-statement DDL errors are
+    swallowed, a ``DEFINE FIELD`` of this family that stopped parsing would
+    otherwise leave nothing but a success line in the log. That is exactly the
+    failure mode 3.x exhibits today (#1584), where these clauses do not parse.
+
+    The expected set is derived from the DDL rather than hardcoded, so a new
+    ``FLEXIBLE`` field on ``document`` is covered the moment it is added.
+    """
+    from khora.storage.backends.surrealdb.schema import _TABLE_DEFINITIONS
+
+    declared = set(re.findall(r"DEFINE FIELD (?:IF NOT EXISTS )?(\w+) ON document [^\n]*FLEXIBLE", _TABLE_DEFINITIONS))
+    assert declared, "no FLEXIBLE-declared document fields found in _TABLE_DEFINITIONS — has the DDL moved?"
+
+    conn = await _connected()
+    try:
+        fields = await _document_fields(conn)
+        missing = sorted(declared - fields.keys())
+        assert not missing, (
+            f"FLEXIBLE-declared document field(s) {missing} absent after schema init. "
+            "initialize_schema swallows per-statement DDL errors, so this is what a "
+            "silently non-parsing DEFINE FIELD looks like."
+        )
+        not_flexible = sorted(name for name in declared if "FLEXIBLE" not in fields[name])
+        assert not not_flexible, (
+            f"field(s) {not_flexible} lost their FLEXIBLE clause: {[fields[n] for n in not_flexible]}"
+        )
     finally:
         await conn.disconnect()
 
@@ -104,12 +160,25 @@ async def test_existing_database_drops_the_legacy_index_on_connect() -> None:
     The blob re-executes on every ``connect()``, so an upgrade path is the
     normal path here: the pre-existing index must be removed, and the rows it
     used to serve must all still be reachable afterwards.
+
+    The pre-state is reconstructed as *legacy-only* — the sort index is
+    removed before the legacy one is added. ``_connected()`` has already run
+    the current DDL, so leaving the sort index in place would let an
+    initializer that never creates it pass the assertion below on residue from
+    setup rather than on anything the upgrade did.
     """
     conn = await _connected()
     try:
-        # Recreate the pre-#1581 state on a database that already holds rows.
+        # Recreate the pre-change state on a database that already holds rows:
+        # legacy index present, sort index absent.
+        await conn.execute(f"REMOVE INDEX IF EXISTS {SORT_INDEX} ON document")
         await conn.execute(f"DEFINE INDEX IF NOT EXISTS {LEGACY_INDEX} ON document FIELDS namespace_id")
-        assert LEGACY_INDEX in await _document_indexes(conn)
+        before = await _document_indexes(conn)
+        assert LEGACY_INDEX in before, sorted(before)
+        assert SORT_INDEX not in before, (
+            f"pre-state is not legacy-only — {SORT_INDEX} survived setup, so this test "
+            f"could pass without the upgrade creating it: {sorted(before)}"
+        )
         for i in range(20):
             await conn.execute(
                 "CREATE type::thing('document', $id) SET namespace_id = $ns, title = $t, created_at = time::now()",

--- a/tests/unit/test_sqlite_documents_sort_index.py
+++ b/tests/unit/test_sqlite_documents_sort_index.py
@@ -1,0 +1,538 @@
+"""Documents sort index on the raw SQLite backend.
+
+The raw SQLite store keeps its whole schema in ``_SCHEMA_SQL`` and re-runs that
+blob on every ``connect()``; there is no Alembic chain behind it. This module
+guards the three things that arrangement makes fragile:
+
+* ``list_documents`` pins ``ORDER BY created_at DESC, id DESC``. Its index has
+  to carry all of ``(namespace_id, created_at, id)`` or SQLite re-sorts every
+  page through a temp B-tree. Same argument as
+  ``db/migrations/versions/054_documents_namespace_created_at_id.py``, which
+  covers the ORM-backed stores and never reaches this one.
+* An existing database is converted by the blob itself, not by a migration, so
+  the create and the drop both have to be re-runnable and both have to be
+  observable on a database that was opened before the change.
+* ``_create_schema`` splits the blob on ``;``. That makes plain prose in the
+  blob load-bearing, which is not obvious from reading it.
+
+Plan shape is asserted, never wall-clock time or a speed-up ratio: the aggregate
+ratios move with rows-per-namespace and a threshold would flake on CI runners.
+Every assertion here is paired with the opposite index set on the same data, so
+a test that would pass with or without the index fails its own differential.
+
+SQLite only - no Docker, no services.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, NamedTuple
+from uuid import UUID, uuid4
+
+import pytest
+
+from khora.storage.backends.sqlite import (
+    _SCHEMA_SQL,
+    SQLiteRelationalBackend,
+    SQLiteVectorBackend,
+)
+
+SORT_INDEX = "idx_docs_ns_created_id"
+LEGACY_INDEX = "idx_docs_ns"
+
+NAMESPACE_COUNT = 3
+ROWS_PER_NAMESPACE = 400
+# Bulk ingest stamps many documents with one ``created_at``; ties are the
+# realistic case, and they are what makes the trailing ``id`` key load-bearing.
+ROWS_PER_TIMESTAMP = 10
+PAGE_SIZE = 100
+
+BACKENDS = [SQLiteRelationalBackend, SQLiteVectorBackend]
+
+# Both halves of the index swap, matched against the blob as text.
+#
+# ``\b`` is load-bearing: ``_`` is a word character, so ``idx_docs_ns\b`` cannot
+# match inside ``idx_docs_ns_created_id`` or ``idx_docs_ns_external_id``. The
+# decoy check in :class:`TestSchemaBlobStructure` pins that.
+LEGACY_CREATE_RE = re.compile(r"CREATE\s+INDEX(?:\s+IF\s+NOT\s+EXISTS)?\s+idx_docs_ns\b")
+LEGACY_DROP_RE = re.compile(r"DROP\s+INDEX\s+IF\s+EXISTS\s+idx_docs_ns\b")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _RecordingConnection:
+    """Proxy around the backend's aiosqlite connection that records SQL.
+
+    The plan assertions have to be made against the query the shipped
+    ``list_documents`` actually emits. A locally rebuilt SELECT would drift the
+    moment someone edits the backend, and the tests would then keep asserting a
+    good plan for a query nobody runs.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+        self.statements: list[tuple[str, list]] = []
+
+    async def execute(self, sql: str, parameters: Any = None) -> Any:
+        self.statements.append((sql, list(parameters or [])))
+        if parameters is None:
+            return await self._inner.execute(sql)
+        return await self._inner.execute(sql, parameters)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+
+async def _capture_sql(backend: Any, coro_factory: Any) -> tuple[str, list]:
+    """Run a backend method and return the last SQL statement it emitted."""
+    inner = backend._conn
+    recorder = _RecordingConnection(inner)
+    backend._conn = recorder
+    try:
+        result = await coro_factory()
+    finally:
+        backend._conn = inner
+    assert recorder.statements, "the backend emitted no SQL"
+    return result, recorder.statements[-1]
+
+
+class SeededDB(NamedTuple):
+    """What the seeded fixture hands a test."""
+
+    backend: SQLiteRelationalBackend
+    db_path: Path
+    namespace_id: UUID
+    #: Newest ``updated_at`` in the seed. Predicates are expressed relative to
+    #: this rather than to ``datetime.now()``, so they mean the same thing no
+    #: matter how long after collection the test runs.
+    newest: datetime
+
+
+def _seed(db_path: Path) -> tuple[list[UUID], datetime]:
+    """Fill several namespaces with documents; return the ids and the newest stamp.
+
+    More than one namespace so ``namespace_id = ?`` is a real selection rather
+    than a whole-table match, and enough rows for the planner to have something
+    to choose between.
+    """
+    namespaces = [uuid4() for _ in range(NAMESPACE_COUNT)]
+    base = datetime.now(UTC)
+    con = sqlite3.connect(db_path)
+    try:
+        for ns in namespaces:
+            con.execute(
+                "INSERT INTO memory_namespaces (id, namespace_id, version, is_active, tenancy_mode, "
+                "created_at, updated_at) VALUES (?, ?, 1, 1, 'shared', ?, ?)",
+                (str(ns), str(ns), base.isoformat(), base.isoformat()),
+            )
+            con.executemany(
+                "INSERT INTO documents (id, namespace_id, content, checksum, status, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                [
+                    (
+                        str(uuid4()),
+                        str(ns),
+                        f"seed document {i}",
+                        f"{ns}-{i}",
+                        "completed" if i % 3 else "pending",
+                        (base - timedelta(seconds=i // ROWS_PER_TIMESTAMP)).isoformat(),
+                        (base - timedelta(seconds=i // ROWS_PER_TIMESTAMP)).isoformat(),
+                    )
+                    for i in range(ROWS_PER_NAMESPACE)
+                ],
+            )
+        con.execute("ANALYZE")
+        con.commit()
+    finally:
+        con.close()
+    return namespaces, base
+
+
+def _documents_indexes(db_path: Path) -> set[str]:
+    con = sqlite3.connect(db_path)
+    try:
+        return {str(row[1]) for row in con.execute("PRAGMA index_list(documents)").fetchall()}
+    finally:
+        con.close()
+
+
+def _use_legacy_indexes(db_path: Path) -> None:
+    """Put the documents table back on the pre-change index set.
+
+    The change is index-only, so reverting the two index statements reproduces
+    the schema an older database was opened with - and gives every plan
+    assertion below a differential on identical data.
+    """
+    con = sqlite3.connect(db_path)
+    try:
+        con.execute(f"DROP INDEX IF EXISTS {SORT_INDEX}")
+        con.execute(f"CREATE INDEX IF NOT EXISTS {LEGACY_INDEX} ON documents(namespace_id)")
+        con.execute("ANALYZE")
+        con.commit()
+    finally:
+        con.close()
+
+
+def _query_plan(db_path: Path, statement: str, parameters: list) -> list[str]:
+    con = sqlite3.connect(db_path)
+    try:
+        rows = con.execute(f"EXPLAIN QUERY PLAN {statement}", parameters).fetchall()
+    finally:
+        con.close()
+    # The human-readable description is the last column of each row.
+    return [str(row[-1]) for row in rows]
+
+
+def _sorts(plan: list[str]) -> list[str]:
+    """Plan lines describing a sort pass. SQLite spells these 'TEMP B-TREE'."""
+    return [line for line in plan if "TEMP B-TREE" in line.upper()]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def seeded(tmp_path: Path) -> AsyncIterator[SeededDB]:
+    """A seeded database opened through the real backend.
+
+    On disk rather than ``:memory:`` because the plan assertions run through a
+    second connection, and because the conversion tests have to close and
+    reopen the file.
+    """
+    db_path = tmp_path / "documents.db"
+    backend = SQLiteRelationalBackend(str(db_path))
+    # ``connect()`` inside the try: a failure there still leaves aiosqlite's
+    # non-daemon worker thread running, which hangs the whole pytest process at
+    # exit instead of failing the test.
+    try:
+        await backend.connect()
+        namespaces, newest = _seed(db_path)
+        yield SeededDB(backend, db_path, namespaces[1], newest)
+    finally:
+        await backend.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# The schema blob is executed by splitting it on ";" - two traps live there
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaBlobStructure:
+    """Structural properties of ``_SCHEMA_SQL`` itself.
+
+    Deliberately not asserting on comment prose: the wording is expected to
+    change and a prose assertion is brittle for no safety value.
+    """
+
+    def test_legacy_index_is_dropped_and_never_recreated(self) -> None:
+        """The blob must not build ``idx_docs_ns`` and drop it on every connect.
+
+        A create left next to the drop is invisible to a plan assertion - the
+        end state is identical - but it rebuilds and destroys a full index on
+        every single ``connect()``.
+        """
+        assert LEGACY_DROP_RE.search(_SCHEMA_SQL), (
+            f"the schema blob no longer drops {LEGACY_INDEX}; databases created before the sort "
+            f"index landed keep a redundant strict prefix of {SORT_INDEX} forever, paying an "
+            "index write per document insert"
+        )
+        assert not LEGACY_CREATE_RE.search(_SCHEMA_SQL), (
+            f"the schema blob still creates {LEGACY_INDEX} alongside the drop - every connect() "
+            "then builds a full index and immediately destroys it"
+        )
+
+    def test_the_legacy_index_pattern_does_not_match_the_surviving_indexes(self) -> None:
+        """Positive and negative controls for the pattern used above.
+
+        Without this, a pattern that matched nothing at all would make the
+        assertion above pass for the wrong reason.
+        """
+        assert LEGACY_CREATE_RE.search(f"CREATE INDEX IF NOT EXISTS {LEGACY_INDEX} ON documents(namespace_id);")
+        assert not LEGACY_CREATE_RE.search(
+            f"CREATE INDEX IF NOT EXISTS {SORT_INDEX} ON documents(namespace_id, created_at, id);"
+        )
+        assert not LEGACY_CREATE_RE.search(
+            "CREATE INDEX IF NOT EXISTS idx_docs_ns_external_id ON documents(namespace_id, external_id);"
+        )
+
+    def test_every_chunk_of_the_blob_survives_the_splitter(self) -> None:
+        """Each chunk is valid SQL once the blob is split the way it is executed.
+
+        ``_create_schema`` splits ``_SCHEMA_SQL`` on ``;``, which makes prose in
+        the blob load-bearing: a semicolon anywhere inside a comment - leading,
+        trailing, or a block comment - cuts the comment and hands the remainder
+        to SQLite as bare prose. That fails on the very first connect, so the
+        backend does not start at all.
+
+        Executed rather than pattern-matched. A lexical rule would have to model
+        SQLite's lexer to be complete, and an incomplete rule whose docstring
+        claims completeness is exactly the defect being guarded against here.
+        """
+        con = sqlite3.connect(":memory:")
+        try:
+            for index, chunk in enumerate(_SCHEMA_SQL.split(";")):
+                statement = chunk.strip()
+                if not statement:
+                    continue
+                try:
+                    con.execute(statement)
+                except sqlite3.OperationalError as exc:
+                    first_line = statement.splitlines()[0]
+                    pytest.fail(
+                        f"chunk {index} of _SCHEMA_SQL is not executable once the blob is split on "
+                        f"the semicolon: {exc}. The chunk begins: {first_line!r}"
+                    )
+        finally:
+            con.close()
+
+    @pytest.mark.parametrize(
+        "hazard",
+        [
+            pytest.param("-- a note; with a semicolon\nCREATE TABLE a (id TEXT)", id="leading-comment"),
+            pytest.param("CREATE TABLE b (id TEXT); -- a note; with a semicolon", id="trailing-comment"),
+            pytest.param("/* a note; with a semicolon */\nCREATE TABLE c (id TEXT)", id="block-comment"),
+        ],
+    )
+    def test_a_semicolon_inside_a_comment_really_does_break_the_splitter(self, hazard: str) -> None:
+        """The failure the test above prevents, in each shape it can take.
+
+        Evidence that the executed check is not vacuous, and the reason the
+        lexical version of this guard was dropped: only the first of these three
+        shapes starts a line with ``--``.
+        """
+        con = sqlite3.connect(":memory:")
+        try:
+            with pytest.raises(sqlite3.OperationalError):
+                for chunk in hazard.split(";"):
+                    if chunk.strip():
+                        con.execute(chunk.strip())
+        finally:
+            con.close()
+
+    def test_comments_without_a_semicolon_are_not_a_hazard(self) -> None:
+        """The boundary of the rule, so the guard is not widened onto safe prose.
+
+        A comment-only chunk and a comment followed by a statement both execute
+        cleanly - SQLite accepts them. Only a semicolon *inside* the comment
+        breaks anything.
+        """
+        con = sqlite3.connect(":memory:")
+        try:
+            con.execute("-- a comment on its own is a valid statement")
+            con.execute("-- a leading comment\nCREATE TABLE safe (id TEXT)")
+            con.execute("/* a block comment */\nCREATE TABLE also_safe (id TEXT)")
+        finally:
+            con.close()
+
+
+# ---------------------------------------------------------------------------
+# What connect() leaves on disk
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentsIndexSet:
+    """The index set both backends build, fresh and on an existing database."""
+
+    @pytest.mark.parametrize("backend_cls", BACKENDS, ids=lambda c: c.__name__)
+    async def test_fresh_database_has_exactly_the_expected_indexes(self, backend_cls, tmp_path: Path) -> None:
+        """The two partial indexes survive; the bare namespace index does not.
+
+        ``idx_docs_checksum`` and ``idx_docs_ns_external_id`` also lead with
+        ``namespace_id``, but their ``WHERE`` clauses make them a different
+        index - dropping either would be a behaviour change, not a cleanup.
+        """
+        db_path = tmp_path / f"{backend_cls.__name__}.db"
+        backend = backend_cls(str(db_path))
+        try:
+            await backend.connect()
+            indexes = _documents_indexes(db_path)
+        finally:
+            await backend.disconnect()
+
+        assert indexes == {
+            "sqlite_autoindex_documents_1",
+            "idx_docs_checksum",
+            "idx_docs_ns_external_id",
+            SORT_INDEX,
+        }
+
+    @pytest.mark.parametrize("backend_cls", BACKENDS, ids=lambda c: c.__name__)
+    async def test_existing_database_converts_on_the_next_open(self, backend_cls, tmp_path: Path) -> None:
+        """No migration guards this store - the blob has to do the conversion.
+
+        Both backends run the same blob, so both have to convert; whichever one
+        opens the file first is not something a caller controls.
+        """
+        db_path = tmp_path / f"{backend_cls.__name__}-existing.db"
+        first = backend_cls(str(db_path))
+        try:
+            await first.connect()
+            namespaces, _ = _seed(db_path)
+        finally:
+            await first.disconnect()
+
+        _use_legacy_indexes(db_path)
+        before = _documents_indexes(db_path)
+        assert LEGACY_INDEX in before and SORT_INDEX not in before, (
+            f"the pre-change index set was not reproduced, so the reopen below proves nothing: {before}"
+        )
+
+        second = backend_cls(str(db_path))
+        try:
+            await second.connect()
+            after = _documents_indexes(db_path)
+        finally:
+            await second.disconnect()
+
+        assert SORT_INDEX in after, f"reopening an existing database did not build {SORT_INDEX}: {after}"
+        assert LEGACY_INDEX not in after, f"reopening an existing database did not drop {LEGACY_INDEX}: {after}"
+
+        con = sqlite3.connect(db_path)
+        try:
+            surviving = con.execute(
+                "SELECT COUNT(*) FROM documents WHERE namespace_id = ?", (str(namespaces[0]),)
+            ).fetchone()[0]
+        finally:
+            con.close()
+        assert surviving == ROWS_PER_NAMESPACE, "the conversion must not touch the rows"
+
+
+# ---------------------------------------------------------------------------
+# list_documents plan shape
+# ---------------------------------------------------------------------------
+
+# Every predicate combination ``list_documents`` can emit. An intervening
+# predicate defeating the index is the most plausible silent regression here,
+# so all three are pinned rather than just the bare namespace read.
+PREDICATE_SHAPES = ["namespace", "namespace+status", "namespace+status+updated_before"]
+
+
+def _predicate_kwargs(shape: str, newest: datetime) -> dict[str, Any]:
+    """Build the kwargs for a shape, relative to the seed's newest row.
+
+    Never ``datetime.now()``: the rows are stamped when the fixture runs, so a
+    cutoff taken from the wall clock means something different depending on how
+    long after collection the test executes. Anchoring on the seed keeps the
+    predicate a live filter - it excludes the newest slice of rows - and keeps
+    it deterministic.
+    """
+    kwargs: dict[str, Any] = {}
+    if "status" in shape:
+        kwargs["status"] = "completed"
+    if "updated_before" in shape:
+        kwargs["updated_before"] = newest - timedelta(seconds=1)
+    return kwargs
+
+
+@pytest.mark.parametrize("shape", PREDICATE_SHAPES)
+class TestListDocumentsPlanShape:
+    """``list_documents`` reads its page in index order, for every predicate set.
+
+    The two tests are a matched pair on identical data: the second is the
+    evidence that the first is not passing for free.
+    """
+
+    async def _captured(self, seeded: SeededDB, shape: str) -> tuple[str, list]:
+        backend = seeded.backend
+        rows, statement = await _capture_sql(
+            backend,
+            lambda: backend.list_documents(
+                seeded.namespace_id, limit=PAGE_SIZE, offset=0, **_predicate_kwargs(shape, seeded.newest)
+            ),
+        )
+        assert len(rows) == PAGE_SIZE, f"seed too small for shape {shape}: got {len(rows)} rows"
+        return statement
+
+    async def test_sort_index_serves_the_order(self, seeded: SeededDB, shape: str) -> None:
+        statement, parameters = await self._captured(seeded, shape)
+
+        plan = _query_plan(seeded.db_path, statement, parameters)
+
+        assert any(SORT_INDEX in line for line in plan), (
+            f"{SORT_INDEX} is not used for shape {shape} - a listing that falls back to a table "
+            f"scan reads the whole namespace to return one page. Plan: {plan}"
+        )
+        assert not _sorts(plan), (
+            f"SQLite still sorts for shape {shape}, so the index is not covering the pinned order; "
+            f"the sort is redone for every page of a drain. Plan: {plan}"
+        )
+
+    async def test_legacy_index_leaves_a_sort_pass(self, seeded: SeededDB, shape: str) -> None:
+        """The differential: same query, same rows, pre-change index set."""
+        statement, parameters = await self._captured(seeded, shape)
+
+        _use_legacy_indexes(seeded.db_path)
+        plan = _query_plan(seeded.db_path, statement, parameters)
+
+        assert any(LEGACY_INDEX in line for line in plan), f"expected the narrow index to be used: {plan}"
+        assert _sorts(plan), (
+            f"the narrow index was expected to leave SQLite sorting for shape {shape}; if it does "
+            f"not, the premise of this module is wrong and the assertions above prove nothing. Plan: {plan}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Namespace aggregates, which lose the index they used to read
+# ---------------------------------------------------------------------------
+
+AGGREGATES = ["count_documents", "get_last_activity_at", "get_document_stats"]
+
+
+@pytest.mark.parametrize("method", AGGREGATES)
+class TestNamespaceAggregatePlans:
+    """The three namespace aggregates re-plan onto the sort index.
+
+    They used to read the bare namespace index, so dropping it has to leave
+    them on an index rather than on a table scan. Only the index NAME is
+    asserted: whether SQLite also calls the read covering is a planner detail
+    that depends on the projection and can shift under a SQLite upgrade,
+    breaking the suite cosmetically for no added safety.
+
+    Plans only, never timings. The measured effect runs from clearly faster
+    (``get_last_activity_at``, ``get_document_stats``: the ``MAX(created_at)``
+    stops reading the table) to slightly slower (bare ``count_documents``:
+    wider index entries), and both ends scale with rows per namespace, so no
+    ratio here is portable across machines or datasets.
+    """
+
+    async def test_aggregate_reads_the_sort_index(self, seeded: SeededDB, method: str) -> None:
+        _, (statement, parameters) = await _capture_sql(
+            seeded.backend, lambda: getattr(seeded.backend, method)(seeded.namespace_id)
+        )
+
+        plan = _query_plan(seeded.db_path, statement, parameters)
+
+        assert any(SORT_INDEX in line for line in plan), (
+            f"{method} does not read {SORT_INDEX} - with the narrow namespace index dropped, "
+            f"that leaves it scanning the table. Plan: {plan}"
+        )
+
+    async def test_aggregate_read_the_narrow_index_before(self, seeded: SeededDB, method: str) -> None:
+        """The differential: these named a different index before the swap.
+
+        Without this contrast, the assertion above could not tell a real
+        re-plan from an aggregate that would name the sort index either way.
+        """
+        _, (statement, parameters) = await _capture_sql(
+            seeded.backend, lambda: getattr(seeded.backend, method)(seeded.namespace_id)
+        )
+
+        _use_legacy_indexes(seeded.db_path)
+        plan = _query_plan(seeded.db_path, statement, parameters)
+
+        assert any(LEGACY_INDEX in line for line in plan), (
+            f"{method} was expected to read the narrow index while it exists; if it did not, "
+            f"the assertion above proves nothing about the swap. Plan: {plan}"
+        )
+        assert not any(SORT_INDEX in line for line in plan), (
+            f"{method} named {SORT_INDEX} even with the narrow index in place: {plan}"
+        )

--- a/tests/unit/test_sqlite_documents_sort_index.py
+++ b/tests/unit/test_sqlite_documents_sort_index.py
@@ -195,6 +195,24 @@ def _sorts(plan: list[str]) -> list[str]:
     return [line for line in plan if "TEMP B-TREE" in line.upper()]
 
 
+# ``SEARCH documents USING COVERING INDEX idx_docs_ns_created_id (namespace_id=?)``
+# and the non-covering ``SCAN``/``SEARCH ... USING INDEX <name>`` spellings. An
+# unnamed automatic index does not match, which is intended: it is not one of
+# this table's indexes.
+PLAN_INDEX_RE = re.compile(r"USING\s+(?:COVERING\s+)?INDEX\s+(\w+)")
+
+
+def _indexes_used(plan: list[str]) -> set[str]:
+    """The index names a plan reads, extracted whole.
+
+    Matching an index name as a naked substring of a plan line is unsound here:
+    ``idx_docs_ns`` is a strict prefix of both ``idx_docs_ns_created_id`` and
+    ``idx_docs_ns_external_id``, and every one of those lines occurs in this
+    schema's plans. Same hazard the blob regexes above guard with ``\\b``.
+    """
+    return {match.group(1) for line in plan for match in PLAN_INDEX_RE.finditer(line)}
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -285,7 +303,13 @@ class TestSchemaBlobStructure:
                     continue
                 try:
                     con.execute(statement)
-                except sqlite3.OperationalError as exc:
+                # ``sqlite3.Error``, not ``OperationalError``: a cut comment
+                # whose remainder parses on its own raises something else -
+                # ``-- note; SELECT ?;`` leaves ``SELECT ?``, which prepares
+                # cleanly and then raises ``ProgrammingError`` on the missing
+                # binding. A narrow catch lets that escape as a bare traceback
+                # with no chunk index and no chunk text.
+                except sqlite3.Error as exc:
                     first_line = statement.splitlines()[0]
                     pytest.fail(
                         f"chunk {index} of _SCHEMA_SQL is not executable once the blob is split on "
@@ -457,7 +481,7 @@ class TestListDocumentsPlanShape:
 
         plan = _query_plan(seeded.db_path, statement, parameters)
 
-        assert any(SORT_INDEX in line for line in plan), (
+        assert SORT_INDEX in _indexes_used(plan), (
             f"{SORT_INDEX} is not used for shape {shape} - a listing that falls back to a table "
             f"scan reads the whole namespace to return one page. Plan: {plan}"
         )
@@ -473,7 +497,7 @@ class TestListDocumentsPlanShape:
         _use_legacy_indexes(seeded.db_path)
         plan = _query_plan(seeded.db_path, statement, parameters)
 
-        assert any(LEGACY_INDEX in line for line in plan), f"expected the narrow index to be used: {plan}"
+        assert LEGACY_INDEX in _indexes_used(plan), f"expected the narrow index to be used: {plan}"
         assert _sorts(plan), (
             f"the narrow index was expected to leave SQLite sorting for shape {shape}; if it does "
             f"not, the premise of this module is wrong and the assertions above prove nothing. Plan: {plan}"
@@ -511,7 +535,7 @@ class TestNamespaceAggregatePlans:
 
         plan = _query_plan(seeded.db_path, statement, parameters)
 
-        assert any(SORT_INDEX in line for line in plan), (
+        assert SORT_INDEX in _indexes_used(plan), (
             f"{method} does not read {SORT_INDEX} - with the narrow namespace index dropped, "
             f"that leaves it scanning the table. Plan: {plan}"
         )
@@ -521,6 +545,14 @@ class TestNamespaceAggregatePlans:
 
         Without this contrast, the assertion above could not tell a real
         re-plan from an aggregate that would name the sort index either way.
+
+        Asserted as the whole index set, not as a membership test: the sort
+        index is gone from this database, so "the plan does not name the sort
+        index" cannot fail and proves nothing. What can fail - and is the
+        regression worth catching - is the aggregate reading some *other*
+        surviving index (``idx_docs_checksum``, ``idx_docs_ns_external_id``) or
+        no index at all, either of which would make the pre-change state a
+        different comparison than the one this class claims to draw.
         """
         _, (statement, parameters) = await _capture_sql(
             seeded.backend, lambda: getattr(seeded.backend, method)(seeded.namespace_id)
@@ -529,10 +561,8 @@ class TestNamespaceAggregatePlans:
         _use_legacy_indexes(seeded.db_path)
         plan = _query_plan(seeded.db_path, statement, parameters)
 
-        assert any(LEGACY_INDEX in line for line in plan), (
-            f"{method} was expected to read the narrow index while it exists; if it did not, "
-            f"the assertion above proves nothing about the swap. Plan: {plan}"
-        )
-        assert not any(SORT_INDEX in line for line in plan), (
-            f"{method} named {SORT_INDEX} even with the narrow index in place: {plan}"
+        assert _indexes_used(plan) == {LEGACY_INDEX}, (
+            f"{method} was expected to read {LEGACY_INDEX} and nothing else while that index "
+            f"exists; if it did not, the assertion above proves nothing about the swap. "
+            f"Plan: {plan}"
         )


### PR DESCRIPTION
## Summary

Document listing pins a total order — `ORDER BY created_at DESC, id DESC`. The relational backends get a matching `(namespace_id, created_at, id)` index from `db/migrations/versions/054_documents_namespace_created_at_id.py`, but that migration chain never runs against the raw-SQLite or SurrealDB stores: both manage their own DDL. Neither had *any* `created_at` index, so both were paying a full sort per page on the pinned order.

The two halves are very different in value, and the honest framing is below rather than a single headline.

### raw-SQLite — the substance of the change

Adds `idx_docs_ns_created_id (namespace_id, created_at, id)` and drops the superseded `idx_docs_ns`, mirroring **both** halves of that migration.

All three keys are declared ASC. With `namespace_id` equality-constrained the residual index order is `(created_at ASC, id ASC)`, which a backward scan reads as `(created_at DESC, id DESC)`; DESC-declared keys only buy anything for *mixed* sort directions, which the uniform-DESC pin rules out. Without the trailing `id` key SQLite satisfies the leading term off the index and plants a `USE TEMP B-TREE FOR LAST TERM OF ORDER BY` on every page — invisible on a first page, dominant on a full drain, and it does **not** require ties to exist.

Read path, full drain, ~45k rows in namespace:

| query shape | before | after |
| -- | -- | -- |
| namespace only | 2826 ms | **76 ms** (~37x) |
| + `status` | 1290 ms | **180 ms** (~7x) |

Reviewers independently reproduced 29.5x and 6.1x on slower hardware, and 174x at 2 KB rows — the numbers are conservative, and the ratio is row-width sensitive (29.5x at 0 B vs 174x at 2 KB on otherwise identical data). The optional `status` / `updated_at` predicates are residual filters on top of the index-ordered scan and do not defeat it. `MAX(created_at)` becomes a covering-index scan.

The drop is what keeps the write side honest — `idx_docs_ns` is a strict prefix, so every query that used it re-plans onto the wider index. Keeping both roughly triples the per-insert overhead the new index adds (in-memory +18% vs +5%; file-backed WAL +29% vs +12%, on-disk 66.3 → 78.4 vs 73.3 MB). The CREATE is ordered before the DROP so no connect observes the table with neither index, and the old CREATE is *removed* rather than left alongside — the blob re-executes on every connect, so leaving both would rebuild and destroy the index on every open.

One regression, stated plainly: bare `count_documents` loses a narrower covering index and pays roughly **1.3-1.7x**, climbing with namespace size. It stays a covering scan and never becomes a table scan.

### SurrealDB — currently inert, and shipped as groundwork

Adds `idx_document_ns_created (namespace_id, created_at)` — **two** fields, not three, because `id` is the record identifier and not a legal index field (`The field 'id' does not exist`) — and drops the superseded `idx_document_namespace`.

**This index is not selected by any engine khora can currently reach.** That is the accurate statement, and it took three rounds of measurement to arrive at:

- **2.6.5 and embedded 2.0.0** sort in memory unconditionally. Plan is byte-identical with and without the index.
- **3.0.5 / 3.2.0** do drop the sort and push LIMIT/START into a backward index scan (first page 8-23x at 4k rows) — but the `FLEXIBLE TYPE` clauses elsewhere in this DDL do not parse on 3.x, so schema init cannot reach such a server at all. Tracked in #1584.
- Treat that 8-23x as **unconfirmed under the real index set**: on the engines that can be measured the planner picks among equally eligible `(namespace_id, …)` composites by index *name*, and `idx_document_ns_checksum` sorts ahead of this one. If 3.x inherits any of that, the win was measured on a stripped harness and would not transfer.

Dropping the prefix index therefore does **not** promote the sort index — the slot goes to `idx_document_ns_checksum`. The drop stands on write cost alone: it returns inserts to parity with today (measured +8.6%/+13.3% with both indexes present, +0.6%/-0.6% after the drop) rather than making them cheaper. Prefix-matching does work, so no query shape falls back to a table scan, and the substitution was checked for row loss rather than assumed safe, since the composite that takes over has a nullable second column and SurrealDB indexes `NONE`.

Not built `CONCURRENTLY`, deliberately: that build is asynchronous and the planner routes queries through the index before it is populated, so counts come back short for the length of the build with no error (measured: 0, then 3750, then 19750 over ~1 s at 50k rows).

**The trade being accepted:** a small write-side maintenance cost on every reachable deployment for a read benefit that becomes available when #1584 lands. Deferring instead is defensible — `DEFINE INDEX` is declarative and re-runs on connect, so adding it later is a one-line change with no migration. It ships now because the drop offsets the cost to parity and the analysis is captured where the next person will find it.

## Known limitations

- **Mixed khora versions sharing one SQLite file thrash.** The pre-swap blob re-creates `idx_docs_ns` and the post-swap blob drops it, so alternating connects rebuild a full index each time. Self-correcting once every process is on this version. The `DROP` is the first destructive statement this blob has ever contained.
- **`connect()` can now fail where it could not before.** The converting connect is the first real writer in the blob, and `_create_schema` catches `OperationalError` only around the `ALTER TABLE`. A writer holding the lock past sqlite3's default 5000 ms `busy_timeout` makes the build raise `database is locked` out of `connect()`. Measured ~5017 ms then raise, against 1-2 ms on a converged file. A retry heals it. At 60-110 ms per 100k rows the cliff is multi-million-row territory.
- **The tie-order property underpinning 3.x sort elision has no automated coverage and CI cannot acquire any.** A non-unique index carrying the record id as its trailing key holds on embedded 2.0.0, but the row order of an unsorted scan is not a contractual ordering, and 3.x is the engine that would rely on it. Gate it behind a `ws://` pagination test before anything depends on it.
- **`CLAUDE.md` advertises SurrealDB 3.x support khora does not have.** Out of scope here (that file carries an unrelated working-tree edit); folded into #1584.
- **Nothing gates the raw-SQLite `_SCHEMA_SQL` against the ORM.** The drift gate runs the Alembic chain and never touches this store, so mirroring 054 here stays a manual obligation.

## Test plan

- [x] `make format` clean, `make lint` exits 0, `make test` green — **10553 unit + 530 integration passed**, coverage 85.42%
- [x] `tests/unit/test_sqlite_documents_sort_index.py` — plan shape asserted against SQL *captured from the backend* rather than hand-written; differential non-vacuity (index dropped ⇒ temp B-tree reappears) across every predicate variant `list_documents` emits; existing-database pickup through the real connect path for both backend classes; blob-splitter integrity, including a test pinning that a semicolon inside a `--` comment really does break the loader
- [x] **Non-vacuity verified by mutation, not assumed** — reverting `sqlite.py` fails 11 of 23; narrowing the index to two keys fails 3; leaving the legacy CREATE beside the DROP fails 1
- [x] `tests/unit/storage/backends/surrealdb/test_document_sort_index.py` — asserts both index states after schema init on `memory://`. This closes a silent failure mode: `initialize_schema` hands the whole blob to one `execute`, which swallows per-statement DDL errors, so an index that fails to define still logs success
- [x] Every empirical claim in the code comments re-measured; five inaccurate ones corrected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved document listing, sorting, pagination, and namespace aggregate query performance through optimized indexes.
  * Preserved efficient namespace-only lookups and existing checksum and external-ID searches.

* **Bug Fixes**
  * Updated existing databases automatically when index configurations change, while preserving document data.
  * Removed redundant indexing without affecting search behavior.

* **Tests**
  * Added comprehensive coverage for sorting, pagination, migrations, data preservation, and query performance across supported database backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->