### PR TITLE
Add a bounded keyset scan primitive to the raw-SQL document stores

### DIFF
--- a/src/khora/storage/backends/sqlite.py
+++ b/src/khora/storage/backends/sqlite.py
@@ -24,7 +24,7 @@ from khora.core.models.entity import Entity
 from khora.core.models.recall import DocumentProjection
 from khora.core.models.tenancy import TenancyMode
 from khora.storage.backends._fts5 import escape_fts5_query
-from khora.storage.backends.base import PaginatedResult
+from khora.storage.backends.base import DocumentScanKey, DocumentScanStep, PaginatedResult
 
 if TYPE_CHECKING:
     from khora.filter.ast import FilterNode
@@ -506,6 +506,144 @@ class SQLiteRelationalBackend:
         )
         rows = await cursor.fetchall()
         return [self._row_to_document(r) for r in rows]
+
+    async def scan_documents(
+        self,
+        namespace_id: UUID,
+        *,
+        filter_ast: FilterNode | None = None,
+        status: str | None = None,
+        updated_before: datetime | None = None,
+        after: DocumentScanKey | None = None,
+        scan_limit: int = 100,
+    ) -> DocumentScanStep:
+        """Scan one bounded keyset window of a namespace's documents.
+
+        ``@internal``. Not part of the public storage API — the offset-based
+        :meth:`list_documents` is unchanged. One ``SELECT`` on this backend's own
+        connection; no transaction spans steps and no consistent snapshot is
+        claimed. A caller walks the namespace by chaining
+        :attr:`DocumentScanStep.last_scanned` back in as ``after`` until the step
+        reports ``exhausted``.
+
+        The same scan the two SQLAlchemy stores run (khora #1586), written out
+        here rather than shared: this store has no ORM, builds SQL text and a
+        positional bind list by hand, and owns its own ``documents`` DDL. Binds
+        being positional, conjunct order *is* bind order — namespace, ``status``,
+        ``updated_before``, the two cursor operands, the fragment's ``args``, the
+        row bound — and appending out of order shifts every later bind by one.
+
+        **The compiled fragment is spliced in parentheses, a cross-tenant
+        tripwire.** Measured, two namespaces of 6 rows each: grouped returns 6
+        rows, ungrouped returns 12, no error and no warning. Latent today
+        (``compile_lance`` self-parenthesizes every shape it emits), which is why
+        it is enforced rather than assumed. Nothing else from the sqlite_lance
+        splice is ported: that store's ``:`` and ``?``-count guards protect a
+        rewrite into SQLAlchemy named binds, and this driver is natively qmark —
+        ``:`` is not bind syntax here, and a count mismatch is already a loud
+        ``sqlite3.ProgrammingError``. No ``CompileError`` mapping is wrapped
+        around the compile call either, unlike the SurrealDB store; that
+        asymmetry is genuine, since ``compile_lance`` has no ``raise
+        CompileError`` site and raises :class:`RecallFilterUnsupportedError` only
+        under ``on_unsupported="raise"``, which this context never selects.
+
+        **Cursor serialization inverts from sqlite_lance.** ``created_at`` binds
+        through :func:`_dt_to_str` (``datetime.isoformat()``), byte-for-byte what
+        :meth:`create_document` wrote into a TEXT column SQLite compares
+        lexicographically; ``id`` binds as ``str(uuid)``, the **dashed** 36
+        characters that same writer stored. sqlite_lance holds 32 *undashed* hex
+        characters, so a dashed cursor is the bug there and the only correct form
+        here. An undashed cursor sorts *above* every stored id it shares leading
+        hex with — the stored form carries ``-`` (0x2D) at index 8 where the
+        undashed form carries a hex digit — so ``id < :cursor`` matches strictly
+        more rows, including the cursor's own. Measured from mid-tie ``…0003``:
+        dashed yields ``[…0002, …0001, …0005]``, ``.hex`` yields ``[…0004, …0003,
+        …0002, …0001, …0005]``, so the walk runs backwards and never terminates.
+        Positions are store-local: build one from a row this store returned.
+
+        This store therefore enumerates in **stored-text order — a deterministic
+        total order, but not an instant order**, since :func:`_dt_to_str`
+        preserves the writer's offset with no UTC coercion. Pre-existing, and the
+        same property that keeps the date keys out of ``_PUSHABLE_SYSTEM_KEYS``.
+        It does not threaten the walk: keyset correctness needs the cursor
+        predicate to agree with ``ORDER BY``, not with chronology, and both are
+        lexicographic over the same column. Callers must not read this order as
+        chronological.
+
+        ``created_at`` cannot be NULL, belt and braces: ``_SCHEMA_SQL`` declares
+        it ``NOT NULL`` independently of and predating the Alembic chain this
+        store does not have, *and* :meth:`create_document` is the only INSERT and
+        coalesces a missing timestamp to now. A NULL key would make the row-value
+        comparison evaluate to NULL and drop the row from every page.
+        ``updated_before`` narrows with ``updated_at < ?``, the same shape #1586
+        ships; the NULL-``updated_at`` exclusion that tier documents does not
+        arise here, because ``updated_at`` is ``TEXT NOT NULL``.
+
+        ``scan_limit`` bounds rows **returned**, not rows **examined** — a
+        selective fragment can still make one call read the whole namespace, so
+        it is a total-work bound, never a per-call latency bound. What it buys is
+        that a full walk stays O(namespace): ``last_scanned`` is the last *raw*
+        row, so a resumed step never re-examines the rejected gap. Resuming past
+        those rows skips nothing **only because the pushdown is a superset
+        filter** — a property of the compiler and this store's compile context,
+        not of this method.
+
+        ``consumed_keys`` is reported verbatim from the compiler: the leaves the
+        SQL already enforced. It is a reporting signal and **never** permission to
+        skip them — the post-filter must evaluate the whole AST unconditionally.
+        The date-valued system keys are deliberately unpushable here (see
+        :func:`_documents_compile_context`), so they stay out of it by design.
+
+        Raises:
+            ValueError: ``scan_limit`` below 1, matching the shared SQLAlchemy
+                builder. Raised before anything is compiled or executed, so a bad
+                bound is never masked by a compile error.
+        """
+        if scan_limit < 1:
+            raise ValueError(f"scan_limit must be >= 1, got {scan_limit}")
+
+        conditions = ["namespace_id = ?"]
+        params: list[Any] = [str(namespace_id)]
+        if status:
+            conditions.append("status = ?")
+            params.append(status)
+        if updated_before is not None:
+            conditions.append("updated_at < ?")
+            params.append(updated_before.isoformat())
+        if after is not None:
+            cursor_created_at, cursor_id = after
+            conditions.append("(created_at, id) < (?, ?)")
+            params.extend([_dt_to_str(cursor_created_at), str(cursor_id)])
+
+        consumed_keys: frozenset[str] = frozenset()
+        if filter_ast is not None:
+            compiler = CompilerRegistry.get("relational.sqlite", "documents")
+            compiled = compiler(filter_ast, _documents_compile_context())
+            consumed_keys = compiled.consumed_keys
+            # Parenthesized — see the docstring. Ungrouped, a top-level OR in the
+            # fragment absorbs the namespace predicate and leaks other tenants.
+            conditions.append(f"({compiled.predicate})")
+            params.extend(compiled.params["args"])
+
+        where = " AND ".join(conditions)
+        params.append(scan_limit)
+        cursor = await self._conn.execute(
+            f"SELECT * FROM documents WHERE {where} ORDER BY created_at DESC, id DESC LIMIT ?",  # noqa: S608
+            params,
+        )
+        rows = await cursor.fetchall()
+
+        # ``last_scanned`` and ``exhausted`` both describe the RAW window: the
+        # final row scanned, and whether SQL ran out of rows filling it. Neither
+        # may be derived from a post-filtered subset — that would re-scan the
+        # rejected gap on resume, and would call a full window exhausted.
+        documents = [self._row_to_document(r) for r in rows]
+        return DocumentScanStep(
+            documents=documents,
+            last_scanned=(documents[-1].created_at, documents[-1].id) if documents else None,
+            exhausted=len(rows) < scan_limit,
+            consumed_keys=consumed_keys,
+        )
 
     async def claim_orphaned_documents(
         self,

--- a/src/khora/storage/backends/sqlite.py
+++ b/src/khora/storage/backends/sqlite.py
@@ -539,9 +539,15 @@ class SQLiteRelationalBackend:
         (``compile_lance`` self-parenthesizes every shape it emits), which is why
         it is enforced rather than assumed. Nothing else from the sqlite_lance
         splice is ported: that store's ``:`` and ``?``-count guards protect a
-        rewrite into SQLAlchemy named binds, and this driver is natively qmark —
-        ``:`` is not bind syntax here, and a count mismatch is already a loud
-        ``sqlite3.ProgrammingError``. No ``CompileError`` mapping is wrapped
+        rewrite into SQLAlchemy named binds, and this driver is natively qmark, so
+        a count mismatch is already a loud ``sqlite3.ProgrammingError`` in both
+        directions. **The count check is the whole of the protection — do not read
+        this as "``:`` is inert here".** ``sqlite3`` does treat ``:name`` as a
+        parameter and binds it positionally from a sequence, so a stray ``:`` in a
+        spliced fragment shifts the binds exactly as it would under
+        ``text()``; it merely cannot do so *silently*, because the count stops
+        agreeing. Today it warns (``DeprecationWarning``) and from Python 3.14 it
+        raises ``sqlite3.ProgrammingError`` outright. No ``CompileError`` mapping is wrapped
         around the compile call either, unlike the SurrealDB store; that
         asymmetry is genuine, since ``compile_lance`` has no ``raise
         CompileError`` site and raises :class:`RecallFilterUnsupportedError` only

--- a/src/khora/storage/backends/surrealdb/relational.py
+++ b/src/khora/storage/backends/surrealdb/relational.py
@@ -426,10 +426,19 @@ class SurrealDBRelationalAdapter:
         single comparison**, and there are two such sites at different
         severities. This one is **live**: we write the ``OR`` rather than
         inheriting it from a self-parenthesizing compiler, and it is reached on
-        every resumed step. Ungrouped, ``AND`` binds tighter, so the namespace /
-        status / filter conjuncts all land inside the left disjunct and the right
-        one returns every tenant's rows tied on the cursor instant — measured, 3
-        rows grouped against 7 ungrouped, 4 of them foreign. The compiled
+        every resumed step. Ungrouped, ``AND`` binds tighter, so the disjunction
+        splits the conjunct list at its own position: everything appended *before*
+        it (namespace, status, ``updated_before``) lands inside the left disjunct,
+        and the right one carries only the tie clause plus whatever is appended
+        *after* — today just the compiled fragment. Either way the right disjunct
+        has no namespace scope, so it returns other tenants' rows tied on the
+        cursor instant. Measured with no ``filter_ast``, where the right disjunct
+        is bare: 3 rows grouped against 7 ungrouped, 4 of them foreign. With a
+        fragment the leak is narrowed by that fragment rather than removed, so
+        the magnitude drops but the cross-tenant read does not. **The order of
+        the appends is therefore load-bearing to this paragraph, not to the
+        defect** — regrouping the list changes which conjuncts leak, never
+        whether they do. The compiled
         fragment splice is the second site, a tripwire rather than a live hazard
         (``compile_surrealdb`` self-groups every boolean node today) with an
         identical failure mode, measured at 6 rows becoming 12. The inner
@@ -441,7 +450,7 @@ class SurrealDBRelationalAdapter:
         Cursor and bound operands bind as native objects — ``datetime`` for the
         timestamps, ``RecordID`` for the id — matching the write path. **That
         makes ``updated_before`` diverge from :meth:`list_documents`,
-        deliberately and with the team lead's written authorisation.** ``updated_at`` is a ``TYPE
+        deliberately.** ``updated_at`` is a ``TYPE
         datetime`` field and an ISO string compares against no row at all:
         measured on one corpus, no bound 6 rows, ``datetime`` bind 6, string bind
         0. Mirroring that ``.isoformat()`` would ship an ``updated_before``
@@ -459,9 +468,35 @@ class SurrealDBRelationalAdapter:
 
         ``scan_limit`` bounds rows **returned**, not rows **examined**: a
         selective fragment can still make one call read the whole namespace, so
-        it is no latency bound. It bounds total work — because ``last_scanned``
-        is the last *raw* row, a resumed step never re-examines the rejected gap,
-        so a full walk is O(namespace) whatever the selectivity.
+        it is no latency bound. Because ``last_scanned`` is the last *raw* row, a
+        resumed step never re-*returns* the rejected gap.
+
+        **It does not follow that a walk is O(namespace) on this store, and it
+        is not.** Any top-level ``OR`` in the ``WHERE`` collapses SurrealDB's
+        planner to a full table scan — measured on 2.x, the keyset disjunction
+        loses not only the ``created_at`` range but the ``namespace_id`` prefix,
+        so ``EXPLAIN`` reports ``Iterate Table`` where the same statement without
+        the disjunction reports ``Iterate Index`` on ``idx_document_ns_created``.
+        Every resumed step therefore re-examines every ``document`` row in the
+        database, **all namespaces included**, and sorts in memory. A full walk
+        is O(rows-in-table x steps), not O(namespace): measured 3.5x wall time
+        for a 2x namespace, and 13x per step from 5k foreign rows the caller can
+        never see. Cost tracks total corpus *bytes*, since a table scan
+        materializes whole records.
+
+        Two workarounds do not help, so do not re-try them: a ``WITH INDEX``
+        hint still plans ``Iterate Table``, and so does a redundant
+        ``created_at <= $ts`` guard alongside the disjunction. Restoring the
+        index means getting the ``OR`` out of the ``WHERE`` — two
+        index-eligible queries (the tie block by equality, then the strictly
+        below range) merged client-side and capped at ``scan_limit``. That buys
+        namespace scoping, not an O(scan_limit) step: 2.x still sorts the
+        qualifying set in memory (see :mod:`.schema`). Tracked as a follow-up;
+        this is a shipped-and-measured limitation, not an unknown.
+
+        The raw-SQLite sibling has no such problem — its row-value keyset is
+        consumed as an index range constraint, so there the total-work bound
+        holds as stated.
 
         Raises ``ValueError`` when ``scan_limit`` is below 1, before anything is
         compiled or executed, so a bad bound is never masked by a compile error.
@@ -482,8 +517,9 @@ class SurrealDBRelationalAdapter:
             params["status"] = status
         if updated_before is not None:
             # Binds the datetime OBJECT, not ``.isoformat()`` — see the docstring
-            # for the measurement and the team lead's authorisation of the
-            # divergence from ``list_documents``. Do not "correct" it back.
+            # for the measurement behind the deliberate divergence from
+            # ``list_documents``, whose string bind matches no row. Do not
+            # "correct" it back to match that method.
             conditions.append("updated_at < $updated_before")
             params["updated_before"] = updated_before
         if after is not None:

--- a/src/khora/storage/backends/surrealdb/relational.py
+++ b/src/khora/storage/backends/surrealdb/relational.py
@@ -9,7 +9,7 @@ parsed back on read.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from loguru import logger
@@ -17,13 +17,16 @@ from loguru import logger
 from khora.core.models import Document, MemoryNamespace, TenancyMode
 from khora.core.models.document import DocumentSource, DocumentStatus
 from khora.core.models.recall import DocumentProjection
-from khora.storage.backends.base import PaginatedResult
+from khora.storage.backends.base import DocumentScanKey, DocumentScanStep, PaginatedResult
 from khora.storage.backends.surrealdb._helpers import (
     _parse_dt,
     _parse_uuid,
     _record_id,
 )
 from khora.storage.backends.surrealdb.connection import SurrealDBConnection
+
+if TYPE_CHECKING:
+    from khora.filter.ast import FilterNode
 
 # ---------------------------------------------------------------------------
 # Adapter
@@ -397,6 +400,156 @@ class SurrealDBRelationalAdapter:
             params,
         )
         return [self._row_to_document(r) for r in rows]
