### PR TITLE
Add property-based walk fuzzer for the document-enumeration surface

### DIFF
--- a/tests/integration/storage/test_walk_fuzz_pg.py
+++ b/tests/integration/storage/test_walk_fuzz_pg.py
@@ -1,0 +1,840 @@
+"""Property-based walk fuzzer for the document-enumeration surface (PostgreSQL leg).
+
+The embedded twin (``tests/unit/filter/test_walk_fuzz.py``) carries the bulk of
+the generated budget and the whole seed sweep, because it runs without services.
+This module re-runs the same three properties — exactly-once/order/termination,
+cursor stitching, limit invariance — against a live PostgreSQL, at a small budget,
+because two things here are genuinely different and neither is checkable in
+process:
+
+* **The cursor round-trips through ``timestamptz`` and ``uuid``**, not through a
+  lexicographically-compared TEXT column. The embedded store's whole class of
+  serialization hazard (``'T'`` sorting above ``' '``, a missing ``.000000``
+  sorting below its tie-mates) does not exist here — and this store has its own,
+  opposite one, where a *wrong* operand type is silently correct rather than
+  loudly broken. Neither store's behaviour predicts the other's.
+* **The pushdown split is inverted.** This store's compiler pushes every
+  enumerable key, INCLUDING both date keys, so a walk here is nearly all SQL
+  where the embedded twin's is nearly all in-memory post-filter. The properties
+  must hold identically over two very different physical plans, which is what
+  running them twice buys.
+
+What the differential does and does not prove is worth stating, because the
+second bullet invites a stronger reading than it earns. It independently verifies
+the *walk* — paging, cursor stitching, exactly-once, strictly-descending order,
+honest termination — and it catches a too-RESTRICTIVE pushdown that drops a
+keeper: such a row never enters the scanned window, so the post-filter cannot
+recover it and the walk diverges from the oracle. It does NOT independently
+verify filter or pushdown *semantics*. The coordinator's in-memory post-filter
+and the oracle share the same ``compile_python`` predicate, re-checked over every
+row on both sides, so a too-PERMISSIVE pushdown is masked by that shared re-check
+and a bug inside ``compile_python`` itself is common-mode. Those are covered by
+the recall filter fuzzer and the SQL-compiler superset checks, not here.
+
+The eight-seed stability sweep is deliberately OMITTED here: it re-runs one
+property under eight PRNG streams to rule out a lucky stream, which is a
+statement about the *strategy*, not about the store, and the embedded leg already
+makes it at a fraction of the round-trip cost.
+
+Requires a running PostgreSQL (``make dev``). Skipped automatically when the
+configured ``KHORA_DATABASE_URL`` is unreachable; the integration conftest turns
+that skip into a hard failure when ``KHORA_PG_REQUIRED=1``, so a CI job with the
+service down cannot pass by skipping.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timedelta
+from functools import lru_cache
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+from khora.core.models import Document, MemoryNamespace, TenancyMode
+from khora.core.models.document import DocumentCursor, DocumentPage
+from khora.db.session import run_migrations
+from khora.storage.backends._documents_scan import build_documents_scan_query
+from khora.storage.backends.postgresql import PostgreSQLBackend
+from khora.storage.coordinator import StorageCoordinator
+from tests.integration.matrix._conformance_lance import _run_async
+from tests.test_helpers.document_order import id_ladder
+from tests.test_helpers.document_scan import WHOLE_SECOND, ScanSeed, scan_seed
+from tests.test_helpers.walk_fuzz import (
+    CORPUS_SIZE,
+    build_walk_corpus,
+    drive_walk,
+    to_walk_ast,
+    validated_walk_ast,
+    walk_filter,
+    walk_oracle,
+    walk_status,
+    walk_updated_before,
+    walked_ids,
+    walked_keys,
+)
+
+DATABASE_URL = os.environ.get(
+    "KHORA_DATABASE_URL",
+    # This repo's compose puts Postgres on 5434 (see compose.yaml); defaulting to
+    # 5432 would make the whole class silently skip on a local `make test`.
+    "postgresql+asyncpg://khora:khora@localhost:5434/khora",
+)
+
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
+
+
+pytestmark = [pytest.mark.integration]
+
+
+def _pg_reachable() -> bool:
+    import socket
+    from urllib.parse import urlparse
+
+    parsed = urlparse(DATABASE_URL.replace("+asyncpg", ""))
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+skip_no_pg = pytest.mark.skipif(
+    not _pg_reachable(),
+    reason="PostgreSQL not reachable (run `make dev` first)",
+)
+
+
+# --------------------------------------------------------------------------- #
+# The fixed corpus + the seeded PostgreSQL store.
+# --------------------------------------------------------------------------- #
+#
+# Same shape as the embedded twin, and for the same reason: a module-level
+# singleton resolved on the CALLER thread, with only the coroutines submitted to
+# the dedicated loop thread. Hypothesis's ``function_scoped_fixture`` health check
+# fires on a @given test that takes a per-test fixture, and a per-test connect /
+# migrate / seed cycle would dominate the run anyway.
+#
+# Every namespace here is a fresh ``uuid4``, so the module is safe on the shared
+# CI database: no test can see another's rows, and repeated runs never collide.
+
+CORPUS_NAMESPACE_ID = uuid4()
+CORPUS = build_walk_corpus(CORPUS_NAMESPACE_ID)
+
+UNBOUNDED = CORPUS_SIZE + 1
+
+
+def _budget(max_examples: int) -> settings:
+    """The shared Hypothesis profile — small budgets, since each example is a live walk."""
+    return settings(
+        max_examples=max_examples,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+    )
+
+
+class _SeededWalkStorePg:
+    """A connected relational-only coordinator holding the frozen walk corpus."""
+
+    def __init__(self, coord: StorageCoordinator, backend: PostgreSQLBackend) -> None:
+        self.coord = coord
+        self.backend = backend
+
+
+async def _build_seeded_store() -> _SeededWalkStorePg:
+    """Migrate, connect, and seed the corpus into a fresh namespace."""
+    result = await run_migrations(DATABASE_URL)
+    if not result.success:
+        raise RuntimeError(f"migration failed: {result.error}")
+
+    backend = PostgreSQLBackend(database_url=DATABASE_URL)
+    await backend.connect()
+    # ``vector=None``: enumeration is a relational-only read path, and it keeps
+    # the mutation companion's ``delete_document`` scoped to the document row.
+    coord = StorageCoordinator(relational=backend, vector=None)
+    await coord.connect()
+
+    await _create_namespace(coord, CORPUS_NAMESPACE_ID)
+    for document in CORPUS.documents:
+        await coord.create_document(document)
+
+    # Materialization guard (fail loud, at build time): a seeder that silently
+    # dropped rows would make the oracle and the walk agree on a too-small
+    # corpus. Counted through the scan surface, so a broken one-page full read
+    # is caught before any property depends on it.
+    page = await coord.scan_documents_page(CORPUS_NAMESPACE_ID, limit=CORPUS_SIZE + 5, scan_bound=UNBOUNDED)
+    seeded = [doc.id for doc in page]
+    if seeded != list(CORPUS.expected):
+        raise RuntimeError(
+            f"corpus did not materialize as expected: seeded {len(seeded)} rows, "
+            f"expected {len(CORPUS.expected)} in a pinned order\n"
+            f"  missing = {sorted(set(CORPUS.expected) - set(seeded))}\n"
+            f"  extra   = {sorted(set(seeded) - set(CORPUS.expected))}\n"
+            f"  seeded  = {seeded}"
+        )
+    return _SeededWalkStorePg(coord, backend)
+
+
+@lru_cache(maxsize=1)
+def _seeded_store() -> _SeededWalkStorePg:
+    """The process-wide seeded PostgreSQL store (migrated + seeded exactly once).
+
+    Resolved on the CALLER thread, never from inside a coroutine already running
+    on the loop thread — that would block the loop on a future only it can
+    complete. Left open for the process lifetime, like the conformance helper's
+    loop-thread coordinator.
+    """
+    return _run_async(_build_seeded_store())
+
+
+async def _create_namespace(coord: StorageCoordinator, namespace_id: UUID) -> None:
+    """Create a namespace whose row id and stable ``namespace_id`` agree."""
+    await coord.create_namespace(
+        MemoryNamespace(id=namespace_id, namespace_id=namespace_id, tenancy_mode=TenancyMode.SHARED)
+    )
+
+
+def _walk(*, limit: int, scan_bound: int, namespace_id: UUID | None = None, **kwargs: Any) -> list[DocumentPage]:
+    """Drive a whole walk on the loop thread and return its pages.
+
+    ``scan_bound`` is passed straight to ``scan_documents_page``; the facade's
+    config-derived bound (``query.document_scan_overfetch_multiplier`` /
+    ``document_scan_min_bound``) is deliberately bypassed, because no reachable
+    config produces the tiny budgets that force a page boundary between almost
+    every raw row.
+    """
+    store = _seeded_store()  # caller-thread resolution — never inside the loop coroutine
+    return _run_async(
+        drive_walk(
+            store.coord.scan_documents_page,
+            CORPUS_NAMESPACE_ID if namespace_id is None else namespace_id,
+            limit=limit,
+            scan_bound=scan_bound,
+            **kwargs,
+        )
+    )
+
+
+def assert_page_contract(pages: list[DocumentPage], *, limit: int) -> None:
+    """Every page's shape invariants — the ``next_after``/``exhausted`` polarity."""
+    for index, page in enumerate(pages):
+        is_last = index == len(pages) - 1
+        assert len(page) <= limit, f"page {index} returned {len(page)} matches over limit={limit}"
+        assert (page.next_after is None) is page.exhausted, (
+            f"page {index} broke the next_after/exhausted contract: "
+            f"next_after={page.next_after!r}, exhausted={page.exhausted}"
+        )
+        assert page.exhausted is is_last, f"page {index} exhausted={page.exhausted} but is_last={is_last}"
+    assert pages[-1].exhausted is True, "the walk ended without an exhausted page"
+
+
+def assert_strictly_descending(pages: list[DocumentPage]) -> None:
+    """The concatenated ``(created_at, id)`` keys strictly descend across page seams."""
+    keys = walked_keys(pages)
+    for previous, current in zip(keys, keys[1:], strict=False):
+        assert current < previous, f"walk order is not strictly descending: {previous!r} then {current!r}"
+
+
+# --------------------------------------------------------------------------- #
+# Property A — exactly-once + completeness + order + honest termination.
+# --------------------------------------------------------------------------- #
+
+
+@skip_no_pg
+class TestWalkEnumerationPg:
+    """One generated walk must enumerate exactly the oracle, once each, in order."""
+
+    @given(
+        filter_dict=walk_filter(),
+        status=walk_status(),
+        updated_before=walk_updated_before(),
+        scan_bound=st.sampled_from([1, 2, 3, 5]),
+    )
+    @_budget(15)
+    def test_walk_matches_the_oracle_exactly_once_and_in_order(
+        self,
+        filter_dict: dict[str, Any],
+        status: str | None,
+        updated_before: datetime | None,
+        scan_bound: int,
+    ) -> None:
+        ast = validated_walk_ast(filter_dict)
+        assume(ast is not None)
+        assert ast is not None  # narrow for the type checker after the assume
+
+        expected = walk_oracle(CORPUS.documents, filter_ast=ast, status=status, updated_before=updated_before)
+        pages = _walk(
+            limit=3,
+            scan_bound=scan_bound,
+            filter_ast=ast,
+            status=status,
+            updated_before=updated_before,
+        )
+        seen = walked_ids(pages)
+
+        assert len(seen) == len(set(seen)), f"a document was served twice: {filter_dict!r}"
+        assert set(seen) == set(expected), (
+            "walk/oracle set divergence:\n"
+            f"  filter = {filter_dict!r} status={status!r} updated_before={updated_before!r}\n"
+            f"  missing = {sorted(set(expected) - set(seen))}\n"
+            f"  extra   = {sorted(set(seen) - set(expected))}"
+        )
+        assert seen == expected, f"walk/oracle ORDER divergence at scan_bound={scan_bound}: {filter_dict!r}"
+        assert_strictly_descending(pages)
+        assert_page_contract(pages, limit=3)
+
+
+# --------------------------------------------------------------------------- #
+# Property B — cursor stitching (the load-bearing differential).
+# --------------------------------------------------------------------------- #
+
+
+@skip_no_pg
+class TestCursorStitchDifferentialPg:
+    """A walk stitched from many ``timestamptz``/``uuid`` cursors equals one with none.
+
+    The load-bearing property, and the one that justifies running any of this
+    against a live server. The cursor here round-trips through real column types
+    rather than through a text rendering, and the embedded twin's failure modes
+    invert: a wrong-typed operand that the SQLite path rejects loudly is silently
+    *correct* on asyncpg (its uuid parser skips dashes), while a naive
+    ``datetime`` — harmless on the embedded store, whose column has no offset to
+    lose — resolves here against whatever zone the process runs in. A
+    ``scan_bound=1`` walk reassembles the whole answer from ~21 such round trips;
+    the unbounded walk uses none and is the control.
+    """
+
+    @given(filter_dict=walk_filter(), status=walk_status(), updated_before=walk_updated_before())
+    @_budget(15)
+    def test_stitched_walk_equals_unstitched_walk_and_oracle(
+        self, filter_dict: dict[str, Any], status: str | None, updated_before: datetime | None
+    ) -> None:
+        ast = validated_walk_ast(filter_dict)
+        assume(ast is not None)
+        assert ast is not None
+
+        narrowing: dict[str, Any] = {"filter_ast": ast, "status": status, "updated_before": updated_before}
+        stitched = walked_ids(_walk(limit=3, scan_bound=1, **narrowing))
+        unstitched = walked_ids(_walk(limit=CORPUS_SIZE + 5, scan_bound=UNBOUNDED, **narrowing))
+        expected = walk_oracle(CORPUS.documents, **narrowing)
+
+        assert stitched == unstitched, (
+            "cursor-stitched and single-page walks disagree — the cursor is the only "
+            f"difference between them:\n  filter = {filter_dict!r}\n"
+            f"  stitched   = {stitched}\n  unstitched = {unstitched}"
+        )
+        assert stitched == expected, f"both walks agree but diverge from the oracle: {filter_dict!r}"
+
+
+# --------------------------------------------------------------------------- #
+# Property C — limit invariance.
+# --------------------------------------------------------------------------- #
+
+
+@skip_no_pg
+class TestLimitInvariancePg:
+    """``limit`` slices the answer into pages; it must not change the answer."""
+
+    @given(filter_dict=walk_filter(), status=walk_status(), updated_before=walk_updated_before())
+    @_budget(10)
+    def test_answer_is_independent_of_limit(
+        self, filter_dict: dict[str, Any], status: str | None, updated_before: datetime | None
+    ) -> None:
+        ast = validated_walk_ast(filter_dict)
+        assume(ast is not None)
+        assert ast is not None
+
+        narrowing: dict[str, Any] = {"filter_ast": ast, "status": status, "updated_before": updated_before}
+        answers = {limit: walked_ids(_walk(limit=limit, scan_bound=UNBOUNDED, **narrowing)) for limit in (1, 3, 7)}
+        expected = walk_oracle(CORPUS.documents, **narrowing)
+
+        assert answers[1] == answers[3] == answers[7], f"the answer depends on limit: {filter_dict!r}\n  {answers}"
+        assert answers[1] == expected, f"every limit agrees but diverges from the oracle: {filter_dict!r}"
+
+
+# --------------------------------------------------------------------------- #
+# Determinism — a repeated walk over a frozen namespace reproduces itself.
+# --------------------------------------------------------------------------- #
+
+
+def page_shapes(pages: list[DocumentPage]) -> list[tuple[Any, ...]]:
+    """Everything a caller can observe about each page, flattened for comparison.
+
+    The cursor is compared as its ``(created_at, id)`` pair rather than as the
+    dataclass, so a divergence in either half is named by the failure output.
+    """
+    return [
+        (
+            tuple(doc.id for doc in page),
+            None if page.next_after is None else (page.next_after.created_at, page.next_after.id),
+            page.exhausted,
+            page.post_filtered_keys,
+        )
+        for page in pages
+    ]
+
+
+@skip_no_pg
+class TestWalkDeterminismPg:
+    """The same walk, run twice over an unchanged namespace, must be the same walk.
+
+    Worth running against a live server as well as in process: here each page is
+    its own ``SELECT`` in its own session, so a repeated walk depends on the
+    planner returning the same rows for the same keyset predicate — an ordering
+    that is only total because of the ``id`` tie-break. A corpus with tie blocks
+    and no tie-break would be free to reorder between runs and still satisfy every
+    oracle comparison above.
+    """
+
+    def test_repeating_a_walk_reproduces_every_page_exactly(self) -> None:
+        """Two identical walks agree on ids, page boundaries, cursors and flags."""
+        ast = to_walk_ast({"source_type": "library"})
+        first = _walk(limit=3, scan_bound=1, filter_ast=ast)
+        second = _walk(limit=3, scan_bound=1, filter_ast=ast)
+
+        expected = walk_oracle(CORPUS.documents, filter_ast=ast)
+        assert 0 < len(expected) < CORPUS_SIZE, expected
+        # Non-vacuity: a single-page walk would make the comparison below trivial.
+        assert len([page for page in first if len(page) > 0]) >= 2, [len(p) for p in first]
+
+        assert page_shapes(first) == page_shapes(second), (
+            "a repeated walk over a frozen namespace produced a different page sequence:\n"
+            f"  first  = {page_shapes(first)}\n  second = {page_shapes(second)}"
+        )
+        assert walked_ids(first) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Anti-vacuous guards.
+# --------------------------------------------------------------------------- #
+
+
+@skip_no_pg
+class TestWalkDiscriminatesPg:
+    """The corpus, the strategy and the budgets actually exercise what they claim.
+
+    The embedded twin's ``>=50%`` multipage FRACTION guard is deliberately absent
+    here: it assumes one RAW row scanned per budget unit, but this store pushes the
+    filter into SQL, so ``scan_bound=1`` fetches one MATCHING row per page and the
+    premise does not carry over. (The strict-subset fraction guard is absent from
+    *both* legs — this strategy's true strict-subset rate hugs the ``30%`` floor,
+    observed at 26% on a 100-draw sample, so a fraction over it is unsound wherever
+    it runs.) Both properties are evidenced deterministically instead —
+    boundary-crossing by ``test_unfiltered_walk_at_scan_bound_one_pages_the_whole_corpus``
+    and discrimination by ``test_a_partial_filter_keeps_a_strict_subset`` — the same
+    reasoning that keeps the eight-seed sweep on the embedded leg.
+    """
+
+    def test_a_partial_filter_keeps_a_strict_subset(self) -> None:
+        """Explicit (non-Hypothesis) proof that the corpus discriminates on this store."""
+        ast = to_walk_ast({"source_type": "library"})
+        expected = walk_oracle(CORPUS.documents, filter_ast=ast)
+        assert 0 < len(expected) < CORPUS_SIZE, expected
+        assert walked_ids(_walk(limit=3, scan_bound=UNBOUNDED, filter_ast=ast)) == expected
+
+    def test_unfiltered_walk_at_scan_bound_one_pages_the_whole_corpus(self) -> None:
+        """A ``scan_bound=1`` walk takes exactly ``CORPUS_SIZE + 1`` pages, in pinned order.
+
+        One raw row per page, plus the empty exhausted tail page that is the only
+        sound termination signal.
+        """
+        pages = _walk(limit=3, scan_bound=1)
+
+        assert len(pages) == CORPUS_SIZE + 1, [len(p) for p in pages]
+        assert walked_ids(pages) == list(CORPUS.expected)
+        assert [len(p) for p in pages[:-1]] == [1] * CORPUS_SIZE
+        assert len(pages[-1]) == 0
+        assert_page_contract(pages, limit=3)
+
+    def test_this_store_pushes_every_enumerable_key(self) -> None:
+        """The pushdown split is inverted here, and the difference is asserted, not assumed.
+
+        This store's compiler backs — and pushes — all nine enumerable system keys
+        plus every ``metadata`` path shape, so a page reports NO post-filtered
+        keys and the raw window is already the answer. The embedded twin withholds
+        both date keys (their TEXT format does not order against the compiler's
+        binds), so the same filter there leaves scanned-but-rejected rows in the
+        window.
+
+        The consequence is worth naming rather than leaving implicit: the
+        "matches split across pages with a rejected page between them" shape that
+        the embedded leg pins is **not reachable on this store** through the
+        enumerable key set, so that test lives there and only there. What this
+        leg proves instead is that the identical properties hold over a plan
+        where the post-filter narrows nothing at all.
+        """
+        for wire in (
+            {"source_timestamp": {"$eq": "2026-06-01T00:00:00Z"}},
+            {"created_at": {"$gte": "2026-01-01T00:00:00Z"}},
+            {"metadata.a": {"b": "v"}},
+            {"$or": [{"source_type": "library"}, {"metadata.tier": "gold"}]},
+        ):
+            page = _walk(limit=CORPUS_SIZE + 5, scan_bound=UNBOUNDED, filter_ast=to_walk_ast(wire))[0]
+            assert page.post_filtered_keys == (), f"{wire!r} left post-filtered keys {page.post_filtered_keys}"
+
+
+# --------------------------------------------------------------------------- #
+# Mutation during a walk (deterministic — no snapshot spans pages).
+# --------------------------------------------------------------------------- #
+
+
+async def _seed_gap_ladder(coord: StorageCoordinator, namespace_id: UUID, ids: list[UUID], base: datetime) -> None:
+    """Seed ``ids`` with strictly DESCENDING ``created_at``, ten seconds apart."""
+    for offset, doc_id in enumerate(ids):
+        await coord.create_document(
+            Document(
+                id=doc_id,
+                namespace_id=namespace_id,
+                content=f"mutation row {offset}",
+                checksum=f"mut-{doc_id.hex}",
+                created_at=base - timedelta(seconds=10 * offset),
+                updated_at=base,
+            )
+        )
+
+
+async def _insert(coord: StorageCoordinator, namespace_id: UUID, doc_id: UUID, created_at: datetime) -> None:
+    await coord.create_document(
+        Document(
+            id=doc_id,
+            namespace_id=namespace_id,
+            content="inserted mid-walk",
+            checksum=f"mut-{doc_id.hex}",
+            created_at=created_at,
+            updated_at=created_at,
+        )
+    )
+
+
+async def _walk_with_mutations(
+    coord: StorageCoordinator,
+    namespace_id: UUID,
+    mutations: dict[int, Callable[[], Awaitable[None]]],
+    *,
+    max_pages: int = 60,
+) -> list[UUID]:
+    """Walk one row at a time, running ``mutations[i]`` after page ``i`` returns."""
+    seen: list[UUID] = []
+    after: DocumentCursor | None = None
+    index = 0
+    while index < max_pages:
+        page = await coord.scan_documents_page(
+            namespace_id,
+            limit=1,
+            after=None if after is None else (after.created_at, after.id),
+            scan_bound=1,
+        )
+        seen.extend(doc.id for doc in page)
+        mutate = mutations.get(index)
+        if mutate is not None:
+            await mutate()
+        if page.exhausted:
+            return seen
+        assert page.next_after is not None
+        after = page.next_after
+        index += 1
+    raise AssertionError(f"mutating walk did not terminate within {max_pages} pages")
+
+
+async def _fresh_ladder(coord: StorageCoordinator, total: int) -> tuple[UUID, list[UUID], datetime]:
+    """A brand-new namespace seeded with ``total`` gap-separated rows."""
+    namespace_id = uuid4()
+    await _create_namespace(coord, namespace_id)
+    base = WHOLE_SECOND
+    ids = id_ladder(total)
+    await _seed_gap_ladder(coord, namespace_id, ids, base)
+    return namespace_id, ids, base
+
+
+@skip_no_pg
+class TestMutationDuringWalkPg:
+    """What a concurrent insert or delete does to a walk already in flight.
+
+    ``scan_documents_page`` claims no consistent snapshot: each page is its own
+    ``SELECT`` in its own session. On this store that is a statement about real
+    concurrent transactions rather than about an embedded file, so the four exact
+    answers below are worth pinning here as well as on the embedded twin — a
+    future change to session or isolation handling would show up on this leg
+    first.
+    """
+
+    def test_insert_above_the_cursor_is_not_seen(self) -> None:
+        """A row newer than the cursor is already behind the walk — never served."""
+        result = _run_async(self._insert_above())
+        assert result["above_id"] not in result["seen"]
+        assert result["seen"] == result["ladder"]
+
+    async def _insert_above(self) -> dict[str, Any]:
+        coord = _seeded_store().coord
+        namespace_id, ladder, base = await _fresh_ladder(coord, 5)
+        above_id = uuid4()
+
+        async def mutate() -> None:
+            await _insert(coord, namespace_id, above_id, base + timedelta(seconds=30))
+
+        seen = await _walk_with_mutations(coord, namespace_id, {1: mutate})
+        return {"seen": seen, "ladder": ladder, "above_id": above_id}
+
+    def test_insert_below_the_cursor_is_seen(self) -> None:
+        """A row older than the cursor is still ahead of the walk — served IN PLACE.
+
+        The insert lands strictly between two existing rows, so it must appear at
+        that exact position in the concatenation, not appended at the end.
+        """
+        result = _run_async(self._insert_below())
+        ladder = result["ladder"]
+        assert result["seen"] == [*ladder[:3], result["below_id"], *ladder[3:]]
+
+    async def _insert_below(self) -> dict[str, Any]:
+        coord = _seeded_store().coord
+        namespace_id, ladder, base = await _fresh_ladder(coord, 5)
+        below_id = uuid4()
+
+        async def mutate() -> None:
+            # ladder[2] is at base-20s and ladder[3] at base-30s; land between.
+            await _insert(coord, namespace_id, below_id, base - timedelta(seconds=25))
+
+        seen = await _walk_with_mutations(coord, namespace_id, {1: mutate})
+        return {"seen": seen, "ladder": ladder, "below_id": below_id}
+
+    def test_delete_of_an_unscanned_row_below_the_cursor_excludes_it(self) -> None:
+        """A row deleted before the walk reaches it is never served, and leaves no hole."""
+        result = _run_async(self._delete_ahead())
+        ladder = result["ladder"]
+        assert result["seen"] == [d for d in ladder if d != ladder[4]]
+        assert ladder[4] not in result["seen"]
+
+    async def _delete_ahead(self) -> dict[str, Any]:
+        coord = _seeded_store().coord
+        namespace_id, ladder, _base = await _fresh_ladder(coord, 6)
+
+        async def mutate() -> None:
+            await coord.delete_document(ladder[4], namespace_id=namespace_id)
+
+        seen = await _walk_with_mutations(coord, namespace_id, {1: mutate})
+        return {"seen": seen, "ladder": ladder}
+
+    def test_delete_of_an_already_returned_row_does_not_retract_it(self) -> None:
+        """A row deleted AFTER it was served stays served, and the walk still advances.
+
+        The keyset predicate is a comparison, not a lookup, so an anchor row that
+        no longer exists is fine; a walk that re-read its anchor would break here.
+        """
+        result = _run_async(self._delete_behind())
+        assert result["seen"] == result["ladder"]
+
+    async def _delete_behind(self) -> dict[str, Any]:
+        coord = _seeded_store().coord
+        namespace_id, ladder, _base = await _fresh_ladder(coord, 5)
+
+        async def mutate() -> None:
+            await coord.delete_document(ladder[1], namespace_id=namespace_id)
+
+        seen = await _walk_with_mutations(coord, namespace_id, {1: mutate})
+        return {"seen": seen, "ladder": ladder}
+
+    def test_all_four_mutations_in_one_walk(self) -> None:
+        """The umbrella: every shape at once, in a single walk."""
+        result = _run_async(self._umbrella())
+        seen = result["seen"]
+        ladder = result["ladder"]
+
+        assert len(seen) == len(set(seen)), "a document was served twice across the mutating walk"
+        assert set(seen) == (set(ladder) | {result["below_id"]}) - {ladder[4]}
+        assert result["above_id"] not in seen
+        assert ladder[0] in seen, "a row deleted after it was served must stay served"
+        assert seen == [*ladder[:3], result["below_id"], ladder[3], ladder[5]]
+
+    async def _umbrella(self) -> dict[str, Any]:
+        coord = _seeded_store().coord
+        namespace_id, ladder, base = await _fresh_ladder(coord, 6)
+        above_id, below_id = uuid4(), uuid4()
+
+        async def mutate() -> None:
+            await _insert(coord, namespace_id, above_id, base + timedelta(seconds=30))
+            await _insert(coord, namespace_id, below_id, base - timedelta(seconds=25))
+            await coord.delete_document(ladder[4], namespace_id=namespace_id)  # unscanned, ahead
+            await coord.delete_document(ladder[0], namespace_id=namespace_id)  # already served
+
+        seen = await _walk_with_mutations(coord, namespace_id, {1: mutate})
+        return {"seen": seen, "ladder": ladder, "above_id": above_id, "below_id": below_id}
+
+
+# --------------------------------------------------------------------------- #
+# Cursor codec — the DocumentCursor round trip on timestamptz + uuid.
+# --------------------------------------------------------------------------- #
+
+
+async def _fresh_tie_corpus(coord: StorageCoordinator, instant: datetime) -> tuple[UUID, ScanSeed]:
+    """A brand-new namespace seeded with a tie-heavy six-row scan seed."""
+    namespace_id = uuid4()
+    await _create_namespace(coord, namespace_id)
+    plan = scan_seed(6, instant=instant)
+    for doc_id, created_at in plan.writes:
+        await coord.create_document(
+            Document(
+                id=doc_id,
+                namespace_id=namespace_id,
+                content="codec row",
+                checksum=f"codec-{doc_id.hex}",
+                created_at=created_at,
+                updated_at=created_at,
+            )
+        )
+    return namespace_id, plan
+
+
+@skip_no_pg
+class TestCursorCodecPg:
+    """A ``DocumentCursor`` fed back in resumes at the exact next row, on real column types.
+
+    Both microsecond polarities are seeded here too, even though neither is the
+    hazard on this store — ``created_at`` is a ``timestamptz``, not a
+    lexicographically-compared TEXT column, so ``.000000`` and ``.123456`` are the
+    same case. That is precisely why they are worth running: the assertion that
+    the polarity does NOT matter here is what makes the embedded twin's opposite
+    finding a store property rather than an unexplained difference.
+
+    One asymmetry is deliberately NOT asserted, because on this store there is
+    nothing to assert: a ``str`` where the cursor's ``uuid`` belongs is *silently
+    accepted*. ``sqlalchemy.Uuid.bind_processor`` returns ``None`` whenever the
+    dialect supports native UUIDs, so no ``.hex`` lookup runs, and asyncpg's own
+    parser skips ``-`` outright — a dashed cursor decodes to the identical
+    sixteen bytes and works. The same input is loud on the embedded store and
+    harmless here, which is exactly why "build a cursor from a row this store
+    returned, never by hand" is the rule that generalizes rather than any
+    per-store type check.
+    """
+
+    def test_whole_second_tie_block_resume(self) -> None:
+        """microsecond=0: resume from mid-tie excludes the anchor, keeps its tie-mate."""
+        self._assert_mid_tie_resume(WHOLE_SECOND)
+
+    def test_sub_second_tie_block_resume(self) -> None:
+        """microsecond=.123456: identical outcome — the polarity is inert on timestamptz."""
+        self._assert_mid_tie_resume(WHOLE_SECOND.replace(microsecond=123456))
+
+    def _assert_mid_tie_resume(self, instant: datetime) -> None:
+        result = _run_async(self._mid_tie_resume(instant))
+        assert result["anchor"] not in result["resumed"], (
+            "the cursor's own row came back — a resumed walk would never advance"
+        )
+        assert result["tie_mate"] in result["resumed"], (
+            "the cursor's tie-mate was skipped — a resumed walk would lose rows"
+        )
+        assert result["resumed"] == result["expected_tail"]
+
+    async def _mid_tie_resume(self, instant: datetime) -> dict[str, Any]:
+        coord = _seeded_store().coord
+        namespace_id, seed_plan = await _fresh_tie_corpus(coord, instant)
+
+        full = await coord.scan_documents_page(namespace_id, limit=20, scan_bound=50)
+        assert [doc.id for doc in full] == seed_plan.expected
+
+        anchor_doc = next(doc for doc in full if doc.id == seed_plan.tied_ids[0])
+        cursor = DocumentCursor(created_at=anchor_doc.created_at, id=anchor_doc.id)
+        resumed_page = await coord.scan_documents_page(
+            namespace_id, limit=20, after=(cursor.created_at, cursor.id), scan_bound=50
+        )
+        return {
+            "anchor": anchor_doc.id,
+            "tie_mate": seed_plan.tied_ids[1],
+            "resumed": [doc.id for doc in resumed_page],
+            "expected_tail": seed_plan.expected[seed_plan.expected.index(anchor_doc.id) + 1 :],
+        }
+
+    def test_mid_tie_resume_at_limit_one_lands_on_the_exact_next_row(self) -> None:
+        """A one-row page resumed from mid-tie returns exactly the next id.
+
+        With ``limit=1`` there is nowhere for a wrong answer to hide behind a set
+        comparison, and the rows on either side of the anchor share its
+        ``created_at`` to the microsecond — so this lands correctly only if the
+        cursor's ``id`` half is compared as a ``uuid``.
+        """
+        result = _run_async(self._next_row_after_mid_tie())
+        assert result["got"] == [result["want"]]
+
+    async def _next_row_after_mid_tie(self) -> dict[str, Any]:
+        coord = _seeded_store().coord
+        namespace_id, seed_plan = await _fresh_tie_corpus(coord, WHOLE_SECOND)
+
+        full = await coord.scan_documents_page(namespace_id, limit=20, scan_bound=50)
+        anchor_doc = next(doc for doc in full if doc.id == seed_plan.tied_ids[0])
+        page = await coord.scan_documents_page(
+            namespace_id, limit=1, after=(anchor_doc.created_at, anchor_doc.id), scan_bound=50
+        )
+        want = seed_plan.expected[seed_plan.expected.index(anchor_doc.id) + 1]
+        return {"got": [doc.id for doc in page], "want": want}
+
+    def test_a_cursor_carried_into_another_zone_resumes_identically(self) -> None:
+        """Converting the cursor's zone is a no-op here, and STRIPPING it is not portable.
+
+        This is the contrast the embedded twin cannot draw, and the two stores
+        make opposite adjustments look harmless. ``timestamptz`` holds an
+        *instant*, so re-expressing the cursor in another zone selects the same
+        row — asserted here. The embedded store holds wall clock with the
+        writer's offset already discarded, so there the conversion MOVES the
+        position while attaching or stripping ``tzinfo`` is the no-op. Neither
+        rule generalizes; the one that holds on both is narrower than either:
+        bind the value the store returned, unmodified.
+        """
+        result = _run_async(self._zone_shifted_resume())
+        assert result["utc_created_at"].tzinfo is not None, "a timestamptz cursor must come back aware"
+        assert result["shifted"] == result["utc"]
+
+    async def _zone_shifted_resume(self) -> dict[str, Any]:
+        from datetime import timezone
+
+        coord = _seeded_store().coord
+        namespace_id, seed_plan = await _fresh_tie_corpus(coord, WHOLE_SECOND)
+
+        full = await coord.scan_documents_page(namespace_id, limit=20, scan_bound=50)
+        anchor = next(doc for doc in full if doc.id == seed_plan.tied_ids[0])
+
+        utc_page = await coord.scan_documents_page(
+            namespace_id, limit=20, after=(anchor.created_at, anchor.id), scan_bound=50
+        )
+        shifted_at = anchor.created_at.astimezone(timezone(timedelta(hours=5, minutes=30)))
+        shifted_page = await coord.scan_documents_page(
+            namespace_id, limit=20, after=(shifted_at, anchor.id), scan_bound=50
+        )
+        return {
+            "utc_created_at": anchor.created_at,
+            "utc": [doc.id for doc in utc_page],
+            "shifted": [doc.id for doc in shifted_page],
+        }
+
+    def test_the_builder_casts_both_cursor_operands_to_their_column_types(self) -> None:
+        """The rendered statement casts the cursor operands, whatever their Python type.
+
+        The static half: compiling ``build_documents_scan_query`` against the
+        asyncpg dialect shows ``$n::TIMESTAMP WITH TIME ZONE`` and ``$n::UUID``
+        because ``sa.literal`` names the column's type (see
+        ``storage/backends/_documents_scan.py``). Drop that argument and a
+        one-step-off operand renders as its own inferred type instead — a ``date``
+        as ``::DATE``, a ``str`` id as ``::VARCHAR`` — which is how a cursor
+        silently resolves against the wrong instant. Needs no server, so it fails
+        fast and locally when the bind spelling regresses.
+        """
+        from sqlalchemy.dialects import postgresql
+
+        rendered = str(
+            build_documents_scan_query(uuid4(), after=(WHOLE_SECOND.date(), str(uuid4())), scan_limit=5).compile(
+                dialect=postgresql.asyncpg.dialect()
+            )
+        )
+
+        assert "::TIMESTAMP WITH TIME ZONE" in rendered, rendered
+        assert "::DATE" not in rendered, rendered
+        assert "::VARCHAR" not in rendered, rendered
+        # The namespace scope and the cursor's id — the two UUID-typed operands.
+        assert rendered.count("::UUID") == 2, rendered

