### PR TITLE
Add a bounded keyset scan primitive to the SQLAlchemy document stores

### DIFF
--- a/src/khora/storage/backends/_documents_scan.py
+++ b/src/khora/storage/backends/_documents_scan.py
@@ -1,0 +1,154 @@
+"""Shared query construction for the bounded documents scan — ``@internal``.
+
+The two SQLAlchemy-backed relational stores (PostgreSQL and the embedded
+sqlite_lance adapter) run the *same* bounded keyset scan over the *same*
+``DocumentModel``. Only one thing genuinely differs between them: how their
+dialect compiler's pushdown fragment attaches to the statement (PostgreSQL's
+compiler emits a SQLAlchemy expression; the SQLite compiler emits a string plus
+positional binds). Everything else — the namespace scope, the optional ``status``
+/ ``updated_before`` narrowing, the keyset predicate, the enumeration order, and
+the row bound — is identical, so it is written once here rather than twice.
+
+That is not only DRY. The keyset predicate is the one part of this scan whose
+correctness depends on a *serialization* detail, and it is the part that cannot
+be exercised without a live PostgreSQL. Building it once, in a form the embedded
+store's own tests can execute, means the locally-runnable leg proves the shared
+semantics and only the fragment attachment is left to a services-backed CI job.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy import Select
+
+from khora.db.models import DocumentModel
+from khora.storage.backends.base import DocumentScanKey
+
+__all__ = ["build_documents_scan_query"]
+
+
+def build_documents_scan_query(
+    namespace_id: UUID,
+    *,
+    status: str | None = None,
+    updated_before: datetime | None = None,
+    after: DocumentScanKey | None = None,
+    scan_limit: int = 100,
+) -> Select[tuple[DocumentModel]]:
+    """Build the bounded scan ``SELECT``, minus any compiled filter fragment.
+
+    ``@internal``. The caller ``AND``-s its own dialect's pushdown fragment onto
+    the result with a further ``.where(...)`` — appending a WHERE after
+    ``order_by`` / ``limit`` is well-defined and leaves both in place — and then
+    executes it in its own session.
+
+    ``ORDER BY created_at DESC, id DESC`` is the total enumeration order all four
+    relational stores adopted in khora #1576. ``created_at`` is ``NOT NULL`` as of
+    khora #1583; the keyset predicate below depends on that — a NULL key would
+    make the row-value comparison evaluate to NULL and silently drop the row from
+    every page.
+
+    **The explicit ``literal(value, <column>.type)`` on each cursor operand is
+    load-bearing. Do not simplify it away.** A right-hand ``tuple_`` types each of
+    its elements from the *value*, independently of the column it is compared
+    against — nothing propagates leftwards. ``tuple_(a_datetime, a_uuid)``
+    therefore renders correctly only because those two Python types happen to
+    infer to this table's own column types; the agreement is a coincidence, not a
+    mechanism. Hand it an operand one step off and the coincidence lapses
+    silently: a ``date`` where a ``datetime`` belongs infers ``Date`` and binds
+    ``'2026-01-31'``, which on the embedded store's TEXT column sorts below every
+    ``'2026-01-31 …'`` row and skips the whole day. Naming the column's type
+    forces the correct serialization instead, and turns the ``str``-instead-of-
+    ``UUID`` slip from a silently mis-ordering dashed 36-char bind into an
+    immediate ``AttributeError`` from the type's own processor.
+
+    Formatting the cursor by hand is wrong in two directions and neither is loud:
+    on the embedded store an ISO-8601 ``'T'`` separator sorts *above* the stored
+    space-separated form, so the cursor's own row compares less than itself and a
+    resumed walk returns it forever; while a space-separated form that omits the
+    ``.000000`` microseconds sorts *below* its tie-mates, silently skipping them.
+    Passing a bare ``datetime`` through an untyped textual bind picks the second
+    of those, via a deprecated driver-level adapter that warns and continues.
+
+    **Naming the type is a SQLite-side guard only — it is not what makes a cursor
+    correct.** On PostgreSQL no bind processor runs, so a *well-typed* operand
+    reaches the driver untouched under either spelling — though not a no-op even
+    there, because the spelling picks the cast: measured on the asyncpg dialect, a
+    ``date`` renders ``$1::DATE`` bare against ``$1::TIMESTAMP WITH TIME ZONE``
+    typed, and a ``str`` id renders ``$2::VARCHAR`` bare against ``$2::UUID``.
+    Neither spelling rescues the ``date`` — those two forms resolve midnight in
+    the server's zone and the client host's respectively. A ``str`` id diverges
+    the other way and is the sharpest asymmetry here: the typed spelling raises on
+    this store, because the column type's processor asks the operand for ``.hex``,
+    while asyncpg's uuid encoder takes the ``PyUnicode`` branch and its parser
+    skips ``-`` outright, so a dashed cursor decodes to the identical sixteen
+    bytes and is silently *correct* on PostgreSQL. The same bad input is loud on
+    one store and harmless on the other; neither store's behaviour predicts the
+    other's, which is the whole reason this rule lives here rather than in either
+    backend. That store has the same hazard by a different route, on two
+    different evidence standards. Its ``timestamptz`` encoder converts with
+    ``obj.astimezone(utc)``, so a naive cursor resolves against whatever zone the
+    process happens to run in — that is plain-Python arithmetic, run across four
+    zones, and the shift is the host's UTC offset, hence zero and invisible on a
+    UTC host. That the same encoder also wraps a bare ``date`` at midnight in the
+    host's local zone is **read from its source only**: unlike the uuid parser
+    above, it is a ``cdef`` with no Python entry point, so it cannot be exercised
+    without a live server. The guarantee that holds on both stores is therefore
+    the cheap one: **build a cursor from a row this store returned, never by
+    hand.** What the typed bind buys is that the SQLite path fails loudly, or not
+    at all, instead of quietly reordering — worth having, but not a substitute.
+
+    The cursor must not be *adjusted* on the way in either, and the two dialects
+    make opposite adjustments look harmless. The embedded store holds wall clock
+    with the writer's offset discarded, so attaching or stripping ``tzinfo``
+    there is a no-op while converting to another zone moves the position; a
+    ``timestamptz`` holds an instant, so converting is the no-op and stripping
+    ``tzinfo`` is what moves it — by the host's UTC offset, hence exactly zero on
+    a UTC host and invisible to a test that runs there. Neither store's rule
+    generalizes to the other. The one that holds on both is narrower than either:
+    bind the value you read, unmodified.
+
+    Uniform descending on both keys is what makes a single row-value comparison
+    legal; do not expand it to an ``OR`` form. Row values need SQLite >= 3.15,
+    which this package cannot be installed below: ``requires-python >= 3.13`` and
+    CPython 3.13's ``sqlite3`` requires 3.15.2 at build time. No runtime probe.
+
+    Args:
+        namespace_id: Row-level namespace scope. Always applied — a scan is never
+            cross-namespace.
+        status: Optional document-status narrowing, matching ``list_documents``.
+        updated_before: Optional half-open ``updated_at <`` bound.
+        after: Resume position — the ``(created_at, id)`` of the last row a
+            previous step scanned. ``None`` starts from the newest row. Must have
+            come from this same store (the key is store-local; see
+            :data:`~khora.storage.backends.base.DocumentScanKey`).
+        scan_limit: Maximum rows the window returns. Bounds rows *returned*, not
+            rows *examined* — a selective pushdown fragment can still make one
+            call read the whole namespace.
+
+    Raises:
+        ValueError: ``scan_limit`` below 1. A zero bound would return an empty
+            window that reports neither a resume position nor exhaustion, which a
+            walking caller cannot make progress past.
+    """
+    if scan_limit < 1:
+        raise ValueError(f"scan_limit must be >= 1, got {scan_limit}")
+
+    query = sa.select(DocumentModel).where(DocumentModel.namespace_id == namespace_id)
+    if status:
+        query = query.where(DocumentModel.status == status)
+    if updated_before is not None:
+        query = query.where(DocumentModel.updated_at < updated_before)
+    if after is not None:
+        cursor_created_at, cursor_id = after
+        query = query.where(
+            sa.tuple_(DocumentModel.created_at, DocumentModel.id)
+            < sa.tuple_(
+                sa.literal(cursor_created_at, DocumentModel.created_at.type),
+                sa.literal(cursor_id, DocumentModel.id.type),
+            )
+        )
+    return query.order_by(DocumentModel.created_at.desc(), DocumentModel.id.desc()).limit(scan_limit)

--- a/src/khora/storage/backends/_documents_scan.py
+++ b/src/khora/storage/backends/_documents_scan.py
@@ -70,8 +70,10 @@ def build_documents_scan_query(
     space-separated form, so the cursor's own row compares less than itself and a
     resumed walk returns it forever; while a space-separated form that omits the
     ``.000000`` microseconds sorts *below* its tie-mates, silently skipping them.
-    Passing a bare ``datetime`` through an untyped textual bind picks the second
-    of those, via a deprecated driver-level adapter that warns and continues.
+    (An *untyped* ``sa.literal(a_datetime)`` is not one of the wrong forms —
+    SQLAlchemy infers ``DateTime`` from the value and emits the stored form
+    correctly, measured. The explicit type guards the one-step-off operands the
+    paragraph above names, not the well-typed ``datetime`` itself.)
 
     **Naming the type is a SQLite-side guard only — it is not what makes a cursor
     correct.** On PostgreSQL no bind processor runs, so a *well-typed* operand
@@ -81,15 +83,16 @@ def build_documents_scan_query(
     typed, and a ``str`` id renders ``$2::VARCHAR`` bare against ``$2::UUID``.
     Neither spelling rescues the ``date`` — those two forms resolve midnight in
     the server's zone and the client host's respectively. A ``str`` id diverges
-    the other way and is the sharpest asymmetry here: the typed spelling raises on
-    this store, because the column type's processor asks the operand for ``.hex``,
-    while asyncpg's uuid encoder takes the ``PyUnicode`` branch and its parser
-    skips ``-`` outright, so a dashed cursor decodes to the identical sixteen
-    bytes and is silently *correct* on PostgreSQL. The same bad input is loud on
-    one store and harmless on the other; neither store's behaviour predicts the
-    other's, which is the whole reason this rule lives here rather than in either
-    backend. That store has the same hazard by a different route, on two
-    different evidence standards. Its ``timestamptz`` encoder converts with
+    the other way and is the sharpest asymmetry here: the typed spelling raises
+    on either store, because the ``Uuid`` column type's processor asks the
+    operand for ``.hex``, while asyncpg's uuid encoder takes the ``PyUnicode``
+    branch and its parser skips ``-`` outright, so a dashed cursor decodes to
+    the identical sixteen bytes and is silently *correct* on PostgreSQL. The
+    same bad input is loud on one store and harmless on the other; neither
+    store's behaviour predicts the other's, which is the whole reason this rule
+    lives here rather than in either backend. PostgreSQL has the same
+    naive-``datetime`` hazard by a different route, on two different evidence
+    standards. asyncpg's ``timestamptz`` encoder converts with
     ``obj.astimezone(utc)``, so a naive cursor resolves against whatever zone the
     process happens to run in — that is plain-Python arithmetic, run across four
     zones, and the shift is the host's UTC offset, hence zero and invisible on a
@@ -120,14 +123,25 @@ def build_documents_scan_query(
         namespace_id: Row-level namespace scope. Always applied — a scan is never
             cross-namespace.
         status: Optional document-status narrowing, matching ``list_documents``.
-        updated_before: Optional half-open ``updated_at <`` bound.
+        updated_before: Optional half-open ``updated_at <`` bound. ``updated_at``
+            is physically nullable, and ``updated_at < :bound`` is NULL for a
+            NULL row — such rows are excluded from the raw window entirely:
+            never scanned, never resumed past, absent from the whole walk with
+            no signal. Inherited verbatim from ``list_documents``; whether the
+            caller-facing contract keeps, documents, or coalesces that is the
+            facade tier's decision, not this builder's.
         after: Resume position — the ``(created_at, id)`` of the last row a
             previous step scanned. ``None`` starts from the newest row. Must have
             come from this same store (the key is store-local; see
             :data:`~khora.storage.backends.base.DocumentScanKey`).
         scan_limit: Maximum rows the window returns. Bounds rows *returned*, not
             rows *examined* — a selective pushdown fragment can still make one
-            call read the whole namespace.
+            call read the whole namespace, a latency cliff of ~3 orders of
+            magnitude at 200k rows. It is NOT a per-call latency bound. What it
+            does bound is total work: because ``last_scanned`` is the last *raw*
+            row, a resumed step never re-examines the rejected gap, so a full
+            walk is O(namespace) regardless of selectivity. Callers must not
+            document it as a latency guarantee.
 
     Raises:
         ValueError: ``scan_limit`` below 1. A zero bound would return an empty

--- a/src/khora/storage/backends/base.py
+++ b/src/khora/storage/backends/base.py
@@ -43,6 +43,77 @@ class PaginatedResult(Generic[T]):
     offset: int
 
 
+# The keyset position of a single document in the enumeration order, as
+# ``(created_at, id)``. ``@internal``.
+#
+# Deliberately a bare tuple rather than a named cursor type: it has exactly one
+# producer (a scan step) and one consumer (the next scan step's ``after``), both
+# in-tree, and no wire form. A cursor *class* belongs wherever an opaque,
+# caller-facing encoding is first needed, and would pin an encoding this tier has
+# no use for.
+#
+# **The position is store-local, not a normalized instant.** It is read off a
+# document row and bound back through the same column type, so the round-trip is
+# exact by construction on each backend — but the two backends do not agree on
+# its shape. A PostgreSQL ``timestamptz`` yields an aware datetime; the embedded
+# SQLite store's ``DATETIME`` column is TEXT holding writer wall clock with the
+# offset discarded at write, so it yields a *naive* datetime. Never format this
+# into a string, and never carry a position from one store to another.
+DocumentScanKey = tuple[datetime, UUID]
+
+
+@dataclass(frozen=True, slots=True)
+class DocumentScanStep:
+    """One bounded step of a keyset walk over a namespace's documents.
+
+    ``@internal``. Produced by a relational backend's ``scan_documents``; not part
+    of the public storage API and not re-exported from :mod:`khora.storage`.
+
+    A step is one ``SELECT`` in the backend's own session — no transaction spans
+    steps, and no consistent snapshot is claimed. A walk chains steps by feeding
+    :attr:`last_scanned` back as the next call's ``after`` until
+    :attr:`exhausted`.
+
+    * ``documents`` — the window's rows in ``(created_at DESC, id DESC)`` order
+      (the total order all four relational stores share since khora #1576),
+      already narrowed by whatever the dialect compiler pushed down. **Not
+      necessarily the final matches**: a caller with a filter must still evaluate
+      the full filter over these rows (see :attr:`consumed_keys`).
+    * ``last_scanned`` — the keyset position of the window's **final row**, or
+      ``None`` when the window was empty. Resume from this rather than from the
+      last row that survived post-filtering, so a resumed walk does not re-scan
+      the gap of rows that were scanned and rejected.
+    * ``exhausted`` — the window returned fewer rows than the requested bound, so
+      nothing remains after :attr:`last_scanned`. This is the **only** sound
+      termination signal; a short — or empty — ``documents`` list means nothing on
+      its own, because post-filtering can reject an entire window.
+    * ``consumed_keys`` — the dotted filter paths the backend pushed into SQL, as
+      reported by the compiler. A **reporting signal only**: it exists so a caller
+      can tell users which predicate leaves cost a post-filter. It is *not*
+      permission to skip those leaves in the post-filter — the compile contexts on
+      both stores require the full filter to be re-evaluated in memory
+      unconditionally, and everything pushed down is a superset filter, so
+      re-running a pushed leaf can only narrow.
+
+    There is deliberately **no residual-AST field.** The compilers report the
+    split as a key set, not as a pruned tree, and the caller already holds the
+    filter it passed in — so a residual field could only duplicate the caller's
+    own input, while inviting the one mistake the compile contexts warn against
+    (post-filtering the residual alone). A caller that wants to report which
+    predicate leaves cost a post-filter differences its own leaf keys against
+    :attr:`consumed_keys`; :func:`khora.filter.execute.filter_leaf_keys` is the
+    left-hand side.
+
+    Distinct from :class:`PaginatedResult`, which is offset-shaped and carries a
+    total. A keyset walk has neither an offset nor a total.
+    """
+
+    documents: list[Document]
+    last_scanned: DocumentScanKey | None
+    exhausted: bool
+    consumed_keys: frozenset[str]
+
+
 @runtime_checkable
 class RelationalBackendProtocol(Protocol):
     """Protocol for relational database backends (PostgreSQL).

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -512,7 +512,8 @@ class PostgreSQLBackend(AsyncSessionMixin):
         the ``scan_limit`` floor — is built by
         :func:`~khora.storage.backends._documents_scan.build_documents_scan_query`
         and shared with the embedded store; see it for the keyset's typed-bind
-        requirement and the ``created_at`` NOT NULL dependency. Only the
+        requirement, the ``created_at`` NOT NULL dependency, and the
+        ``updated_before`` NULL-``updated_at`` exclusion. Only the
         attachment below is dialect-specific: this store's compiler emits a
         SQLAlchemy expression, so it AND-s straight on.
 

--- a/src/khora/storage/backends/postgresql.py
+++ b/src/khora/storage/backends/postgresql.py
@@ -24,11 +24,12 @@ from khora.db.models import (
     SyncCheckpointModel,
 )
 from khora.db.schema import sync_enum_values
-from khora.storage.backends.base import PaginatedResult
+from khora.storage.backends._documents_scan import build_documents_scan_query
+from khora.storage.backends.base import DocumentScanKey, DocumentScanStep, PaginatedResult
 from khora.storage.backends.mixins import AsyncSessionMixin, retry_on_deadlock
 
 if TYPE_CHECKING:
-    pass
+    from khora.filter.ast import FilterNode
 
 
 def _none_if_empty(v: str | None) -> str | None:
@@ -487,6 +488,86 @@ class PostgreSQLBackend(AsyncSessionMixin):
             query = query.limit(limit).offset(offset).order_by(DocumentModel.created_at.desc(), DocumentModel.id.desc())
             result = await session.execute(query)
             return [self._document_model_to_domain(m) for m in result.scalars().all()]
+
+    async def scan_documents(
+        self,
+        namespace_id: UUID,
+        *,
+        filter_ast: FilterNode | None = None,
+        status: str | None = None,
+        updated_before: datetime | None = None,
+        after: DocumentScanKey | None = None,
+        scan_limit: int = 100,
+    ) -> DocumentScanStep:
+        """Scan one bounded window of a namespace's documents by keyset.
+
+        ``@internal``. Not part of the public storage API — the offset-based
+        :meth:`list_documents` is. One ``SELECT`` in its own session; a walk is
+        the caller's job, chaining :attr:`DocumentScanStep.last_scanned` back in
+        as ``after`` until the step reports ``exhausted``. No transaction spans
+        steps and no consistent snapshot is claimed.
+
+        Everything but the pushdown fragment — the namespace scope, ``status`` /
+        ``updated_before``, the keyset predicate, the order, the row bound, and
+        the ``scan_limit`` floor — is built by
+        :func:`~khora.storage.backends._documents_scan.build_documents_scan_query`
+        and shared with the embedded store; see it for the keyset's typed-bind
+        requirement and the ``created_at`` NOT NULL dependency. Only the
+        attachment below is dialect-specific: this store's compiler emits a
+        SQLAlchemy expression, so it AND-s straight on.
+
+        ``filter_ast`` is compiled by the compiler registered for this store's
+        ``documents`` target. Only the leaves reported in ``consumed_keys`` were
+        pushed; **the caller must still evaluate the full filter over the
+        returned rows.** Re-running a pushed leaf can only narrow, because
+        everything the compiler pushes is a superset filter — which is why
+        resuming past the rows the pushdown rejected skips nothing. That property
+        belongs to the compilers, not to this method: it holds because their
+        ``$or`` / ``$not`` gate defers a whole subtree it cannot fully express
+        rather than leaving a match-all placeholder that would invert under
+        negation and wrongly exclude rows.
+
+        One store-specific note on the cursor: a position taken from a row here
+        is timezone-aware, since it comes off a ``timestamptz`` column. A
+        hand-built naive one is not rejected — the driver resolves it against the
+        host's local zone — so build positions from rows rather than by hand. The
+        damage is signed by that zone's offset: east of UTC the cursor lands
+        early and rows in the gap are silently skipped, west of UTC it lands late
+        and already-returned rows come back, which can stall a walk. On a UTC
+        host it is an exact no-op, so a test cannot see it.
+
+        Raises ``ValueError`` when ``scan_limit`` is below 1. It comes from the
+        shared builder, before anything is compiled or executed, so a bad bound
+        is never masked by a compile error.
+        """
+        consumed_keys: frozenset[str] = frozenset()
+        query = build_documents_scan_query(
+            namespace_id,
+            status=status,
+            updated_before=updated_before,
+            after=after,
+            scan_limit=scan_limit,
+        )
+        if filter_ast is not None:
+            compiler = CompilerRegistry.get("relational.postgresql", "documents")
+            compiled = compiler(filter_ast, _documents_compile_context())
+            consumed_keys = compiled.consumed_keys
+            query = query.where(compiled.predicate)
+
+        async with self._get_session() as session:
+            result = await session.execute(query)
+            rows = list(result.scalars().all())
+
+        # ``last_scanned`` and ``exhausted`` both describe the RAW window: the
+        # final row scanned, and whether SQL ran out of rows filling it. Neither
+        # may be derived from a post-filtered subset — that would re-scan the
+        # rejected gap on resume, and would call a full window exhausted.
+        return DocumentScanStep(
+            documents=[self._document_model_to_domain(m) for m in rows],
+            last_scanned=(rows[-1].created_at, rows[-1].id) if rows else None,
+            exhausted=len(rows) < scan_limit,
+            consumed_keys=consumed_keys,
+        )
 
     async def claim_orphaned_documents(
         self,

--- a/src/khora/storage/backends/sqlite_lance/relational.py
+++ b/src/khora/storage/backends/sqlite_lance/relational.py
@@ -501,9 +501,10 @@ class SQLiteLanceRelationalAdapter(AsyncSessionMixin):
         namespace scope, the optional ``status`` / ``updated_before`` narrowing,
         the keyset predicate, the enumeration order, the row bound, and the
         ``scan_limit`` floor — is built by
-        :func:`~khora.storage.backends._documents_scan.build_documents_scan_query`.
-        Only the pushdown fragment's attachment is dialect-specific, and it is the
-        one thing below.
+        :func:`~khora.storage.backends._documents_scan.build_documents_scan_query`;
+        see it for the ``updated_before`` NULL-``updated_at`` exclusion. Only the
+        pushdown fragment's attachment is dialect-specific, and it is the one
+        thing below.
 
         **What this store makes hazardous is the cursor's serialization, and the
         remedy is to write none.** The shared builder binds both operands through
@@ -1309,6 +1310,17 @@ def _lance_fragment_to_text(fragment: str, args: list[Any]) -> TextClause:
     ``?`` would silently shift every later bind by one position; a stray ``:``
     would be parsed as the start of a bind name, so the fragment would either
     reference a parameter nobody supplied or swallow the ``:kfN`` that follows.
+
+    The returned clause is wrapped in parentheses — the third tripwire, and the
+    only one whose failure mode is silent. ``TextClause.self_group()`` returns
+    ``self``, so ``.where()`` does NOT parenthesize a text fragment the way it
+    does its own expressions: a fragment with a top-level ``OR`` would absorb
+    the namespace predicate into its left disjunct (``ns = ? AND a = 1 OR
+    b = 2``), returning another tenant's rows. ``compile_lance``
+    self-parenthesizes every boolean node and every OR-emitting leaf today, so
+    no reachable fragment is ungrouped — but unlike the two loud guards above,
+    an ungrouped fragment fails as a cross-namespace read, not a
+    ``ValueError``, so the grouping is enforced here rather than assumed.
     """
     if ":" in fragment:
         raise ValueError(f"compiled filter fragment contains a colon, which text() parses as a bind name: {fragment!r}")
@@ -1318,7 +1330,7 @@ def _lance_fragment_to_text(fragment: str, args: list[Any]) -> TextClause:
             f"compiled filter fragment has {len(parts) - 1} positional binds but {len(args)} bind values were supplied"
         )
     rewritten = parts[0] + "".join(f":kf{i}{part}" for i, part in enumerate(parts[1:]))
-    return text(rewritten).bindparams(**{f"kf{i}": value for i, value in enumerate(args)})
+    return text("(" + rewritten + ")").bindparams(**{f"kf{i}": value for i, value in enumerate(args)})
 
 
 # Register the deterministic recall-filter compiler for this store/target at

--- a/src/khora/storage/backends/sqlite_lance/relational.py
+++ b/src/khora/storage/backends/sqlite_lance/relational.py
@@ -14,7 +14,7 @@ this adapter assumes tables already exist.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from loguru import logger
@@ -35,6 +35,7 @@ from sqlalchemy import (
     insert,
     or_,
     select,
+    text,
     update,
 )
 from sqlalchemy.ext.asyncio import (
@@ -51,13 +52,18 @@ from khora.core.models.recall import DocumentProjection
 from khora.db.models import DocumentModel, MemoryNamespaceModel, SyncCheckpointModel
 from khora.engines.chronicle.compression import MemoryFact
 from khora.engines.chronicle.events import ChronicleEvent
-from khora.storage.backends.base import PaginatedResult
+from khora.storage.backends._documents_scan import build_documents_scan_query
+from khora.storage.backends.base import DocumentScanKey, DocumentScanStep, PaginatedResult
 from khora.storage.backends.mixins import AsyncSessionMixin
 from khora.storage.backends.postgresql import _reingestable_exclusion
 
 from ..._log_safe import _safe_url_for_log
 
 if TYPE_CHECKING:
+    from sqlalchemy.sql.elements import TextClause
+
+    from khora.filter import FilterNode
+
     from .connection import EmbeddedStorageHandle
 
 
@@ -471,6 +477,103 @@ class SQLiteLanceRelationalAdapter(AsyncSessionMixin):
             query = query.limit(limit).offset(offset).order_by(DocumentModel.created_at.desc(), DocumentModel.id.desc())
             result = await session.execute(query)
             return [self._document_model_to_domain(m) for m in result.scalars().all()]
+
+    async def scan_documents(
+        self,
+        namespace_id: UUID,
+        *,
+        filter_ast: FilterNode | None = None,
+        status: str | None = None,
+        updated_before: datetime | None = None,
+        after: DocumentScanKey | None = None,
+        scan_limit: int = 100,
+    ) -> DocumentScanStep:
+        """Scan one bounded keyset window of a namespace's documents.
+
+        ``@internal``. Not part of the public storage API — the offset-based
+        :meth:`list_documents` is unchanged. One ``SELECT`` in this adapter's own
+        session; no transaction spans calls and no consistent snapshot is
+        claimed. A caller walks the namespace by chaining
+        :attr:`DocumentScanStep.last_scanned` back in as ``after`` until the step
+        reports ``exhausted``.
+
+        Everything the two SQLAlchemy-backed relational stores share — the
+        namespace scope, the optional ``status`` / ``updated_before`` narrowing,
+        the keyset predicate, the enumeration order, the row bound, and the
+        ``scan_limit`` floor — is built by
+        :func:`~khora.storage.backends._documents_scan.build_documents_scan_query`.
+        Only the pushdown fragment's attachment is dialect-specific, and it is the
+        one thing below.
+
+        **What this store makes hazardous is the cursor's serialization, and the
+        remedy is to write none.** The shared builder binds both operands through
+        the ORM column types, which is what makes the comparison line up with the
+        bytes this store actually holds: ``created_at`` is TEXT
+        ``'YYYY-MM-DD HH:MM:SS.ffffff'`` — space separator, no offset,
+        microseconds always six digits including ``.000000`` — and ``id`` is 32
+        undashed hex characters despite its ``VARCHAR(36)`` declared type.
+        Hand-formatting the timestamp does not merely skip a row: an
+        ``isoformat()`` string sorts ABOVE every stored value because ``'T'``
+        outranks ``' '``, so the window matches the cursor's own row and a walk
+        chaining ``last_scanned`` never advances. Dashing the id is the quiet
+        mirror of that — 36 characters never match a 32-character column, so
+        every tie mis-resolves. Values read back from this store are naive
+        datetimes, because SQLAlchemy's SQLite ``DATETIME`` discards the writer's
+        offset at write time rather than converting it; the key is store-local,
+        so leave it naive and never carry it to another store.
+
+        ``filter_ast`` is compiled by this store's registered compiler and
+        ``AND``-ed into the ``WHERE``, so the window holds only rows that passed
+        the pushdown. The compiler emits positional binds for a qmark driver, so
+        the fragment is rewritten to named binds by
+        :func:`_lance_fragment_to_text` before it can join a SQLAlchemy
+        statement. Resuming past rows the pushdown rejected skips nothing **only
+        because the pushdown is a superset filter** — a row it rejected could not
+        have satisfied the full predicate either. That is a property of the
+        compilers and this store's compile context, not of this method: were a
+        compiler ever to emit a match-all placeholder inside a negation, this
+        scan would start dropping documents silently.
+
+        The date-valued system keys are deliberately unpushable here (see
+        :func:`_documents_compile_context`), so a ``created_at`` or
+        ``source_timestamp`` leaf compiles to the match-all placeholder, stays
+        out of ``consumed_keys``, and reaches the caller's post-filter. That is
+        the intended split and the reason this store's ``consumed_keys`` differs
+        from PostgreSQL's for the same filter — not drift to be "fixed" by
+        widening the pushdown whitelist.
+
+        ``consumed_keys`` is reported verbatim from the compiler. It records
+        which leaves the SQL already enforced; it is **not** permission to skip
+        them in a post-filter, which must evaluate the whole AST unconditionally.
+        """
+        consumed_keys: frozenset[str] = frozenset()
+        query = build_documents_scan_query(
+            namespace_id,
+            status=status,
+            updated_before=updated_before,
+            after=after,
+            scan_limit=scan_limit,
+        )
+        if filter_ast is not None:
+            compiler = CompilerRegistry.get("relational.sqlite_lance", "documents")
+            compiled = compiler(filter_ast, _documents_compile_context())
+            consumed_keys = compiled.consumed_keys
+            query = query.where(_lance_fragment_to_text(compiled.predicate, compiled.params["args"]))
+
+        async with self._get_session() as session:
+            result = await session.execute(query)
+            rows = list(result.scalars().all())
+
+        # ``last_scanned`` and ``exhausted`` both describe the RAW window: the
+        # final row scanned, and whether SQL ran out of rows filling it. Neither
+        # may be derived from a post-filtered subset — that would re-scan the
+        # rejected gap on resume, and would call a full window exhausted.
+        return DocumentScanStep(
+            documents=[self._document_model_to_domain(m) for m in rows],
+            last_scanned=(rows[-1].created_at, rows[-1].id) if rows else None,
+            exhausted=len(rows) < scan_limit,
+            consumed_keys=consumed_keys,
+        )
 
     async def claim_orphaned_documents(
         self,
@@ -1184,6 +1287,38 @@ def _documents_compile_context() -> CompileContext:
         on_unsupported="split",
         schema_capabilities=SchemaCapabilities(sqlite_json1=sqlite_has_json1()),
     )
+
+
+def _lance_fragment_to_text(fragment: str, args: list[Any]) -> TextClause:
+    """Rewrite ``compile_lance``'s positional binds into a SQLAlchemy ``text()``.
+
+    ``compile_lance`` targets a qmark DBAPI: it returns a SQL string carrying one
+    ``?`` per entry of ``CompiledFilter.params["args"]``, in depth-first emit
+    order. SQLAlchemy's :func:`text` wants named binds, so each ``?`` is replaced
+    positionally with ``:kf0`` … ``:kfN`` and the values are bound under the same
+    names. The ``kf`` prefix keeps them clear of the ``param_N`` /
+    ``namespace_id_1`` names SQLAlchemy generates for the rest of the statement.
+
+    Splitting on ``?`` is sound because the compiler never inlines a caller
+    value: every literal it emits is one of its own constants, and the only
+    user-derived text — a metadata JSON path — is bound rather than inlined. So
+    neither guard below can fire today. Both are kept as tripwires for the day
+    that stops being true, and both fail at construction rather than at execute.
+
+    The two guards cover the two characters ``text()`` treats as syntax. A stray
+    ``?`` would silently shift every later bind by one position; a stray ``:``
+    would be parsed as the start of a bind name, so the fragment would either
+    reference a parameter nobody supplied or swallow the ``:kfN`` that follows.
+    """
+    if ":" in fragment:
+        raise ValueError(f"compiled filter fragment contains a colon, which text() parses as a bind name: {fragment!r}")
+    parts = fragment.split("?")
+    if len(parts) - 1 != len(args):
+        raise ValueError(
+            f"compiled filter fragment has {len(parts) - 1} positional binds but {len(args)} bind values were supplied"
+        )
+    rewritten = parts[0] + "".join(f":kf{i}{part}" for i, part in enumerate(parts[1:]))
+    return text(rewritten).bindparams(**{f"kf{i}": value for i, value in enumerate(args)})
 
 
 # Register the deterministic recall-filter compiler for this store/target at

--- a/tests/integration/storage/test_scan_documents_pg.py
+++ b/tests/integration/storage/test_scan_documents_pg.py
@@ -1,0 +1,360 @@
+"""``PostgreSQLBackend.scan_documents`` — the bounded keyset scan.
+
+The shared half of this scan is proved by the embedded sibling
+(``tests/unit/storage/backends/sqlite_lance/test_relational_scan_documents.py``):
+both stores build the same statement through ``build_documents_scan_query``, and
+the embedded lane runs without services, so it carries the cursor semantics.
+What only a live server can show is here — that the cursor round-trips through
+``timestamptz`` / ``uuid`` rather than through a text serialization, and that
+this store's compiler reports a *different*, and correct, pushdown split for the
+same filter.
+
+Requires a running PostgreSQL (``make dev``). Skipped automatically when the
+configured ``KHORA_DATABASE_URL`` is unreachable; the integration conftest turns
+that skip into a hard failure when ``KHORA_PG_REQUIRED=1``, so a CI job with the
+service down cannot pass by skipping.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+from khora.core.models import Document, MemoryNamespace
+from khora.core.models.document import DocumentStatus
+from khora.db.session import run_migrations
+from khora.filter import RecallFilter
+from khora.filter.ast import parse_to_ast
+from khora.storage.backends.postgresql import PostgreSQLBackend
+from tests.test_helpers.document_scan import ScanSeed, scan_seed, walk_scan
+
+DATABASE_URL = os.environ.get(
+    "KHORA_DATABASE_URL",
+    # This repo's compose puts Postgres on 5434 (see compose.yaml); defaulting to
+    # 5432 would make the whole class silently skip on a local `make test`.
+    "postgresql+asyncpg://khora:khora@localhost:5434/khora",
+)
+
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
+
+
+pytestmark = [pytest.mark.integration]
+
+
+def _pg_reachable() -> bool:
+    import socket
+    from urllib.parse import urlparse
+
+    parsed = urlparse(DATABASE_URL.replace("+asyncpg", ""))
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+skip_no_pg = pytest.mark.skipif(
+    not _pg_reachable(),
+    reason="PostgreSQL not reachable (run `make dev` first)",
+)
+
+
+@pytest.fixture(scope="module")
+async def _run_migrations_once():
+    result = await run_migrations(DATABASE_URL)
+    assert result.success, f"Migrations failed: {result.error}"
+
+
+@pytest.fixture
+async def backend(_run_migrations_once):
+    be = PostgreSQLBackend(database_url=DATABASE_URL)
+    await be.connect()
+    try:
+        yield be
+    finally:
+        await be.disconnect()
+
+
+@pytest.fixture
+async def namespace(backend: PostgreSQLBackend):
+    """A fresh namespace per test, so a scan never sees another test's rows."""
+    return await backend.create_namespace(MemoryNamespace())
+
+
+def _filter_ast(wire: dict[str, Any]) -> Any:
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+async def _write(
+    backend: PostgreSQLBackend, namespace_id: UUID, doc_id: UUID, created_at: datetime, **fields: Any
+) -> None:
+    """Insert one document through the production write API."""
+    await backend.create_document(
+        Document(
+            id=doc_id,
+            namespace_id=namespace_id,
+            content="scanned content",
+            checksum=f"scan-{doc_id.hex}",
+            created_at=created_at,
+            updated_at=fields.pop("updated_at", created_at),
+            **fields,
+        )
+    )
+
+
+async def _seed(backend: PostgreSQLBackend, namespace_id: UUID, seed: ScanSeed) -> None:
+    for doc_id, created_at in seed.writes:
+        await _write(backend, namespace_id, doc_id, created_at)
+
+
+@skip_no_pg
+class TestScanDocumentsWindowPg:
+    async def test_scan_limit_bounds_the_window(self, backend: PostgreSQLBackend, namespace) -> None:
+        seed = scan_seed(6)
+        await _seed(backend, namespace.id, seed)
+
+        step = await backend.scan_documents(namespace.id, scan_limit=2)
+
+        assert [d.id for d in step.documents] == seed.expected[:2]
+        assert step.last_scanned == (step.documents[-1].created_at, step.documents[-1].id)
+        assert step.exhausted is False
+
+    async def test_a_full_window_is_not_yet_exhausted(self, backend: PostgreSQLBackend, namespace) -> None:
+        """``exhausted`` means SQL ran short, not "the caller has seen everything".
+
+        A window filled exactly to the bound cannot distinguish "six rows and no
+        more" from "six rows and a seventh waiting", so it must report
+        not-exhausted and let the next step find the empty tail. Reporting
+        exhaustion here would silently truncate every namespace whose size is a
+        multiple of the bound.
+        """
+        seed = scan_seed(6)
+        await _seed(backend, namespace.id, seed)
+
+        exact = await backend.scan_documents(namespace.id, scan_limit=6)
+        assert len(exact.documents) == 6
+        assert exact.exhausted is False
+
+        over = await backend.scan_documents(namespace.id, scan_limit=7)
+        assert len(over.documents) == 6
+        assert over.exhausted is True
+
+    async def test_scan_limit_below_one_is_rejected(self, backend: PostgreSQLBackend, namespace) -> None:
+        """A zero bound would return an empty window that reports neither a resume
+        position nor exhaustion — the one pair a walking caller cannot act on."""
+        with pytest.raises(ValueError, match="scan_limit"):
+            await backend.scan_documents(namespace.id, scan_limit=0)
+
+    async def test_empty_window_reports_exhausted_without_a_position(
+        self, backend: PostgreSQLBackend, namespace
+    ) -> None:
+        """Both the never-seeded namespace and the tail past the last row."""
+        empty = await backend.scan_documents(namespace.id, scan_limit=5)
+        assert empty.documents == []
+        assert empty.last_scanned is None
+        assert empty.exhausted is True
+
+        seed = scan_seed(6)
+        await _seed(backend, namespace.id, seed)
+        full = await backend.scan_documents(namespace.id, scan_limit=10)
+        oldest = full.documents[-1]
+
+        tail = await backend.scan_documents(namespace.id, after=(oldest.created_at, oldest.id), scan_limit=5)
+        assert tail.documents == []
+        assert tail.last_scanned is None
+        assert tail.exhausted is True
+
+    async def test_status_and_updated_before_narrow_the_window(self, backend: PostgreSQLBackend, namespace) -> None:
+        seed = scan_seed(6)
+        cutoff = seed.tie_instant + timedelta(hours=1)
+        for i, (doc_id, created_at) in enumerate(seed.writes):
+            await _write(
+                backend,
+                namespace.id,
+                doc_id,
+                created_at,
+                status=DocumentStatus.COMPLETED if i % 2 == 0 else DocumentStatus.PENDING,
+                updated_at=cutoff - timedelta(minutes=1) if i < 4 else cutoff + timedelta(minutes=1),
+            )
+
+        by_status = await backend.scan_documents(namespace.id, status=DocumentStatus.COMPLETED.value, scan_limit=10)
+        assert {d.id for d in by_status.documents} == {
+            doc_id for i, (doc_id, _) in enumerate(seed.writes) if i % 2 == 0
+        }
+
+        by_updated = await backend.scan_documents(namespace.id, updated_before=cutoff, scan_limit=10)
+        assert {d.id for d in by_updated.documents} == {doc_id for i, (doc_id, _) in enumerate(seed.writes) if i < 4}
+
+
+@skip_no_pg
+class TestScanDocumentsCursorPg:
+    async def test_walk_visits_every_document_exactly_once_in_total_order(
+        self, backend: PostgreSQLBackend, namespace
+    ) -> None:
+        """One row per step across a tie block, chaining ``last_scanned``.
+
+        ``scan_limit=1`` puts a cursor boundary between every pair of rows,
+        including between rows that share a ``created_at`` to the microsecond —
+        so every resume in this walk is a mid-tie resume, and the ``id DESC``
+        leg decides all of them.
+        """
+        seed = scan_seed(6)
+        await _seed(backend, namespace.id, seed)
+
+        steps = await walk_scan(backend.scan_documents, namespace.id, scan_limit=1)
+        seen = [d.id for step in steps for d in step.documents]
+
+        assert len(seen) == len(set(seen))  # no document served twice
+        assert set(seen) == set(seed.expected)  # every document served
+        assert seen == seed.expected  # and in one total order across the concatenation
+        assert steps[-1].documents == []
+        assert steps[-1].last_scanned is None
+        assert steps[-1].exhausted is True
+
+    async def test_mid_tie_cursor_resumes_at_the_exact_next_row(self, backend: PostgreSQLBackend, namespace) -> None:
+        """A position taken from the middle of a tie block, in one step.
+
+        The rows on either side of the cursor share its ``created_at`` exactly,
+        so this only lands on the right row if the ``id`` half of the position is
+        compared as a ``uuid`` rather than as some rendering of one.
+        """
+        seed = scan_seed(6)
+        await _seed(backend, namespace.id, seed)
+
+        full = await backend.scan_documents(namespace.id, scan_limit=10)
+        assert [d.id for d in full.documents] == seed.expected
+
+        cursor_doc = next(d for d in full.documents if d.id == seed.tied_ids[0])
+        step = await backend.scan_documents(namespace.id, after=(cursor_doc.created_at, cursor_doc.id), scan_limit=10)
+        ids = [d.id for d in step.documents]
+
+        assert cursor_doc.id not in ids, "the cursor's own row came back — a resumed walk would never advance"
+        assert seed.tied_ids[1] in ids, "the cursor's tie-mate was skipped — a resumed walk would lose rows"
+        assert ids == seed.expected[seed.expected.index(cursor_doc.id) + 1 :]
+
+    async def test_cursor_read_off_a_row_is_timezone_aware(self, backend: PostgreSQLBackend, namespace) -> None:
+        """This store's position is an aware instant, and the round trip is exact.
+
+        ``created_at`` is ``timestamptz`` here, so a position read off a row
+        carries a ``tzinfo`` and can be compared to the seeded instant directly —
+        unlike the embedded store, whose ``DATETIME`` discards the writer's
+        offset and reads back naive. The two shapes are why a position is
+        store-local and must never be carried across stores.
+        """
+        seed = scan_seed(6)
+        await _seed(backend, namespace.id, seed)
+
+        step = await backend.scan_documents(namespace.id, scan_limit=10)
+        cursor_created_at, _ = step.last_scanned
+
+        assert cursor_created_at.tzinfo is not None
+        assert cursor_created_at == seed.tie_instant - timedelta(seconds=1)
+        assert cursor_created_at.microsecond == 0
+
+
+@skip_no_pg
+class TestScanDocumentsSplitPg:
+    async def test_date_system_keys_are_pushed_down_by_this_store(self, backend: PostgreSQLBackend, namespace) -> None:
+        """``created_at`` pushes here, and the same filter does NOT push on the
+        embedded store — the asymmetry is intended, not drift.
+
+        This store keeps ``created_at`` in a real ``timestamptz``, so the
+        compiler's bind orders against the stored value and the leaf is both
+        consumed and enforced in SQL. The embedded store withholds the key
+        because its TEXT format does not order against the same bind; its
+        sibling test asserts the opposite answer for this same filter.
+        """
+        seed = scan_seed(6)
+        await _seed(backend, namespace.id, seed)
+
+        step = await backend.scan_documents(
+            namespace.id,
+            filter_ast=_filter_ast({"created_at": {"$gte": "2999-01-01T00:00:00+00:00"}}),
+            scan_limit=10,
+        )
+
+        assert step.consumed_keys == frozenset({"created_at"})
+        # Consumed AND enforced: every seeded row is older than the bound.
+        assert step.documents == []
+
+    async def test_split_reports_only_the_leaves_sql_enforced(self, backend: PostgreSQLBackend, namespace) -> None:
+        """A mixed filter: one pushable leaf, one this table cannot back.
+
+        ``occurred_at`` is a recall-chunk key with no ``documents`` column, so it
+        compiles to a match-all placeholder, stays out of ``consumed_keys``, and
+        reaches the caller's post-filter.
+        """
+        seed = scan_seed(6)
+        for i, (doc_id, created_at) in enumerate(seed.writes):
+            await _write(backend, namespace.id, doc_id, created_at, source_type="report" if i % 2 == 0 else "library")
+
+        step = await backend.scan_documents(
+            namespace.id,
+            filter_ast=_filter_ast(
+                {"source_type": {"$eq": "report"}, "occurred_at": {"$gte": "2026-01-01T00:00:00+00:00"}}
+            ),
+            scan_limit=10,
+        )
+
+        assert step.consumed_keys == frozenset({"source_type"})
+        # The pushed leaf really did narrow the window; the unpushed one did not.
+        assert {d.source_type for d in step.documents} == {"report"}
+        assert len(step.documents) == 3
+
+    async def test_last_scanned_is_the_final_raw_row_not_the_last_match(
+        self, backend: PostgreSQLBackend, namespace
+    ) -> None:
+        """Resume from the last row SCANNED, not from the last row that matches.
+
+        The window here deliberately ENDS on a row the caller's post-filter will
+        reject: the filter is an ``$or`` mixing a pushable leaf with one this
+        table cannot back, which the compiler defers as a whole rather than
+        pushing half of a disjunction, so SQL narrows nothing and the oldest row
+        — which does not satisfy the filter — is the last row of the raw window.
+
+        A walk that resumed from the last *matching* row instead would re-scan
+        the rejected gap on every step — and when a whole window is rejected
+        there is no matching row to resume from at all, so such a walk cannot
+        advance past a run of non-matching rows longer than one window. Taking
+        the position from the raw window is what lets ``exhausted`` be the only
+        termination signal.
+        """
+        newest, middle, oldest = (uuid4() for _ in range(3))
+        base = datetime(2026, 1, 31, 12, 30, tzinfo=UTC)
+        await _write(backend, namespace.id, newest, base + timedelta(seconds=2), source_type="report")
+        await _write(backend, namespace.id, middle, base + timedelta(seconds=1), source_type="report")
+        await _write(backend, namespace.id, oldest, base, source_type="library")
+
+        step = await backend.scan_documents(
+            namespace.id,
+            filter_ast=_filter_ast(
+                {
+                    "$or": [
+                        {"source_type": {"$eq": "report"}},
+                        {"occurred_at": {"$gte": "2026-01-01T00:00:00+00:00"}},
+                    ]
+                }
+            ),
+            scan_limit=10,
+        )
+
+        # Nothing was pushed, so the raw window is the whole namespace and its
+        # last row is the one the post-filter will drop.
+        assert step.consumed_keys == frozenset()
+        assert [d.id for d in step.documents] == [newest, middle, oldest]
+        assert step.documents[-1].source_type == "library"
+
+        last_row = step.documents[-1]
+        assert step.last_scanned == (last_row.created_at, last_row.id)
+
+        last_match = step.documents[1]
+        assert step.last_scanned != (last_match.created_at, last_match.id)

--- a/tests/integration/storage/test_scan_documents_pg.py
+++ b/tests/integration/storage/test_scan_documents_pg.py
@@ -413,3 +413,35 @@ class TestScanDocumentsSplitPg:
 
         last_match = step.documents[1]
         assert step.last_scanned != (last_match.created_at, last_match.id)
+
+
+@skip_no_pg
+class TestScanDocumentsNamespaceIsolationPg:
+    """The scan's namespace scope, asserted rather than inherited.
+
+    Every other class here runs against a fresh single-namespace fixture, so
+    none of it can notice a scan that ignores its scope — on the shared CI
+    database that failure would surface only as nondeterministic contamination
+    from other tests' residue. This seeds a second namespace with the same
+    varied corpus (every row a guaranteed filter hit) and walks the first at
+    ``scan_limit=1``, so both the scope predicate and its AND-composition with
+    the keyset predicate are load-bearing on every page. Deleting the
+    namespace predicate from ``build_documents_scan_query`` must fail here.
+    """
+
+    async def test_scan_never_returns_another_namespaces_rows(self, backend: PostgreSQLBackend, namespace) -> None:
+        seed = scan_seed(6)
+        await _seed_varied(backend, namespace.id, seed)
+        other = await backend.create_namespace(MemoryNamespace())
+        await _seed_varied(backend, other.id, scan_seed(6))
+
+        wire = {"$or": [{"source_type": {"$eq": "report"}}, {"title": {"$eq": "doc-1"}}]}
+        steps = await walk_scan(backend.scan_documents, namespace.id, scan_limit=1, filter_ast=_filter_ast(wire))
+        seen = [d for step in steps for d in step.documents]
+
+        assert seen, "the filter must match rows in the scanned namespace for this test to bite"
+        assert all(d.namespace_id == namespace.id for d in seen)
+
+        unfiltered = await backend.scan_documents(namespace.id, scan_limit=50)
+        assert len(unfiltered.documents) == 6
+        assert all(d.namespace_id == namespace.id for d in unfiltered.documents)

--- a/tests/integration/storage/test_scan_documents_pg.py
+++ b/tests/integration/storage/test_scan_documents_pg.py
@@ -116,6 +116,24 @@ async def _seed(backend: PostgreSQLBackend, namespace_id: UUID, seed: ScanSeed) 
         await _write(backend, namespace_id, doc_id, created_at)
 
 
+async def _seed_varied(backend: PostgreSQLBackend, namespace_id: UUID, seed: ScanSeed) -> None:
+    """Seed the same corpus with attribute variety, so a filter can split it.
+
+    Attributes are assigned by *write* index, which is deliberately not the
+    enumeration order — every expectation below is therefore derived from the
+    rows a scan actually returns, never from this loop's counter.
+    """
+    for i, (doc_id, created_at) in enumerate(seed.writes):
+        await _write(
+            backend,
+            namespace_id,
+            doc_id,
+            created_at,
+            title=f"doc-{i}",
+            source_type="report" if i % 2 == 0 else "library",
+        )
+
+
 @skip_no_pg
 class TestScanDocumentsWindowPg:
     async def test_scan_limit_bounds_the_window(self, backend: PostgreSQLBackend, namespace) -> None:
@@ -240,6 +258,43 @@ class TestScanDocumentsCursorPg:
         assert cursor_doc.id not in ids, "the cursor's own row came back — a resumed walk would never advance"
         assert seed.tied_ids[1] in ids, "the cursor's tie-mate was skipped — a resumed walk would lose rows"
         assert ids == seed.expected[seed.expected.index(cursor_doc.id) + 1 :]
+
+    async def test_filtered_walk_puts_a_cursor_and_a_compiled_fragment_in_one_statement(
+        self, backend: PostgreSQLBackend, namespace
+    ) -> None:
+        """A cursor and a pushdown fragment in the same ``SELECT``, walked to the end.
+
+        Every other test here passes ``after`` or ``filter_ast``, never both.
+        This store's compiler emits a SQLAlchemy expression, so its operands are
+        named by the same machinery that names the keyset's — there is no
+        hand-written bind splice to collide, unlike the embedded store. What is
+        worth proving is the rest of it: that the fragment's ``literal_column``
+        references add no second FROM entry, and that a filtered walk still
+        enumerates exactly once, in order, and terminates.
+        """
+        seed = scan_seed(6)
+        await _seed_varied(backend, namespace.id, seed)
+
+        full = await backend.scan_documents(namespace.id, scan_limit=10)
+        wire = {"$or": [{"source_type": {"$eq": "report"}}, {"title": {"$eq": "doc-1"}}]}
+        expected = [d.id for d in full.documents if d.source_type == "report" or d.title == "doc-1"]
+        assert 1 < len(expected) < len(full.documents), "the filter must narrow, but not to a single row"
+
+        steps = await walk_scan(
+            backend.scan_documents,
+            namespace.id,
+            scan_limit=1,
+            filter_ast=_filter_ast(wire),
+        )
+        seen = [d.id for step in steps for d in step.documents]
+
+        assert len(seen) == len(set(seen))
+        assert seen == expected
+        assert steps[-1].exhausted is True
+        # Both leaves are real columns here, so this store pushes the whole
+        # disjunction — the embedded sibling reports the same filter differently
+        # only when a leaf is one it cannot back.
+        assert steps[0].consumed_keys == frozenset({"source_type", "title"})
 
     async def test_cursor_read_off_a_row_is_timezone_aware(self, backend: PostgreSQLBackend, namespace) -> None:
         """This store's position is an aware instant, and the round trip is exact.

--- a/tests/test_helpers/document_scan.py
+++ b/tests/test_helpers/document_scan.py
@@ -1,0 +1,142 @@
+"""Seed + walk helpers for the bounded ``scan_documents`` tests.
+
+Shared by the two SQLAlchemy-backed relational stores (the embedded sqlite_lance
+adapter and PostgreSQL), which run the same keyset scan over the same
+``DocumentModel``. The seed reasoning is subtle enough to be worth stating once
+here rather than twice in the two test modules.
+
+Two properties of the seed are load-bearing:
+
+**The tie block.** ``total - 2`` rows share one ``created_at``, so only the
+``id DESC`` leg can order them and a resume position taken from the middle of
+that block is genuinely mid-tie. The other two rows sit outside the block with
+timestamp and id in deliberate conflict — the newest row carries the LOWEST id
+and the oldest row the HIGHEST — so a scan that sorted on ``id`` first would
+park them at exactly the wrong ends and could not reproduce
+:attr:`ScanSeed.expected`. This half is borrowed wholesale from the
+``list_documents`` ordering seed; see :mod:`tests.test_helpers.document_order`.
+
+**The whole second.** :data:`WHOLE_SECOND` pins ``microsecond=0`` and every
+stamp derives from it by whole seconds, which is *not* incidental. The embedded
+store holds ``created_at`` as TEXT and compares it lexicographically, and at
+non-zero microseconds a cursor formatted with ``str(naive_datetime)`` happens to
+be byte-identical to the stored form — so a corpus seeded from
+``datetime.now(UTC)`` silently agrees with a broken cursor bind and proves
+nothing. At exactly ``.000000`` the two forms diverge (SQLAlchemy writes the
+six-digit microsecond field, ``str()`` omits it entirely), which is what makes
+the cursor tests able to fail.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+from tests.test_helpers.document_order import id_ladder, seed_order
+
+# Whole second, zero microseconds — see the module docstring for why this is
+# pinned rather than sampled from the clock.
+WHOLE_SECOND = datetime(2026, 1, 31, 12, 30, 0, 0, tzinfo=UTC)
+
+
+@dataclass(frozen=True)
+class ScanSeed:
+    """A seed plan: rows to write, and the one order a scan must enumerate them in."""
+
+    writes: list[tuple[UUID, datetime]]
+    """``(id, created_at)`` pairs, in the (non-monotonic) order rows are written."""
+
+    expected: list[UUID]
+    """The single correct full enumeration, ``(created_at DESC, id DESC)``."""
+
+    tied_ids: list[UUID]
+    """The ids sharing :attr:`tie_instant`, already in expected (descending) order."""
+
+    newest_id: UUID
+    """Newest ``created_at``, lowest id — must enumerate FIRST."""
+
+    oldest_id: UUID
+    """Oldest ``created_at``, highest id — must enumerate LAST."""
+
+    tie_instant: datetime
+    """The ``created_at`` every row in :attr:`tied_ids` was written with."""
+
+
+def scan_seed(total: int = 6, *, instant: datetime = WHOLE_SECOND) -> ScanSeed:
+    """Build a tie-heavy seed of ``total`` documents pinning both sort keys."""
+    if total < 5:
+        raise ValueError(f"total must leave a tie block of at least 3 rows to resume from the middle of, got {total}")
+
+    ids = id_ladder(total)
+    newest_id, oldest_id = ids[0], ids[-1]
+    tied = ids[1:-1]
+
+    stamps = dict.fromkeys(tied, instant)
+    stamps[newest_id] = instant + timedelta(seconds=1)
+    stamps[oldest_id] = instant - timedelta(seconds=1)
+
+    return ScanSeed(
+        writes=[(doc_id, stamps[doc_id]) for doc_id in seed_order(ids)],
+        expected=[newest_id, *reversed(tied), oldest_id],
+        tied_ids=list(reversed(tied)),
+        newest_id=newest_id,
+        oldest_id=oldest_id,
+        tie_instant=instant,
+    )
+
+
+def as_utc(value: datetime) -> datetime:
+    """Attach UTC to a naive datetime, leave an aware one alone.
+
+    The two stores disagree about the cursor's tzinfo: PostgreSQL reads an aware
+    value off ``timestamptz``, while the embedded store's ``DATETIME`` discards
+    the writer's offset at write time and reads back naive. Both are correct for
+    their store — the key is store-local — so a shared assertion that wants to
+    compare a read-back stamp against a seeded one normalizes here rather than
+    pretending the two shapes are the same.
+    """
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+async def walk_scan(
+    scan_documents: Callable[..., Awaitable[Any]],
+    namespace_id: UUID,
+    *,
+    scan_limit: int,
+    max_steps: int = 50,
+    **scan_kwargs: Any,
+) -> list[Any]:
+    """Walk a namespace one bounded step at a time, chaining ``last_scanned``.
+
+    Returns every :class:`~khora.storage.backends.base.DocumentScanStep` in
+    order; the caller asserts on their concatenation (order, exhaustiveness, no
+    repeats) and on the terminal step.
+
+    Two guardrails, because both failures this walk exists to catch are
+    non-terminating rather than wrong-answer. A cursor that fails to advance past
+    its own row — the exact symptom of a hand-formatted timestamp bind, whose
+    ISO ``'T'`` separator sorts above every stored value — would otherwise spin
+    forever, so the walk raises the moment ``last_scanned`` repeats. ``max_steps``
+    is the backstop for any other form of non-termination. A guardrail test must
+    fail, not hang.
+    """
+    steps: list[Any] = []
+    after = None
+    while len(steps) < max_steps:
+        step = await scan_documents(namespace_id, after=after, scan_limit=scan_limit, **scan_kwargs)
+        steps.append(step)
+        if step.exhausted:
+            return steps
+        if step.last_scanned == after:
+            raise AssertionError(
+                f"scan cursor did not advance: step {len(steps) - 1} resumed from {after!r} and "
+                f"reported the same position again, so the walk can never terminate"
+            )
+        after = step.last_scanned
+    raise AssertionError(f"scan did not report exhausted within {max_steps} steps of scan_limit={scan_limit}")
+
+
+__all__ = ["WHOLE_SECOND", "ScanSeed", "as_utc", "scan_seed", "walk_scan"]

--- a/tests/test_helpers/document_scan.py
+++ b/tests/test_helpers/document_scan.py
@@ -16,6 +16,15 @@ park them at exactly the wrong ends and could not reproduce
 :attr:`ScanSeed.expected`. This half is borrowed wholesale from the
 ``list_documents`` ordering seed; see :mod:`tests.test_helpers.document_order`.
 
+The ladder does a second job here that it was not written for, and it is worth
+knowing before anyone "simplifies" it to plain ``uuid4``: its ids share a 24-hex
+prefix, and ``str(uuid)`` puts its first dash *inside* that prefix. Since ``-``
+(0x2D) sorts below every hex digit, a cursor rendered as a dashed string sorts
+below the whole tie block — measured, the tie-mate assertion in the cursor test
+drops from four rows to one. With random ids the comparison is decided before
+the first dash and that mistake is invisible (it needs two ids agreeing on all
+eight leading hex characters). The shared prefix is what makes it catchable.
+
 **The whole second.** :data:`WHOLE_SECOND` pins ``microsecond=0`` and every
 stamp derives from it by whole seconds, which is *not* incidental. The embedded
 store holds ``created_at`` as TEXT and compares it lexicographically, and at

--- a/tests/unit/storage/backends/sqlite_lance/test_relational_scan_documents.py
+++ b/tests/unit/storage/backends/sqlite_lance/test_relational_scan_documents.py
@@ -1,0 +1,355 @@
+"""``SQLiteLanceRelationalAdapter.scan_documents`` — the bounded keyset scan.
+
+Runs against the real Alembic-migrated SQLite schema (no Docker, no services),
+which matters more here than usual: this store keeps ``created_at`` as TEXT and
+compares it lexicographically, so the scan's cursor is only correct if it is
+bound in the store's own serialization. That property cannot be checked against
+a mock, and it is shared with the PostgreSQL leg — both stores build the same
+statement through ``build_documents_scan_query`` — so this locally-runnable
+module carries most of the semantics and its PostgreSQL sibling
+(``tests/integration/storage/test_scan_documents_pg.py``) covers what only a
+live server can show.
+
+Seeding goes through ``create_document``, the production write API, so every row
+is serialized by the same path production writes take. Timestamps are pinned to
+a whole second on purpose; see :mod:`tests.test_helpers.document_scan`.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+try:
+    import aiosqlite  # noqa: F401
+    import lancedb  # noqa: F401
+
+    _HAS_EMBEDDED = True
+except ImportError:
+    _HAS_EMBEDDED = False
+
+from khora.core.models import Document, MemoryNamespace, TenancyMode
+from khora.core.models.document import DocumentStatus
+from khora.filter import RecallFilter
+from khora.filter.ast import parse_to_ast
+from tests.test_helpers.document_scan import ScanSeed, scan_seed, walk_scan
+
+# Lives in the unit lane next to the rest of this adapter's tests, and also
+# carries the ``embedded`` marker so ``make test-embedded`` — the no-Docker
+# command a developer reaches for to check this stack — actually selects it.
+pytestmark = [
+    pytest.mark.embedded,
+    pytest.mark.skipif(not _HAS_EMBEDDED, reason="aiosqlite/lancedb not installed"),
+]
+
+if _HAS_EMBEDDED:
+    from khora.storage.backends.sqlite_lance.connection import (
+        EmbeddedStorageHandle,
+        EmbeddedStorageHandleConfig,
+    )
+    from khora.storage.backends.sqlite_lance.relational import SQLiteLanceRelationalAdapter
+
+
+@pytest.fixture
+async def adapter(migrated_sqlite_db, tmp_path):
+    handle = EmbeddedStorageHandle(
+        EmbeddedStorageHandleConfig(db_path=str(migrated_sqlite_db), lance_path=str(tmp_path / "khora.lance")),
+    )
+    adapter = SQLiteLanceRelationalAdapter(handle)
+    await adapter.connect()
+    try:
+        yield adapter
+    finally:
+        await adapter.disconnect()
+        await handle.disconnect()
+
+
+@pytest.fixture
+async def namespace(adapter):
+    nid = uuid4()
+    return await adapter.create_namespace(MemoryNamespace(id=nid, namespace_id=nid, tenancy_mode=TenancyMode.SHARED))
+
+
+def _filter_ast(wire: dict[str, Any]) -> Any:
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+async def _write(adapter: Any, namespace_id: UUID, doc_id: UUID, created_at: datetime, **fields: Any) -> None:
+    """Insert one document through the production write API."""
+    await adapter.create_document(
+        Document(
+            id=doc_id,
+            namespace_id=namespace_id,
+            content="scanned content",
+            checksum=f"scan-{doc_id.hex}",
+            created_at=created_at,
+            updated_at=fields.pop("updated_at", created_at),
+            **fields,
+        )
+    )
+
+
+async def _seed(adapter: Any, namespace_id: UUID, seed: ScanSeed) -> None:
+    for doc_id, created_at in seed.writes:
+        await _write(adapter, namespace_id, doc_id, created_at)
+
+
+# --------------------------------------------------------------------------- #
+# The window bound
+# --------------------------------------------------------------------------- #
+
+
+async def test_scan_limit_bounds_the_window(adapter, namespace) -> None:
+    seed = scan_seed(6)
+    await _seed(adapter, namespace.id, seed)
+
+    step = await adapter.scan_documents(namespace.id, scan_limit=2)
+
+    assert [d.id for d in step.documents] == seed.expected[:2]
+    assert step.last_scanned == (step.documents[-1].created_at, step.documents[-1].id)
+    assert step.exhausted is False
+
+
+async def test_a_full_window_is_not_yet_exhausted(adapter, namespace) -> None:
+    """``exhausted`` means SQL ran short, not "the caller has seen everything".
+
+    A window filled exactly to the bound cannot distinguish "six rows and no
+    more" from "six rows and a seventh waiting", so it must report not-exhausted
+    and let the next step find the empty tail. Reporting exhaustion here would
+    silently truncate every namespace whose size is a multiple of the bound.
+    """
+    seed = scan_seed(6)
+    await _seed(adapter, namespace.id, seed)
+
+    exact = await adapter.scan_documents(namespace.id, scan_limit=6)
+    assert len(exact.documents) == 6
+    assert exact.exhausted is False
+
+    over = await adapter.scan_documents(namespace.id, scan_limit=7)
+    assert len(over.documents) == 6
+    assert over.exhausted is True
+
+
+async def test_scan_limit_below_one_is_rejected(adapter, namespace) -> None:
+    """A zero bound would return an empty window that reports neither a resume
+    position nor exhaustion — the one pair a walking caller cannot act on."""
+    with pytest.raises(ValueError, match="scan_limit"):
+        await adapter.scan_documents(namespace.id, scan_limit=0)
+
+
+# --------------------------------------------------------------------------- #
+# The keyset cursor
+# --------------------------------------------------------------------------- #
+
+
+async def test_walk_visits_every_document_exactly_once_in_total_order(adapter, namespace) -> None:
+    """One row per step across a tie block, chaining ``last_scanned``.
+
+    ``scan_limit=1`` puts a cursor boundary between every pair of rows,
+    including between rows that share a ``created_at`` to the microsecond — so
+    every resume in this walk is a mid-tie resume, and the ``id DESC`` leg
+    decides all of them.
+    """
+    seed = scan_seed(6)
+    await _seed(adapter, namespace.id, seed)
+
+    steps = await walk_scan(adapter.scan_documents, namespace.id, scan_limit=1)
+    seen = [d.id for step in steps for d in step.documents]
+
+    assert len(seen) == len(set(seen))  # no document served twice
+    assert set(seen) == set(seed.expected)  # every document served
+    assert seen == seed.expected  # and in one total order across the concatenation
+    assert steps[-1].documents == []
+    assert steps[-1].last_scanned is None
+    assert steps[-1].exhausted is True
+
+
+async def test_whole_second_cursor_excludes_its_own_row_and_keeps_its_tie_mates(adapter, namespace) -> None:
+    """The cursor round-trips exactly at ``.000000`` microseconds.
+
+    This store writes ``created_at`` as TEXT and orders it lexicographically, so
+    a cursor is only correct if it is serialized byte-for-byte the way the
+    column was written. The two ways to get that wrong fail in opposite
+    directions and neither raises, so both are asserted:
+
+    * A hand-built ISO-8601 string sorts ABOVE every stored value, because
+      ``'T'`` outranks the stored space separator. The window then matches the
+      cursor's OWN row, and a walk chaining ``last_scanned`` never advances.
+    * A space-separated form that omits the six-digit microsecond field — which
+      is what ``str(datetime)`` produces at a whole second, and what a bare
+      ``datetime`` handed to an untyped bind produces via the driver's
+      deprecated adapter — sorts BELOW its tie-mates, silently skipping them.
+
+    At non-zero microseconds the second form is byte-identical to the stored
+    value and this test would pass against it, which is why the seed pins a
+    whole second rather than sampling the clock.
+    """
+    seed = scan_seed(6)
+    await _seed(adapter, namespace.id, seed)
+
+    full = await adapter.scan_documents(namespace.id, scan_limit=10)
+    assert [d.id for d in full.documents] == seed.expected
+
+    cursor_doc = next(d for d in full.documents if d.id == seed.tied_ids[0])
+    # The whole second survived the write/read round trip, so the divergence
+    # between the stored form and a hand-formatted one is live in this corpus.
+    assert cursor_doc.created_at.microsecond == 0
+    assert cursor_doc.created_at.replace(tzinfo=UTC) == seed.tie_instant
+
+    step = await adapter.scan_documents(
+        namespace.id,
+        after=(cursor_doc.created_at, cursor_doc.id),
+        scan_limit=10,
+    )
+    ids = [d.id for d in step.documents]
+
+    assert cursor_doc.id not in ids, "the cursor's own row came back — a resumed walk would never advance"
+    assert seed.tied_ids[1] in ids, "the cursor's tie-mate was skipped — a resumed walk would lose rows"
+    assert ids == seed.expected[seed.expected.index(cursor_doc.id) + 1 :]
+
+
+async def test_empty_window_reports_exhausted_without_a_position(adapter, namespace) -> None:
+    """Both the never-seeded namespace and the tail past the last row."""
+    empty = await adapter.scan_documents(namespace.id, scan_limit=5)
+    assert empty.documents == []
+    assert empty.last_scanned is None
+    assert empty.exhausted is True
+
+    seed = scan_seed(6)
+    await _seed(adapter, namespace.id, seed)
+    full = await adapter.scan_documents(namespace.id, scan_limit=10)
+    oldest = full.documents[-1]
+
+    tail = await adapter.scan_documents(namespace.id, after=(oldest.created_at, oldest.id), scan_limit=5)
+    assert tail.documents == []
+    assert tail.last_scanned is None
+    assert tail.exhausted is True
+
+
+# --------------------------------------------------------------------------- #
+# The compile split
+# --------------------------------------------------------------------------- #
+
+
+async def test_date_system_keys_are_not_pushed_down_by_this_store(adapter, namespace) -> None:
+    """``created_at`` reaches the caller's post-filter here, and that is intended.
+
+    This store withholds the date-valued system keys from its pushdown
+    whitelist because its stored ``DATETIME`` text does not order against the
+    compiler's ISO binds. The leaf therefore compiles to a match-all placeholder,
+    stays out of ``consumed_keys``, and narrows nothing — asserted positively,
+    because a widened whitelist would show up here as a suddenly-shorter window
+    rather than as an error. PostgreSQL reports the same filter as pushed; the
+    two answers differing is the intended split, not drift.
+    """
+    seed = scan_seed(6)
+    await _seed(adapter, namespace.id, seed)
+
+    step = await adapter.scan_documents(
+        namespace.id,
+        filter_ast=_filter_ast({"created_at": {"$gte": "2999-01-01T00:00:00+00:00"}}),
+        scan_limit=10,
+    )
+
+    assert step.consumed_keys == frozenset()
+    # Every row is older than the bound, so a pushed-down comparison would have
+    # returned nothing at all.
+    assert [d.id for d in step.documents] == seed.expected
+
+
+async def test_split_reports_only_the_leaves_sql_enforced(adapter, namespace) -> None:
+    """A mixed filter: one pushable leaf, one that must reach the post-filter."""
+    seed = scan_seed(6)
+    for i, (doc_id, created_at) in enumerate(seed.writes):
+        await _write(adapter, namespace.id, doc_id, created_at, source_type="report" if i % 2 == 0 else "library")
+
+    step = await adapter.scan_documents(
+        namespace.id,
+        filter_ast=_filter_ast({"source_type": {"$eq": "report"}, "created_at": {"$gte": "2026-01-01T00:00:00+00:00"}}),
+        scan_limit=10,
+    )
+
+    assert step.consumed_keys == frozenset({"source_type"})
+    # The pushed leaf really did narrow the window; the unpushed one did not.
+    assert {d.source_type for d in step.documents} == {"report"}
+    assert len(step.documents) == 3
+
+
+# --------------------------------------------------------------------------- #
+# What the position means
+# --------------------------------------------------------------------------- #
+
+
+async def test_last_scanned_is_the_final_raw_row_not_the_last_match(adapter, namespace) -> None:
+    """Resume from the last row SCANNED, not from the last row that matches.
+
+    The window here deliberately ENDS on a row the caller's post-filter will
+    reject: the filter is an ``$or`` mixing a pushable leaf with an unbacked
+    one, which the compiler defers as a whole rather than pushing half of a
+    disjunction, so SQL narrows nothing and the oldest row — which does not
+    satisfy the filter — is the last row of the raw window.
+
+    A walk that resumed from the last *matching* row instead would re-scan the
+    rejected gap on every step — and when a whole window is rejected there is no
+    matching row to resume from at all, so such a walk cannot advance past a run
+    of non-matching rows longer than one window. Taking the position from the
+    raw window is what lets ``exhausted`` be the only termination signal.
+    """
+    newest, middle, oldest = (uuid4() for _ in range(3))
+    base = datetime(2026, 1, 31, 12, 30, tzinfo=UTC)
+    await _write(adapter, namespace.id, newest, base + timedelta(seconds=2), source_type="report")
+    await _write(adapter, namespace.id, middle, base + timedelta(seconds=1), source_type="report")
+    await _write(adapter, namespace.id, oldest, base, source_type="library")
+
+    step = await adapter.scan_documents(
+        namespace.id,
+        filter_ast=_filter_ast(
+            {
+                "$or": [
+                    {"source_type": {"$eq": "report"}},
+                    {"occurred_at": {"$gte": "2026-01-01T00:00:00+00:00"}},
+                ]
+            }
+        ),
+        scan_limit=10,
+    )
+
+    # Nothing was pushed, so the raw window is the whole namespace and its last
+    # row is the one the post-filter will drop.
+    assert step.consumed_keys == frozenset()
+    assert [d.id for d in step.documents] == [newest, middle, oldest]
+    assert step.documents[-1].source_type == "library"
+
+    last_row = step.documents[-1]
+    assert step.last_scanned == (last_row.created_at, last_row.id)
+
+    last_match = step.documents[1]
+    assert step.last_scanned != (last_match.created_at, last_match.id)
+
+
+# --------------------------------------------------------------------------- #
+# The non-filter narrowing legs
+# --------------------------------------------------------------------------- #
+
+
+async def test_status_and_updated_before_narrow_the_window(adapter, namespace) -> None:
+    seed = scan_seed(6)
+    cutoff = seed.tie_instant + timedelta(hours=1)
+    for i, (doc_id, created_at) in enumerate(seed.writes):
+        await _write(
+            adapter,
+            namespace.id,
+            doc_id,
+            created_at,
+            status=DocumentStatus.COMPLETED if i % 2 == 0 else DocumentStatus.PENDING,
+            updated_at=cutoff - timedelta(minutes=1) if i < 4 else cutoff + timedelta(minutes=1),
+        )
+
+    by_status = await adapter.scan_documents(namespace.id, status=DocumentStatus.COMPLETED.value, scan_limit=10)
+    assert {d.id for d in by_status.documents} == {doc_id for i, (doc_id, _) in enumerate(seed.writes) if i % 2 == 0}
+
+    by_updated = await adapter.scan_documents(namespace.id, updated_before=cutoff, scan_limit=10)
+    assert {d.id for d in by_updated.documents} == {doc_id for i, (doc_id, _) in enumerate(seed.writes) if i < 4}

--- a/tests/unit/storage/backends/sqlite_lance/test_relational_scan_documents.py
+++ b/tests/unit/storage/backends/sqlite_lance/test_relational_scan_documents.py
@@ -508,3 +508,80 @@ async def test_status_and_updated_before_narrow_the_window(adapter, namespace) -
 
     by_updated = await adapter.scan_documents(namespace.id, updated_before=cutoff, scan_limit=10)
     assert {d.id for d in by_updated.documents} == {doc_id for i, (doc_id, _) in enumerate(seed.writes) if i < 4}
+
+
+# ---------------------------------------------------------------------------
+# Namespace isolation
+# ---------------------------------------------------------------------------
+#
+# Everything above runs in a single-namespace fixture, so no assertion up there
+# can notice a scan that ignores its namespace scope — deleting the namespace
+# predicate from ``build_documents_scan_query`` left the whole module green
+# (found by two reviewers independently, by mutation). These two tests exist to
+# make that mutant, and the fragment-grouping mutant, fail.
+
+
+async def test_scan_never_returns_another_namespaces_rows(adapter, namespace) -> None:
+    """A filtered walk over one namespace must not see a byte of the other.
+
+    The second namespace is seeded with the SAME varied corpus, so every row in
+    it matches the same filter — if the namespace predicate is dropped (or
+    stops AND-composing with the fragment), the foreign rows are not merely
+    reachable, they are guaranteed hits. Walked at ``scan_limit=1`` so the
+    keyset predicate is exercised across pages too: the cursor is namespace-
+    blind on its own, and only the scope predicate keeps a resume inside its
+    tenant.
+    """
+    seed = scan_seed(6)
+    await _seed_varied(adapter, namespace.id, seed)
+
+    other_id = uuid4()
+    other = await adapter.create_namespace(
+        MemoryNamespace(id=other_id, namespace_id=other_id, tenancy_mode=TenancyMode.SHARED)
+    )
+    await _seed_varied(adapter, other.id, scan_seed(6))
+
+    wire = {"$or": [{"source_type": {"$eq": "report"}}, {"title": {"$eq": "doc-1"}}]}
+    steps = await walk_scan(adapter.scan_documents, namespace.id, scan_limit=1, filter_ast=_filter_ast(wire))
+    seen = [d for step in steps for d in step.documents]
+
+    assert seen, "the filter must match rows in the scanned namespace for this test to bite"
+    assert all(d.namespace_id == namespace.id for d in seen)
+
+    unfiltered = await adapter.scan_documents(namespace.id, scan_limit=50)
+    assert len(unfiltered.documents) == 6
+    assert all(d.namespace_id == namespace.id for d in unfiltered.documents)
+
+
+async def test_ungrouped_or_fragment_cannot_absorb_the_namespace_scope(adapter, namespace) -> None:
+    """The splice's parentheses are load-bearing — proven on rows, not prose.
+
+    No compiler emits an ungrouped fragment today (``compile_lance``
+    self-parenthesizes every boolean node), so no compiled-filter test can
+    catch ``_lance_fragment_to_text`` losing its grouping. This drives the
+    splice directly with a top-level ``OR`` — the shape that, ungrouped,
+    absorbs the namespace predicate into its left disjunct
+    (``ns = ? AND a = 1 OR b = 2``) and returns the other tenant's rows.
+    Removing the parentheses from ``_lance_fragment_to_text`` must fail here.
+    """
+    from khora.storage.backends._documents_scan import build_documents_scan_query
+    from khora.storage.backends.sqlite_lance.relational import _lance_fragment_to_text
+
+    seed = scan_seed(6)
+    await _seed_varied(adapter, namespace.id, seed)
+    other_id = uuid4()
+    other = await adapter.create_namespace(
+        MemoryNamespace(id=other_id, namespace_id=other_id, tenancy_mode=TenancyMode.SHARED)
+    )
+    await _seed_varied(adapter, other.id, scan_seed(6))
+
+    # Every row in BOTH namespaces satisfies the right disjunct, so an absorbed
+    # namespace predicate yields foreign rows deterministically.
+    fragment = _lance_fragment_to_text("documents.title = ? OR documents.content = ?", ["doc-0", "scanned content"])
+    query = build_documents_scan_query(namespace.id, scan_limit=50).where(fragment)
+
+    async with adapter._get_session() as session:  # noqa: SLF001 — the splice has no public executor yet
+        rows = (await session.execute(query)).scalars().all()
+
+    assert rows, "the fragment must match rows in the scanned namespace for this test to bite"
+    assert all(row.namespace_id == namespace.id for row in rows)

--- a/tests/unit/storage/backends/sqlite_lance/test_relational_scan_documents.py
+++ b/tests/unit/storage/backends/sqlite_lance/test_relational_scan_documents.py
@@ -31,10 +31,13 @@ try:
 except ImportError:
     _HAS_EMBEDDED = False
 
+import sqlalchemy.exc
+
 from khora.core.models import Document, MemoryNamespace, TenancyMode
 from khora.core.models.document import DocumentStatus
 from khora.filter import RecallFilter
 from khora.filter.ast import parse_to_ast
+from khora.filter.compilers.python import compile_python
 from tests.test_helpers.document_scan import ScanSeed, scan_seed, walk_scan
 
 # Lives in the unit lane next to the rest of this adapter's tests, and also
@@ -50,7 +53,14 @@ if _HAS_EMBEDDED:
         EmbeddedStorageHandle,
         EmbeddedStorageHandleConfig,
     )
-    from khora.storage.backends.sqlite_lance.relational import SQLiteLanceRelationalAdapter
+
+    # ``_documents_compile_context`` is private, and imported on purpose: the
+    # superset test below must use the *same* context the scan itself compiles
+    # with, or it would prove a property of some other context.
+    from khora.storage.backends.sqlite_lance.relational import (
+        SQLiteLanceRelationalAdapter,
+        _documents_compile_context,
+    )
 
 
 @pytest.fixture
@@ -95,6 +105,25 @@ async def _write(adapter: Any, namespace_id: UUID, doc_id: UUID, created_at: dat
 async def _seed(adapter: Any, namespace_id: UUID, seed: ScanSeed) -> None:
     for doc_id, created_at in seed.writes:
         await _write(adapter, namespace_id, doc_id, created_at)
+
+
+async def _seed_varied(adapter: Any, namespace_id: UUID, seed: ScanSeed) -> None:
+    """Seed the same corpus with attribute variety, so a filter can split it.
+
+    Attributes are assigned by *write* index, which is deliberately not the
+    enumeration order — every expectation below is therefore derived from the
+    rows a scan actually returns, never from this loop's counter.
+    """
+    for i, (doc_id, created_at) in enumerate(seed.writes):
+        await _write(
+            adapter,
+            namespace_id,
+            doc_id,
+            created_at,
+            title=f"doc-{i}",
+            source_type="report" if i % 2 == 0 else "library",
+            metadata={"tier": "gold"} if i < 2 else {},
+        )
 
 
 # --------------------------------------------------------------------------- #
@@ -211,6 +240,68 @@ async def test_whole_second_cursor_excludes_its_own_row_and_keeps_its_tie_mates(
     assert ids == seed.expected[seed.expected.index(cursor_doc.id) + 1 :]
 
 
+async def test_filtered_walk_puts_a_cursor_and_a_compiled_fragment_in_one_statement(adapter, namespace) -> None:
+    """The only place a cursor and a pushdown fragment share a statement.
+
+    This store's compiler emits positional binds for a qmark driver, which are
+    rewritten to ``:kf0`` … ``:kfN`` before the fragment can join a SQLAlchemy
+    statement — while the keyset predicate and the namespace scope carry
+    SQLAlchemy's own generated names (``param_N``, ``namespace_id_1``). The
+    ``kf`` prefix is what keeps the two families apart, and nothing proves it
+    unless both appear in the same ``SELECT``.
+
+    The filter is a two-leaf disjunction on purpose: it compiles to two
+    positional binds rather than one, so a rewrite that collided or dropped a
+    name would show up as a wrong row set rather than as a lucky pass.
+    """
+    seed = scan_seed(6)
+    await _seed_varied(adapter, namespace.id, seed)
+
+    full = await adapter.scan_documents(namespace.id, scan_limit=10)
+    wire = {"$or": [{"source_type": {"$eq": "report"}}, {"title": {"$eq": "doc-1"}}]}
+    expected = [d.id for d in full.documents if d.source_type == "report" or d.title == "doc-1"]
+    assert 1 < len(expected) < len(full.documents), "the filter must narrow, but not to a single row"
+
+    steps = await walk_scan(
+        adapter.scan_documents,
+        namespace.id,
+        scan_limit=1,
+        filter_ast=_filter_ast(wire),
+    )
+    seen = [d.id for step in steps for d in step.documents]
+
+    assert len(seen) == len(set(seen))
+    assert seen == expected
+    assert steps[-1].exhausted is True
+
+
+async def test_off_type_cursor_operands_are_rejected(adapter, namespace) -> None:
+    """A position must be the pair of values a row yielded, not a rendering of it.
+
+    Binding each operand through its ORM column type turns the two ways a caller
+    could hand-render a position into an immediate failure instead of a silent
+    mis-ordering: the id's type processor wants a ``UUID`` (it reads ``.hex``)
+    and the timestamp's wants a ``datetime``. SQLAlchemy raises during bind
+    processing, so the error surfaces wrapped rather than as the driver-level
+    ``AttributeError`` / ``TypeError`` underneath.
+
+    This has no PostgreSQL counterpart — no bind processor runs on that dialect,
+    so the same operands reach asyncpg untouched and a dashed id string decodes
+    to the very same bytes. The contract is enforced here and documented there.
+    """
+    seed = scan_seed(6)
+    await _seed(adapter, namespace.id, seed)
+    row = (await adapter.scan_documents(namespace.id, scan_limit=1)).documents[0]
+
+    with pytest.raises(sqlalchemy.exc.StatementError) as rendered_id:
+        await adapter.scan_documents(namespace.id, after=(row.created_at, str(row.id)))
+    assert isinstance(rendered_id.value.orig, AttributeError)
+
+    with pytest.raises(sqlalchemy.exc.StatementError) as rendered_ts:
+        await adapter.scan_documents(namespace.id, after=(str(row.created_at), row.id))
+    assert isinstance(rendered_ts.value.orig, TypeError)
+
+
 async def test_empty_window_reports_exhausted_without_a_position(adapter, namespace) -> None:
     """Both the never-seeded namespace and the tail past the last row."""
     empty = await adapter.scan_documents(namespace.id, scan_limit=5)
@@ -276,6 +367,70 @@ async def test_split_reports_only_the_leaves_sql_enforced(adapter, namespace) ->
     # The pushed leaf really did narrow the window; the unpushed one did not.
     assert {d.source_type for d in step.documents} == {"report"}
     assert len(step.documents) == 3
+
+
+# The pushdown must never reject a row the full filter would keep. Shapes are
+# chosen for the ways a compiler can get that wrong, not for operator coverage:
+# the three wrapping an unpushable leaf in a disjunction or a negation are the
+# ones that matter, because a match-all placeholder left inside a negation
+# inverts into a match-nothing and excludes rows.
+_SUPERSET_SHAPES: dict[str, dict[str, Any]] = {
+    "pushable_eq": {"source_type": {"$eq": "report"}},
+    "pushable_ne": {"source_type": {"$ne": "report"}},
+    "pushable_nin": {"source_type": {"$nin": ["report"]}},
+    "pushable_exists": {"source_url": {"$exists": False}},
+    "metadata_eq": {"metadata.tier": {"$eq": "gold"}},
+    "unpushable_date": {"created_at": {"$gte": "2026-01-31T12:30:00+00:00"}},
+    "or_over_unpushable": {
+        "$or": [
+            {"created_at": {"$gte": "2026-01-31T12:30:00+00:00"}},
+            {"source_type": {"$eq": "report"}},
+        ]
+    },
+    "not_over_pushable": {"$not": {"source_type": {"$eq": "report"}}},
+    "not_over_unpushable": {"$not": {"created_at": {"$gte": "2026-01-31T12:30:00+00:00"}}},
+    "and_of_in_and_not": {
+        "$and": [
+            {"source_type": {"$in": ["report", "library"]}},
+            {"$not": {"title": {"$eq": "doc-0"}}},
+        ]
+    },
+}
+
+
+@pytest.mark.parametrize("wire", _SUPERSET_SHAPES.values(), ids=_SUPERSET_SHAPES.keys())
+async def test_pushdown_never_rejects_a_row_the_full_filter_would_keep(adapter, namespace, wire) -> None:
+    """The superset property the resume contract depends on.
+
+    Resuming past the rows a pushdown rejected is sound only because a rejected
+    row could not have satisfied the full filter either. Both ``scan_documents``
+    docstrings name that as an assumption about the *compilers*; this checks the
+    consequence where it actually lands, by comparing the scan's window against
+    the in-process ``compile_python`` evaluation of the same AST over the same
+    corpus. If it ever fails, a walk is silently and permanently dropping
+    documents — a post-filter can only narrow, never recover a row the window
+    never returned.
+
+    Scope, so a green run is not read as more than it is: ten shapes on one
+    store is a tripwire, not a proof over the operator space. The general
+    property belongs to the compilers and to the forced-residual conformance
+    corpus.
+    """
+    seed = scan_seed(6)
+    await _seed_varied(adapter, namespace.id, seed)
+    ast = _filter_ast(wire)
+
+    step = await adapter.scan_documents(namespace.id, filter_ast=ast, scan_limit=100)
+    # Precondition: the comparison below is only meaningful if this one window
+    # covered the whole namespace. Without it, growing the corpus past the bound
+    # would fail the test for a reason that has nothing to do with the pushdown.
+    assert step.exhausted is True
+
+    all_docs = (await adapter.scan_documents(namespace.id, scan_limit=100)).documents
+    matches = compile_python(ast, _documents_compile_context()).predicate
+    oracle = {d.id for d in all_docs if matches(d)}
+
+    assert oracle <= {d.id for d in step.documents}
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Adds an internal `scan_documents` to the two SQLAlchemy-backed relational document stores (PostgreSQL and the embedded sqlite_lance adapter), plus the shared `DocumentScanStep` result type.

One call runs one bounded `SELECT`: a dialect-compiled pushdown fragment AND-composed with the namespace scope, the optional `status` / `updated_before` narrowing, and a keyset resume predicate, ordered by the total order pinned in #1576 and capped by a row bound. The backend resolves its own compiler through the registry keys added in #1577 and executes the step in its own session; no transaction spans steps.

**Nothing calls this yet.** The scan loop and the caller-facing surface are follow-up work, so this lands as an internal primitive with its tests.

Deliberate scope choices:

- The **public storage API is untouched** — `list_documents` is unchanged on both stores.
- `scan_documents` is **not** added to `RelationalBackendProtocol`. That protocol is `@runtime_checkable` and an existing test asserts `isinstance` against it; an abstract member would make that assertion false for the two stores that do not implement it yet. The protocol addition belongs with the change that lands all four.
- The step type is not exported publicly.
- The two remaining relational stores are out of scope.

Two things worth a reviewer's attention:

**The shared statement builder.** Both stores scan the same model, and only the compiled fragment's attachment is genuinely dialect-specific, so the statement is built once in `_documents_scan.py`. That is not only deduplication: the Postgres leg cannot be exercised without a live server, so building the predicate once — in a form the service-free embedded tests can execute — is what lets the locally-runnable leg prove the shared semantics.

**The keyset operands bind through the ORM column types** rather than being formatted by hand, which is load-bearing rather than stylistic. On the embedded store, `created_at` is stored as fixed-width text with a space separator and always-6-digit microseconds. A hand-formatted ISO-8601 cursor puts a `T` (0x54) where the stored form has a space (0x20), so it sorts *above* every row and the cursor compares less than its own row — a resumed walk returns that row forever instead of advancing. A space-separated form that drops the `.000000` sorts *below* its tie-mates and silently skips them. A test pins this: swapping the typed binds for `isoformat()` fails it.

Two smaller invariants that are invisible on a full-pushdown backend and wrong everywhere else:

- `last_scanned` is the key of the final row of the **raw** window, not the last row that survived filtering, so a resumed walk does not re-scan the non-matching gap.
- `exhausted` derives from the **raw** window count against the row bound, not the post-filter count, so it remains a sound termination signal.

The step reports `consumed_keys` verbatim from the compiler and carries no residual AST — no compiler produces a pruned tree, the caller already holds the filter it passed in, and a field named `residual` would invite exactly the mistake the compile-context docstrings warn against (the post-filter must evaluate the full filter unconditionally; `consumed_keys` is a reporting signal, not permission to skip leaves).

## Test plan

- [x] Unit tests pass — 11 new tests. The full CI-shaped unit invocation is green on this branch: `10658 passed, 35 skipped`.
- [x] Embedded (sqlite_lance) suite passes locally with no services: 10 tests.
- [x] **Mutation-verified**: replacing the typed cursor binds with `isoformat()` / `str()` fails 3 tests with exactly the predicted pathology (the cursor returns its own row instead of an empty tail); reverted to green. The guarantee is tested, not merely asserted.
- [x] `make format` clean, `make lint` exit 0, new module type-checks clean.
- [ ] Integration tests — the 11 Postgres tests **skip locally** (no Docker in the dev container) and run for the first time in CI against the real service. This is the one leg not verified locally.

Covered per backend: the row bound is honored; a mid-tie cursor resume over a tie-heavy corpus walks exactly-once in strict total order; the compile split is reported correctly for a forced-residual filter; an empty window reports exhausted; and `last_scanned` is asserted non-vacuously (the raw window deliberately ends on a non-matching row, and the test asserts the key differs from the last match).

Also pinned: the date system keys stay out of the embedded store's pushdown set, per #1580 — that store writes wall clock, so a pushed-down date compare would be wrong. A test asserts they route to the residual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bounded document scanning for PostgreSQL and SQLite/Lance storage.
  * Supports status and update-time filters, configurable scan limits, and cursor-based continuation.
  * Scans now provide completion status and continuation metadata for reliable traversal.
  * Added filter pushdown support where available.

* **Bug Fixes**
  * Improved handling of timestamp and identifier ordering during resumed scans.

* **Tests**
  * Added comprehensive coverage for pagination, filtering, exhaustion, validation, and cursor resumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->