### PR TITLE
Wire the document-enumeration surface (facade, DocumentPage, engine threading, coordinator scan loop)

### DIFF
--- a/src/khora/__init__.py
+++ b/src/khora/__init__.py
@@ -43,7 +43,7 @@ Example usage:
 """
 
 from .config import KhoraConfig
-from .core.models.document import DocumentSource
+from .core.models.document import DocumentCursor, DocumentPage, DocumentSource
 from .core.models.event import EventType
 from .core.recall_context import context_text
 from .dream import DreamConfig, DreamMode, DreamResult, DreamRunInfo, DreamScope, OpKind
@@ -103,6 +103,8 @@ __all__ = [
     "SearchMode",
     "KhoraConfig",
     "DocumentSource",
+    "DocumentPage",
+    "DocumentCursor",
     # Engine functions
     "create_engine",
     "list_engines",

--- a/src/khora/config/schema.py
+++ b/src/khora/config/schema.py
@@ -1578,6 +1578,20 @@ class QuerySettings(BaseSettings):
         default=0.05, ge=0.0, le=1.0, description="Minimum entity similarity threshold"
     )
 
+    # Document enumeration (list_documents) keyset scan bound. When a filter is
+    # active the coordinator over-fetches raw rows to absorb post-filter
+    # rejection before giving up on filling a page; this caps the total rows a
+    # single page may scan at ``max(limit × multiplier, min_bound)``. Not a
+    # public list_documents parameter — tuned here only. Raising the multiplier
+    # trades more scan work per page for fewer under-full pages under a very
+    # selective filter; the floor keeps small page limits from starving.
+    document_scan_overfetch_multiplier: int = Field(
+        default=10, ge=1, description="Per-page scan bound = max(limit × this, document_scan_min_bound)"
+    )
+    document_scan_min_bound: int = Field(
+        default=1000, ge=1, description="Floor for the per-page document enumeration scan bound"
+    )
+
     # Fusion weights. Wired onto the default VectorCypher engine in #1406
     # (previously dead there - the engine read only VectorCypherConfig). The
     # defaults were canonicalized to the values the engine already used

--- a/src/khora/core/models/__init__.py
+++ b/src/khora/core/models/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .document import Chunk, Document, DocumentSource
+from .document import Chunk, Document, DocumentCursor, DocumentPage, DocumentSource
 from .entity import CommunityNode, Entity, Episode, Relationship
 from .event import EventType, MemoryEvent
 from .recall import (
@@ -21,6 +21,8 @@ __all__ = [
     # Document
     "Document",
     "DocumentSource",
+    "DocumentCursor",
+    "DocumentPage",
     "Chunk",
     # Entity
     "CommunityNode",

--- a/src/khora/core/models/document.py
+++ b/src/khora/core/models/document.py
@@ -6,10 +6,11 @@ for semantic search and retrieval.
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Any
+from typing import Any, overload
 from uuid import UUID, uuid4
 
 
@@ -152,6 +153,81 @@ class Document:
         self.status = DocumentStatus.FAILED
         self.error_message = error
         self.updated_at = datetime.now(UTC)
+
+
+@dataclass(frozen=True, slots=True)
+class DocumentCursor:
+    """An opaque keyset resume position for document enumeration: ``(created_at, id)``.
+
+    The public form of the internal ``DocumentScanKey`` — the position of a
+    single document in the ``(created_at DESC, id DESC)`` enumeration order. A
+    caller feeds the previous page's :attr:`DocumentPage.next_after` back in as
+    the next ``list_documents(after=...)`` to resume exactly-once.
+
+    The position is store-local (each backend round-trips ``created_at`` in the
+    shape it stores it). Treat it as opaque: do not reformat, adjust ``tzinfo``,
+    or carry a cursor from one backend to another.
+    """
+
+    created_at: datetime
+    id: UUID
+
+
+class DocumentPage(Sequence["Document"]):
+    """One page of a keyset document enumeration — a :class:`~collections.abc.Sequence` of documents.
+
+    Subclasses :class:`collections.abc.Sequence` so existing call sites that
+    iterate, ``len()``, index, or test truthiness on the result of
+    ``list_documents`` keep working unchanged. Beyond the sequence surface it
+    carries the walk-control metadata:
+
+    * :attr:`next_after` — the **last-scanned** keyset position to resume from,
+      or ``None`` when the scan is exhausted. ``None`` **iff** :attr:`exhausted`.
+    * :attr:`exhausted` — the scan bound was consumed and no rows remain past
+      the last one scanned. **The only sound termination signal** — a short (or
+      empty) page means nothing on its own, because a filter can reject an entire
+      scanned window.
+    * :attr:`post_filtered_keys` — the filter leaf keys the backend could NOT
+      push into SQL and that were therefore enforced by the in-memory
+      post-filter. A reporting signal; empty when there is no filter.
+
+    Distinct from the storage tier's offset-shaped ``PaginatedResult`` (which
+    carries ``items`` + ``total`` + ``offset``); a keyset walk has neither an
+    offset nor a total.
+    """
+
+    __slots__ = ("_documents", "next_after", "exhausted", "post_filtered_keys")
+
+    def __init__(
+        self,
+        documents: Iterable[Document],
+        *,
+        next_after: DocumentCursor | None,
+        exhausted: bool,
+        post_filtered_keys: tuple[str, ...] = (),
+    ) -> None:
+        self._documents: tuple[Document, ...] = tuple(documents)
+        self.next_after = next_after
+        self.exhausted = exhausted
+        self.post_filtered_keys = tuple(post_filtered_keys)
+
+    @overload
+    def __getitem__(self, index: int) -> Document: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[Document]: ...
+
+    def __getitem__(self, index: int | slice) -> Document | Sequence[Document]:
+        return self._documents[index]
+
+    def __len__(self) -> int:
+        return len(self._documents)
+
+    def __repr__(self) -> str:
+        return (
+            f"DocumentPage(len={len(self._documents)}, exhausted={self.exhausted}, "
+            f"next_after={self.next_after!r}, post_filtered_keys={self.post_filtered_keys!r})"
+        )
 
 
 @dataclass(slots=True)

--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -65,9 +65,11 @@ from khora.telemetry import trace
 from khora.telemetry.metrics import metric_counter, metric_histogram
 
 if TYPE_CHECKING:
+    from khora.core.models.document import DocumentPage
     from khora.extraction.chunkers import ChunkStrategy
     from khora.extraction.skills import ExpertiseConfig
     from khora.filter import FilterNode
+    from khora.storage.backends.base import DocumentScanKey
 
 ChronicleStorageBackend = Literal["pgvector", "lancedb"]
 
@@ -3620,10 +3622,23 @@ class ChronicleEngine:
         self,
         namespace_id: UUID,
         *,
+        filter_ast: FilterNode | None = None,
+        status: str | None = None,
+        updated_before: datetime | None = None,
         limit: int = 100,
-    ) -> list[Document]:
-        """List documents in a namespace."""
-        return await self._get_storage().list_documents(namespace_id, limit=limit)
+        after: DocumentScanKey | None = None,
+        scan_bound: int | None = None,
+    ) -> DocumentPage:
+        """Enumerate one keyset page of a namespace's documents (delegates to the coordinator)."""
+        return await self._get_storage().scan_documents_page(
+            namespace_id,
+            filter_ast=filter_ast,
+            status=status,
+            updated_before=updated_before,
+            limit=limit,
+            after=after,
+            scan_bound=scan_bound,
+        )
 
     @trace("khora.chronicle.search_entities", exclude={"query"}, result=lambda r: {"result_count": len(r)})
     async def search_entities(

--- a/src/khora/engines/protocol.py
+++ b/src/khora/engines/protocol.py
@@ -10,11 +10,13 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from khora.core.models import Document, Entity, MemoryNamespace
+    from khora.core.models.document import DocumentPage
     from khora.extraction.chunkers import ChunkStrategy
     from khora.extraction.skills import ExpertiseConfig
     from khora.filter import FilterNode
     from khora.khora import BatchResult, RecallResult, RememberResult, Stats
     from khora.query import SearchMode
+    from khora.storage.backends.base import DocumentScanKey
 
 
 @runtime_checkable
@@ -322,16 +324,32 @@ class MemoryEngineProtocol(Protocol):
         self,
         namespace_id: UUID,
         *,
+        filter_ast: FilterNode | None = None,
+        status: str | None = None,
+        updated_before: datetime | None = None,
         limit: int = 100,
-    ) -> list[Document]:
-        """List documents in a namespace, newest first, ties broken by descending id.
+        after: DocumentScanKey | None = None,
+        scan_bound: int | None = None,
+    ) -> DocumentPage:
+        """Enumerate one keyset page of a namespace's documents, newest first.
+
+        A one-line delegation to the storage coordinator's keyset scan loop.
+        Engines thread the pre-resolved arguments through unchanged and MUST NOT
+        interpret ``filter_ast`` — the facade validated and lowered it, the
+        coordinator compiles and applies it.
 
         Args:
             namespace_id: Namespace UUID