--- a/tests/test_helpers/walk_fuzz.py
+++ b/tests/test_helpers/walk_fuzz.py
@@ -1,0 +1,629 @@
+"""Corpus, oracle, strategies and walk driver for the document-enumeration walk fuzzer.
+
+The keyset enumeration surface (``StorageCoordinator.scan_documents_page``, the
+engine ``list_documents`` passthrough, and the ``Khora.list_documents`` facade
+above it) is pinned by hand-authored tests per store: the bounded scan primitive,
+the cursor serialization, the pushdown split. Those are precise but finite — they
+check the shapes someone thought to enumerate, one page at a time.
+
+This module is the shared half of the complementary force: a *walk* fuzzer. It
+generates a filter + ``status`` + ``updated_before`` triple, drives a whole
+multi-page walk to exhaustion, and checks the concatenation against a pure-Python
+oracle. What that catches is the class of defect a single-page test structurally
+cannot see — a cursor that skips a tie-mate on the page boundary, a page that
+reports ``exhausted`` while rows remain, a walk whose answer depends on how the
+scan budget happened to slice it.
+
+Five properties ride on this module (the test legs assert them; the helpers here
+make them expressible):
+
+1. **Exactly-once / completeness** — the concatenation of every page is the
+   oracle's survivor set, no repeats, nothing missing.
+2. **Cursor stitching** — the same walk at ``scan_bound=1`` (a cursor boundary
+   between every raw row) and unbounded (one page, no cursor at all) agree.
+3. **Order** — the concatenation is strictly descending on ``(created_at, id)``.
+4. **Limit invariance** — the answer does not depend on ``limit``.
+5. **Honest termination** — ``next_after is None`` iff ``exhausted``, and only
+   the terminal page carries either.
+
+Two shapes are deliberately NOT in the corpus, and both are worth stating so a
+future reader does not "fix" them:
+
+* **No ``occurred_at``.** The facade rejects it as non-enumerable (a document row
+  has no event-time column), so :func:`walk_filter` draws its date channel from
+  ``created_at`` / ``source_timestamp`` only.
+* **No NULL ``updated_at``.** ``updated_before`` compiles to a half-open
+  ``updated_at < :bound``, which is NULL — and therefore excluding — for a row
+  whose ``updated_at`` is NULL. That exclusion is real and documented on
+  ``build_documents_scan_query``, but it is *unreachable through the production
+  write API*: ``DocumentModel.updated_at`` carries a Python-side ``default``, so
+  an explicit ``None`` at INSERT is replaced by ``now()``, and both
+  ``update_document`` and the partial-update path stamp the column themselves
+  (``updated_at`` is not in the partial-update allowlist). Seeding a NULL would
+  require raw SQL against a state production cannot produce, and this corpus
+  seeds only through ``create_document``. The oracle below still implements the
+  NULL branch, so it stays correct if a write path ever gains one.
+"""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+from hypothesis import strategies as st
+
+from khora.core.models import Document
+from khora.core.models.document import DocumentCursor, DocumentPage, DocumentStatus
+from khora.filter import RecallFilter, RecallFilterValidationError
+from khora.filter.ast import FilterNode, parse_to_ast
+from khora.filter.compilers.python import compile_python
+from khora.filter.execute import build_compile_context
+from tests.test_helpers.document_order import id_ladder, seed_order
+from tests.test_helpers.document_scan import WHOLE_SECOND, as_utc
+
+# --------------------------------------------------------------------------- #
+# Value pools.
+# --------------------------------------------------------------------------- #
+#
+# The seven string keys are exactly the ones the embedded store declares
+# pushable (``_PUSHABLE_SYSTEM_KEYS``), so a drawn predicate exercises the SQL
+# half; the two date keys are the ones it deliberately withholds, so a drawn date
+# predicate exercises the in-memory post-filter half, so the walk properties hold
+# over both physical plans. That is NOT a cross-check of the two halves against
+# each other: the post-filter re-checks the whole AST with the same
+# ``compile_python`` predicate the oracle uses, so it silently repairs a
+# too-permissive pushdown. See the leg modules' docstrings.
+
+STRING_POOLS: dict[str, list[str]] = {
+    "source_type": ["library", "connection", "direct"],
+    "source_name": ["linear", "slack"],
+    "content_type": ["text/markdown", "application/pdf"],
+    # Unique per row in the corpus — ``(namespace_id, external_id)`` is a UNIQUE
+    # index — so these operands select single rows plus one guaranteed miss.
+    "external_id": ["ext-01", "ext-05", "ext-13", "ext-missing"],
+    "source": ["api", "ingest"],
+    "title": ["alpha", "beta", "gamma", "delta", "epsilon"],
+    "source_url": ["https://example.test/a", "https://example.test/o"],
+}
+
+METADATA_PATHS: tuple[str, ...] = (
+    "metadata.tier",
+    "metadata.score",
+    "metadata.tags",
+    "metadata.a.b",
+    "metadata.mk",
+)
+
+META_SCALAR_POOL: list[Any] = ["gold", "silver", "urgent", "release", "okrs", 0, 3, 7, 10, "v", "w"]
+
+# Six blobs cycled across the corpus: scalars, an array, the EMPTY array, a
+# nested sub-document, a present JSON null, and a bare ``{}``.
+_META_BLOBS: tuple[dict[str, Any], ...] = (
+    {"tier": "gold", "score": 10, "tags": ["urgent", "release"]},
+    {"tier": "silver", "score": 0, "tags": ["okrs"]},
+    {"tier": "gold", "score": 3, "tags": []},
+    {"score": 7, "a": {"b": "v"}},
+    {"tier": "silver", "score": 7, "mk": None, "a": {"b": "w"}},
+    {},
+)
+
+# ``created_at`` blocks, newest first. Two blocks of one row are single rows; the
+# 3- and 4-row blocks are the tie blocks the ``id DESC`` leg has to resolve, and
+# the walk puts a cursor boundary INSIDE both of them at ``scan_bound=1``.
+_TIE_PLAN: tuple[int, ...] = (3, 1, 1, 4, 1, 1, 1, 2, 1, 1, 1, 1, 2)
+
+CORPUS_SIZE: int = sum(_TIE_PLAN)
+
+# ``updated_at`` spreads over distinct whole seconds on distinct days, so an
+# ``updated_before`` bound cuts the corpus at a known, non-trivial fraction.
+_UPDATED_BASE = datetime(2026, 2, 1, 9, 0, 0, tzinfo=UTC)
+
+# ``source_timestamp`` operands (and the NULL some rows carry) — the second date
+# channel, which unlike ``created_at`` is nullable.
+_TS_POOL: tuple[datetime, ...] = (
+    datetime(2026, 6, 1, tzinfo=UTC),
+    datetime(2026, 3, 15, tzinfo=UTC),
+    datetime(2026, 1, 1, tzinfo=UTC),
+)
+_TS_MISS = datetime(2020, 1, 1, tzinfo=UTC)
+
+
+@dataclass(frozen=True)
+class WalkCorpus:
+    """A seeded document corpus plus everything an assertion needs to be non-vacuous."""
+
+    namespace_id: UUID
+    """The namespace every :attr:`documents` row is written to."""
+
+    documents: tuple[Document, ...]
+    """The rows, in the deliberately non-monotonic order they must be WRITTEN in."""
+
+    expected: tuple[UUID, ...]
+    """The one correct unfiltered enumeration, ``(created_at DESC, id DESC)``."""
+
+    tie_blocks: tuple[tuple[UUID, ...], ...]
+    """Ids sharing one ``created_at`` (blocks of >= 2 only), already in expected order."""
+
+    def by_id(self) -> dict[UUID, Document]:
+        """The corpus keyed by document id."""
+        return {doc.id: doc for doc in self.documents}
+
+
+def build_walk_corpus(namespace_id: UUID) -> WalkCorpus:
+    """Build the ~20-document corpus the read-only walk properties share.
+
+    Three things are load-bearing and none of them are incidental.
+
+    **The ladder.** Ids come from
+    :func:`~tests.test_helpers.document_order.id_ladder`, so they ascend by
+    construction and the expected enumeration is known up front rather than
+    sampled. With random ids a scan that dropped the ``id DESC`` tie-break could
+    still match by luck inside a two-row block.
+
+    **The tie blocks.** Four blocks share a ``created_at`` to the microsecond (one
+    of three rows, one of four, two of two), so at ``scan_bound=1`` the walk puts
+    a cursor boundary strictly INSIDE a tie block — the mid-tie resume that only
+    lands correctly when the cursor's ``id`` half is compared as a UUID and its
+    ``created_at`` half is bound in the store's own serialization. Every stamp is
+    a whole second derived from
+    :data:`~tests.test_helpers.document_scan.WHOLE_SECOND`; see that module for
+    why the microsecond field is pinned rather than sampled from the clock.
+
+    **The attribute spread.** Every filterable surface carries distinct, repeated
+    AND absent values, so a generated predicate lands a STRICT subset rather than
+    all-or-nothing. Attributes are assigned by *ladder* index with deliberately
+    co-prime strides, which is neither the write order nor the enumeration order —
+    so no expectation anywhere can accidentally be derived from a loop counter.
+
+    ``created_at`` and ``id`` are in conflict across blocks: the newest block
+    holds the LOWEST ids. An implementation that sorted ``id`` first would park
+    those rows at exactly the wrong end and cannot reproduce :attr:`expected`.
+    """
+    ladder = id_ladder(CORPUS_SIZE)
+
+    # Assign each ladder index its block's created_at; blocks descend in time as
+    # the ladder ascends, so the two sort keys disagree.
+    stamps: dict[UUID, datetime] = {}
+    blocks: list[tuple[UUID, ...]] = []
+    cursor = 0
+    for block_index, size in enumerate(_TIE_PLAN):
+        block = tuple(ladder[cursor : cursor + size])
+        instant = WHOLE_SECOND + timedelta(seconds=2 * (len(_TIE_PLAN) - block_index))
+        for doc_id in block:
+            stamps[doc_id] = instant
+        blocks.append(block)
+        cursor += size
+
+    expected: list[UUID] = []
+    for block in blocks:
+        expected.extend(reversed(block))
+
+    documents = tuple(
+        _build_document(namespace_id, doc_id, ladder.index(doc_id), stamps[doc_id]) for doc_id in seed_order(ladder)
+    )
+
+    return WalkCorpus(
+        namespace_id=namespace_id,
+        documents=documents,
+        expected=tuple(expected),
+        tie_blocks=tuple(tuple(reversed(b)) for b in blocks if len(b) > 1),
+    )
+
+
+def _build_document(namespace_id: UUID, doc_id: UUID, index: int, created_at: datetime) -> Document:
+    """One corpus row: attributes derived from the LADDER index with co-prime strides.
+
+    The strides (3 / 5 / 7 / 6 / 8 / 2) are chosen so no two string keys are
+    perfectly correlated — a conjunction over two of them narrows further than
+    either alone, which is what makes a composed filter discriminate.
+    """
+    return Document(
+        id=doc_id,
+        namespace_id=namespace_id,
+        content=f"walk corpus row {index}",
+        checksum=f"walk-{doc_id.hex}",
+        created_at=created_at,
+        updated_at=_UPDATED_BASE + timedelta(days=index, seconds=index),
+        status=_STATUS_CYCLE[index % len(_STATUS_CYCLE)],
+        source_type=STRING_POOLS["source_type"][index % 3],
+        source_name=None if index % 5 == 0 else STRING_POOLS["source_name"][index % 2],
+        content_type=None if index % 7 == 0 else STRING_POOLS["content_type"][(index // 2) % 2],
+        external_id=None if index % 6 == 0 else f"ext-{index:02d}",
+        source=None if index % 8 == 0 else STRING_POOLS["source"][(index // 3) % 2],
+        title=STRING_POOLS["title"][index % 5],
+        source_url=None if index % 3 == 0 else STRING_POOLS["source_url"][(index // 3) % 2],
+        source_timestamp=None if index % 4 == 3 else _TS_POOL[index % 3],
+        metadata=copy.deepcopy(_META_BLOBS[index % len(_META_BLOBS)]),
+    )
+
+
+# Four of the five statuses, cycled — enough that a ``status`` narrowing keeps a
+# strict subset on every value in the pool.
+_STATUS_CYCLE: tuple[DocumentStatus, ...] = (
+    DocumentStatus.PENDING,
+    DocumentStatus.COMPLETED,
+    DocumentStatus.FAILED,
+    DocumentStatus.ARCHIVED,
+)
+
+STATUS_POOL: tuple[str | None, ...] = (None, *(s.value for s in _STATUS_CYCLE))
+"""``status`` operands the strategies draw from — ``None`` (unfiltered) plus every seeded value."""
+
+UPDATED_BEFORE_POOL: tuple[datetime | None, ...] = (
+    None,
+    # Exactly one row's ``updated_at``. Half-open means that row is EXCLUDED and
+    # only the one below it survives — the boundary case an inclusive ``<=`` would
+    # get wrong, and a near-empty walk without being a vacuously empty one.
+    _UPDATED_BASE + timedelta(days=1, seconds=1),
+    _UPDATED_BASE + timedelta(days=7),
+    _UPDATED_BASE + timedelta(days=14),
+    _UPDATED_BASE + timedelta(days=CORPUS_SIZE + 1),  # after every row -> full corpus
+)
+"""``updated_before`` operands: unfiltered, the exact half-open boundary, two cuts, and saturation.
+
+Deliberately no operand strictly below every row: the empty-result walk (a whole
+scanned window rejected, page after page) is already the single most common shape
+the generated *filters* produce, so spending a fifth of every draw's bound
+reproducing it would only dilute the strict-subset draws the properties actually
+discriminate on.
+"""
+
+
+# --------------------------------------------------------------------------- #
+# The oracle.
+# --------------------------------------------------------------------------- #
+
+
+def walk_oracle(
+    documents: Sequence[Document],
+    *,
+    filter_ast: FilterNode | None = None,
+    status: str | None = None,
+    updated_before: datetime | None = None,
+) -> list[UUID]:
+    """The ids a correct walk must enumerate, in the one correct order.
+
+    Pure Python over the in-memory corpus — no store, no cursor, no paging. The
+    three narrowings are applied in the same semantics the read path uses:
+
+    * ``status`` is compared against the enum's stored VALUE string
+      (``DocumentModel.status`` is an ``Enum`` with ``values_callable``, so the
+      column holds ``'completed'``, not ``'DocumentStatus.COMPLETED'``).
+    * ``updated_before`` is half-open (``updated_at < bound``) and a NULL
+      ``updated_at`` is EXCLUDED — the SQL ``NULL < :bound`` outcome, preserved
+      here even though the corpus cannot seed one (see the module docstring).
+    * ``filter_ast`` is compiled through the SAME call shape the coordinator uses
+      (``compile_python`` over ``build_compile_context("documents",
+      on_unsupported="split")``), so the oracle is the coordinator's own
+      post-filter applied to a corpus the coordinator never touched.
+
+    Survivors are then sorted on ``(created_at, id)`` DESCENDING — the total
+    enumeration order — and returned as ids. ``as_utc`` normalizes the naive
+    stamps the embedded store reads back, so a corpus and a read-back row sort
+    identically.
+    """
+    predicate: Callable[[Any], bool] | None = None
+    if filter_ast is not None:
+        predicate = compile_python(filter_ast, build_compile_context("documents", on_unsupported="split")).predicate
+
+    survivors: list[Document] = []
+    for doc in documents:
+        if status is not None and doc.status.value != status:
+            continue
+        if updated_before is not None and (doc.updated_at is None or as_utc(doc.updated_at) >= as_utc(updated_before)):
+            continue
+        if predicate is not None and not predicate(doc):
+            continue
+        survivors.append(doc)
+
+    survivors.sort(key=lambda d: (as_utc(d.created_at), d.id), reverse=True)
+    return [d.id for d in survivors]
+
+
+# --------------------------------------------------------------------------- #
+# Filter strategy.
+# --------------------------------------------------------------------------- #
+#
+# Per-key operator rules mirror the validator's typed submodels so nearly every
+# draw validates; the rare rejection is discarded by ``validated_walk_ast``.
+# Operands come from the corpus's own value pools so a predicate separates a
+# known subset rather than matching everything or nothing.
+
+_DATE_KEYS: tuple[str, ...] = ("created_at", "source_timestamp")
+
+# ``source_timestamp`` operands come from its own pool (plus a guaranteed miss);
+# the four ``WHOLE_SECOND`` offsets land INSIDE the ``created_at`` block ladder,
+# which spans ``+2s`` to ``+26s``. Without them a ``created_at`` predicate would
+# be all-or-nothing — every row shares one minute — and the date channel would
+# stop discriminating.
+_DATE_OPERANDS: tuple[datetime, ...] = (
+    *_TS_POOL,
+    _TS_MISS,
+    WHOLE_SECOND + timedelta(seconds=6),
+    WHOLE_SECOND + timedelta(seconds=14),
+    WHOLE_SECOND + timedelta(seconds=20),
+    WHOLE_SECOND + timedelta(seconds=25),  # strictly BETWEEN two blocks
+)
+
+
+def _date_iso(value: datetime) -> str:
+    """The system-key ``DateOps`` operand form (a plain ISO-8601 string, not ``$date``)."""
+    return value.isoformat().replace("+00:00", "Z")
+
+
+@st.composite
+def _date_predicate(draw: st.DrawFn) -> Any:
+    """A date-key predicate: a bare ISO scalar or a ``DateOps`` operator-expression."""
+    if draw(st.booleans()):
+        return _date_iso(draw(st.sampled_from(_DATE_OPERANDS)))
+    op = draw(st.sampled_from(["$eq", "$ne", "$gt", "$gte", "$lt", "$lte", "$in", "$nin"]))
+    if op in ("$in", "$nin"):
+        values = draw(st.lists(st.sampled_from(_DATE_OPERANDS), min_size=0, max_size=3))
+        return {op: [_date_iso(v) for v in values]}
+    return {op: _date_iso(draw(st.sampled_from(_DATE_OPERANDS)))}
+
+
+@st.composite
+def _string_predicate(draw: st.DrawFn, key: str) -> Any:
+    """A string-key predicate: a bare scalar, an exact-array, or a ``StringOps`` expression."""
+    pool = STRING_POOLS[key]
+    kind = draw(st.sampled_from(["bare", "eq", "ne", "in", "nin", "exists", "bare_list"]))
+    if kind == "bare":
+        return draw(st.sampled_from(pool))
+    if kind == "bare_list":  # bare list => $eq exact-array (NOT $in)
+        return draw(st.lists(st.sampled_from(pool), min_size=1, max_size=2))
+    if kind == "exists":
+        return {"$exists": draw(st.booleans())}
+    if kind in ("eq", "ne"):
+        return {f"${kind}": draw(st.sampled_from(pool))}
+    return {f"${kind}": draw(st.lists(st.sampled_from(pool), min_size=0, max_size=3))}
+
+
+@st.composite
+def _metadata_predicate(draw: st.DrawFn) -> tuple[str, Any]:
+    """A ``metadata.<path>`` key + predicate over the corpus's metadata surface."""
+    key = draw(st.sampled_from(METADATA_PATHS))
+    kind = draw(
+        st.sampled_from(["bare", "bare_list", "eq", "ne", "gt", "gte", "lt", "lte", "in", "nin", "exists", "date"])
+    )
+    if kind == "bare":
+        return key, draw(st.sampled_from(META_SCALAR_POOL))
+    if kind == "bare_list":  # bare list => $eq exact-array
+        return key, draw(st.lists(st.sampled_from(["urgent", "release", "okrs"]), min_size=0, max_size=3))
+    if kind == "exists":
+        return key, {"$exists": draw(st.booleans())}
+    if kind == "date":
+        return key, {"$eq": {"$date": _date_iso(draw(st.sampled_from(_DATE_OPERANDS)))}}
+    if kind in ("in", "nin"):
+        return key, {f"${kind}": draw(st.lists(st.sampled_from(META_SCALAR_POOL), min_size=0, max_size=3))}
+    return key, {f"${kind}": draw(st.sampled_from(META_SCALAR_POOL))}
+
+
+@st.composite
+def _single_predicate(draw: st.DrawFn) -> dict[str, Any]:
+    """One single-field predicate (a date key, a string key, or a metadata path).
+
+    ``occurred_at`` is absent by construction: the enumeration facade rejects it
+    with ``key_not_enumerable``, so drawing it would generate filters no caller
+    can submit rather than filters that stress the walk.
+    """
+    channel = draw(st.sampled_from(["date", "string", "metadata"]))
+    if channel == "date":
+        return {draw(st.sampled_from(_DATE_KEYS)): draw(_date_predicate())}
+    if channel == "string":
+        key = draw(st.sampled_from(list(STRING_POOLS)))
+        return {key: draw(_string_predicate(key))}
+    meta_key, predicate = draw(_metadata_predicate())
+    return {meta_key: predicate}
+
+
+def walk_filter(max_depth: int = 3) -> st.SearchStrategy[dict[str, Any]]:
+    """A recursively-composed enumerable filter dict (bounded depth/breadth).
+
+    A leaf is a single-field predicate; an internal node composes children with a
+    logical operator. Depth- and breadth-bounded so a single draw stays cheap —
+    each draw drives a whole multi-page walk, so the budget per example is far
+    larger here than in a single-query fuzzer.
+    """
+
+    def extend(children: st.SearchStrategy[dict[str, Any]]) -> st.SearchStrategy[dict[str, Any]]:
+        branch = st.lists(children, min_size=1, max_size=3)
+        return st.one_of(
+            children,
+            branch.map(lambda cs: {"$and": cs}),
+            branch.map(lambda cs: {"$or": cs}),
+            branch.map(lambda cs: {"$nor": cs}),
+            children.map(lambda c: {"$not": c}),
+            # A bag of sibling single-field predicates (implicit AND).
+            st.lists(_single_predicate(), min_size=2, max_size=3).map(
+                lambda preds: {k: v for p in preds for k, v in p.items()}
+            ),
+        )
+
+    return st.recursive(_single_predicate(), extend, max_leaves=max_depth * 3)
+
+
+def walk_status() -> st.SearchStrategy[str | None]:
+    """A ``status`` narrowing drawn from the seeded values (or ``None``)."""
+    return st.sampled_from(STATUS_POOL)
+
+
+def walk_updated_before() -> st.SearchStrategy[datetime | None]:
+    """An ``updated_before`` bound: unfiltered, both saturating ends, or a real cut."""
+    return st.sampled_from(UPDATED_BEFORE_POOL)
+
+
+def validated_walk_ast(filter_dict: dict[str, Any]) -> FilterNode | None:
+    """Validate + lower a generated dict, or ``None`` if it fails validation.
+
+    A draw the validator rejects (a malformed shape the per-key rules did not
+    fully constrain) is discarded by the caller — the strategy is biased so this
+    is rare, not the common path.
+    """
+    try:
+        model = RecallFilter.model_validate(filter_dict)
+    except RecallFilterValidationError:
+        return None
+    return parse_to_ast(model)
+
+
+def to_walk_ast(wire: dict[str, Any]) -> FilterNode:
+    """Lower a known-valid wire filter to the canonical AST (deterministic tests)."""
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+# --------------------------------------------------------------------------- #
+# The walk driver.
+# --------------------------------------------------------------------------- #
+
+
+ScanPage = Callable[..., Awaitable[DocumentPage]]
+
+
+async def drive_walk(
+    scan_page: ScanPage,
+    namespace_id: UUID,
+    *,
+    limit: int,
+    scan_bound: int,
+    max_pages: int = 200,
+    **kwargs: Any,
+) -> list[DocumentPage]:
+    """Walk a namespace to exhaustion, chaining ``next_after``; return every page.
+
+    The caller asserts on the pages' concatenation (order, exactly-once,
+    completeness) and on their individual shape (``next_after`` / ``exhausted``
+    polarity, ``len <= limit``). This only drives.
+
+    ``scan_bound`` is passed on EVERY call, so the whole walk runs under one
+    budget regime — that is what makes the differential property (a
+    ``scan_bound=1`` walk against an unbounded one) compare like for like.
+
+    Two guardrails, because both failures a walk fuzzer exists to catch are
+    non-terminating rather than wrong-answer. A cursor that fails to advance past
+    its own row — the symptom of a hand-formatted timestamp bind, whose ISO
+    ``'T'`` separator sorts above every stored value — would otherwise spin
+    forever, so the driver raises the moment ``next_after`` repeats.
+    ``max_pages`` is the backstop for every other form of non-termination. A
+    guardrail must fail, not hang.
+
+    A non-terminal page with ``next_after is None`` also raises here rather than
+    silently ending the walk: it is a contract violation
+    (``next_after is None`` iff ``exhausted``), and continuing would restart the
+    walk from the newest row and loop forever.
+    """
+    pages: list[DocumentPage] = []
+    after: DocumentCursor | None = None
+    seen_positions: set[tuple[datetime, UUID]] = set()
+    while len(pages) < max_pages:
+        page = await scan_page(
+            namespace_id,
+            limit=limit,
+            after=None if after is None else (after.created_at, after.id),
+            scan_bound=scan_bound,
+            **kwargs,
+        )
+        pages.append(page)
+        if page.exhausted:
+            return pages
+        if page.next_after is None:
+            raise AssertionError(
+                f"page {len(pages) - 1} reported next_after=None without exhausted; "
+                "the walk has no sound position to resume from"
+            )
+        # Any repeat, not only an immediate one: a longer cycle (A -> B -> A)
+        # cannot terminate either, and would otherwise burn the whole max_pages
+        # backstop instead of naming the offending position.
+        position = (page.next_after.created_at, page.next_after.id)
+        if position in seen_positions:
+            raise AssertionError(
+                f"walk cursor repeated position {page.next_after!r} at page {len(pages) - 1}; "
+                "the walk revisits an earlier cursor and can never terminate"
+            )
+        seen_positions.add(position)
+        after = page.next_after
+    raise AssertionError(f"walk did not report exhausted within {max_pages} pages of limit={limit}")
+
+
+def walked_ids(pages: Sequence[DocumentPage]) -> list[UUID]:
+    """The concatenated document ids across every page, in walk order."""
+    return [doc.id for page in pages for doc in page]
+
+
+def walked_keys(pages: Sequence[DocumentPage]) -> list[tuple[datetime, UUID]]:
+    """The concatenated ``(created_at, id)`` sort keys, UTC-normalized, in walk order."""
+    return [(as_utc(doc.created_at), doc.id) for page in pages for doc in page]
+
+
+# --------------------------------------------------------------------------- #
+# Anti-vacuous collectors.
+# --------------------------------------------------------------------------- #
+#
+# A walk property that always compared the FULL corpus against the FULL corpus
+# would agree trivially and prove nothing, and so would one whose every walk fit
+# in a single page. Both legs record what their draws actually produced and a
+# later plain test judges the distribution. A module-level collector is robust and
+# simple (no dependence on Hypothesis statistics plumbing).
+
+
+@dataclass
+class WalkCollectors:
+    """Per-module records of what the generated walks actually exercised."""
+
+    page_counts: list[int] = field(default_factory=list)
+    """Page count per ``scan_bound=1`` walk — judged for a multi-page fraction."""
+
+
+def assert_multipage_fraction(page_counts: Sequence[int], *, minimum: float = 0.50) -> None:
+    """At least ``minimum`` of recorded walks produced >= 2 NON-TERMINAL pages.
+
+    The anti-vacuous guard for the WALK half specifically. A suite whose every
+    walk terminated on its first page would check the page contract and never the
+    cursor — the stitching across a page boundary is the whole point.
+
+    This is a FLOOR, not a claim about match distribution. Under the budget the
+    properties actually run at (``scan_bound=1``) it is satisfied by construction,
+    because a page scans one raw row whether or not that row matches — so it
+    cannot detect "every walk's matches happened to land on one page". It exists
+    to catch a future budget or corpus change that quietly collapsed the walks to
+    a single page. The complementary check — that matches are genuinely SPLIT
+    across pages with rejected pages between them — is a deterministic test in the
+    leg modules, where it can assert a concrete filter's page shape instead of a
+    fraction that would sit one standard deviation from its own threshold.
+    """
+    assert page_counts, "no walk page counts recorded"
+    # The terminal page is the empty exhausted one; a walk that "crossed a
+    # boundary" needs two pages BEFORE it.
+    multi = sum(1 for count in page_counts if count - 1 >= 2)
+    fraction = multi / len(page_counts)
+    assert fraction >= minimum, (
+        f"only {fraction:.0%} of {len(page_counts)} walks produced >=2 non-terminal pages "
+        f"(need >={minimum:.0%}); the walks are not crossing page boundaries"
+    )
+
+
+__all__ = [
+    "CORPUS_SIZE",
+    "METADATA_PATHS",
+    "META_SCALAR_POOL",
+    "STATUS_POOL",
+    "STRING_POOLS",
+    "UPDATED_BEFORE_POOL",
+    "WalkCollectors",
+    "WalkCorpus",
+    "assert_multipage_fraction",
+    "build_walk_corpus",
+    "drive_walk",
+    "to_walk_ast",
+    "validated_walk_ast",
+    "walk_filter",
+    "walk_oracle",
+    "walk_status",
+    "walk_updated_before",
+    "walked_ids",
+    "walked_keys",
+]

--- a/tests/unit/filter/test_walk_fuzz.py
+++ b/tests/unit/filter/test_walk_fuzz.py
@@ -1,0 +1,1017 @@
+"""Property-based walk fuzzer for the document-enumeration surface (embedded leg).
+
+``StorageCoordinator.scan_documents_page`` is pinned per store by hand-authored
+tests: the bounded scan primitive, the cursor serialization, the pushdown split.
+Those are precise but finite, and — more to the point — they are *page* tests.
+They check one ``SELECT`` at a time.
+
+This module checks the WALK. It generates a ``(filter, status,
+updated_before)`` triple with Hypothesis, drives the whole multi-page
+enumeration to exhaustion under an injected scan budget, and compares the
+concatenation against a pure-Python oracle over the same corpus. The defects
+that live only there are the ones a page test structurally cannot see: a cursor
+that skips a tie-mate exactly on a page boundary, a page that reports
+``exhausted`` while rows remain, a walk whose answer depends on how the budget
+happened to slice it.
+
+What it does NOT check is filter semantics: the coordinator's post-filter and the
+oracle share the same ``compile_python`` predicate, so a bug inside it corrupts
+both sides identically — that surface belongs to the recall filter fuzzer and the
+SQL-compiler superset checks. On this store the withheld date keys are
+post-filtered on BOTH sides, so their filtering in particular is not
+independently cross-checked here (the PostgreSQL leg, which pushes them into SQL,
+is where that comparison happens).
+
+Five properties, folded into three walks so the SELECT count stays bounded:
+
+* **A — exactly-once, order, honest termination** (``TestWalkEnumeration``).
+  One walk per draw at ``limit=3`` and a deliberately tiny ``scan_bound``, so
+  most pages return one match and the walk is nearly all cursor boundaries. The
+  concatenation must equal the oracle *as a sequence* (completeness + no repeats
+  + total order), every page's ``(created_at, id)`` must strictly descend across
+  the seam, and ``next_after is None`` must hold exactly on the terminal page.
+* **B — cursor stitching** (``TestCursorStitchDifferential``, load-bearing). The
+  same draw walked at ``scan_bound=1`` (a cursor boundary between every raw row)
+  and unbounded (one page, no cursor at all) must agree with each other AND with
+  the oracle. The unbounded walk never serializes a cursor, so it is the control:
+  a divergence is the cursor, not the filter.
+* **C — limit invariance** (``TestLimitInvariance``). ``limit`` is a page-size
+  knob, not a semantic one; three limits over one large budget must produce one
+  answer.
+
+Plus two deterministic companions that a generated corpus cannot express:
+``TestMutationDuringWalk`` (no snapshot spans pages — what a concurrent insert or
+delete does to a walk in flight) and ``TestCursorCodec`` (the ``DocumentCursor``
+round trip at both microsecond polarities, and the typed-bind contrast the whole
+keyset predicate rests on).
+
+The store is the real embedded ``sqlite_lance`` relational adapter behind a real
+``StorageCoordinator``, seeded once per process through ``create_document`` — the
+production write API. Seeding by raw SQL would compare the walk against a corpus
+production could never produce, which is exactly the comparison the cursor tests
+must not make.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timedelta
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from hypothesis import HealthCheck, assume, given, seed, settings
+from hypothesis import strategies as st
+
+from khora.core.models import Document, MemoryNamespace, TenancyMode
+from khora.core.models.document import DocumentCursor, DocumentPage
+from khora.db.session import run_migrations
+from khora.storage.backends._documents_scan import build_documents_scan_query
+from khora.storage.backends.sqlite_lance import SQLiteLanceRelationalAdapter
+from khora.storage.backends.sqlite_lance._helpers import uuid_to_text
+from khora.storage.backends.sqlite_lance.connection import (
+    EmbeddedStorageHandle,
+    EmbeddedStorageHandleConfig,
+)
+from khora.storage.coordinator import StorageCoordinator
+from tests.integration._sqlite_lance_fixtures import EMBED_DIM
+from tests.integration.matrix._conformance_lance import _run_async
+from tests.test_helpers.document_order import id_ladder
+from tests.test_helpers.document_scan import WHOLE_SECOND, ScanSeed, as_utc, scan_seed
+from tests.test_helpers.walk_fuzz import (
+    CORPUS_SIZE,
+    WalkCollectors,
+    assert_multipage_fraction,
+    build_walk_corpus,
+    drive_walk,
+    to_walk_ast,
+    validated_walk_ast,
+    walk_filter,
+    walk_oracle,
+    walk_status,
+    walk_updated_before,
+    walked_ids,
+    walked_keys,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- #
+# The fixed corpus + the seeded embedded store.
+# --------------------------------------------------------------------------- #
+#
+# RE-ENTRANCY: the ``@lru_cache`` singleton is resolved on the CALLER (test)
+# thread; only the read/write coroutines are submitted to the loop thread that
+# owns the aiosqlite connection (``_run_async``). An aiosqlite handle is bound to
+# the loop it was opened on, so every later call MUST go through that same loop —
+# and resolving the cache from inside a coroutine already running there would
+# deadlock (the loop would block on a future only it can complete). Module-level
+# singletons (not a function-scoped fixture) also keep Hypothesis's
+# ``function_scoped_fixture`` health check from firing on the @given tests.
+
+CORPUS_NAMESPACE_ID = uuid4()
+CORPUS = build_walk_corpus(CORPUS_NAMESPACE_ID)
+
+# Anything at or above the corpus size is "unbounded" for these walks: the budget
+# counts RAW rows scanned per page, so a bound past the corpus can never cut a
+# page short and the whole namespace is one page. Deliberately +1 so a corpus
+# that grew by one row would still be covered by the name.
+UNBOUNDED = CORPUS_SIZE + 1
+
+COLLECTORS = WalkCollectors()
+
+
+def _budget(max_examples: int) -> settings:
+    """The shared Hypothesis profile: no deadline (a walk is many round trips).
+
+    ``function_scoped_fixture`` is suppressed because these tests take none — the
+    store is a module-level singleton — and ``too_slow`` because a single example
+    drives a whole multi-page enumeration, which is inherently slower than the
+    single-query draws Hypothesis's default budget assumes.
+    """
+    return settings(
+        max_examples=max_examples,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+    )
+
+
+class _SeededWalkStore:
+    """A connected relational-only coordinator holding the frozen walk corpus."""
+
+    def __init__(self, coord: StorageCoordinator, handle: EmbeddedStorageHandle) -> None:
+        self.coord = coord
+        self.handle = handle
+
+
+async def _build_seeded_store() -> _SeededWalkStore:
+    """Migrate a tmp SQLite file, wire the relational adapter, seed the corpus."""
+    tmp_path = Path(tempfile.mkdtemp(prefix="khora-walk-fuzz-"))
+    db_path = str(tmp_path / "khora.db")
+    result = await run_migrations(f"sqlite+aiosqlite:///{db_path}")
+    if not result.success:
+        raise RuntimeError(f"migration failed: {result.error}")
+
+    handle = EmbeddedStorageHandle(
+        EmbeddedStorageHandleConfig(
+            db_path=db_path,
+            lance_path=str(tmp_path / "khora.lance"),
+            embedding_dimension=EMBED_DIM,
+        )
+    )
+    await handle.connect()
+    # ``vector=None``: enumeration is a relational-only read path, and a
+    # ``delete_document`` with no vector backend skips the chunk purge, which is
+    # what the mutation companion wants — it mutates the document table only.
+    coord = StorageCoordinator(relational=SQLiteLanceRelationalAdapter(handle), vector=None)
+    await coord.connect()
+
+    await _create_namespace(coord, CORPUS_NAMESPACE_ID)
+    for document in CORPUS.documents:
+        await coord.create_document(document)
+
+    # Materialization guard (fail loud, at build time). If the seeder silently
+    # dropped rows, BOTH the oracle and the walk would later agree on a too-small
+    # corpus — the empty-store false-green. Counted through the scan surface at a
+    # budget past the corpus, so the guard also proves a one-page full read works
+    # before any property depends on it.
+    page = await coord.scan_documents_page(CORPUS_NAMESPACE_ID, limit=CORPUS_SIZE + 5, scan_bound=UNBOUNDED)
+    seeded = [doc.id for doc in page]
+    if seeded != list(CORPUS.expected):
+        raise RuntimeError(
+            f"corpus did not materialize as expected: seeded {len(seeded)} rows, "
+            f"expected {len(CORPUS.expected)} in a pinned order\n"
+            f"  missing = {sorted(set(CORPUS.expected) - set(seeded))}\n"
+            f"  extra   = {sorted(set(seeded) - set(CORPUS.expected))}\n"
+            f"  seeded  = {seeded}"
+        )
+    return _SeededWalkStore(coord, handle)
+
+
+@lru_cache(maxsize=1)
+def _seeded_store() -> _SeededWalkStore:
+    """The process-wide seeded embedded store (built + seeded exactly once).
+
+    Resolved on the CALLER thread, never inside a coroutine already running on the
+    loop thread. Like the conformance helper's loop-thread coordinator, the store
+    is intentionally process-lived and left to interpreter shutdown rather than
+    closed via an ``atexit`` hook that would log into a torn-down loguru sink.
+    """
+    return _run_async(_build_seeded_store())
+
+
+async def _create_namespace(coord: StorageCoordinator, namespace_id: UUID) -> None:
+    """Create a namespace whose row id and stable ``namespace_id`` agree.
+
+    Documents are scoped by the row-level ``id`` here (that is what
+    ``DocumentModel.namespace_id`` references), so pinning both to one UUID keeps
+    every call site in this module unambiguous.
+    """
+    await coord.create_namespace(
+        MemoryNamespace(id=namespace_id, namespace_id=namespace_id, tenancy_mode=TenancyMode.SHARED)
+    )
+
+
+def _walk(*, limit: int, scan_bound: int, namespace_id: UUID | None = None, **kwargs: Any) -> list[DocumentPage]:
+    """Drive a whole walk on the loop thread and return its pages.
+
+    ``scan_bound`` is passed straight to ``scan_documents_page``. The facade
+    (``Khora.list_documents``) derives it from
+    ``query.document_scan_overfetch_multiplier`` / ``document_scan_min_bound``
+    instead; that path is deliberately BYPASSED here, because the fuzzer's whole
+    leverage is choosing budgets small enough to force a page boundary between
+    almost every raw row — which no reachable config produces.
+    """
+    store = _seeded_store()  # caller-thread resolution — never inside the loop coroutine
+    return _run_async(
+        drive_walk(
+            store.coord.scan_documents_page,
+            CORPUS_NAMESPACE_ID if namespace_id is None else namespace_id,
+            limit=limit,
+            scan_bound=scan_bound,
+            **kwargs,
+        )
+    )
+
+
+def assert_page_contract(pages: list[DocumentPage], *, limit: int) -> None:
+    """Every page's shape invariants — the ``next_after``/``exhausted`` polarity.
+
+    ``next_after is None`` **iff** ``exhausted`` is the contract
+    ``DocumentPage`` states, and it is the one a caller's loop condition rests
+    on: a page that returned neither a resume position nor exhaustion silently
+    truncates the walk, and one that returned both invites an extra round trip
+    that re-reads the tail. Only the terminal page may be exhausted — an interior
+    ``exhausted=True`` would have ended the walk early.
+    """
+    for index, page in enumerate(pages):
+        is_last = index == len(pages) - 1
+        assert len(page) <= limit, f"page {index} returned {len(page)} matches over limit={limit}"
+        assert (page.next_after is None) is page.exhausted, (
+            f"page {index} broke the next_after/exhausted contract: "
+            f"next_after={page.next_after!r}, exhausted={page.exhausted}"
+        )
+        assert page.exhausted is is_last, f"page {index} exhausted={page.exhausted} but is_last={is_last}"
+    assert pages[-1].exhausted is True, "the walk ended without an exhausted page"
+
+
+def assert_strictly_descending(pages: list[DocumentPage]) -> None:
+    """The concatenated ``(created_at, id)`` keys strictly descend across page seams.
+
+    Strict (not merely non-increasing) is the assertion that matters: an equal
+    adjacent pair is a row served twice, and the tie blocks in the corpus mean a
+    tie-break bug shows up here as an equality rather than as an inversion.
+    """
+    keys = walked_keys(pages)
+    for previous, current in zip(keys, keys[1:], strict=False):
+        assert current < previous, f"walk order is not strictly descending: {previous!r} then {current!r}"
+
+
+# --------------------------------------------------------------------------- #
+# Property A — exactly-once + completeness + order + honest termination.
+# --------------------------------------------------------------------------- #
+
+
+class TestWalkEnumeration:
+    """One generated walk must enumerate exactly the oracle, once each, in order.
+
+    Combined into a single walk per draw on purpose: each of the four properties
+    it asserts is cheap to check and expensive to produce (a ``scan_bound=1``
+    walk over the corpus is ~21 round trips), so splitting them across four
+    ``@given`` tests would quadruple the SELECT count for no additional coverage.
+    """
+
+    @given(
+        filter_dict=walk_filter(),
+        status=walk_status(),
+        updated_before=walk_updated_before(),
+        scan_bound=st.sampled_from([1, 2, 3, 5]),
+    )
+    @_budget(100)
+    def test_walk_matches_the_oracle_exactly_once_and_in_order(
+        self,
+        filter_dict: dict[str, Any],
+        status: str | None,
+        updated_before: datetime | None,
+        scan_bound: int,
+    ) -> None:
+        ast = validated_walk_ast(filter_dict)
+        assume(ast is not None)  # invalid draw — rare; the strategy is biased to validate
+        assert ast is not None  # narrow for the type checker after the assume
+
+        expected = walk_oracle(CORPUS.documents, filter_ast=ast, status=status, updated_before=updated_before)
+        pages = _walk(
+            limit=3,
+            scan_bound=scan_bound,
+            filter_ast=ast,
+            status=status,
+            updated_before=updated_before,
+        )
+        seen = walked_ids(pages)
+
+        if scan_bound == 1:
+            COLLECTORS.page_counts.append(len(pages))
+
+        assert len(seen) == len(set(seen)), f"a document was served twice: {filter_dict!r}"
+        assert set(seen) == set(expected), (
+            "walk/oracle set divergence:\n"
+            f"  filter = {filter_dict!r} status={status!r} updated_before={updated_before!r}\n"
+            f"  missing = {sorted(set(expected) - set(seen))}\n"
+            f"  extra   = {sorted(set(seen) - set(expected))}"
+        )
+        assert seen == expected, f"walk/oracle ORDER divergence at scan_bound={scan_bound}: {filter_dict!r}"
+        assert_strictly_descending(pages)
+        assert_page_contract(pages, limit=3)
+
+
+# --------------------------------------------------------------------------- #
+# Property B — cursor stitching (the load-bearing differential).
+# --------------------------------------------------------------------------- #
+
+
+class TestCursorStitchDifferential:
+    """A walk stitched from many cursors equals one that never serializes a cursor.
+
+    The load-bearing property. At ``scan_bound=1`` every raw row is a page
+    boundary, so the whole answer is reassembled from ~21 round-tripped
+    ``DocumentCursor`` positions — several of them strictly inside a tie block,
+    where only a correctly-bound ``(created_at, id)`` lands on the right row. The
+    unbounded walk reads the same namespace in ONE page with ``after=None``, so
+    it exercises no cursor at all and is the control: if the two disagree, the
+    cursor is what broke, not the filter (the oracle third leg then says which
+    side moved).
+    """
+
+    @given(filter_dict=walk_filter(), status=walk_status(), updated_before=walk_updated_before())
+    @_budget(60)
+    def test_stitched_walk_equals_unstitched_walk_and_oracle(
+        self, filter_dict: dict[str, Any], status: str | None, updated_before: datetime | None
+    ) -> None:
+        ast = validated_walk_ast(filter_dict)
+        assume(ast is not None)
+        assert ast is not None
+
+        narrowing: dict[str, Any] = {"filter_ast": ast, "status": status, "updated_before": updated_before}
+        stitched = walked_ids(_walk(limit=3, scan_bound=1, **narrowing))
+        unstitched = walked_ids(_walk(limit=CORPUS_SIZE + 5, scan_bound=UNBOUNDED, **narrowing))
+        expected = walk_oracle(CORPUS.documents, **narrowing)
+
+        assert stitched == unstitched, (
+            "cursor-stitched and single-page walks disagree — the cursor is the only "
+            f"difference between them:\n  filter = {filter_dict!r}\n"
+            f"  stitched   = {stitched}\n  unstitched = {unstitched}"
+        )
+        assert stitched == expected, f"both walks agree but diverge from the oracle: {filter_dict!r}"
+
+
+class TestWalkSeedSweep:
+    """Property B re-run under eight distinct Hypothesis seeds — stability sweep.
+
+    A single PRNG stream could miss a discriminating draw by luck; eight fixed
+    seeds (few examples each, so total CI time stays bounded) confirm the
+    stitching agreement holds across independent streams, not one.
+    """
+
+    @pytest.mark.parametrize("hypothesis_seed", range(8))
+    def test_stitch_holds_under_seed(self, hypothesis_seed: int) -> None:
+        @seed(hypothesis_seed)
+        @given(filter_dict=walk_filter(), status=walk_status(), updated_before=walk_updated_before())
+        @_budget(12)
+        def _check(filter_dict: dict[str, Any], status: str | None, updated_before: datetime | None) -> None:
+            ast = validated_walk_ast(filter_dict)
+            assume(ast is not None)
+            assert ast is not None
+
+            narrowing: dict[str, Any] = {"filter_ast": ast, "status": status, "updated_before": updated_before}
+            stitched = walked_ids(_walk(limit=3, scan_bound=1, **narrowing))
+            expected = walk_oracle(CORPUS.documents, **narrowing)
+            assert stitched == expected, (
+                f"seed={hypothesis_seed} stitched walk diverged from the oracle:\n  filter = {filter_dict!r}"
+            )
+
+        _check()
+
+
+# --------------------------------------------------------------------------- #
+# Property C — limit invariance.
+# --------------------------------------------------------------------------- #
+
+
+class TestLimitInvariance:
+    """``limit`` slices the answer into pages; it must not change the answer.
+
+    Three limits (one below, one at, one above the natural page shape) over one
+    budget large enough that the scan bound never cuts a page short — so the ONLY
+    thing varying is where the page boundaries fall. A ``limit``-dependent answer
+    would mean the page-fill loop is dropping or duplicating rows at the seam
+    (the coordinator sizes each scan step to the match shortfall, so a
+    mis-computed shortfall shows up here and nowhere else).
+    """
+
+    @given(filter_dict=walk_filter(), status=walk_status(), updated_before=walk_updated_before())
+    @_budget(50)
+    def test_answer_is_independent_of_limit(
+        self, filter_dict: dict[str, Any], status: str | None, updated_before: datetime | None
+    ) -> None:
+        ast = validated_walk_ast(filter_dict)
+        assume(ast is not None)
+        assert ast is not None
+
+        narrowing: dict[str, Any] = {"filter_ast": ast, "status": status, "updated_before": updated_before}
+        answers = {limit: walked_ids(_walk(limit=limit, scan_bound=UNBOUNDED, **narrowing)) for limit in (1, 3, 7)}
+        expected = walk_oracle(CORPUS.documents, **narrowing)
+
+        assert answers[1] == answers[3] == answers[7], f"the answer depends on limit: {filter_dict!r}\n  {answers}"
+        assert answers[1] == expected, f"every limit agrees but diverges from the oracle: {filter_dict!r}"
+
+
+# --------------------------------------------------------------------------- #
+# Determinism — a repeated walk over a frozen namespace reproduces itself.
+# --------------------------------------------------------------------------- #
+
+
+def page_shapes(pages: list[DocumentPage]) -> list[tuple[Any, ...]]:
+    """Everything a caller can observe about each page, flattened for comparison.
+
+    The cursor is compared as its ``(created_at, id)`` pair rather than as the
+    dataclass, so a divergence in either half is named by the failure output.
+    """
+    return [
+        (
+            tuple(doc.id for doc in page),
+            None if page.next_after is None else (page.next_after.created_at, page.next_after.id),
+            page.exhausted,
+            page.post_filtered_keys,
+        )
+        for page in pages
+    ]
+
+
+class TestWalkDeterminism:
+    """The same walk, run twice over an unchanged namespace, must be the same walk.
+
+    Every generated property above compares a walk to an oracle, which would still
+    pass if the store returned a *different but equally correct* slicing on each
+    run — a page-boundary that moved, a cursor that landed one row earlier. A
+    caller resuming a paged enumeration depends on more than the concatenation:
+    the cursor it stored must still mean what it meant, page for page. This pins
+    the whole page sequence, not just its concatenation.
+    """
+
+    def test_repeating_a_walk_reproduces_every_page_exactly(self) -> None:
+        """Two identical walks agree on ids, page boundaries, cursors and flags.
+
+        ``source_type = library`` keeps a strict, multi-row subset, and
+        ``limit=3, scan_bound=1`` forces the answer to be stitched from one raw
+        row per page — so the walk genuinely crosses boundaries rather than
+        collapsing into a single page where determinism would be trivial.
+        """
+        ast = to_walk_ast({"source_type": "library"})
+        first = _walk(limit=3, scan_bound=1, filter_ast=ast)
+        second = _walk(limit=3, scan_bound=1, filter_ast=ast)
+
+        expected = walk_oracle(CORPUS.documents, filter_ast=ast)
+        assert 0 < len(expected) < CORPUS_SIZE, expected
+        # Non-vacuity: a single-page walk would make the comparison below trivial.
+        assert len([page for page in first if len(page) > 0]) >= 2, [len(p) for p in first]
+
+        assert page_shapes(first) == page_shapes(second), (
+            "a repeated walk over a frozen namespace produced a different page sequence:\n"
+            f"  first  = {page_shapes(first)}\n  second = {page_shapes(second)}"
+        )
+        assert walked_ids(first) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Anti-vacuous guards.
+# --------------------------------------------------------------------------- #
+
+
+class TestWalkDiscriminates:
+    """The corpus, the strategy and the budgets actually exercise what they claim.
+
+    Two false-green shapes are ruled out here without leaning on any generated
+    draw. A corpus every filter keeps whole (or drops whole) would make the oracle
+    comparison trivial — ``test_a_partial_filter_keeps_a_strict_subset`` rules it
+    out deterministically. A budget regime where every walk fits in one page would
+    make the *walk* half of a walk fuzzer inert — the multipage floor below plus
+    the hand-written reachability check rule that out.
+
+    There is deliberately no strict-subset *fraction* guard. A ``>=30%`` floor over
+    this strategy is not sound: its true strict-subset rate hugs the floor (a
+    100-draw oracle sample has been observed at 26%), and under ``-n auto`` the
+    process-local collector holds only the draws that landed on this worker, so a
+    fraction read off it is a partial sample of an already-marginal rate. The
+    deterministic partial-filter test is the discrimination proof instead. The
+    multipage floor survives because it is not marginal: at ``scan_bound=1`` every
+    walk crosses boundaries by construction, and it falls back to one concrete
+    full-corpus walk when the collector is empty.
+    """
+
+    def test_most_generated_walks_cross_a_page_boundary(self) -> None:
+        """At least half the ``scan_bound=1`` walks needed two or more pages.
+
+        Falls back to one concrete unfiltered walk when the collector is empty.
+        The bound makes multi-page walks the norm by construction; the assertion
+        exists so a future budget change that quietly collapsed every walk to a
+        single page cannot pass silently.
+        """
+        counts = COLLECTORS.page_counts or [len(_walk(limit=3, scan_bound=1))]
+        assert_multipage_fraction(counts)
+
+    def test_matches_are_split_across_pages_with_rejected_pages_between(self) -> None:
+        """A filtered walk really does stitch matches across a rejected gap.
+
+        The complementary half of the page-count floor above, which by
+        construction cannot see this: at ``scan_bound=1`` a page scans one raw
+        row whether or not it matches, so a walk can be long and still have every
+        match land on one page. What must be reachable is the shape the
+        coordinator's "resume from the last RAW row, not the last MATCH" design
+        exists for — two match-bearing pages with at least one page that scanned a
+        row and returned nothing in between. A walk that resumed from the last
+        matching row instead could not advance past a rejected gap at all.
+
+        The filter is a ``source_timestamp`` leaf on purpose. This store WITHHOLDS
+        both date system keys from pushdown (their stored TEXT format does not
+        order against the compiler's ISO binds), so the leaf is enforced only in
+        memory and the raw window is the whole namespace — which is what produces
+        scanned-but-rejected pages. A pushable leaf such as ``source_type`` would
+        narrow the window in SQL and every scanned row would match, so this test
+        would prove nothing. The ``post_filtered_keys`` assertion pins that
+        premise rather than trusting it.
+        """
+        ast = to_walk_ast({"source_timestamp": {"$eq": "2026-06-01T00:00:00Z"}})
+        pages = _walk(limit=3, scan_bound=1, filter_ast=ast)
+
+        assert pages[0].post_filtered_keys == ("source_timestamp",), pages[0].post_filtered_keys
+        bearing = [index for index, page in enumerate(pages) if len(page) > 0]
+        assert len(bearing) >= 2, f"the filter did not split its matches across pages: {bearing}"
+        gaps = [
+            index
+            for index in range(bearing[0] + 1, bearing[-1])
+            if len(pages[index]) == 0 and not pages[index].exhausted
+        ]
+        assert gaps, "no rejected page sits between two match-bearing pages"
+        assert walked_ids(pages) == walk_oracle(CORPUS.documents, filter_ast=ast)
+
+    def test_a_partial_filter_keeps_a_strict_subset(self) -> None:
+        """Explicit (non-Hypothesis) proof that the corpus discriminates.
+
+        A concrete partial filter must keep a strict, non-empty subset on both
+        the oracle and the real walk. If this fails, every generated agreement
+        above was an agreement about the whole corpus.
+        """
+        ast = to_walk_ast({"source_type": "library"})
+        expected = walk_oracle(CORPUS.documents, filter_ast=ast)
+        assert 0 < len(expected) < CORPUS_SIZE, expected
+        assert walked_ids(_walk(limit=3, scan_bound=UNBOUNDED, filter_ast=ast)) == expected
+
+    def test_unfiltered_walk_at_scan_bound_one_pages_the_whole_corpus(self) -> None:
+        """The reachability check the two fraction guards lean on.
+
+        A ``scan_bound=1`` walk over the unfiltered corpus scans one raw row per
+        page, so it takes exactly ``CORPUS_SIZE + 1`` pages — the corpus, plus the
+        empty tail page that is the only sound termination signal — and its
+        concatenation is the pinned ``(created_at DESC, id DESC)`` enumeration.
+        """
+        pages = _walk(limit=3, scan_bound=1)
+
+        assert len(pages) == CORPUS_SIZE + 1, [len(p) for p in pages]
+        assert walked_ids(pages) == list(CORPUS.expected)
+        assert [len(p) for p in pages[:-1]] == [1] * CORPUS_SIZE
+        assert len(pages[-1]) == 0
+        assert_page_contract(pages, limit=3)
+
+
+# --------------------------------------------------------------------------- #
+# Mutation during a walk (deterministic — no snapshot spans pages).
+# --------------------------------------------------------------------------- #
+#
+# ``scan_documents_page`` explicitly claims no consistent snapshot: each page is
+# its own SELECT in its own session. That is a real, caller-visible property, and
+# it is *not* "anything can happen" — a keyset walk moving monotonically down
+# ``(created_at DESC, id DESC)`` has an exact, checkable answer for each of the
+# four mutation shapes. Pinning them is what stops a future "improvement" from
+# quietly changing which rows a concurrent writer's document lands in.
+
+
+async def _seed_gap_ladder(coord: StorageCoordinator, namespace_id: UUID, ids: list[UUID], base: datetime) -> None:
+    """Seed ``ids`` with strictly DESCENDING ``created_at``, ten seconds apart.
+
+    No ties and a deliberate gap between neighbours, so a mutation test can place
+    a new row strictly between two existing ones and name where it must land. The
+    enumeration order is therefore exactly ``ids`` — ladder order — which keeps
+    these scenarios readable. (The tie-break itself is covered exhaustively by the
+    generated properties above; repeating it here would only obscure the
+    mutation semantics.)
+    """
+    for offset, doc_id in enumerate(ids):
+        await coord.create_document(
+            Document(
+                id=doc_id,
+                namespace_id=namespace_id,
+                content=f"mutation row {offset}",
+                checksum=f"mut-{doc_id.hex}",
+                created_at=base - timedelta(seconds=10 * offset),
+                updated_at=base,
+            )
+        )
+
+
+async def _insert(coord: StorageCoordinator, namespace_id: UUID, doc_id: UUID, created_at: datetime) -> None:
+    await coord.create_document(
+        Document(
+            id=doc_id,
+            namespace_id=namespace_id,
+            content="inserted mid-walk",
+            checksum=f"mut-{doc_id.hex}",
+            created_at=created_at,
+            updated_at=created_at,
+        )
+    )
+
+
+async def _walk_with_mutations(
+    coord: StorageCoordinator,
+    namespace_id: UUID,
+    mutations: dict[int, Callable[[], Awaitable[None]]],
+    *,
+    max_pages: int = 60,
+) -> list[UUID]:
+    """Walk one row at a time, running ``mutations[i]`` after page ``i`` returns.
+
+    ``limit=1, scan_bound=1`` puts a mutation window between every pair of rows,
+    which is the only way to place a write at a *known* point in the walk. Returns
+    the concatenated ids the walk served.
+    """
+    seen: list[UUID] = []
+    after: DocumentCursor | None = None
+    index = 0
+    while index < max_pages:
+        page = await coord.scan_documents_page(
+            namespace_id,
+            limit=1,
+            after=None if after is None else (after.created_at, after.id),
+            scan_bound=1,
+        )
+        seen.extend(doc.id for doc in page)
+        mutate = mutations.get(index)
+        if mutate is not None:
+            await mutate()
+        if page.exhausted:
+            return seen
+        assert page.next_after is not None
+        after = page.next_after
+        index += 1
+    raise AssertionError(f"mutating walk did not terminate within {max_pages} pages")
+
+
+class TestMutationDuringWalk:
+    """What a concurrent insert or delete does to a walk already in flight.
+
+    Each scenario runs in its own fresh namespace inside the shared store, so a
+    mutation can never leak into the read-only corpus the generated properties
+    depend on. Deliberately NOT a Hypothesis test: these are four exact,
+    hand-placed answers, and generating them would only obscure which one broke.
+    """
+
+    def test_insert_above_the_cursor_is_not_seen(self) -> None:
+        """A row newer than the cursor is already behind the walk — never served.
+
+        A keyset walk moves monotonically down ``(created_at DESC, id DESC)`` and
+        never looks back, so a document inserted with a ``created_at`` above the
+        current position is invisible to THIS walk. That is not a bug to fix at
+        the walk layer — it is the price of resumability, and a caller that needs
+        the new row starts a new walk.
+        """
+        result = _run_async(self._insert_above())
+        assert result["above_id"] not in result["seen"]
+        assert result["seen"] == result["ladder"]
+
+    async def _insert_above(self) -> dict[str, Any]:
+        coord = _seeded_store().coord
+        namespace_id, ladder, base = await _fresh_ladder(coord, 5)
+        above_id = uuid4()
+
+        async def mutate() -> None:
+            await _insert(coord, namespace_id, above_id, base + timedelta(seconds=30))
+
+        seen = await _walk_with_mutations(coord, namespace_id, {1: mutate})
+        return {"seen": seen, "ladder": ladder, "above_id": above_id}
+
+    def test_insert_below_the_cursor_is_seen(self) -> None:
+        """A row older than the cursor is still ahead of the walk — served in order.
+
+        The mirror of the case above, and the half that is easy to get wrong: the
+        insert lands strictly between two existing rows, so it must appear at that
+        exact position in the concatenation, not appended at the end.
+        """
+        result = _run_async(self._insert_below())
+        ladder = result["ladder"]
+        # Placed between ladder[2] and ladder[3] by construction.
+        assert result["seen"] == [*ladder[:3], result["below_id"], *ladder[3:]]
+
+    async def _insert_below(self) -> dict[str, Any]:
+        coord = _seeded_store().coord
+        namespace_id, ladder, base = await _fresh_ladder(coord, 5)
+        below_id = uuid4()
+
+        async def mutate() -> None:
+            # ladder[2] is at base-20s and ladder[3] at base-30s; land between.
+            await _insert(coord, namespace_id, below_id, base - timedelta(seconds=25))
+
+        seen = await _walk_with_mutations(coord, namespace_id, {1: mutate})
+        return {"seen": seen, "ladder": ladder, "below_id": below_id}
+
+    def test_delete_of_an_unscanned_row_below_the_cursor_excludes_it(self) -> None:
+        """A row deleted before the walk reaches it is simply never served.
+
+        The walk must also not stall on the hole: the rows after the deleted one
+        still come back, in order.
+        """
+        result = _run_async(self._delete_ahead())
+        ladder = result["ladder"]
+        assert result["seen"] == [d for d in ladder if d != ladder[4]]
+        assert ladder[4] not in result["seen"]
+
+    async def _delete_ahead(self) -> dict[str, Any]:
+        coord = _seeded_store().coord
+        namespace_id, ladder, _base = await _fresh_ladder(coord, 6)
+
+        async def mutate() -> None:
+            await coord.delete_document(ladder[4], namespace_id=namespace_id)
+
+        seen = await _walk_with_mutations(coord, namespace_id, {1: mutate})
+        return {"seen": seen, "ladder": ladder}
+
+    def test_delete_of_an_already_returned_row_does_not_retract_it(self) -> None:
+        """A row deleted AFTER it was served stays in the caller's hands.
+
+        Nothing can unsend a page, and — the part worth pinning — the walk also
+        does not stumble on resuming from a cursor whose own row no longer
+        exists. The keyset predicate is a comparison, not a lookup, so a deleted
+        anchor is fine; a walk that re-read its anchor row would break here.
+        """
+        result = _run_async(self._delete_behind())
+        assert result["seen"] == result["ladder"]
+
+    async def _delete_behind(self) -> dict[str, Any]:
+        coord = _seeded_store().coord
+        namespace_id, ladder, _base = await _fresh_ladder(coord, 5)
+
+        async def mutate() -> None:
+            # Delete the row page 1 just served — the walk's current anchor.
+            await coord.delete_document(ladder[1], namespace_id=namespace_id)
+
+        seen = await _walk_with_mutations(coord, namespace_id, {1: mutate})
+        return {"seen": seen, "ladder": ladder}
+
+    def test_all_four_mutations_in_one_walk(self) -> None:
+        """The umbrella: every shape at once, in a single walk.
+
+        ``seen`` must be exactly ``(initial ∪ inserted-below) − deleted-before-
+        scanned``, each id once, with the row deleted after it was served still
+        present and the row inserted above the cursor still absent. Running the
+        four together is not redundant with running them apart — it is the case
+        where a fix for one could regress another.
+        """
+        result = _run_async(self._umbrella())
+        seen = result["seen"]
+        ladder = result["ladder"]
+
+        assert len(seen) == len(set(seen)), "a document was served twice across the mutating walk"
+        assert set(seen) == (set(ladder) | {result["below_id"]}) - {ladder[4]}
+        assert result["above_id"] not in seen
+        assert ladder[0] in seen, "a row deleted after it was served must stay served"
+        assert seen == [*ladder[:3], result["below_id"], ladder[3], ladder[5]]
+
+    async def _umbrella(self) -> dict[str, Any]:
+        coord = _seeded_store().coord
+        namespace_id, ladder, base = await _fresh_ladder(coord, 6)
+        above_id, below_id = uuid4(), uuid4()
+
+        async def mutate() -> None:
+            await _insert(coord, namespace_id, above_id, base + timedelta(seconds=30))
+            await _insert(coord, namespace_id, below_id, base - timedelta(seconds=25))
+            await coord.delete_document(ladder[4], namespace_id=namespace_id)  # unscanned, ahead
+            await coord.delete_document(ladder[0], namespace_id=namespace_id)  # already served
+
+        seen = await _walk_with_mutations(coord, namespace_id, {1: mutate})
+        return {"seen": seen, "ladder": ladder, "above_id": above_id, "below_id": below_id}
+
+
+async def _fresh_ladder(coord: StorageCoordinator, total: int) -> tuple[UUID, list[UUID], datetime]:
+    """A brand-new namespace seeded with ``total`` gap-separated rows.
+
+    Returns ``(namespace_id, ids-in-enumeration-order, base_instant)``.
+    """
+    namespace_id = uuid4()
+    await _create_namespace(coord, namespace_id)
+    base = WHOLE_SECOND
+    ids = id_ladder(total)
+    await _seed_gap_ladder(coord, namespace_id, ids, base)
+    return namespace_id, ids, base
+
+
+# --------------------------------------------------------------------------- #
+# Cursor codec — the DocumentCursor round trip at the public layer.
+# --------------------------------------------------------------------------- #
+
+
+class TestCursorCodec:
+    """A ``DocumentCursor`` fed back in resumes at the exact next row.
+
+    The adapter-level scan tests already pin that the *builder* binds its operands
+    through the ORM column types. What is checked here is one level up: that a
+    :class:`DocumentCursor` handed to a caller by ``scan_documents_page`` and
+    handed straight back resumes correctly — including from the middle of a tie
+    block, at BOTH microsecond polarities, which is where this store's TEXT
+    ``created_at`` column is most fragile.
+
+    Both polarities are seeded because neither one alone is conclusive on this
+    store. At ``.000000`` a hand-formatted ``str(naive_datetime)`` omits the
+    microsecond field entirely and diverges from the stored six-digit form; at a
+    non-zero microsecond it is byte-identical to it, so a corpus seeded only from
+    ``datetime.now(UTC)`` would silently agree with a broken bind. See
+    :mod:`tests.test_helpers.document_scan`.
+    """
+
+    def test_whole_second_tie_block_resume(self) -> None:
+        """microsecond=0: resume from mid-tie excludes the anchor, keeps its tie-mate."""
+        self._assert_mid_tie_resume(WHOLE_SECOND)
+
+    def test_sub_second_tie_block_resume(self) -> None:
+        """microsecond=.123456: the opposite polarity, same contract."""
+        self._assert_mid_tie_resume(WHOLE_SECOND.replace(microsecond=123456))
+
+    def _assert_mid_tie_resume(self, instant: datetime) -> None:
+        result = _run_async(self._mid_tie_resume(instant))
+        anchor, tie_mate, resumed, expected_tail = (
+            result["anchor"],
+            result["tie_mate"],
+            result["resumed"],
+            result["expected_tail"],
+        )
+        assert anchor not in resumed, "the cursor's own row came back — a resumed walk would never advance"
+        assert tie_mate in resumed, "the cursor's tie-mate was skipped — a resumed walk would lose rows"
+        assert resumed == expected_tail
+
+    async def _mid_tie_resume(self, instant: datetime) -> dict[str, Any]:
+        coord = _seeded_store().coord
+        namespace_id, seed_plan = await _fresh_tie_corpus(coord, instant)
+
+        full = await coord.scan_documents_page(namespace_id, limit=20, scan_bound=50)
+        assert [doc.id for doc in full] == seed_plan.expected
+
+        anchor_doc = next(doc for doc in full if doc.id == seed_plan.tied_ids[0])
+        cursor = DocumentCursor(created_at=anchor_doc.created_at, id=anchor_doc.id)
+        resumed_page = await coord.scan_documents_page(
+            namespace_id, limit=20, after=(cursor.created_at, cursor.id), scan_bound=50
+        )
+        return {
+            "anchor": anchor_doc.id,
+            "tie_mate": seed_plan.tied_ids[1],
+            "resumed": [doc.id for doc in resumed_page],
+            "expected_tail": seed_plan.expected[seed_plan.expected.index(anchor_doc.id) + 1 :],
+        }
+
+    def test_mid_tie_resume_at_limit_one_lands_on_the_exact_next_row(self) -> None:
+        """A one-row page resumed from mid-tie returns exactly the next id.
+
+        The sharpest form of the tie-break assertion: with ``limit=1`` there is
+        nowhere for a wrong answer to hide behind a set comparison. The rows on
+        either side of the anchor share its ``created_at`` to the microsecond, so
+        this lands correctly only if the cursor's ``id`` half is compared as a
+        UUID rather than as some rendering of one.
+        """
+        result = _run_async(self._next_row_after_mid_tie())
+        assert result["got"] == [result["want"]]
+
+    async def _next_row_after_mid_tie(self) -> dict[str, Any]:
+        coord = _seeded_store().coord
+        namespace_id, seed_plan = await _fresh_tie_corpus(coord, WHOLE_SECOND)
+
+        full = await coord.scan_documents_page(namespace_id, limit=20, scan_bound=50)
+        anchor_doc = next(doc for doc in full if doc.id == seed_plan.tied_ids[0])
+        page = await coord.scan_documents_page(
+            namespace_id, limit=1, after=(anchor_doc.created_at, anchor_doc.id), scan_bound=50
+        )
+        want = seed_plan.expected[seed_plan.expected.index(anchor_doc.id) + 1]
+        return {"got": [doc.id for doc in page], "want": want}
+
+    def test_typed_cursor_bind_excludes_its_own_row_where_a_naive_one_does_not(self) -> None:
+        """The typed bind is what makes the cursor exclude its anchor. Contrast, not assertion.
+
+        ``build_documents_scan_query`` binds each cursor operand through the
+        column's own type (``sa.literal(value, DocumentModel.created_at.type)``,
+        see ``storage/backends/_documents_scan.py``), which serializes
+        ``created_at`` in the space-separated, six-digit-microsecond form this
+        store actually holds. Hand-formatting the same instant with
+        ``isoformat()`` produces a ``'T'`` separator, and ``'T'`` (0x54) sorts
+        ABOVE ``' '`` (0x20) in the TEXT column's lexicographic comparison — so
+        the row-value predicate matches the cursor's OWN row and everything above
+        it.
+
+        This runs both forms against the same seeded namespace: the typed one via
+        the public ``scan_documents_page`` / ``DocumentCursor`` layer, the naive
+        one as raw SQL of the identical shape with only the timestamp
+        serialization changed. The failure mode is non-terminating, not
+        wrong-answer — a walk chaining that cursor returns its anchor forever —
+        so the assertion is that the two forms DISAGREE in exactly that
+        direction.
+        """
+        result = _run_async(self._typed_vs_naive())
+
+        assert result["anchor"] not in result["typed"], "the typed cursor did not exclude its own row"
+        assert result["anchor"] in result["naive"], (
+            "the naive isoformat bind did not return its own row — the contrast this "
+            "test draws no longer holds, so the typed bind is no longer the thing keeping it out"
+        )
+        assert result["typed"] != result["naive"]
+        # The naive bind does not merely include one extra row: it fails to
+        # exclude anything at or above the anchor's whole second, so the tie
+        # block comes back with it.
+        assert set(result["typed"]) < set(result["naive"])
+
+    async def _typed_vs_naive(self) -> dict[str, Any]:
+        store = _seeded_store()
+        coord = store.coord
+        namespace_id, seed_plan = await _fresh_tie_corpus(coord, WHOLE_SECOND)
+
+        full = await coord.scan_documents_page(namespace_id, limit=20, scan_bound=50)
+        anchor = next(doc for doc in full if doc.id == seed_plan.tied_ids[0])
+
+        typed_page = await coord.scan_documents_page(
+            namespace_id, limit=20, after=(anchor.created_at, anchor.id), scan_bound=50
+        )
+
+        # The same statement shape the builder produces, with ONE thing changed:
+        # the timestamp operand is hand-formatted instead of bound through the
+        # column type. The id operand keeps the store's own encoding so the
+        # contrast isolates the timestamp.
+        cursor = await store.handle.sqlite.execute(
+            "SELECT id FROM documents WHERE namespace_id = ? AND (created_at, id) < (?, ?) "
+            "ORDER BY created_at DESC, id DESC",
+            (
+                uuid_to_text(namespace_id),
+                as_utc(anchor.created_at).replace(tzinfo=None).isoformat(),
+                uuid_to_text(anchor.id),
+            ),
+        )
+        rows = await cursor.fetchall()
+        return {
+            "anchor": anchor.id,
+            "typed": [doc.id for doc in typed_page],
+            "naive": [UUID(row[0]) for row in rows],
+        }
+
+    def test_the_builder_binds_created_at_in_the_stored_serialization(self) -> None:
+        """The rendered statement carries the space-separated form, not an ISO ``'T'``.
+
+        The static half of the contrast above: compiling
+        ``build_documents_scan_query`` with literal binds shows the operand this
+        store compares against, without needing a row. Guards the one-line change
+        (dropping the explicit column type from ``sa.literal``) that would put the
+        wrong bytes in the predicate.
+        """
+        from sqlalchemy.dialects import sqlite
+
+        anchor_id = uuid4()
+        query = build_documents_scan_query(uuid4(), after=(WHOLE_SECOND.replace(tzinfo=None), anchor_id), scan_limit=5)
+        rendered = str(query.compile(dialect=sqlite.dialect(), compile_kwargs={"literal_binds": True}))
+
+        assert "2026-01-31 12:30:00.000000" in rendered, rendered
+        assert "2026-01-31T12:30:00" not in rendered, rendered
+        # The id renders in this store's own 32-hex-undashed encoding, not the
+        # dashed 36-character rendering that never matches the column.
+        assert anchor_id.hex in rendered, rendered
+        assert str(anchor_id) not in rendered, rendered
+
+
+async def _fresh_tie_corpus(coord: StorageCoordinator, instant: datetime) -> tuple[UUID, ScanSeed]:
+    """A brand-new namespace seeded with a tie-heavy six-row scan seed.
+
+    Reuses the shared ``scan_seed`` plan (a four-row tie block flanked by two rows
+    whose timestamp and id deliberately disagree) so the codec cases resume from
+    the middle of a genuine tie rather than from a boundary any ordering would get
+    right.
+    """
+    namespace_id = uuid4()
+    await _create_namespace(coord, namespace_id)
+    plan = scan_seed(6, instant=instant)
+    for doc_id, created_at in plan.writes:
+        await coord.create_document(
+            Document(
+                id=doc_id,
+                namespace_id=namespace_id,
+                content="codec row",
+                checksum=f"codec-{doc_id.hex}",
+                created_at=created_at,
+                updated_at=created_at,
+            )
+        )
+    return namespace_id, plan


### PR DESCRIPTION
## Summary
- Adds a property-based (Hypothesis) fuzzer that exercises the document-enumeration walk against the **real** coordinator scan loop and the per-backend `scan_documents` primitive — not a harness executor — on two independent backends: the embedded `sqlite_lance` store (unit) and a live PostgreSQL (integration).
- The differential oracle is the shipped `compile_python` filter compiler (the same one the production coordinator uses), reused exactly as the recall fuzzer does, so the walk is checked against an independent implementation rather than against itself.
- Walk properties covered:
  - **Completeness / exactly-once** — the union of all pages equals the oracle set, and no document id is served twice across a walk.
  - **Cursor-stitch differential** — a walk stitched from many one-row scans equals an effectively-unbounded single-shot walk and equals the oracle.
  - **Order** — concatenated pages are strictly descending on `(created_at, id)`.
  - **Limit-invariance** — walks at different page limits concatenate to identical sequences.
  - **Honest termination** — the `exhausted` / `next_after` polarity holds (a short or empty page is never mistaken for the end), and the walk terminates within a bounded call count.
  - **Determinism** — a repeated walk over a frozen namespace reproduces every page (ids, boundaries, cursors, flags) byte for byte.
- Deterministic companions: mutation between scan steps (insert/delete above and below the cursor, asserting as-scanned semantics) and cursor-codec round-trips (microsecond and zero-microsecond `isoformat` boundaries, canonical lowercase-hex UUID, per-backend re-serialization).
- An eight-seed stability sweep runs on the embedded leg to rule out a lucky PRNG stream.
- The `>=50%` multipage-fraction anti-vacuity guard is **embedded-leg-only** by design: it holds by construction only where a page scans one raw row per budget unit. The PostgreSQL store pushes the filter into SQL, so a bounded scan fetches one *matching* row per page and the premise does not carry over; boundary-crossing there is evidenced deterministically instead (an unfiltered bounded walk that pages the whole corpus).

Test-only change — no production code is modified.

## Test plan
- [x] Unit leg: `pytest tests/unit/filter/test_walk_fuzz.py` — 27 passed.
- [x] Integration leg (PostgreSQL): `pytest tests/integration/storage/test_walk_fuzz_pg.py -m integration` — 18 passed.
- [x] `ruff check .` clean; touched files `ruff format`-clean; `ty check src/` unchanged (no src changes).
- [ ] CI green across the full matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive property-based coverage for multi-page document walks across embedded and PostgreSQL storage.
  * Validated ordering, exactly-once delivery, cursor stitching, pagination limits, determinism, filtering, and termination.
  * Added coverage for inserts and deletes during active walks.
  * Expanded cursor validation for timestamp ties, UUID ordering, time zones, precision, and SQL type handling.
  * Added shared fuzzing utilities and automatic PostgreSQL integration-test availability detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->