### PR TITLE
Restructure OR-defeating SurrealDB chunk and live-filter reads into index-eligible legs

### DIFF
--- a/src/khora/db/migrations/versions/054_documents_namespace_created_at_id.py
+++ b/src/khora/db/migrations/versions/054_documents_namespace_created_at_id.py
@@ -4,6 +4,27 @@ Revision ID: 054_documents_namespace_created_at_id
 Revises: 053_khora_chunks_bookkeeping_to_chunker_info
 Create Date: 2026-08-04
 
+Operational profile — read this first
+-------------------------------------
+* **This migration can be slow, and it holds the migration advisory lock for
+  the whole time it runs.** A btree ``CREATE INDEX CONCURRENTLY`` over a large
+  ``documents`` table takes as long as it takes, and ``run_migrations()`` takes
+  a session-scoped ``pg_advisory_lock`` *before* Alembic's transaction
+  demarcation and holds it for the entire run — including the autocommit
+  ``CREATE INDEX CONCURRENTLY`` block below.
+* **A concurrent caller gets 60s, then fails to boot.** It waits only 60s for
+  that lock before raising ``TimeoutError``, which surfaces as
+  ``MigrationResult(success=False)`` and then ``RuntimeError: Database
+  migration failed`` at startup. A concurrent build over a large ``documents``
+  table can easily exceed 60s, so on a large deployment every other service
+  booting with ``run_migrations=True`` would fail to start for the duration of
+  the build.
+* **Run this migration out-of-band on such deployments**, rather than during a
+  rolling deploy.
+* **Migration 029's BRIN build is not a precedent for "concurrent builds are
+  fine".** It does not carry this risk — BRIN indexes are KB-sized and build in
+  seconds.
+
 ``list_documents`` now pins a total order — ``ORDER BY created_at DESC, id
 DESC`` — across the relational backends so that offset pagination cannot drop
 or repeat a row when two documents share a ``created_at``. The pre-existing
@@ -30,27 +51,15 @@ added the 2-column index for ``get_last_activity_at()``'s
 query on its ``(namespace_id, created_at)`` prefix. The new index is created
 **before** the old one is dropped so that query never runs unindexed.
 
-Both dialects are handled. Postgres builds concurrently (see the caveats
-below); every other dialect takes the plain-DDL branch, which is what migration
-019 already did when it created the 2-column index unconditionally. That keeps
+Both dialects are handled. Postgres builds concurrently (see the operational
+profile above and the invalid-index caveat below); every other dialect takes the
+plain-DDL branch, which is what migration 019 already did when it created the
+2-column index unconditionally. That keeps
 the invariant simple: wherever 019 ran, 054 runs, so the ORM declaration and the
 physical schema agree on every backend. The embedded ``sqlite_lance`` stack runs
 this chain too, and its own full-drain pagination callers are the ones that
 motivated the change, so skipping SQLite would have left the regression in place
 on the stack it was measured on.
-
-Operational caveat — this migration can be slow, and it holds the migration
-advisory lock while it runs. ``run_migrations()`` takes a session-scoped
-``pg_advisory_lock`` *before* Alembic's transaction demarcation and holds it for
-the whole run, including the autocommit block below. A concurrent caller waits
-only 60s before raising ``TimeoutError``, which surfaces as
-``MigrationResult(success=False)`` and then ``RuntimeError: Database migration
-failed`` at startup. A btree ``CREATE INDEX CONCURRENTLY`` over a large
-``documents`` table can easily exceed that, so on a large deployment every other
-service booting with ``run_migrations=True`` would fail to start for the
-duration of the build. Run this migration out-of-band on such deployments rather
-than during a rolling deploy. (Migration 029's BRIN build does not carry this
-risk — BRIN indexes are KB-sized and build in seconds.)
 
 Invalid-index recovery — a failed ``CREATE INDEX CONCURRENTLY`` (deadlock,
 cancellation, connection loss) leaves an **INVALID** index behind: ignored by

--- a/src/khora/storage/backends/surrealdb/graph.py
+++ b/src/khora/storage/backends/surrealdb/graph.py
@@ -141,6 +141,54 @@ def _row_to_relationship(row: dict[str, Any]) -> Relationship:
     )
 
 
+_LIVE_LEGS: tuple[str, str] = ("valid_until IS NONE", "valid_until > time::now()")
+"""The two OR-free legs of the ``(valid_until IS NONE OR valid_until > now)`` live
+filter, run separately and merged in Python (#1592).
+
+A disjunction anywhere in the ``WHERE`` collapses the SurrealDB 2.x planner to
+``Iterate Table`` and drops the namespace index prefix, so the recall reads
+(``list_entities`` / ``list_relationships``) would scan every row in the
+database, all tenants included. Each leg on its own is a plain conjunction that
+plans ``Iterate Index`` on the namespace index. The legs are disjoint on a
+single row's ``valid_until`` value (``NONE`` vs a future datetime), so the union
+is the original set; the merge de-duplicates by id anyway to stay correct if a
+concurrent dream-apply stamps ``valid_until`` between the two statements."""
+
+
+async def _query_live_ordered(
+    conn: SurrealDBConnection,
+    table: str,
+    base_conditions: list[str],
+    bindings: dict[str, Any],
+    *,
+    limit: int,
+    offset: int,
+) -> list[dict[str, Any]]:
+    """Run the ``valid_until`` live filter as two index-eligible legs, merged.
+
+    Each leg selects ``ORDER BY created_at DESC`` over the shared
+    ``base_conditions`` plus one live-filter conjunct, capped at ``offset +
+    limit`` rows — the global ``created_at``-DESC window of that size is a subset
+    of the union of each leg's own window, so fetching that many per leg and
+    slicing after the merge reproduces the single disjunctive statement exactly.
+    ``base_conditions`` must NOT contain a disjunction (that is the whole point).
+    """
+    window = offset + limit
+    merged: dict[str, dict[str, Any]] = {}
+    for leg in _LIVE_LEGS:
+        conds = " AND ".join([*base_conditions, leg])
+        sql = f"SELECT * FROM {table} WHERE {conds} ORDER BY created_at DESC LIMIT $__live_window"  # noqa: S608
+        rows = await conn.query(sql, {**bindings, "__live_window": window})
+        for row in rows:
+            merged[str(row.get("id"))] = row
+    ordered = sorted(
+        merged.values(),
+        key=lambda r: (_parse_dt(r.get("created_at")) or datetime.min.replace(tzinfo=UTC), str(r.get("id"))),
+        reverse=True,
+    )
+    return ordered[offset : offset + limit]
+
+
 def _row_to_episode(row: dict[str, Any]) -> Episode:
     """Map a SurrealDB result row to a domain :class:`Episode`."""
     episode_id = _parse_uuid(row.get("id", ""))