-            limit: Maximum documents to return
+            filter_ast: Canonical recall-filter AST (already validated + scoped
+                by the facade), or ``None`` for an unfiltered enumeration.
+            status: Document status string, or ``None``.
+            updated_before: Half-open ``updated_at < bound``, or ``None``.
+            limit: Maximum matches per page.
+            after: Internal ``(created_at, id)`` keyset resume position, or ``None``.
+            scan_bound: Per-page raw-row scan budget, or ``None`` for the default.
 
         Returns:
-            List of Documents
+            The coordinator's ``DocumentPage`` unchanged.
         """
         ...
 

--- a/src/khora/engines/skeleton/engine.py
+++ b/src/khora/engines/skeleton/engine.py
@@ -44,9 +44,11 @@ from khora.storage.temporal import TemporalVectorStore
 from khora.telemetry import trace, trace_span
 
 if TYPE_CHECKING:
+    from khora.core.models.document import DocumentPage
     from khora.extraction.chunkers import ChunkStrategy
     from khora.extraction.skills import ExpertiseConfig
     from khora.filter import FilterNode
+    from khora.storage.backends.base import DocumentScanKey
 
 
 class SkeletonConstructionEngine:
@@ -1193,10 +1195,23 @@ class SkeletonConstructionEngine:
         self,
         namespace_id: UUID,
         *,
+        filter_ast: FilterNode | None = None,
+        status: str | None = None,
+        updated_before: datetime | None = None,
         limit: int = 100,
-    ) -> list[Document]:
-        """List documents in a namespace."""
-        return await self._get_storage().list_documents(namespace_id, limit=limit)
+        after: DocumentScanKey | None = None,
+        scan_bound: int | None = None,
+    ) -> DocumentPage:
+        """Enumerate one keyset page of a namespace's documents (delegates to the coordinator)."""
+        return await self._get_storage().scan_documents_page(
+            namespace_id,
+            filter_ast=filter_ast,
+            status=status,
+            updated_before=updated_before,
+            limit=limit,
+            after=after,
+            scan_bound=scan_bound,
+        )
 
     async def search_entities(
         self,

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -75,11 +75,13 @@ from .temporal_detection import TemporalCategory, TemporalDetector, TemporalSign
 if TYPE_CHECKING:
     from neo4j import AsyncDriver
 
+    from khora.core.models.document import DocumentPage
     from khora.extraction.chunkers import ChunkStrategy
     from khora.extraction.skills import ExpertiseConfig
     from khora.filter import FilterNode
     from khora.khora import _GlobalChunkSemaphore
     from khora.storage import StorageCoordinator
+    from khora.storage.backends.base import DocumentScanKey
 
 
 _VC_ABSTENTION_SIGNAL_COUNTER = metric_counter(
@@ -4787,10 +4789,23 @@ class VectorCypherEngine:
         self,
         namespace_id: UUID,
         *,
+        filter_ast: FilterNode | None = None,
+        status: str | None = None,
+        updated_before: datetime | None = None,
         limit: int = 100,
-    ) -> list[Document]:
-        """List documents in a namespace."""
-        return await self._get_storage().list_documents(namespace_id, limit=limit)
+        after: DocumentScanKey | None = None,
+        scan_bound: int | None = None,
+    ) -> DocumentPage:
+        """Enumerate one keyset page of a namespace's documents (delegates to the coordinator)."""
+        return await self._get_storage().scan_documents_page(
+            namespace_id,
+            filter_ast=filter_ast,
+            status=status,
+            updated_before=updated_before,
+            limit=limit,
+            after=after,
+            scan_bound=scan_bound,
+        )
 
     async def stats(self, namespace_id: UUID) -> Stats:
         """Get document/chunk/entity/relationship counts for a namespace."""

