### PR TITLE
Split OR-defeating SurrealDB document queries into index-eligible legs

### DIFF
--- a/src/khora/storage/backends/surrealdb/relational.py
+++ b/src/khora/storage/backends/surrealdb/relational.py
@@ -62,6 +62,46 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
+# Disjunctions and index selection
+#
+# **No ``document`` read in this module may contain an ``OR``.** Three of them
+# used to, and each one made the statement read every ``document`` row in the
+# database — all tenants included, not just the namespace asked for.
+#
+# The rule, measured on 2.x rather than assumed. SurrealDB *can* answer a
+# disjunction as a union of index scans, but only when EVERY disjunct is a
+# comparison on a field carried by a **single-field** index. A composite index
+# does not qualify, not even on its own leading column:
+#
+# * ``status = 'a' OR status = 'b'`` with a one-field ``status`` index — two
+#   ``Iterate Index`` operations, and it stays indexed when wrapped in an outer
+#   ``AND`` (three operations, the extra one serving the conjunct).
+# * ``checksum = $a OR checksum = $b`` with only the two-field
+#   ``idx_document_ns_checksum`` — ``Iterate Table``.
+#
+# When one disjunct cannot be served, the fallback is not scoped to that
+# disjunct: the whole statement becomes ``Iterate Table`` and the conjuncts
+# around it lose their indexes too. That is why the ``namespace_id`` scope
+# disappears along with the keyset — the tenant filter still *filters*, it just
+# stops *narrowing*, so correctness is unaffected and cost is not.
+#
+# ``document`` carries composite ``(namespace_id, …)`` indexes and nothing else,
+# by design: the one-field ``idx_document_namespace`` was dropped as a redundant
+# prefix of the sort index. So on this table the qualifying case cannot arise and
+# **every** ``OR`` scans, whatever its shape — verified over eight, including a
+# bare ``OR`` of two composite leading columns and an ``OR`` of two full
+# composite matches. Defining one-field indexes to buy the union back is not a
+# trade worth making: it is permanent write amplification on every ``document``
+# insert to salvage a predicate that splits into conjunctive legs for free.
+#
+# The measurements above are on ``memory://`` with the SDK-bundled core; the
+# adapter's three former ``OR`` sites were each confirmed ``Iterate Table``
+# before the split and ``Iterate Index`` per leg after. Any predicate added here
+# should be checked the same way — the plan tests re-issue every statement this
+# adapter sends with ``EXPLAIN`` appended, so a new ``OR`` fails there.
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
 # Adapter
 # ---------------------------------------------------------------------------
 
@@ -70,8 +110,8 @@ def _none_if_empty(v: str | None) -> str | None:
     return v if v else None
 
 
-def _checksum_reingestable_clause(pending_stale_before: datetime | None) -> tuple[str, dict[str, Any]]:
-    """Build the checksum-dedup exclusion clause + binds for SurrealDB (#1464).
+def _checksum_reingestable_legs(pending_stale_before: datetime | None) -> list[tuple[str, dict[str, Any]]]:
+    """Build the checksum-dedup exclusion as OR-free, index-eligible legs.
 
     FAILED rows are always excluded (re-ingestable). When ``pending_stale_before``
     is given, PENDING rows older than that cutoff are also excluded so a
@@ -79,15 +119,43 @@ def _checksum_reingestable_clause(pending_stale_before: datetime | None) -> tupl
     preserving the concurrent in-flight guard. When ``None`` only FAILED is
     excluded (legacy behavior).
 
+    **Why legs rather than one clause.** The predicate this replaces was
+    ``status != 'failed' AND (status != 'pending' OR updated_at >= $cutoff)``. A
+    nested ``OR`` costs the whole statement its indexes on this table, the
+    ``namespace_id`` prefix included (see the disjunction note at the top of this
+    module), so a dedup probe read every ``document`` row in the database, all
+    namespaces included. Since ``pending_stale_before`` is set on the production
+    ingest path, that was every dedup probe. The same set is expressed as two
+    disjoint conjunctions:
+
+    * ``status != 'failed' AND status != 'pending'`` — neither failed nor pending
+    * ``status = 'pending' AND updated_at >= $cutoff`` — pending but still fresh
+
+    Their union is exactly the original predicate and their intersection is empty
+    (they disagree on ``status``), so a caller may concatenate leg results with no
+    comparator and no dedup. Each leg alone plans ``Iterate Index`` on
+    ``idx_document_ns_checksum`` / ``idx_document_ns_status``.
+
     The cutoff binds as a ``datetime`` object (see the datetime-binds note at the
     top of this module). Bound as an ISO string the ``>=`` compare is
-    unconditionally true, which makes the disjunct always hold and silently
-    disables the re-ingest — every PENDING row stays a dedup hit however stale.
+    unconditionally true, so the fresh-PENDING leg would match every PENDING row
+    however stale and silently disable the re-ingest.
+
+    Returns:
+        ``[(clause, binds), ...]`` — one entry when ``pending_stale_before`` is
+        ``None``, two otherwise. Legs are ordered non-pending first, matching the
+        precedence a single-row consumer wants: a settled row outranks an
+        in-flight one.
     """
     if pending_stale_before is None:
-        return "status != 'failed'", {}
-    clause = "status != 'failed' AND (status != 'pending' OR updated_at >= $pending_stale_before)"
-    return clause, {"pending_stale_before": pending_stale_before}
+        return [("status != 'failed'", {})]
+    return [
+        ("status != 'failed' AND status != 'pending'", {}),
+        (
+            "status = 'pending' AND updated_at >= $pending_stale_before",
+            {"pending_stale_before": pending_stale_before},
+        ),
+    ]
 
 
 def _scan_key_from_row(row: dict[str, Any]) -> DocumentScanKey:
@@ -118,6 +186,72 @@ def _scan_key_from_row(row: dict[str, Any]) -> DocumentScanKey:
     if created_at is None:
         raise ValueError(f"document row has no readable created_at; cannot build a scan cursor: {row.get('id')!r}")
     return (created_at, _parse_uuid(row["id"], strict=True))
+
+
+# Bind names :meth:`SurrealDBRelationalAdapter.scan_documents` owns. A compiled
+# filter fragment that emitted any of them would silently overwrite a scan bind —
+# a compiled ``ns`` would replace the tenant scope and return another namespace's
+# rows with no error anywhere — so the splice checks against this set rather than
+# against whichever optional binds happen to be present on the current call.
+_SCAN_RESERVED_BINDS: frozenset[str] = frozenset(
+    {"ns", "lim", "status", "updated_before", "after_created_at", "after_id"}
+)
+
+
+def _documents_where(
+    namespace_id: UUID,
+    *,
+    status: str | None,
+    updated_before: datetime | None,
+    filter_ast: FilterNode | None,
+) -> tuple[list[str], dict[str, Any], frozenset[str]]:
+    """Build the namespace/status/filter conjuncts shared by every scan statement.
+
+    :meth:`SurrealDBRelationalAdapter.scan_documents` issues up to two statements
+    per step and both must carry the identical narrowing, so the block lives here
+    once instead of being duplicated per statement. The cursor bound is NOT
+    included — it is the only part that differs between the two.
+
+    Returns ``(conditions, params, consumed_keys)``. ``conditions`` is a list of
+    ``AND``-joinable fragments; every fragment is parenthesized unless it is a
+    single comparison, so a caller may append its own conjunct without thinking
+    about operator precedence.
+
+    Raises ``ValueError`` when a compiled filter's binds collide with the scan's
+    own reserved names (see :data:`_SCAN_RESERVED_BINDS`).
+    """
+    conditions = ["namespace_id = $ns"]
+    params: dict[str, Any] = {"ns": str(namespace_id)}
+    if status:
+        conditions.append("status = $status")
+        params["status"] = status
+    if updated_before is not None:
+        conditions.append("updated_at < $updated_before")
+        params["updated_before"] = updated_before
+
+    consumed_keys: frozenset[str] = frozenset()
+    if filter_ast is not None:
+        compiler = CompilerRegistry.get("relational.surrealdb", "documents")
+        # No ``CompileError`` mapping here. Under this context's
+        # ``on_unsupported="split"``, an unrenderable metadata segment is a
+        # capability gap the compiler defers (see
+        # ``_documents_compile_context``), so the only ``CompileError`` left
+        # reaching this line would be a genuine compiler fault — which must
+        # escape as itself rather than be relabelled a caller input problem.
+        compiled = compiler(filter_ast, _documents_compile_context())
+        consumed_keys = compiled.consumed_keys
+        conditions.append(f"({compiled.predicate})")
+        # Compiled binds are ``{param_namespace}_{n}`` — ``f_0``, ``f_1``, … — and
+        # the scan's are the reserved set, so the two families are disjoint by
+        # construction. The invariant runs BOTH ways and neither direction is safe
+        # to break: never name a scan bind ``f_<n>``, and never set this context's
+        # ``param_namespace`` to anything that could produce a reserved name.
+        collisions = _SCAN_RESERVED_BINDS & compiled.params.keys()
+        if collisions:
+            raise ValueError(f"compiled filter binds collide with scan binds: {sorted(collisions)}")
+        params.update(compiled.params)
+
+    return conditions, params, consumed_keys
 
 
 class SurrealDBRelationalAdapter:
@@ -482,36 +616,48 @@ class SurrealDBRelationalAdapter:
         """Scan one bounded window of a namespace's documents by keyset.
 
         ``@internal``. Not part of the public storage API — the offset-based