@@ -397,8 +445,12 @@ class SurrealDBGraphAdapter(GraphBackendBase):
         # (the P1-4 cross-store invariant). A future ``valid_until`` is still a
         # live temporal window; retirement stamps ``valid_until = now``, so the
         # ``> time::now()`` comparison hides it.
-        where = ["namespace = $ns_rid", "(valid_until IS NONE OR valid_until > time::now())"]
-        bindings: dict[str, Any] = {"ns_rid": ns_rid, "limit": limit, "offset": offset}
+        # The live filter is split into two OR-free legs merged in Python so the
+        # read plans ``Iterate Index`` instead of scanning every tenant's rows
+        # (#1592); see ``_query_live_ordered``. The narrowing below is shared
+        # by both legs.
+        where = ["namespace = $ns_rid"]
+        bindings: dict[str, Any] = {"ns_rid": ns_rid}
         if entity_type is not None:
             where.append("entity_type = $entity_type")
             bindings["entity_type"] = entity_type
@@ -408,8 +460,7 @@ class SurrealDBGraphAdapter(GraphBackendBase):
             where.append("source_chunk_ids CONTAINSANY $source_chunk_ids")
             bindings["source_chunk_ids"] = [str(c) for c in source_chunk_ids]
 
-        sql = f"SELECT * FROM entity WHERE {' AND '.join(where)} ORDER BY created_at DESC LIMIT $limit START $offset"  # noqa: S608
-        rows = await self._conn.query(sql, bindings)
+        rows = await _query_live_ordered(self._conn, "entity", where, bindings, limit=limit, offset=offset)
         return [_row_to_entity(r) for r in rows]
 
     @trace(
@@ -731,8 +782,11 @@ class SurrealDBGraphAdapter(GraphBackendBase):
         # on a soft-deleted edge, and recall must filter it out in lockstep with
         # the PG / Neo4j read filters so the stores agree on the live set (the
         # P1-4 cross-store invariant).
-        conditions = ["namespace_id = $ns", "(valid_until IS NONE OR valid_until > time::now())"]
-        bindings: dict[str, Any] = {"ns": str(namespace_id), "limit": limit, "offset": offset}
+        # Split the live filter into two OR-free legs merged in Python so the
+        # read plans ``Iterate Index`` rather than a cross-tenant table scan
+        # (#1592); see ``_query_live_ordered``.
+        conditions = ["namespace_id = $ns"]
+        bindings: dict[str, Any] = {"ns": str(namespace_id)}
 
         if relationship_type is not None:
             conditions.append("relationship_type = $rt")
@@ -744,11 +798,7 @@ class SurrealDBGraphAdapter(GraphBackendBase):
             conditions.append("in IN $between_eids AND out IN $between_eids")
             bindings["between_eids"] = [_rid("entity", e) for e in between_entity_ids]
 
-        sql = (
-            f"SELECT * FROM relates_to WHERE {' AND '.join(conditions)} "  # noqa: S608
-            "ORDER BY created_at DESC LIMIT $limit START $offset"
-        )
-        rows = await self._conn.query(sql, bindings)
+        rows = await _query_live_ordered(self._conn, "relates_to", conditions, bindings, limit=limit, offset=offset)
         return [_row_to_relationship(r) for r in rows]
 
     @trace(

--- a/src/khora/storage/backends/surrealdb/schema.py
+++ b/src/khora/storage/backends/surrealdb/schema.py
@@ -172,6 +172,14 @@ DEFINE INDEX IF NOT EXISTS idx_chunk_namespace ON chunk FIELDS namespace;
 DEFINE INDEX IF NOT EXISTS idx_chunk_document ON chunk FIELDS document;
 DEFINE INDEX IF NOT EXISTS idx_chunk_doc_idx ON chunk FIELDS document, chunk_index;
 DEFINE INDEX IF NOT EXISTS idx_chunk_ns_session ON chunk FIELDS namespace_id, session_id;
+-- Single-field index on the scalar ``namespace_id`` so a chunk read scoped by
+-- namespace plans ``Iterate Index`` (#1592). Chunk reads scope with
+-- ``(namespace = $ns_rid OR namespace_id = $ns_str)``; a disjunction unions
+-- index scans only when EVERY disjunct is a comparison on a SINGLE-FIELD index,
+-- so the record-link leg needs ``idx_chunk_namespace`` and the scalar leg needs
+-- this one. The composite ``idx_chunk_ns_session`` leading column is NOT a
+-- reliable substitute across engine versions, so give the scalar its own index.
+DEFINE INDEX IF NOT EXISTS idx_chunk_namespace_id ON chunk FIELDS namespace_id;
 -- HNSW + BM25 indexes deferred to ensure_search_indexes() for bulk load performance
 
 -- Entity (with HNSW vector index and unique constraint)

--- a/src/khora/storage/backends/surrealdb/vector.py
+++ b/src/khora/storage/backends/surrealdb/vector.py
@@ -176,9 +176,7 @@ class SurrealDBVectorAdapter:
 
     async def get_chunk(self, chunk_id: UUID, *, namespace_id: UUID) -> Chunk | None:
         """Fetch a single chunk by primary key, filtered to ``namespace_id``."""
-        sql = (
-            "SELECT * FROM chunk WHERE id = $rid AND (namespace = $ns_rid OR namespace.namespace_id = $ns_str) LIMIT 1"
-        )
+        sql = "SELECT * FROM chunk WHERE id = $rid AND (namespace = $ns_rid OR namespace_id = $ns_str) LIMIT 1"
         row = await self._conn.query_one(
             sql,
             {
@@ -197,7 +195,7 @@ class SurrealDBVectorAdapter:
             return {}
 
         chunk_rids = [_rid("chunk", uid) for uid in chunk_ids]
-        sql = "SELECT * FROM chunk WHERE id IN $ids AND (namespace = $ns_rid OR namespace.namespace_id = $ns_str)"
+        sql = "SELECT * FROM chunk WHERE id IN $ids AND (namespace = $ns_rid OR namespace_id = $ns_str)"
         rows = await self._conn.query(
             sql,
             {
@@ -217,7 +215,7 @@ class SurrealDBVectorAdapter:
         sql = (
             "SELECT * FROM chunk "
             "WHERE document = $doc_rid "
-            "AND (namespace = $ns_rid OR namespace.namespace_id = $ns_str) "
+            "AND (namespace = $ns_rid OR namespace_id = $ns_str) "
             "ORDER BY chunk_index ASC"
         )
         rows = await self._conn.query(
@@ -240,29 +238,28 @@ class SurrealDBVectorAdapter:
         ns_rid = _rid("memory_namespace", namespace_id)
         ns_str = str(namespace_id)
         # Match the compound namespace predicate every sibling read method uses
-        # (scalar `namespace_id` OR the `namespace` record-link), so the delete
-        # works for newly written rows and any pre-#1221 rows that carry only
-        # the record-link.
+        # (the `namespace` record-link OR the scalar `namespace_id`), so the
+        # delete works for newly written rows and any pre-#1221 rows that carry
+        # only the record-link. The scalar leg replaces the former
+        # ``namespace.namespace_id`` record-traversal, which is unservable and
+        # collapsed the whole statement to ``Iterate Table`` (#1592); the
+        # scalar leg is index-eligible (``idx_chunk_namespace_id``) and covers
+        # the same rows.
         bindings = {"doc_rid": doc_rid, "ns_rid": ns_rid, "ns_str": ns_str}
-        # First count so we can report back
-        count_sql = (
-            "SELECT count() AS cnt FROM chunk "
+        # Delete and count what was actually removed via ``RETURN BEFORE`` rather
+        # than a separate ``count() ... GROUP ALL``: SurrealDB's aggregate count
+        # over an OR that unions two index scans double-counts rows matching both
+        # legs (a chunk carrying both namespace forms is counted per leg), so the
+        # old count query would over-report. The row set returned by DELETE is
+        # the real deletion, de-duplicated by id for the same union reason.
+        del_sql = (
+            "DELETE FROM chunk "
             "WHERE document = $doc_rid "
-            "AND (namespace = $ns_rid OR namespace.namespace_id = $ns_str OR namespace_id = $ns_str) "
-            "GROUP ALL"
+            "AND (namespace = $ns_rid OR namespace_id = $ns_str) "
+            "RETURN BEFORE"
         )
-        count_row = await self._conn.query_one(count_sql, bindings)
-        count = int(count_row.get("cnt", 0)) if count_row else 0
-
-        if count > 0:
-            del_sql = (
-                "DELETE FROM chunk "
-                "WHERE document = $doc_rid "
-                "AND (namespace = $ns_rid OR namespace.namespace_id = $ns_str OR namespace_id = $ns_str)"
-            )
-            await self._conn.execute(del_sql, bindings)
-
-        return count
+        deleted = await self._conn.query(del_sql, bindings)
+        return len({str(row.get("id")) for row in deleted if isinstance(row, dict)})
 
     async def update_last_accessed(
         self,
@@ -332,12 +329,15 @@ class SurrealDBVectorAdapter:
         and sorts by descending similarity.  HNSW index accelerates
         the distance computation when available.
         """
-        # Build WHERE predicates
+        # Build the shared narrowing WITHOUT the namespace disjunct. The
+        # namespace scope must be run as two OR-free legs merged in Python
+        # (#1592): a disjunction sitting beside ``embedding IS NOT NULL``
+        # collapses the plan to ``Iterate Table`` over the whole corpus, all
+        # tenants included, and the guard cannot move to Python because
+        # ``vector::dot()`` errors on a NONE embedding. Each leg on its own is a
+        # plain conjunction that plans ``Iterate Index`` on the namespace index.
         ns_rid = _rid("memory_namespace", namespace_id)
-        where_clauses = [
-            "(namespace = $ns_rid OR namespace.namespace_id = $ns_str)",
-            "embedding IS NOT NULL",
-        ]
+        shared_clauses = ["embedding IS NOT NULL"]
         bindings: dict[str, Any] = {
             "ns_rid": ns_rid,
             "ns_str": str(namespace_id),
@@ -348,44 +348,49 @@ class SurrealDBVectorAdapter:
 
         if filter_document_ids:
             doc_rids = [_rid("document", uid) for uid in filter_document_ids]
-            where_clauses.append("document IN $filter_doc_ids")
+            shared_clauses.append("document IN $filter_doc_ids")
             bindings["filter_doc_ids"] = doc_rids
 
         if created_after is not None:
-            where_clauses.append("(source_timestamp ?? created_at) >= $created_after")
+            shared_clauses.append("(source_timestamp ?? created_at) >= $created_after")
             bindings["created_after"] = created_after
 
         if created_before is not None:
-            where_clauses.append("(source_timestamp ?? created_at) <= $created_before")
+            shared_clauses.append("(source_timestamp ?? created_at) <= $created_before")
             bindings["created_before"] = created_before
 
         if metadata_filters:
             for i, (key, value) in enumerate(metadata_filters.items()):
                 safe_key = _sanitize_field_name(key)
                 param = f"mf_{i}"
-                where_clauses.append(f"metadata_.{safe_key} = ${param}")
+                shared_clauses.append(f"metadata_.{safe_key} = ${param}")
                 bindings[param] = value
 
-        where_sql = " AND ".join(where_clauses)
         # Use brute-force similarity + ORDER BY instead of <|K|> KNN operator
         # (KNN is unreliable in embedded mode and rejects parameterised limits).
         # vector::dot() is ~3x faster than vector::similarity::cosine() and
         # produces identical results for L2-normalized embeddings (unit vectors).
-        sql = (
-            "SELECT *, vector::dot(embedding, $query_embedding) AS similarity "  # noqa: S608
-            f"FROM chunk WHERE {where_sql} "
-            f"ORDER BY similarity DESC LIMIT {int(limit)}"
-        )
+        # Both legs cap at ``limit``; the global top-``limit`` by similarity is a
+        # subset of the union of each leg's top-``limit``, so merging then
+        # slicing reproduces the single-statement result. The legs overlap for
+        # rows carrying both namespace forms, so de-duplicate by chunk id.
+        merged: dict[UUID, tuple[Chunk, float]] = {}
+        for leg in ("namespace = $ns_rid", "namespace_id = $ns_str"):
+            where_sql = " AND ".join([leg, *shared_clauses])
+            sql = (
+                "SELECT *, vector::dot(embedding, $query_embedding) AS similarity "  # noqa: S608
+                f"FROM chunk WHERE {where_sql} "
+                f"ORDER BY similarity DESC LIMIT {int(limit)}"
+            )
+            rows = await self._conn.query(sql, bindings)
+            for row in rows:
+                sim = float(row.get("similarity", 0.0))
+                if sim < min_similarity:
+                    continue
+                chunk = self._row_to_chunk(row)
+                merged[chunk.id] = (chunk, sim)
 
-        rows = await self._conn.query(sql, bindings)
-
-        results: list[tuple[Chunk, float]] = []
-        for row in rows:
-            sim = float(row.get("similarity", 0.0))
-            if sim < min_similarity:
-                continue
-            results.append((self._row_to_chunk(row), sim))
-        return results
+        return sorted(merged.values(), key=lambda t: t[1], reverse=True)[:limit]
 
     @trace(
         "khora.surrealdb.search_fulltext",
@@ -413,8 +418,11 @@ class SurrealDBVectorAdapter:
         filter, so it is ignored.
         """
         ns_rid = _rid("memory_namespace", namespace_id)
+        # Scalar ``namespace_id`` leg (not the unservable ``namespace.namespace_id``
+        # record-traversal) so the disjunction unions two index scans; the BM25
+        # ``idx_chunk_content_ft`` anchors the plan (#1592).
         where_clauses = [
-            "(namespace = $ns_rid OR namespace.namespace_id = $ns_str)",
+            "(namespace = $ns_rid OR namespace_id = $ns_str)",
             "content @1@ $query_text",
         ]
         bindings: dict[str, Any] = {

--- a/tests/unit/storage/backends/surrealdb/test_chunk_valid_until_query_plans.py
+++ b/tests/unit/storage/backends/surrealdb/test_chunk_valid_until_query_plans.py
@@ -1,0 +1,366 @@
+"""Chunk namespace-scoped reads and the graph live filter must plan ``Iterate Index``.
+
+Two OR shapes on ``chunk`` / ``entity`` / ``relates_to`` used to collapse the
+SurrealDB 2.x planner to ``Iterate Table`` — a full cross-tenant scan of the
+whole corpus on recall hot paths (#1592):
+
+* **chunk namespace scope** — ``(namespace = $ns_rid OR namespace.namespace_id =
+  $ns_str)``. The ``namespace.namespace_id`` leg is a record traversal, not a
+  comparison on an indexed field, so the disjunction was unservable. Rewritten to
+  the scalar ``namespace_id`` (denormalised onto every chunk since #1221 and now
+  indexed by ``idx_chunk_namespace_id``), the two legs union index scans. The one
+  read where a plain disjunction still table-scans regardless — ``search_similar``,
+  whose ``embedding IS NOT NULL`` guard poisons the union and whose
+  ``vector::dot`` errors on a NONE embedding so the guard cannot move to Python —
+  is split into two OR-free legs merged in Python.
+* **graph live filter** — ``(valid_until IS NONE OR valid_until > time::now())``
+  on ``list_entities`` / ``list_relationships``. Split into two OR-free legs
+  merged in Python, the #1590 pattern.
+
+Like ``test_document_query_plans``, these tests do NOT retype the SQL: they drive
+the real adapter methods through a recording connection and re-issue each captured
+statement with ``EXPLAIN`` appended. They run against ``memory://`` — no server,
+no docker.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+pytest.importorskip("surrealdb")
+
+from khora.core.models import Chunk, Entity, MemoryNamespace, Relationship, TenancyMode  # noqa: E402
+from khora.storage.backends.surrealdb.connection import SurrealDBConnection  # noqa: E402
+from khora.storage.backends.surrealdb.graph import SurrealDBGraphAdapter  # noqa: E402
+from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter  # noqa: E402
+from khora.storage.backends.surrealdb.schema import ensure_search_indexes  # noqa: E402
+from khora.storage.backends.surrealdb.vector import SurrealDBVectorAdapter  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+_BASE = datetime(2026, 3, 1, tzinfo=UTC)
+_EMB = [0.1, 0.2, 0.3, 0.9]
+
+
+class _RecordingConnection:
+    """Pass-through wrapper keeping every ``(sql, params)`` the adapter issues."""
+
+    def __init__(self, conn: SurrealDBConnection) -> None:
+        self._conn = conn
+        self.statements: list[tuple[str, dict[str, Any]]] = []
+
+    async def query(self, sql: str, params: dict[str, Any] | None = None) -> Any:
+        self.statements.append((sql, params or {}))
+        return await self._conn.query(sql, params)
+
+    async def query_one(self, sql: str, params: dict[str, Any] | None = None) -> Any:
+        self.statements.append((sql, params or {}))
+        return await self._conn.query_one(sql, params)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._conn, name)
+
+    def reset(self) -> None:
+        self.statements.clear()
+
+    def selects(self) -> list[tuple[str, dict[str, Any]]]:
+        return [(sql, params) for sql, params in self.statements if sql.lstrip().upper().startswith("SELECT")]
+
+
+@pytest.fixture
+async def recorder():
+    conn = SurrealDBConnection(mode="memory", namespace="khora_test", database="plans", embedding_dimension=4)
+    await conn.connect()
+    await ensure_search_indexes(conn)
+    recording = _RecordingConnection(conn)
+    try:
+        yield recording
+    finally:
+        await conn.disconnect()
+
+
+@pytest.fixture
+async def seeded(recorder):
+    """Two namespaces, each with chunks + entities + a relationship.
+
+    A populated, multi-tenant table is what makes the plan assertion meaningful:
+    the point is that the planner *chose* an index (rows to choose over) and that
+    a regression would leak the foreign namespace's rows. Entities carry a mix of
+    live (``valid_until`` NONE), live-with-future-window, and retired (past
+    ``valid_until``) rows so the live filter has something to hide.
+    """
+    rel = SurrealDBRelationalAdapter(recorder)
+    graph = SurrealDBGraphAdapter(recorder)
+    vector = SurrealDBVectorAdapter(recorder)
+
+    namespaces: list[UUID] = []
+    for _ in range(2):
+        nid = uuid4()
+        await rel.create_namespace(MemoryNamespace(id=nid, namespace_id=nid, tenancy_mode=TenancyMode.SHARED))
+        namespaces.append(nid)
+
+    doc = uuid4()
+    for nid in namespaces:
+        ents: list[Entity] = []
+        for i in range(18):
+            await vector.create_chunk(
+                Chunk(
+                    namespace_id=nid,
+                    document_id=doc,
+                    content=f"hello world chunk {i}",
+                    chunk_index=i,
+                    start_char=0,
+                    end_char=1,
+                    embedding=_EMB,
+                    created_at=_BASE + timedelta(minutes=i),
+                )
+            )
+            # i % 3 == 0 -> retired (past); i % 3 == 1 -> future window; else NONE.
+            if i % 3 == 0:
+                valid_until = _BASE - timedelta(days=1)
+            elif i % 3 == 1:
+                valid_until = _BASE + timedelta(days=365)
+            else:
+                valid_until = None
+            e = Entity(
+                namespace_id=nid,
+                name=f"e-{nid}-{i}",
+                entity_type="PERSON",
+                valid_until=valid_until,
+                created_at=_BASE + timedelta(minutes=i),
+                updated_at=_BASE + timedelta(minutes=i),
+            )
+            ents.append((await graph.upsert_entities_batch(nid, [e]))[0][0])
+        # One live and one retired relationship between the first two entities.
+        await graph.create_relationship(
+            Relationship(
+                namespace_id=nid,
+                source_entity_id=ents[1].id,
+                target_entity_id=ents[2].id,
+                relationship_type="KNOWS",
+                created_at=_BASE,
+            )
+        )
+        await graph.create_relationship(
+            Relationship(
+                namespace_id=nid,
+                source_entity_id=ents[3].id,
+                target_entity_id=ents[4].id,
+                relationship_type="KNEW",
+                valid_until=_BASE - timedelta(days=1),
+                created_at=_BASE + timedelta(minutes=1),
+            )
+        )
+    recorder.reset()
+    return {"rel": rel, "graph": graph, "vector": vector, "ns": namespaces[0], "other_ns": namespaces[1], "doc": doc}
+
+
+async def _explain(recorder: _RecordingConnection, *, expected_statements: int, label: str) -> list[Any]:
+    recorded = recorder.selects()
+    assert len(recorded) == expected_statements, (
+        f"{label}: expected {expected_statements} SELECT(s), captured {len(recorded)}:\n"
+        + "\n".join(sql for sql, _ in recorded)
+    )
+    plans = []
+    for sql, params in recorded:
+        plan = await recorder._conn.query(f"{sql} EXPLAIN", params)
+        plans.append((sql, plan))
+    return plans
+
+
+def _assert_no_table_scan(sql: str, plan: Any, *, label: str) -> None:
+    ops = [step["operation"] for step in plan]
+    assert not any("Iterate Table" in op for op in ops), (
+        f"{label}: statement fell back to a full table scan — it reads every row in the "
+        f"database, all namespaces included.\n  sql:  {sql}\n  ops: {ops}"
+    )
+    assert any(op.startswith("Iterate Index") for op in ops), (
+        f"{label}: no index iteration in plan.\n  sql: {sql}\n  ops: {ops}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# chunk namespace scope
+# --------------------------------------------------------------------------- #
+
+
+async def test_search_similar_legs_plan_index_scans(seeded, recorder) -> None:
+    """Semantic search is split into two namespace legs, each index-eligible."""
+    res = await seeded["vector"].search_similar(seeded["ns"], _EMB, limit=5)
+    assert res, "fixture produced no similarity hits"
+    plans = await _explain(recorder, expected_statements=2, label="search_similar")
+    for sql, plan in plans:
+        _assert_no_table_scan(sql, plan, label="search_similar leg")
+
+
+async def test_search_fulltext_plans_index_scan(seeded, recorder) -> None:
+    res = await seeded["vector"].search_fulltext(seeded["ns"], "hello", limit=5)
+    assert res, "fixture produced no BM25 hits"
+    ((sql, plan),) = await _explain(recorder, expected_statements=1, label="search_fulltext")
+    _assert_no_table_scan(sql, plan, label="search_fulltext")
+
+
+async def test_get_chunks_by_document_plans_index_scan(seeded, recorder) -> None:
+    res = await seeded["vector"].get_chunks_by_document(seeded["doc"], namespace_id=seeded["ns"])
+    assert res, "fixture produced no chunks for the document"
+    ((sql, plan),) = await _explain(recorder, expected_statements=1, label="get_chunks_by_document")
+    _assert_no_table_scan(sql, plan, label="get_chunks_by_document")
+
+
+async def test_no_chunk_read_uses_the_namespace_record_traversal(seeded, recorder) -> None:
+    """Source tripwire: the unservable ``namespace.namespace_id`` form is gone.
+
+    ``EXPLAIN`` reports the plan this engine picked; a later SurrealDB that learned
+    to index the traversal would let the plan assertions pass while the statement
+    still table-scans on older deployments. This checks the text instead.
+    """
+    v = seeded["vector"]
+    ns, doc = seeded["ns"], seeded["doc"]
+    await v.get_chunk(uuid4(), namespace_id=ns)
+    await v.get_chunks_batch([uuid4()], namespace_id=ns)
+    await v.get_chunks_by_document(doc, namespace_id=ns)
+    await v.search_similar(ns, _EMB, limit=5)
+    await v.search_fulltext(ns, "hello", limit=5)
+    offenders = [sql for sql, _ in recorder.selects() if "namespace.namespace_id" in sql]
+    assert not offenders, "a chunk read still uses the record-traversal namespace form:\n" + "\n".join(offenders)
+
+
+async def test_search_similar_stays_namespace_scoped(seeded, recorder) -> None:
+    """The leg split must not leak the foreign tenant's chunks into the result."""
+    res = await seeded["vector"].search_similar(seeded["ns"], _EMB, limit=100)
+    ns_ids = {c.namespace_id for c, _ in res}
+    assert ns_ids == {seeded["ns"]}, f"search_similar leaked foreign namespaces: {ns_ids}"
+
+
+async def test_delete_chunks_by_document_counts_the_real_deletion(seeded, recorder) -> None:
+    """The returned count is the rows actually deleted, scoped to one tenant.
+
+    A ``count() ... GROUP ALL`` over the namespace OR double-counts rows matching
+    both legs on this engine, so the count is taken from ``DELETE ... RETURN
+    BEFORE`` instead. Both namespaces hold 18 chunks for the shared document;
+    deleting one tenant's must report 18 (not a doubled 36/72) and leave the
+    other tenant untouched.
+    """
+    v, ns, other, doc = seeded["vector"], seeded["ns"], seeded["other_ns"], seeded["doc"]
+    deleted = await v.delete_chunks_by_document(doc, namespace_id=ns)
+    assert deleted == 18, f"delete over-/under-counted: {deleted}"
+    assert await v.get_chunks_by_document(doc, namespace_id=ns) == []
+    survivors = await v.get_chunks_by_document(doc, namespace_id=other)
+    assert len(survivors) == 18, f"cross-tenant deletion: {len(survivors)} of the other tenant's chunks survived"
+
+
+# --------------------------------------------------------------------------- #
+# graph live filter (valid_until)
+# --------------------------------------------------------------------------- #
+
+
+async def test_list_entities_legs_plan_index_scans(seeded, recorder) -> None:
+    res = await seeded["graph"].list_entities(seeded["ns"], limit=100)
+    assert res, "fixture produced no live entities"
+    plans = await _explain(recorder, expected_statements=2, label="list_entities")
+    for sql, plan in plans:
+        _assert_no_table_scan(sql, plan, label="list_entities leg")
+
+
+async def test_list_relationships_legs_plan_index_scans(seeded, recorder) -> None:
+    res = await seeded["graph"].list_relationships(seeded["ns"], limit=100)
+    assert res, "fixture produced no live relationships"
+    plans = await _explain(recorder, expected_statements=2, label="list_relationships")
+    for sql, plan in plans:
+        _assert_no_table_scan(sql, plan, label="list_relationships leg")
+
+
+async def test_no_live_filter_read_contains_a_disjunction(seeded, recorder) -> None:
+    """The live-filter reads must carry neither an ``OR`` nor the record traversal."""
+    await seeded["graph"].list_entities(seeded["ns"], limit=100)
+    await seeded["graph"].list_relationships(seeded["ns"], limit=100)
+    for sql, _ in recorder.selects():
+        assert " OR " not in sql.upper(), f"a disjunction is back in a live-filter read:\n{sql}"
+
+
+async def test_list_entities_hides_retired_and_keeps_live(seeded, recorder) -> None:
+    """Retired entities (past ``valid_until``) are excluded; NONE and future kept.
+
+    The fixture retires ``i % 3 == 0`` (6 of 18) and keeps the rest live, so the
+    split legs must together return exactly the 12 live rows — no retired row
+    leaking through, no live row dropped by the merge.
+    """
+    res = await seeded["graph"].list_entities(seeded["ns"], limit=100)
+    assert len(res) == 12, f"live set wrong after merge: {len(res)}"
+    assert all(e.valid_until is None or e.valid_until > _BASE for e in res), "a retired entity leaked through"
+
+
+async def test_list_relationships_hides_retired(seeded, recorder) -> None:
+    res = await seeded["graph"].list_relationships(seeded["ns"], limit=100)
+    types = sorted(r.relationship_type for r in res)
+    assert types == ["KNOWS"], f"retired relationship leaked or live one dropped: {types}"
+
+
+async def test_list_entities_pagination_walks_every_live_row_once(seeded, recorder) -> None:
+    """Paging the merged legs visits each live entity exactly once, newest first.
+
+    The merge fetches ``offset + limit`` from each leg and slices after re-sorting;
+    a per-leg slice or a lost tenant conjunct would drop or duplicate rows across
+    page boundaries. Small page size forces several boundaries over the mixed
+    NONE / future-window live set.
+    """
+    graph, ns = seeded["graph"], seeded["ns"]
+    full = await graph.list_entities(ns, limit=100)
+    created = [e.created_at for e in full]
+    assert created == sorted(created, reverse=True), "merge did not order created_at DESC"
+
+    seen: list[UUID] = []
+    for offset in range(0, len(full) + 5, 5):
+        page = await graph.list_entities(ns, limit=5, offset=offset)
+        seen.extend(e.id for e in page)
+        if not page:
+            break
+    assert len(seen) == len(set(seen)), "pagination returned a duplicate across a page boundary"
+    assert set(seen) == {e.id for e in full}, "pagination skipped a live entity"
+
+
+async def test_the_disjunctive_forms_really_table_scan(seeded, recorder) -> None:
+    """The premise, pinned: the replaced OR shapes really do ``Iterate Table``.
+
+    If a future engine plans any of these on an index, the client-side splits are
+    no longer forced and can be reconsidered — that is the intended signal.
+    """
+    conn = recorder._conn
+    ns = seeded["ns"]
+    from khora.storage.backends.surrealdb._helpers import _rid
+
+    ns_rid = _rid("memory_namespace", ns)
+    ns_str = str(ns)
+    shapes = {
+        "chunk_traversal": (
+            "SELECT * FROM chunk WHERE (namespace = $ns_rid OR namespace.namespace_id = $ns_str)",
+            {"ns_rid": ns_rid, "ns_str": ns_str},
+        ),
+        "chunk_similar_or": (
+            "SELECT *, vector::dot(embedding, $q) AS similarity FROM chunk "
+            "WHERE (namespace = $ns_rid OR namespace_id = $ns_str) AND embedding IS NOT NULL "
+            "ORDER BY similarity DESC LIMIT 5",
+            {"ns_rid": ns_rid, "ns_str": ns_str, "q": _EMB},
+        ),
+        "entity_live_or": (
+            "SELECT * FROM entity WHERE namespace = $ns_rid "
+            "AND (valid_until IS NONE OR valid_until > time::now()) ORDER BY created_at DESC LIMIT 100",
+            {"ns_rid": ns_rid},
+        ),
+        "relationship_live_or": (
+            "SELECT * FROM relates_to WHERE namespace_id = $ns "
+            "AND (valid_until IS NONE OR valid_until > time::now()) ORDER BY created_at DESC LIMIT 100",
+            {"ns": ns_str},
+        ),
+    }
+    for label, (sql, params) in shapes.items():
+        plan = await conn.query(f"{sql} EXPLAIN", params)
+        ops = [step["operation"] for step in plan]
+        assert any("Iterate Table" in op for op in ops), (
+            f"{label}: this engine now indexes the disjunctive form. The client-side split is no "
+            f"longer forced — revisit it.\n  ops: {ops}"
+        )

--- a/tests/unit/test_surrealdb_backend.py
+++ b/tests/unit/test_surrealdb_backend.py
@@ -1509,24 +1509,27 @@ class TestVectorAdapterChunkOps:
     async def test_delete_chunks_by_document(self) -> None:
         from khora.storage.backends.surrealdb.vector import SurrealDBVectorAdapter
 
+        # The count is derived from the rows DELETE ... RETURN BEFORE returns,
+        # de-duplicated by id (the namespace OR unions two index scans, so a
+        # separate count() would double-count — #1592).
         conn = _make_mock_conn()
-        conn.query_one = AsyncMock(return_value={"cnt": 3})
+        conn.query = AsyncMock(return_value=[{"id": f"chunk:{uuid4()}"} for _ in range(3)])
         adapter = SurrealDBVectorAdapter(conn)
 
         result = await adapter.delete_chunks_by_document(uuid4(), namespace_id=uuid4())
         assert result == 3
-        conn.execute.assert_awaited_once()
+        conn.query.assert_awaited_once()
+        assert "RETURN BEFORE" in conn.query.await_args.args[0]
 
     async def test_delete_chunks_by_document_zero(self) -> None:
         from khora.storage.backends.surrealdb.vector import SurrealDBVectorAdapter
 
         conn = _make_mock_conn()
-        conn.query_one = AsyncMock(return_value={"cnt": 0})
+        conn.query = AsyncMock(return_value=[])
         adapter = SurrealDBVectorAdapter(conn)
 
         result = await adapter.delete_chunks_by_document(uuid4(), namespace_id=uuid4())
         assert result == 0
-        conn.execute.assert_not_awaited()
 
     async def test_count_chunks(self) -> None:
         from khora.storage.backends.surrealdb.vector import SurrealDBVectorAdapter
@@ -2201,10 +2204,15 @@ class TestSurrealDBGraphAdapterEntity:
         from khora.storage.backends.surrealdb.graph import SurrealDBGraphAdapter
 
         ns_id = uuid4()
-        rows = [
-            _graph_entity_row(ns_id=ns_id, name="E1"),
-            _graph_entity_row(ns_id=ns_id, name="E2"),
-        ]
+        # The live filter runs as two OR-free legs merged in Python and re-sorted
+        # by created_at DESC (#1592), so give the rows distinct timestamps and
+        # assert newest-first ordering. The mock returns the same rows for both
+        # legs; the merge de-duplicates by id.
+        e1 = _graph_entity_row(ns_id=ns_id, name="E1")
+        e2 = _graph_entity_row(ns_id=ns_id, name="E2")
+        e1["created_at"] = datetime(2026, 3, 2, tzinfo=UTC).isoformat()
+        e2["created_at"] = datetime(2026, 3, 1, tzinfo=UTC).isoformat()
+        rows = [e1, e2]
 
         conn = _make_mock_conn()
         conn.query = AsyncMock(return_value=rows)
@@ -2214,6 +2222,10 @@ class TestSurrealDBGraphAdapterEntity:
         assert len(result) == 2
         assert result[0].name == "E1"
         assert result[1].name == "E2"
+        # Two legs issued, both namespace-scoped and OR-free.
+        assert conn.query.await_count == 2
+        for call in conn.query.await_args_list:
+            assert " OR " not in call.args[0].upper()
 
     async def test_list_entities_with_type_filter(self) -> None:
         from khora.storage.backends.surrealdb.graph import SurrealDBGraphAdapter


### PR DESCRIPTION
## What & why

Spun out of the SurrealQL `OR`-in-`WHERE` sweep. Two disjunction shapes collapsed the SurrealDB 2.x planner to `Iterate Table` on **recall hot paths** — a full cross-tenant scan of the entire corpus. All plans below were EXPLAIN-measured on the bundled embedded core (`memory://`).

## P1 — `chunk` dual-form namespace scope

`(namespace = $ns_rid OR namespace.namespace_id = $ns_str)` → **Iterate Table**. The traversal leg is unservable. Fix:

- Rewrite the traversal to the **scalar `namespace_id`** (denormalised onto every chunk since #1221) and add a single-field **`idx_chunk_namespace_id`**. Both legs now union index scans.
- `get_chunk`, `get_chunks_batch`, `get_chunks_by_document`, `search_fulltext`, and the delete predicate now plan `Iterate Index`.
- **`search_similar`** is split into two OR-free legs merged in Python: its `embedding IS NOT NULL` guard poisons *any* in-query disjunction (measured), and `vector::dot()` errors on a `NONE` embedding so the guard can't move to Python. Each leg plans `Iterate Index`; results merge by similarity, de-duplicated by id.
- **`delete_chunks_by_document`** now counts via `DELETE … RETURN BEFORE` instead of `count() … GROUP ALL` — the aggregate count double-counts rows matching both union legs on this engine (measured 80 for 20 rows), while the `SELECT`/`DELETE` themselves are correct.

## P1 — `valid_until` live filter

`(valid_until IS NONE OR valid_until > time::now())` on `list_entities` / `list_relationships` → **Iterate Table**. Split into two OR-free legs merged in Python via a shared `_query_live_ordered` helper, preserving `created_at DESC` ordering and `offset`/`limit` pagination. NONE-semantics unchanged — no schema/behaviour change, no backfill.

## Design decision (kept both namespace forms)

The scalar disjunct is **not** dropped: `update_last_accessed` deliberately expands to all namespace row-ids, confirming the scalar genuinely matters under namespace versioning. Keeping both forms is provably no-coverage-loss vs. today; the change is query-shape + one additive index only.

## Tests

New `test_chunk_valid_until_query_plans.py` drives the **real adapters** through a recording connection and re-issues each captured statement with `EXPLAIN`, asserting no read falls to `Iterate Table` — plus correctness (retired-row hiding, pagination walk, namespace scoping, accurate delete count) and a premise-pin that the replaced disjunctive shapes really do table-scan on this engine. Existing mock-based unit tests updated for the new query structure.

- New plan+correctness tests: 13 passed
- Full unit suite: 10212 passed, 35 skipped
- SurrealDB embedded integration tests: passed
- Docker-backed integration/e2e: not runnable in this sandbox (no docker) — left to CI

## Deferred (P3, per the issue)

`graph.py:366` endpoint OR, `dream/surrealdb_apply.py` predicate, and the bounded `resolve_namespace` lookups — lower-impact, recorded on the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved SurrealDB query performance for namespace-scoped graph, vector, and full-text searches.
  - Added indexed namespace filtering for chunk queries.
  - Reduced unnecessary scans while preserving filtering, ordering, pagination, and deduplication.

- **Bug Fixes**
  - Improved live-record filtering and document deletion counts.
  - Ensured search and graph results remain isolated to the selected namespace.

- **Tests**
  - Added coverage for query plans, index usage, namespace isolation, pagination, ordering, and deletion behavior.

- **Documentation**
  - Expanded migration guidance for index creation and deployment considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->