### PR TITLE
Add documents-enumeration conformance legs to the recall-filter harness

### DIFF
--- a/.github/workflows/filter-conformance.yml
+++ b/.github/workflows/filter-conformance.yml
@@ -1,14 +1,27 @@
 name: Filter Conformance
 
 # ---------------------------------------------------------------------------
-# Recall-filter conformance matrix. One leg per engine; each leg provisions
+# Recall-filter conformance matrices. One leg per engine; each leg provisions
 # ONLY the live store it needs via an `if:`-guarded `docker run` (Postgres for
 # the postgres leg, Neo4j for the cypher leg, Weaviate for the weaviate leg),
 # so a leg that runs in-process never waits on an idle container.
 #
+# Two jobs, because there are two SURFACES with different corpora and different
+# contracts:
+#
+# * `conformance` — the chunk RECALL surface. Postgres/SurrealDB are total-exact
+#   there and a filter they cannot express RAISES, so the corpus carries
+#   `expect_unsupported` legs. Selected by KHORA_CONFORMANCE_BACKEND.
+# * `documents-conformance` — the document ENUMERATION surface. Uniformly split +
+#   post-filter on every backend, so nothing raises and every case is a plain
+#   row-set comparison; each case also runs in both a natural (backend pushdown)
+#   and a residual (post-filter-only) mode. Selected by
+#   KHORA_CONFORMANCE_DOC_BACKEND, and its Postgres leg has its own corpus, its
+#   own seed invocation and its own seed-map path.
+#
 # This file is intentionally separate from ci.yml: GitHub schedules a separate
-# workflow file as its own check, so this matrix runs concurrently with the
-# main `test` job and gates the PR on its own.
+# workflow file as its own check, so these matrices run concurrently with the
+# main `test` job and gate the PR on their own.
 # ---------------------------------------------------------------------------
 
 on:
@@ -325,3 +338,125 @@ jobs:
       - name: Stop Weaviate
         if: ${{ always() && matrix.weaviate }}
         run: docker rm -f khora-conformance-weaviate || true