-        :meth:`list_documents` is. One ``SELECT`` on this adapter's own
+        :meth:`list_documents` is. One or two ``SELECT``s on this adapter's own
         connection; a walk is the caller's job, chaining
         :attr:`DocumentScanStep.last_scanned` back in as ``after`` until the step
         reports ``exhausted``. No transaction spans steps and no consistent
         snapshot is claimed.
 
-        SurrealQL has no row-value comparison, so #1586's single
-        ``(created_at, id) < (…)`` expands to ``created_at < $ts OR (created_at =
-        $ts AND id < $id)``. **Every conjunct is parenthesized unless it is a
-        single comparison**, and there are two such sites at different
-        severities. This one is **live**: we write the ``OR`` rather than
-        inheriting it from a self-parenthesizing compiler, and it is reached on
-        every resumed step. Ungrouped, ``AND`` binds tighter, so the disjunction
-        splits the conjunct list at its own position: everything appended *before*
-        it (namespace, status, ``updated_before``) lands inside the left disjunct,
-        and the right one carries only the tie clause plus whatever is appended
-        *after* — today just the compiled fragment. Either way the right disjunct
-        has no namespace scope, so it returns other tenants' rows tied on the
-        cursor instant. Measured with no ``filter_ast``, where the right disjunct
-        is bare: 3 rows grouped against 7 ungrouped, 4 of them foreign. With a
-        fragment the leak is narrowed by that fragment rather than removed, so
-        the magnitude drops but the cross-tenant read does not. **The order of
-        the appends is therefore load-bearing to this paragraph, not to the
-        defect** — regrouping the list changes which conjuncts leak, never
-        whether they do. The compiled
-        fragment splice is the second site, a tripwire rather than a live hazard
-        (``compile_surrealdb`` self-groups every boolean node today) with an
-        identical failure mode, measured at 6 rows becoming 12. The inner
-        ``(created_at = $ts AND id < $id)`` keeps its parens too: we do not lean
-        on operator precedence for a predicate that fails cross-tenant.
+        **A resumed step is TWO statements, not one.** SurrealQL has no row-value
+        comparison, so the keyset bound ``(created_at, id) < (…)`` has to be
+        written out — and written as one predicate it needs an ``OR``, which is
+        exactly what this store's planner cannot take (see the complexity note
+        below). It is issued as two ``OR``-free statements instead, both carrying
+        the identical narrowing from ``_documents_where``:
+
+        * **Q1, the tie block** — ``created_at = $ts AND id < $id``, ordered
+          ``id DESC``. Every row it returns sits at the cursor instant.
+        * **Q2, strictly older** — ``created_at < $ts``, ordered
+          ``created_at DESC, id DESC``.
+
+        Their concatenation *is* the merged window, in order, with no comparator
+        and no dedup: under ``created_at DESC, id DESC`` every Q1 row (equal to
+        ``$ts``) sorts strictly before every Q2 row (below ``$ts``), and the two
+        sets are disjoint by the same equality. The result is byte-identical to
+        the single disjunctive window it replaces. Q2 runs with
+        ``LIMIT scan_limit - len(Q1)`` and is skipped outright when Q1 already
+        filled the window, so a step resumed deep inside a tie block costs one
+        statement rather than two. The **first** step (``after is None``) has no
+        tie block at all and is the single Q2 shape without the cursor bound —
+        unchanged from before.
+
+        **No transaction spans the two statements, and none is claimed.** A write
+        landing between Q1 and Q2 can change what Q2 sees. Contractually that
+        changes nothing: this method already promises no consistent snapshot, no
+        transaction spans steps, and a concurrent insert lands *above* the
+        descending cursor — in the region the walk has already passed and never
+        revisits. The observable difference against the old single statement is
+        the width of that race, not its existence.
+
+        **Every conjunct is parenthesized unless it is a single comparison.** With
+        the keyset disjunction gone, the compiled-fragment splice in
+        ``_documents_where`` is the only remaining site, and it is a tripwire
+        rather than a live hazard (``compile_surrealdb`` self-groups every boolean
+        node today) — measured at 6 rows becoming 12 if it ever stopped.
         ``created_at`` is a non-optional ``TYPE datetime`` (``schema.py``), so the
         engine rejects ``NONE`` by type and the keyset needs no null guard.
 
@@ -520,8 +666,9 @@ class SurrealDBRelationalAdapter:
         :meth:`list_documents`. See the datetime-binds note at the top of this
         module for why the ISO-string form would ship an ``updated_before``
         returning an empty walk that reports itself exhausted on the first call.
-        The narrowing is otherwise the shape #1586 ships; its NULL-``updated_at``
-        exclusion does not arise, the field being non-optional here.
+        The narrowing is otherwise the shape the raw-SQL siblings ship; its
+        NULL-``updated_at`` exclusion does not arise, the field being
+        non-optional here.
 
         ``filter_ast`` is compiled by the compiler registered for this store's
         ``documents`` target. Only the leaves in ``consumed_keys`` were pushed;
@@ -536,28 +683,36 @@ class SurrealDBRelationalAdapter:
         it is no latency bound. Because ``last_scanned`` is the last *raw* row, a
         resumed step never re-*returns* the rejected gap.
 
-        **It does not follow that a walk is O(namespace) on this store, and it
-        is not.** Any top-level ``OR`` in the ``WHERE`` collapses SurrealDB's
-        planner to a full table scan — measured on 2.x, the keyset disjunction
-        loses not only the ``created_at`` range but the ``namespace_id`` prefix,
-        so ``EXPLAIN`` reports ``Iterate Table`` where the same statement without
-        the disjunction reports ``Iterate Index`` on ``idx_document_ns_created``.
-        Every resumed step therefore re-examines every ``document`` row in the
-        database, **all namespaces included**, and sorts in memory. A full walk
-        is O(rows-in-table x steps), not O(namespace): measured 3.5x wall time
-        for a 2x namespace, and 13x per step from 5k foreign rows the caller can
-        never see. Cost tracks total corpus *bytes*, since a table scan
-        materializes whole records.
+        **A step is namespace-scoped, but it is not O(scan_limit).** Both
+        statements plan ``Iterate Index`` on ``idx_document_ns_created``
+        (``(namespace_id, created_at)``), so a step examines the namespace, not
+        the table: no other tenant's rows are read, and cost no longer tracks
+        total corpus size. What the index does *not* buy is a bounded step —
+        SurrealDB 2.x still materializes and sorts the qualifying set in memory
+        before applying ``LIMIT`` (see :mod:`.schema`), so a step is
+        O(rows-below-the-cursor-in-this-namespace), and a full walk is quadratic
+        in namespace size. ``scan_limit`` bounds rows returned, never rows
+        examined.
 
-        Two workarounds do not help, so do not re-try them: a ``WITH INDEX``
-        hint still plans ``Iterate Table``, and so does a redundant
-        ``created_at <= $ts`` guard alongside the disjunction. Restoring the
-        index means getting the ``OR`` out of the ``WHERE`` — two
-        index-eligible queries (the tie block by equality, then the strictly
-        below range) merged client-side and capped at ``scan_limit``. That buys
-        namespace scoping, not an O(scan_limit) step: 2.x still sorts the
-        qualifying set in memory (see :mod:`.schema`). Tracked as a follow-up;
-        this is a shipped-and-measured limitation, not an unknown.
+        The ``OR``-freedom is the whole mechanism and it is fragile: on this
+        table an ``OR`` anywhere in the ``WHERE``, nested inside a conjunct
+        included, collapses the plan to ``Iterate Table`` and takes the
+        ``namespace_id`` prefix down with it — a cross-tenant scan. The note at
+        the top of this module says exactly when a disjunction can be indexed and
+        why ``document`` never qualifies. Two near-miss workarounds were measured
+        and do **not** restore the index, so do not re-try them: a
+        ``WITH INDEX`` hint still plans ``Iterate Table``, and so does a redundant
+        ``created_at <= $ts`` range guard bracketing a disjunction. Nor does a
+        pure ``created_at <= $ts`` range with the tie resolved client-side: that
+        is index-eligible but re-reads the whole tie block on every step, which is
+        quadratic inside one.
+
+        **Out of scope, and still true:** a compiled filter fragment containing a
+        ``$or`` re-introduces a top-level ``OR`` and table-scans — including on
+        the very first step, which carries no cursor. Nothing here can prevent
+        that; whether an ``$or`` leaf is pushed down or deferred to the caller's
+        post-filter belongs to the compiler and its compile context. The
+        EXPLAIN-pinning tests therefore cover the no-filter shapes only.
 
         The raw-SQLite sibling has no such problem — its row-value keyset is
         consumed as an index range constraint, so there the total-work bound
