### PR TITLE
Read the migration head from the script directory in tests

### DIFF
--- a/tests/integration/db/test_migration_032_dream_runs.py
+++ b/tests/integration/db/test_migration_032_dream_runs.py
@@ -35,6 +35,7 @@ from alembic.config import Config
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from khora.db.session import run_migrations
+from tests.test_helpers.alembic_head import current_head
 
 DATABASE_URL = os.environ.get(
     "KHORA_DATABASE_URL",
@@ -304,7 +305,7 @@ class TestMigration032OnSqlite:
                 async with engine.connect() as conn:
                     # Chain reached head (sanity).
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "057_drop_documents_created_at_index"
+                    assert result.scalar() == current_head()
 
                     # khora_dream_runs exists on SQLite (#896) so dream_history /
                     # dream_status work on the embedded sqlite_lance stack.

--- a/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
+++ b/tests/integration/db/test_migration_041_chunks_denormalized_columns.py
@@ -41,6 +41,7 @@ from alembic.config import Config
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from khora.db.session import run_migrations
+from tests.test_helpers.alembic_head import current_head
 
 DATABASE_URL = os.environ.get(
     "KHORA_DATABASE_URL",
@@ -322,7 +323,7 @@ class TestMigration041OnPostgres:
                 async with engine.connect() as conn:
                     # Chain reached head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "057_drop_documents_created_at_index"
+                    assert result.scalar() == current_head()
 
                     # The migration did not create the table.
                     result = await conn.execute(
@@ -353,7 +354,7 @@ class TestMigration041OnSqlite:
             try:
                 async with engine.connect() as conn:
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == "057_drop_documents_created_at_index"
+                    assert result.scalar() == current_head()
             finally:
                 await engine.dispose()
 

--- a/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
+++ b/tests/integration/db/test_migration_042_widen_chunks_source_external_id.py
@@ -43,6 +43,7 @@ from alembic.config import Config
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from khora.db.session import run_migrations
+from tests.test_helpers.alembic_head import current_head
 
 DATABASE_URL = os.environ.get(
     "KHORA_DATABASE_URL",
@@ -69,7 +70,6 @@ pytestmark = pytest.mark.integration
 
 
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
-_HEAD = "057_drop_documents_created_at_index"
 _PREV = "041_khora_chunks_denormalized_columns"
 
 
@@ -296,7 +296,7 @@ class TestMigration042OnPostgres:
             try:
                 async with engine.connect() as conn:
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == _HEAD
+                    assert result.scalar() == current_head()
 
                     result = await conn.execute(
                         sa.text(
@@ -326,7 +326,7 @@ class TestMigration042OnSqlite:
             try:
                 async with engine.connect() as conn:
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == _HEAD
+                    assert result.scalar() == current_head()
             finally:
                 await engine.dispose()
 

--- a/tests/integration/db/test_migration_044_chunks_backfill.py
+++ b/tests/integration/db/test_migration_044_chunks_backfill.py
@@ -65,6 +65,7 @@ from alembic.config import Config
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, create_async_engine
 
 from khora.db.session import run_migrations
+from tests.test_helpers.alembic_head import current_head
 
 DATABASE_URL = os.environ.get(
     "KHORA_DATABASE_URL",
@@ -93,7 +94,6 @@ pytestmark = pytest.mark.integration
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
 
 _PREV_REVISION = "043_khora_chunks_metadata_backfill"
-_HEAD_REVISION = "057_drop_documents_created_at_index"
 
 _TSV_TRIGGER = "khora_chunks_content_tsv_update"
 
@@ -781,7 +781,7 @@ class TestMigration044OnPostgres:
             try:
                 async with engine.connect() as conn:
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == _HEAD_REVISION
+                    assert result.scalar() == current_head()
 
                     result = await conn.execute(
                         sa.text(
@@ -811,7 +811,7 @@ class TestMigration044OnSqlite:
             try:
                 async with engine.connect() as conn:
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert result.scalar() == _HEAD_REVISION
+                    assert result.scalar() == current_head()
             finally:
                 await engine.dispose()
 

--- a/tests/integration/db/test_migration_049_hook_subscriptions.py
+++ b/tests/integration/db/test_migration_049_hook_subscriptions.py
@@ -45,6 +45,7 @@ from khora.db.session import run_migrations
 from khora.hooks.dispatcher import HookDispatcher
 from khora.hooks.models import SemanticFilter
 from khora.hooks.subscription_store import HookSubscriptionStore, PersistentSubscription
+from tests.test_helpers.alembic_head import current_head
 
 DATABASE_URL = os.environ.get(
     "KHORA_DATABASE_URL",
@@ -71,7 +72,6 @@ pytestmark = pytest.mark.integration
 
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
 
-_HEAD = "057_drop_documents_created_at_index"
 _PREV = "048_dream_conflicts_reconcile"
 
 
@@ -174,7 +174,7 @@ class TestMigration049Schema:
                     assert "ix_khora_hook_subscriptions_ns_event" in idx_names
 
                     ver = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
-                    assert ver.scalar() == _HEAD
+                    assert ver.scalar() == current_head()
             finally:
                 await engine.dispose()
 

--- a/tests/integration/db/test_migration_052_entities_source_chunk_ids_gin.py
+++ b/tests/integration/db/test_migration_052_entities_source_chunk_ids_gin.py
@@ -64,7 +64,7 @@ pytestmark = pytest.mark.integration
 
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
 
-_HEAD = "052_entities_source_chunk_ids_gin"
+_TARGET = "052_entities_source_chunk_ids_gin"
 _PREV = "051_documents_graph_mirror_pending"
 
 _INDEX_NAME = "ix_entities_source_chunk_ids_gin"
@@ -100,7 +100,7 @@ class TestMigration052GinIndex:
 
         # Migration 052 builds the GIN index. Idempotent when the shared dev
         # DB is already at head.
-        command.upgrade(cfg, _HEAD)
+        command.upgrade(cfg, _TARGET)
         rows = asyncio.run(_index_rows(DATABASE_URL))
         assert len(rows) == 1, f"expected the GIN index at head, found {rows}"
         assert rows[0][0] == _INDEX_NAME
@@ -112,7 +112,7 @@ class TestMigration052GinIndex:
             assert asyncio.run(_index_rows(DATABASE_URL)) == []
         finally:
             # Always restore the true chain head so the shared dev DB is never
-            # left rewound — "head" (not the pinned _HEAD) stays correct once a
+            # left rewound — "head" (not the pinned _TARGET) stays correct once a
             # future migration lands on top of 052.
             command.upgrade(cfg, "head")
 

--- a/tests/integration/db/test_migration_054_documents_namespace_created_at_id.py
+++ b/tests/integration/db/test_migration_054_documents_namespace_created_at_id.py
@@ -78,7 +78,7 @@ skip_no_pg = pytest.mark.skipif(
 
 _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
 
-_HEAD = "054_documents_namespace_created_at_id"
+_TARGET = "054_documents_namespace_created_at_id"
 _PREV = "053_khora_chunks_bookkeeping_to_chunker_info"
 
 # The revision that first added the 2-column index, and the one immediately

--- a/tests/integration/db/test_migration_055_documents_source_type.py
+++ b/tests/integration/db/test_migration_055_documents_source_type.py
@@ -35,7 +35,6 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from tests.test_helpers.documents_source_type import (
     BACKFILL_VALUE,
     DECLARED_INDEX_COLUMNS,
-    HEAD_REVISION,
     ID_EMPTY_STRING,
     ID_NULL,
     ID_REAL_VALUE,
@@ -43,6 +42,7 @@ from tests.test_helpers.documents_source_type import (
     NS,
     PREV_REVISION,
     REAL_VALUE,
+    TARGET_REVISION,
     make_config,
     read_source_types,
     seed_rows,
@@ -157,7 +157,7 @@ class TestMigration055OnPostgres:
         before = asyncio.run(read_source_types(pg_url, [ID_NULL]))
         assert before[ID_NULL] is None
 
-        command.upgrade(make_config(pg_url), HEAD_REVISION)
+        command.upgrade(make_config(pg_url), TARGET_REVISION)
 
         after = asyncio.run(read_source_types(pg_url, [ID_NULL, ID_REAL_VALUE, ID_EMPTY_STRING]))
         assert after[ID_NULL] == BACKFILL_VALUE, "the NULL row was not backfilled"
@@ -169,13 +169,13 @@ class TestMigration055OnPostgres:
             f"precondition: source_type must be NULLABLE at revision {PREV_REVISION}"
         )
 
-        command.upgrade(make_config(pg_url), HEAD_REVISION)
+        command.upgrade(make_config(pg_url), TARGET_REVISION)
 
         assert asyncio.run(_pg_source_type_is_nullable(pg_url)) is False
         assert asyncio.run(_pg_index_columns(pg_url)) == DECLARED_INDEX_COLUMNS
 
     def test_pre_existing_index_does_not_wedge_the_backfill(self, pg_url_preindexed: str) -> None:
-        command.upgrade(make_config(pg_url_preindexed), HEAD_REVISION)
+        command.upgrade(make_config(pg_url_preindexed), TARGET_REVISION)
 
         after = asyncio.run(read_source_types(pg_url_preindexed, [ID_NULL]))
         assert after[ID_NULL] == BACKFILL_VALUE
@@ -184,7 +184,7 @@ class TestMigration055OnPostgres:
 
     def test_downgrade_drops_the_constraint_and_index_but_not_the_backfill(self, pg_url: str) -> None:
         cfg = make_config(pg_url)
-        command.upgrade(cfg, HEAD_REVISION)
+        command.upgrade(cfg, TARGET_REVISION)
 
         command.downgrade(cfg, PREV_REVISION)
 

--- a/tests/test_helpers/alembic_head.py
+++ b/tests/test_helpers/alembic_head.py
@@ -5,19 +5,18 @@ Migration tests that run ``upgrade head`` and then assert what landed in
 migration therefore had to bump the same literal in six files, and those bumps
 collided with any other migration PR in flight.
 
-How much the resulting assertion is worth depends on where the compared value
-came from, and the split is not by dialect:
-
-* Where the test body has no upgrade of its own and the version table was
-  written by the fixture's ``run_migrations()`` — only the hook-subscriptions
-  case today — the comparison carries real signal. That call returns
-  ``success=True, skipped=True`` without running anything when the database is
-  ahead, and the fixture checks only ``success``, so the assertion is the one
-  thing standing between a skipped migration and a green test.
-* Everywhere else, on both dialects, a ``command.upgrade(cfg, "head")`` a few
-  lines above wrote the value moments earlier and any real failure raises out
-  of that call first. The comparison is close to decoration there — kept
-  because it costs nothing, not because it is load-bearing.
+Every one of those assertions is decoration today. A ``command.upgrade(cfg,
+"head")`` a few lines above wrote the value moments earlier and any real
+failure raises out of that call first, so the comparison is kept because it
+costs nothing, not because it is load-bearing. The hook-subscriptions case
+reads like the exception — its version row is written by the fixture's
+``run_migrations()``, which returns ``success=True, skipped=True`` without
+running anything when the database is ahead, and the fixture checks only
+``success`` — but that skip is unreachable as the fixture stands: it drops and
+recreates ``public`` first, so the version table is empty, ahead-detection
+cannot fire, and every other failure sets ``success=False``. The assertion
+*would* become load-bearing if that reset ever stopped clearing the version
+table.
 
 This is only for *head* references. An explicit upgrade or downgrade target — a
 migration's own revision, or its predecessor — stays a literal, because those
@@ -27,12 +26,21 @@ migration lands.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from alembic.config import Config
 from alembic.script import ScriptDirectory
 
-from tests.test_helpers.schema_drift import MIGRATIONS_DIR
+import khora.db.migrations
 
 __all__ = ["current_head"]
+
+#: Derive the migrations directory from the installed package — not relative to
+#: this file — so the head is read from the same chain ``run_migrations()``
+#: walks. The two are identical under an editable install and diverge under a
+#: wheel, which is exactly the case ``test_versions_dir_is_fully_bundled``
+#: exists to guard.
+MIGRATIONS_DIR = Path(khora.db.migrations.__file__).parent
 
 
 def current_head() -> str:
@@ -48,5 +56,6 @@ def current_head() -> str:
     cfg = Config()
     cfg.set_main_option("script_location", str(MIGRATIONS_DIR))
     head = ScriptDirectory.from_config(cfg).get_current_head()
-    assert head is not None, f"no head revision found in {MIGRATIONS_DIR / 'versions'}"
+    if head is None:
+        raise AssertionError(f"no head revision found in {MIGRATIONS_DIR / 'versions'}")
     return head

--- a/tests/test_helpers/alembic_head.py
+++ b/tests/test_helpers/alembic_head.py
@@ -1,0 +1,52 @@
+"""The head revision of the bundled Alembic chain, read from the sources.
+
+Migration tests that run ``upgrade head`` and then assert what landed in
+``khora_alembic_version`` used to spell the revision id out. Every new
+migration therefore had to bump the same literal in six files, and those bumps
+collided with any other migration PR in flight.
+
+How much the resulting assertion is worth depends on where the compared value
+came from, and the split is not by dialect:
+
+* Where the test body has no upgrade of its own and the version table was
+  written by the fixture's ``run_migrations()`` — only the hook-subscriptions
+  case today — the comparison carries real signal. That call returns
+  ``success=True, skipped=True`` without running anything when the database is
+  ahead, and the fixture checks only ``success``, so the assertion is the one
+  thing standing between a skipped migration and a green test.
+* Everywhere else, on both dialects, a ``command.upgrade(cfg, "head")`` a few
+  lines above wrote the value moments earlier and any real failure raises out
+  of that call first. The comparison is close to decoration there — kept
+  because it costs nothing, not because it is load-bearing.
+
+This is only for *head* references. An explicit upgrade or downgrade target — a
+migration's own revision, or its predecessor — stays a literal, because those
+tests are about that specific revision and must not drift forward when the next
+migration lands.
+"""
+
+from __future__ import annotations
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+from tests.test_helpers.schema_drift import MIGRATIONS_DIR
+
+__all__ = ["current_head"]
+
+
+def current_head() -> str:
+    """Return the single head revision declared by the bundled migrations.
+
+    Call this inside a test body, never at module scope: building the script
+    directory imports every version module, and at module scope a broken chain
+    becomes a collection error that takes unrelated tests down with it.
+
+    Deliberately uncached — a memoized head would survive a migration being
+    added mid-session and hand back a stale answer.
+    """
+    cfg = Config()
+    cfg.set_main_option("script_location", str(MIGRATIONS_DIR))
+    head = ScriptDirectory.from_config(cfg).get_current_head()
+    assert head is not None, f"no head revision found in {MIGRATIONS_DIR / 'versions'}"
+    return head

--- a/tests/test_helpers/documents_source_type.py
+++ b/tests/test_helpers/documents_source_type.py
@@ -41,7 +41,6 @@ from sqlalchemy.ext.asyncio import AsyncConnection, create_async_engine
 __all__ = [
     "BACKFILL_VALUE",
     "DECLARED_INDEX_COLUMNS",
-    "HEAD_REVISION",
     "ID_EMPTY_STRING",
     "ID_NULL",
     "ID_REAL_VALUE",
@@ -50,6 +49,7 @@ __all__ = [
     "OPTIMIZE_CREATE_INDEX",
     "PREV_REVISION",
     "REAL_VALUE",
+    "TARGET_REVISION",
     "bind_id",
     "insert_document",
     "insert_namespace",
@@ -60,7 +60,7 @@ __all__ = [
 
 MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "src" / "khora" / "db" / "migrations"
 
-HEAD_REVISION = "055_documents_source_type_alignment"
+TARGET_REVISION = "055_documents_source_type_alignment"
 PREV_REVISION = "054_documents_namespace_created_at_id"
 
 INDEX_NAME = "ix_documents_namespace_source_type"

--- a/tests/unit/db/test_migration_055_documents_source_type.py
+++ b/tests/unit/db/test_migration_055_documents_source_type.py
@@ -40,7 +40,6 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from tests.test_helpers.documents_source_type import (
     BACKFILL_VALUE,
     DECLARED_INDEX_COLUMNS,
-    HEAD_REVISION,
     ID_EMPTY_STRING,
     ID_NULL,
     ID_REAL_VALUE,
@@ -48,6 +47,7 @@ from tests.test_helpers.documents_source_type import (
     NS,
     PREV_REVISION,
     REAL_VALUE,
+    TARGET_REVISION,
     insert_document,
     make_config,
     read_source_types,
@@ -104,7 +104,7 @@ class TestMigration055OnSqlite:
         before = asyncio.run(read_source_types(sqlite_url, [ID_NULL]))
         assert before[ID_NULL] is None
 
-        command.upgrade(make_config(sqlite_url), HEAD_REVISION)
+        command.upgrade(make_config(sqlite_url), TARGET_REVISION)
 
         after = asyncio.run(read_source_types(sqlite_url, [ID_NULL, ID_REAL_VALUE, ID_EMPTY_STRING]))
         assert after[ID_NULL] == BACKFILL_VALUE, "the NULL row was not backfilled"
@@ -118,13 +118,13 @@ class TestMigration055OnSqlite:
             f"precondition: source_type must be NULLABLE at revision {PREV_REVISION}"
         )
 
-        command.upgrade(make_config(sqlite_url), HEAD_REVISION)
+        command.upgrade(make_config(sqlite_url), TARGET_REVISION)
 
         assert asyncio.run(_sqlite_source_type_is_nullable(sqlite_url)) is False
 
     def test_index_is_created_over_the_declared_columns(self, sqlite_url: str) -> None:
         _seed_sqlite(sqlite_url)
-        command.upgrade(make_config(sqlite_url), HEAD_REVISION)
+        command.upgrade(make_config(sqlite_url), TARGET_REVISION)
 
         assert _documents_indexes(sqlite_url).get(INDEX_NAME) == DECLARED_INDEX_COLUMNS
 
@@ -137,7 +137,7 @@ class TestMigration055OnSqlite:
         """
         _seed_sqlite(sqlite_url, pre_create_index=True)
 
-        command.upgrade(make_config(sqlite_url), HEAD_REVISION)
+        command.upgrade(make_config(sqlite_url), TARGET_REVISION)
 
         after = asyncio.run(read_source_types(sqlite_url, [ID_NULL]))
         assert after[ID_NULL] == BACKFILL_VALUE
@@ -149,7 +149,7 @@ class TestMigration055OnSqlite:
     def test_downgrade_drops_the_constraint_and_index_but_not_the_backfill(self, sqlite_url: str) -> None:
         _seed_sqlite(sqlite_url)
         cfg = make_config(sqlite_url)
-        command.upgrade(cfg, HEAD_REVISION)
+        command.upgrade(cfg, TARGET_REVISION)
 
         command.downgrade(cfg, PREV_REVISION)
 

--- a/tests/unit/test_alembic_head_helper.py
+++ b/tests/unit/test_alembic_head_helper.py
@@ -1,0 +1,82 @@
+"""Coverage for the shared migration-head helper.
+
+``current_head()`` exists so migration tests stop spelling the chain head out
+as a literal. The property that buys — adding a migration needs no test edit —
+holds only while the lookup stays uncached, and nothing else in the suite would
+notice if it stopped: a memoized head returns the stale-but-correct answer for
+every test that ran before the new revision appeared, so the suite goes green
+either way. That is what this module pins.
+
+The chain is synthetic and the helper is pointed at it via monkeypatch, so
+these tests never touch the real ``versions/`` directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.test_helpers import alembic_head
+from tests.test_helpers.alembic_head import current_head
+
+pytestmark = pytest.mark.unit
+
+_REVISION_TEMPLATE = '''\
+"""synthetic revision"""
+
+revision = "{revision}"
+down_revision = {down_revision}
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass
+'''
+
+
+def _write_revision(versions_dir: Path, revision: str, down_revision: str | None) -> None:
+    down = "None" if down_revision is None else f'"{down_revision}"'
+    (versions_dir / f"{revision}.py").write_text(_REVISION_TEMPLATE.format(revision=revision, down_revision=down))
+
+
+@pytest.fixture
+def synthetic_chain(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point ``current_head()`` at a two-revision chain under ``tmp_path``."""
+    versions_dir = tmp_path / "versions"
+    versions_dir.mkdir()
+    _write_revision(versions_dir, "001_first", None)
+    _write_revision(versions_dir, "002_second", "001_first")
+    monkeypatch.setattr(alembic_head, "MIGRATIONS_DIR", tmp_path)
+    return versions_dir
+
+
+def test_returns_the_chain_head(synthetic_chain: Path) -> None:
+    assert current_head() == "002_second"
+
+
+def test_tracks_a_revision_added_mid_session(synthetic_chain: Path) -> None:
+    """A newly added revision must be visible to the very next call.
+
+    This is the ticket's bought property in miniature. Memoizing the lookup —
+    ``@lru_cache`` on ``current_head()`` — makes this test fail and is the one
+    change that would silently reintroduce the per-migration test edit.
+    """
+    assert current_head() == "002_second"
+
+    _write_revision(synthetic_chain, "003_third", "002_second")
+
+    assert current_head() == "003_third", (
+        "current_head() returned a stale head after a revision was added — the lookup must not be cached"
+    )
+
+
+def test_raises_when_the_chain_is_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "versions").mkdir()
+    monkeypatch.setattr(alembic_head, "MIGRATIONS_DIR", tmp_path)
+
+    with pytest.raises(AssertionError, match="no head revision found"):
+        current_head()

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -21,9 +21,11 @@ from khora.khora import Khora
 # Derive migrations directory from the installed package — not relative to this test file
 _MIGRATIONS_DIR = Path(khora.db.migrations.__file__).parent
 
-#: Lower bound on the number of migration files the chain ships. Never bumped
-#: when a migration is added — raise it only to deliberately tighten the floor.
-_MIGRATION_COUNT_FLOOR = 56
+#: A revision the chain must still reach. Anchors the walk to a known point so
+#: a stray revision chained onto head cannot pass unnoticed. Bumped only
+#: deliberately — never as part of adding a migration — so it does not
+#: reintroduce the per-PR edit an exact file count used to require.
+_ANCHOR_REVISION = "055_documents_source_type_alignment"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -451,57 +453,74 @@ class TestMigrationPackageStructure:
     def test_versions_dir_is_fully_bundled(self):
         """No migration file goes missing from the chain the package ships.
 
-        The floor catches a versions directory that ships nothing, or fewer
-        files than the chain had when the floor was last raised, at any time.
-        It catches a *truncated tail* only while the file count still equals
-        the floor. Once a migration lands beyond it — 57 files against a floor
-        of 56 — deleting the newest revision passes here, and passes every
-        other gate too: ``test_migration_chain_is_contiguous`` is invariant
-        under truncation (the survivors are still a contiguous chain starting
-        at ``down_revision=None``), and the walk below shrinks in step with the
-        file list. That decay is the deliberate price of a floor that is never
-        bumped when a migration is added; an exact count held the stronger
-        property but had to be edited on every migration PR and conflicted with
-        every other one in flight. Raise the floor when tightening is worth an
-        edit.
+        A packaging tripwire first of all: ``_MIGRATIONS_DIR`` resolves through
+        ``khora.db.migrations.__file__``, i.e. the *installed* package rather
+        than the repo tree, so this fails if a build config ever stops shipping
+        ``versions/*.py`` — which would leave ``run_migrations()`` silently
+        building a partial schema. Keep it reading the installed package.
 
-        Do not lean on "each migration's own test pins its revision id" as the
-        backstop — several revisions in the chain have no dedicated test module
-        and are referenced nowhere in ``tests/``.
+        No file count is asserted. An exact count had to be edited on every
+        migration PR and conflicted with every other one in flight, and a floor
+        decays into uselessness: once a migration lands beyond it, deleting the
+        newest revision passes the floor, passes the walk below (both sides
+        shrink together), and passes ``test_migration_chain_is_contiguous``,
+        which is invariant under truncation — the survivors are still a
+        contiguous chain starting at ``down_revision=None``.
 
-        Resolving the chain covers a different failure than the floor, and does
-        not backfill what the floor loses. Alembic skips a file its filename
-        filter excludes — an editor lockfile such as ``.#zz.py`` is skipped
-        while still being globbed here — so a file can exist, count toward the
-        floor, and belong to no chain; the walk count is what rejects it.
-        Anything else unreadable raises outright rather than being skipped: a
-        syntax error raises ``SyntaxError``, and a file with no ``revision``
-        raises ``CommandError``. Resolving the head additionally rejects a stray
-        revision nothing points at, which reads as a second head.
+        Truncation is instead caught by the ORM drift gate in
+        ``tests/unit/test_migration_drift.py``: deleting a revision leaves the
+        objects it created missing from the live schema and absent from the
+        baseline ledger, so the ratchet fails. That covers any migration with
+        an ORM-visible footprint — most of them — and genuinely misses
+        data-only backfills and Postgres-only objects with no ORM counterpart.
+        Do not lean on "each migration's own test pins its revision id" as a
+        second backstop: nearly half the revisions in the chain have no
+        dedicated test module and are referenced nowhere in ``tests/``.
 
-        Both sides of that count come from this one directory, so it is a
-        self-consistency check: it sees a file that is present and unreachable,
-        and is blind to a file that is simply absent — delete one and the walk
-        shrinks with it.
+        The anchor pins the walk to a known revision, so a chain re-pointed to
+        bypass it, or truncated at or below it, fails here rather than reading
+        as a healthy shorter chain. It is bumped only deliberately, never as
+        part of adding a migration. Note what it does *not* catch: a stray
+        revision chained onto head leaves the anchor reachable, and only the
+        head literals this module stopped asserting would have caught that.
+
+        Resolving the chain covers a different failure again. Alembic skips a
+        file its filename filter excludes — an editor lockfile such as
+        ``.#zz.py`` is skipped while still being globbed here — so a file can
+        exist and belong to no chain; the walk is what rejects it. Anything
+        else unreadable raises outright rather than being skipped: a syntax
+        error raises ``SyntaxError``, and a file with no ``revision`` raises
+        ``CommandError``. A branched chain — a shipped revision nothing points
+        at — is rejected by ``get_current_head()`` alone: neither
+        ``from_config`` nor ``walk_revisions`` raises on two heads, so that call
+        is made for its raise rather than its value.
         """
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
-        # Filter out __pycache__ and __init__
+        # ``__init__.py`` is globbed but is not a revision.
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
-        assert len(migration_files) >= _MIGRATION_COUNT_FLOOR, (
-            f"Expected at least {_MIGRATION_COUNT_FLOOR} migration files, "
-            f"found {len(migration_files)}: {[f.name for f in migration_files]}"
-        )
+        assert migration_files, f"No migration files shipped in {versions_dir}"
 
         cfg = Config()
         cfg.set_main_option("script_location", str(_MIGRATIONS_DIR))
         script = ScriptDirectory.from_config(cfg)
-        # Raises on a branched chain — a shipped revision the chain never reaches.
-        assert script.get_current_head() is not None, f"Shipped migrations have no head: {versions_dir}"
         walked = list(script.walk_revisions())
-        assert len(walked) == len(migration_files), (
-            f"Chain resolves {len(walked)} revisions but {len(migration_files)} migration "
-            f"files are shipped: {[f.name for f in migration_files]}"
+        # Called for its raise, not its value: this is the only call here that
+        # rejects a branched chain. Neither ``from_config`` nor
+        # ``walk_revisions`` raises — both happily traverse two heads.
+        head = script.get_current_head()
+
+        walked_paths = {Path(str(rev.path)) for rev in walked}
+        orphans = sorted(f.name for f in migration_files if f not in walked_paths)
+        assert not orphans, (
+            f"Shipped migration files that belong to no chain: {orphans}. "
+            f"Chain resolves {len(walked)} revisions from {len(migration_files)} files."
+        )
+
+        revisions = {rev.revision for rev in walked}
+        assert _ANCHOR_REVISION in revisions, (
+            f"Chain no longer reaches the anchor revision {_ANCHOR_REVISION!r}; "
+            f"head is {head!r}. Truncated or re-pointed below the anchor?"
         )
 
     @pytest.mark.unit

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -21,11 +21,14 @@ from khora.khora import Khora
 # Derive migrations directory from the installed package — not relative to this test file
 _MIGRATIONS_DIR = Path(khora.db.migrations.__file__).parent
 
-#: A revision the chain must still reach. Anchors the walk to a known point so
-#: a stray revision chained onto head cannot pass unnoticed. Bumped only
-#: deliberately — never as part of adding a migration — so it does not
-#: reintroduce the per-PR edit an exact file count used to require.
-_ANCHOR_REVISION = "055_documents_source_type_alignment"
+#: A revision the chain must still reach, pinning the walk to a known point.
+#: Not bumped as part of adding a migration — that is the per-PR edit an exact
+#: file count used to require. Bump it when a migration lands that the ORM
+#: drift ratchet cannot back up: one that only *drops* things, backfills data,
+#: or creates Postgres-only objects with no ORM counterpart. Deleting such a
+#: revision leaves nothing missing from the live schema, so the ratchet stays
+#: green and this anchor is the only thing left that would notice.
+_ANCHOR_REVISION = "057_drop_documents_created_at_index"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -470,19 +473,24 @@ class TestMigrationPackageStructure:
         Truncation is instead caught by the ORM drift gate in
         ``tests/unit/test_migration_drift.py``: deleting a revision leaves the
         objects it created missing from the live schema and absent from the
-        baseline ledger, so the ratchet fails. That covers any migration with
-        an ORM-visible footprint — most of them — and genuinely misses
-        data-only backfills and Postgres-only objects with no ORM counterpart.
-        Do not lean on "each migration's own test pins its revision id" as a
-        second backstop: nearly half the revisions in the chain have no
-        dedicated test module and are referenced nowhere in ``tests/``.
+        baseline ledger, so the ratchet fails. That covers any migration with an
+        ORM-visible footprint — most of them, verified by deleting
+        ``056_documents_created_at_not_null`` and watching the ratchet go red.
+        It is blind to a migration that leaves nothing missing: one that only
+        *drops* an object, backfills data, or creates a Postgres-only object
+        with no ORM counterpart. Deleting ``057_drop_documents_created_at_index``
+        keeps the whole drift module green, which is why the anchor below sits
+        on it. Do not lean on "each migration's own test pins its revision id"
+        as a second backstop either: nearly half the revisions in the chain have
+        no dedicated test module and are referenced nowhere in ``tests/``.
 
         The anchor pins the walk to a known revision, so a chain re-pointed to
         bypass it, or truncated at or below it, fails here rather than reading
-        as a healthy shorter chain. It is bumped only deliberately, never as
-        part of adding a migration. Note what it does *not* catch: a stray
+        as a healthy shorter chain. Note what it does *not* catch: a stray
         revision chained onto head leaves the anchor reachable, and only the
-        head literals this module stopped asserting would have caught that.
+        head literals this module stopped asserting would have caught that —
+        restoring them would reinstate the per-migration edit this change
+        exists to remove.
 
         Resolving the chain covers a different failure again. Alembic skips a
         file its filename filter excludes — an editor lockfile such as

--- a/tests/unit/test_migration_bundling.py
+++ b/tests/unit/test_migration_bundling.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
 
 import khora.db.migrations
 from khora.db.session import MigrationResult, _DatabaseAheadError, _run_migrations_sync, run_migrations
@@ -19,10 +21,9 @@ from khora.khora import Khora
 # Derive migrations directory from the installed package — not relative to this test file
 _MIGRATIONS_DIR = Path(khora.db.migrations.__file__).parent
 
-#: Number of migration files the chain is expected to ship. Bump this by one
-#: whenever a revision is added — see ``test_versions_dir_is_fully_bundled``
-#: for why the count is declared rather than derived.
-_EXPECTED_MIGRATION_COUNT = 58
+#: Lower bound on the number of migration files the chain ships. Never bumped
+#: when a migration is added — raise it only to deliberately tighten the floor.
+_MIGRATION_COUNT_FLOOR = 56
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -448,24 +449,59 @@ class TestMigrationPackageStructure:
 
     @pytest.mark.unit
     def test_versions_dir_is_fully_bundled(self):
-        """Every migration in the chain is present in the installed package.
+        """No migration file goes missing from the chain the package ships.
 
-        ``_MIGRATIONS_DIR`` resolves through ``khora.db.migrations.__file__``,
-        i.e. the *installed* package rather than the repo tree, so this is a
-        packaging tripwire: it fails if a build config ever stops shipping
-        ``versions/*.py``, which would leave ``run_migrations()`` silently
-        building a partial schema. Deriving the expected count from the very
-        directory it checks would make the assertion vacuous, so the number is
-        declared. Bump ``_EXPECTED_MIGRATION_COUNT`` when you add a migration;
-        it is deliberately the only place the number appears.
+        The floor catches a versions directory that ships nothing, or fewer
+        files than the chain had when the floor was last raised, at any time.
+        It catches a *truncated tail* only while the file count still equals
+        the floor. Once a migration lands beyond it — 57 files against a floor
+        of 56 — deleting the newest revision passes here, and passes every
+        other gate too: ``test_migration_chain_is_contiguous`` is invariant
+        under truncation (the survivors are still a contiguous chain starting
+        at ``down_revision=None``), and the walk below shrinks in step with the
+        file list. That decay is the deliberate price of a floor that is never
+        bumped when a migration is added; an exact count held the stronger
+        property but had to be edited on every migration PR and conflicted with
+        every other one in flight. Raise the floor when tightening is worth an
+        edit.
+
+        Do not lean on "each migration's own test pins its revision id" as the
+        backstop — several revisions in the chain have no dedicated test module
+        and are referenced nowhere in ``tests/``.
+
+        Resolving the chain covers a different failure than the floor, and does
+        not backfill what the floor loses. Alembic skips a file its filename
+        filter excludes — an editor lockfile such as ``.#zz.py`` is skipped
+        while still being globbed here — so a file can exist, count toward the
+        floor, and belong to no chain; the walk count is what rejects it.
+        Anything else unreadable raises outright rather than being skipped: a
+        syntax error raises ``SyntaxError``, and a file with no ``revision``
+        raises ``CommandError``. Resolving the head additionally rejects a stray
+        revision nothing points at, which reads as a second head.
+
+        Both sides of that count come from this one directory, so it is a
+        self-consistency check: it sees a file that is present and unreachable,
+        and is blind to a file that is simply absent — delete one and the walk
+        shrinks with it.
         """
         versions_dir = _MIGRATIONS_DIR / "versions"
         migration_files = sorted(versions_dir.glob("*.py"))
         # Filter out __pycache__ and __init__
         migration_files = [f for f in migration_files if not f.name.startswith("__")]
-        assert len(migration_files) == _EXPECTED_MIGRATION_COUNT, (
-            f"Expected {_EXPECTED_MIGRATION_COUNT} migration files, "
+        assert len(migration_files) >= _MIGRATION_COUNT_FLOOR, (
+            f"Expected at least {_MIGRATION_COUNT_FLOOR} migration files, "
             f"found {len(migration_files)}: {[f.name for f in migration_files]}"
+        )
+
+        cfg = Config()
+        cfg.set_main_option("script_location", str(_MIGRATIONS_DIR))
+        script = ScriptDirectory.from_config(cfg)
+        # Raises on a branched chain — a shipped revision the chain never reaches.
+        assert script.get_current_head() is not None, f"Shipped migrations have no head: {versions_dir}"
+        walked = list(script.walk_revisions())
+        assert len(walked) == len(migration_files), (
+            f"Chain resolves {len(walked)} revisions but {len(migration_files)} migration "
+            f"files are shipped: {[f.name for f in migration_files]}"
         )
 
     @pytest.mark.unit

--- a/tests/unit/test_sqlite_migrations.py
+++ b/tests/unit/test_sqlite_migrations.py
@@ -14,6 +14,8 @@ from alembic import command
 from alembic.config import Config
 from sqlalchemy.ext.asyncio import create_async_engine
 
+from tests.test_helpers.alembic_head import current_head
+
 
 def _make_config(url: str) -> Config:
     """Build a programmatic Alembic Config pointing at the bundled migrations."""
@@ -84,7 +86,7 @@ class TestSqliteMigrations:
                     # Version table must point at head.
                     result = await conn.execute(sa.text("SELECT version_num FROM khora_alembic_version"))
                     version = result.scalar()
-                    assert version == "057_drop_documents_created_at_index"
+                    assert version == current_head()
             finally:
                 await engine.dispose()
 


### PR DESCRIPTION
## Summary

Migration tests spelled the chain head out as a literal (`055_documents_source_type_alignment`). Landing the previous migration therefore required the same mechanical bump in six files, and each of those bumps conflicts with any other migration PR in flight. This removes the bump.

- **One shared helper**, `tests/test_helpers/alembic_head.py::current_head()`, resolves the head through Alembic's `ScriptDirectory`. It is deliberately **uncached** — a memoized head would survive a migration being added mid-session and hand back a stale answer — and is documented as call-inside-the-test-body, because building the script directory at module scope turns a broken chain into a collection error that takes unrelated tests down with it.
- **Only *head* references became dynamic.** Explicit upgrade/downgrade targets keep their literals: those tests are about one specific revision and must not drift forward when the next migration lands. `test_migration_052/053/054`'s own target/predecessor constants are untouched.
- **`HEAD_REVISION` → `TARGET_REVISION`** in the 055 lane. That constant is 055's own upgrade target and merely *happens* to equal the head today; the rename records which of the two it is, so the next migration doesn't silently make it wrong.

### The file-count assertion: floor, not deletion

The exact `_EXPECTED_MIGRATION_COUNT = 56` had the same bump-on-every-PR problem, but deleting it outright would have opened a hole. It was load-bearing in one direction: it catches a **truncated tail**, and nothing else does. `test_migration_chain_is_contiguous` is invariant under truncation — delete the newest revision and the survivors are still a valid contiguous chain from `down_revision=None`. The fallback "each migration's own test pins its revision id" doesn't hold either; several revisions have no dedicated test module.

So the count becomes a **floor** (never bumped when a migration is added — only raised deliberately to tighten), plus a chain-resolution check that covers what a floor cannot: Alembic skips a file its *filename filter* excludes — an editor lockfile such as `.#zz.py` is skipped while still being globbed here — so a file can exist, count toward the floor, and belong to no chain; the walk count rejects it. Anything else unreadable raises outright rather than being skipped (`SyntaxError`, or `CommandError` for a file with no `revision`). Resolving the head additionally rejects a stray revision nothing points at, which reads as a second head.

**Known limits, stated rather than implied:** the floor catches a truncated tail only while the file count still equals it — once migration 056 lands, 57 files against a floor of 56 means deleting the newest revision passes every gate here. Both sides of the walk count read the same directory, so it is a self-consistency check: it sees a file present-and-unreachable and is blind to a file simply absent. The test docstring spells this out. A stray revision chained *onto* head is likewise not detected, where the old head literals would have caught it.

## Test plan

- [x] `make format` clean; `make lint` exits 0 (the `ty` diagnostics it prints are pre-existing warnings in `src/`, none in changed files)
- [x] Unit migration suites green — `tests/unit/test_migration_bundling.py`, `test_sqlite_migrations.py`, `test_migration_drift.py`, `tests/unit/db/`: **158 passed**
- [x] **The property this buys, demonstrated end to end.** Added a throwaway no-op revision chained to head, confirmed the resolved head moved to it, and re-ran the unit + integration migration suites with **zero test edits**: `172 passed, 54 skipped`. Throwaway then removed; `git status` clean under `src/`.
- [x] **Counterfactual, so the proof isn't vacuous.** Same throwaway against the *pre-change* tests fails exactly where expected — `test_versions_dir_is_fully_bundled` and `test_upgrade_head_fresh_sqlite` — `2 failed, 57 passed`.
- [x] Residue audit: every surviving revision literal under `tests/` is a migration's own revision, its predecessor, or an explicit walk destination. No head reference remains.
- [ ] **PostgreSQL lanes not executed locally** — no Docker in the dev container, so those tests skip rather than run (54 skips above). They run in CI.

Full-suite note: the unit run reports 69 failures / 20 errors in `langgraph`, `filter`, `sqlite_lance`, and `dream` suites. These reproduce identically on clean `main` in this container (missing optional deps) and are unrelated to this change, which touches only `tests/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved database migration validation to track the current migration state, reducing failures when new migrations are added.
  - Expanded migration packaging checks to detect missing, malformed, unreachable, or improperly bundled migrations.
  - Refined targeted migration tests to keep upgrade, rollback, and backfill scenarios isolated and reliable.
  - Added coverage for migration-chain updates and missing migration heads.

- **Chores**
  - Updated shared migration test utilities and revision naming for clearer, more maintainable test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