+
+  documents-conformance:
+    # The document-ENUMERATION conformance matrix. Same per-leg provisioning
+    # discipline as the `conformance` job above, over a different corpus and a
+    # different read path: every leg drives the REAL
+    # `StorageCoordinator.scan_documents_page` keyset walk over documents seeded
+    # through the coordinator's write API, and asserts the row-set against the
+    # Python oracle. Every case runs TWICE — once natural (the AST reaches the
+    # backend, which pushes what it can) and once residual (the AST is withheld
+    # and the identical compile_python post-filter is applied in-harness, which
+    # is what pins the predicate against each store's round-trip document shape).
+    name: documents-conformance (${{ matrix.backend }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Raw `backend: sqlite` — the hand-written aiosqlite tier with its own
+          # `documents` DDL. In-process; the first conformance coverage of this
+          # backend at all (the chunk corpus reaches SQLite only via sqlite_lance).
+          - backend: sqlite
+          # Embedded sqlite_lance — the shared Alembic `documents` model over a
+          # tmp SQLite file migrated to head. In-process.
+          - backend: sqlite_lance
+          # Embedded SurrealDB `memory://` with the production schema. In-process.
+          - backend: surrealdb
+          # Live Postgres — the only tier whose date columns are real timestamptz,
+          # and therefore the only one that pushes the two date keys into SQL.
+          - backend: postgres
+            postgres: true
+    env:
+      KHORA_CONFORMANCE_DOC_BACKEND: ${{ matrix.backend }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          prune-cache: false
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        # crewai combo — matches ci.yml's `install` job (NEVER `--all-extras`:
+        # crewai/google-adk conflict on opentelemetry-api).
+        run: uv sync --all-extras --no-extra google-adk
+
+      # -- Per-leg Postgres -------------------------------------------------- #
+      # Same `if:`-guarded `docker run` pattern as the chunk job: only the
+      # postgres leg starts a container, so the three embedded legs never wait on
+      # an idle DB. Image, creds and host port mirror ci.yml / `make dev`.
+      - name: Start Postgres
+        if: matrix.postgres
+        run: |
+          docker run -d --name khora-docs-conformance-pg \
+            -e POSTGRES_USER=khora \
+            -e POSTGRES_PASSWORD=khora \
+            -e POSTGRES_DB=khora \
+            -p 5434:5432 \
+            --health-cmd "pg_isready -U khora -d khora" \
+            --health-interval 5s \
+            --health-timeout 5s \
+            --health-retries 10 \
+            pgvector/pgvector:pg17
+
+      - name: Wait for Postgres readiness
+        if: matrix.postgres
+        run: |
+          for i in $(seq 1 30); do
+            if pg_isready -h localhost -p 5434 -U khora >/dev/null 2>&1; then
+              echo "postgres ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "postgres did not become ready within 60s"
+          exit 1
+
+      - name: Apply database migrations
+        if: matrix.postgres
+        env:
+          KHORA_DATABASE_URL: postgresql://khora:khora@localhost:5434/khora
+        run: uv run alembic upgrade head
+
+      - name: Seed documents conformance corpus
+        if: matrix.postgres
+        # One-time seed, run ONCE before pytest, so the `-n auto` workers below
+        # only read. `documents-postgres` is its own seed-entrypoint backend (its
+        # own corpus and its own table), and it writes the per-case
+        # `seed_id -> document uuid` map to KHORA_CONFORMANCE_DOCS_SEED_MAP — a
+        # different artifact from the chunk leg's. Namespaces are derived
+        # deterministically, so re-running this step against an already-seeded
+        # database fails loudly rather than duplicating the corpus.
+        env:
+          KHORA_DATABASE_URL: postgresql://khora:khora@localhost:5434/khora
+          KHORA_CONFORMANCE_DOCS_SEED_MAP: ${{ github.workspace }}/.conformance_docs_seed_map.json
+        run: uv run python -m tests.integration.matrix._conformance_seed documents-postgres
+
+      # -- Documents conformance suite --------------------------------------- #
+      - name: Run documents conformance
+        # KHORA_PG_REQUIRED=1 (postgres only) makes tests/integration/conftest.py
+        # abort the session RED if Postgres is unreachable, so the postgres leg can
+        # never silently skip its cases. The three embedded legs set no service
+        # var and gate on their runner module's reachable().
+        env:
+          KHORA_DATABASE_URL: ${{ matrix.postgres && 'postgresql://khora:khora@localhost:5434/khora' || '' }}
+          KHORA_PG_REQUIRED: ${{ matrix.postgres && '1' || '' }}
+          KHORA_CONFORMANCE_DOCS_SEED_MAP: ${{ matrix.postgres && format('{0}/.conformance_docs_seed_map.json', github.workspace) || '' }}
+        run: |
+          uv run pytest \
+            tests/integration/matrix/test_documents_conformance.py \
+            -m "filter_conformance" -n auto --no-cov -v
+
+      - name: Stop Postgres
+        if: ${{ always() && matrix.postgres }}
+        run: docker rm -f khora-docs-conformance-pg || true

--- a/src/khora/filter/conformance.py
+++ b/src/khora/filter/conformance.py
@@ -34,6 +34,17 @@ and an ``exercises`` tag tuple the coverage meta-test reads.
   seeded coordinator. The live-Postgres wiring is the CI ticket's concern; this
   module defines only the seam.
 
+**Two targets.** Everything above describes the chunk RECALL surface. The same
+catalog also drives the document ENUMERATION surface, through a parallel and
+deliberately smaller set of pieces: :func:`documents_conformance_cases` (the
+enumerable-key subset of the corpus, plus a re-seeded ``external_id`` family),
+:func:`seed_documents_case` (one Document per :class:`SeedRecord`, no chunks),
+:func:`documents_oracle_survivors` (the oracle over a document-row mapping), and a
+single :class:`DocumentsExecutor` — one, not one per backend, because that read path
+is uniformly split + post-filter everywhere and nothing raises on it. The one system
+key enumeration does NOT accept is ``occurred_at``, encoded as a rejection
+(:data:`_DOCUMENTS_REJECTED_FILTERS`) rather than as a row-set case.
+
 ``@internal``. Reachable as ``khora.filter.conformance`` for khora's own test
 suite; **not** re-exported from :mod:`khora.__init__` or :mod:`khora.filter`.
 """
@@ -77,6 +88,8 @@ __all__ = [
     "ChronicleExecutor",
     "ConformanceCase",
     "CypherExecutor",
+    "DocumentsExecutor",
+    "DocumentsRunner",
     "LanceExecutor",
     "LiveRunner",
     "PostgresExecutor",
@@ -87,6 +100,8 @@ __all__ = [
     "WeaviateExecutor",
     "assert_case",
     "assert_recall_conformance",
+    "documents_conformance_cases",
+    "documents_oracle_survivors",
     "f_array_cases",
     "f_coerce_cases",
     "f_dates_cases",
@@ -97,6 +112,7 @@ __all__ = [
     "f_nullval_cases",
     "f_objeq_cases",
     "f_op_cases",
+    "f_op_documents_cases",
     "f_polarity_cases",
     "f_sel_cases",
     "f_sugar_cases",
@@ -104,6 +120,7 @@ __all__ = [
     "oracle_survivors",
     "run_case_for_backend",
     "seed_case",
+    "seed_documents_case",
 ]
 
 # The backend names a case may target / a runner may dispatch on. ``python`` is
@@ -238,6 +255,32 @@ def _record_mapping(record: SeedRecord) -> dict[str, Any]:
     """
     mapping: dict[str, Any] = {
         "occurred_at": record.occurred_at if record.occurred_at is not None else record.source_timestamp,
+        "created_at": record.created_at,
+        "source_timestamp": record.source_timestamp,
+        "metadata": record.metadata or {},
+    }
+    for key in _DOC_STRING_KEYS:
+        value = getattr(record, key)
+        if value is not None:
+            mapping[key] = value
+    return mapping
+
+
+def _documents_record_mapping(record: SeedRecord) -> dict[str, Any]:
+    """Build the in-memory record mapping the **documents** oracle reads.
+
+    The document-row counterpart to :func:`_record_mapping`. A ``documents`` row
+    carries the two date columns (``created_at`` / ``source_timestamp``), the
+    ``metadata`` blob, and the seven denormalized string keys — but **no**
+    ``occurred_at``: that is the chunk event-time axis and no document column
+    backs it, which is why the enumeration surface rejects the key outright
+    (:data:`_DOCUMENTS_REJECTED_FILTERS`). So this mapping omits the
+    ``COALESCE(occurred_at, source_timestamp)`` synthesis :func:`_record_mapping`
+    performs; every other field resolves identically. A document key left
+    ``None`` stays absent, matching the live row's NULL (``compile_python``
+    resolves an absent system key to ``None``).
+    """
+    mapping: dict[str, Any] = {
         "created_at": record.created_at,
         "source_timestamp": record.source_timestamp,
         "metadata": record.metadata or {},
@@ -569,6 +612,109 @@ def _python_post_filter(filter_ast: FilterNode, target: str) -> Callable[[Mappin
 
 
 # --------------------------------------------------------------------------- #
+# Document-enumeration executor (one executor, four backends).
+# --------------------------------------------------------------------------- #
+#
+# The document-enumeration read path is uniformly split + post-filter on EVERY
+# backend, so — unlike the chunk surface — there is no per-backend executor here.
+# ``StorageCoordinator.scan_documents_page`` compiles the full AST once with
+# ``build_compile_context("documents", on_unsupported="split")`` and re-checks that
+# predicate over every scanned row, while all four relational stores compile their
+# server-side prefilter with a module-level ``_documents_compile_context()`` that is
+# also ``on_unsupported="split"``. Read output therefore equals the ``compile_python``
+# oracle by construction on postgres / sqlite / sqlite_lance / surrealdb alike, and no
+# backend raises :class:`RecallFilterUnsupportedError` on this surface — there is no
+# ``expect_unsupported`` leg to assert.
+#
+# What differs per backend is only WHICH leaves reach SQL, so the harness drives each
+# store in two modes (the ``forced_residual`` flag):
+#
+# * **natural** — hand ``filter_ast`` to ``scan_documents_page``: the backend pushes
+#   what it can and the coordinator's own post-filter narrows the rest. This is the
+#   production path, and it is also the ONLY mode that exercises the coordinator's
+#   post-filter — including its no-pushdown extreme, which a case whose leaves the
+#   backend defers wholesale (an ``$or`` over an undeclared key, a date key on the
+#   three non-Postgres tiers) already reaches.
+# * **residual** — withhold ``filter_ast``, so ``scan_documents_page`` performs RAW
+#   ENUMERATION (with no AST it compiles no post-filter and does no filtering at all),
+#   and apply the ``compile_python("documents")`` predicate externally, in-harness, to
+#   each returned :class:`~khora.core.models.Document`. **This is not a coordinator
+#   code path** — nothing inside the coordinator behaves this way, and reading it as
+#   "the residual branch" would be wrong. What it buys is a different thing: with SQL
+#   removed from the picture entirely, every leaf is forced to evaluate against each
+#   store's ROUND-TRIP document shape (raw-sqlite TEXT datetimes, SurrealDB's
+#   ``metadata_`` remap, SQLAlchemy's offset-discarding ``DATETIME``) rather than
+#   against the seed objects — so a round-trip that mangles a value cannot hide behind
+#   a pushdown that happened to reject the row for the right reason by accident.
+#   A ``SchemaCapabilities`` override cannot express this — ``scan_documents`` takes no
+#   context override — so withholding the AST is how the mode is realized.
+
+
+class DocumentsRunner(Protocol):
+    """Walk a seeded namespace's documents to exhaustion -> surviving seed ids.
+
+    ``@internal``. The injected seam :class:`DocumentsExecutor` calls. An
+    implementation drives :meth:`StorageCoordinator.scan_documents_page` over the
+    case's namespace until the page reports ``exhausted``, and maps the surviving
+    ``Document.id`` values back to their :class:`SeedRecord` ids.
+
+    * ``filter_ast`` — the canonical AST. Passed to ``scan_documents_page`` in
+      **natural** mode; withheld (``filter_ast=None``) in **residual** mode, which
+      makes that call a RAW ENUMERATION — with no AST the coordinator compiles no
+      post-filter and applies no narrowing whatsoever.
+    * ``post_filter`` — the ``compile_python`` predicate over the FULL AST, built with
+      the same ``build_compile_context("documents", on_unsupported="split")`` the
+      coordinator uses. In residual mode the runner MUST apply it to each returned
+      :class:`~khora.core.models.Document` — it is the ONLY filtering in that mode, and
+      it runs OUTSIDE the coordinator, not through any branch of it. In natural mode
+      the coordinator already applied its own identical copy, so the runner leaves it
+      alone.
+    * ``forced_residual`` — which of the two modes to drive.
+    """
+
+    def __call__(
+        self,
+        filter_ast: FilterNode,
+        post_filter: Callable[[Any], bool],
+        *,
+        forced_residual: bool,
+    ) -> frozenset[str]: ...
+
+
+class DocumentsExecutor:
+    """Drive the real ``scan_documents`` keyset primitive; run via an injected runner.
+
+    ``@internal``. The document-enumeration counterpart to the five chunk-surface
+    executors. It builds the production post-filter — ``compile_python`` over the FULL
+    AST with ``build_compile_context("documents", on_unsupported="split")``, the exact
+    call ``StorageCoordinator.scan_documents_page`` makes — and hands it, with the AST,
+    to the injected :class:`DocumentsRunner`.
+
+    Unlike the chunk executors this one does NOT compile a per-backend prefilter: on
+    this surface the backend compiles its own inside ``scan_documents``, from its
+    module-level ``_documents_compile_context()``. Driving the store through the real
+    coordinator method is what exercises that compiler, so the harness must not
+    duplicate it here.
+
+    ``records`` is ignored — the live rows are the truth, exactly as for the chunk
+    live-store executors, whose runners also read the seeded store rather than the
+    in-memory mappings.
+    """
+
+    def __init__(self, runner: DocumentsRunner, *, forced_residual: bool) -> None:
+        self._runner = runner
+        self._forced_residual = forced_residual
+
+    def survivors(
+        self,
+        filter_ast: FilterNode,
+        records: Sequence[tuple[str, Mapping[str, Any]]],
+    ) -> frozenset[str]:
+        post_filter = _python_post_filter(filter_ast, "documents")
+        return self._runner(filter_ast, post_filter, forced_residual=self._forced_residual)
+
+
+# --------------------------------------------------------------------------- #
 # Corpus runner.
 # --------------------------------------------------------------------------- #
 
@@ -626,6 +772,29 @@ def oracle_survivors(case: ConformanceCase) -> frozenset[str]:
     expectation to whatever it currently computes.
     """
     return run_case_for_backend(case, "python", executor=PythonExecutor())
+
+
+def documents_oracle_survivors(case: ConformanceCase) -> frozenset[str]:
+    """Run the Python oracle over a case's **document-row** mappings.
+
+    ``@internal``. The documents-target twin of :func:`oracle_survivors`: same real
+    validator + :func:`parse_to_ast` + :func:`compile_python` (``on_unsupported``
+    ``"raise"`` — the oracle must express the whole filter or surface the gap), but
+    over :func:`_documents_record_mapping` rather than the chunk mapping, so no
+    ``occurred_at`` is synthesized.
+
+    Every documents-target case is carried over from the chunk corpus with its
+    ``expected_ids`` UNCHANGED, on the claim that a filter which never reads
+    ``occurred_at`` selects the same records on either mapping
+    (:func:`_documents_eligible` enforces the antecedent). This function is what
+    makes that claim falsifiable: the unit leg asserts
+    ``documents_oracle_survivors(case) == case.expected_ids`` for the whole corpus,
+    so a carried-over expectation that does NOT survive the mapping change fails
+    there rather than looking like a backend bug on a live leg.
+    """
+    ctx = build_compile_context("documents", on_unsupported="raise")
+    predicate = compile_python(_resolve_ast(case.filter), ctx).predicate
+    return frozenset(rec.id for rec in case.seed_records if predicate(_documents_record_mapping(rec)))
 
 
 # --------------------------------------------------------------------------- #
@@ -811,6 +980,79 @@ async def seed_case(coord: StorageCoordinator, case: ConformanceCase) -> dict[st
     return id_map
 
 
+def _documents_case_namespace_id(case: ConformanceCase) -> UUID:
+    """Derive the deterministic namespace for a case's **documents** seed.
+
+    Namespaced apart from :func:`_case_namespace_id` (the ``"documents:"`` prefix)
+    because the two corpora share case ids and, on the Postgres leg, one database:
+    ``memory_namespaces`` carries ``UNIQUE (namespace_id, version)`` plus a unique
+    partial index on ``namespace_id WHERE is_active``, so seeding a documents case
+    under the same stable id as its chunk twin would violate both. Deterministic for
+    the same reason ``_case_namespace_id`` is — same case id → same namespace on
+    every xdist worker, distinct case ids never collide, never a random ``uuid4``.
+    """
+    return uuid5(_CONFORMANCE_NS_ROOT, f"documents:{case.id}")
+
+
+async def seed_documents_case(coord: StorageCoordinator, case: ConformanceCase) -> dict[str, UUID]:
+    """Seed a case's records as **documents**; return ``seed_id -> document UUID``.
+
+    ``@internal``. The document-enumeration counterpart to :func:`seed_case`, and
+    deliberately NOT a reuse of it: ``seed_case`` writes one Chunk per record and
+    groups records by ``external_id`` under a shared Document (production-NORMAL for
+    a chunked document). Enumeration filters the document ROW, so here every
+    :class:`SeedRecord` must be its own Document — a grouped write would collapse two
+    records into one enumerable row and silently change every ``expected_ids``.
+
+    Writes through the coordinator's **write API only**
+    (:meth:`create_namespace`, :meth:`create_document`) — never raw SQL/SurrealQL — so
+    each row is serialized by the path production writes take. No vector backend is
+    needed: enumeration reads the relational store alone, so a relational-only
+    coordinator suffices.
+
+    All nine enumerable system keys are native ``Document`` columns, so the mapping is
+    direct: the seven strings verbatim, ``metadata`` as the blob, and the two date
+    keys passed **only when set** so the dataclass default (``created_at``) or NULL
+    (``source_timestamp``) applies otherwise. ``occurred_at`` is ignored — it has no
+    document column, which is exactly why it is the rejected enumeration key.
+
+    The namespace row id is pinned to :func:`_documents_case_namespace_id` so a
+    read-only leg in a separate process (Postgres) can re-derive it without carrying
+    it through the seed-map artifact. A consequence worth knowing: re-running the
+    seed against an already-seeded database now fails loudly on the primary key
+    rather than quietly duplicating the corpus.
+    """
+    namespace_id = _documents_case_namespace_id(case)
+    ns = await coord.create_namespace(
+        MemoryNamespace(
+            id=namespace_id,
+            namespace_id=namespace_id,
+            metadata={"conformance_case": case.id, "conformance_target": "documents"},
+        )
+    )
+
+    id_map: dict[str, UUID] = {}
+    for record in case.seed_records:
+        kwargs: dict[str, Any] = {
+            "namespace_id": ns.id,
+            "content": record.content,
+            "metadata": dict(record.metadata),
+        }
+        for key in _DOC_STRING_KEYS:
+            kwargs[key] = getattr(record, key)
+        # Only stamp a date the record actually carries: an explicit ``None``
+        # ``created_at`` would defeat the dataclass default (the column is NOT NULL
+        # on both Alembic-managed tiers as of migration 056).
+        if record.created_at is not None:
+            kwargs["created_at"] = record.created_at
+        if record.source_timestamp is not None:
+            kwargs["source_timestamp"] = record.source_timestamp
+        document = Document(**kwargs)
+        await coord.create_document(document)
+        id_map[record.id] = document.id
+    return id_map
+
+
 # --------------------------------------------------------------------------- #
 # Case-family generators.
 # --------------------------------------------------------------------------- #
@@ -934,6 +1176,70 @@ def _drop_json_nulls(value: Any) -> Any:
 def _with_metadata(rec: SeedRecord, metadata: dict[str, Any]) -> SeedRecord:
     """A copy of ``rec`` with ``metadata`` replaced (for the null-drop probe)."""
     return replace(rec, metadata=metadata)
+
+
+def _documents_surreal_excluded(filter_: dict[str, Any] | RecallFilter, seed: tuple[SeedRecord, ...]) -> bool:
+    """Whether a case must be pruned from the **surreal documents** leg.
+
+    ``@internal``. Two of :func:`_surreal_excluded`'s three buckets carry over; the
+    third does not, and the difference is the whole point of this function.
+
+    Carried over — both are STORAGE-REPRESENTATION quirks, which no post-filter can
+    undo because they corrupt the row before the filter ever runs:
+
+    * **Metadata ``$date`` / datetime operand** — a metadata datetime round-trips
+      through the FLEXIBLE object column as a string and the operand binds as
+      ``.isoformat()`` (``+00:00``) against a possibly ``Z``-suffixed stored form, so
+      the pushed lexicographic compare can wrongly EXCLUDE a row. On a split surface a
+      prefilter may only over-return; a false exclude is unrecoverable. This bucket is
+      a **class-level** prune, deliberately coarser than what is measured. Of the 12
+      corpus cases it catches, 4 actually diverge today — ``F-COERCE-date-eq``,
+      ``F-DATES-md-date-eq``, ``F-DATES-naive-utc``, ``F-DATES-tz-by-instant`` — and
+      the pattern is legible rather than arbitrary: every one is an EQUALITY shape, and
+      every one diverges in natural mode only (it returns zero rows where the oracle
+      keeps one, and passes in residual). Equality is where a string compare is least
+      forgiving — two ISO renderings of the same instant differ byte-for-byte, so a
+      naive operand, a ``+02:00`` operand and a ``Z``-suffixed stored value all miss —
+      while a range compare still lands on the right side of the bound often enough to
+      pass on these seeds. The 8 surviving range shapes are pruned with them because
+      that is luck of the operand's form, not soundness. Natural-mode-only is also what
+      pins the PUSHDOWN, not the round-trip, as the cause. Same shape and same
+      rationale as the chunk-surface bucket in :func:`_surreal_excluded`, which is
+      declarative for the same reason.
+    * **Present-JSON-null metadata value the filter distinguishes from absent** —
+      SurrealDB drops an explicit ``null`` inside a FLEXIBLE object on WRITE, so the
+      stored document genuinely differs from the seed. Detected empirically by
+      :func:`_surreal_null_drop_diverges` (reused verbatim: it probes the oracle over a
+      null-coerced seed, and the ``occurred_at`` synthesis in the mapping it uses is
+      inert here because a documents-eligible case never reads that key). Measured: all
+      6 cases it catches diverge in BOTH modes — unlike the ``$date`` bucket, the row is
+      already wrong before any filter runs, so evaluating the whole predicate in memory
+      cannot rescue them either. That both-modes signature is the cleanest way to tell
+      a write-side corruption from a pushdown defect.
+
+    The two buckets are disjoint on the current corpus (12 + 6 = the 18 cases the
+    surreal leg drops, of which 10 are measured to diverge). Counts are a snapshot of
+    the corpus, not an invariant — the predicates above are the contract; re-measure
+    rather than trusting these numerals if the corpus grows.
+
+    DROPPED — the **unsafe metadata segment** bucket. On the chunk surface
+    ``compile_surrealdb`` runs with ``on_unsupported="raise"`` and its injection guard
+    turns a ``$``-prefixed / hyphenated segment into a ``CompileError``. The documents
+    context is ``on_unsupported="split"``, under which the same guard routes the leaf
+    to the unsupported path — placeholder, unconsumed, deferred to the post-filter.
+    Such a case is therefore an ORDINARY oracle-equal row-set case on this leg, not a
+    prune and not an ``expect_unsupported`` leg.
+    """
+    ast = _resolve_ast(filter_)
+    for leaf in iter_leaf_clauses(ast):
+        if not (leaf.path and leaf.path[0] == "metadata"):
+            continue
+        operand = leaf.operand
+        if isinstance(operand, (DateLiteral, datetime)):
+            return True
+        if isinstance(operand, (list, tuple)) and any(isinstance(x, (DateLiteral, datetime)) for x in operand):
+            return True
+    return _surreal_null_drop_diverges(ast, seed)
 
 
 # The system keys the skeleton SurrealDB ``temporal_chunk`` table does NOT back with
@@ -1313,6 +1619,128 @@ def f_op_cases() -> list[ConformanceCase]:
         cases.extend(_string_op_cases(key))
     cases.append(_metadata_op_case())
     return cases
+
+
+# --------------------------------------------------------------------------- #
+# Documents-target corpus (the enumerable-key subset of the chunk corpus).
+# --------------------------------------------------------------------------- #
+#
+# Document enumeration accepts NINE of the ten system keys plus ``metadata.*``. A
+# case is carried over from the chunk corpus UNCHANGED — same filter, same seed,
+# same ``expected_ids`` — because both are target-agnostic; only the surface the
+# records are written to changes. Two carry-over blockers exist, and each has its
+# own remedy rather than a silent skip:
+#
+# 1. ``occurred_at`` — not an enumerable key at all. Encoded as a REJECTION
+#    (:data:`_DOCUMENTS_REJECTED_FILTERS`), not as a row-set case.
+# 2. a seed with a duplicate ``external_id`` — ``documents`` carries
+#    ``UNIQUE (namespace_id, external_id)``, and ``seed_documents_case`` writes one
+#    document per record (it cannot group the way ``seed_case`` does), so such a seed
+#    is an ``IntegrityError`` rather than a divergence. Exactly one family trips this
+#    — the F-OP ``external_id`` seed ties ``-2``/``-3`` at ``"connection"`` so ``$eq``
+#    keeps a pair — and it gets a documents variant with five DISTINCT values.
+
+
+def _documents_eligible(case: ConformanceCase) -> bool:
+    """Whether a chunk-corpus case carries over to the documents target verbatim.
+
+    ``@internal``. Two gates, both above. A filter reading ``occurred_at`` at ANY
+    nesting depth is not an enumeration filter; a seed whose non-NULL ``external_id``
+    values are not distinct cannot be written one-document-per-record. Anything else
+    keeps its filter, seed and ``expected_ids`` untouched — the documents oracle
+    (:func:`documents_oracle_survivors`) is what proves that claim per case.
+    """
+    ast = _resolve_ast(case.filter)
+    if any(clause.path and clause.path[0] == "occurred_at" for clause in iter_leaf_clauses(ast)):
+        return False
+    external_ids = [rec.external_id for rec in case.seed_records if rec.external_id is not None]
+    return len(external_ids) == len(set(external_ids))
+
+
+# The five DISTINCT ``external_id`` values the documents variant seeds. ``-2`` and
+# ``-3`` are a minimal pair (``"connection"`` / ``"connexion"``) rather than the chunk
+# seed's tie, so ``$eq`` singles ONE row out instead of keeping a pair — the operator
+# still separates a known subset, and the UNIQUE constraint is satisfied. ``-5`` is
+# the NULL row (``external_id`` is nullable, and NULL never violates UNIQUE), so F1
+# negation coverage is preserved.
+_DOCUMENTS_EXTERNAL_IDS: tuple[str | None, ...] = ("library", "connection", "connexion", "direct", None)
+
+
+def _external_id_documents_op_cases() -> list[ConformanceCase]:
+    """The F-OP ``external_id`` family, re-seeded with five distinct values.
+
+    ``@internal``. The stock :func:`_string_op_cases` ``external_id`` seed ties two
+    records at one value, which ``seed_documents_case`` cannot write (one document per
+    record vs. ``UNIQUE (namespace_id, external_id)``). This variant keeps the same
+    operator set and the same five-record shape but draws from
+    :data:`_DOCUMENTS_EXTERNAL_IDS`, and recomputes every ``expected_ids`` BY
+    CONSTRUCTION from that seed — never by copying the chunk family's counts, which
+    the de-tie invalidates.
+
+    ``backends`` / ``expect_unsupported`` are left at the chunk-corpus defaults
+    (:func:`_backends_for_filter` / :func:`_surreal_unsupported`) so this reads as an
+    ordinary member of the corpus; the documents legs select on
+    :func:`_documents_eligible` and :func:`_documents_surreal_excluded`, not on
+    ``backends``.
+    """
+    key = "external_id"
+    seed = tuple(
+        SeedRecord(id=f"{key}-{i}", **({} if value is None else {key: value}))
+        for i, value in enumerate(_DOCUMENTS_EXTERNAL_IDS, start=1)
+    )
+    r1, r2, r3, r4, r5 = (rec.id for rec in seed)
+
+    def case(suffix: str, predicate: Any, expected: frozenset[str], op_tag: str) -> ConformanceCase:
+        filter_ = {key: predicate}
+        backends = _backends_for_filter(filter_, seed)
+        return ConformanceCase(
+            id=f"F-OP-{key}-documents-{suffix}",
+            filter=filter_,
+            seed_records=seed,
+            expected_ids=expected,
+            backends=backends,
+            expect_unsupported=_surreal_unsupported(filter_) & backends,
+            exercises=("F-OP", key, op_tag),
+        )
+
+    all_five = frozenset({r1, r2, r3, r4, r5})
+    return [
+        # "connection" is now unique to -2 (the chunk seed's -3 twin is "connexion").
+        case("eq", {"$eq": "connection"}, frozenset({r2}), "$eq"),
+        # F1: the NULL -5 row survives every negation.
+        case("ne", {"$ne": "direct"}, frozenset({r1, r2, r3, r5}), "$ne"),
+        case("in", {"$in": ["library", "direct"]}, frozenset({r1, r4}), "$in"),
+        case("in-empty", {"$in": []}, frozenset(), "$in"),
+        case("nin", {"$nin": ["connection"]}, frozenset({r1, r3, r4, r5}), "$nin"),
+        case("nin-empty", {"$nin": []}, all_five, "$nin"),
+        case("exists-true", {"$exists": True}, all_five, "$exists"),
+        # Bare-list ⇒ $eq exact-array ⇒ constant-false against a scalar column.
+        case("eq-barelist", ["library", "direct"], frozenset(), "$eq"),
+    ]
+
+
+def f_op_documents_cases() -> list[ConformanceCase]:
+    """The ``F-OP`` family as the documents target sees it.
+
+    ``@internal``. Every eligible chunk F-OP case verbatim, plus the re-seeded
+    ``external_id`` variant. The ten ``occurred_at`` cases drop out (that key is
+    rejected, not filtered) and the eight stock ``external_id`` cases are replaced;
+    everything else — the two remaining date keys, the six other string keys, the
+    metadata scalar — carries over untouched. The coverage meta-test reads the
+    ``exercises`` tags off this list and asserts it covers every enumerable key and
+    NOT ``occurred_at``.
+    """
+    return [c for c in f_op_cases() if _documents_eligible(c)] + _external_id_documents_op_cases()
+
+
+# Two filters the document-enumeration surface must REJECT rather than evaluate — a
+# bare ``occurred_at`` leaf and one buried inside an ``$and`` (the rejection walks
+# every leaf, at any depth). This is how ``occurred_at`` is represented in the
+# documents corpus: as a validation outcome, never as a row-set case.
+_DOCUMENTS_REJECTED_FILTERS: tuple[dict[str, Any], ...] = (
+    {"occurred_at": {"$gte": "2026-01-01T00:00:00Z"}},
+    {"$and": [{"source_name": "linear"}, {"occurred_at": {"$gt": "2026-01-01T00:00:00Z"}}]},
+)
 
 
 # --------------------------------------------------------------------------- #
@@ -2759,3 +3187,63 @@ def f_impossible_cases() -> list[ConformanceCase]:
             ("F-IMPOSSIBLE", "metadata.flag", "bool"),
         ),
     ]
+
+
+# --------------------------------------------------------------------------- #
+# Documents-target corpus assembly.
+# --------------------------------------------------------------------------- #
+
+
+# The hand-authored families whose cases carry over to the documents target with no
+# edit at all — their filters and ``expected_ids`` are target-agnostic. ``f_op_cases``
+# is the one absentee, because it needs the ``external_id`` re-seed
+# (:func:`f_op_documents_cases`). Members of any family that read ``occurred_at`` prune
+# themselves through :func:`_documents_eligible`.
+#
+# ``f_dates_cases`` is INCLUDED, and the reasoning is worth keeping because the
+# tempting shortcut is wrong. Its ``$date`` range shapes do duplicate
+# ``f_coerce_cases``, but three of its cases carry coverage that exists nowhere else in
+# the documents corpus — ``lexicographic`` (a bare string operand is NOT date-parsed),
+# ``naive-utc`` and ``tz-instant`` (a naive and a non-UTC operand normalize to the same
+# instant). Those are precisely the metadata-datetime coercion shapes the residual mode
+# exists to pin against a store's round-trip: raw-sqlite's TEXT datetimes and
+# SQLAlchemy's offset-discarding ``DATETIME`` are where a "close enough" ISO form stops
+# being close enough. Dropping the family to avoid four redundant ``$date`` cases would
+# have forfeited them.
+#
+# What IS forfeited, unavoidably: the family's three ``occurred_at`` cases (two
+# ``boundary``, one ``and-compose``) auto-prune, so the documents corpus has no
+# system-date-key boundary case and no case composing two system date keys. That is a
+# consequence of ``occurred_at`` not being enumerable, not of this tuple — the
+# ``boundary`` shape is unreachable for it, and ``and-compose`` needs two of the three
+# date keys to be filterable at once. ``created_at`` / ``source_timestamp`` boundary
+# behaviour is still covered by the F-OP date families' ``$gt`` / ``$gte`` pair.
+_DOC_SHARED_FAMILIES: tuple[Callable[[], list[ConformanceCase]], ...] = (
+    f_coerce_cases,
+    f_polarity_cases,
+    f_array_cases,
+    f_exists_cases,
+    f_logic_cases,
+    f_sugar_cases,
+    f_dates_cases,
+    f_nullval_cases,
+    f_objeq_cases,
+    f_dotkey_cases,
+    f_sel_cases,
+    f_unsup_cases,
+    f_impossible_cases,
+)
+
+
+def documents_conformance_cases() -> list[ConformanceCase]:
+    """The full documents-target corpus: F-OP plus every eligible shared-family case.
+
+    ``@internal``. The single source of truth for *what the documents legs seed and
+    assert* — the seed entrypoint, the embedded runner modules, and the parametrized
+    test module all call this so they never drift. Every case runs on all four
+    relational stores in BOTH modes; the surreal leg additionally drops the two
+    storage-representation buckets :func:`_documents_surreal_excluded` names. Nothing
+    is skipped without one of those documented reasons.
+    """
+    shared = [c for family in _DOC_SHARED_FAMILIES for c in family() if _documents_eligible(c)]
+    return f_op_documents_cases() + shared

--- a/tests/integration/matrix/_conformance_docs_common.py
+++ b/tests/integration/matrix/_conformance_docs_common.py
@@ -47,6 +47,12 @@ SCAN_BOUND = 100_000
 # failure instead of a hung CI job.
 _MAX_PAGES = 1_000
 
+# Upper bound on any single submitted coroutine. The ``_MAX_PAGES`` guard only covers
+# a non-advancing walk, not a coroutine that stalls inside a store call; a bounded
+# wait converts a hung CI job into a named ``TimeoutError`` there too. Generous enough
+# for a full corpus seed on a cold store, short enough that a stalled store fails.
+_RUN_TIMEOUT_S = 600
+
 
 class _LoopThread:
     """A daemon thread running one asyncio loop; submit coroutines, block for results."""
@@ -57,7 +63,7 @@ class _LoopThread:
         self._thread.start()
 
     def run(self, coro: Any) -> Any:
-        return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
+        return asyncio.run_coroutine_threadsafe(coro, self._loop).result(timeout=_RUN_TIMEOUT_S)
 
 
 @lru_cache(maxsize=1)

--- a/tests/integration/matrix/_conformance_docs_common.py
+++ b/tests/integration/matrix/_conformance_docs_common.py
@@ -1,0 +1,172 @@
+"""Backend-agnostic wiring shared by the four documents-target conformance legs.
+
+The chunk-surface conformance seam gives each backend its own ``run_live`` because
+each one executes a *different compiled artifact* (a SQLAlchemy expression, a SurrealQL
+string, a Cypher string, a weaviate ``Filter``). The documents surface is not shaped
+that way: every leg drives the same public coordinator method,
+:meth:`~khora.storage.coordinator.StorageCoordinator.scan_documents_page`, and the
+backend compiles its own prefilter *inside* ``scan_documents``. So the walk is
+genuinely one piece of code, and it lives here rather than in four near-copies that
+could drift.
+
+What stays per-backend (in the sibling ``_conformance_docs_<backend>`` modules) is only
+the part that really differs: standing up a relational-only coordinator for that store,
+and — for the read-only Postgres leg — the seed-map artifact.
+
+Kept out of ``conftest.py`` and named with a leading underscore (not a ``test_``
+module) so it is a plain helper the test modules import, never collected as tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Callable, Mapping
+from functools import lru_cache
+from typing import Any
+from uuid import UUID
+
+from khora.filter.ast import FilterNode
+from khora.filter.conformance import DocumentsExecutor
+from khora.storage.backends.base import DocumentScanKey
+from khora.storage.coordinator import StorageCoordinator
+
+# One page is sized to swallow any corpus case whole (the largest seeds ten records),
+# so a green run does not depend on multi-page resume — that is
+# ``tests/**/test_*scan_documents*.py``'s subject, not conformance's. The walk below
+# still loops on ``exhausted``, so a smaller page would only cost round-trips.
+PAGE_LIMIT = 100
+# Raw rows the page may scan. Comfortably above any case's seed so the bound is never
+# the reason a walk stops: a bound-limited page reports ``exhausted=False`` with a
+# non-``None`` position, which the loop would follow, but silent truncation of the
+# LAST page is the failure mode worth designing out entirely.
+SCAN_BOUND = 100_000
+
+# A walk that neither advances its cursor nor reports exhaustion would spin forever.
+# No store does that today; the guard converts a future regression into a named
+# failure instead of a hung CI job.
+_MAX_PAGES = 1_000
+
+
+class _LoopThread:
+    """A daemon thread running one asyncio loop; submit coroutines, block for results."""
+
+    def __init__(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._loop.run_forever, daemon=True)
+        self._thread.start()
+
+    def run(self, coro: Any) -> Any:
+        return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
+
+
+@lru_cache(maxsize=1)
+def _loop_thread() -> _LoopThread:
+    """The ONE process-wide loop thread that owns every seeded documents store.
+
+    Deliberately shared across all three embedded backends rather than one apiece: an
+    aiosqlite connection and an embedded SurrealDB connection are each bound to the
+    loop they were opened on, and the unit smoke leg drives all three in a single
+    process. One loop for all of them keeps every open-and-use pair on the same loop
+    with no coordination between the modules.
+    """
+    return _LoopThread()
+
+
+def run_async(coro: Any) -> Any:
+    """Run ``coro`` on the dedicated loop that owns the seeded documents stores."""
+    return _loop_thread().run(coro)
+
+
+async def walk_documents(
+    coord: StorageCoordinator,
+    namespace_id: UUID,
+    *,
+    filter_ast: FilterNode,
+    post_filter: Callable[[Any], bool],
+    forced_residual: bool,
+    id_map: Mapping[str, UUID],
+) -> frozenset[str]:
+    """Enumerate a case's namespace to exhaustion; return the surviving seed ids.
+
+    The :class:`~khora.filter.conformance.DocumentsRunner` body, shared by all four
+    legs. Drives the REAL ``scan_documents_page`` — which drives the store's real
+    ``scan_documents`` keyset primitive and its own ``_documents_compile_context()``
+    pushdown — and translates surviving ``Document.id`` values back to
+    :class:`~khora.filter.conformance.SeedRecord` ids.
+
+    The two modes differ in exactly one place, which is the point of having them:
+
+    * **natural** — ``filter_ast`` goes to the coordinator, which pushes what the
+      backend can take and applies its OWN ``compile_python`` post-filter to the rest.
+      ``post_filter`` is not applied here; doing so would be a second, redundant copy
+      and would mask a coordinator that forgot to run its own.
+    * **residual** — the coordinator gets ``filter_ast=None``, which makes the call a
+      RAW ENUMERATION: with no AST it compiles no post-filter and does no filtering at
+      all. ``post_filter`` (the identical predicate, built by the executor) is the only
+      narrowing, and it runs HERE — outside the coordinator, not through any branch of
+      it. With SQL out of the picture entirely, every leaf is forced to evaluate
+      against each store's ROUND-TRIP document shape rather than against whatever SQL
+      happened to accept.
+
+    ``exhausted`` is the only termination signal read — a short page means nothing
+    under a selective filter, and an empty one means nothing at all.
+    """
+    doc_to_seed = {doc_id: seed_id for seed_id, doc_id in id_map.items()}
+    survivors: set[str] = set()
+    after: DocumentScanKey | None = None
+
+    for _ in range(_MAX_PAGES):
+        page = await coord.scan_documents_page(
+            namespace_id,
+            filter_ast=None if forced_residual else filter_ast,
+            limit=PAGE_LIMIT,
+            after=after,
+            scan_bound=SCAN_BOUND,
+        )
+        for document in page:
+            seed_id = doc_to_seed.get(document.id)
+            if seed_id is None:
+                # Unreachable: each case owns a private namespace. Guarding rather
+                # than indexing blindly keeps a namespace-scope regression a failed
+                # assertion downstream instead of a KeyError here.
+                continue
+            if forced_residual and not post_filter(document):
+                continue
+            survivors.add(seed_id)
+        if page.exhausted:
+            return frozenset(survivors)
+        assert page.next_after is not None, "a non-exhausted page must carry a resume position"
+        after = (page.next_after.created_at, page.next_after.id)
+
+    raise AssertionError(f"documents walk did not reach exhaustion within {_MAX_PAGES} pages")
+
+
+def documents_executor(
+    coord: StorageCoordinator,
+    namespace_id: UUID,
+    id_map: Mapping[str, UUID],
+    *,
+    forced_residual: bool,
+) -> DocumentsExecutor:
+    """Bind :func:`walk_documents` to one seeded case and wrap it in the executor.
+
+    The runner is *synchronous* (the ``DocumentsRunner`` contract) while the walk is
+    async and the seeded store belongs to :func:`_loop_thread`'s loop, so the bridge
+    submits the coroutine there and blocks — the same shape the chunk legs' embedded
+    runners use.
+    """
+
+    def runner(filter_ast, post_filter, *, forced_residual):  # noqa: ANN001, ANN202 - matches DocumentsRunner
+        return run_async(
+            walk_documents(
+                coord,
+                namespace_id,
+                filter_ast=filter_ast,
+                post_filter=post_filter,
+                forced_residual=forced_residual,
+                id_map=id_map,
+            )
+        )
+
+    return DocumentsExecutor(runner, forced_residual=forced_residual)

--- a/tests/integration/matrix/_conformance_docs_lance.py
+++ b/tests/integration/matrix/_conformance_docs_lance.py
@@ -1,0 +1,102 @@
+"""Embedded ``sqlite_lance`` wiring for the documents-target conformance leg.
+
+The store is :class:`~khora.storage.backends.sqlite_lance.SQLiteLanceRelationalAdapter`
+over a tmp SQLite file migrated to head — the shared ``DocumentModel`` schema, built by
+the real Alembic chain, so ``documents`` here is the same table PostgreSQL has (down to
+``source_type`` being ``NOT NULL`` and the metadata column being named ``metadata``).
+What differs from its Postgres twin is entirely serialization: SQLAlchemy's SQLite
+``DATETIME`` writes a space-separated, offset-DISCARDED string, which is why this
+store's ``_documents_compile_context`` withholds ``created_at`` / ``source_timestamp``
+from pushdown where Postgres pushes both against real ``timestamptz`` columns.
+
+No LanceDB and no vector backend: document enumeration reads the relational store
+alone, so the embedded handle's Lance side is never touched and no embeddings are
+generated.
+
+Exposes the two callables the documents test modules inject:
+
+* ``reachable() -> bool`` — the local-dev skip gate. In-process, so always ``True``.
+* ``executor_for(case, *, forced_residual) -> DocumentsExecutor`` — seeds the case
+  (once per process, cached) and returns a ready executor bound to its namespace.
+
+Kept out of ``conftest.py`` and named with a leading underscore (not a ``test_``
+module) so it is a plain helper the test modules import, never collected as tests.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from functools import lru_cache
+from pathlib import Path
+from uuid import UUID
+
+from khora.db.session import run_migrations
+from khora.filter.conformance import (
+    ConformanceCase,
+    DocumentsExecutor,
+    _documents_case_namespace_id,
+    seed_documents_case,
+)
+from khora.storage.backends.sqlite_lance import SQLiteLanceRelationalAdapter
+from khora.storage.backends.sqlite_lance.connection import (
+    EmbeddedStorageHandle,
+    EmbeddedStorageHandleConfig,
+)
+from khora.storage.coordinator import StorageCoordinator
+from tests.integration.matrix._conformance_docs_common import documents_executor, run_async
+
+
+def reachable() -> bool:
+    """Whether the sqlite_lance store is reachable — always ``True`` (embedded in-process)."""
+    return True
+
+
+async def _build_coordinator() -> StorageCoordinator:
+    """Migrate a tmp SQLite file to head and wire a relational-only coordinator over it.
+
+    The full Alembic chain runs (not a hand-written DDL string), so ``documents`` is
+    the shared model at head — including migration 055's ``NOT NULL source_type`` and
+    056's ``NOT NULL created_at``, both of which the seeder must satisfy.
+    """
+    tmp_path = Path(tempfile.mkdtemp(prefix="khora-conformance-docs-lance-"))
+    db_path = str(tmp_path / "khora.db")
+    result = await run_migrations(f"sqlite+aiosqlite:///{db_path}")
+    if not result.success:
+        raise RuntimeError(f"migration failed: {result.error}")
+
+    handle = EmbeddedStorageHandle(
+        EmbeddedStorageHandleConfig(db_path=db_path, lance_path=str(tmp_path / "khora.lance")),
+    )
+    await handle.connect()
+    coord = StorageCoordinator(relational=SQLiteLanceRelationalAdapter(handle))
+    await coord.connect()
+    return coord
+
+
+@lru_cache(maxsize=1)
+def _coordinator() -> StorageCoordinator:
+    """The process-wide connected coordinator (migrated + built exactly once)."""
+    return run_async(_build_coordinator())
+
+
+# ``case.id -> {seed_id: document UUID}``, filled on first use. See the sibling
+# raw-sqlite module for why this is a plain dict rather than an ``lru_cache``.
+_SEED_MAPS: dict[str, dict[str, UUID]] = {}
+
+
+def _seed(case: ConformanceCase) -> dict[str, UUID]:
+    """Seed one case's documents (once per process) and return ``seed_id -> document UUID``."""
+    if case.id not in _SEED_MAPS:
+        _SEED_MAPS[case.id] = run_async(seed_documents_case(_coordinator(), case))
+    return _SEED_MAPS[case.id]
+
+
+def executor_for(case: ConformanceCase, *, forced_residual: bool) -> DocumentsExecutor:
+    """Seed ``case`` (in-process, cached) and return a ready :class:`DocumentsExecutor`."""
+    id_map = _seed(case)
+    return documents_executor(
+        _coordinator(),
+        _documents_case_namespace_id(case),
+        id_map,
+        forced_residual=forced_residual,
+    )

--- a/tests/integration/matrix/_conformance_docs_pg.py
+++ b/tests/integration/matrix/_conformance_docs_pg.py
@@ -1,0 +1,191 @@
+"""Live-Postgres wiring for the documents-target conformance leg.
+
+The store is :class:`~khora.storage.backends.postgresql.PostgreSQLBackend` — the only
+documents tier whose ``created_at`` / ``source_timestamp`` are real ``timestamptz``
+columns, so it is the only one whose ``_documents_compile_context`` declares all NINE
+enumerable system keys pushable. Every other leg withholds the two date keys because
+their stored text does not order against a datetime bind. That asymmetry is the reason
+this leg is worth a live server: the date-key F-OP cases are the ones that reach SQL
+here and reach the post-filter everywhere else.
+
+**Seed/read split (write-once, read-many).** Unlike the three embedded legs, the
+Postgres store outlives the process that seeds it, so the seed runs out-of-band exactly
+once via :mod:`tests.integration.matrix._conformance_seed` and the pytest step is
+strictly READ-ONLY — under ``-n auto`` every xdist worker only reads.
+
+The map that bridges the two processes is narrower than the chunk leg's. ``seed_case``
+assigns random chunk UUIDs, so its map is the only way to find those rows again; here
+the *namespace* is what the reader needs, and ``seed_documents_case`` pins it
+deterministically to ``_documents_case_namespace_id(case)``. The persisted map is
+therefore needed only to translate surviving ``Document.id`` values back to
+:class:`~khora.filter.conformance.SeedRecord` ids.
+
+Kept out of ``conftest.py`` and named with a leading underscore (not a ``test_``
+module) so it is a plain helper shared by the seed entrypoint and the test module,
+never collected as tests itself.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from functools import lru_cache
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from khora.filter.conformance import (
+    ConformanceCase,
+    DocumentsExecutor,
+    _documents_case_namespace_id,
+    documents_conformance_cases,
+    seed_documents_case,
+)
+from khora.storage.backends.postgresql import PostgreSQLBackend
+from khora.storage.coordinator import StorageCoordinator
+from tests.integration.matrix._conformance_docs_common import documents_executor, run_async
+
+# Same default + normalization as the sibling conformance / skeleton PG modules.
+DATABASE_URL = os.environ.get(
+    "KHORA_DATABASE_URL",
+    "postgresql+asyncpg://khora:khora@localhost:5434/khora",
+)
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
+
+# Path of the JSON seed-map artifact the seed entrypoint writes and the test reads.
+# Distinct from the chunk leg's ``KHORA_CONFORMANCE_SEED_MAP`` — the two corpora seed
+# different tables and are written by separate invocations of the seed entrypoint.
+SEED_MAP_PATH = os.environ.get("KHORA_CONFORMANCE_DOCS_SEED_MAP", ".conformance_docs_seed_map.json")
+
+
+def reachable() -> bool:
+    """Whether the Postgres server accepts a TCP connection (the local-dev skip gate)."""
+    import socket
+    from urllib.parse import urlparse
+
+    parsed = urlparse(DATABASE_URL.replace("+asyncpg", ""))
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+@asynccontextmanager
+async def conformance_docs_pg_coordinator() -> AsyncIterator[StorageCoordinator]:
+    """Yield a connected relational-only coordinator over the live Postgres database.
+
+    No vector backend: document enumeration reads ``documents`` alone, so — unlike the
+    chunk leg, which has to wire the skeleton ``khora_chunks`` temporal store to land
+    rows in the table its predicate reads — the plain relational backend is the
+    production target here.
+    """
+    engine = create_async_engine(DATABASE_URL)
+    coord = StorageCoordinator(relational=PostgreSQLBackend(DATABASE_URL, engine=engine))
+    await coord.connect()
+    try:
+        yield coord
+    finally:
+        await coord.disconnect()
+        await engine.dispose()
+
+
+# --------------------------------------------------------------------------- #
+# Seed-map persistence (write-once by the entrypoint, read-many by the test).
+# --------------------------------------------------------------------------- #
+
+
+async def build_seed_map() -> dict[str, dict[str, str]]:
+    """Seed every documents case ONCE and return ``case_id -> {seed_id: document_uuid}``.
+
+    Reuses ``seed_documents_case`` verbatim, so the rows the test reads are
+    byte-for-byte the rows the harness's own seeder writes. Called only by the one-time
+    seed entrypoint — never by the test. Re-running against an already-seeded database
+    fails on the namespace primary key rather than duplicating the corpus, because
+    ``seed_documents_case`` pins that id deterministically.
+    """
+    seed_map: dict[str, dict[str, str]] = {}
+    async with conformance_docs_pg_coordinator() as coord:
+        for case in documents_conformance_cases():
+            id_map = await seed_documents_case(coord, case)
+            seed_map[case.id] = {seed_id: str(doc_id) for seed_id, doc_id in id_map.items()}
+    return seed_map
+
+
+def write_seed_map(seed_map: Mapping[str, Mapping[str, str]]) -> None:
+    """Write the seed map to ``SEED_MAP_PATH`` (the one-time artifact write)."""
+    with open(SEED_MAP_PATH, "w", encoding="utf-8") as fh:
+        json.dump(seed_map, fh, sort_keys=True, indent=2)
+
+
+@lru_cache(maxsize=1)
+def load_seed_map() -> dict[str, dict[str, UUID]]:
+    """Load the seed map written by the entrypoint; ``case_id -> {seed_id: document UUID}``.
+
+    Cached so every xdist worker parses the JSON at most once. Raises a clear,
+    actionable error if the map is absent — this leg is read-only and depends on the
+    one-time seed step having run first; an opaque ``FileNotFoundError`` would obscure
+    that contract.
+    """
+    if not os.path.exists(SEED_MAP_PATH):
+        raise FileNotFoundError(
+            f"documents conformance seed map not found at {SEED_MAP_PATH!r}; the postgres "
+            f"documents leg is read-only and requires the one-time seed step to run first: "
+            f"`python -m tests.integration.matrix._conformance_seed documents-postgres` "
+            f"(set KHORA_CONFORMANCE_DOCS_SEED_MAP to the same path for both steps)"
+        )
+    with open(SEED_MAP_PATH, encoding="utf-8") as fh:
+        raw: dict[str, dict[str, str]] = json.load(fh)
+    return {case_id: {seed_id: UUID(doc_id) for seed_id, doc_id in m.items()} for case_id, m in raw.items()}
+
+
+# --------------------------------------------------------------------------- #
+# Read-only executor over the pre-seeded store.
+# --------------------------------------------------------------------------- #
+
+
+@lru_cache(maxsize=1)
+def _coordinator() -> StorageCoordinator:
+    """A process-wide connected coordinator on the shared documents loop thread.
+
+    The coordinator is opened on the same loop every walk is submitted to (see
+    ``_conformance_docs_common``), so the asyncpg pool is never used across loops. It
+    is READ-ONLY: this module's ``executor_for`` never seeds.
+    """
+
+    async def build() -> StorageCoordinator:
+        engine = create_async_engine(DATABASE_URL, connect_args={"server_settings": {"TimeZone": "UTC"}})
+        coord = StorageCoordinator(relational=PostgreSQLBackend(DATABASE_URL, engine=engine))
+        await coord.connect()
+        return coord
+
+    return run_async(build())
+
+
+def executor_for(case: ConformanceCase, *, forced_residual: bool) -> DocumentsExecutor:
+    """Wire a READ-ONLY :class:`DocumentsExecutor` over ``case``'s pre-seeded rows.
+
+    Looks the case up in the persisted seed map (loaded once, cached) and binds the
+    walk to the case's deterministic namespace. No seeding — the rows already exist.
+    """
+    import pytest
+
+    seed_map = load_seed_map()
+    if case.id not in seed_map:
+        pytest.fail(
+            f"case {case.id!r} missing from the documents seed map "
+            f"(re-run `python -m tests.integration.matrix._conformance_seed documents-postgres`)"
+        )
+    return documents_executor(
+        _coordinator(),
+        _documents_case_namespace_id(case),
+        seed_map[case.id],
+        forced_residual=forced_residual,
+    )

--- a/tests/integration/matrix/_conformance_docs_pg.py
+++ b/tests/integration/matrix/_conformance_docs_pg.py
@@ -161,6 +161,10 @@ def _coordinator() -> StorageCoordinator:
     """
 
     async def build() -> StorageCoordinator:
+        # TimeZone=UTC is load-bearing, not cosmetic: it fixes the tzinfo asyncpg
+        # attaches to timestamptz values, which residual mode feeds straight into the
+        # in-harness compile_python predicate. Dropping it changes residual-mode results
+        # on any server whose default TimeZone is not UTC.
         engine = create_async_engine(DATABASE_URL, connect_args={"server_settings": {"TimeZone": "UTC"}})
         coord = StorageCoordinator(relational=PostgreSQLBackend(DATABASE_URL, engine=engine))
         await coord.connect()

--- a/tests/integration/matrix/_conformance_docs_sqlite.py
+++ b/tests/integration/matrix/_conformance_docs_sqlite.py
@@ -1,0 +1,101 @@
+"""Raw-``backend: sqlite`` wiring for the documents-target conformance leg.
+
+The store is :class:`~khora.storage.backends.sqlite.SQLiteRelationalBackend` — the
+hand-written aiosqlite tier that owns its ``documents`` DDL as a string literal at
+``connect()`` time and has no Alembic chain behind it. **This is the first conformance
+coverage of that backend at all**: the chunk corpus reaches SQLite only through
+``sqlite_lance``, whose ``documents`` table is the shared SQLAlchemy model. The two
+diverge in ways the corpus can see, which is why both legs exist rather than one
+standing in for the other:
+
+* the physical metadata column is ``metadata_`` here and ``metadata`` there (the
+  compile context remaps accordingly);
+* timestamps are written by ``dt.isoformat()`` into ``TEXT`` — a ``'T'`` separator with
+  the writer's offset preserved — where the ORM tier writes SQLAlchemy's
+  space-separated, offset-discarded ``DATETIME``;
+* ``source_type`` is nullable here with a ``''`` default, and ``NOT NULL`` there
+  (migration 055).
+
+Both stores withhold ``created_at`` / ``source_timestamp`` from pushdown for those
+serialization reasons, so the date-key cases land on the post-filter on both legs —
+which is exactly the property the residual mode makes load-bearing.
+
+Exposes the two callables the documents test modules inject:
+
+* ``reachable() -> bool`` — the local-dev skip gate. In-process, so always ``True``.
+* ``executor_for(case, *, forced_residual) -> DocumentsExecutor`` — seeds the case
+  (once per process, cached) and returns a ready executor bound to its namespace.
+
+Kept out of ``conftest.py`` and named with a leading underscore (not a ``test_``
+module) so it is a plain helper the test modules import, never collected as tests.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from uuid import UUID
+
+from khora.filter.conformance import (
+    ConformanceCase,
+    DocumentsExecutor,
+    _documents_case_namespace_id,
+    seed_documents_case,
+)
+from khora.storage.backends.sqlite import SQLiteRelationalBackend
+from khora.storage.coordinator import StorageCoordinator
+from tests.integration.matrix._conformance_docs_common import documents_executor, run_async
+
+
+def reachable() -> bool:
+    """Whether the raw-sqlite store is reachable — always ``True`` (in-process)."""
+    return True
+
+
+async def _build_coordinator() -> StorageCoordinator:
+    """A connected relational-only coordinator over an in-memory SQLite database.
+
+    ``:memory:`` rather than a tmp file: this store keeps ONE aiosqlite connection for
+    its whole lifetime, so the database survives as long as the coordinator does, and
+    nothing else needs to read the file. No vector backend — document enumeration
+    reads the relational store alone.
+    """
+    coord = StorageCoordinator(relational=SQLiteRelationalBackend(":memory:"))
+    await coord.connect()
+    return coord
+
+
+@lru_cache(maxsize=1)
+def _coordinator() -> StorageCoordinator:
+    """The process-wide connected coordinator (built exactly once)."""
+    return run_async(_build_coordinator())
+
+
+# ``case.id -> {seed_id: document UUID}``, filled on first use. A plain dict, not an
+# ``lru_cache``: :class:`ConformanceCase` is frozen but carries wire-dict filters, so
+# it is unhashable and cannot be a cache key.
+_SEED_MAPS: dict[str, dict[str, UUID]] = {}
+
+
+def _seed(case: ConformanceCase) -> dict[str, UUID]:
+    """Seed one case's documents (once per process) and return ``seed_id -> document UUID``.
+
+    Seeding is LAZY and per-case rather than a whole-corpus pass, because the embedded
+    stores have no cross-process seed-map artifact to build: a leg pays only for the
+    cases it actually runs, which keeps the unit smoke subset cheap while the full
+    matrix leg still gets every case. Both modes of a case share one seed — the walk
+    is read-only.
+    """
+    if case.id not in _SEED_MAPS:
+        _SEED_MAPS[case.id] = run_async(seed_documents_case(_coordinator(), case))
+    return _SEED_MAPS[case.id]
+
+
+def executor_for(case: ConformanceCase, *, forced_residual: bool) -> DocumentsExecutor:
+    """Seed ``case`` (in-process, cached) and return a ready :class:`DocumentsExecutor`."""
+    id_map = _seed(case)
+    return documents_executor(
+        _coordinator(),
+        _documents_case_namespace_id(case),
+        id_map,
+        forced_residual=forced_residual,
+    )

--- a/tests/integration/matrix/_conformance_docs_surreal.py
+++ b/tests/integration/matrix/_conformance_docs_surreal.py
@@ -1,0 +1,103 @@
+"""Embedded-SurrealDB wiring for the documents-target conformance leg.
+
+The store is :class:`~khora.storage.backends.surrealdb.relational.SurrealDBRelationalAdapter`
+over an in-process ``memory://`` connection, with the production schema
+(``DEFINE ... IF NOT EXISTS``, applied by ``connect()``) — no docker and no trimmed
+test-only table. Unlike the chunk surreal leg, which hand-writes a cut-down
+``temporal_chunk`` because the production chunk table needs record links the corpus
+never uses, ``document`` has no such obstacle: ``namespace_id`` is a plain string
+field, so the production DDL is exactly what the enumeration reads.
+
+**Surreal is not total-exact on this surface.** On the chunk surface it compiles with
+``on_unsupported="raise"``, so a leaf it cannot express is a fail-loud gap. Document
+enumeration compiles with ``on_unsupported="split"`` and always has the coordinator's
+post-filter behind it, so nothing raises and every case is an ordinary oracle-equal
+row-set comparison — there is no ``expect_unsupported`` leg here. Two buckets are still
+pruned by :func:`~khora.filter.conformance._documents_surreal_excluded`, and both are
+storage-representation quirks a post-filter cannot undo (a metadata datetime stored as
+a string, and an explicit JSON ``null`` dropped from a FLEXIBLE object on write).
+
+Exposes the two callables the documents test modules inject:
+
+* ``reachable() -> bool`` — the local-dev skip gate. Embedded ``memory://`` is
+  in-process, so always ``True``.
+* ``executor_for(case, *, forced_residual) -> DocumentsExecutor`` — seeds the case
+  (once per process, cached) and returns a ready executor bound to its namespace.
+
+Kept out of ``conftest.py`` and named with a leading underscore (not a ``test_``
+module) so it is a plain helper the test modules import, never collected as tests.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from uuid import UUID
+
+from khora.filter.conformance import (
+    ConformanceCase,
+    DocumentsExecutor,
+    _documents_case_namespace_id,
+    seed_documents_case,
+)
+from khora.storage.coordinator import StorageCoordinator
+from tests.integration.matrix._conformance_docs_common import documents_executor, run_async
+
+
+def reachable() -> bool:
+    """Whether the embedded SurrealDB store is importable + reachable.
+
+    ``memory://`` is in-process, so the only way this leg is unavailable is the
+    ``surrealdb`` extra not being installed.
+    """
+    try:
+        import surrealdb  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+async def _build_coordinator() -> StorageCoordinator:
+    """A connected relational-only coordinator over an embedded ``memory://`` SurrealDB.
+
+    The adapter's ``connect()`` applies the declarative schema, so the ``document``
+    table and its indexes exist before the first seed. No vector/graph adapter is
+    wired: document enumeration reads the relational adapter alone, and leaving the
+    other roles unset also keeps the coordinator off its unified-backend path.
+    """
+    from khora.storage.backends.surrealdb.connection import SurrealDBConnection
+    from khora.storage.backends.surrealdb.relational import SurrealDBRelationalAdapter
+
+    connection = SurrealDBConnection(mode="memory", namespace="khora_test", database="docs_conformance")
+    await connection.connect()
+    coord = StorageCoordinator(relational=SurrealDBRelationalAdapter(connection))
+    await coord.connect()
+    return coord
+
+
+@lru_cache(maxsize=1)
+def _coordinator() -> StorageCoordinator:
+    """The process-wide connected coordinator (built exactly once)."""
+    return run_async(_build_coordinator())
+
+
+# ``case.id -> {seed_id: document UUID}``, filled on first use. See the sibling
+# raw-sqlite module for why this is a plain dict rather than an ``lru_cache``.
+_SEED_MAPS: dict[str, dict[str, UUID]] = {}
+
+
+def _seed(case: ConformanceCase) -> dict[str, UUID]:
+    """Seed one case's documents (once per process) and return ``seed_id -> document UUID``."""
+    if case.id not in _SEED_MAPS:
+        _SEED_MAPS[case.id] = run_async(seed_documents_case(_coordinator(), case))
+    return _SEED_MAPS[case.id]
+
+
+def executor_for(case: ConformanceCase, *, forced_residual: bool) -> DocumentsExecutor:
+    """Seed ``case`` (in-process, cached) and return a ready :class:`DocumentsExecutor`."""
+    id_map = _seed(case)
+    return documents_executor(
+        _coordinator(),
+        _documents_case_namespace_id(case),
+        id_map,
+        forced_residual=forced_residual,
+    )

--- a/tests/integration/matrix/_conformance_seed.py
+++ b/tests/integration/matrix/_conformance_seed.py
@@ -2,9 +2,10 @@
 
 Run ONCE before a docker-backed pytest leg, naming the backend to seed::
 
-    python -m tests.integration.matrix._conformance_seed            # postgres (default)
-    python -m tests.integration.matrix._conformance_seed neo4j      # cypher leg
-    python -m tests.integration.matrix._conformance_seed weaviate   # weaviate leg
+    python -m tests.integration.matrix._conformance_seed                    # postgres (default)
+    python -m tests.integration.matrix._conformance_seed neo4j              # cypher leg
+    python -m tests.integration.matrix._conformance_seed weaviate           # weaviate leg
+    python -m tests.integration.matrix._conformance_seed documents-postgres # documents leg
 
 Each backend builds its live store, seeds every corpus case that targets it (a
 random chunk UUID per record), and persists the ``case_id -> {seed_id: chunk_uuid}``
@@ -14,9 +15,17 @@ under ``-n auto`` every xdist worker only reads the pre-seeded store — no writ
 contention against the shared container. This is the ONE-TIME seed (a workflow step
 before pytest), NOT a per-xdist-worker fixture.
 
-The embedded legs (sqlite_lance / surrealdb) are NOT seeded here: they run on a
-per-worker in-process store (tmp SQLite+LanceDB / embedded ``memory://``) and seed
-inside their own pytest fixture, so they need no shared seed-map artifact.
+``documents-postgres`` is the document-ENUMERATION corpus rather than the chunk one:
+a different corpus, a different table, and its own seed-map path, so it is a separate
+invocation rather than a mode of ``postgres``. Both may be seeded into the same
+database — the documents seeder derives its namespaces under a ``"documents:"``
+prefix precisely so the two corpora cannot collide on
+``memory_namespaces (namespace_id, version)``.
+
+The embedded legs (sqlite_lance / surrealdb, and all three embedded documents legs)
+are NOT seeded here: they run on a per-worker in-process store (tmp SQLite+LanceDB /
+embedded ``memory://``) and seed lazily on first use, so they need no shared seed-map
+artifact.
 
 This is a thin driver: each backend's ``build_seed_map`` / ``write_seed_map`` lives
 in its sibling ``_conformance_<backend>`` helper (which the test module also imports),
@@ -29,9 +38,11 @@ import asyncio
 import sys
 from types import ModuleType
 
-# The backends this driver can seed. Embedded legs (sqlite_lance / surrealdb) are
-# absent on purpose — they seed per-worker in their own pytest fixture.
-_BACKENDS: frozenset[str] = frozenset({"postgres", "neo4j", "weaviate"})
+# The backends this driver can seed. Embedded legs (sqlite_lance / surrealdb, and the
+# three embedded documents legs) are absent on purpose — they seed in-process on first
+# use. ``documents-postgres`` is the documents-target corpus, not a mode of
+# ``postgres``: different corpus, different table, different seed-map path.
+_BACKENDS: frozenset[str] = frozenset({"postgres", "neo4j", "weaviate", "documents-postgres"})
 
 
 def _seeder_module(backend: str) -> ModuleType:
@@ -47,6 +58,8 @@ def _seeder_module(backend: str) -> ModuleType:
         from tests.integration.matrix import _conformance_neo4j as module
     elif backend == "weaviate":
         from tests.integration.matrix import _conformance_weaviate as module
+    elif backend == "documents-postgres":
+        from tests.integration.matrix import _conformance_docs_pg as module
     else:  # pragma: no cover - guarded by the caller's membership check
         raise SystemExit(f"unknown conformance backend {backend!r}; choose one of {sorted(_BACKENDS)}")
     return module

--- a/tests/integration/matrix/test_documents_conformance.py
+++ b/tests/integration/matrix/test_documents_conformance.py
@@ -1,0 +1,144 @@
+"""Documents-target conformance corpus — parametrized matrix leg.
+
+The sibling of ``test_filter_conformance.py``, for the document-ENUMERATION surface
+rather than the chunk-recall one. Every case in
+:func:`~khora.filter.conformance.documents_conformance_cases` is lowered through the
+real validator + ``parse_to_ast``, seeded as documents through the coordinator's write
+API, and enumerated back through the REAL
+:meth:`~khora.storage.coordinator.StorageCoordinator.scan_documents_page` keyset walk.
+A backend is *conformant* iff the walk's output equals the Python oracle's, case for
+case.
+
+**Why this is a separate module rather than another backend of the chunk one.** The
+two corpora differ (``occurred_at`` is not enumerable, and ``external_id`` needs a
+distinct-value re-seed), the seeder differs (one document per record, no chunks), and
+— most of all — the *shape of the claim* differs. On the chunk surface, postgres and
+surrealdb are TOTAL-exact and a filter they cannot express RAISES; the corpus carries
+``expect_unsupported`` legs to assert that. Document enumeration is uniformly split +
+post-filter on all four backends: the coordinator compiles the whole AST once with
+``build_compile_context("documents", on_unsupported="split")`` and re-checks it over
+every scanned row, and each store's ``scan_documents`` compiles its prefilter with the
+same mode. **Nothing raises here**, so every case is a plain row-set comparison and
+there is no ``expect_unsupported`` leg to assert.
+
+Which backend this leg runs is selected by ``KHORA_CONFORMANCE_DOC_BACKEND`` (default
+``sqlite``), so the CI matrix runs one leg per backend from one module:
+
+* ``sqlite`` — the raw ``backend: sqlite`` tier. In-process, no Docker. **The first
+  conformance coverage of that backend at all** (the chunk corpus reaches SQLite only
+  through ``sqlite_lance``, a different ``documents`` schema).
+* ``sqlite_lance`` — the shared Alembic ``documents`` model over embedded SQLite.
+  In-process, no Docker.
+* ``surrealdb`` — embedded ``memory://`` with the production schema. In-process; needs
+  the ``surrealdb`` extra. Drops the two storage-representation buckets
+  :func:`~khora.filter.conformance._documents_surreal_excluded` names — a documented
+  capability prune, never a silent skip.
+* ``postgres`` — the live server, read-only over a store seeded ONCE out-of-band
+  (``python -m tests.integration.matrix._conformance_seed documents-postgres``), so
+  every xdist worker only reads. The only tier with real ``timestamptz`` columns, and
+  therefore the only one that pushes the two date keys into SQL.
+
+Every case runs in BOTH modes:
+
+* ``natural`` — the AST reaches ``scan_documents_page``, so the backend pushes what it
+  can and the coordinator post-filters the rest. This is the production path, and the
+  only mode that exercises the coordinator's post-filter at all (including its
+  no-pushdown extreme, which any case whose leaves the backend defers wholesale
+  already reaches).
+* ``residual`` — the AST is WITHHELD, which makes ``scan_documents_page`` a RAW
+  ENUMERATION (no AST ⇒ no compiled post-filter ⇒ no narrowing), and the identical
+  ``compile_python`` predicate is applied in-harness over the returned documents.
+  **This is not a coordinator code path** — the filtering happens outside it. What it
+  pins is ``compile_python`` over ``"documents"`` against each store's ROUND-TRIP
+  document shape — raw-sqlite's TEXT datetimes, SurrealDB's ``metadata_`` remap,
+  SQLAlchemy's offset-discarding ``DATETIME`` — rather than against whatever SQL
+  happened to accept, so a mangled round-trip cannot hide behind a pushdown that
+  rejected the row for the right reason by accident. A ``SchemaCapabilities`` override
+  cannot express this: ``scan_documents`` takes no context override, so withholding
+  the AST is how the mode is realized.
+
+The corpus is excluded from the main test/integration jobs via the
+``filter_conformance`` marker (see ``pyproject.toml`` addopts); it runs only in its own
+CI job.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import pytest
+
+from khora.filter.conformance import (
+    ConformanceCase,
+    _documents_surreal_excluded,
+    documents_conformance_cases,
+    run_case_for_backend,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.filter_conformance]
+
+# backend name -> runner-module import path. Every module exposes the same two
+# callables: ``reachable() -> bool`` and ``executor_for(case, *, forced_residual)``.
+# Imports are LAZY (inside the dispatch) so the sqlite leg never imports the lancedb /
+# surrealdb / asyncpg stacks.
+_DOC_BACKENDS: dict[str, str] = {
+    "sqlite": "tests.integration.matrix._conformance_docs_sqlite",
+    "sqlite_lance": "tests.integration.matrix._conformance_docs_lance",
+    "surrealdb": "tests.integration.matrix._conformance_docs_surreal",
+    "postgres": "tests.integration.matrix._conformance_docs_pg",
+}
+
+# Default ``sqlite``: in-process and dependency-free, so a bare
+# ``pytest -m filter_conformance`` on the no-Docker path still runs the whole corpus.
+SELECTED_BACKEND = os.environ.get("KHORA_CONFORMANCE_DOC_BACKEND", "sqlite")
+
+if SELECTED_BACKEND not in _DOC_BACKENDS:
+    pytest.skip(
+        f"backend {SELECTED_BACKEND!r} is not a documents-conformance backend (available: {sorted(_DOC_BACKENDS)})",
+        allow_module_level=True,
+    )
+
+
+def _runner_module():  # noqa: ANN202 - the runner module
+    """Lazily import the selected backend's ``_conformance_docs_<backend>`` module."""
+    return importlib.import_module(_DOC_BACKENDS[SELECTED_BACKEND])
+
+
+# Gate the leg on its store being reachable. LOCAL-DEV CONVENIENCE ONLY for the
+# postgres leg: in CI the parent ``tests/integration/conftest.py::pytest_configure``
+# aborts the session RED first when ``KHORA_PG_REQUIRED=1`` and PG is unreachable, so a
+# PG-down leg fails loudly rather than silently skipping — keep this module under
+# ``tests/integration/`` so that parent conftest loads.
+if not _runner_module().reachable():
+    pytest.skip(
+        f"{SELECTED_BACKEND} documents store not reachable "
+        f"(postgres: run `make dev`; surrealdb: install the `surrealdb` extra)",
+        allow_module_level=True,
+    )
+
+
+def _cases_for(backend: str) -> list[ConformanceCase]:
+    """The corpus this leg runs — the whole thing, minus the surreal capability prune.
+
+    Only ``surrealdb`` prunes, and only the two storage-representation buckets
+    :func:`_documents_surreal_excluded` names (a metadata datetime stored as a string;
+    an explicit JSON ``null`` dropped from a FLEXIBLE object on WRITE). Both corrupt
+    the stored row before any filter runs, so no post-filter can recover them — they
+    are capability facts about the store, not gaps in the compiler.
+    """
+    cases = documents_conformance_cases()
+    if backend != "surrealdb":
+        return cases
+    return [c for c in cases if not _documents_surreal_excluded(c.filter, c.seed_records)]
+
+
+_SELECTED_CASES = _cases_for(SELECTED_BACKEND)
+
+
+@pytest.mark.parametrize("mode", ["natural", "residual"])
+@pytest.mark.parametrize("case", _SELECTED_CASES, ids=lambda c: c.id)
+def test_documents_conformance_case(case: ConformanceCase, mode: str) -> None:
+    """Assert one case's row-set on the selected backend, in one mode, vs the oracle."""
+    executor = _runner_module().executor_for(case, forced_residual=(mode == "residual"))
+    assert run_case_for_backend(case, SELECTED_BACKEND, executor=executor) == case.expected_ids

--- a/tests/unit/filter/test_documents_conformance.py
+++ b/tests/unit/filter/test_documents_conformance.py
@@ -18,7 +18,7 @@ Three things live here, in increasing cost:
    ``backend: sqlite``, embedded ``sqlite_lance``, embedded SurrealDB), in BOTH modes.
    No Docker, no LLM, no embeddings.
 
-The smoke leg is a *slice*, not the corpus: the full 186-case × 2-mode × 4-backend
+The smoke leg is a *slice*, not the corpus: the full 193-case x 2-mode x 4-backend
 matrix belongs to ``tests/integration/matrix/test_documents_conformance.py`` behind the
 ``filter_conformance`` marker. What this leg buys is that the seam itself — seeder,
 walk, both modes, all three embedded stores — cannot rot unnoticed between runs of

--- a/tests/unit/filter/test_documents_conformance.py
+++ b/tests/unit/filter/test_documents_conformance.py
@@ -1,0 +1,293 @@
+"""Documents-target conformance: the oracle leg, the rejected key, and an embedded smoke.
+
+Three things live here, in increasing cost:
+
+1. **The oracle leg** — every case in :func:`documents_conformance_cases` is run
+   through :func:`documents_oracle_survivors` and asserted against the ``expected_ids``
+   it was authored with on the CHUNK surface. The whole documents corpus is carried
+   over verbatim on the claim that a filter which never reads ``occurred_at`` selects
+   the same records off a document-row mapping as off a chunk one; this leg is what
+   makes that claim falsifiable rather than assumed. Pure Python, no store.
+2. **The rejected key** — ``occurred_at`` is the one system key document enumeration
+   does not accept, and the corpus encodes it as a *validation outcome* instead of a
+   row-set case. These tests drive the real
+   :func:`khora.khora._reject_non_enumerable_keys` and pin the structured error,
+   including the substitute keys the message names.
+3. **The embedded smoke leg** — a representative slice of the corpus driven through
+   the REAL ``scan_documents_page`` walk against three in-process stores (raw
+   ``backend: sqlite``, embedded ``sqlite_lance``, embedded SurrealDB), in BOTH modes.
+   No Docker, no LLM, no embeddings.
+
+The smoke leg is a *slice*, not the corpus: the full 186-case × 2-mode × 4-backend
+matrix belongs to ``tests/integration/matrix/test_documents_conformance.py`` behind the
+``filter_conformance`` marker. What this leg buys is that the seam itself — seeder,
+walk, both modes, all three embedded stores — cannot rot unnoticed between runs of
+that job.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+
+from khora.filter import SYSTEM_KEYS
+from khora.filter.conformance import (
+    _DOCUMENTS_REJECTED_FILTERS,
+    ConformanceCase,
+    _documents_surreal_excluded,
+    documents_conformance_cases,
+    documents_oracle_survivors,
+    run_case_for_backend,
+)
+
+pytestmark = pytest.mark.unit
+
+_CASES = documents_conformance_cases()
+
+
+# --------------------------------------------------------------------------- #
+# 1. The oracle leg.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("case", _CASES, ids=lambda c: c.id)
+def test_documents_oracle_agrees_with_the_declared_expectations(case: ConformanceCase) -> None:
+    """Every carried-over case selects the same records off a document-row mapping.
+
+    ``expected_ids`` is hand-authored against the chunk mapping, which synthesizes
+    ``occurred_at`` as ``COALESCE(occurred_at, source_timestamp)``; the documents
+    mapping has no such key. A case that quietly depended on that synthesis would show
+    up here as a mismatch — not as a mysterious failure on a live leg hours later.
+    """
+    assert documents_oracle_survivors(case) == case.expected_ids
+
+
+def test_the_corpus_has_unique_case_ids() -> None:
+    """Case ids double as namespace keys, so a duplicate would alias two seeds."""
+    ids = [case.id for case in _CASES]
+    duplicates = sorted({cid for cid in ids if ids.count(cid) > 1})
+    assert not duplicates, f"duplicate documents case ids: {duplicates}"
+
+
+def test_no_case_filters_the_non_enumerable_key() -> None:
+    """``occurred_at`` never appears as a row-set case — only as a rejection.
+
+    The complement of the corpus-assembly rule. ``_documents_eligible`` drops such a
+    case at assembly time; this asserts the result rather than trusting the filter.
+    """
+    from khora.filter.conformance import _resolve_ast
+    from khora.filter.execute import iter_leaf_clauses
+
+    offenders = [
+        case.id
+        for case in _CASES
+        if any(
+            clause.path and clause.path[0] == "occurred_at" for clause in iter_leaf_clauses(_resolve_ast(case.filter))
+        )
+    ]
+    assert not offenders, f"documents cases filtering the non-enumerable key occurred_at: {offenders}"
+
+
+# --------------------------------------------------------------------------- #
+# 2. The rejected key.
+# --------------------------------------------------------------------------- #
+
+
+def _reject(wire: dict[str, Any]) -> Any:
+    """Lower a wire filter through the real validator + ``parse_to_ast``, then reject."""
+    from khora.filter import RecallFilter, parse_to_ast
+    from khora.khora import _reject_non_enumerable_keys
+
+    return _reject_non_enumerable_keys(parse_to_ast(RecallFilter.model_validate(wire)))
+
+
+@pytest.mark.parametrize("wire", _DOCUMENTS_REJECTED_FILTERS, ids=("bare", "nested-in-and"))
+def test_occurred_at_is_rejected_at_any_depth(wire: dict[str, Any]) -> None:
+    """An ``occurred_at`` leaf is a structured validation failure, not a zero-match query.
+
+    Both shapes matter: a bare leaf, and one buried inside an ``$and`` next to a key
+    that IS enumerable. The rejection walks every leaf, so the second must fail exactly
+    like the first — a depth-1-only check would let the composed form through, where it
+    would silently match nothing (no document row backs the column).
+    """
+    from khora.filter.model import RecallFilterValidationError
+
+    with pytest.raises(RecallFilterValidationError) as excinfo:
+        _reject(wire)
+
+    error = excinfo.value.errors[0]
+    assert error.path == "occurred_at"
+    assert error.code == "key_not_enumerable"
+    assert error.allowed == sorted(SYSTEM_KEYS - {"occurred_at"})
+
+
+def test_the_rejection_names_both_substitutes_and_denies_equivalence() -> None:
+    """The message must offer the two time axes AND deny they are the same thing.
+
+    Naming ``source_timestamp`` / ``created_at`` without the denial would read as
+    "use this instead", which is wrong: they are the source-provided and ingest times,
+    neither of which is the event time. The denial is the load-bearing half, so it is
+    asserted rather than left to the reader of the docstring.
+    """
+    from khora.filter.model import RecallFilterValidationError
+
+    with pytest.raises(RecallFilterValidationError) as excinfo:
+        _reject(_DOCUMENTS_REJECTED_FILTERS[0])
+
+    message = excinfo.value.errors[0].message
+    assert "source_timestamp" in message
+    assert "created_at" in message
+    assert "different time axes, not equivalent substitutes" in message
+
+
+def test_an_enumerable_filter_is_not_rejected() -> None:
+    """The gate has to let the nine enumerable keys through, or it proves nothing."""
+    assert _reject({"$and": [{"source_name": "linear"}, {"created_at": {"$gt": "2026-01-01T00:00:00Z"}}]}) is None
+
+
+# --------------------------------------------------------------------------- #
+# 3. The embedded smoke leg.
+# --------------------------------------------------------------------------- #
+#
+# One case per distinct shape the documents read path can take, chosen so that a
+# regression in any single mechanism turns at least one of them red:
+#
+# * pushed vs. post-filtered SYSTEM keys — a string key (pushed everywhere) and the two
+#   date keys (pushed only on Postgres; TEXT-serialization-unsafe everywhere else, so
+#   they land on the post-filter on all three stores here);
+# * the F1 negation polarity over a NULL column, and the bare-``null`` match;
+# * the documents-only ``external_id`` re-seed (the UNIQUE-constraint variant);
+# * metadata: a scalar, a ``$``-prefixed segment (unrenderable as a SurrealQL
+#   identifier — under ``"split"`` it must DEFER, which is precisely the bucket the
+#   documents surreal prune drops), array containment, and whole-subdoc equality;
+# * the all-or-nothing boolean gate — a mixed system+metadata ``$or`` and a
+#   ``$not($exists)``, the two shapes a compiler must defer WHOLE or invert;
+# * the constant-false bare-list, and a multi-predicate AND.
+_SMOKE_CASE_IDS: tuple[str, ...] = (
+    "F-OP-source_type-eq",
+    "F-OP-source_name-ne",
+    "F-OP-title-exists-true",
+    "F-OP-external_id-documents-eq",
+    "F-OP-external_id-documents-nin",
+    "F-OP-created_at-gte",
+    "F-OP-source_timestamp-lt",
+    "F-OP-metadata-tier-eq",
+    "F-EXISTS-md-false",
+    "F-LOGIC-mixed-or",
+    "F-LOGIC-not-exists",
+    "F-DOTKEY-dollar-key",
+    "F-NULLVAL-sys-bare-null",
+    "F-OBJEQ-exact",
+    "F-ARRAY-in-any",
+    "F-IMPOSSIBLE-name-barelist",
+    "F-SEL-composite",
+)
+
+_BY_ID = {case.id: case for case in _CASES}
+
+# backend name -> runner-module import path. Imported LAZILY inside the test so a
+# missing optional extra skips its own leg instead of erroring collection for all.
+_EMBEDDED_BACKENDS: dict[str, str] = {
+    "sqlite": "tests.integration.matrix._conformance_docs_sqlite",
+    "sqlite_lance": "tests.integration.matrix._conformance_docs_lance",
+    "surrealdb": "tests.integration.matrix._conformance_docs_surreal",
+}
+
+
+def test_every_smoke_case_id_resolves() -> None:
+    """A renamed or dropped case must break loudly, not shrink the smoke set silently."""
+    missing = [cid for cid in _SMOKE_CASE_IDS if cid not in _BY_ID]
+    assert not missing, f"smoke case ids not present in the documents corpus: {missing}"
+
+
+@pytest.mark.parametrize("backend", sorted(_EMBEDDED_BACKENDS), ids=sorted(_EMBEDDED_BACKENDS))
+@pytest.mark.parametrize("mode", ["natural", "residual"])
+@pytest.mark.parametrize("case_id", _SMOKE_CASE_IDS)
+def test_embedded_documents_smoke(case_id: str, mode: str, backend: str) -> None:
+    """One case, one mode, one embedded store: the read output must equal the oracle.
+
+    ``natural`` hands the AST to ``scan_documents_page`` (backend pushdown + the
+    coordinator's own post-filter); ``residual`` withholds it and applies the identical
+    post-filter over the returned documents. Both drive the same real keyset primitive,
+    and both must land on ``expected_ids`` — the surface is split + post-filter on every
+    backend, so no case is expected to raise.
+    """
+    try:
+        module = importlib.import_module(_EMBEDDED_BACKENDS[backend])
+    except ImportError as exc:  # optional extra absent (lancedb / surrealdb)
+        pytest.skip(f"{backend} documents leg unavailable: {exc}")
+    if not module.reachable():
+        pytest.skip(f"{backend} documents store not reachable")
+
+    case = _BY_ID[case_id]
+    if backend == "surrealdb" and _documents_surreal_excluded(case.filter, case.seed_records):
+        pytest.skip(
+            f"{case.id} is pruned from the surreal documents leg by a documented storage-"
+            f"representation quirk (see _documents_surreal_excluded)"
+        )
+
+    executor = module.executor_for(case, forced_residual=(mode == "residual"))
+    assert run_case_for_backend(case, backend, executor=executor) == case.expected_ids
+
+
+# --------------------------------------------------------------------------- #
+# 4. The Postgres seed-map artifact (DB-free).
+# --------------------------------------------------------------------------- #
+#
+# The three embedded legs above seed in-process, so their whole path is exercised by
+# this module. The Postgres leg cannot be: it is read-only over a store seeded by a
+# separate process, bridged by a JSON artifact. That artifact is therefore the one
+# piece of the documents seam no live-store run in this file can reach — and if its
+# round-trip drifts (the ``{case_id: {seed_id: document_id}}`` shape, the
+# ``str``↔``UUID`` coercion, the missing-file contract) the leg silently mis-maps every
+# survivor. These two checks are pure ``tmp_path`` file I/O, so they run here rather
+# than being deferred to a job that needs a container. Same guard the chunk leg has in
+# ``tests/integration/matrix/test_seed_map_roundtrip.py``, for the documents map.
+
+
+@pytest.fixture
+def _docs_seed_map_at(tmp_path, monkeypatch):  # noqa: ANN001, ANN202 - pytest fixture
+    """Point the documents seed-map helpers at a ``tmp_path`` file; reset the load cache."""
+    from tests.integration.matrix import _conformance_docs_pg
+
+    monkeypatch.setattr(_conformance_docs_pg, "SEED_MAP_PATH", str(tmp_path / "docs_seed_map.json"))
+    _conformance_docs_pg.load_seed_map.cache_clear()
+    try:
+        yield _conformance_docs_pg
+    finally:
+        _conformance_docs_pg.load_seed_map.cache_clear()
+
+
+def test_documents_seed_map_round_trip_preserves_ids_and_uuid_type(_docs_seed_map_at) -> None:  # noqa: ANN001
+    """``write_seed_map`` -> ``load_seed_map`` preserves case ids, seed ids, and UUID identity."""
+    from uuid import UUID, uuid4
+
+    doc_a, doc_b = uuid4(), uuid4()
+    original = {"F-OP-source_name-eq": {"source_name-1": str(doc_a), "source_name-2": str(doc_b)}}
+
+    _docs_seed_map_at.write_seed_map(original)
+    loaded = _docs_seed_map_at.load_seed_map()
+
+    assert loaded.keys() == original.keys()
+    assert loaded["F-OP-source_name-eq"].keys() == {"source_name-1", "source_name-2"}
+    assert loaded["F-OP-source_name-eq"]["source_name-1"] == doc_a
+    assert isinstance(loaded["F-OP-source_name-eq"]["source_name-1"], UUID)
+    assert loaded["F-OP-source_name-eq"]["source_name-2"] == doc_b
+
+
+def test_documents_seed_map_missing_file_raises_an_actionable_error(_docs_seed_map_at) -> None:  # noqa: ANN001
+    """A missing map names the documents seed step, not just the absent path.
+
+    The chunk and documents corpora have separate seed invocations and separate
+    artifact paths, so a generic "no such file" would send an operator to the wrong
+    command.
+    """
+    with pytest.raises(FileNotFoundError) as excinfo:
+        _docs_seed_map_at.load_seed_map()
+
+    message = str(excinfo.value)
+    assert "_conformance_seed documents-postgres" in message
+    assert "read-only" in message
+    assert "KHORA_CONFORMANCE_DOCS_SEED_MAP" in message

--- a/tests/unit/filter/test_system_keys_coverage.py
+++ b/tests/unit/filter/test_system_keys_coverage.py
@@ -19,9 +19,17 @@ from __future__ import annotations
 import pytest
 
 from khora.filter import SYSTEM_KEYS
-from khora.filter.conformance import ConformanceCase, f_op_cases
+from khora.filter.conformance import ConformanceCase, f_op_cases, f_op_documents_cases
 
 pytestmark = pytest.mark.unit
+
+# The document-enumeration surface accepts nine of the ten system keys. ``occurred_at``
+# is the chunk event-time axis and no ``documents`` column backs it, so the documents
+# corpus encodes it as a REJECTION (``_DOCUMENTS_REJECTED_FILTERS``, asserted in
+# ``test_documents_conformance.py``) rather than as a row-set case — which is why the
+# coverage target below is a strict subset and why its absence is asserted, not
+# tolerated.
+_ENUMERABLE_KEYS = SYSTEM_KEYS - {"occurred_at"}
 
 
 def _covered_keys(cases: list[ConformanceCase]) -> frozenset[str]:
@@ -58,4 +66,35 @@ def test_coverage_check_is_falsifiable() -> None:
     assert depleted != cases, "expected to remove at least one case for the target key"
 
     missing = SYSTEM_KEYS - _covered_keys(depleted)
+    assert target in missing, f"coverage check failed to notice {target!r} went uncovered — the meta-test has no teeth"
+
+
+def test_every_enumerable_key_has_a_documents_op_case() -> None:
+    """The documents corpus covers all nine enumerable keys — and NOT ``occurred_at``.
+
+    Two assertions, both load-bearing. The superset check is the same contract as the
+    chunk corpus's, narrowed to the enumerable subset. The second is the tighter one:
+    an ``occurred_at`` tag reappearing would mean a case filtering a key the
+    enumeration surface rejects had slipped back into the corpus as a row-set case,
+    which ``_documents_eligible`` exists to prevent.
+    """
+    covered = _covered_keys(f_op_documents_cases())
+    missing = _ENUMERABLE_KEYS - covered
+    assert not missing, f"enumerable keys with no documents F-OP case: {sorted(missing)}"
+    assert "occurred_at" not in covered, (
+        "occurred_at is not an enumerable document key — it must be encoded as a "
+        "rejection, never as a documents row-set case"
+    )
+
+
+def test_documents_coverage_is_falsifiable() -> None:
+    """The documents coverage assertion has teeth: deplete one key and it must fail."""
+    cases = f_op_documents_cases()
+    # Pick a key the corpus genuinely covers, so dropping its cases is a real change.
+    target = sorted(_ENUMERABLE_KEYS & _covered_keys(cases))[0]
+
+    depleted = [case for case in cases if target not in case.exercises]
+    assert depleted != cases, "expected to remove at least one case for the target key"
+
+    missing = _ENUMERABLE_KEYS - _covered_keys(depleted)
     assert target in missing, f"coverage check failed to notice {target!r} went uncovered — the meta-test has no teeth"


### PR DESCRIPTION
## Summary

Extends the internal recall-filter conformance harness so the existing filter-case corpus also runs against the **document-enumeration** surface, not just the chunk-recall surface. Concretely, it drives the storage coordinator's document keyset-scan primitive (`scan_documents_page`) — the primitive that backs the public `list_documents(filter=…)` enumeration API — and asserts that every backend's surviving row set equals the in-memory `compile_python` oracle.

- **New executor seam.** A single `DocumentsExecutor` plus an injected `DocumentsRunner` walks the real coordinator document-scan path to exhaustion and maps surviving rows back to seed ids. Seeding goes exclusively through the `create_document` write API, namespace-partitioned per case (xdist-safe).
- **Both read modes per case.** Natural pushdown (backend prefilter + coordinator post-filter) and a forced-residual mode (raw enumeration with `filter_ast` withheld, then the identical `compile_python` post-filter applied over the round-tripped document row), so oracle equality is checked on every backend, not only where residuals occur naturally.
- **Case-family carryover.** F-OP over the nine enumerable document keys, plus F-EXISTS, F-COERCE, F-OBJEQ, F-DOTKEY, F-LOGIC, F-NULLVAL, F-SEL and the metadata-datetime shapes of F-DATES. The chunk-only event-time key is not enumerable on this surface and is encoded as a structured-rejection case with its error copy asserted.
- **SurrealDB representation exclusions carried over** (metadata datetime ISO-form divergence; present-JSON-null drop on write), each with a documented capability reason — never a silent skip. The unsafe metadata-segment case defers to the post-filter under split semantics rather than raising.
- **Coverage meta-test extended** to the enumerable-key set: an enumerable key with zero documents-target operator case fails CI.
- **CI + local coverage.** New no-Docker embedded unit smoke legs (raw-sqlite, sqlite_lance, embedded SurrealDB) in both modes, plus a new CI matrix job covering all four relational backends. This is the first conformance coverage of the raw `sqlite` relational backend.

Test-harness change only — no production behavior is modified (`src/` diff is a single additive file, `+488/−0`).

## Test plan

- [x] Unit tests pass (`tests/unit/filter/` incl. the new documents module and the extended coverage meta-test; full unit suite green, coverage 84%)
- [x] Embedded documents-target legs pass in both modes on raw-sqlite, sqlite_lance, and embedded SurrealDB (no Docker)
- [x] Chunk-target conformance legs unregressed
- [ ] Integration matrix (Postgres + SurrealDB documents legs) — exercised by the new CI job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added document-enumeration conformance coverage alongside existing chunk-recall checks.
  - Added support for validating document filtering across SQLite, SQLite/LanceDB, SurrealDB, and PostgreSQL.
  - Added deterministic document seed data and backend-specific test execution modes.

- **Bug Fixes**
  - Added validation and clear errors for unsupported document filters, including `occurred_at`.
  - Added coverage checks to ensure enumerable system fields are tested consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->