--- a/src/khora/khora.py
+++ b/src/khora/khora.py
@@ -86,6 +86,41 @@ def _normalize_recall_bound(value: datetime | None) -> datetime | None:
     return value.astimezone(UTC)
 
 
+def _reject_non_enumerable_keys(filter_ast: Any) -> None:
+    """Reject a document-enumeration filter that references a non-enumerable key.
+
+    Document enumeration filters a document row, so it accepts the nine
+    enumerable system keys plus ``metadata.*`` — but NOT ``occurred_at``, the
+    event-time axis, which lives on chunks and has no column on a document row.
+    Any ``occurred_at`` leaf (at any nesting depth) raises
+    :class:`~khora.filter.RecallFilterValidationError` with the structured
+    ``key_not_enumerable`` code rather than silently matching nothing.
+    """
+    from khora.filter import SYSTEM_KEYS
+    from khora.filter.execute import iter_leaf_clauses
+    from khora.filter.model import FieldError, RecallFilterValidationError
+
+    if not any(clause.path == ("occurred_at",) for clause in iter_leaf_clauses(filter_ast)):
+        return
+
+    enumerable = sorted(SYSTEM_KEYS - {"occurred_at"})
+    raise RecallFilterValidationError(
+        [
+            FieldError(
+                path="occurred_at",
+                code="key_not_enumerable",
+                message=(
+                    "occurred_at is not an enumerable document key: it is the chunk event-time axis "
+                    "and a document row carries no such column. Filter enumeration on source_timestamp "
+                    "(the source/ingest-provided time) or created_at (the ingest time) instead — these are "
+                    "different time axes, not equivalent substitutes for occurred_at."
+                ),
+                allowed=enumerable,
+            )
+        ]
+    )
+
+
 def _safe_exc_summary(exc: BaseException, *, max_len: int = 200) -> str:
     """Return a bounded, safe one-line summary of *exc* for logging.
 
@@ -185,11 +220,13 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from khora.core.models import Relationship
+    from khora.core.models.document import DocumentCursor, DocumentPage, DocumentStatus
     from khora.engines.protocol import MemoryEngineProtocol
     from khora.extraction.chunkers import ChunkStrategy
     from khora.extraction.skills import ExpertiseConfig
     from khora.filter import RecallFilter
     from khora.storage import NamespaceDeletionResult, StorageConfig, StorageCoordinator
+    from khora.storage.backends.base import DocumentScanKey
 
 
 # LLMUsage is a public API type consumed by external cost-tracking integrations.
@@ -2889,19 +2926,86 @@ class Khora:
         self,
         *,
         namespace: str | UUID,
+        filter: RecallFilter | dict[str, Any] | None = None,
+        status: DocumentStatus | str | None = None,
+        updated_before: datetime | None = None,
         limit: int = 100,
-    ) -> list[Document]:
-        """List documents in a namespace, newest first, ties broken by descending id.
+        after: DocumentCursor | Document | None = None,
+    ) -> DocumentPage:
+        """Enumerate documents in a namespace by keyset, newest first (``created_at DESC, id DESC``).
+
+        Returns a :class:`~khora.core.models.document.DocumentPage` — a
+        ``Sequence[Document]`` (iteration / ``len`` / truthiness keep working)
+        carrying the keyset walk-control metadata (``next_after`` /
+        ``exhausted`` / ``post_filtered_keys``). Resume the next page by passing
+        the previous page's ``next_after`` (or any returned :class:`Document`)
+        back in as ``after``; ``exhausted`` is the only sound termination signal.
 
         Args:
-            namespace: Namespace UUID (as UUID or string)
-            limit: Maximum documents to return
+            namespace: Namespace UUID (as UUID or string).
+            filter: Optional deterministic recall filter — a
+                :class:`~khora.filter.RecallFilter` or its dict/wire form. The
+                event-time key ``occurred_at`` is NOT enumerable here (a document
+                row has no event-time column); referencing it raises
+                :class:`~khora.filter.RecallFilterValidationError`.
+            status: Optional :class:`~khora.core.models.document.DocumentStatus`
+                (or its string value). An unknown status raises ``ValueError``
+                rather than silently matching nothing.
+            updated_before: Optional half-open upper bound — ``updated_at < bound``.
+            limit: Maximum matches per page (default 100); a page may return fewer.
+            after: Keyset resume position — a
+                :class:`~khora.core.models.document.DocumentCursor` or a
+                :class:`Document` whose ``(created_at, id)`` is used. There is no
+                ``offset``.
 
         Returns:
-            List of Documents
+            A ``DocumentPage`` of matching documents.
+
+        Raises:
+            RecallFilterValidationError: If ``filter`` fails validation or
+                references ``occurred_at``.
+            RecallFilterUnsupportedError: If a backend cannot honor a predicate.
+            ValueError: If ``status`` is not a known ``DocumentStatus``.
         """