+
+    async def scan_documents(
+        self,
+        namespace_id: UUID,
+        *,
+        filter_ast: FilterNode | None = None,
+        status: str | None = None,
+        updated_before: datetime | None = None,
+        after: DocumentScanKey | None = None,
+        scan_limit: int = 100,
+    ) -> DocumentScanStep:
+        """Scan one bounded window of a namespace's documents by keyset.
+
+        ``@internal``. Not part of the public storage API — the offset-based
+        :meth:`list_documents` is. One ``SELECT`` on this adapter's own
+        connection; a walk is the caller's job, chaining
+        :attr:`DocumentScanStep.last_scanned` back in as ``after`` until the step
+        reports ``exhausted``. No transaction spans steps and no consistent
+        snapshot is claimed.
+
+        SurrealQL has no row-value comparison, so #1586's single
+        ``(created_at, id) < (…)`` expands to ``created_at < $ts OR (created_at =
+        $ts AND id < $id)``. **Every conjunct is parenthesized unless it is a
+        single comparison**, and there are two such sites at different
+        severities. This one is **live**: we write the ``OR`` rather than
+        inheriting it from a self-parenthesizing compiler, and it is reached on
+        every resumed step. Ungrouped, ``AND`` binds tighter, so the namespace /
+        status / filter conjuncts all land inside the left disjunct and the right
+        one returns every tenant's rows tied on the cursor instant — measured, 3
+        rows grouped against 7 ungrouped, 4 of them foreign. The compiled
+        fragment splice is the second site, a tripwire rather than a live hazard
+        (``compile_surrealdb`` self-groups every boolean node today) with an
+        identical failure mode, measured at 6 rows becoming 12. The inner
+        ``(created_at = $ts AND id < $id)`` keeps its parens too: we do not lean
+        on operator precedence for a predicate that fails cross-tenant.
+        ``created_at`` is a non-optional ``TYPE datetime`` (``schema.py``), so the
+        engine rejects ``NONE`` by type and the keyset needs no null guard.
+
+        Cursor and bound operands bind as native objects — ``datetime`` for the
+        timestamps, ``RecordID`` for the id — matching the write path. **That
+        makes ``updated_before`` diverge from :meth:`list_documents`,
+        deliberately and with the team lead's written authorisation.** ``updated_at`` is a ``TYPE
+        datetime`` field and an ISO string compares against no row at all:
+        measured on one corpus, no bound 6 rows, ``datetime`` bind 6, string bind
+        0. Mirroring that ``.isoformat()`` would ship an ``updated_before``
+        returning an empty walk that reports itself exhausted on the first call.
+        The narrowing is otherwise the shape #1586 ships; its NULL-``updated_at``
+        exclusion does not arise, the field being non-optional here.
+
+        ``filter_ast`` is compiled by the compiler registered for this store's
+        ``documents`` target. Only the leaves in ``consumed_keys`` were pushed;
+        **the caller must still evaluate the full filter over the returned
+        rows.** Re-running a pushed leaf can only narrow, because everything
+        pushed is a superset filter — which is why resuming past the rows the
+        pushdown rejected skips nothing. That belongs to the compiler and its
+        compile context, not to this method.
+
+        ``scan_limit`` bounds rows **returned**, not rows **examined**: a
+        selective fragment can still make one call read the whole namespace, so
+        it is no latency bound. It bounds total work — because ``last_scanned``
+        is the last *raw* row, a resumed step never re-examines the rejected gap,
+        so a full walk is O(namespace) whatever the selectivity.
+
+        Raises ``ValueError`` when ``scan_limit`` is below 1, before anything is
+        compiled or executed, so a bad bound is never masked by a compile error.
+        Raises ``RecallFilterUnsupportedError`` when the compiler rejects a
+        metadata path segment it cannot render as an identifier. **That mapping
+        is best-effort and sibling-dependent:** the guard fires only when the emit
+        walk reaches the leaf, so a hyphenated key in conjunctive position raises
+        while the same key inside an ``$or`` the all-or-nothing gate defers does
+        not — it reaches the caller's post-filter instead. Both are correct.
+        """
+        if scan_limit < 1:
+            raise ValueError(f"scan_limit must be >= 1, got {scan_limit}")
+
+        conditions = ["namespace_id = $ns"]
+        params: dict[str, Any] = {"ns": str(namespace_id), "lim": scan_limit}
+        if status:
+            conditions.append("status = $status")
+            params["status"] = status
+        if updated_before is not None:
+            # Binds the datetime OBJECT, not ``.isoformat()`` — see the docstring
+            # for the measurement and the team lead's authorisation of the
+            # divergence from ``list_documents``. Do not "correct" it back.
+            conditions.append("updated_at < $updated_before")
+            params["updated_before"] = updated_before
+        if after is not None:
+            cursor_created_at, cursor_id = after
+            conditions.append("(created_at < $after_created_at OR (created_at = $after_created_at AND id < $after_id))")
+            params["after_created_at"] = cursor_created_at
+            params["after_id"] = _record_id("document", cursor_id)
+
+        consumed_keys: frozenset[str] = frozenset()
+        if filter_ast is not None:
+            compiler = CompilerRegistry.get("relational.surrealdb", "documents")
+            # The catch is narrowed two ways, and both are load-bearing. By
+            # SCOPE: this ``try`` holds the compile call and nothing else, so it
+            # cannot swallow anything raised by the splice, the bind merge or the
+            # driver. And by DISCRIMINATOR: only the guard's own message maps.
+            #
+            # The mapped case is ``compile_surrealdb``'s sole ``raise
+            # CompileError`` — the ``_SAFE_SEGMENT_RE`` injection guard in
+            # ``_Builder._metadata_path`` (``filter/compilers/surrealdb.py:260``),
+            # which fires under both ``on_unsupported`` modes because it is a
+            # guard rather than a capability gap. ``_documents_compile_context``
+            # states this obligation on the scan path; the compiler-side fix it
+            # also describes is deliberately out of scope.
+            #
+            # Scope alone would blanket-swallow the class: every future genuine
+            # compiler bug would be relabelled a caller input problem and hidden
+            # behind a structured rejection forever. Matching the message
+            # coarsens if the guard is reworded, but it fails SAFE — the mapping
+            # stops firing and ``CompileError`` escapes loudly, the direction
+            # that surfaces bugs rather than burying them. The guard has no error
+            # subclass to key on, and adding one means editing a compiler this
+            # scan does not own.
+            try:
+                compiled = compiler(filter_ast, _documents_compile_context())
+            except CompileError as exc:
+                if _UNSAFE_METADATA_SEGMENT_MARKER not in str(exc):
+                    raise
+                raise RecallFilterUnsupportedError("metadata", str(exc)) from exc
+            consumed_keys = compiled.consumed_keys
+            conditions.append(f"({compiled.predicate})")
+            # Compiled binds are ``{param_namespace}_{n}`` — ``f_0``, ``f_1``, …
+            # — disjoint from this method's names, so no merge guard is needed.
+            # Never name a scan bind ``f_<n>``.
+            params.update(compiled.params)
+
+        where = " AND ".join(conditions)
+        rows = await self._conn.query(
+            f"SELECT * FROM document WHERE {where} ORDER BY created_at DESC, id DESC LIMIT $lim",  # noqa: S608
+            params,
+        )
+        # ``last_scanned`` and ``exhausted`` both describe the RAW window: the
+        # final row scanned, and whether SurrealQL ran out of rows filling it.
+        # Neither may be derived from a post-filtered subset — that would re-scan
+        # the rejected gap on resume, and would call a full window exhausted.
+        # The key is built from the converted ``Document`` because
+        # ``_row_to_document`` runs the ``RecordID`` -> ``UUID`` conversion that
+        # ``DocumentScanKey`` requires; the raw row's ``id`` would seat a
+        # ``RecordID`` in that tuple and still round-trip into this same store,
+        # i.e. silently green.
+        docs = [self._row_to_document(r) for r in rows]
+        return DocumentScanStep(
+            documents=docs,
+            last_scanned=(docs[-1].created_at, docs[-1].id) if docs else None,
+            exhausted=len(rows) < scan_limit,
+            consumed_keys=consumed_keys,
+        )
 
     async def claim_orphaned_documents(
         self,
@@ -1140,8 +1293,20 @@ def _row_to_memory_fact(row: dict[str, Any]) -> _MemoryFactRow:
 # --------------------------------------------------------------------------- #
 # Documents-tier recall-filter compile context + compiler registration.
 # --------------------------------------------------------------------------- #
-from khora.filter import CompileContext, CompilerRegistry  # noqa: E402
+from khora.filter import (  # noqa: E402
+    CompileContext,
+    CompileError,
+    CompilerRegistry,
+    RecallFilterUnsupportedError,
+)
 from khora.filter.compilers.surrealdb import compile_surrealdb  # noqa: E402
+
+# The message of the one ``CompileError`` a well-formed filter can provoke:
+# ``compile_surrealdb._metadata_path``'s injection guard, which raises
+# ``CompileError(f"unsafe metadata path segment {seg!r} (not a SurrealQL
+# identifier)")``. ``scan_documents`` keys its re-raise on this so that mapping
+# the caller-provoked case does not also swallow genuine compiler faults.
+_UNSAFE_METADATA_SEGMENT_MARKER = "unsafe metadata path segment"
 
 # The system keys this table backs with a real field — the single source of
 # truth for the documents tier. Nine of the ten ``SYSTEM_KEYS``; ``occurred_at``

--- a/tests/integration/storage/backends/surrealdb/test_relational_scan_documents.py
+++ b/tests/integration/storage/backends/surrealdb/test_relational_scan_documents.py
@@ -1,0 +1,1008 @@
+"""``SurrealDBRelationalAdapter.scan_documents`` — the bounded keyset scan.
+
+Runs against an in-memory SurrealDB (``mode="memory"``) — no docker required,
+same fixture shape as :mod:`tests.integration.storage.backends.surrealdb.test_list_documents_order`.
+Skipped when the ``surrealdb`` extra is not installed.
+
+This leg is not a transcription of the SQLAlchemy pair (khora #1586). Three
+things are structurally different on this store and each gets its own coverage
+below:
+
+* **The keyset predicate is two clauses, not a row-value compare.** SurrealQL
+  has no ``(a, b) < (x, y)``, so the resume position is expressed as
+  ``created_at < $ts OR (created_at = $ts AND id < $id)`` — a top-level ``OR``
+  sitting in a ``WHERE`` that also carries the namespace scope. That makes
+  *grouping* a correctness property of this store rather than a style choice,
+  and it makes mid-tie resume the interesting case.
+* **``id`` is a ``RecordID``, not a UUID column.** ``id < $rid`` is a record-id
+  compare, and nothing outside these tests establishes that it agrees with the
+  statement's own ``ORDER BY id DESC``. It was the ticket's highest-risk
+  unknown; :func:`test_walk_visits_every_document_exactly_once_in_total_order`
+  is the answer, and it is kept as a regression guard now that the answer is
+  known.
+* **Cursor and ``updated_before`` operands bind as Python objects.** A
+  stringified datetime does not compare against a ``TYPE datetime`` field at
+  all on this store — it matches nothing rather than mis-ordering. Measured:
+  no bound = 6 rows, ``datetime`` bind = 6 rows, ``.isoformat()`` bind = 0 rows.
+
+Seeding goes through ``create_document``, the production write API, so every row
+is serialized by the same path production writes take. Timestamps are pinned to
+a whole second on purpose; see :mod:`tests.test_helpers.document_scan`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+pytest.importorskip("surrealdb")
+
+from khora.core.models import Document, MemoryNamespace, TenancyMode  # noqa: E402
+from khora.core.models.document import DocumentStatus  # noqa: E402
+from khora.filter import (  # noqa: E402
+    CompiledFilter,
+    CompileError,
+    CompilerRegistry,
+    RecallFilter,
+    RecallFilterUnsupportedError,
+)
+from khora.filter.ast import parse_to_ast  # noqa: E402
+from khora.filter.compilers.python import compile_python  # noqa: E402
+from khora.storage.backends.surrealdb.connection import SurrealDBConnection  # noqa: E402
+
+# ``_documents_compile_context`` is private, and imported on purpose: the
+# superset test below must compile with the *same* context the scan itself uses,
+# or it would prove a property of some other context.
+from khora.storage.backends.surrealdb.relational import (  # noqa: E402
+    SurrealDBRelationalAdapter,
+    _documents_compile_context,
+)
+from tests.test_helpers.document_order import seed_order  # noqa: E402
+from tests.test_helpers.document_scan import WHOLE_SECOND, ScanSeed, as_utc, walk_scan  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+_COMPILER_KEY = ("relational.surrealdb", "documents")
+
+
+@pytest.fixture
+async def adapter():
+    conn = SurrealDBConnection(mode="memory", namespace="khora_test", database="doc_scan")
+    await conn.connect()
+    adapter = SurrealDBRelationalAdapter(conn)
+    try:
+        yield adapter
+    finally:
+        await conn.disconnect()
+
+
+async def _make_namespace(adapter: Any) -> MemoryNamespace:
+    nid = uuid4()
+    return await adapter.create_namespace(MemoryNamespace(id=nid, namespace_id=nid, tenancy_mode=TenancyMode.SHARED))
+
+
+@pytest.fixture
+async def namespace(adapter):
+    return await _make_namespace(adapter)
+
+
+def _filter_ast(wire: dict[str, Any]) -> Any:
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+# --------------------------------------------------------------------------- #
+# Seeding
+# --------------------------------------------------------------------------- #
+
+
+def _seed_from_ladder(ids: list[UUID], *, instant: datetime = WHOLE_SECOND) -> ScanSeed:
+    """Build a :class:`ScanSeed` over a caller-supplied ascending id ladder.
+
+    Identical in construction to :func:`tests.test_helpers.document_scan.scan_seed`
+    — ``total - 2`` rows share ``instant`` so only the ``id DESC`` leg can order
+    them, and the two rows outside that block carry timestamp and id in
+    deliberate conflict. The one difference is that the ids come from the
+    caller instead of from a fresh random ladder, which is what
+    :func:`_two_namespace_ladders` needs to pin the relative order of two
+    namespaces' ids. See that function for why that matters.
+    """
+    if len(ids) < 5:
+        raise ValueError(f"need a tie block of at least 3 rows to resume from the middle of, got {len(ids)}")
+
+    newest_id, oldest_id = ids[0], ids[-1]
+    tied = ids[1:-1]
+    stamps = dict.fromkeys(tied, instant)
+    stamps[newest_id] = instant + timedelta(seconds=1)
+    stamps[oldest_id] = instant - timedelta(seconds=1)
+
+    return ScanSeed(
+        writes=[(doc_id, stamps[doc_id]) for doc_id in seed_order(ids)],
+        expected=[newest_id, *reversed(tied), oldest_id],
+        tied_ids=list(reversed(tied)),
+        newest_id=newest_id,
+        oldest_id=oldest_id,
+        tie_instant=instant,
+    )
+
+
+def _ladder(prefix: str, discriminator: str, n: int) -> list[UUID]:
+    return [UUID(f"{prefix}{discriminator}{i:08x}") for i in range(n)]
+
+
+def _two_namespace_ladders(n: int = 6) -> tuple[list[UUID], list[UUID]]:
+    """Return ``(scanned_ids, foreign_ids)`` where EVERY foreign id sorts BELOW
+    every scanned id.
+
+    **This ordering is the whole point, and it must not be left to chance.**
+    The keyset-grouping tripwire below resumes from a cursor inside the scanned
+    namespace's tie block and asserts the ungrouped form leaks foreign rows. The
+    unscoped right disjunct is ``created_at = $ts AND id < $cursor_id``, so it
+    can only match foreign rows whose ids sort *below* the cursor. Measured on
+    this store, with the two namespaces' ids in the two possible arrangements:
+
+    * foreign ids above the cursor — the mutant leaks **0** rows and the test
+      passes while proving nothing;
+    * foreign ids below the cursor — the mutant leaks **4** rows and the test
+      bites.
+
+    ``id_ladder`` draws a fresh random 24-hex prefix per call, so building the
+    two namespaces from two independent ``scan_seed()`` calls decides that
+    arrangement by coin flip: the test would pass for the wrong reason about
+    half the time and flake the rest. Here both ladders share one random
+    **23**-hex-character head and differ at the very next nibble — ``0`` for the
+    foreign rows, ``1`` for the scanned ones — followed by the same 8-hex
+    counter, so the two ladders are 32 hex characters wide like any UUID and the
+    first character that can differ is the discriminator. That fixes the relative
+    order by construction while keeping the ids unique across runs, which a fixed
+    all-zeros prefix would not: these tests run against a fresh ``memory://``
+    instance today, but a persistent one would collide.
+
+    Do NOT "simplify" this back to two ``id_ladder`` / ``scan_seed`` calls.
+    """
+    prefix = uuid4().hex[:23]
+    return _ladder(prefix, "1", n), _ladder(prefix, "0", n)
+
+
+async def _write(adapter: Any, namespace_id: UUID, doc_id: UUID, created_at: datetime, **fields: Any) -> None:
+    """Insert one document through the production write API."""
+    await adapter.create_document(
+        Document(
+            id=doc_id,
+            namespace_id=namespace_id,
+            content="scanned content",
+            checksum=f"scan-{doc_id.hex}",
+            created_at=created_at,
+            updated_at=fields.pop("updated_at", created_at),
+            **fields,
+        )
+    )
+
+
+async def _seed(adapter: Any, namespace_id: UUID, seed: ScanSeed) -> None:
+    for doc_id, created_at in seed.writes:
+        await _write(adapter, namespace_id, doc_id, created_at)
+
+
+async def _seed_varied(adapter: Any, namespace_id: UUID, seed: ScanSeed) -> None:
+    """Seed the same corpus with attribute variety, so a filter can split it.
+
+    Attributes are assigned by *write* index, which is deliberately not the
+    enumeration order — every expectation below is therefore derived from the
+    rows a scan actually returns, never from this loop's counter.
+    """
+    for i, (doc_id, created_at) in enumerate(seed.writes):
+        await _write(
+            adapter,
+            namespace_id,
+            doc_id,
+            created_at,
+            title=f"doc-{i}",
+            source_type="report" if i % 2 == 0 else "library",
+            metadata={"tier": "gold"} if i < 2 else {},
+        )
+
+
+def _seeded(n: int = 6) -> ScanSeed:
+    """A single-namespace seed; ids may be random because nothing compares across
+    namespaces."""
+    return _seed_from_ladder(_ladder(uuid4().hex[:23], "1", n))
+
+
+# --------------------------------------------------------------------------- #
+# The window bound
+# --------------------------------------------------------------------------- #
+
+
+async def test_scan_limit_bounds_the_window(adapter, namespace) -> None:
+    seed = _seeded()
+    await _seed(adapter, namespace.id, seed)
+
+    step = await adapter.scan_documents(namespace.id, scan_limit=2)
+
+    assert [d.id for d in step.documents] == seed.expected[:2]
+    assert step.last_scanned == (step.documents[-1].created_at, step.documents[-1].id)
+    assert step.exhausted is False
+
+
+async def test_a_full_window_is_not_yet_exhausted(adapter, namespace) -> None:
+    """``exhausted`` means SurrealQL ran short, not "the caller has seen everything".
+
+    A window filled exactly to the bound cannot distinguish "six rows and no
+    more" from "six rows and a seventh waiting", so it must report not-exhausted
+    and let the next step find the empty tail. Reporting exhaustion here would
+    silently truncate every namespace whose size is a multiple of the bound. The
+    short window is the other half of the same contract.
+    """
+    seed = _seeded()
+    await _seed(adapter, namespace.id, seed)
+
+    exact = await adapter.scan_documents(namespace.id, scan_limit=6)
+    assert len(exact.documents) == 6
+    assert exact.exhausted is False
+
+    short = await adapter.scan_documents(namespace.id, scan_limit=7)
+    assert len(short.documents) == 6
+    assert short.exhausted is True
+
+
+async def test_exhausted_describes_the_raw_window_not_what_survives_a_post_filter(adapter, namespace) -> None:
+    """A full window that the caller's post-filter empties is still not exhausted.
+
+    ``exhausted`` derives from ``len(rows) < scan_limit`` — the RAW window — and
+    it has to, because it is the walk's only termination signal. The filter here
+    matches nothing at all in memory (no row carries that ``source_type``, and no
+    ``document`` backs ``occurred_at``) while pushing nothing to SurrealQL, so
+    the raw window fills to the bound and the caller's post-filter then rejects
+    every row it contains.
+
+    Deriving ``exhausted`` from the surviving subset instead would report ``True``
+    here and end the walk at the first window — silently truncating every
+    namespace whose leading rows happen not to match.
+
+    **Honest scope.** ``scan_documents`` post-filters nothing, so it has no
+    surviving subset to derive the wrong answer *from*; no mutation of this
+    method makes the two values differ, and measured, the mutant
+    ``exhausted=not rows`` leaves this test green (it is caught by
+    :func:`test_a_full_window_is_not_yet_exhausted` instead). What this test
+    establishes is the property one tier up: a full window really can post-filter
+    to zero on real rows, so a *caller* must not read "no matching documents" as
+    exhaustion. It guards the coordinator loop that consumes this method, and a
+    future refactor that moved post-filtering inside it — not today's arithmetic.
+    """
+    seed = _seeded()
+    await _seed_varied(adapter, namespace.id, seed)
+
+    wire = {
+        "$or": [
+            {"source_type": {"$eq": "no-such-source-type"}},
+            {"occurred_at": {"$gte": "2999-01-01T00:00:00+00:00"}},
+        ]
+    }
+    ast = _filter_ast(wire)
+    step = await adapter.scan_documents(namespace.id, filter_ast=ast, scan_limit=6)
+
+    # Nothing pushed, so the raw window is the whole namespace, filled to the bound.
+    assert step.consumed_keys == frozenset()
+    assert len(step.documents) == 6
+    assert step.exhausted is False
+
+    # …and the caller's post-filter keeps none of it. The two really do diverge.
+    matches = compile_python(ast, _documents_compile_context()).predicate
+    assert [d for d in step.documents if matches(d)] == []
+
+
+async def test_scan_limit_below_one_is_rejected_before_anything_is_compiled(adapter, namespace, monkeypatch) -> None:
+    """A zero bound would return an empty window that reports neither a resume
+    position nor exhaustion — the one pair a walking caller cannot act on.
+
+    The bound is validated *first*, before the filter is compiled, so a bad bound
+    surfaces as its own ``ValueError`` rather than being masked by whatever the
+    compiler happens to raise on the same call. Asserted by counting compiler
+    invocations rather than by reading the source: a later reordering that moved
+    the guard below the compile would still raise ``ValueError`` here for a
+    filter that compiles cleanly, and only the call count notices.
+    """
+    calls: list[Any] = []
+
+    def counting_compiler(ast, ctx):
+        calls.append(ast)
+        raise AssertionError("the filter was compiled despite an invalid scan_limit")
+
+    monkeypatch.setitem(CompilerRegistry._registry, _COMPILER_KEY, counting_compiler)  # noqa: SLF001
+
+    with pytest.raises(ValueError, match="scan_limit"):
+        await adapter.scan_documents(
+            namespace.id,
+            filter_ast=_filter_ast({"source_type": {"$eq": "report"}}),
+            scan_limit=0,
+        )
+
+    assert calls == []
+
+
+# --------------------------------------------------------------------------- #
+# The keyset cursor
+# --------------------------------------------------------------------------- #
+
+
+async def test_walk_visits_every_document_exactly_once_in_total_order(adapter, namespace) -> None:
+    """``id < $rid`` on a ``RecordID`` agrees with ``ORDER BY id DESC``.
+
+    This was the ticket's highest-risk unknown, and it is the reason this module
+    exists separately from the SQLAlchemy pair. On the two SQL stores ``id`` is a
+    UUID column and the keyset comparison is the same comparison the ``ORDER BY``
+    uses, by construction. Here ``id`` is a ``RecordID`` (``document:<uuid>``):
+    the scan resumes with ``id < $rid`` while the statement sorts with
+    ``ORDER BY id DESC``, and if SurrealDB ordered record ids by anything other
+    than the comparison it uses in a ``WHERE`` — a different collation, the table
+    part weighing in, the UUID part compared as text — a resumed walk would skip
+    rows or repeat them.
+
+    ``scan_limit=1`` puts a cursor boundary between every pair of rows, including
+    between the four that share a ``created_at``, so every resume here is a
+    mid-tie resume decided solely by the ``id DESC`` leg. The assertion is
+    exact-equality against the seed's single correct enumeration, not a set
+    comparison: a wrong-but-complete order has to fail too.
+    """
+    seed = _seeded()
+    await _seed(adapter, namespace.id, seed)
+
+    steps = await walk_scan(adapter.scan_documents, namespace.id, scan_limit=1)
+    seen = [d.id for step in steps for d in step.documents]
+
+    assert len(seen) == len(set(seen))  # no document served twice
+    assert set(seen) == set(seed.expected)  # every document served
+    assert seen == seed.expected  # and in one total order across the concatenation
+    assert steps[-1].documents == []
+    assert steps[-1].last_scanned is None
+    assert steps[-1].exhausted is True
+
+
+async def test_cursor_excludes_its_own_row_and_keeps_its_tie_mates(adapter, namespace) -> None:
+    """A mid-tie cursor is strict on its own row and inclusive of the rest of the block.
+
+    The two-clause keyset form has one failure mode in each direction and neither
+    raises. If the ``created_at = $ts AND id < $id`` leg were ``<=`` (or the
+    first leg ``<=``), the cursor's own row comes back and a walk chaining
+    ``last_scanned`` never advances. If the first leg were ``<=`` without the
+    id guard — or if the disjunction collapsed to ``created_at < $ts`` — the
+    cursor's tie-mates are skipped and a walk silently loses rows. Both are
+    asserted, plus the exact remaining suffix.
+    """
+    seed = _seeded()
+    await _seed(adapter, namespace.id, seed)
+
+    full = await adapter.scan_documents(namespace.id, scan_limit=10)
+    assert [d.id for d in full.documents] == seed.expected
+
+    cursor_doc = next(d for d in full.documents if d.id == seed.tied_ids[0])
+    assert as_utc(cursor_doc.created_at) == seed.tie_instant
+
+    step = await adapter.scan_documents(
+        namespace.id,
+        after=(cursor_doc.created_at, cursor_doc.id),
+        scan_limit=10,
+    )
+    ids = [d.id for d in step.documents]
+
+    assert cursor_doc.id not in ids, "the cursor's own row came back — a resumed walk would never advance"
+    assert seed.tied_ids[1] in ids, "the cursor's tie-mate was skipped — a resumed walk would lose rows"
+    assert ids == seed.expected[seed.expected.index(cursor_doc.id) + 1 :]
+
+
+async def test_filtered_walk_puts_a_cursor_and_a_compiled_fragment_in_one_statement(adapter, namespace) -> None:
+    """The only place a cursor and a pushdown fragment share a statement.
+
+    ``scan_documents`` merges the compiler's binds into its own ``params`` with a
+    bare ``dict.update``, resting on the two families being disjoint by
+    construction: the scan names its own ``ns`` / ``lim`` / ``after_created_at`` /
+    ``after_id``, the compiler names its own ``f_0`` … ``f_N``. Nothing exercises
+    that merge unless both families are present in one call, which happens only
+    when a cursor and a compiled fragment appear in the same ``SELECT``. A
+    collision would silently overwrite a bind — the namespace scope among them —
+    rather than raise, so it has to be caught on rows.
+
+    The filter is a two-leaf disjunction on purpose, so it compiles to two binds
+    rather than one, and the walk runs at ``scan_limit=1`` so every step past the
+    first carries both families at once.
+    """
+    seed = _seeded()
+    await _seed_varied(adapter, namespace.id, seed)
+
+    full = await adapter.scan_documents(namespace.id, scan_limit=10)
+    wire = {"$or": [{"source_type": {"$eq": "report"}}, {"title": {"$eq": "doc-1"}}]}
+    expected = [d.id for d in full.documents if d.source_type == "report" or d.title == "doc-1"]
+    assert 1 < len(expected) < len(full.documents), "the filter must narrow, but not to a single row"
+
+    steps = await walk_scan(
+        adapter.scan_documents,
+        namespace.id,
+        scan_limit=1,
+        filter_ast=_filter_ast(wire),
+    )
+    seen = [d.id for step in steps for d in step.documents]
+
+    assert len(seen) == len(set(seen))
+    assert seen == expected
+    assert steps[-1].exhausted is True
+
+
+async def test_empty_window_reports_exhausted_without_a_position(adapter, namespace) -> None:
+    """Both the never-seeded namespace and the tail past the last row."""
+    empty = await adapter.scan_documents(namespace.id, scan_limit=5)
+    assert empty.documents == []
+    assert empty.last_scanned is None
+    assert empty.exhausted is True
+
+    seed = _seeded()
+    await _seed(adapter, namespace.id, seed)
+    full = await adapter.scan_documents(namespace.id, scan_limit=10)
+    oldest = full.documents[-1]
+
+    tail = await adapter.scan_documents(namespace.id, after=(oldest.created_at, oldest.id), scan_limit=5)
+    assert tail.documents == []
+    assert tail.last_scanned is None
+    assert tail.exhausted is True
+
+
+# --------------------------------------------------------------------------- #
+# The compile split
+# --------------------------------------------------------------------------- #
+
+
+async def test_split_reports_only_the_leaves_surrealql_enforced(adapter, namespace) -> None:
+    """A forced-residual AST: one pushable leaf, one that must reach the post-filter.
+
+    ``occurred_at`` is a recall-chunk key with no ``document`` field behind it,
+    so it is absent from this store's ``field_mapping`` and
+    ``compile_surrealdb`` defers it under ``on_unsupported="split"``. The
+    conjunction still pushes its other leaf, so ``consumed_keys`` must name
+    ``source_type`` and only ``source_type``.
+
+    Both halves are asserted on rows as well as on the reported set: the pushed
+    leaf really did narrow the window, and the deferred one narrowed nothing —
+    every row survives a bound that would have excluded all of them had it been
+    pushed. Reporting alone would pass against a compiler that pushed
+    ``occurred_at`` against a missing field, which on this SCHEMAFULL table reads
+    ``NONE`` and returns an empty result set that looks exactly like a
+    legitimate no-match.
+    """
+    seed = _seeded()
+    for i, (doc_id, created_at) in enumerate(seed.writes):
+        await _write(adapter, namespace.id, doc_id, created_at, source_type="report" if i % 2 == 0 else "library")
+
+    step = await adapter.scan_documents(
+        namespace.id,
+        filter_ast=_filter_ast(
+            {"source_type": {"$eq": "report"}, "occurred_at": {"$gte": "2999-01-01T00:00:00+00:00"}}
+        ),
+        scan_limit=10,
+    )
+
+    assert step.consumed_keys == frozenset({"source_type"})
+    assert {d.source_type for d in step.documents} == {"report"}
+    assert len(step.documents) == 3
+
+
+# The pushdown must never reject a row the full filter would keep. Shapes are
+# chosen for the ways a compiler can get that wrong, not for operator coverage:
+# the ones wrapping an unpushable leaf in a disjunction or a negation matter
+# most, because a match-all placeholder left inside a negation inverts into a
+# match-nothing and excludes rows.
+_SUPERSET_SHAPES: dict[str, dict[str, Any]] = {
+    "pushable_eq": {"source_type": {"$eq": "report"}},
+    "pushable_ne": {"source_type": {"$ne": "report"}},
+    "pushable_nin": {"source_type": {"$nin": ["report"]}},
+    "pushable_exists": {"source_url": {"$exists": False}},
+    "metadata_eq": {"metadata.tier": {"$eq": "gold"}},
+    "pushable_date": {"created_at": {"$gte": "2026-01-31T12:30:00+00:00"}},
+    "unpushable_key": {"occurred_at": {"$gte": "2026-01-01T00:00:00+00:00"}},
+    "or_over_unpushable": {
+        "$or": [
+            {"occurred_at": {"$gte": "2026-01-01T00:00:00+00:00"}},
+            {"source_type": {"$eq": "report"}},
+        ]
+    },
+    "not_over_pushable": {"$not": {"source_type": {"$eq": "report"}}},
+    "not_over_unpushable": {"$not": {"occurred_at": {"$gte": "2026-01-01T00:00:00+00:00"}}},
+    "and_of_in_and_not": {
+        "$and": [
+            {"source_type": {"$in": ["report", "library"]}},
+            {"$not": {"title": {"$eq": "doc-0"}}},
+        ]
+    },
+}
+
+
+@pytest.mark.parametrize("wire", _SUPERSET_SHAPES.values(), ids=_SUPERSET_SHAPES.keys())
+async def test_pushdown_never_rejects_a_row_the_full_filter_would_keep(adapter, namespace, wire) -> None:
+    """The superset property the resume contract depends on.
+
+    Resuming past the rows a pushdown rejected is sound only because a rejected
+    row could not have satisfied the full filter either. The ``scan_documents``
+    docstring names that as an assumption about the *compiler*; this checks the
+    consequence where it actually lands, by comparing the scan's window against
+    the in-process ``compile_python`` evaluation of the same AST over the same
+    corpus. If it ever fails, a walk is silently and permanently dropping
+    documents — a post-filter can only narrow, never recover a row the window
+    never returned.
+
+    Scope, so a green run is not read as more than it is: eleven shapes on one
+    store is a tripwire, not a proof over the operator space. The general
+    property belongs to the compilers and to the forced-residual conformance
+    corpus.
+    """
+    seed = _seeded()
+    await _seed_varied(adapter, namespace.id, seed)
+    ast = _filter_ast(wire)
+
+    step = await adapter.scan_documents(namespace.id, filter_ast=ast, scan_limit=100)
+    # Precondition: the comparison below is only meaningful if this one window
+    # covered the whole namespace. Without it, growing the corpus past the bound
+    # would fail the test for a reason that has nothing to do with the pushdown.
+    assert step.exhausted is True
+
+    all_docs = (await adapter.scan_documents(namespace.id, scan_limit=100)).documents
+    matches = compile_python(ast, _documents_compile_context()).predicate
+    oracle = {d.id for d in all_docs if matches(d)}
+
+    assert oracle <= {d.id for d in step.documents}
+
+
+# --------------------------------------------------------------------------- #
+# What the position means
+# --------------------------------------------------------------------------- #
+
+
+async def test_last_scanned_is_the_final_raw_row_not_the_last_match(adapter, namespace) -> None:
+    """Resume from the last row SCANNED, not from the last row that matches.
+
+    The seed is arranged so the two genuinely differ — otherwise the assertion is
+    vacuous. The window deliberately ENDS on a row the caller's post-filter will
+    reject: the filter is an ``$or`` mixing a pushable leaf with an unbacked one,
+    which ``compile_surrealdb``'s all-or-nothing gate defers wholesale rather
+    than pushing half a disjunction, so SurrealQL narrows nothing and the oldest
+    row — a ``library`` row that does not satisfy the filter — is the final row
+    of the raw window.
+
+    A walk that resumed from the last *matching* row instead would re-scan the
+    rejected gap on every step, and when a whole window is rejected there is no
+    matching row to resume from at all, so such a walk cannot advance past a run
+    of non-matching rows longer than one window. Taking the position from the raw
+    window is what lets ``exhausted`` be the only termination signal.
+    """
+    newest, middle, oldest = (uuid4() for _ in range(3))
+    base = WHOLE_SECOND
+    await _write(adapter, namespace.id, newest, base + timedelta(seconds=2), source_type="report")
+    await _write(adapter, namespace.id, middle, base + timedelta(seconds=1), source_type="report")
+    await _write(adapter, namespace.id, oldest, base, source_type="library")
+
+    step = await adapter.scan_documents(
+        namespace.id,
+        filter_ast=_filter_ast(
+            {
+                "$or": [
+                    {"source_type": {"$eq": "report"}},
+                    {"occurred_at": {"$gte": "2026-01-01T00:00:00+00:00"}},
+                ]
+            }
+        ),
+        scan_limit=10,
+    )
+
+    # Nothing was pushed, so the raw window is the whole namespace and its last
+    # row is the one the post-filter will drop.
+    assert step.consumed_keys == frozenset()
+    assert [d.id for d in step.documents] == [newest, middle, oldest]
+    assert step.documents[-1].source_type == "library"
+
+    last_row = step.documents[-1]
+    assert step.last_scanned == (last_row.created_at, last_row.id)
+
+    last_match = step.documents[1]
+    assert step.last_scanned != (last_match.created_at, last_match.id)
+
+
+async def test_last_scanned_carries_a_uuid_not_a_record_id(adapter, namespace) -> None:
+    """``DocumentScanKey`` declares ``tuple[datetime, UUID]``, and the id half is
+    the easy one to get wrong.
+
+    ``id`` on this store is a ``RecordID`` (``document:<uuid>``) in the raw row,
+    and the implementation builds the key from the converted ``Document`` — where
+    ``_row_to_document`` has already run the ``RecordID`` -> ``UUID`` conversion —
+    rather than off ``rows[-1]["id"]``. This asserts the declared type directly,
+    on both a mid-walk key and one taken under a filter.
+
+    Scope note, because it was proposed to me as a mutant that "stays green
+    across every walk test": on this store it does not. Building the key from the
+    raw row instead fails five tests in this module, the walks dying inside the
+    SDK with ``ValueError: Failed to decode CBOR request`` when the ``RecordID``
+    is bound back in as a cursor operand, and the raw-window test above failing
+    on the tuple compare. So this test is a *clearer* statement of the contract,
+    not the only thing standing between a ``RecordID`` key and a green suite.
+    Keep it for the former reason.
+    """
+    seed = _seeded()
+    await _seed_varied(adapter, namespace.id, seed)
+
+    step = await adapter.scan_documents(namespace.id, scan_limit=3)
+    assert step.last_scanned is not None
+    created_at, doc_id = step.last_scanned
+    assert isinstance(doc_id, UUID)
+    assert not isinstance(doc_id, bool)  # UUID has no bool subclass; guards a stub returning a truthy sentinel
+    assert isinstance(created_at, datetime)
+
+    filtered = await adapter.scan_documents(
+        namespace.id,
+        filter_ast=_filter_ast({"source_type": {"$eq": "report"}}),
+        scan_limit=2,
+    )
+    assert filtered.last_scanned is not None
+    assert isinstance(filtered.last_scanned[1], UUID)
+
+
+async def test_a_hyphenated_metadata_key_in_a_deferred_subtree_does_not_raise(adapter, namespace) -> None:
+    """The ``RecallFilterUnsupportedError`` mapping is sibling-dependent, by design.
+
+    The injection guard fires only when the emit walk *reaches* the offending
+    leaf. Inside an ``$or`` that ``compile_surrealdb``'s all-or-nothing gate
+    defers wholesale for an unrelated reason — here the unbacked ``occurred_at``
+    sibling — the subtree never emits, the hyphenated segment is never rendered,
+    and the whole filter goes to the caller's post-filter, which handles
+    hyphenated keys correctly. Rows are right either way.
+
+    This is asserted **positively**, as a non-raise, on purpose. The tempting
+    assertion is the unconditional one — "a hyphenated metadata key always
+    raises" — and it would be wrong: it would pin behaviour the compiler does not
+    promise and would block the documented future improvement of routing an
+    unrenderable segment onto the unsupported path under ``"split"`` instead of
+    raising. Its conjunctive sibling
+    (:func:`test_unsafe_metadata_segment_raises_the_public_error`) pins the case
+    that *is* promised.
+    """
+    seed = _seeded()
+    await _seed_varied(adapter, namespace.id, seed)
+
+    step = await adapter.scan_documents(
+        namespace.id,
+        filter_ast=_filter_ast(
+            {
+                "$or": [
+                    {"metadata.due-date": {"$eq": "2026-01-01"}},
+                    {"occurred_at": {"$gte": "2026-01-01T00:00:00+00:00"}},
+                ]
+            }
+        ),
+        scan_limit=50,
+    )
+
+    # Deferred wholesale: nothing consumed, nothing narrowed, no exception.
+    assert step.consumed_keys == frozenset()
+    assert len(step.documents) == 6
+
+
+# --------------------------------------------------------------------------- #
+# The non-filter narrowing legs
+# --------------------------------------------------------------------------- #
+
+
+async def test_status_and_updated_before_narrow_the_window(adapter, namespace) -> None:
+    """``updated_before`` binds a ``datetime`` OBJECT, and that is why it narrows.
+
+    This store's ``updated_at`` is ``TYPE datetime``. A stringified operand does
+    not compare against it at all — it matches no row, so a walk reports itself
+    exhausted at the first step and the caller sees an empty namespace rather
+    than an error. Measured on an in-memory instance over this exact corpus: no
+    bound = 6 rows, ``datetime`` bind = 6 rows, ``.isoformat()`` bind = 0 rows.
+
+    That is why the assertion below is on *which* rows came back, not merely on
+    a count: the string form's 0 rows and a correct 4 are both "narrower than 6",
+    and only an exact row set separates a working bound from a broken one.
+
+    ``scan_documents`` therefore diverges deliberately from ``list_documents`` on
+    this same adapter, which binds ``.isoformat()`` and is defective for it. That
+    defect is tracked separately and is deliberately not touched or tested here.
+    """
+    seed = _seeded()
+    cutoff = seed.tie_instant + timedelta(hours=1)
+    for i, (doc_id, created_at) in enumerate(seed.writes):
+        await _write(
+            adapter,
+            namespace.id,
+            doc_id,
+            created_at,
+            status=DocumentStatus.COMPLETED if i % 2 == 0 else DocumentStatus.PENDING,
+            updated_at=cutoff - timedelta(minutes=1) if i < 4 else cutoff + timedelta(minutes=1),
+        )
+
+    by_status = await adapter.scan_documents(namespace.id, status=DocumentStatus.COMPLETED.value, scan_limit=10)
+    assert {d.id for d in by_status.documents} == {doc_id for i, (doc_id, _) in enumerate(seed.writes) if i % 2 == 0}
+
+    unbounded = await adapter.scan_documents(namespace.id, scan_limit=10)
+    assert len(unbounded.documents) == 6
+
+    by_updated = await adapter.scan_documents(namespace.id, updated_before=cutoff, scan_limit=10)
+    assert {d.id for d in by_updated.documents} == {doc_id for i, (doc_id, _) in enumerate(seed.writes) if i < 4}
+
+
+async def test_every_narrowing_leg_composes_in_one_statement(adapter, namespace) -> None:
+    """Cursor + compiled fragment + ``status`` + ``updated_before``, all at once.
+
+    Each leg has its own test above; none of those puts more than two of them in
+    the same ``WHERE``. This is the shape that a grouping or bind-merge mistake
+    actually reaches in production, and the one where a mis-composed conjunct
+    hides: with four conditions joined by ``AND``, a predicate absorbed into a
+    disjunct or a bind quietly overwritten still returns *some* plausible subset.
+
+    The expectation is computed from the rows the store returns rather than from
+    the seeding loop's counter, and each leg is asserted to be doing work — a
+    leg that narrowed nothing would make its own conjunct untested while the
+    overall assertion still passed.
+    """
+    seed = _seeded()
+    cutoff = seed.tie_instant + timedelta(hours=1)
+    for i, (doc_id, created_at) in enumerate(seed.writes):
+        await _write(
+            adapter,
+            namespace.id,
+            doc_id,
+            created_at,
+            title=f"doc-{i}",
+            source_type="report" if i % 2 == 0 else "library",
+            status=DocumentStatus.COMPLETED if i < 5 else DocumentStatus.PENDING,
+            updated_at=cutoff - timedelta(minutes=1) if i < 4 else cutoff + timedelta(minutes=1),
+        )
+
+    everything = await adapter.scan_documents(namespace.id, scan_limit=50)
+    assert len(everything.documents) == 6
+
+    # Resume from inside the tie block, so the keyset's right disjunct is live.
+    cursor_doc = next(d for d in everything.documents if d.id == seed.tied_ids[0])
+    after_cursor = everything.documents[everything.documents.index(cursor_doc) + 1 :]
+
+    def surviving(docs: list[Any]) -> list[UUID]:
+        return [
+            d.id
+            for d in docs
+            if d.source_type == "report" and d.status == DocumentStatus.COMPLETED and as_utc(d.updated_at) < cutoff
+        ]
+
+    expected = surviving(after_cursor)
+
+    # Every leg must actually remove something, or its conjunct is untested here.
+    assert expected, "the four-way conjunction must keep at least one row"
+    assert len(after_cursor) < len(everything.documents), "the cursor narrowed nothing"
+    assert len(expected) < len(after_cursor), "the filter/status/updated_before legs narrowed nothing"
+
+    step = await adapter.scan_documents(
+        namespace.id,
+        filter_ast=_filter_ast({"source_type": {"$eq": "report"}}),
+        status=DocumentStatus.COMPLETED.value,
+        updated_before=cutoff,
+        after=(cursor_doc.created_at, cursor_doc.id),
+        scan_limit=50,
+    )
+
+    assert [d.id for d in step.documents] == expected
+    assert step.consumed_keys == frozenset({"source_type"})
+
+
+# --------------------------------------------------------------------------- #
+# The CompileError mapping
+# --------------------------------------------------------------------------- #
+
+
+async def test_unsafe_metadata_segment_raises_the_public_error(adapter, namespace) -> None:
+    """A hyphenated metadata key is a caller mistake, not an internal fault.
+
+    ``compile_surrealdb``'s injection guard raises the internal ``CompileError``
+    on a metadata path segment it cannot render as a SurrealQL identifier — and
+    ``metadata.due-date`` is legal JSON and common in the wild, so a caller can
+    provoke it with a perfectly well-formed filter. ``CompileError`` is
+    documented as "a bug, not a capability gap", so letting it escape would
+    present a user-input problem as an internal error. ``scan_documents`` maps it
+    to the public ``RecallFilterUnsupportedError``.
+
+    The reported path is the ``metadata`` root rather than the offending dotted
+    path, because the guard reports only the segment — asserted, so a later
+    change that starts reporting the full path is a visible decision rather than
+    a silent one.
+    """
+    with pytest.raises(RecallFilterUnsupportedError) as excinfo:
+        await adapter.scan_documents(
+            namespace.id,
+            filter_ast=_filter_ast({"metadata.foo-bar": {"$eq": "x"}}),
+            scan_limit=10,
+        )
+
+    assert not isinstance(excinfo.value, CompileError)
+    assert "foo-bar" in str(excinfo.value)
+    assert excinfo.value.__cause__ is not None
+    assert isinstance(excinfo.value.__cause__, CompileError)
+
+
+async def test_an_unrelated_compile_error_still_propagates(adapter, namespace, monkeypatch) -> None:
+    """The catch is narrow — it maps ONE message, it does not swallow the class.
+
+    ``scan_documents`` discriminates on the guard's message substring because the
+    guard has no error subclass of its own. The hazard in that design is the
+    obvious widening: an ``except CompileError: raise RecallFilterUnsupportedError``
+    with no discriminator would relabel every genuine compiler bug as a user
+    input problem and hide it behind a 4xx-shaped error forever. Nothing in the
+    filter language can provoke a second ``CompileError`` on this path today —
+    ``grep -rn "raise CompileError" src/khora/filter/`` returns exactly one hit —
+    so the only way to test the other branch is to inject one through the
+    registry, which is also how the real lookup reaches its compiler.
+
+    **This is not hypothetical.** An intermediate revision of ``scan_documents``
+    dropped the discriminator and kept only the scope narrowing, on the (true)
+    reasoning that the compiler has a single raise site. This test failed against
+    it: the injected bug came back as ``RecallFilterUnsupportedError: metadata:
+    internal compiler invariant violated…`` — relabelled as a caller input
+    problem and attributed to a ``metadata`` path it had nothing to do with. The
+    discriminator was restored. Do not re-widen the catch without deleting this
+    test on purpose.
+    """
+
+    def broken_compiler(ast, ctx):
+        raise CompileError("internal compiler invariant violated while emitting a node")
+
+    monkeypatch.setitem(CompilerRegistry._registry, _COMPILER_KEY, broken_compiler)  # noqa: SLF001
+
+    with pytest.raises(CompileError, match="internal compiler invariant"):
+        await adapter.scan_documents(
+            namespace.id,
+            filter_ast=_filter_ast({"source_type": {"$eq": "report"}}),
+            scan_limit=10,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Namespace isolation and the two ungrouped-OR tripwires
+# --------------------------------------------------------------------------- #
+#
+# Everything above runs in a single-namespace fixture, so no assertion up there
+# can notice a scan that ignores its namespace scope. The three tests below are
+# the ones that make the mutants fail; each records the mutation that was run
+# against it and what it measured.
+
+
+async def test_scan_never_returns_another_namespaces_rows(adapter, namespace) -> None:
+    """A filtered walk over one namespace must not see a byte of the other.
+
+    The second namespace is seeded with the SAME varied corpus, so every row in
+    it matches the same filter — if the namespace predicate is dropped (or stops
+    AND-composing with the fragment), the foreign rows are not merely reachable,
+    they are guaranteed hits. Walked at ``scan_limit=1`` so the keyset predicate
+    is exercised across pages too: the cursor is namespace-blind on its own, and
+    only the scope predicate keeps a resume inside its tenant.
+
+    **Mutation-verified, and reverted afterwards.** Neutralising the namespace
+    predicate — ``conditions = ["namespace_id = $ns"]`` becoming
+    ``conditions = ["true"]``, the faithful SurrealQL form of "delete the
+    scope", since an empty list would emit ``WHERE`` with no operand and fail as
+    a syntax error rather than as wrong rows — fails this test. Measured: the
+    filtered walk returns **8 rows instead of 4**, four of them the other
+    tenant's, and the unfiltered read below returns **12 instead of 6**. The two
+    grouping tripwires fail on the same mutant.
+    """
+    scanned_ids, foreign_ids = _two_namespace_ladders()
+    await _seed_varied(adapter, namespace.id, _seed_from_ladder(scanned_ids))
+    other = await _make_namespace(adapter)
+    await _seed_varied(adapter, other.id, _seed_from_ladder(foreign_ids))
+
+    wire = {"$or": [{"source_type": {"$eq": "report"}}, {"title": {"$eq": "doc-1"}}]}
+    steps = await walk_scan(adapter.scan_documents, namespace.id, scan_limit=1, filter_ast=_filter_ast(wire))
+    seen = [d for step in steps for d in step.documents]
+
+    assert seen, "the filter must match rows in the scanned namespace for this test to bite"
+    assert all(d.namespace_id == namespace.id for d in seen)
+    assert set(foreign_ids).isdisjoint({d.id for d in seen})
+
+    unfiltered = await adapter.scan_documents(namespace.id, scan_limit=50)
+    assert len(unfiltered.documents) == 6
+    assert all(d.namespace_id == namespace.id for d in unfiltered.documents)
+
+
+async def test_ungrouped_or_fragment_cannot_absorb_the_namespace_scope(adapter, namespace, monkeypatch) -> None:
+    """The parentheses around the spliced fragment are load-bearing.
+
+    ``scan_documents`` joins its conditions with ``AND`` and wraps the compiled
+    fragment in parentheses at the splice. Ungrouped, ``AND`` binds tighter than
+    ``OR``, so ``namespace_id = $ns AND a = $x OR b = $y`` parses as
+    ``(namespace_id = $ns AND a = $x) OR (b = $y)`` — the right disjunct is
+    unscoped and returns every tenant's rows. It fails as somebody else's data,
+    not as an error.
+
+    No compiler emits an ungrouped fragment today (``compile_surrealdb``
+    self-groups its boolean nodes), so no compiled-filter test can reach this;
+    the registered compiler is therefore replaced with one that emits the bare
+    ungrouped shape, and the real ``scan_documents`` is called. Both namespaces'
+    rows satisfy the right disjunct, so an absorbed scope predicate yields
+    foreign rows deterministically rather than by luck.
+
+    **Mutation-verified, and reverted afterwards.** Removing the parentheses at
+    the splice — ``conditions.append(f"({compiled.predicate})")`` becoming
+    ``conditions.append(compiled.predicate)`` — fails this test, and the measured
+    magnitude is **6 rows becomes 12**: a full cross-tenant read of both
+    namespaces, with no error and nothing in the logs.
+    """
+    scanned_ids, foreign_ids = _two_namespace_ladders()
+    await _seed_varied(adapter, namespace.id, _seed_from_ladder(scanned_ids))
+    other = await _make_namespace(adapter)
+    await _seed_varied(adapter, other.id, _seed_from_ladder(foreign_ids))
+
+    def ungrouped_compiler(ast, ctx):
+        # Bind names deliberately in the compiler's own ``f_N`` family so the
+        # scan's collision guard stays out of the way; the shape under test is
+        # the missing parentheses, nothing else.
+        return CompiledFilter(
+            predicate="title = $f_0 OR content = $f_1",
+            params={"f_0": "doc-0", "f_1": "scanned content"},
+            consumed_keys=frozenset({"title", "content"}),
+            consumed_slice_hash="ungrouped-or-tripwire",
+        )
+
+    monkeypatch.setitem(CompilerRegistry._registry, _COMPILER_KEY, ungrouped_compiler)  # noqa: SLF001
+
+    step = await adapter.scan_documents(
+        namespace.id,
+        filter_ast=_filter_ast({"title": {"$eq": "doc-0"}}),
+        scan_limit=50,
+    )
+
+    assert step.documents, "the fragment must match rows in the scanned namespace for this test to bite"
+    assert len(step.documents) == 6
+    assert all(d.namespace_id == namespace.id for d in step.documents)
+    assert set(foreign_ids).isdisjoint({d.id for d in step.documents})
+
+
+async def test_ungrouped_keyset_disjunction_cannot_absorb_the_namespace_scope(adapter, namespace) -> None:
+    """The parentheses around the keyset disjunction are load-bearing too.
+
+    This is the store-specific half of the same hazard. SurrealQL has no
+    row-value comparison, so the resume predicate is a top-level ``OR``:
+    ``created_at < $ts OR (created_at = $ts AND id < $id)``. Ungrouped, the
+    namespace scope is absorbed into the left disjunct and the right one —
+    ``created_at = $ts AND id < $cursor_id`` — reads every tenant's tie block.
+    The SQLAlchemy stores cannot have this bug at all; it exists only because the
+    predicate had to be written out by hand here.
+
+    The seed is built by :func:`_two_namespace_ladders` so the foreign ids sort
+    BELOW the cursor deterministically. That is not cosmetic: measured, with the
+    foreign ids above the cursor the mutant leaks **0** rows and this test passes
+    while proving nothing; below, it leaks **4**. Read that function's docstring
+    before touching the seed.
+
+    **Mutation-verified, and reverted afterwards.** Dropping the outer pair from
+    the ``conditions`` entry — ``"(created_at < $after_created_at OR (created_at
+    = $after_created_at AND id < $after_id))"`` becoming the same string without
+    its enclosing parentheses — fails this test: the resumed window returns **8
+    rows instead of 4**, the four extra being the other tenant's tie block. The
+    same mutant also fails the filtered-walk and namespace-isolation tests above,
+    both of which resume across pages.
+    """
+    scanned_ids, foreign_ids = _two_namespace_ladders()
+    seed = _seed_from_ladder(scanned_ids)
+    await _seed(adapter, namespace.id, seed)
+    other = await _make_namespace(adapter)
+    await _seed(adapter, other.id, _seed_from_ladder(foreign_ids))
+
+    full = await adapter.scan_documents(namespace.id, scan_limit=50)
+    assert [d.id for d in full.documents] == seed.expected
+
+    # Resume from INSIDE the tie block: the right disjunct is only reachable at
+    # a cursor whose ``created_at`` some other row also carries.
+    cursor_doc = next(d for d in full.documents if d.id == seed.tied_ids[0])
+    step = await adapter.scan_documents(
+        namespace.id,
+        after=(cursor_doc.created_at, cursor_doc.id),
+        scan_limit=50,
+    )
+
+    assert [d.id for d in step.documents] == seed.expected[seed.expected.index(cursor_doc.id) + 1 :]
+    assert all(d.namespace_id == namespace.id for d in step.documents)
+    assert set(foreign_ids).isdisjoint({d.id for d in step.documents})

--- a/tests/unit/filter/test_documents_scan_error_marker.py
+++ b/tests/unit/filter/test_documents_scan_error_marker.py
@@ -1,0 +1,89 @@
+"""The SurrealDB document scan's ``CompileError`` discriminator vs. the real guard.
+
+``@internal``. ``SurrealDBRelationalAdapter.scan_documents`` maps the compiler's
+internal :class:`~khora.filter.context.CompileError` onto the public
+:class:`~khora.filter.model.RecallFilterUnsupportedError` for exactly one cause —
+``compile_surrealdb``'s injection guard rejecting a metadata path segment it
+cannot render as a SurrealQL identifier. The guard has no error subclass of its
+own, so the scan discriminates on a substring of the guard's message:
+``_UNSAFE_METADATA_SEGMENT_MARKER``.
+
+That constant lives in a storage module while the message it matches lives in a
+compiler module the store does not own. Reword the guard and the mapping stops
+firing: a hyphenated metadata key — legal JSON, common in the wild — starts
+escaping as an internal fault instead of a structured rejection. That is the
+*safe* direction to fail, but it should be caught here rather than discovered in
+production.
+
+**Why this is its own module rather than an assertion inside the scan's
+integration tests.** The end-to-end mapping test
+(``tests/integration/storage/backends/surrealdb/test_relational_scan_documents.py::
+test_unsafe_metadata_segment_raises_the_public_error``) does drive the real
+compiler and does go red on a reworded guard — verified by patching the marker to
+a string the guard no longer emits. But that protection is **incidental**: that
+test was written to pin the mapping, not the constant, and narrowing it to a stub
+compiler would remove the protection with nothing to announce the loss. It also
+fails for a confusing reason — "expected ``RecallFilterUnsupportedError``, got
+``CompileError``" reads like a bug in the scan path rather than a reworded
+message two modules away.
+
+**Unit lane, and deliberately not behind ``pytest.importorskip("surrealdb")``.**
+The whole path exercised here is pure compilation: no server, no adapter, no
+``scan_documents``. Both imports resolve without the ``surrealdb`` extra — the
+adapter module's only SurrealDB dependency is ``SurrealDBConnection``, which has
+no module-level ``surrealdb`` import. Verified by blocking the package at the
+import hook and re-running this file's imports and assertions. Putting it behind
+an ``importorskip`` would skip it exactly in the degraded environment where a
+silent mapping failure is least likely to be noticed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from khora.filter import CompileError, RecallFilter, parse_to_ast
+from khora.filter.compilers.surrealdb import compile_surrealdb
+from khora.storage.backends.surrealdb.relational import (
+    _UNSAFE_METADATA_SEGMENT_MARKER,
+    _documents_compile_context,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_marker_still_matches_the_real_guard_message() -> None:
+    """The discriminator matches what ``compile_surrealdb`` actually raises.
+
+    Drives the real compiler with the real ``CompileContext`` the scan uses, so
+    the message compared against is the one production would produce. Asserts the
+    coupling directly instead of inferring it from an end-to-end mapping result.
+    """
+    ast = parse_to_ast(RecallFilter.model_validate({"metadata.foo-bar": {"$eq": "x"}}))
+
+    with pytest.raises(CompileError) as excinfo:
+        compile_surrealdb(ast, _documents_compile_context())
+
+    assert _UNSAFE_METADATA_SEGMENT_MARKER in str(excinfo.value)
+
+
+def test_the_marker_excludes_the_interpolated_segment() -> None:
+    """Granularity: the marker is the invariant prefix, not the whole message.
+
+    The guard's message interpolates the offending segment
+    (``unsafe metadata path segment 'foo-bar' (not a SurrealQL identifier)``), so
+    a marker that reached past the invariant prefix into the quoted segment would
+    match only the one key it was written against and silently stop mapping every
+    other hyphenated key. Pinned as its own assertion because widening the marker
+    is a natural-looking "make the check stricter" edit whose damage is invisible:
+    the mapping keeps working for the key in the tests and fails for every other.
+    """
+    ast = parse_to_ast(RecallFilter.model_validate({"metadata.due-date": {"$eq": "x"}}))
+
+    with pytest.raises(CompileError) as excinfo:
+        compile_surrealdb(ast, _documents_compile_context())
+
+    # A different segment, and the same marker still matches.
+    assert _UNSAFE_METADATA_SEGMENT_MARKER in str(excinfo.value)
+    assert "due-date" in str(excinfo.value), "the guard should still report which segment it rejected"
+    assert "due-date" not in _UNSAFE_METADATA_SEGMENT_MARKER
+    assert "foo-bar" not in _UNSAFE_METADATA_SEGMENT_MARKER

--- a/tests/unit/test_sqlite_scan_documents.py
+++ b/tests/unit/test_sqlite_scan_documents.py
@@ -1,0 +1,978 @@
+"""``SQLiteRelationalBackend.scan_documents`` — the bounded keyset scan.
+
+Runs against a real in-memory SQLite database through the store's own
+``_SCHEMA_SQL`` (no Alembic chain behind this backend, no Docker, no services),
+which matters more here than usual: this store keeps ``created_at`` as TEXT and
+compares it lexicographically, so the scan's cursor is only correct if it is
+bound in the store's own serialization. That cannot be checked against a mock.
+
+This leg is not a transcription of the SQLAlchemy pair (khora #1586). Three
+things are structurally different on this store, and each of them inverts a trap
+that the sibling modules encode the other way round:
+
+* **Binds are positional, so conjunct order IS bind order.** The statement is
+  built as SQL text with ``?`` placeholders and a parallel ``params`` list —
+  namespace, ``status``, ``updated_before``, the two cursor operands, the
+  fragment's ``args``, the row bound. Appending a condition and its bind out of
+  step shifts every later bind by one, and SQLite reports that as wrong rows
+  whenever the shifted values happen to be type-compatible. That is what
+  :func:`test_every_narrowing_leg_composes_in_one_statement` is for.
+* **The cursor id is DASHED here, and ``uuid.hex`` is the mistake.** This store
+  writes ``str(document.id)`` — the 36-character dashed form — so the cursor must
+  bind ``str(cursor_id)``. sqlite_lance holds 32 undashed hex characters and the
+  trap points the other way there. See the id-ladder note below.
+* **``created_at`` is written by a bare ``dt.isoformat()``**, which OMITS the
+  microsecond field at exactly ``.000000`` and emits six digits otherwise. Both
+  polarities are seeded here; see the whole-second note below.
+
+Seeding goes through ``create_document``, the production write API, so every row
+is serialized by the same path production writes take.
+
+**Why the ``id_ladder`` seed is non-negotiable.**
+:func:`tests.test_helpers.document_scan.scan_seed` draws its ids from
+:func:`tests.test_helpers.document_order.id_ladder`, whose ids share a 24-hex
+prefix and differ only in a trailing 8-hex counter. Do NOT "simplify" this seed
+to plain ``uuid4``. The shared prefix is the only thing that makes the id half of
+the cursor observable on this store: ``str(uuid)`` puts a dash at index 8, inside
+that shared prefix, and ``-`` (0x2D) sorts BELOW every hex digit. So an undashed
+``cursor_id.hex`` sorts ABOVE every stored id it shares leading hex with, and
+``(created_at, id) < (?, ?)`` then matches strictly MORE rows — including the
+cursor's own row and the row above it, so a chained walk runs backwards and never
+terminates. Measured on this store from a mid-tie cursor at ``…0003``: the
+correct dashed form yields ``[…0002, …0001, …0005]``; ``.hex`` yields ``[…0004,
+…0003, …0002, …0001, …0005]``. With ``uuid4`` ids the comparison is decided long
+before index 8 (it would need two ids agreeing on eight leading hex characters),
+and the whole defect is invisible.
+
+**Why both microsecond polarities are seeded.** The cursor binds through the same
+``dt.isoformat()`` the writer used, and ``isoformat()`` omits the ``.ffffff``
+field entirely when the microsecond is zero. That makes the two plausible
+mis-serializations fail on OPPOSITE seeds, so a single-polarity corpus silently
+loses half the coverage:
+
+* a cursor forced to six digits (``'…T12:30:00.000000+00:00'``) is byte-identical
+  to the stored form at µs != 0 and therefore INVISIBLE there, but at µs == 0 it
+  sorts above the stored ``'…T12:30:00+00:00'`` (``.`` 0x2E > ``+`` 0x2B) and the
+  cursor's own row comes back;
+* a cursor that truncates the microsecond is byte-identical at µs == 0 and
+  therefore INVISIBLE there, but at µs != 0 it sorts below its tie-mates and
+  silently skips the rest of the tie block.
+
+Note this is the exact reverse of the sqlite_lance polarity note in
+:mod:`tests.test_helpers.document_scan`: that store's ORM writes six digits
+unconditionally, so ``.000000`` is the divergent case there and the agreeing case
+here. Porting either seed unchanged would prove nothing.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+from khora.core.models import Document, MemoryNamespace
+from khora.core.models.document import DocumentStatus
+from khora.core.models.tenancy import TenancyMode
+from khora.filter import CompiledFilter, CompilerRegistry, RecallFilter
+from khora.filter.ast import parse_to_ast
+from khora.filter.compilers.python import compile_python
+
+# ``_documents_compile_context`` is private, and imported on purpose: the
+# superset test below must compile with the *same* context the scan itself uses,
+# or it would prove a property of some other context.
+from khora.storage.backends.sqlite import SQLiteRelationalBackend, _documents_compile_context
+from tests.test_helpers.document_order import seed_order
+from tests.test_helpers.document_scan import WHOLE_SECOND, ScanSeed, scan_seed, walk_scan
+
+_COMPILER_KEY = ("relational.sqlite", "documents")
+
+# The two microsecond polarities, both live in every cursor assertion below. See
+# the module docstring for why one of them is not enough.
+_SUB_SECOND = WHOLE_SECOND.replace(microsecond=123456)
+_INSTANTS: dict[str, datetime] = {"whole_second": WHOLE_SECOND, "sub_second": _SUB_SECOND}
+
+
+@pytest.fixture
+async def backend():
+    store = SQLiteRelationalBackend(":memory:")
+    await store.connect()
+    try:
+        yield store
+    finally:
+        await store.disconnect()
+
+
+async def _make_namespace(store: SQLiteRelationalBackend) -> MemoryNamespace:
+    nid = uuid4()
+    return await store.create_namespace(MemoryNamespace(id=nid, namespace_id=nid, tenancy_mode=TenancyMode.SHARED))
+
+
+@pytest.fixture
+async def namespace(backend):
+    return await _make_namespace(backend)
+
+
+def _filter_ast(wire: dict[str, Any]) -> Any:
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+async def _write(store: Any, namespace_id: UUID, doc_id: UUID, created_at: datetime, **fields: Any) -> None:
+    """Insert one document through the production write API."""
+    await store.create_document(
+        Document(
+            id=doc_id,
+            namespace_id=namespace_id,
+            content="scanned content",
+            checksum=f"scan-{doc_id.hex}",
+            created_at=created_at,
+            updated_at=fields.pop("updated_at", created_at),
+            **fields,
+        )
+    )
+
+
+async def _seed(store: Any, namespace_id: UUID, seed: ScanSeed) -> None:
+    for doc_id, created_at in seed.writes:
+        await _write(store, namespace_id, doc_id, created_at)
+
+
+def _two_namespace_ladders(n: int = 6) -> tuple[list[UUID], list[UUID]]:
+    """Return ``(scanned_ids, foreign_ids)`` with every foreign id sorting BELOW
+    every scanned id.
+
+    Both ladders share one random 23-hex head and differ at the very next nibble
+    — ``f`` for the scanned rows, ``0`` for the foreign ones — followed by the
+    same 8-hex counter. That fixes the relative order by construction while
+    keeping the ids unique across runs, which the fixed all-zeros prefix an
+    earlier draft used would not: these tests run against ``:memory:`` today, but
+    a file-backed database that is not truncated between runs would collide.
+    The shared-prefix property ``id_ladder`` provides is preserved, so the
+    undashed-cursor trap stays catchable.
+
+    **Determinism only — NOT load-bearing on this store, and do not write a
+    docstring claiming otherwise.** The SurrealDB sibling needs the fixed
+    arrangement because its resume position expands to a top-level ``OR`` whose
+    unscoped disjunct can only reach rows below the cursor, so the leak size
+    depends on which tenant's ids sort lower. SQLite has a native row-value
+    comparison, so the cursor here is one ``(created_at, id) < (?, ?)`` conjunct
+    with no disjunction in it, and both mutants below leak on predicates every
+    row in both namespaces satisfies. Measured: the namespace and grouping
+    mutants each failed on independent random ladders too. The pair is used here
+    so the corpus is identical run to run, not because the order decides anything.
+    """
+    head = uuid4().hex[:23]
+    return (
+        [UUID(f"{head}f{i:08x}") for i in range(n)],
+        [UUID(f"{head}0{i:08x}") for i in range(n)],
+    )
+
+
+def _seed_from_ladder(ids: list[UUID], *, instant: datetime = WHOLE_SECOND) -> ScanSeed:
+    """Build a :class:`ScanSeed` over a caller-supplied ascending id ladder.
+
+    Identical in construction to :func:`tests.test_helpers.document_scan.scan_seed`
+    — ``total - 2`` rows share ``instant`` so only the ``id DESC`` leg can order
+    them, and the two rows outside that block carry timestamp and id in
+    deliberate conflict. The one difference is that the ids come from the caller
+    instead of from a fresh random ladder, so the two namespaces below can be
+    seeded at the same tie instant with a pinned relative id order.
+    """
+    if len(ids) < 5:
+        raise ValueError(f"need a tie block of at least 3 rows to resume from the middle of, got {len(ids)}")
+
+    newest_id, oldest_id = ids[0], ids[-1]
+    tied = ids[1:-1]
+    stamps = dict.fromkeys(tied, instant)
+    stamps[newest_id] = instant + timedelta(seconds=1)
+    stamps[oldest_id] = instant - timedelta(seconds=1)
+
+    return ScanSeed(
+        writes=[(doc_id, stamps[doc_id]) for doc_id in seed_order(ids)],
+        expected=[newest_id, *reversed(tied), oldest_id],
+        tied_ids=list(reversed(tied)),
+        newest_id=newest_id,
+        oldest_id=oldest_id,
+        tie_instant=instant,
+    )
+
+
+async def _seed_varied(store: Any, namespace_id: UUID, seed: ScanSeed) -> None:
+    """Seed the same corpus with attribute variety, so a filter can split it.
+
+    Attributes are assigned by *write* index, which is deliberately not the
+    enumeration order — every expectation below is therefore derived from the
+    rows a scan actually returns, never from this loop's counter.
+    """
+    for i, (doc_id, created_at) in enumerate(seed.writes):
+        await _write(
+            store,
+            namespace_id,
+            doc_id,
+            created_at,
+            title=f"doc-{i}",
+            source_type="report" if i % 2 == 0 else "library",
+            metadata={"tier": "gold"} if i < 2 else {},
+        )
+
+
+# --------------------------------------------------------------------------- #
+# The window bound
+# --------------------------------------------------------------------------- #
+
+
+async def test_scan_limit_bounds_the_window(backend, namespace) -> None:
+    seed = scan_seed(6)
+    await _seed(backend, namespace.id, seed)
+
+    step = await backend.scan_documents(namespace.id, scan_limit=2)
+
+    assert [d.id for d in step.documents] == seed.expected[:2]
+    assert step.last_scanned == (step.documents[-1].created_at, step.documents[-1].id)
+    assert step.exhausted is False
+
+
+async def test_a_full_window_is_not_yet_exhausted(backend, namespace) -> None:
+    """``exhausted`` means SQL ran short, not "the caller has seen everything".
+
+    A window filled exactly to the bound cannot distinguish "six rows and no
+    more" from "six rows and a seventh waiting", so it must report not-exhausted
+    and let the next step find the empty tail. Reporting exhaustion here would
+    silently truncate every namespace whose size is a multiple of the bound. The
+    short window is the other half of the same contract.
+    """
+    seed = scan_seed(6)
+    await _seed(backend, namespace.id, seed)
+
+    exact = await backend.scan_documents(namespace.id, scan_limit=6)
+    assert len(exact.documents) == 6
+    assert exact.exhausted is False
+
+    short = await backend.scan_documents(namespace.id, scan_limit=7)
+    assert len(short.documents) == 6
+    assert short.exhausted is True
+
+
+async def test_exhausted_describes_the_raw_window_not_what_survives_a_post_filter(backend, namespace) -> None:
+    """A full window that the caller's post-filter empties is still not exhausted.
+
+    ``exhausted`` derives from ``len(rows) < scan_limit`` — the RAW window — and
+    it has to, because it is the walk's only termination signal. The filter here
+    matches nothing at all in memory while pushing nothing to SQLite (``$or``
+    over an unbacked ``occurred_at``, which ``compile_lance``'s all-or-nothing
+    gate defers wholesale), so the raw window fills to the bound and the caller's
+    post-filter then rejects every row it contains.
+
+    Deriving ``exhausted`` from the surviving subset instead would report ``True``
+    here and end the walk at the first window — silently truncating every
+    namespace whose leading rows happen not to match.
+
+    Scope note, stated rather than implied: ``scan_documents`` runs no
+    post-filter of its own, so this cannot fail against a mutant that swaps
+    ``len(rows)`` for ``len(documents)`` — those are the same list here by
+    construction. What it does pin is that the window and the caller's own
+    evaluation of the same AST genuinely diverge, which is the premise the
+    raw-window contract rests on.
+    """
+    seed = scan_seed(6)
+    await _seed_varied(backend, namespace.id, seed)
+
+    ast = _filter_ast(
+        {
+            "$or": [
+                {"source_type": {"$eq": "no-such-source-type"}},
+                {"occurred_at": {"$gte": "2999-01-01T00:00:00+00:00"}},
+            ]
+        }
+    )
+    step = await backend.scan_documents(namespace.id, filter_ast=ast, scan_limit=6)
+
+    # Nothing pushed, so the raw window is the whole namespace, filled to the bound.
+    assert step.consumed_keys == frozenset()
+    assert len(step.documents) == 6
+    assert step.exhausted is False
+
+    # …and the caller's post-filter keeps none of it. The two really do diverge.
+    matches = compile_python(ast, _documents_compile_context()).predicate
+    assert [d for d in step.documents if matches(d)] == []
+
+
+async def test_scan_limit_below_one_is_rejected_before_anything_is_compiled(backend, namespace, monkeypatch) -> None:
+    """A zero bound would return an empty window that reports neither a resume
+    position nor exhaustion — the one pair a walking caller cannot act on.
+
+    The bound is validated *first*, before the filter is compiled, so a bad bound
+    surfaces as its own ``ValueError`` rather than being masked by whatever the
+    compiler happens to raise on the same call. Asserted by counting compiler
+    invocations rather than by reading the source: a later reordering that moved
+    the guard below the compile would still raise ``ValueError`` here for a
+    filter that compiles cleanly, and only the call count notices.
+    """
+    calls: list[Any] = []
+
+    def counting_compiler(ast, ctx):
+        calls.append(ast)
+        raise AssertionError("the filter was compiled despite an invalid scan_limit")
+
+    monkeypatch.setitem(CompilerRegistry._registry, _COMPILER_KEY, counting_compiler)  # noqa: SLF001
+
+    with pytest.raises(ValueError, match="scan_limit"):
+        await backend.scan_documents(
+            namespace.id,
+            filter_ast=_filter_ast({"source_type": {"$eq": "report"}}),
+            scan_limit=0,
+        )
+
+    assert calls == []
+
+
+# --------------------------------------------------------------------------- #
+# The keyset cursor
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("instant", _INSTANTS.values(), ids=_INSTANTS.keys())
+async def test_walk_visits_every_document_exactly_once_in_total_order(backend, namespace, instant) -> None:
+    """One row per step across a tie block, chaining ``last_scanned``.
+
+    ``scan_limit=1`` puts a cursor boundary between every pair of rows, including
+    between the four that share a ``created_at`` — so every resume here is a
+    mid-tie resume decided solely by the ``id DESC`` leg, over the dashed stored
+    form. The assertion is exact-equality against the seed's single correct
+    enumeration, not a set comparison: a wrong-but-complete order has to fail too.
+
+    Run at both microsecond polarities because the cursor's timestamp half is
+    serialized by ``isoformat()``, whose output shape changes at ``.000000``; see
+    the module docstring. ``walk_scan`` raises rather than hangs if a cursor fails
+    to advance, which is the shape both serialization defects take.
+    """
+    seed = scan_seed(6, instant=instant)
+    await _seed(backend, namespace.id, seed)
+
+    steps = await walk_scan(backend.scan_documents, namespace.id, scan_limit=1)
+    seen = [d.id for step in steps for d in step.documents]
+
+    assert len(seen) == len(set(seen))  # no document served twice
+    assert set(seen) == set(seed.expected)  # every document served
+    assert seen == seed.expected  # and in one total order across the concatenation
+    assert steps[-1].documents == []
+    assert steps[-1].last_scanned is None
+    assert steps[-1].exhausted is True
+
+
+@pytest.mark.parametrize("instant", _INSTANTS.values(), ids=_INSTANTS.keys())
+async def test_cursor_excludes_its_own_row_and_keeps_its_tie_mates(backend, namespace, instant) -> None:
+    """A mid-tie cursor is strict on its own row and inclusive of the rest of the block.
+
+    Both cursor operands are hand-serialized on this store, and each has a
+    failure mode in either direction; none of the four raises.
+
+    The cursor is taken from the SECOND row of the tie block, not the first, so
+    that the block has members on both sides of it. A cursor that matched too
+    much then returns rows ABOVE itself as well as its own row, and the walk runs
+    backwards rather than merely stalling — the assertions below separate those
+    two symptoms.
+
+    *The timestamp half.* The bind is ``created_at.isoformat()``, byte-for-byte
+    what ``create_document`` wrote into a TEXT column SQLite compares
+    lexicographically. **Measured, by mutating the implementation and reverting
+    it** — the correct window here is 3 rows, ``[…0002, …0001, …0005]``:
+
+    * forcing six microsecond digits (``isoformat(timespec="microseconds")``) —
+      at ``whole_second`` the window becomes 5 rows,
+      ``[…0004, …0003, …0002, …0001, …0005]``: the cursor's own row and the one
+      above it, and ``walk_scan`` raises "scan cursor did not advance". At
+      ``sub_second`` the mutant is byte-identical to the stored form and the
+      whole module stays green.
+    * truncating the microsecond (``.replace(microsecond=0)``) — the exact
+      reverse: green at ``whole_second``, and at ``sub_second`` the window drops
+      to 1 row, ``[…0005]``, losing the cursor's entire tie block. Across the
+      module that mutant fails **only** the two ``sub_second`` parametrizations;
+      every other test here is seeded at a whole second and never sees it.
+
+    Neither polarity alone catches both, which is why this test is parametrized
+    rather than pinned to one instant.
+
+    *The id half.* The bind is ``str(cursor_id)`` — dashed, matching the stored
+    form. Mutating it to ``cursor_id.hex`` gives the same 5-row backwards window
+    as the first case above, at BOTH polarities (it fails 8 tests in this
+    module). See the module docstring for why the ``id_ladder`` seed is what
+    makes that visible at all.
+    """
+    seed = scan_seed(6, instant=instant)
+    await _seed(backend, namespace.id, seed)
+
+    full = await backend.scan_documents(namespace.id, scan_limit=10)
+    assert [d.id for d in full.documents] == seed.expected
+
+    cursor_doc = next(d for d in full.documents if d.id == seed.tied_ids[1])
+    # The instant survived the write/read round trip, so whichever divergence
+    # this polarity carries is live in this corpus.
+    assert cursor_doc.created_at == seed.tie_instant
+    assert cursor_doc.created_at.microsecond == instant.microsecond
+
+    step = await backend.scan_documents(
+        namespace.id,
+        after=(cursor_doc.created_at, cursor_doc.id),
+        scan_limit=10,
+    )
+    ids = [d.id for d in step.documents]
+    position = seed.expected.index(cursor_doc.id)
+
+    assert cursor_doc.id not in ids, "the cursor's own row came back — a resumed walk would never advance"
+    assert set(ids).isdisjoint(seed.expected[:position]), (
+        "a row that enumerates ABOVE the cursor came back — a resumed walk runs backwards"
+    )
+    assert seed.tied_ids[2] in ids, "the cursor's tie-mate was skipped — a resumed walk would lose rows"
+    assert ids == seed.expected[position + 1 :]
+
+
+async def test_filtered_walk_puts_a_cursor_and_a_compiled_fragment_in_one_statement(backend, namespace) -> None:
+    """The only place a cursor and a pushdown fragment share one bind list.
+
+    Binds are positional here, so the fragment's ``args`` must be appended after
+    the cursor's two operands and before the row bound — the order the conditions
+    themselves are joined in. Nothing exercises that unless both families are
+    present in one call, which happens only when a cursor and a compiled fragment
+    appear in the same ``SELECT``. A mis-ordered append does not raise: it shifts
+    later binds by one and returns a wrong-but-plausible row set.
+
+    The filter is a two-leaf disjunction on purpose, so it compiles to two binds
+    rather than one, and the walk runs at ``scan_limit=1`` so every step past the
+    first carries both families at once.
+    """
+    seed = scan_seed(6)
+    await _seed_varied(backend, namespace.id, seed)
+
+    full = await backend.scan_documents(namespace.id, scan_limit=10)
+    wire = {"$or": [{"source_type": {"$eq": "report"}}, {"title": {"$eq": "doc-1"}}]}
+    expected = [d.id for d in full.documents if d.source_type == "report" or d.title == "doc-1"]
+    assert 1 < len(expected) < len(full.documents), "the filter must narrow, but not to a single row"
+
+    steps = await walk_scan(
+        backend.scan_documents,
+        namespace.id,
+        scan_limit=1,
+        filter_ast=_filter_ast(wire),
+    )
+    seen = [d.id for step in steps for d in step.documents]
+
+    assert len(seen) == len(set(seen))
+    assert seen == expected
+    assert steps[-1].exhausted is True
+
+
+async def test_mid_tie_resume_returns_the_exact_next_row(backend, namespace) -> None:
+    """A one-row window resumed from mid-tie yields the next row, not any row.
+
+    ``scan_limit=1`` on top of a mid-tie cursor is the narrowest statement of the
+    resume contract: the ordering and the cursor predicate have to agree on which
+    single row is next, and a bounded window gives the mistake nowhere to hide.
+    A cursor that only compared ``created_at`` would return an arbitrary member
+    of the tie block here and still look "sorted".
+    """
+    seed = scan_seed(6)
+    await _seed(backend, namespace.id, seed)
+
+    full = await backend.scan_documents(namespace.id, scan_limit=10)
+    assert [d.id for d in full.documents] == seed.expected
+
+    for position, cursor_id in enumerate(seed.expected[:-1]):
+        cursor_doc = next(d for d in full.documents if d.id == cursor_id)
+        step = await backend.scan_documents(
+            namespace.id,
+            after=(cursor_doc.created_at, cursor_doc.id),
+            scan_limit=1,
+        )
+        assert [d.id for d in step.documents] == [seed.expected[position + 1]]
+        assert step.exhausted is False
+
+
+async def test_empty_window_reports_exhausted_without_a_position(backend, namespace) -> None:
+    """Both the never-seeded namespace and the tail past the last row."""
+    empty = await backend.scan_documents(namespace.id, scan_limit=5)
+    assert empty.documents == []
+    assert empty.last_scanned is None
+    assert empty.exhausted is True
+
+    seed = scan_seed(6)
+    await _seed(backend, namespace.id, seed)
+    full = await backend.scan_documents(namespace.id, scan_limit=10)
+    oldest = full.documents[-1]
+
+    tail = await backend.scan_documents(namespace.id, after=(oldest.created_at, oldest.id), scan_limit=5)
+    assert tail.documents == []
+    assert tail.last_scanned is None
+    assert tail.exhausted is True
+
+
+# --------------------------------------------------------------------------- #
+# The compile split
+# --------------------------------------------------------------------------- #
+
+
+async def test_split_reports_only_the_leaves_sql_enforced(backend, namespace) -> None:
+    """A forced-residual AST: one pushable leaf, one that must reach the post-filter.
+
+    ``occurred_at`` is a recall-chunk key with no ``documents`` column behind it,
+    so it is absent from this store's ``field_mapping`` and ``compile_lance``
+    defers it under ``on_unsupported="split"``. The conjunction still pushes its
+    other leaf, so ``consumed_keys`` must name ``source_type`` and only
+    ``source_type``.
+
+    Both halves are asserted on rows as well as on the reported set: the pushed
+    leaf really did narrow the window, and the deferred one narrowed nothing —
+    every ``report`` row survives a bound that would have excluded all of them
+    had it been pushed. Reporting alone would pass against a compiler that
+    emitted a predicate against a column this table does not have, which SQLite
+    would answer with an error rather than with rows.
+    """
+    seed = scan_seed(6)
+    for i, (doc_id, created_at) in enumerate(seed.writes):
+        await _write(backend, namespace.id, doc_id, created_at, source_type="report" if i % 2 == 0 else "library")
+
+    step = await backend.scan_documents(
+        namespace.id,
+        filter_ast=_filter_ast(
+            {"source_type": {"$eq": "report"}, "occurred_at": {"$gte": "2999-01-01T00:00:00+00:00"}}
+        ),
+        scan_limit=10,
+    )
+
+    assert step.consumed_keys == frozenset({"source_type"})
+    assert {d.source_type for d in step.documents} == {"report"}
+    assert len(step.documents) == 3
+
+
+async def test_date_system_keys_are_not_pushed_down_by_this_store(backend, namespace) -> None:
+    """``created_at`` reaches the caller's post-filter here, and that is intended.
+
+    This store withholds the date-valued system keys from ``_PUSHABLE_SYSTEM_KEYS``
+    because ``_dt_to_str`` preserves the writer's offset with no UTC coercion,
+    while ``compile_lance`` binds a UTC-normalized ISO string — so a pushed
+    comparison would be on wall clock rather than on instant, and its
+    false-EXCLUDE half is unrecoverable once the key is reported consumed. The
+    leaf therefore compiles to a match-all placeholder, stays out of
+    ``consumed_keys``, and narrows nothing — asserted positively, because a
+    widened whitelist would show up here as a suddenly-shorter window rather than
+    as an error.
+    """
+    seed = scan_seed(6)
+    await _seed(backend, namespace.id, seed)
+
+    step = await backend.scan_documents(
+        namespace.id,
+        filter_ast=_filter_ast({"created_at": {"$gte": "2999-01-01T00:00:00+00:00"}}),
+        scan_limit=10,
+    )
+
+    assert step.consumed_keys == frozenset()
+    # Every row is older than the bound, so a pushed-down comparison would have
+    # returned nothing at all.
+    assert [d.id for d in step.documents] == seed.expected
+
+
+# The pushdown must never reject a row the full filter would keep. Shapes are
+# chosen for the ways a compiler can get that wrong, not for operator coverage:
+# the ones wrapping an unpushable leaf in a disjunction or a negation matter
+# most, because a match-all placeholder left inside a negation inverts into a
+# match-nothing and excludes rows.
+_SUPERSET_SHAPES: dict[str, dict[str, Any]] = {
+    "pushable_eq": {"source_type": {"$eq": "report"}},
+    "pushable_ne": {"source_type": {"$ne": "report"}},
+    "pushable_nin": {"source_type": {"$nin": ["report"]}},
+    "pushable_exists": {"source_url": {"$exists": False}},
+    "metadata_eq": {"metadata.tier": {"$eq": "gold"}},
+    "unpushable_date": {"created_at": {"$gte": "2026-01-31T12:30:00+00:00"}},
+    "unpushable_key": {"occurred_at": {"$gte": "2026-01-01T00:00:00+00:00"}},
+    "or_over_unpushable": {
+        "$or": [
+            {"created_at": {"$gte": "2026-01-31T12:30:00+00:00"}},
+            {"source_type": {"$eq": "report"}},
+        ]
+    },
+    "not_over_pushable": {"$not": {"source_type": {"$eq": "report"}}},
+    "not_over_unpushable": {"$not": {"created_at": {"$gte": "2026-01-31T12:30:00+00:00"}}},
+    "and_of_in_and_not": {
+        "$and": [
+            {"source_type": {"$in": ["report", "library"]}},
+            {"$not": {"title": {"$eq": "doc-0"}}},
+        ]
+    },
+}
+
+
+@pytest.mark.parametrize("wire", _SUPERSET_SHAPES.values(), ids=_SUPERSET_SHAPES.keys())
+async def test_pushdown_never_rejects_a_row_the_full_filter_would_keep(backend, namespace, wire) -> None:
+    """The superset property the resume contract depends on.
+
+    Resuming past the rows a pushdown rejected is sound only because a rejected
+    row could not have satisfied the full filter either. The ``scan_documents``
+    docstring names that as an assumption about the *compiler*; this checks the
+    consequence where it actually lands, by comparing the scan's window against
+    the in-process ``compile_python`` evaluation of the same AST over the same
+    corpus. If it ever fails, a walk is silently and permanently dropping
+    documents — a post-filter can only narrow, never recover a row the window
+    never returned.
+
+    Scope, so a green run is not read as more than it is: eleven shapes on one
+    store is a tripwire, not a proof over the operator space. The general
+    property belongs to the compilers and to the forced-residual conformance
+    corpus.
+    """
+    seed = scan_seed(6)
+    await _seed_varied(backend, namespace.id, seed)
+    ast = _filter_ast(wire)
+
+    step = await backend.scan_documents(namespace.id, filter_ast=ast, scan_limit=100)
+    # Precondition: the comparison below is only meaningful if this one window
+    # covered the whole namespace. Without it, growing the corpus past the bound
+    # would fail the test for a reason that has nothing to do with the pushdown.
+    assert step.exhausted is True
+
+    all_docs = (await backend.scan_documents(namespace.id, scan_limit=100)).documents
+    matches = compile_python(ast, _documents_compile_context()).predicate
+    oracle = {d.id for d in all_docs if matches(d)}
+
+    assert oracle <= {d.id for d in step.documents}
+
+
+# --------------------------------------------------------------------------- #
+# What the position means
+# --------------------------------------------------------------------------- #
+
+
+async def test_last_scanned_is_the_final_raw_row_not_the_last_match(backend, namespace) -> None:
+    """Resume from the last row SCANNED, not from the last row that matches.
+
+    The seed is arranged so the two genuinely differ — otherwise the assertion is
+    vacuous. The window deliberately ENDS on a row the caller's post-filter will
+    reject: the filter is an ``$or`` mixing a pushable leaf with an unbacked one,
+    which ``compile_lance``'s all-or-nothing gate defers wholesale rather than
+    pushing half a disjunction, so SQLite narrows nothing and the oldest row — a
+    ``library`` row that does not satisfy the filter — is the final row of the raw
+    window.
+
+    A walk that resumed from the last *matching* row would re-scan the rejected
+    gap on every step, and when a whole window is rejected there is no matching
+    row to resume from at all, so such a walk cannot advance past a run of
+    non-matching rows longer than one window. Taking the position from the raw
+    window is what lets ``exhausted`` be the only termination signal.
+
+    **Scope, measured rather than asserted past.** Against the shipped
+    implementation ``last_scanned == documents[-1]`` is true by construction —
+    ``scan_documents`` post-filters nothing — so no single-line edit of the
+    current code can separate the two, and this test cannot be read as covering
+    the current expression. What it does kill is the *plausible wrong
+    implementation* the #1586 comment warns against, and that was verified rather
+    than assumed: re-implementing the tail as ``matching = [d for d in documents
+    if compile_python(filter_ast, …)(d)]`` and keying off ``matching[-1]`` fails
+    this test and **only** this test — the entire rest of the module, walks
+    included, stays green, because on every other seed here the final raw row
+    also matches. That is the whole reason for the deliberately non-matching
+    final row.
+
+    The "only this test" figure is scoped to that exact construction, which
+    post-filters solely when ``filter_ast`` is not ``None``. A variant that
+    post-filters unconditionally moves the key on the *unfiltered* call too, and
+    is therefore caught a second time by the
+    ``(created_at, doc_id) == (documents[-1].created_at, documents[-1].id)``
+    assertion in :func:`test_last_scanned_carries_a_datetime_and_a_uuid`
+    (independently measured at 2 failures). Treat 1 as the conservative floor for
+    this family of mutant, not as a claim that no other assertion can notice one —
+    a bare "only this test fails" is the kind of figure that later gets quoted as
+    licence to delete whatever looked redundant.
+    """
+    newest, middle, oldest = (uuid4() for _ in range(3))
+    base = WHOLE_SECOND
+    await _write(backend, namespace.id, newest, base + timedelta(seconds=2), source_type="report")
+    await _write(backend, namespace.id, middle, base + timedelta(seconds=1), source_type="report")
+    await _write(backend, namespace.id, oldest, base, source_type="library")
+
+    ast = _filter_ast(
+        {
+            "$or": [
+                {"source_type": {"$eq": "report"}},
+                {"occurred_at": {"$gte": "2026-01-01T00:00:00+00:00"}},
+            ]
+        }
+    )
+    step = await backend.scan_documents(namespace.id, filter_ast=ast, scan_limit=10)
+
+    # Nothing was pushed, so the raw window is the whole namespace and its last
+    # row is the one the post-filter will drop.
+    assert step.consumed_keys == frozenset()
+    assert [d.id for d in step.documents] == [newest, middle, oldest]
+    assert step.documents[-1].source_type == "library"
+
+    # The premise the assertion rests on: the caller's own evaluation of the same
+    # AST really does reject that final row, so the two candidate positions are
+    # different rows rather than the same row named twice.
+    matches = compile_python(ast, _documents_compile_context()).predicate
+    surviving = [d for d in step.documents if matches(d)]
+    assert surviving == step.documents[:2]
+
+    last_row = step.documents[-1]
+    assert step.last_scanned == (last_row.created_at, last_row.id)
+    assert step.last_scanned != (surviving[-1].created_at, surviving[-1].id)
+
+
+async def test_last_scanned_carries_a_datetime_and_a_uuid(backend, namespace) -> None:
+    """``DocumentScanKey`` declares ``tuple[datetime, UUID]``, and the timestamp
+    half is the one this store can get wrong silently.
+
+    ``created_at`` lives in the raw row as TEXT, and the implementation builds the
+    key from the converted :class:`Document` — where ``_parse_dt`` has already run
+    — rather than off ``rows[-1]["created_at"]``.
+
+    **Measured, by mutating the implementation to ``rows[-1]["created_at"]`` and
+    reverting it:** that mutant is not silent on this store, contrary to the
+    premise this test was originally written under. It fails 7 tests here — this
+    one on the type assertion, and every walk with ``AttributeError: 'str' object
+    has no attribute 'isoformat'`` when the raw string is bound back in through
+    ``_dt_to_str``. So keep this test as the direct, legible statement of the
+    declared contract, not as the only thing standing between a TEXT key and a
+    green suite.
+
+    Its sibling is :func:`test_last_scanned_is_the_final_raw_row_not_the_last_match`
+    above, which pins *which row* the key comes from while this one pins *what
+    type* it carries. The two are not redundant and neither subsumes the other:
+    the type mutant leaves the right row and the wrong type, the last-match mutant
+    leaves the right type and the wrong row.
+
+    The unfiltered assertion below is also what separates the two constructions of
+    that last-match mutant — see that test's docstring for the 1-vs-2 figure. A
+    variant that post-filters unconditionally moves the key on this call too and
+    trips the equality here; one guarded on ``filter_ast is not None`` does not.
+    Do not weaken it to the filtered call alone.
+    """
+    seed = scan_seed(6)
+    await _seed_varied(backend, namespace.id, seed)
+
+    step = await backend.scan_documents(namespace.id, scan_limit=3)
+    assert step.last_scanned is not None
+    created_at, doc_id = step.last_scanned
+    assert isinstance(created_at, datetime)
+    assert isinstance(doc_id, UUID)
+    assert not isinstance(doc_id, bool)  # UUID has no bool subclass; guards a stub returning a truthy sentinel
+    assert (created_at, doc_id) == (step.documents[-1].created_at, step.documents[-1].id)
+
+    filtered = await backend.scan_documents(
+        namespace.id,
+        filter_ast=_filter_ast({"source_type": {"$eq": "report"}}),
+        scan_limit=2,
+    )
+    assert filtered.last_scanned is not None
+    assert isinstance(filtered.last_scanned[0], datetime)
+    assert isinstance(filtered.last_scanned[1], UUID)
+
+
+# --------------------------------------------------------------------------- #
+# The non-filter narrowing legs
+# --------------------------------------------------------------------------- #
+
+
+async def test_status_and_updated_before_narrow_the_window(backend, namespace) -> None:
+    """Both optional legs bind positionally, ahead of the cursor and the fragment.
+
+    Asserted on exact row sets rather than on counts: a bind shifted by one
+    position produces a narrower-but-wrong window just as readily as a correct
+    one, and only the identities separate them.
+    """
+    seed = scan_seed(6)
+    cutoff = seed.tie_instant + timedelta(hours=1)
+    for i, (doc_id, created_at) in enumerate(seed.writes):
+        await _write(
+            backend,
+            namespace.id,
+            doc_id,
+            created_at,
+            status=DocumentStatus.COMPLETED if i % 2 == 0 else DocumentStatus.PENDING,
+            updated_at=cutoff - timedelta(minutes=1) if i < 4 else cutoff + timedelta(minutes=1),
+        )
+
+    unbounded = await backend.scan_documents(namespace.id, scan_limit=10)
+    assert len(unbounded.documents) == 6
+
+    by_status = await backend.scan_documents(namespace.id, status=DocumentStatus.COMPLETED.value, scan_limit=10)
+    assert {d.id for d in by_status.documents} == {doc_id for i, (doc_id, _) in enumerate(seed.writes) if i % 2 == 0}
+
+    by_updated = await backend.scan_documents(namespace.id, updated_before=cutoff, scan_limit=10)
+    assert {d.id for d in by_updated.documents} == {doc_id for i, (doc_id, _) in enumerate(seed.writes) if i < 4}
+
+
+async def test_every_narrowing_leg_composes_in_one_statement(backend, namespace) -> None:
+    """Cursor + compiled fragment + ``status`` + ``updated_before``, all at once.
+
+    Each leg has its own test above; none of those puts more than two of them in
+    the same ``WHERE``. On a positional-bind store this is the shape where an
+    append-order mistake actually lands: with six binds ahead of the row bound, a
+    conjunct appended out of step shifts every later value by one and SQLite
+    answers with a plausible subset rather than an error.
+
+    The expectation is computed from the rows the store returns rather than from
+    the seeding loop's counter, and each leg is asserted to be doing work — a leg
+    that narrowed nothing would make its own conjunct untested while the overall
+    assertion still passed.
+    """
+    seed = scan_seed(6)
+    cutoff = seed.tie_instant + timedelta(hours=1)
+    for i, (doc_id, created_at) in enumerate(seed.writes):
+        await _write(
+            backend,
+            namespace.id,
+            doc_id,
+            created_at,
+            title=f"doc-{i}",
+            source_type="report" if i % 2 == 0 else "library",
+            status=DocumentStatus.COMPLETED if i < 5 else DocumentStatus.PENDING,
+            updated_at=cutoff - timedelta(minutes=1) if i < 4 else cutoff + timedelta(minutes=1),
+        )
+
+    everything = await backend.scan_documents(namespace.id, scan_limit=50)
+    assert len(everything.documents) == 6
+
+    # Resume from inside the tie block, so the cursor's id leg is live.
+    cursor_doc = next(d for d in everything.documents if d.id == seed.tied_ids[0])
+    after_cursor = everything.documents[everything.documents.index(cursor_doc) + 1 :]
+
+    def surviving(docs: list[Any]) -> list[UUID]:
+        return [
+            d.id
+            for d in docs
+            if d.source_type == "report" and d.status == DocumentStatus.COMPLETED and d.updated_at < cutoff
+        ]
+
+    expected = surviving(after_cursor)
+
+    # Every leg must actually remove something, or its conjunct is untested here.
+    assert expected, "the four-way conjunction must keep at least one row"
+    assert len(after_cursor) < len(everything.documents), "the cursor narrowed nothing"
+    assert len(expected) < len(after_cursor), "the filter/status/updated_before legs narrowed nothing"
+
+    step = await backend.scan_documents(
+        namespace.id,
+        filter_ast=_filter_ast({"source_type": {"$eq": "report"}}),
+        status=DocumentStatus.COMPLETED.value,
+        updated_before=cutoff,
+        after=(cursor_doc.created_at, cursor_doc.id),
+        scan_limit=50,
+    )
+
+    assert [d.id for d in step.documents] == expected
+    assert step.consumed_keys == frozenset({"source_type"})
+
+
+# --------------------------------------------------------------------------- #
+# Namespace isolation and the ungrouped-OR tripwire
+# --------------------------------------------------------------------------- #
+#
+# Everything above runs in a single-namespace fixture, so no assertion up there
+# can notice a scan that ignores its namespace scope. The two tests below are the
+# ones that make the mutants fail; each records the mutation that was run against
+# it and what it measured.
+#
+# Both seed their two namespaces through :func:`_two_namespace_ladders`, so the
+# corpus is identical run to run. Read that function before touching the seed:
+# the fixed relative order is determinism, NOT a correctness requirement on this
+# store, and the reason it is load-bearing on the SurrealDB sibling does not
+# transfer here.
+
+
+async def test_scan_never_returns_another_namespaces_rows(backend, namespace) -> None:
+    """A filtered walk over one namespace must not see a byte of the other.
+
+    The second namespace is seeded with the SAME varied corpus, so every row in
+    it matches the same filter — if the namespace predicate is dropped (or stops
+    AND-composing with the fragment), the foreign rows are not merely reachable,
+    they are guaranteed hits. Walked at ``scan_limit=1`` so the keyset predicate
+    is exercised across pages too: the cursor is namespace-blind on its own, and
+    only the scope predicate keeps a resume inside its tenant.
+
+    **Mutation-verified, and reverted afterwards.** Neutralising the namespace
+    predicate — ``conditions = ["namespace_id = ?"]`` / ``params = [str(namespace_id)]``
+    becoming ``conditions = ["1"]`` / ``params = []``, the faithful SQLite form of
+    "delete the scope", since an empty condition list would emit a bare ``WHERE``
+    and fail as a syntax error rather than as wrong rows — fails this test.
+    Measured: the filtered walk returns **8 rows instead of 4**, four of them the
+    other tenant's, and the walk assertion fires before the unfiltered read below
+    is reached. The grouping tripwire that follows fails on the same mutant, at
+    **12 rows instead of 6**; those two are the only failures the mutant produces
+    across this module, which is exactly why both of them exist.
+    """
+    scanned_ids, foreign_ids = _two_namespace_ladders()
+    await _seed_varied(backend, namespace.id, _seed_from_ladder(scanned_ids))
+    other = await _make_namespace(backend)
+    # Same tie instant, same varied corpus: every foreign row is a guaranteed hit
+    # for the filter below, so a dropped predicate fails on every run rather than
+    # on a lucky arrangement.
+    await _seed_varied(backend, other.id, _seed_from_ladder(foreign_ids))
+
+    wire = {"$or": [{"source_type": {"$eq": "report"}}, {"title": {"$eq": "doc-1"}}]}
+    steps = await walk_scan(backend.scan_documents, namespace.id, scan_limit=1, filter_ast=_filter_ast(wire))
+    seen = [d for step in steps for d in step.documents]
+
+    assert seen, "the filter must match rows in the scanned namespace for this test to bite"
+    assert len(seen) == 4
+    assert all(d.namespace_id == namespace.id for d in seen)
+    assert set(foreign_ids).isdisjoint({d.id for d in seen})
+
+    unfiltered = await backend.scan_documents(namespace.id, scan_limit=50)
+    assert len(unfiltered.documents) == 6
+    assert all(d.namespace_id == namespace.id for d in unfiltered.documents)
+
+
+async def test_ungrouped_or_fragment_cannot_absorb_the_namespace_scope(backend, namespace, monkeypatch) -> None:
+    """The parentheses around the spliced fragment are load-bearing.
+
+    ``scan_documents`` joins its conditions with ``AND`` and wraps the compiled
+    fragment in parentheses at the splice. Ungrouped, ``AND`` binds tighter than
+    ``OR``, so ``namespace_id = ? AND title = ? OR content = ?`` parses as
+    ``(namespace_id = ? AND title = ?) OR (content = ?)`` — the right disjunct is
+    unscoped and returns every tenant's rows. It fails as somebody else's data,
+    not as an error.
+
+    No compiler emits an ungrouped fragment today (``compile_lance``
+    self-parenthesizes every boolean node it emits), so no compiled-filter test
+    can reach this. The registered compiler is therefore replaced with one that
+    emits the bare ungrouped shape and the real ``scan_documents`` is driven
+    through it — deliberately, rather than adding a fragment-rendering seam to
+    production code just to make the parentheses reachable from a test. Both
+    namespaces' rows satisfy the right disjunct, so an absorbed scope predicate
+    yields foreign rows deterministically rather than by luck.
+
+    **Mutation-verified, and reverted afterwards.** Removing the parentheses at
+    the splice — ``conditions.append(f"({compiled.predicate})")`` becoming
+    ``conditions.append(compiled.predicate)`` — fails this test, and the measured
+    magnitude is **12 rows where the grouped form returns 6**: a literal 2x
+    cross-tenant leak, a full read of both namespaces, with no error and nothing
+    in the logs. It is the ONLY test in this module that mutant fails.
+    """
+    scanned_ids, foreign_ids = _two_namespace_ladders()
+    await _seed_varied(backend, namespace.id, _seed_from_ladder(scanned_ids))
+    other = await _make_namespace(backend)
+    await _seed_varied(backend, other.id, _seed_from_ladder(foreign_ids))
+
+    def ungrouped_compiler(ast, ctx):
+        # Positional binds, in emit order, exactly as ``compile_lance`` returns
+        # them. The shape under test is the missing parentheses, nothing else.
+        return CompiledFilter(
+            predicate="title = ? OR content = ?",
+            params={"args": ["doc-0", "scanned content"]},
+            consumed_keys=frozenset({"title", "content"}),
+            consumed_slice_hash="ungrouped-or-tripwire",
+        )
+
+    monkeypatch.setitem(CompilerRegistry._registry, _COMPILER_KEY, ungrouped_compiler)  # noqa: SLF001
+
+    step = await backend.scan_documents(
+        namespace.id,
+        filter_ast=_filter_ast({"title": {"$eq": "doc-0"}}),
+        scan_limit=50,
+    )
+
+    assert step.documents, "the fragment must match rows in the scanned namespace for this test to bite"
+    assert len(step.documents) == 6
+    assert all(d.namespace_id == namespace.id for d in step.documents)
+    assert set(foreign_ids).isdisjoint({d.id for d in step.documents})


### PR DESCRIPTION
## Summary

Ports the bounded document-scan step that the two SQLAlchemy-backed stores already ship (#1586) to the two stores that hand-write their SQL: the raw SQLite backend and the SurrealDB relational adapter. Both are `@internal` with no callers yet, so the public storage API is untouched and nothing changes for existing users.

Each store emits a single `SELECT` combining the compiled pushdown fragment, the namespace scope, the optional `status` / `updated_before` narrowing and a keyset condition, ordered by `(created_at DESC, id DESC)` and bounded by `scan_limit`. Step semantics mirror #1586 exactly:

- `last_scanned` is the key of the final row of the **raw** window, not the last match
- `exhausted` means the raw window came back shorter than `scan_limit`
- `consumed_keys` is reported verbatim from the compiler, as a reporting signal only — never permission for a caller to skip leaves
- one step per call, in the store's own connection/session; no transaction spans steps
- `scan_limit` bounds rows **returned**, not examined — a total-work bound, not a latency bound

### Per-store differences that are not incidental

- **raw-SQLite** splices the compiler's positional binds natively and expresses the keyset as a row-value comparison. Cursor timestamps bind through the same serialization the writer uses, so cursor and stored TEXT sort identically across the microsecond-format boundary. The cursor id binds dashed — an undashed cursor sorts *above* its own row and walks the scan backwards forever.
- **SurrealQL has no row-value comparison**, so the keyset is written out as an explicit disjunction. `updated_before` binds the datetime *object* rather than a string: the column is `TYPE datetime`, and a string operand matches no row at all, which would report a populated namespace as exhausted on the first step. This diverges deliberately from `list_documents` on the same adapter, which has that defect; it is tracked separately and deliberately not fixed here.
- **Unsafe metadata path segments** make the SurrealDB compiler raise, which would otherwise escape the scan as an internal error. The scan path maps that one case to the public unsupported-filter error, with the catch scoped so unrelated compile failures still propagate.

### On the parentheses

The compiled fragment is parenthesized at the splice on both stores. Both compilers self-parenthesize every shape reachable today, so this is a **tripwire rather than a fix** — without it an ungrouped top-level `OR` reassociates past the namespace predicate and returns twice the rows, across tenants. Measured at 12 rows where the grouped form returns 6, on both stores.

## Test plan

- [x] Unit tests pass — `tests/unit/test_sqlite_scan_documents.py`, `tests/unit/filter/test_documents_scan_error_marker.py`
- [x] Integration tests pass — `tests/integration/storage/backends/surrealdb/test_relational_scan_documents.py` (executes rather than skips; the SurrealDB extra is installed)
- [x] Full suite green: `make test` → 560 passed, 356 skipped, coverage 85.43% (≥77% gate)
- [x] `make lint` exits clean; `make format` reports no changes
- [x] **Mutation-verified rather than assumed** — 14 mutations run against an isolated worktree, all 14 killed:
  - namespace predicate removed → fails on both stores
  - fragment-splice parentheses removed → fails on both stores
  - keyset disjunction parentheses removed (SurrealDB) → fails
  - cursor id bound undashed → fails
  - cursor timestamp forced to six µs digits, and separately truncated → each fails, and **only** at its own microsecond polarity, which is why the cursor tests are parametrized at both
  - cursor operands bound in the wrong order → fails
  - fragment args spliced at the wrong bind position → fails
  - `last_scanned` taken from the first row / the last match → fails
  - `updated_before` reverted to `.isoformat()` (SurrealDB) → fails
  - compiler's guard message reworded two modules away → fails, via the co-located marker test
- [x] Adjacent regression sweep (sqlite backend, sqlite sort index, surrealdb backend + unit suites, filter suites): 1973 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added document scanning for SQLite and SurrealDB storage.
  * Supports bounded results, cursor-based pagination, status filtering, update-time limits, and compiled filters.
  * Provides resume information to continue scans reliably and detect when results are exhausted.
  * Maintains namespace isolation and consistent ordering across pages.
* **Bug Fixes**
  * Improved handling of unsupported or unsafe filter expressions with clear storage-specific errors.
  * Prevented filtering, cursor, and namespace conditions from affecting unrelated documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->