@@ -589,8 +744,10 @@ class SurrealDBRelationalAdapter:
         stores nanoseconds; the Python SDK truncates to microseconds on read. So a
         cursor read back from a row stored at ``.0000015`` is ``.000001`` — below
         the row's own stored instant — and every row between the two is invisible
-        to both disjuncts at once: not ``created_at < $ts`` (they are above it), not
-        ``created_at = $ts`` (they are not equal to it). Measured on three rows at
+        to both statements at once: not Q2's ``created_at < $ts`` (they are above
+        it), not Q1's ``created_at = $ts`` (they are not equal to it). The split
+        neither introduces nor repairs this; it is the same two comparisons in two
+        statements instead of two disjuncts. Measured on three rows at
         ``.0000015`` / ``.0000012`` / ``.000001``, resuming from the first returned
         an EMPTY window: the walk reports itself exhausted and silently drops the
         entire remainder, rather than dropping one tie-mate. Unreachable through
@@ -600,7 +757,7 @@ class SurrealDBRelationalAdapter:
         Raises ``ValueError`` when ``scan_limit`` is below 1, before anything is
         compiled or executed, so a bad bound is never masked by a compile error;
         also when a compiled filter's binds collide with this method's own (see
-        the splice below), and when the final raw row carries no readable
+        ``_documents_where``), and when the final raw row carries no readable
         ``created_at`` to resume from.
 
         An unrenderable metadata path segment does NOT raise here. Under this
@@ -613,54 +770,58 @@ class SurrealDBRelationalAdapter:
         if scan_limit < 1:
             raise ValueError(f"scan_limit must be >= 1, got {scan_limit}")
 
-        conditions = ["namespace_id = $ns"]
-        params: dict[str, Any] = {"ns": str(namespace_id), "lim": scan_limit}
-        if status:
-            conditions.append("status = $status")
-            params["status"] = status
-        if updated_before is not None:
-            conditions.append("updated_at < $updated_before")
-            params["updated_before"] = updated_before
+        conditions, params, consumed_keys = _documents_where(
+            namespace_id,
+            status=status,
+            updated_before=updated_before,
+            filter_ast=filter_ast,
+        )
+        where = " AND ".join(conditions)
+
+        rows: list[dict[str, Any]] = []
+        remaining = scan_limit
         if after is not None:
             cursor_created_at, cursor_id = after
-            conditions.append("(created_at < $after_created_at OR (created_at = $after_created_at AND id < $after_id))")
-            params["after_created_at"] = cursor_created_at
-            params["after_id"] = _record_id("document", cursor_id)
+            # Q1 — the tie block at the cursor instant. ``ORDER BY id DESC`` is
+            # the whole sort: ``created_at`` is pinned by equality, so ordering on
+            # it too would be dead weight.
+            rows = await self._conn.query(
+                f"SELECT * FROM document WHERE {where} "  # noqa: S608
+                "AND created_at = $after_created_at AND id < $after_id "
+                "ORDER BY id DESC LIMIT $lim",
+                {
+                    **params,
+                    "after_created_at": cursor_created_at,
+                    "after_id": _record_id("document", cursor_id),
+                    "lim": scan_limit,
+                },
+            )
+            remaining = scan_limit - len(rows)
 
-        consumed_keys: frozenset[str] = frozenset()
-        if filter_ast is not None:
-            compiler = CompilerRegistry.get("relational.surrealdb", "documents")
-            # No ``CompileError`` mapping here. Under this context's
-            # ``on_unsupported="split"``, an unrenderable metadata segment is a
-            # capability gap the compiler defers (see
-            # ``_documents_compile_context``), so the only ``CompileError`` left
-            # reaching this line would be a genuine compiler fault — which must
-            # escape as itself rather than be relabelled a caller input problem.
-            compiled = compiler(filter_ast, _documents_compile_context())
-            consumed_keys = compiled.consumed_keys
-            conditions.append(f"({compiled.predicate})")
-            # Compiled binds are ``{param_namespace}_{n}`` — ``f_0``, ``f_1``, …
-            # — and this method's are ``ns`` / ``lim`` / ``status`` /
-            # ``updated_before`` / ``after_*``, so the two families are disjoint
-            # by construction. The invariant runs BOTH ways and neither direction
-            # is safe to break: never name a scan bind ``f_<n>``, and never set
-            # this context's ``param_namespace`` to anything that could produce
-            # ``ns`` / ``lim`` / ``status``. The check below is what stops a
-            # violation from being silent — a compiled ``ns`` bind would overwrite
-            # the tenant scope in ``params`` and return another namespace's rows
-            # with no error anywhere.
-            collisions = params.keys() & compiled.params.keys()
-            if collisions:
-                raise ValueError(f"compiled filter binds collide with scan binds: {sorted(collisions)}")
-            params.update(compiled.params)
+        if remaining > 0:
+            # Q2 — strictly below the cursor instant, or the whole namespace when
+            # there is no cursor. Skipped entirely when Q1 already filled the
+            # window, so a step resumed inside a large tie block costs one
+            # statement. Its own ``LIMIT`` is the shortfall, not ``scan_limit``,
+            # which is what makes ``len(Q1) + len(Q2) <= scan_limit`` hold by
+            # arithmetic — the concatenation needs no trailing slice.
+            older_where = where if after is None else f"{where} AND created_at < $after_created_at"
+            older_params: dict[str, Any] = {**params, "lim": remaining}
+            if after is not None:
+                older_params["after_created_at"] = after[0]
+            rows = rows + await self._conn.query(
+                f"SELECT * FROM document WHERE {older_where} "  # noqa: S608
+                "ORDER BY created_at DESC, id DESC LIMIT $lim",
+                older_params,
+            )
 
-        where = " AND ".join(conditions)
-        rows = await self._conn.query(
-            f"SELECT * FROM document WHERE {where} ORDER BY created_at DESC, id DESC LIMIT $lim",  # noqa: S608
-            params,
-        )
-        # ``last_scanned`` and ``exhausted`` both describe the RAW window: the
-        # final row scanned, and whether SurrealQL ran out of rows filling it.
+        # ``last_scanned`` and ``exhausted`` both describe the RAW window — now
+        # the MERGED one: the final row scanned across both statements, and
+        # whether the pair together ran out of rows filling ``scan_limit``.
+        # ``exhausted`` must be read off the merge and not off either leg: Q1
+        # returning fewer rows than asked is the normal case (a tie block is
+        # usually one row), and calling that exhausted would end every walk after
+        # its first resumed step.
         # Neither may be derived from a post-filtered subset — that would re-scan
         # the rejected gap on resume, and would call a full window exhausted. The
         # key comes from ``rows[-1]``, not from ``docs[-1]``: ``_row_to_document``
@@ -685,23 +846,61 @@ class SurrealDBRelationalAdapter:
         processing_before: datetime,
         limit: int = 100,
     ) -> list[Document]:
-        """Claim stale orphaned documents (no row locking - SurrealDB plain claim)."""
+        """Claim stale orphaned documents (no row locking - SurrealDB plain claim).
+
+        **Two statements, one per status/cutoff pair, merged client-side.** As a
+        single predicate the two pairs need a top-level ``OR``, which costs the
+        statement its indexes on this table, the ``namespace_id`` prefix included
+        (see the disjunction note at the top of this module) — the sweep read
+        every ``document`` row in the database, all namespaces included. Each leg
+        alone plans ``Iterate Index`` on ``idx_document_ns_status``.
+
+        The legs are disjoint by ``status``, so the union is exactly the original
+        row set. Unlike the keyset split in :meth:`scan_documents`, the
+        concatenation is **not** already ordered — either leg can supply any
+        position in ``updated_at`` order — so the merge re-sorts before applying
+        ``limit``. Both legs must therefore fetch the full ``limit``: either one
+        alone can own the whole claim. ``updated_at`` cannot be ``NONE`` on a
+        returned row, the leg predicates having compared it.
+
+        Rows returned, and their ``updated_at`` order, are unchanged. What *can*
+        differ from the single-statement form is which of several rows sharing one
+        ``updated_at`` instant lands inside ``limit`` — measured on a seeded
+        namespace, the two forms returned the same timestamp multiset with one id
+        swapped. The old ``ORDER BY updated_at`` had no secondary key either, so
+        that choice was already arbitrary and is not a contract; the merge's
+        stable sort now makes it at least deterministic, PENDING before
+        PROCESSING.
+
+        **The id de-duplication in the merge is not defensive padding — the split
+        created the race it closes.** At any single instant the legs are disjoint,
+        a row being either PENDING or PROCESSING and never both, so a reader
+        checking the predicates concludes no row can arrive twice. That holds for
+        one statement and not for two: nothing spans them, so a *concurrent*
+        claimer that flips a row PENDING -> PROCESSING between them makes the
+        first leg return it as pending and the second return the same row as
+        processing. Reproduced deterministically by interleaving that flip: a
+        namespace holding one document returned it twice, claiming it twice and
+        spending two of ``limit`` on one row. Keyed on the record id and
+        first-wins, so the row keeps the earlier leg's ``orphan_prior_status`` —
+        the status it actually held when this call observed it.
+        """
         ns_str = str(namespace_id)