+        from khora.core.models.document import DocumentCursor as _DocumentCursor
+        from khora.core.models.document import DocumentStatus as _DocumentStatus
+
+        # --- filter: validate, lower, then the enumeration key-scope pass ------ #
+        filter_ast: Any = None
+        if filter is not None:
+            from khora.filter import RecallFilter as _RecallFilter
+            from khora.filter import parse_to_ast
+
+            recall_filter = filter if isinstance(filter, _RecallFilter) else _RecallFilter.model_validate(filter)
+            filter_ast = parse_to_ast(recall_filter)
+            _reject_non_enumerable_keys(filter_ast)
+
+        # --- status: enum-validate (never a silent zero-match query) ----------- #
+        status_value: str | None = None
+        if status is not None:
+            # DocumentStatus("bogus") raises ValueError on an unknown value; an
+            # already-typed status is passed through by its .value.
+            status_value = (status if isinstance(status, _DocumentStatus) else _DocumentStatus(status)).value
+
+        # --- after: normalize the public cursor to the internal keyset ---------- #
+        after_key: DocumentScanKey | None = None
+        if after is not None:
+            after_key = (after.created_at, after.id) if isinstance(after, (_DocumentCursor, Document)) else after
+
+        # --- scan bound: max(limit × multiplier, floor), config-overridable ----- #
+        q = self._config.query
+        scan_bound = max(limit * q.document_scan_overfetch_multiplier, q.document_scan_min_bound)
+
         namespace_id = await self._resolve_namespace(namespace)
-        return await self._get_engine().list_documents(namespace_id, limit=limit)
+        return await self._get_engine().list_documents(
+            namespace_id,
+            filter_ast=filter_ast,
+            status=status_value,
+            updated_before=updated_before,
+            limit=limit,
+            after=after_key,
+            scan_bound=scan_bound,
+        )
 
     async def search_entities(
         self,

--- a/src/khora/storage/backends/base.py
+++ b/src/khora/storage/backends/base.py
@@ -348,6 +348,28 @@ class RelationalBackendProtocol(Protocol):
         """List documents in a namespace, newest first, ties broken by descending id."""
         ...
 
+    async def scan_documents(
+        self,
+        namespace_id: UUID,
+        *,
+        filter_ast: FilterNode | None = None,
+        status: str | None = None,
+        updated_before: datetime | None = None,
+        after: DocumentScanKey | None = None,
+        scan_limit: int = 100,
+    ) -> DocumentScanStep:
+        """Scan one bounded keyset window of a namespace's documents. ``@internal``.
+
+        The keyset scan primitive the coordinator's ``scan_documents_page`` drives
+        one step at a time in ``(created_at DESC, id DESC)`` order, chaining
+        :attr:`DocumentScanStep.last_scanned` back in as ``after`` until
+        :attr:`DocumentScanStep.exhausted`. Not part of the public storage API and
+        not abstract: it is declared on the protocol only so the coordinator can
+        call it across the protocol boundary; the four relational stores own the
+        implementation. See :class:`DocumentScanStep` for the row/cursor contract.
+        """
+        ...
+
     @abstractmethod
     async def claim_orphaned_documents(
         self,

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import time as _time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -31,10 +31,10 @@ from khora.core.models import (
     MemoryNamespace,
     Relationship,
 )
-from khora.core.models.document import DocumentSource
+from khora.core.models.document import DocumentCursor, DocumentPage, DocumentSource
 from khora.core.models.recall import DocumentProjection
 from khora.exceptions import GraphMirrorFailedAfterPGCommitError
-from khora.storage.backends.base import PaginatedResult
+from khora.storage.backends.base import DocumentScanKey, PaginatedResult
 from khora.storage.replace_mirror import apply_replace_mirror_payload, build_replace_mirror_payload
 from khora.telemetry import get_collector, metric_counter, trace_span
 
@@ -262,6 +262,19 @@ class NamespaceDeletionResult:
     def partial_failure(self) -> bool:
         """True when at least one backend purge failed."""
         return bool(self.degradations)
+
+
+def _cursor_from_key(key: DocumentScanKey | None) -> DocumentCursor | None:
+    """Lift an internal ``(created_at, id)`` scan key to the public cursor.
+
+    ``None`` maps to ``None`` (an exhausted or never-advanced walk). The key is
+    stored verbatim off the raw row by the scan primitive; this only re-wraps it,
+    it does not reshape ``created_at`` or ``id``.
+    """
+    if key is None:
+        return None
+    created_at, doc_id = key
+    return DocumentCursor(created_at=created_at, id=doc_id)
 
 
 @dataclass
@@ -893,6 +906,116 @@ class StorageCoordinator:
             raise RuntimeError("Relational backend not configured")
         return await self._relational.list_documents(
             namespace_id, status=status, updated_before=updated_before, limit=limit, offset=offset
+        )
+
+    async def scan_documents_page(
+        self,
+        namespace_id: UUID,
+        *,
+        filter_ast: FilterNode | None = None,
+        status: str | None = None,
+        updated_before: datetime | None = None,
+        limit: int = 100,
+        after: DocumentScanKey | None = None,
+        scan_bound: int | None = None,
+    ) -> DocumentPage:
+        """Enumerate one keyset page of a namespace's documents.
+
+        The keyset counterpart to the offset-based :meth:`list_documents`.
+        Drives the relational backend's ``scan_documents`` primitive one bounded
+        step at a time in ``(created_at DESC, id DESC)`` order, applies the
+        in-memory filter post-check to each step's rows, and accumulates matches
+        until the page is full, the scan bound is consumed, or the namespace is
+        exhausted. No transaction spans steps — each step is its own ``SELECT``.
+
+        ``filter_ast`` is compiled to an in-memory predicate **once** (not per
+        step) and re-checks the WHOLE filter over every scanned row: everything a
+        backend pushed into SQL is a superset filter, so re-running a pushed leaf
+        can only narrow. ``after`` is the internal ``(created_at, id)`` resume
+        position; callers thread the previous page's
+        :attr:`~khora.core.models.document.DocumentPage.next_after`.
+
+        Step sizing is the shortfall ``limit - len(matches)`` (bounded by the
+        remaining scan budget), so a step never returns more matches than the
+        page still needs — a page holds **at most** ``limit`` matches, its
+        ``next_after`` is always a raw last-scanned position (never derived from a
+        converted document), and exactly-once resume holds. Under a very selective
+        filter the tail steps shrink; the total raw rows scanned per page is
+        capped at ``scan_bound`` (default ``max(limit × 10, 1000)``).
+
+        **Memory note:** ``scan_limit`` bounds *rows*, and the raw stores
+        ``SELECT *``; a step over large documents is large in bytes even when the
+        row count is modest. The scan bound is a row count, not a byte budget.
+
+        Returns a :class:`~khora.core.models.document.DocumentPage`:
+        ``next_after`` is the last-scanned position (``None`` iff ``exhausted``),
+        ``exhausted`` is the only sound termination signal, and
+        ``post_filtered_keys`` are the filter leaf keys the backend could not push
+        and that the post-filter enforced (empty without a filter).
+        """
+        if not self._relational:
+            raise RuntimeError("Relational backend not configured")
+        if limit < 1:
+            raise ValueError(f"limit must be >= 1, got {limit}")
+
+        if scan_bound is None:
+            scan_bound = max(limit * 10, 1000)
+
+        # Compile the post-filter ONCE per page. filter_leaf_keys is the
+        # left-hand side of the pushdown split reported per step in consumed_keys.
+        post_filter: Callable[[Any], bool] | None = None
+        leaf_keys: frozenset[str] = frozenset()
+        if filter_ast is not None:
+            from khora.filter.compilers.python import compile_python
+            from khora.filter.execute import build_compile_context, filter_leaf_keys
+
+            leaf_keys = filter_leaf_keys(filter_ast)
+            post_filter = compile_python(
+                filter_ast, build_compile_context("documents", on_unsupported="split")
+            ).predicate
+
+        matches: list[Document] = []
+        consumed_keys: frozenset[str] = frozenset()
+        cursor: DocumentScanKey | None = after
+        last_scanned: DocumentScanKey | None = None
+        remaining = scan_bound
+        exhausted = False
+
+        while True:
+            need = limit - len(matches)
+            if need <= 0:
+                break  # page full
+            step_limit = min(need, remaining)
+            if step_limit <= 0:
+                break  # scan bound consumed
+            step = await self._relational.scan_documents(
+                namespace_id,
+                filter_ast=filter_ast,
+                status=status,
+                updated_before=updated_before,
+                after=cursor,
+                scan_limit=step_limit,
+            )
+            consumed_keys |= step.consumed_keys
+            rows = step.documents
+            if post_filter is not None:
+                rows = [doc for doc in rows if post_filter(doc)]
+            matches.extend(rows)
+            # Budget counts RAW rows scanned (scan_documents never post-filters,
+            # so len(step.documents) is the raw window size), not surviving matches.
+            remaining -= len(step.documents)
+            if step.last_scanned is not None:
+                last_scanned = step.last_scanned
+            if step.exhausted:
+                exhausted = True
+                break
+            cursor = step.last_scanned
+
+        return DocumentPage(
+            matches,
+            next_after=None if exhausted else _cursor_from_key(last_scanned),
+            exhausted=exhausted,
+            post_filtered_keys=tuple(sorted(leaf_keys - consumed_keys)) if filter_ast is not None else (),
         )
 
     @_record_storage_op("claim_orphaned_documents", "postgresql")

--- a/tests/integration/test_list_documents_enumeration_facade.py
+++ b/tests/integration/test_list_documents_enumeration_facade.py
@@ -1,0 +1,217 @@
+"""Facade document-enumeration wiring on the embedded stack (DYT-5537).
+
+The keyset ``list_documents`` facade returns a ``DocumentPage`` walked by
+``next_after`` until ``exhausted``. These co-located tests prove the three
+things the assembly ticket calls for against a real sqlite_lance namespace:
+
+* a multi-page cursor walk is exactly-once, correctly ordered, and terminates
+  only on ``exhausted`` (with ``next_after is None``), and the page is a
+  ``Sequence`` at every step;
+* the facade result set equals the offset-based ``kb.storage.list_documents``
+  for the same ``status`` / ``updated_before`` constraints (closes khora#1527's
+  documented workaround);
+* a filter narrows the enumeration exactly, and ``occurred_at`` is refused.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+try:
+    import aiosqlite  # noqa: F401
+    import lancedb  # noqa: F401
+
+    _HAS_EMBEDDED = True
+except ImportError:
+    _HAS_EMBEDDED = False
+
+from khora.core.models import Document
+from khora.core.models.document import DocumentPage, DocumentStatus
+from khora.filter import RecallFilterValidationError
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not _HAS_EMBEDDED, reason="aiosqlite/lancedb not installed"),
+]
+
+_BASE = datetime(2026, 1, 15, 9, 0, 0, tzinfo=UTC)
+
+
+def _config(tmp_path: Path):
+    from khora.config import KhoraConfig
+    from khora.config.schema import SQLiteLanceConfig
+
+    config = KhoraConfig()
+    config.storage.backend = "sqlite_lance"
+    config.storage.sqlite_lance = SQLiteLanceConfig(
+        db_path=str(tmp_path / "k.db"),
+        lance_path=str(tmp_path / "k.lance"),
+        embedding_dimension=8,
+    )
+    config.storage.embedding_dimension = 8
+    config.llm.embedding_dimension = 8
+    return config
+
+
+async def _seed(kb, row_ns: UUID, specs: list[dict]) -> list[Document]:
+    """Write documents directly through the storage tier (no extraction)."""
+    docs: list[Document] = []
+    for spec in specs:
+        doc = Document(
+            namespace_id=row_ns,
+            content=spec.get("content", "seed"),
+            checksum=f"chk-{uuid4().hex}",
+            created_at=spec["created_at"],
+            updated_at=spec.get("updated_at", spec["created_at"]),
+            status=spec.get("status", DocumentStatus.COMPLETED),
+            source_type=spec.get("source_type", "library"),
+            metadata=spec.get("metadata", {}),
+        )
+        await kb.storage.create_document(doc)
+        docs.append(doc)
+    return docs
+
+
+def _expected_order(docs: list[Document]) -> list[UUID]:
+    """The single correct enumeration order: created_at DESC, then id DESC."""
+    return [d.id for d in sorted(docs, key=lambda d: (d.created_at, d.id), reverse=True)]
+
+
+async def test_basic_walk_exactly_once_and_sequence_compat(tmp_path: Path) -> None:
+    from khora import Khora
+
+    async with Khora(_config(tmp_path), run_migrations=True) as kb:
+        ns = await kb.create_namespace()
+        row_ns = await kb._resolve_namespace(ns.namespace_id)
+        seeded = await _seed(
+            kb,
+            row_ns,
+            [{"created_at": _BASE + timedelta(minutes=i)} for i in range(7)],
+        )
+        expected = _expected_order(seeded)
+
+        collected: list[UUID] = []
+        pages = 0
+        after = None
+        while True:
+            page = await kb.list_documents(namespace=ns.namespace_id, limit=3, after=after)
+            pages += 1
+            assert isinstance(page, DocumentPage)
+            assert len(page) <= 3
+            collected.extend(d.id for d in page)  # Sequence iteration
+            if page.exhausted:
+                assert page.next_after is None
+                break
+            assert page.next_after is not None
+            after = page.next_after
+            assert pages < 20, "walk did not terminate"
+
+        assert pages >= 3, "limit=3 over 7 rows must span multiple pages"
+        assert collected == expected, "walk must be ordered and exactly-once"
+        assert len(set(collected)) == len(collected), "no document returned twice"
+
+
+async def test_resume_from_returned_document(tmp_path: Path) -> None:
+    """``after`` also accepts a Document — its (created_at, id) is the cursor."""
+    from khora import Khora
+
+    async with Khora(_config(tmp_path), run_migrations=True) as kb:
+        ns = await kb.create_namespace()
+        row_ns = await kb._resolve_namespace(ns.namespace_id)
+        seeded = await _seed(kb, row_ns, [{"created_at": _BASE + timedelta(minutes=i)} for i in range(5)])
+        expected = _expected_order(seeded)
+
+        first = await kb.list_documents(namespace=ns.namespace_id, limit=2)
+        assert [d.id for d in first] == expected[:2]
+
+        # Resume from the last returned Document object rather than next_after.
+        rest = await kb.list_documents(namespace=ns.namespace_id, limit=10, after=first[-1])
+        assert [d.id for d in rest] == expected[2:]
+        assert rest.exhausted
+
+
+async def test_facade_storage_parity_status_and_updated_before(tmp_path: Path) -> None:
+    from khora import Khora
+
+    async with Khora(_config(tmp_path), run_migrations=True) as kb:
+        ns = await kb.create_namespace()
+        row_ns = await kb._resolve_namespace(ns.namespace_id)
+        cutoff = _BASE + timedelta(hours=1)
+        await _seed(
+            kb,
+            row_ns,
+            [
+                {"created_at": _BASE + timedelta(minutes=0), "status": DocumentStatus.COMPLETED, "updated_at": _BASE},
+                {
+                    "created_at": _BASE + timedelta(minutes=1),
+                    "status": DocumentStatus.PENDING,
+                    "updated_at": _BASE + timedelta(minutes=1),
+                },
+                {
+                    "created_at": _BASE + timedelta(minutes=2),
+                    "status": DocumentStatus.COMPLETED,
+                    "updated_at": cutoff + timedelta(minutes=5),
+                },
+                {
+                    "created_at": _BASE + timedelta(minutes=3),
+                    "status": DocumentStatus.FAILED,
+                    "updated_at": _BASE + timedelta(minutes=3),
+                },
+            ],
+        )
+
+        # status parity
+        facade = await kb.list_documents(namespace=ns.namespace_id, status="completed", limit=100)
+        offset = await kb.storage.list_documents(row_ns, status="completed", limit=100)
+        assert [d.id for d in facade] == [d.id for d in offset]
+        assert facade.exhausted
+
+        # status enum object parity (same as the string form)
+        facade_enum = await kb.list_documents(namespace=ns.namespace_id, status=DocumentStatus.COMPLETED, limit=100)
+        assert [d.id for d in facade_enum] == [d.id for d in offset]
+
+        # updated_before parity
+        facade_ub = await kb.list_documents(namespace=ns.namespace_id, updated_before=cutoff, limit=100)
+        offset_ub = await kb.storage.list_documents(row_ns, updated_before=cutoff, limit=100)
+        assert [d.id for d in facade_ub] == [d.id for d in offset_ub]
+
+
+async def test_filter_narrows_and_occurred_at_rejected(tmp_path: Path) -> None:
+    from khora import Khora
+
+    async with Khora(_config(tmp_path), run_migrations=True) as kb:
+        ns = await kb.create_namespace()
+        row_ns = await kb._resolve_namespace(ns.namespace_id)
+        seeded = await _seed(
+            kb,
+            row_ns,
+            [
+                {"created_at": _BASE + timedelta(minutes=0), "source_type": "report", "metadata": {"tier": "gold"}},
+                {"created_at": _BASE + timedelta(minutes=1), "source_type": "library", "metadata": {"tier": "silver"}},
+                {"created_at": _BASE + timedelta(minutes=2), "source_type": "report", "metadata": {"tier": "gold"}},
+            ],
+        )
+        by_id = {d.id: d for d in seeded}
+
+        # System-key filter narrows to the matching rows, still ordered.
+        page = await kb.list_documents(namespace=ns.namespace_id, filter={"source_type": "report"}, limit=100)
+        assert all(by_id[d.id].source_type == "report" for d in page)
+        assert {d.id for d in page} == {d.id for d in seeded if d.source_type == "report"}
+        assert isinstance(page.post_filtered_keys, tuple)
+
+        # Metadata filter — exercises the in-memory post-filter path.
+        gold = await kb.list_documents(namespace=ns.namespace_id, filter={"metadata.tier": "gold"}, limit=100)
+        assert {d.id for d in gold} == {d.id for d in seeded if d.metadata.get("tier") == "gold"}
+
+        # occurred_at is not enumerable on a document row.
+        with pytest.raises(RecallFilterValidationError) as exc_info:
+            await kb.list_documents(namespace=ns.namespace_id, filter={"occurred_at": {"$gte": "2020-01-01T00:00:00Z"}})
+        assert exc_info.value.errors[0].code == "key_not_enumerable"
+
+        # Unknown status is a hard error, never a silent zero-match query.
+        with pytest.raises(ValueError, match="bogus"):
+            await kb.list_documents(namespace=ns.namespace_id, status="bogus")

--- a/tests/unit/engines/skeleton/test_engine_coverage.py
+++ b/tests/unit/engines/skeleton/test_engine_coverage.py
@@ -558,11 +558,14 @@ class TestDelegatingMethods:
     @pytest.mark.asyncio
     async def test_list_documents_delegates(self) -> None:
         eng = _connected()
-        eng._storage.list_documents = AsyncMock(return_value=[])
+        sentinel = MagicMock()
+        eng._storage.scan_documents_page = AsyncMock(return_value=sentinel)
         ns = uuid4()
         out = await eng.list_documents(ns, limit=25)
-        assert out == []
-        eng._storage.list_documents.assert_awaited_once_with(ns, limit=25)
+        assert out is sentinel
+        eng._storage.scan_documents_page.assert_awaited_once_with(
+            ns, filter_ast=None, status=None, updated_before=None, limit=25, after=None, scan_bound=None
+        )
 
     @pytest.mark.asyncio
     async def test_search_entities_not_implemented(self) -> None:

--- a/tests/unit/engines/vectorcypher/test_engine_coverage.py
+++ b/tests/unit/engines/vectorcypher/test_engine_coverage.py
@@ -536,10 +536,13 @@ class TestPassthroughOperations:
     async def test_list_documents(self) -> None:
         engine = _make_connected_engine()
         ns = uuid4()
-        engine._storage.list_documents = AsyncMock(return_value=[])
+        sentinel = MagicMock()
+        engine._storage.scan_documents_page = AsyncMock(return_value=sentinel)
         out = await engine.list_documents(ns, limit=10)
-        assert out == []
-        engine._storage.list_documents.assert_awaited_once_with(ns, limit=10)
+        assert out is sentinel
+        engine._storage.scan_documents_page.assert_awaited_once_with(
+            ns, filter_ast=None, status=None, updated_before=None, limit=10, after=None, scan_bound=None
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -22,6 +22,10 @@ def mock_config() -> MagicMock:
     mock_config.get_neo4j_password.return_value = None
     mock_config.get_neo4j_database.return_value = None
     mock_config.storage.embedding_dimension = 1536
+    # Document-enumeration scan-bound knobs (real ints so list_documents can
+    # compute max(limit × multiplier, floor) without a MagicMock comparison).
+    mock_config.query.document_scan_overfetch_multiplier = 10
+    mock_config.query.document_scan_min_bound = 1000
     mock_config.llm.model = "gpt-4o-mini"
     mock_config.llm.embedding_model = "text-embedding-3-small"
     mock_config.llm.embedding_dimension = 1536

--- a/tests/unit/test_khora.py
+++ b/tests/unit/test_khora.py
@@ -1495,16 +1495,25 @@ class TestConvenienceMethods:
 
     @pytest.mark.asyncio
     async def test_list_documents(self) -> None:
-        """list_documents delegates to engine with resolved namespace."""
+        """list_documents threads the enumeration args to the engine with a resolved namespace."""
         kb = _make_kb(connected=True)
         ns_id = uuid4()
 
-        mock_docs = [MagicMock(), MagicMock()]
-        kb._engine.list_documents = AsyncMock(return_value=mock_docs)
+        mock_page = MagicMock()
+        kb._engine.list_documents = AsyncMock(return_value=mock_page)
 
         result = await kb.list_documents(namespace=ns_id, limit=50)
-        assert result == mock_docs
-        kb._engine.list_documents.assert_awaited_once_with(_RESOLVE_ROW_ID, limit=50)
+        assert result is mock_page
+        # scan_bound = max(50 × 10, 1000) = 1000 (from the mock config knobs).
+        kb._engine.list_documents.assert_awaited_once_with(
+            _RESOLVE_ROW_ID,
+            filter_ast=None,
+            status=None,
+            updated_before=None,
+            limit=50,
+            after=None,
+            scan_bound=1000,
+        )
 
     @pytest.mark.asyncio
     async def test_search_entities(self) -> None:

--- a/tests/unit/test_list_documents_enumeration.py
+++ b/tests/unit/test_list_documents_enumeration.py
@@ -1,0 +1,106 @@
+"""Unit coverage for the document-enumeration facade surface (DYT-5537).
+
+Covers the pieces that need no live backend: the ``DocumentPage`` sequence
+contract, the ``occurred_at`` enumeration key-scope rejection (structured error
++ asserted copy), and the ``status`` enum validation. The multi-page cursor walk
+and facade/storage parity live in the integration lane (they need a seeded
+namespace on the sqlite_lance stack).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from khora.core.models import Document
+from khora.core.models.document import DocumentCursor, DocumentPage
+from khora.filter import RecallFilter, RecallFilterValidationError
+from khora.filter.ast import parse_to_ast
+from khora.khora import _reject_non_enumerable_keys
+
+
+def _ast(wire: dict) -> object:
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+class TestDocumentPageSequence:
+    """DocumentPage is a Sequence[Document]: iterate / len / truthiness / index."""
+
+    def _page(self, docs: list[Document], **kw: object) -> DocumentPage:
+        kw.setdefault("next_after", None)
+        kw.setdefault("exhausted", True)
+        return DocumentPage(docs, **kw)  # type: ignore[arg-type]
+
+    def test_is_sequence(self) -> None:
+        assert isinstance(self._page([]), Sequence)
+
+    def test_len_iter_index(self) -> None:
+        docs = [Document(content="a"), Document(content="b")]
+        page = self._page(docs)
+        assert len(page) == 2
+        assert list(page) == docs
+        assert page[0] is docs[0]
+        assert page[-1] is docs[1]
+        assert list(page[0:1]) == [docs[0]]
+
+    def test_truthiness_tracks_length(self) -> None:
+        # khora-benchmarks-style `if await kb.list_documents(...)` usage.
+        assert not self._page([])
+        assert self._page([Document(content="x")])
+
+    def test_carries_walk_metadata(self) -> None:
+        cur = DocumentCursor(created_at=datetime.now(UTC), id=uuid4())
+        page = DocumentPage(
+            [Document(content="x")],
+            next_after=cur,
+            exhausted=False,
+            post_filtered_keys=("metadata.tier",),
+        )
+        assert page.next_after is cur
+        assert page.exhausted is False
+        assert page.post_filtered_keys == ("metadata.tier",)
+
+
+class TestOccurredAtRejection:
+    """occurred_at is the chunk event-time axis — not enumerable on a document row."""
+
+    @pytest.mark.parametrize(
+        "wire",
+        [
+            {"occurred_at": {"$gte": "2020-01-01T00:00:00Z"}},
+            {"$or": [{"occurred_at": {"$gte": "2020-01-01T00:00:00Z"}}, {"source_type": "report"}]},
+            {"$not": {"occurred_at": {"$lte": "2020-01-01T00:00:00Z"}}},
+        ],
+    )
+    def test_rejected_with_structured_error(self, wire: dict) -> None:
+        with pytest.raises(RecallFilterValidationError) as exc_info:
+            _reject_non_enumerable_keys(_ast(wire))
+        errors = exc_info.value.errors
+        assert len(errors) == 1
+        fe = errors[0]
+        assert fe.path == "occurred_at"
+        assert fe.code == "key_not_enumerable"
+        # The nine enumerable keys (the ten system keys minus occurred_at).
+        assert fe.allowed is not None and len(fe.allowed) == 9
+        assert "occurred_at" not in fe.allowed
+        # Copy names both substitutes and refuses to call the axes equivalent.
+        assert "source_timestamp" in fe.message
+        assert "created_at" in fe.message
+        assert "equivalent" in fe.message
+
+    @pytest.mark.parametrize(
+        "wire",
+        [
+            {"source_type": "report"},
+            {"created_at": {"$gte": "2020-01-01T00:00:00Z"}},
+            {"source_timestamp": {"$gte": "2020-01-01T00:00:00Z"}},
+            {"metadata.tier": "gold"},
+            {"title": {"$in": ["a", "b"]}},
+        ],
+    )
+    def test_enumerable_keys_pass(self, wire: dict) -> None:
+        # Does not raise.
+        _reject_non_enumerable_keys(_ast(wire))

--- a/tests/unit/test_public_surface.py
+++ b/tests/unit/test_public_surface.py
@@ -28,6 +28,8 @@ EXPECTED_PUBLIC_SURFACE = frozenset(
         "BatchHandle",
         "BatchResult",
         "DateOps",
+        "DocumentCursor",
+        "DocumentPage",
         "DocumentProjection",
         "DocumentResult",
         "DocumentSource",


### PR DESCRIPTION
## Changes

- **`DocumentPage` + `DocumentCursor`** (`core/models/document.py`, exported from `khora`): `DocumentPage` is a `Sequence[Document]` (iteration / `len` / truthiness keep working) carrying `next_after` (last-scanned position; `None` iff `exhausted`), `exhausted` (the only termination signal), and `post_filtered_keys`. `DocumentCursor` is the opaque public `(created_at, id)` keyset position. Distinct from the storage tier's offset-shaped `PaginatedResult`.
- **Facade `Khora.list_documents`** rewritten to the ADR contract: validates + lowers `filter`, runs the enumeration key-scope pass rejecting `occurred_at` with a structured `RecallFilterValidationError(FieldError(code="key_not_enumerable", allowed=<9 keys>))` whose copy names `source_timestamp`/`created_at` as substitutes without claiming equivalence; enum-validates `status` (unknown → `ValueError`); normalizes `after` (`DocumentCursor | Document` → keyset); resolves the config-overridable scan bound; returns a `DocumentPage`. No `offset`.
- **Engine threading** (`engines/protocol.py` + skeleton/vectorcypher/chronicle): `list_documents` now threads `filter_ast/status/updated_before/limit/after/scan_bound` and returns the coordinator's `DocumentPage` unchanged — one-line delegations; no engine interprets the AST.
- **Coordinator scan loop** (`StorageCoordinator.scan_documents_page`): drives `scan_documents` one bounded step at a time, compiles the `compile_python` residual **once per page**, sizes each step to the shortfall (`limit - len(matches)`) so a page never exceeds `limit`, `next_after` is always a raw last-scanned position (never derived from a converted document), and exactly-once resume holds. Scan bound = `max(limit × 10, 1000)`, config-overridable, never a caller parameter. The offset-based `list_documents` is untouched (its `gc` / integration callers keep working).
- **Protocol declaration**: the internal `scan_documents` primitive is now declared (non-abstract) on `RelationalBackendProtocol` so the coordinator calls it across the protocol boundary cleanly.
- **Config**: `document_scan_overfetch_multiplier` (10) / `document_scan_min_bound` (1000) on `QuerySettings`.

## Tests (co-located)

- `tests/unit/test_list_documents_enumeration.py` — `DocumentPage` sequence contract; `occurred_at` rejection (structured error + asserted copy, incl. `$or`/`$not` nesting); enumerable keys pass.
- `tests/integration/test_list_documents_enumeration_facade.py` (sqlite_lance) — multi-page cursor walk (exactly-once / ordered / terminates on `exhausted` / Sequence-compat); resume from a returned `Document`; facade↔`kb.storage` parity for `status` / `updated_before`; filter narrows + `occurred_at` refused + unknown-status `ValueError`.

## Verification

- `make format` + `make lint` clean.
- Full unit suite green (**9984 passed, 77 skipped**) with the embedded/langgraph/weaviate extras installed locally.
- New unit (12) + sqlite_lance integration (4) tests pass; the langgraph adapter (a real consumer of the facade) passes against the `DocumentPage` return.
- Postgres/Neo4j/SurrealDB integration + e2e lanes run in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paginated document enumeration with continuation cursors.
  * Added filtering by status, update time, and supported document fields.
  * Document results now include pagination metadata, including exhaustion status and resume position.
  * Added configurable scan limits for efficient large-result queries.

* **Bug Fixes**
  * Added validation with clear errors for unsupported `occurred_at` document filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->