-        rows = await self._conn.query(
-            "SELECT * FROM document WHERE namespace_id = $ns AND ("
-            "(status = $pending AND updated_at < $pending_before) OR "
-            "(status = $processing AND updated_at < $processing_before)"
-            ") ORDER BY updated_at LIMIT $lim",
-            {
-                "ns": ns_str,
-                "pending": DocumentStatus.PENDING.value,
-                "processing": DocumentStatus.PROCESSING.value,
-                "pending_before": pending_before,
-                "processing_before": processing_before,
-                "lim": limit,
-            },
+        legs = (
+            (DocumentStatus.PENDING.value, pending_before),
+            (DocumentStatus.PROCESSING.value, processing_before),
         )
-        docs = [self._row_to_document(r) for r in rows]
+        by_id: dict[str, dict[str, Any]] = {}
+        for status_value, cutoff in legs:
+            for row in await self._conn.query(
+                "SELECT * FROM document WHERE namespace_id = $ns "
+                "AND status = $status AND updated_at < $cutoff "
+                "ORDER BY updated_at LIMIT $lim",
+                {"ns": ns_str, "status": status_value, "cutoff": cutoff, "lim": limit},
+            ):
+                by_id.setdefault(str(row["id"]), row)
+        rows = sorted(by_id.values(), key=lambda r: _parse_dt(r["updated_at"]) or datetime.max.replace(tzinfo=UTC))
+        docs = [self._row_to_document(r) for r in rows[:limit]]
         if not docs:
             return []
         # Both cutoffs above and this stamp bind as ``datetime`` objects. As ISO
@@ -842,16 +1041,23 @@ class SurrealDBRelationalAdapter:
         older than that cutoff are also excluded so a crash-abandoned
         half-ingest (#1464) re-ingests; fresh PENDING rows stay a dedup hit,
         preserving the concurrent in-flight guard.
+
+        Probes one index-eligible leg at a time (see
+        ``_checksum_reingestable_legs``) and stops at the first hit, so the common
+        settled-document case costs one statement. The legs are disjoint, so which
+        one answers does not change the row set — only which of several rows
+        sharing a checksum an unordered ``LIMIT 1`` happens to surface, and that
+        was already unordered.
         """
         ns_str = str(namespace_id)
-        where, binds = _checksum_reingestable_clause(pending_stale_before)
-        row = await self._conn.query_one(
-            f"SELECT * FROM document WHERE namespace_id = $ns AND checksum = $checksum AND {where} LIMIT 1",  # noqa: S608
-            {"ns": ns_str, "checksum": checksum, **binds},
-        )
-        if row is None:
-            return None
-        return self._row_to_document(row)
+        for where, binds in _checksum_reingestable_legs(pending_stale_before):
+            row = await self._conn.query_one(
+                f"SELECT * FROM document WHERE namespace_id = $ns AND checksum = $checksum AND {where} LIMIT 1",  # noqa: S608
+                {"ns": ns_str, "checksum": checksum, **binds},
+            )
+            if row is not None:
+                return self._row_to_document(row)
+        return None
 
     async def get_document_by_external_id(self, external_id: str | None, *, namespace_id: UUID) -> Document | None:
         """Get a document by (namespace_id, external_id).
@@ -887,23 +1093,38 @@ class SurrealDBRelationalAdapter:
             checksums: List of content checksums to look up
             pending_stale_before: Cutoff for reclaiming stale PENDING half-ingests
 
+        One index-eligible statement per leg (see
+        ``_checksum_reingestable_legs``), accumulated into one mapping. Unlike the
+        single-row probe, both legs always run: a batch needs every checksum
+        answered, and the two legs cover different rows.
+
+        **First write wins, and that is what keeps this method agreeing with**
+        :meth:`get_document_by_checksum`. The legs are disjoint by ``status``, but
+        the *checksums* they return are not: ``(namespace_id, checksum)`` carries
+        no unique constraint, so one checksum can have both a settled row (leg A)
+        and a fresh-PENDING row (leg B). Under plain last-wins the later leg would
+        take it — handing the batch caller the in-flight row while the single-row
+        probe, which stops at its first hit, hands back the settled one. Two dedup
+        entry points disagreeing about the same checksum is the kind of split that
+        surfaces as a phantom duplicate ingest much later, so both resolve it the
+        same way: leg order is precedence, settled ahead of in-flight.
+
         Returns:
             Dictionary mapping checksum to Document (only for existing documents)
         """
         if not checksums:
             return {}
         ns_str = str(namespace_id)
-        where, binds = _checksum_reingestable_clause(pending_stale_before)
-        rows = await self._conn.query(
-            f"SELECT * FROM document WHERE namespace_id = $ns AND checksum IN $checksums AND {where}",  # noqa: S608
-            {"ns": ns_str, "checksums": checksums, **binds},
-        )
         result: dict[str, Document] = {}
-        for r in rows:
-            doc = self._row_to_document(r)
-            cs = r.get("checksum", "")
-            if cs:
-                result[cs] = doc
+        for where, binds in _checksum_reingestable_legs(pending_stale_before):
+            rows = await self._conn.query(
+                f"SELECT * FROM document WHERE namespace_id = $ns AND checksum IN $checksums AND {where}",  # noqa: S608
+                {"ns": ns_str, "checksums": checksums, **binds},
+            )
+            for r in rows:
+                cs = r.get("checksum", "")
+                if cs and cs not in result:
+                    result[cs] = self._row_to_document(r)
         return result
 
     async def get_documents_batch(self, document_ids: list[UUID], *, namespace_id: UUID) -> dict[UUID, Document]:

--- a/tests/integration/storage/backends/surrealdb/test_relational_scan_documents.py
+++ b/tests/integration/storage/backends/surrealdb/test_relational_scan_documents.py
@@ -8,12 +8,17 @@ This leg is not a transcription of the SQLAlchemy pair (khora #1586). Three
 things are structurally different on this store and each gets its own coverage
 below:
 
-* **The keyset predicate is two clauses, not a row-value compare.** SurrealQL
-  has no ``(a, b) < (x, y)``, so the resume position is expressed as
-  ``created_at < $ts OR (created_at = $ts AND id < $id)`` — a top-level ``OR``
-  sitting in a ``WHERE`` that also carries the namespace scope. That makes
-  *grouping* a correctness property of this store rather than a style choice,
-  and it makes mid-tie resume the interesting case.
+* **The keyset predicate is two STATEMENTS, not a row-value compare.** SurrealQL
+  has no ``(a, b) < (x, y)``, and written out as one predicate the resume
+  position needs an ``OR`` — which this store's planner answers by dropping to a
+  full table scan, namespace prefix included. So a resumed step issues the tie
+  block (``created_at = $ts AND id < $id``) and the strictly-older range
+  (``created_at < $ts``) as two ``OR``-free queries and concatenates them; see
+  ``scan_documents``. Mid-tie resume is therefore the interesting case here, and
+  several tests below still reason in terms of the old single-``WHERE`` shape
+  because that is the hazard they were written against — their assertions are on
+  rows and hold either way. The plan-level guards live in
+  ``tests/unit/storage/backends/surrealdb/test_document_query_plans.py``.
 * **``id`` is a ``RecordID``, not a UUID column.** ``id < $rid`` is a record-id
   compare, and nothing outside these tests establishes that it agrees with the
   statement's own ``ORDER BY id DESC``. It was the ticket's highest-risk
@@ -1093,15 +1098,20 @@ async def test_ungrouped_or_fragment_cannot_absorb_the_namespace_scope(adapter, 
 
 
 async def test_ungrouped_keyset_disjunction_cannot_absorb_the_namespace_scope(adapter, namespace) -> None:
-    """The parentheses around the keyset disjunction are load-bearing too.
+    """A resumed step must not read another tenant's tie block.
 
-    This is the store-specific half of the same hazard. SurrealQL has no
-    row-value comparison, so the resume predicate is a top-level ``OR``:
-    ``created_at < $ts OR (created_at = $ts AND id < $id)``. Ungrouped, the
-    namespace scope is absorbed into the left disjunct and the right one —
-    ``created_at = $ts AND id < $cursor_id`` — reads every tenant's tie block.
-    The SQLAlchemy stores cannot have this bug at all; it exists only because the
-    predicate had to be written out by hand here.
+    **The name is historical and the mechanism it names is gone.** This was
+    written against a resume predicate that was a single top-level ``OR``
+    (``created_at < $ts OR (created_at = $ts AND id < $id)``), where the
+    parentheses were load-bearing: ungrouped, the namespace scope was absorbed
+    into the left disjunct and the right one — ``created_at = $ts AND
+    id < $cursor_id`` — read every tenant's tie block. There is no disjunction to
+    group any more; the resume is two ``OR``-free statements, each independently
+    namespace-scoped, so the shape this guards against is now unrepresentable
+    rather than merely avoided. What the assertions check is the outcome, not the
+    mechanism, so they are kept as-is: a future rewrite that reintroduces a
+    hand-written predicate is exactly what should trip here. The seed and the
+    mutation numbers below describe the pre-split code.
 
     The seed is built by :func:`_two_namespace_ladders` so the foreign ids sort
     BELOW the cursor deterministically. That is not cosmetic: measured, with the

--- a/tests/unit/storage/backends/surrealdb/test_document_query_plans.py
+++ b/tests/unit/storage/backends/surrealdb/test_document_query_plans.py
@@ -1,0 +1,670 @@
+"""Every ``document`` read this adapter issues must plan ``Iterate Index``.
+
+An ``OR`` anywhere in a ``document`` ``WHERE`` — top-level or nested inside a
+conjunct — collapses the planner to ``Iterate Table``, and the collapse does not
+stop at the predicate that caused it: the ``namespace_id`` index prefix goes too,
+so the statement reads every ``document`` row in the database, all tenants
+included. Three adapter reads used to be written that way (the keyset resume in
+``scan_documents``, the checksum-dedup exclusion, the orphan-claim sweep) and each
+is now a set of ``OR``-free legs merged in Python.
+
+The scope of that claim is the ``document`` table, not SurrealDB in general.
+2.x *can* union index scans across a disjunction, but only when every disjunct
+is a comparison on a **single-field** index; ``document`` carries composite
+``(namespace_id, …)`` indexes and nothing else, so no disjunct on it ever
+qualifies. The disjunction note atop
+``khora/storage/backends/surrealdb/relational.py`` has the measurements, and
+``test_the_replaced_disjunctive_shapes_really_do_table_scan`` below keeps the
+premise honest against a future engine.
+
+**These tests do not retype the SQL.** They drive the real adapter methods
+through a recording connection, then re-issue each captured statement verbatim
+with ``EXPLAIN`` appended. A future edit that reintroduces an ``OR`` — or that
+adds a fourth statement to one of these paths — is covered without anyone
+remembering to update a literal here.
+
+Scope, deliberately: the ``filter_ast`` shapes are NOT pinned. A legal filter
+fragment containing ``$or`` compiles to a real ``OR`` and table-scans, which this
+change does not address and cannot; see the complexity note on
+``scan_documents``. Pinning a filtered plan would encode that gap as a
+requirement.
+
+They run against ``memory://`` — no server, no docker.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+pytest.importorskip("surrealdb")
+
+from khora.core.models import MemoryNamespace, TenancyMode  # noqa: E402
+from khora.core.models.document import Document, DocumentStatus  # noqa: E402
+from khora.storage.backends.surrealdb._helpers import _record_id  # noqa: E402
+from khora.storage.backends.surrealdb.connection import SurrealDBConnection  # noqa: E402
+from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+_BASE = datetime(2026, 3, 1, tzinfo=UTC)
+
+
+class _RecordingConnection:
+    """Pass-through wrapper that keeps every ``(sql, params)`` the adapter issues.
+
+    Only the two read entry points are intercepted; everything else (``connect``,
+    ``execute``, the seeding path) forwards untouched via ``__getattr__``, so the
+    adapter is exercised exactly as in production.
+    """
+
+    def __init__(self, conn: SurrealDBConnection) -> None:
+        self._conn = conn
+        self.statements: list[tuple[str, dict[str, Any]]] = []
+
+    async def query(self, sql: str, params: dict[str, Any] | None = None) -> Any:
+        self.statements.append((sql, params or {}))
+        return await self._conn.query(sql, params)
+
+    async def query_one(self, sql: str, params: dict[str, Any] | None = None) -> Any:
+        self.statements.append((sql, params or {}))
+        return await self._conn.query_one(sql, params)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._conn, name)
+
+    def reset(self) -> None:
+        self.statements.clear()
+
+    def selects(self) -> list[tuple[str, dict[str, Any]]]:
+        """Recorded ``SELECT``s only — the writes a claim issues are not plans."""
+        return [(sql, params) for sql, params in self.statements if sql.lstrip().upper().startswith("SELECT")]
+
+
+@pytest.fixture
+async def recorder():
+    conn = SurrealDBConnection(mode="memory", namespace="khora_test", database="plans")
+    await conn.connect()
+    recording = _RecordingConnection(conn)
+    try:
+        yield recording
+    finally:
+        await conn.disconnect()
+
+
+@pytest.fixture
+async def seeded(recorder):
+    """An adapter over a namespace holding rows in every status, plus a foreign one.
+
+    A populated table matters: the point of the assertion is that the planner
+    *chose* an index, and rows are what give it something to choose over. The
+    foreign namespace is what a regression would leak into.
+    """
+    adapter = SurrealDBRelationalAdapter(recorder)
+    namespaces = []
+    for _ in range(2):
+        nid = uuid4()
+        namespaces.append(
+            await adapter.create_namespace(MemoryNamespace(id=nid, namespace_id=nid, tenancy_mode=TenancyMode.SHARED))
+        )
+    statuses = list(DocumentStatus)
+    for target in namespaces:
+        for i in range(24):
+            # Three rows per instant, so a resumed scan lands inside a tie block.
+            await adapter.create_document(
+                Document(
+                    namespace_id=target.namespace_id,
+                    content=f"body {i}",
+                    title=f"doc {i}",
+                    source_type="library",
+                    checksum=f"cs{i:03d}",
+                    status=statuses[i % len(statuses)],
+                    created_at=_BASE + timedelta(minutes=i // 3),
+                    updated_at=_BASE + timedelta(minutes=i // 3),
+                )
+            )
+    recorder.reset()
+    return adapter, namespaces[0].namespace_id
+
+
+async def _explain(recorder: _RecordingConnection, *, expected_statements: int, label: str) -> list[Any]:
+    """Re-issue every recorded ``SELECT`` verbatim with ``EXPLAIN``; return the plans.
+
+    Returns one plan per captured statement, in issue order. Each caller asserts
+    what its own shape is supposed to have used.
+    """
+    recorded = recorder.selects()
+    assert len(recorded) == expected_statements, (
+        f"{label}: expected {expected_statements} SELECT(s), captured {len(recorded)}:\n"
+        + "\n".join(sql for sql, _ in recorded)
+    )
+    plans = []
+    for sql, params in recorded:
+        plan: Any = await recorder._conn.query(f"{sql} EXPLAIN", params)
+        plans.append((sql, plan))
+    return plans
+
+
+def _assert_indexed(sql: str, plan: Any, *, index: str | None, label: str) -> dict[str, Any]:
+    """Require an index scan, optionally on a named index. Returns the seek detail.
+
+    ``index=None`` means "any namespace-scoped composite" and is used for the one
+    shape whose winner is decided by a name-ordered planner tie-break rather than
+    by the predicate — pinning that would harden an undocumented tie-break into a
+    test, which the sibling ``test_document_sort_index`` module already declines
+    to do.
+    """
+    iterate = plan[0]
+    assert iterate["operation"] == "Iterate Index", (
+        f"{label}: statement fell back to a full table scan — it reads every document row "
+        f"in the database, all namespaces included. An OR anywhere in a document WHERE "
+        f"does this, whatever its shape.\n  sql:  {sql}\n  plan: {plan}"
+    )
+    chosen = iterate["detail"]["plan"]["index"]
+    if index is None:
+        assert chosen.startswith("idx_document_ns"), f"{label}: not a namespace-scoped index ({chosen})\n  sql: {sql}"
+    else:
+        assert chosen == index, f"{label}: expected {index}, planner chose {chosen}\n  sql: {sql}\n  plan: {plan}"
+    return iterate["detail"]["plan"]
+
+
+# --------------------------------------------------------------------------- #
+# scan_documents
+# --------------------------------------------------------------------------- #
+
+
+async def test_first_scan_step_plans_an_index_scan(seeded, recorder) -> None:
+    """The un-resumed step is one statement, seeking on the namespace prefix.
+
+    The index is left unpinned here alone: with no cursor there is no second
+    column to constrain, so every ``(namespace_id, …)`` composite is equally
+    applicable and the winner falls to a name-ordered tie-break. What IS pinned is
+    that the seek is the namespace equality — a plan that reached the index some
+    other way would not scope the read to one tenant.
+    """
+    adapter, ns = seeded
+    step = await adapter.scan_documents(ns, scan_limit=5)
+    assert step.documents, "fixture produced no rows to plan over"
+    ((sql, plan),) = await _explain(recorder, expected_statements=1, label="scan step 1")
+    seek = _assert_indexed(sql, plan, index=None, label="scan step 1")
+    assert seek.get("operator") == "=" and seek.get("value") == str(ns), (
+        f"first step did not seek on the namespace equality: {seek}"
+    )
+
+
+async def test_resumed_scan_step_seeks_the_cursor_through_the_index_on_both_statements(seeded, recorder) -> None:
+    """Both resumed statements use ``idx_document_ns_created``, cursor bound included.
+
+    ``Iterate Index`` alone is too weak an assertion to rest this fix on: a plan
+    that seeks the namespace prefix and then evaluates the cursor as a residual
+    filter also prints ``Iterate Index``, while still reading the whole namespace.
+    So the seek detail is asserted, and the two statements want different shapes:
+    the tie query pins BOTH index columns by equality (``operator '='`` over a
+    two-element ``(namespace, instant)`` value), and the range query pins the
+    namespace as a ``prefix`` and carries a real ``<`` entry in ``ranges``.
+
+    The window must be wider than the tie block the cursor sits in, or the tie
+    query fills it and the range query is skipped by design — the sibling test
+    below pins that shortcut. The fixture holds three rows per instant and 24 in
+    total, so resuming at ``scan_limit=100`` guarantees both statements run.
+    """
+    adapter, ns = seeded
+    first = await adapter.scan_documents(ns, scan_limit=1)
+    recorder.reset()
+    resumed = await adapter.scan_documents(ns, after=first.last_scanned, scan_limit=100)
+    assert len(resumed.documents) > 2, (
+        f"resumed step stayed inside the tie block ({len(resumed.documents)} rows); "
+        "the strictly-older query was never reached"
+    )
+    (tie_sql, tie_plan), (range_sql, range_plan) = await _explain(
+        recorder, expected_statements=2, label="resumed scan step"
+    )
+
+    tie_seek = _assert_indexed(tie_sql, tie_plan, index="idx_document_ns_created", label="tie query")
+    assert tie_seek.get("operator") == "=", f"tie query is not an equality seek: {tie_seek}"
+    assert isinstance(tie_seek.get("value"), list) and len(tie_seek["value"]) == 2, (
+        f"tie query pinned only part of the index key — the cursor instant is being "
+        f"evaluated as a residual filter, so the step still reads the namespace: {tie_seek}"
+    )
+    assert tie_seek["value"][0] == str(ns), f"tie query seek is not namespace-led: {tie_seek}"
+
+    range_seek = _assert_indexed(range_sql, range_plan, index="idx_document_ns_created", label="range query")
+    assert range_seek.get("prefix") == [str(ns)], (
+        f"range query did not seek the namespace as an index prefix: {range_seek}"
+    )
+    assert [r["operator"] for r in range_seek.get("ranges", [])] == ["<"], (
+        f"range query has no '<' bound in the index range — the cursor is a residual "
+        f"filter and the step still reads the whole namespace: {range_seek}"
+    )
+
+
+async def test_both_resumed_statements_are_namespace_scoped(seeded, recorder) -> None:
+    """The tenant conjunct must reach BOTH legs, in the text and in the binds.
+
+    A narrowing that lands in only one leg makes that leg's window diverge, and
+    for ``namespace_id`` specifically it re-creates the exact cross-tenant read
+    this whole change exists to remove — half a resumed window coming back
+    unscoped. Cheap to assert, catastrophic to miss, and not covered by the row
+    assertions in the integration suite unless a foreign row happens to sort into
+    the window.
+    """
+    adapter, ns = seeded
+    first = await adapter.scan_documents(ns, scan_limit=1)
+    recorder.reset()
+    await adapter.scan_documents(ns, after=first.last_scanned, scan_limit=100)
+    recorded = recorder.selects()
+    assert len(recorded) == 2, [sql for sql, _ in recorded]
+    for sql, params in recorded:
+        assert "namespace_id = $ns" in sql, f"leg is not namespace-scoped:\n{sql}"
+        assert params["ns"] == str(ns), f"leg bound the wrong namespace: {params.get('ns')!r} != {str(ns)!r}"
+
+
+async def test_resumed_step_skips_the_range_query_when_the_tie_block_fills_it(seeded, recorder) -> None:
+    """A step satisfied inside the tie block costs one statement, not two.
+
+    The fixture puts three rows on each instant. Resuming from the first of them
+    at ``scan_limit=1`` leaves two tie-mates, so the tie query fills the window on
+    its own and the range query must not be issued.
+    """
+    adapter, ns = seeded
+    first = await adapter.scan_documents(ns, scan_limit=1)
+    recorder.reset()
+    step = await adapter.scan_documents(ns, after=first.last_scanned, scan_limit=1)
+    assert len(step.documents) == 1
+    assert len(recorder.selects()) == 1, (
+        "the strictly-older query ran even though the tie block already filled the window:\n"
+        + "\n".join(sql for sql, _ in recorder.selects())
+    )
+
+
+@pytest.mark.parametrize("scan_limit", [1, 2, 3, 4, 5, 6, 7])
+async def test_a_resumed_step_never_returns_more_than_scan_limit(seeded, recorder, scan_limit) -> None:
+    """The two statements together must not overfill the window.
+
+    This is the arithmetic that replaces a trailing slice: the strictly-older
+    query runs with ``scan_limit - len(tie rows)``, not ``scan_limit``. Giving it
+    the full limit is an easy and completely silent regression — it only shows up
+    when the cursor sits inside a non-empty tie block, which a fixture with one
+    row per instant never produces. Hence three rows per instant here, and
+    ``raw_row_count`` asserted alongside the document count: ``exhausted`` is
+    derived from the former, so an overfilled raw window also corrupts
+    termination.
+    """
+    adapter, ns = seeded
+    first = await adapter.scan_documents(ns, scan_limit=1)
+    step = await adapter.scan_documents(ns, after=first.last_scanned, scan_limit=scan_limit)
+    assert len(step.documents) <= scan_limit, (
+        f"step returned {len(step.documents)} documents for scan_limit={scan_limit}; "
+        "the strictly-older query was given the full limit instead of the shortfall"
+    )
+
+
+@pytest.mark.parametrize("scan_limit", [1, 2, 3, 4, 7, 50])
+async def test_a_walk_over_tied_rows_visits_every_document_exactly_once(seeded, recorder, scan_limit) -> None:
+    """End to end over a namespace whose rows are three-deep on every instant.
+
+    The split's whole correctness claim is that concatenating the tie query's
+    rows in front of the strictly-older query's rows reproduces the single
+    disjunctive window exactly. Tie blocks are where that can fail — skipping a
+    tie-mate, or re-returning one — and a fixture with one row per instant cannot
+    see either. The foreign namespace seeded alongside is the cross-tenant guard.
+    """
+    adapter, ns = seeded
+    seen: list[UUID] = []
+    after = None
+    for _ in range(200):
+        step = await adapter.scan_documents(ns, after=after, scan_limit=scan_limit)
+        seen.extend(d.id for d in step.documents)
+        if step.exhausted:
+            break
+        after = step.last_scanned
+    else:  # pragma: no cover - only reached if the walk fails to terminate
+        pytest.fail(f"walk did not terminate within 200 steps at scan_limit={scan_limit}")
+
+    assert len(seen) == len(set(seen)), f"walk returned duplicates at scan_limit={scan_limit}"
+    total = await adapter.count_documents(ns)
+    assert len(seen) == total, f"walk saw {len(seen)}/{total} documents at scan_limit={scan_limit}"
+
+
+async def test_status_and_updated_before_narrow_both_scan_statements(seeded, recorder) -> None:
+    """The shared conjuncts reach the tie query as well as the range query.
+
+    A narrowing carried by only one of the two would silently widen half of every
+    resumed window — rows the caller excluded coming back from whichever statement
+    dropped the conjunct.
+    """
+    adapter, ns = seeded
+    first = await adapter.scan_documents(
+        ns, status=DocumentStatus.COMPLETED.value, updated_before=_BASE + timedelta(hours=1), scan_limit=1
+    )
+    recorder.reset()
+    await adapter.scan_documents(
+        ns,
+        status=DocumentStatus.COMPLETED.value,
+        updated_before=_BASE + timedelta(hours=1),
+        after=first.last_scanned,
+        scan_limit=100,
+    )
+    recorded = recorder.selects()
+    assert len(recorded) == 2, [sql for sql, _ in recorded]
+    for sql, params in recorded:
+        assert "status = $status" in sql, sql
+        assert "updated_at < $updated_before" in sql, sql
+        assert params["status"] == DocumentStatus.COMPLETED.value
+    for sql, plan in await _explain(recorder, expected_statements=2, label="narrowed resumed step"):
+        _assert_indexed(sql, plan, index=None, label="narrowed resumed step")
+
+
+async def test_no_scan_statement_contains_a_disjunction(seeded, recorder) -> None:
+    """A source-level tripwire the ``EXPLAIN`` assertions cannot replace.
+
+    ``EXPLAIN`` reports the plan the engine picked on *this* engine version. If a
+    later SurrealDB learned to index a disjunction, the plan assertions above
+    would go green while the statement quietly regained an ``OR`` that older
+    deployments still table-scan. This checks the text instead.
+    """
+    adapter, ns = seeded
+    first = await adapter.scan_documents(ns, scan_limit=1)
+    await adapter.scan_documents(ns, after=first.last_scanned, scan_limit=100)
+    for sql, _ in recorder.selects():
+        assert " OR " not in sql.upper(), f"a disjunction is back in a scan statement:\n{sql}"
+
+
+# --------------------------------------------------------------------------- #
+# checksum dedup
+# --------------------------------------------------------------------------- #
+
+
+async def test_checksum_dedup_legs_plan_index_scans(seeded, recorder) -> None:
+    """The single-row dedup probe is index-eligible on every leg it runs.
+
+    ``pending_stale_before`` is set on the production ingest path, which is the
+    configuration that used to make every ``remember()`` full-scan ``document``.
+    The checksum chosen is a FAILED row so neither leg short-circuits and both are
+    captured.
+    """
+    adapter, ns = seeded
+    failed_checksum = f"cs{list(DocumentStatus).index(DocumentStatus.FAILED):03d}"
+    hit = await adapter.get_document_by_checksum(ns, failed_checksum, pending_stale_before=_BASE + timedelta(minutes=5))
+    assert hit is None, "fixture checksum is not a FAILED-only row; both legs would not run"
+    plans = await _explain(recorder, expected_statements=2, label="dedup probe")
+    settled_sql, settled_plan = plans[0]
+    settled = _assert_indexed(settled_sql, settled_plan, index="idx_document_ns_checksum", label="dedup leg A")
+    assert settled.get("value") == [str(ns), failed_checksum], (
+        f"settled leg did not seek (namespace, checksum) — the checksum is a residual "
+        f"filter and the probe still reads the namespace: {settled}"
+    )
+    # Leg B leads on ``status`` equality, so the planner prefers the status
+    # composite over the checksum one; either is namespace-scoped, which is the
+    # property that matters, so the name is not pinned for this leg.
+    _assert_indexed(plans[1][0], plans[1][1], index=None, label="dedup leg B")
+
+
+async def test_checksum_dedup_probe_stops_at_the_first_leg_that_hits(seeded, recorder) -> None:
+    """A settled document is answered by one statement."""
+    adapter, ns = seeded
+    completed_checksum = f"cs{list(DocumentStatus).index(DocumentStatus.COMPLETED):03d}"
+    hit = await adapter.get_document_by_checksum(
+        ns, completed_checksum, pending_stale_before=_BASE + timedelta(minutes=5)
+    )
+    assert hit is not None
+    assert len(recorder.selects()) == 1, [sql for sql, _ in recorder.selects()]
+
+
+async def test_batch_checksum_dedup_legs_plan_index_scans(seeded, recorder) -> None:
+    """The batch form runs both legs — a batch needs every checksum answered."""
+    adapter, ns = seeded
+    found = await adapter.get_documents_by_checksums(
+        ns, [f"cs{i:03d}" for i in range(24)], pending_stale_before=_BASE + timedelta(minutes=5)
+    )
+    assert found, "fixture produced no dedup hits"
+    for sql, plan in await _explain(recorder, expected_statements=2, label="batch dedup"):
+        _assert_indexed(sql, plan, index=None, label="batch dedup")
+
+
+async def test_both_dedup_entry_points_agree_when_one_checksum_matches_both_legs(seeded, recorder) -> None:
+    """A checksum with a settled row AND a fresh-PENDING row resolves the same way.
+
+    ``(namespace_id, checksum)`` has no unique constraint, so both legs can return
+    a row for one checksum. The single-row probe stops at the first hit and yields
+    the settled row; a batch built with plain last-wins would yield the PENDING
+    one, because its leg runs second. Two dedup entry points disagreeing about the
+    same checksum is how a phantom duplicate ingest gets born, so both apply leg
+    order as precedence.
+
+    Not reachable from the shared fixture (its checksums are one row each), so the
+    pair is seeded here.
+    """
+    adapter, ns = seeded
+    for title, status, updated_at in (
+        ("settled", DocumentStatus.COMPLETED, _BASE),
+        ("fresh-pending", DocumentStatus.PENDING, _BASE + timedelta(hours=1)),
+    ):
+        await adapter.create_document(
+            Document(
+                namespace_id=ns,
+                content="x",
+                title=title,
+                source_type="library",
+                checksum="shared-checksum",
+                status=status,
+                created_at=_BASE,
+                updated_at=updated_at,
+            )
+        )
+    # Cutoff between the two, so the PENDING row is FRESH and both legs match.
+    cutoff = _BASE + timedelta(minutes=30)
+    single = await adapter.get_document_by_checksum(ns, "shared-checksum", pending_stale_before=cutoff)
+    batch = await adapter.get_documents_by_checksums(ns, ["shared-checksum"], pending_stale_before=cutoff)
+
+    assert single is not None and "shared-checksum" in batch
+    assert single.id == batch["shared-checksum"].id, (
+        f"dedup entry points disagree: probe returned {single.title!r}, "
+        f"batch returned {batch['shared-checksum'].title!r}"
+    )
+    assert single.title == "settled", f"settled row must outrank the in-flight one, got {single.title!r}"
+
+
+async def test_a_concurrent_status_flip_between_legs_cannot_double_claim(seeded, recorder) -> None:
+    """The orphan split's own race: one row returned by both legs must claim once.
+
+    At any single instant the legs are disjoint — a row is PENDING or PROCESSING,
+    never both — which is exactly why this looks impossible and is not. Nothing
+    spans the two statements, so a concurrent claimer flipping a row
+    PENDING -> PROCESSING in between makes leg one return it as pending and leg
+    two return the same row as processing. The single statement it replaced could
+    not do this; the id de-duplication in the merge is what closes it.
+
+    The flip is injected deterministically between the two SELECTs rather than
+    raced for.
+    """
+    adapter, ns = seeded
+    victim = await adapter.create_document(
+        Document(
+            namespace_id=ns,
+            content="x",
+            title="racy",
+            source_type="library",
+            status=DocumentStatus.PENDING,
+            created_at=_BASE,
+            updated_at=_BASE,
+        )
+    )
+    real_query = recorder._conn.query
+    state = {"selects": 0}
+
+    async def flipping_query(sql: str, params: Any = None) -> Any:
+        rows = await real_query(sql, params)
+        if sql.lstrip().upper().startswith("SELECT") and "status = $status" in sql:
+            state["selects"] += 1
+            if state["selects"] == 1:  # between the PENDING leg and the PROCESSING leg
+                # ``_record_id`` and nothing else: khora writes every document id
+                # as ``document:⟨uuid⟩``, and ``type::thing('document', <str>)``
+                # builds ``document:u'…'`` — a DIFFERENT record. Addressing the
+                # wrong one makes this test pass vacuously (verified: the id
+                # de-duplication mutant survives when the flip misses).
+                await real_query("UPDATE $rid SET status = 'processing'", {"rid": _record_id("document", victim.id)})
+        return rows
+
+    recorder._conn.query = flipping_query  # type: ignore[method-assign]
+    try:
+        claimed = await adapter.claim_orphaned_documents(
+            ns,
+            pending_before=_BASE + timedelta(hours=1),
+            processing_before=_BASE + timedelta(hours=1),
+            limit=50,
+        )
+    finally:
+        recorder._conn.query = real_query  # type: ignore[method-assign]
+
+    assert state["selects"] == 2, f"the flip was not injected between two legs ({state['selects']} selects)"
+    ids = [d.id for d in claimed]
+    assert len(ids) == len(set(ids)), f"a row was claimed twice across the two legs: {sorted(ids)}"
+    assert ids.count(victim.id) == 1, f"the flipped row appears {ids.count(victim.id)}x, expected once"
+
+
+async def test_legacy_dedup_without_a_stale_cutoff_is_one_indexed_statement(seeded, recorder) -> None:
+    """``pending_stale_before=None`` keeps its single-clause shape."""
+    adapter, ns = seeded
+    await adapter.get_documents_by_checksums(ns, ["cs000"], pending_stale_before=None)
+    ((sql, plan),) = await _explain(recorder, expected_statements=1, label="legacy dedup")
+    _assert_indexed(sql, plan, index="idx_document_ns_checksum", label="legacy dedup")
+
+
+# --------------------------------------------------------------------------- #
+# orphan claim
+# --------------------------------------------------------------------------- #
+
+
+async def test_orphan_claim_legs_plan_index_scans(seeded, recorder) -> None:
+    """Both status legs of the orphan sweep are index-eligible."""
+    adapter, ns = seeded
+    cutoff = _BASE + timedelta(hours=1)
+    claimed = await adapter.claim_orphaned_documents(ns, pending_before=cutoff, processing_before=cutoff, limit=5)
+    assert claimed, "fixture produced no claimable rows"
+    seeks = []
+    for sql, plan in await _explain(recorder, expected_statements=2, label="orphan claim"):
+        seek = _assert_indexed(sql, plan, index="idx_document_ns_status", label="orphan claim")
+        assert seek.get("operator") == "=", f"orphan leg is not an equality seek: {seek}"
+        seeks.append(seek.get("value"))
+    # Both index columns are pinned by equality. ``updated_at`` is deliberately
+    # NOT in this index, so the cutoff stays a residual filter over the
+    # (namespace, status) slice — which is fine, and is the honest claim: the
+    # index buys tenant+status scoping, not a time-bounded seek.
+    assert seeks == [
+        [str(ns), DocumentStatus.PENDING.value],
+        [str(ns), DocumentStatus.PROCESSING.value],
+    ], f"orphan legs did not seek (namespace, status) per status: {seeks}"
+
+
+async def test_orphan_claim_returns_the_oldest_rows_in_updated_at_order(seeded, recorder) -> None:
+    """The client-side merge reproduces the single statement's ordering contract.
+
+    The legs are ordered independently, so concatenating them would interleave
+    wrongly; only the re-sort makes ``limit`` mean "the oldest ``limit`` stale
+    rows" as it did before. Timestamps, not ids, are asserted: ties among equal
+    ``updated_at`` were resolved arbitrarily by the old ``ORDER BY updated_at``
+    too, and are not a contract.
+    """
+    adapter, ns = seeded
+    cutoff = _BASE + timedelta(hours=1)
+    everything = await adapter.claim_orphaned_documents(ns, pending_before=cutoff, processing_before=cutoff, limit=500)
+    assert len(everything) > 4, "fixture is too small to distinguish a merge from a concatenation"
+    # Reconstructed from ``orphan_prior_status``: the claim overwrites both status
+    # and updated_at on what it returns, so the pre-claim order is read off the
+    # created_at ladder the fixture wrote in lockstep with updated_at.
+    ladder = [d.created_at for d in everything]
+    assert ladder == sorted(ladder), f"claim did not return rows oldest-first: {ladder}"
+
+    statuses = {d.orphan_prior_status for d in everything}
+    assert statuses == {DocumentStatus.PENDING.value, DocumentStatus.PROCESSING.value}, (
+        f"both legs must contribute or the merge is untested: {statuses}"
+    )
+
+
+async def test_orphan_claim_limit_takes_the_oldest_across_both_legs(seeded, recorder) -> None:
+    """``limit`` bounds the merged set, not each leg.
+
+    Fetching ``limit`` per leg and slicing after the merge is what makes this
+    hold; slicing per leg would return up to ``2 * limit`` rows, and taking
+    ``limit // 2`` from each would miss older rows whenever one status dominates.
+    """
+    adapter, ns = seeded
+    cutoff = _BASE + timedelta(hours=1)
+    limited = await adapter.claim_orphaned_documents(ns, pending_before=cutoff, processing_before=cutoff, limit=3)
+    assert len(limited) == 3, [d.created_at for d in limited]
+
+
+async def test_orphan_claim_respects_each_status_cutoff_independently(seeded, recorder) -> None:
+    """Splitting the pairs must not cross-apply the cutoffs."""
+    adapter, ns = seeded
+    claimed = await adapter.claim_orphaned_documents(
+        ns,
+        pending_before=_BASE + timedelta(hours=1),
+        processing_before=_BASE,  # excludes every PROCESSING row
+        limit=500,
+    )
+    assert claimed, "fixture produced no PENDING rows"
+    assert {d.orphan_prior_status for d in claimed} == {DocumentStatus.PENDING.value}, (
+        f"a PROCESSING row was claimed under a cutoff that excludes all of them: "
+        f"{sorted({d.orphan_prior_status for d in claimed})}"
+    )
+
+
+async def test_no_document_read_contains_a_disjunction(seeded, recorder) -> None:
+    """Whole-adapter sweep: none of the reads touched here may carry an ``OR``."""
+    adapter, ns = seeded
+    cutoff = _BASE + timedelta(hours=1)
+    first = await adapter.scan_documents(ns, scan_limit=1)
+    await adapter.scan_documents(ns, after=first.last_scanned, scan_limit=100)
+    await adapter.get_document_by_checksum(ns, "cs002", pending_stale_before=cutoff)
+    await adapter.get_documents_by_checksums(ns, ["cs002", "cs003"], pending_stale_before=cutoff)
+    await adapter.claim_orphaned_documents(ns, pending_before=cutoff, processing_before=cutoff, limit=5)
+    offenders = [sql for sql, _ in recorder.selects() if " OR " in sql.upper()]
+    assert not offenders, "document reads carrying a disjunction:\n" + "\n".join(offenders)
+
+
+async def test_the_replaced_disjunctive_shapes_really_do_table_scan(seeded, recorder) -> None:
+    """The premise, pinned. Without it the assertions above look like cargo cult.
+
+    Each of the three predicates below is what the adapter used to send. If a
+    future engine plans any of them on an index, this test fails and the split
+    can be reconsidered — that is the intended signal, not a false alarm.
+    """
+    _adapter, ns = seeded
+    conn = recorder._conn
+    ns_str = str(ns)
+    shapes = {
+        "keyset": (
+            "SELECT * FROM document WHERE namespace_id = $ns AND "
+            "(created_at < $ts OR (created_at = $ts AND id < $rid)) "
+            "ORDER BY created_at DESC, id DESC LIMIT 5",
+            {"ns": ns_str, "ts": _BASE, "rid": f"document:⟨{UUID(int=0)}⟩"},
+        ),
+        "dedup": (
+            "SELECT * FROM document WHERE namespace_id = $ns AND checksum = $cs AND "
+            "status != 'failed' AND (status != 'pending' OR updated_at >= $stale) LIMIT 1",
+            {"ns": ns_str, "cs": "cs001", "stale": _BASE},
+        ),
+        "orphan": (
+            "SELECT * FROM document WHERE namespace_id = $ns AND ("
+            "(status = $p AND updated_at < $pb) OR (status = $pr AND updated_at < $prb)"
+            ") ORDER BY updated_at LIMIT 5",
+            {
+                "ns": ns_str,
+                "p": DocumentStatus.PENDING.value,
+                "pr": DocumentStatus.PROCESSING.value,
+                "pb": _BASE,
+                "prb": _BASE,
+            },
+        ),
+    }
+    for label, (sql, params) in shapes.items():
+        plan: Any = await conn.query(f"{sql} EXPLAIN", params)
+        assert plan[0]["operation"] == "Iterate Table", (
+            f"{label}: this engine now indexes the disjunctive form. The client-side "
+            f"split is no longer forced — revisit it.\n  plan: {plan}"
+        )


### PR DESCRIPTION
## Summary

An `OR` anywhere in a `document`-table `WHERE` collapses the SurrealDB 2.x planner to a full table scan — and the collapse also drops the `namespace_id` index prefix, so the statement reads every `document` row in the database, all tenants included, then filters and sorts in memory. On a resumed keyset walk this makes each step's cost track total corpus bytes rather than the caller's page size or namespace, turning a bounded page into a cross-tenant scan.

The scope of that behavior is the `document` table specifically: 2.x *can* union index scans across a disjunction, but only when every disjunct is a comparison on a single-field index, and `document` carries composite `(namespace_id, …)` indexes and nothing else — so no disjunct on it ever qualifies. (Measured with `EXPLAIN`; the reasoning is recorded in a note atop the adapter, and a test keeps the premise honest against future engine changes.)

Three affected reads are restructured into `OR`-free conjunctive legs merged in Python:

- **Keyset resume (`scan_documents`)** — the disjunctive cursor becomes a tie-block query (`created_at = cursor AND id < cursor_id`) and a strictly-older query (`created_at < cursor`), concatenated in that order. Because every tie-block row sorts strictly above every strictly-older row under `created_at DESC, id DESC`, the concatenation is the same total order as the old single query — byte-identical windows, no comparator, no dedup. The second query runs only for the remaining limit and is skipped entirely when the first fills the window. The shared narrowing (namespace, `status`, `updated_before`, compiled filter fragment) is factored into one helper carried by both legs.
- **Checksum dedup** — the nested `OR` becomes two disjoint status legs, the settled leg probed first so a settled row still outranks a fresh-pending one.
- **Orphan-claim sweep** — one query per status/cutoff pair, merge-sorted by `updated_at` and sliced to the limit before claiming.

A repo-wide sweep of remaining `OR`-in-`WHERE` sites was done; the ones on other tables that share this defect class (larger, schema-level) are recorded separately and left out of this change.

## Test plan

- [x] Unit tests pass (new plan-assertion module: 31 tests, `memory://`, no docker)
- [x] Integration tests pass (existing `scan_documents` suite unchanged; 578 integration passed)
- [x] Full suite green (`make test`), coverage 85.48% (≥77% gate)
- [x] Lint/format clean (`make format`, `make lint` — zero new type diagnostics vs baseline)
- New tests drive the real adapter through a recording connection and re-issue each captured statement with `EXPLAIN`, asserting a namespace-scoped `Iterate Index` for every `document` read (keyset step 1, both resumed-step statements, both dedup legs, both orphan legs); a companion test pins that the old disjunctive shapes really do `Iterate Table`, so the split is not cargo-culted. No-filter shapes only — a filtered `$or` fragment still table-scans by construction and is out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved database query planning for document scans, checksum lookups, and orphan recovery.
  * Increased use of indexes by splitting complex searches into efficient query operations.
  * Preserved correct ordering, filtering, deduplication, and namespace isolation during scans.
* **Bug Fixes**
  * Ensured settled documents take precedence over newer pending records during checksum lookups.
  * Improved handling of resumed scans and concurrent orphan claims.
* **Tests**
  * Added comprehensive coverage for query plans, index usage, cursor boundaries, and result consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->