### PR TITLE
Add split-honesty verification tests for document enumeration

### DIFF
--- a/tests/integration/storage/backends/surrealdb/test_relational_scan_documents.py
+++ b/tests/integration/storage/backends/surrealdb/test_relational_scan_documents.py
@@ -57,6 +57,7 @@ from khora.filter import (  # noqa: E402
     CompilerRegistry,
 )
 from khora.filter.compilers.python import compile_python  # noqa: E402
+from khora.filter.execute import filter_leaf_keys  # noqa: E402
 from khora.storage.backends.surrealdb.connection import SurrealDBConnection  # noqa: E402
 
 # ``_documents_compile_context`` is private, and imported on purpose: the
@@ -65,6 +66,12 @@ from khora.storage.backends.surrealdb.connection import SurrealDBConnection  # n
 from khora.storage.backends.surrealdb.relational import (  # noqa: E402
     SurrealDBRelationalAdapter,
     _documents_compile_context,
+)
+from khora.storage.coordinator import StorageCoordinator  # noqa: E402
+from tests.test_helpers.document_page_oracle import (  # noqa: E402
+    assert_page_compliant,
+    assert_walk_compliant,
+    assert_walk_matches_expected,
 )
 from tests.test_helpers.document_scan import (  # noqa: E402
     SUPERSET_SHAPES,
@@ -77,6 +84,12 @@ from tests.test_helpers.document_scan import (  # noqa: E402
     to_filter_ast,
     walk_scan,
     write_document,
+)
+from tests.test_helpers.document_scan_spy import (  # noqa: E402
+    PROBE_VALUE,
+    assert_split_honest,
+    force_residual,
+    method_sql_log,
 )
 
 pytestmark = pytest.mark.integration
@@ -522,6 +535,332 @@ async def test_pushdown_never_rejects_a_row_the_full_filter_would_keep(adapter, 
         assert oracle, f"{shape}: the oracle keeps no rows, so the superset assertion below is vacuous"
 
     assert oracle <= {d.id for d in step.documents}
+
+
+# --------------------------------------------------------------------------- #
+# Is the reported split HONEST?
+#
+# Everything above reads ``consumed_keys`` and believes it. These three drive the
+# same scans and check the report against the statements the adapter actually
+# issued. The seam is ``SurrealDBConnection.query(sql, bindings)``, wrapped by
+# name — and it is the one seam of the four where a single step can issue TWO
+# statements (the Q1 tie block and the Q2 strictly-older range), so the spy's
+# assertions are over the UNION of both. See
+# :mod:`tests.test_helpers.document_scan_spy` for why the assertion is on bound
+# VALUES rather than on field names.
+# --------------------------------------------------------------------------- #
+
+
+async def _seed_probe_corpus(adapter, namespace_id) -> tuple[int, ScanSeed]:
+    """Seed the corpus with the probe literal on half the rows.
+
+    Returns ``(matching_row_count, seed)`` — the count so a test can assert the
+    pushed leaf really narrowed rather than trusting the ``i % 2`` arithmetic, and
+    the seed so a resumed step can be positioned mid-tie.
+    """
+    seed = _seeded()
+    for i, (doc_id, created_at) in enumerate(seed.writes):
+        await write_document(
+            adapter,
+            namespace_id,
+            doc_id,
+            created_at,
+            source_type=PROBE_VALUE if i % 2 == 0 else "library",
+        )
+    return sum(1 for i in range(len(seed.writes)) if i % 2 == 0), seed
+
+
+async def test_a_pushed_leaf_really_reaches_the_statement(adapter, namespace) -> None:
+    """The perf-lie catch: a leaf reported as pushed must be bound in the statement.
+
+    ``consumed_keys == {"source_type"}`` is satisfied just as well by a compiler
+    that reported the leaf and emitted nothing for it — the caller's post-filter
+    would return the same rows, and the pushdown's entire purpose (a narrowed
+    window) would be silently gone. The probe literal appearing among the bound
+    params is what distinguishes the two.
+    """
+    matching, _seed = await _seed_probe_corpus(adapter, namespace.id)
+    ast = to_filter_ast({"source_type": {"$eq": PROBE_VALUE}})
+
+    with method_sql_log(adapter._conn, "query") as sql_log:  # noqa: SLF001 — the driver seam has no public accessor
+        step = await adapter.scan_documents(namespace.id, filter_ast=ast, scan_limit=10)
+
+    assert step.consumed_keys == frozenset({"source_type"})
+    assert_split_honest(sql_log, pushed_values=[PROBE_VALUE])
+    assert len(step.documents) == matching
+    assert {d.source_type for d in step.documents} == {PROBE_VALUE}
+
+
+async def test_a_pushed_leaf_reaches_BOTH_statements_of_a_resumed_step(adapter, namespace) -> None:
+    """The two-statement seam: the narrowing must ride on Q1 as well as on Q2.
+
+    Unique to this store. A resumed step splits the keyset bound across the tie
+    block (``created_at = $ts AND id < $id``) and the strictly-older range
+    (``created_at < $ts``), and ``_documents_where`` builds the shared narrowing
+    ONCE for both — so a regression that spliced the compiled fragment into only
+    one of them would leave the other statement returning rows the filter excludes.
+    ``consumed_keys`` cannot see that: it is reported once per step, from the one
+    compile. The cursor is seated mid-tie so both statements genuinely run, which
+    the two-statement assertion below pins.
+    """
+    _matching, seed = await _seed_probe_corpus(adapter, namespace.id)
+    ast = to_filter_ast({"source_type": {"$eq": PROBE_VALUE}})
+
+    full = await adapter.scan_documents(namespace.id, scan_limit=10)
+    cursor_doc = next(d for d in full.documents if d.id == seed.tied_ids[0])
+
+    with method_sql_log(adapter._conn, "query") as sql_log:  # noqa: SLF001
+        await adapter.scan_documents(
+            namespace.id,
+            filter_ast=ast,
+            after=(cursor_doc.created_at, cursor_doc.id),
+            scan_limit=10,
+        )
+
+    assert len(sql_log) == 2, "a mid-tie resume must issue both the Q1 tie block and the Q2 older range"
+    for statement in sql_log:
+        assert_split_honest([statement], pushed_values=[PROBE_VALUE])
+
+
+async def test_a_naturally_deferred_leaf_never_reaches_the_statement(adapter, namespace) -> None:
+    """The correctness-lie catch WITHOUT monkeypatching anything.
+
+    The stronger of the two residual tests, and the reason it exists separately: it
+    needs no ``force_residual``, so it tests the store as it actually ships. The
+    unpushable half is ``occurred_at`` here rather than ``created_at`` — this store
+    backs ``created_at`` with a real ``datetime`` field and pushes it — and
+    ``compile_surrealdb``'s all-or-nothing gate defers the whole ``$or`` rather than
+    pushing half a disjunction. So ``source_type``, which this store normally
+    pushes, must NOT be bound.
+
+    ``occurred_at`` reaches the compiler at all only because this is the storage
+    tier: the facade's ``_reject_non_enumerable_keys`` refuses it one level up. The
+    gate itself is what this store's ``_documents_compile_context`` docstring calls
+    the precondition for its ``"split"`` posture — relaxing it makes a deferred leaf
+    inside a ``$not`` compile to ``!true`` and match ZERO rows while reporting the
+    other leaf as pushed.
+    """
+    await _seed_probe_corpus(adapter, namespace.id)
+    ast = to_filter_ast(
+        {"$or": [{"occurred_at": {"$gte": "2026-01-01T00:00:00+00:00"}}, {"source_type": {"$eq": PROBE_VALUE}}]}
+    )
+
+    with method_sql_log(adapter._conn, "query") as sql_log:  # noqa: SLF001
+        step = await adapter.scan_documents(namespace.id, filter_ast=ast, scan_limit=10)
+
+    assert step.consumed_keys == frozenset()
+    assert_split_honest(sql_log, residual_values=[PROBE_VALUE])
+    # The whole disjunction deferred, so SurrealQL narrowed nothing: the raw window
+    # is the entire corpus and the post-filter owns every leaf.
+    assert len(step.documents) == 6
+
+
+async def test_a_residual_leaf_never_reaches_the_statement(adapter, namespace, monkeypatch) -> None:
+    """The correctness-lie catch, on the same filter with the leaf forced residual.
+
+    ``force_residual`` drops ``source_type`` from this store's ``field_mapping``,
+    which ``compile_surrealdb`` reads as the declared+pushable whitelist — so the
+    identical AST now defers. Two things must follow together, and asserting either
+    alone is weak: the report must say the leaf was NOT consumed, and the operand
+    must be absent from the statement. A disagreement in this direction means
+    SurrealQL enforced a leaf the split told the caller it owned — which on this
+    SCHEMAFULL table is the failure mode that looks most like a legitimate result.
+    """
+    await _seed_probe_corpus(adapter, namespace.id)
+    from khora.storage.backends.surrealdb import relational as surreal_module
+
+    force_residual(monkeypatch, surreal_module)
+    ast = to_filter_ast({"source_type": {"$eq": PROBE_VALUE}})
+
+    with method_sql_log(adapter._conn, "query") as sql_log:  # noqa: SLF001
+        step = await adapter.scan_documents(namespace.id, filter_ast=ast, scan_limit=10)
+
+    assert step.consumed_keys == frozenset()
+    assert_split_honest(sql_log, residual_values=[PROBE_VALUE])
+    # Deferred means "narrowed nothing here": the raw window is the whole corpus,
+    # which is the only correct compilation of a leaf this context cannot push.
+    assert len(step.documents) == 6
+
+
+# The split this store reports, per AST shape. The expected set is PINNED as well
+# as recomputed, because the recompute alone is satisfiable by two compilers that
+# agree on the wrong answer — including the degenerate "consumes nothing ever",
+# which would make every comparison ``frozenset() == frozenset()``. The spread is
+# what makes the parametrization non-vacuous, and the date shapes are where this
+# store differs from the two SQLite tiers: ``created_at`` is a real ``datetime``
+# field here, so it PUSHES, and ``occurred_at`` is the unbacked key instead.
+_SPLIT_SHAPES: dict[str, tuple[dict[str, Any], frozenset[str]]] = {
+    "pushed_whole": ({"source_type": {"$eq": PROBE_VALUE}}, frozenset({"source_type"})),
+    "date_key_pushes_here": (
+        {"source_type": {"$eq": PROBE_VALUE}, "created_at": {"$gte": "2026-01-01T00:00:00+00:00"}},
+        frozenset({"created_at", "source_type"}),
+    ),
+    "unbacked_key_is_the_residual": (
+        {"source_type": {"$eq": PROBE_VALUE}, "occurred_at": {"$gte": "2026-01-01T00:00:00+00:00"}},
+        frozenset({"source_type"}),
+    ),
+    "or_wholly_pushable": (
+        {"$or": [{"source_type": {"$eq": PROBE_VALUE}}, {"title": {"$eq": "doc-1"}}]},
+        frozenset({"source_type", "title"}),
+    ),
+    "or_wholly_deferred": (
+        {"$or": [{"occurred_at": {"$gte": "2026-01-01T00:00:00+00:00"}}, {"source_type": {"$eq": PROBE_VALUE}}]},
+        frozenset(),
+    ),
+    "metadata_path": ({"metadata.tier": {"$eq": "gold"}}, frozenset({"metadata.tier"})),
+}
+
+
+@pytest.mark.parametrize(("wire", "expected"), _SPLIT_SHAPES.values(), ids=_SPLIT_SHAPES.keys())
+async def test_reported_split_equals_a_fresh_compile_of_the_same_ast(adapter, namespace, wire, expected) -> None:
+    """``consumed_keys`` is the compiler's answer, verbatim — no store-side edits.
+
+    The scan is free to compile once and report; what it must not do is add or drop
+    keys on the way out (a store that unioned in the keys it *hoped* were pushed,
+    or that stripped one it found inconvenient, would still look plausible on every
+    row assertion here, because the caller re-checks the full AST regardless).
+    Recomputed with the SAME compiler and the SAME context the scan uses — through
+    ``_documents_where``, which is where this store does its compiling — so a
+    difference can only be the store's own editing.
+
+    This is also how ``created_at`` pushdown is covered. Its *value* is
+    deliberately out of the spy's scope (dialects bind datetimes and strings
+    differently, so a value probe there is a dialect quiz), but its membership in
+    the split is exactly what the second shape compares, and it is the answer the
+    two SQLite tiers give the other way round.
+    """
+    await _seed_probe_corpus(adapter, namespace.id)
+    ast = to_filter_ast(wire)
+
+    step = await adapter.scan_documents(namespace.id, filter_ast=ast, scan_limit=10)
+
+    assert step.consumed_keys == expected
+    assert step.consumed_keys == CompilerRegistry.get(*_COMPILER_KEY)(ast, _documents_compile_context()).consumed_keys
+
+
+# The page-level face of the same split. Pinned as well as recomputed: a recompute
+# alone is satisfied by two computations agreeing on the wrong answer, and by the
+# degenerate all-empty case that would make every comparison ``() == ()``. This
+# store's answer matches PostgreSQL's and inverts the two SQLite tiers' —
+# ``created_at`` is a real ``datetime`` field so it pushes and is NOT a residual,
+# while ``occurred_at`` (no ``document`` field behind it) is.
+#
+# ``occurred_at`` reaches the compiler at all only because this is the storage
+# tier: the facade's ``_reject_non_enumerable_keys`` refuses it one level up.
+#
+# Each shape carries the wire filter, the residual the coordinator must REPORT, and
+# an independent plain-Python matcher over the seeded rows giving the id set it must
+# RETURN. The matcher is hand-written on purpose: deriving it with ``compile_python``
+# would reproduce the predicate the coordinator itself applies, so the comparison
+# could not fail. ``seed_varied`` assigns ``source_type`` by WRITE index (report on
+# even, library on odd), which is what the matchers read.
+#
+# The date bound is ``WHOLE_SECOND`` so it BITES (the seed puts one row a second
+# below the tie instant, so ``$gte`` there keeps 5 of 6); a bound every row
+# satisfies would reduce completeness to "returns everything".
+_PAGE_SPLIT_SHAPES: dict[str, tuple[dict[str, Any], tuple[str, ...], Any]] = {
+    "no_residual": (
+        {"source_type": {"$eq": "report"}},
+        (),
+        lambda r: r["source_type"] == "report",
+    ),
+    "date_key_pushes_here": (
+        {"created_at": {"$gte": WHOLE_SECOND.isoformat()}},
+        (),
+        lambda r: r["created_at"] >= WHOLE_SECOND,
+    ),
+    "unbacked_key_residual": (
+        {"source_type": {"$eq": "report"}, "occurred_at": {"$gte": "2020-01-01T00:00:00+00:00"}},
+        ("occurred_at",),
+        # No ``document`` field backs ``occurred_at``, so a range compare on it is
+        # false for every row — but the compiler DEFERS the leaf, leaving the
+        # coordinator's post-filter to reject everything. Expect ZERO matches.
+        lambda _r: False,
+    ),
+    "or_wholly_deferred": (
+        {"$or": [{"occurred_at": {"$gte": "2020-01-01T00:00:00+00:00"}}, {"source_type": {"$eq": "report"}}]},
+        ("occurred_at", "source_type"),
+        lambda r: r["source_type"] == "report",
+    ),
+}
+
+
+def _seed_rows(seed: ScanSeed) -> list[dict[str, Any]]:
+    """The independent record of what :func:`seed_varied` writes, for the matchers.
+
+    Mirrors ``seed_varied``'s own by-write-index assignment. Kept as a separate
+    computation rather than read back from the store, so the completeness
+    expectation never comes from the implementation under test.
+    """
+    return [
+        {"id": doc_id, "created_at": created_at, "source_type": "report" if i % 2 == 0 else "library"}
+        for i, (doc_id, created_at) in enumerate(seed.writes)
+    ]
+
+
+@pytest.mark.parametrize(("wire", "expected", "matcher"), _PAGE_SPLIT_SHAPES.values(), ids=_PAGE_SPLIT_SHAPES.keys())
+async def test_page_reports_its_residual_and_returns_exactly_the_matches(
+    adapter, namespace, wire, expected, matcher
+) -> None:
+    """The coordinator's page-level residual report AND its completeness.
+
+    ``post_filtered_keys`` is ``sorted(filter_leaf_keys(ast) - consumed_keys)``
+    unioned across a page's steps: recomputed with the same compiler and context the
+    store scans with (so a difference can only be the coordinator's own arithmetic)
+    and pinned per shape (so an all-empty degeneration fails too).
+
+    The row-set assertion is the one that can fail for a reason nobody planned:
+    compared against a hand-written matcher over the seed, never against another
+    enumeration and never against ``compile_python``.
+    """
+    seed = _seeded()
+    await seed_varied(adapter, namespace.id, seed)
+    coordinator = StorageCoordinator(relational=adapter)
+    ast = to_filter_ast(wire)
+    rows = _seed_rows(seed)
+    expected_ids = [r["id"] for r in rows if matcher(r)]
+    assert len(expected_ids) < len(rows), "the shape must narrow, or completeness proves nothing"
+
+    page = await coordinator.scan_documents_page(namespace.id, filter_ast=ast, limit=100)
+
+    assert page.post_filtered_keys == expected
+    consumed = CompilerRegistry.get(*_COMPILER_KEY)(ast, _documents_compile_context()).consumed_keys
+    assert page.post_filtered_keys == tuple(sorted(filter_leaf_keys(ast) - consumed))
+    assert_walk_matches_expected(page, expected_ids)
+    assert_page_compliant(page, ast)
+
+
+async def test_a_multi_page_walk_loses_no_match_across_cursor_boundaries(adapter, namespace) -> None:
+    """Completeness across a REAL walk — and on this store that means TWO statements.
+
+    The single-page cases above never resume, so they never issue the Q1 tie block at
+    all. ``limit=2`` over a 5-row match set forces page boundaries inside the seed's
+    ``created_at`` tie block, which is exactly where this store's split keyset runs
+    both statements: Q1 (``created_at = $ts AND id < $id``) then Q2
+    (``created_at < $ts``). A row that falls between the two — the failure the
+    ``scan_documents`` docstring describes for a sub-microsecond stamp, or that a
+    ``RecordID``/``UUID`` mismatch would cause — is returned by neither and appears
+    nowhere. No per-returned-row assertion can see that; only this comparison can.
+    """
+    seed = _seeded()
+    await seed_varied(adapter, namespace.id, seed)
+    coordinator = StorageCoordinator(relational=adapter)
+    ast = to_filter_ast({"created_at": {"$gte": WHOLE_SECOND.isoformat()}})
+    expected_ids = [r["id"] for r in _seed_rows(seed) if r["created_at"] >= WHOLE_SECOND]
+    assert len(expected_ids) == 5, "5 of 6 rows sit at or above the tie instant"
+
+    walked = []
+    after = None
+    while True:
+        page = await coordinator.scan_documents_page(namespace.id, filter_ast=ast, limit=2, after=after)
+        walked.append(page)
+        assert len(walked) < 10, "walk did not terminate"
+        if page.exhausted:
+            break
+        after = (page.next_after.created_at, page.next_after.id)
+
+    assert len(walked) >= 3, "limit=2 over 5 matches must span multiple pages"
+    assert_walk_compliant(walked, ast, expected_ids=expected_ids)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/integration/storage/test_scan_documents_pg.py
+++ b/tests/integration/storage/test_scan_documents_pg.py
@@ -26,14 +26,33 @@ import pytest
 from khora.core.models import MemoryNamespace
 from khora.core.models.document import DocumentStatus
 from khora.db.session import run_migrations
-from khora.storage.backends.postgresql import PostgreSQLBackend
+from khora.filter import CompilerRegistry
+from khora.filter.execute import filter_leaf_keys
+
+# ``_documents_compile_context`` is private, and imported on purpose: the
+# split-equality test below must recompile with the *same* context the scan uses,
+# or it would prove a property of some other context.
+from khora.storage.backends.postgresql import PostgreSQLBackend, _documents_compile_context
+from khora.storage.coordinator import StorageCoordinator
+from tests.test_helpers.document_page_oracle import (
+    assert_page_compliant,
+    assert_walk_compliant,
+    assert_walk_matches_expected,
+)
 from tests.test_helpers.document_scan import (
+    WHOLE_SECOND,
     scan_seed,
     seed_documents,
     seed_varied,
     to_filter_ast,
     walk_scan,
     write_document,
+)
+from tests.test_helpers.document_scan_spy import (
+    PROBE_VALUE,
+    assert_split_honest,
+    force_residual,
+    sqlalchemy_sql_log,
 )
 
 DATABASE_URL = os.environ.get(
@@ -269,6 +288,10 @@ class TestScanDocumentsCursorPg:
         await seed_documents(backend, namespace.id, seed)
 
         step = await backend.scan_documents(namespace.id, scan_limit=10)
+        # Guard before the unpack: ``last_scanned`` is ``DocumentScanKey | None``, so
+        # a regression that returned no position would raise ``TypeError`` from the
+        # tuple unpack rather than failing this test's actual subject.
+        assert step.last_scanned is not None
         cursor_created_at, _ = step.last_scanned
 
         assert cursor_created_at.tzinfo is not None
@@ -375,6 +398,294 @@ class TestScanDocumentsSplitPg:
 
         last_match = step.documents[1]
         assert step.last_scanned != (last_match.created_at, last_match.id)
+
+
+@skip_no_pg
+class TestScanDocumentsSplitHonestyPg:
+    """Is the reported split HONEST? — checked at the driver boundary.
+
+    Every other class here reads ``consumed_keys`` and believes it, which cannot
+    distinguish an honest report from a *perf lie* (leaf reported as pushed, SQL
+    never saw it, the caller's post-filter quietly covering) or a *correctness lie*
+    (leaf reported as pushed and therefore, for any caller that trusted the report,
+    enforced nowhere). Neither is visible on the result surface while the
+    coordinator re-checks the full AST — hence a seam-level check.
+
+    The spy listens on ``before_cursor_execute`` on this backend's
+    ``AsyncEngine``, so the params recorded are the ones asyncpg receives.
+    Assertions are on bound VALUES, never on column names: ``created_at``, ``id``,
+    ``namespace_id`` and ``status`` appear in every statement's ORDER BY / keyset /
+    scope whether or not a filter leaf pushed. See
+    :mod:`tests.test_helpers.document_scan_spy`.
+    """
+
+    async def _seed_probe_corpus(self, backend: PostgreSQLBackend, namespace_id) -> int:
+        """Seed the corpus with the probe literal on half the rows; return that count."""
+        seed = scan_seed(6)
+        for i, (doc_id, created_at) in enumerate(seed.writes):
+            await write_document(
+                backend,
+                namespace_id,
+                doc_id,
+                created_at,
+                source_type=PROBE_VALUE if i % 2 == 0 else "library",
+            )
+        return sum(1 for i in range(len(seed.writes)) if i % 2 == 0)
+
+    async def test_a_pushed_leaf_really_reaches_the_statement(self, backend: PostgreSQLBackend, namespace) -> None:
+        """The perf-lie catch: a leaf reported as pushed must be bound in the SQL."""
+        matching = await self._seed_probe_corpus(backend, namespace.id)
+        ast = to_filter_ast({"source_type": {"$eq": PROBE_VALUE}})
+
+        with sqlalchemy_sql_log(backend._engine) as sql_log:  # noqa: SLF001 — no public driver-seam accessor
+            step = await backend.scan_documents(namespace.id, filter_ast=ast, scan_limit=10)
+
+        assert step.consumed_keys == frozenset({"source_type"})
+        assert_split_honest(sql_log, pushed_values=[PROBE_VALUE])
+        # And the pushdown narrowed for real, rather than leaving the work owed.
+        assert len(step.documents) == matching
+        assert {d.source_type for d in step.documents} == {PROBE_VALUE}
+
+    async def test_a_naturally_deferred_leaf_never_reaches_the_statement(
+        self, backend: PostgreSQLBackend, namespace
+    ) -> None:
+        """The correctness-lie catch WITHOUT monkeypatching anything.
+
+        The stronger of the two residual tests, and the reason it exists separately:
+        it needs no ``force_residual``, so it tests the store as it ships. The
+        unpushable half is ``occurred_at`` (no ``documents`` column backs it) rather
+        than ``created_at``, which is a real ``timestamptz`` here and pushes — and
+        ``compile_postgres``'s all-or-nothing gate defers the whole ``$or`` rather
+        than pushing half a disjunction. So ``source_type``, which this store
+        normally pushes, must NOT be bound.
+
+        ``occurred_at`` reaches the compiler at all only because this is the storage
+        tier: the facade's ``_reject_non_enumerable_keys`` refuses it one level up.
+        The gate is what this store's ``_documents_compile_context`` docstring names
+        as the reason the pushdown is superset-safe — a match-all placeholder left
+        inside a negation inverts into a match-nothing and wrongly EXCLUDES rows.
+        """
+        await self._seed_probe_corpus(backend, namespace.id)
+        ast = to_filter_ast(
+            {"$or": [{"occurred_at": {"$gte": "2026-01-01T00:00:00+00:00"}}, {"source_type": {"$eq": PROBE_VALUE}}]}
+        )
+
+        with sqlalchemy_sql_log(backend._engine) as sql_log:  # noqa: SLF001
+            step = await backend.scan_documents(namespace.id, filter_ast=ast, scan_limit=10)
+
+        assert step.consumed_keys == frozenset()
+        assert_split_honest(sql_log, residual_values=[PROBE_VALUE])
+        # The whole disjunction deferred, so SQL narrowed nothing: the raw window is
+        # the entire corpus and the post-filter owns every leaf.
+        assert len(step.documents) == 6
+
+    async def test_a_residual_leaf_never_reaches_the_statement(
+        self, backend: PostgreSQLBackend, namespace, monkeypatch
+    ) -> None:
+        """The correctness-lie catch, same filter with the leaf forced residual.
+
+        ``force_residual`` drops ``source_type`` from this store's
+        ``field_mapping``, which ``compile_postgres`` reads as the pushdown
+        whitelist, so the identical AST defers. Both halves must hold together: the
+        report says not-consumed, and the operand is absent from the statement.
+
+        This is also the only *uniform* forced-residual lever across the four
+        stores. A ``SchemaCapabilities`` override would not work here — the
+        postgres documents compiler never reads ``schema_capabilities`` at all.
+        """
+        await self._seed_probe_corpus(backend, namespace.id)
+        from khora.storage.backends import postgresql as pg_module
+
+        force_residual(monkeypatch, pg_module)
+        ast = to_filter_ast({"source_type": {"$eq": PROBE_VALUE}})
+
+        with sqlalchemy_sql_log(backend._engine) as sql_log:  # noqa: SLF001
+            step = await backend.scan_documents(namespace.id, filter_ast=ast, scan_limit=10)
+
+        assert step.consumed_keys == frozenset()
+        assert_split_honest(sql_log, residual_values=[PROBE_VALUE])
+        # Deferred means "narrowed nothing here": the raw window is the whole corpus.
+        assert len(step.documents) == 6
+
+    # The split this store reports, per AST shape. PINNED as well as recomputed:
+    # the recompute alone is satisfiable by two compilers agreeing on the wrong
+    # answer, including the degenerate "consumes nothing ever" that would make
+    # every comparison ``frozenset() == frozenset()``. The date shapes are where
+    # this store differs from the two SQLite tiers — ``created_at`` is a real
+    # ``timestamptz`` here so it PUSHES, and ``occurred_at`` is the unbacked key.
+    _SPLIT_SHAPES: dict[str, tuple[dict, frozenset[str]]] = {
+        "pushed_whole": ({"source_type": {"$eq": PROBE_VALUE}}, frozenset({"source_type"})),
+        "date_key_pushes_here": (
+            {"source_type": {"$eq": PROBE_VALUE}, "created_at": {"$gte": "2026-01-01T00:00:00+00:00"}},
+            frozenset({"created_at", "source_type"}),
+        ),
+        "unbacked_key_is_the_residual": (
+            {"source_type": {"$eq": PROBE_VALUE}, "occurred_at": {"$gte": "2026-01-01T00:00:00+00:00"}},
+            frozenset({"source_type"}),
+        ),
+        "or_wholly_pushable": (
+            {"$or": [{"source_type": {"$eq": PROBE_VALUE}}, {"title": {"$eq": "doc-1"}}]},
+            frozenset({"source_type", "title"}),
+        ),
+        "or_wholly_deferred": (
+            {"$or": [{"occurred_at": {"$gte": "2026-01-01T00:00:00+00:00"}}, {"source_type": {"$eq": PROBE_VALUE}}]},
+            frozenset(),
+        ),
+        "metadata_path": ({"metadata.tier": {"$eq": "gold"}}, frozenset({"metadata.tier"})),
+    }
+
+    @pytest.mark.parametrize(("wire", "expected"), _SPLIT_SHAPES.values(), ids=_SPLIT_SHAPES.keys())
+    async def test_reported_split_equals_a_fresh_compile_of_the_same_ast(
+        self, backend: PostgreSQLBackend, namespace, wire, expected
+    ) -> None:
+        """``consumed_keys`` is the compiler's answer, verbatim — no store-side edits.
+
+        The scan may compile once and report; what it must not do is add or drop
+        keys on the way out. A store that unioned in the keys it *hoped* were
+        pushed, or stripped one it found inconvenient, still looks plausible on
+        every row assertion here, because the caller re-checks the full AST
+        regardless. Recomputed with the SAME compiler and context the scan uses.
+
+        This is also how ``created_at`` pushdown is covered: its *value* is out of
+        the spy's scope (asyncpg binds a ``datetime`` object where the SQLite tiers
+        bind their own string serializations, so a value probe is a dialect quiz),
+        but its membership in the split is exactly what the second shape compares —
+        and it is the answer the embedded siblings give the other way round.
+        """
+        await self._seed_probe_corpus(backend, namespace.id)
+        ast = to_filter_ast(wire)
+
+        step = await backend.scan_documents(namespace.id, filter_ast=ast, scan_limit=10)
+
+        assert step.consumed_keys == expected
+        compiler = CompilerRegistry.get("relational.postgresql", "documents")
+        assert step.consumed_keys == compiler(ast, _documents_compile_context()).consumed_keys
+
+
+@skip_no_pg
+class TestScanDocumentsPageSplitPg:
+    """The page-level split: ``DocumentPage.post_filtered_keys`` over a live server.
+
+    The coordinator derives it as ``sorted(filter_leaf_keys(ast) - consumed_keys)``
+    unioned across the steps of a page, and this store's answer is the *opposite* of
+    the embedded tiers' for the shape that matters: ``created_at`` pushes here, so
+    it is NOT a residual, while ``occurred_at`` — which no ``documents`` column
+    backs — is. The embedded sibling
+    (``tests/unit/test_list_documents_enumeration.py``) asserts the mirror image on
+    the same helper, which is what makes this leg worth its own run rather than a
+    transcription.
+
+    ``occurred_at`` reaches the compiler at all only because this is the storage
+    tier: the facade's ``_reject_non_enumerable_keys`` refuses it one level up.
+    """
+
+    @pytest.fixture
+    async def seeded(self, backend: PostgreSQLBackend, namespace):
+        """A coordinator over a varied six-row namespace.
+
+        Returns ``(coordinator, ns_id, rows)``. ``rows`` is the seed as plain dicts
+        — the INDEPENDENT record of what was written, which the completeness
+        matchers evaluate against. Nothing here reads it back out of the store.
+        """
+        seed = scan_seed(6)
+        rows: list[dict] = []
+        for i, (doc_id, created_at) in enumerate(seed.writes):
+            fields = {"title": f"doc-{i}", "source_type": "report" if i % 2 == 0 else "library"}
+            await write_document(backend, namespace.id, doc_id, created_at, **fields)
+            rows.append({"id": doc_id, "created_at": created_at, **fields})
+        return StorageCoordinator(relational=backend), namespace.id, rows
+
+    # Wire filter, the residual the coordinator must REPORT, and an independent
+    # plain-Python matcher over the seeded rows giving the id set it must RETURN.
+    # The matcher is hand-written on purpose: deriving it with ``compile_python``
+    # would reproduce the predicate the coordinator itself applies, so the
+    # comparison could not fail. The residual is pinned as well as recomputed —
+    # a recompute alone is satisfied by two computations agreeing on the wrong
+    # answer, including the all-empty case that makes every comparison ``() == ()``.
+    #
+    # The date bound is ``WHOLE_SECOND`` so it BITES (the seed puts one row a second
+    # below the tie instant, so ``$gte`` there keeps 5 of 6); a bound every row
+    # satisfies would reduce completeness to "returns everything".
+    _PAGE_SPLIT_SHAPES: dict[str, tuple[dict, tuple[str, ...], object]] = {
+        "no_residual": (
+            {"source_type": {"$eq": "report"}},
+            (),
+            lambda r: r["source_type"] == "report",
+        ),
+        "date_key_pushes_here": (
+            {"created_at": {"$gte": WHOLE_SECOND.isoformat()}},
+            (),
+            lambda r: r["created_at"] >= WHOLE_SECOND,
+        ),
+        "unbacked_key_residual": (
+            {"source_type": {"$eq": "report"}, "occurred_at": {"$gte": "2020-01-01T00:00:00+00:00"}},
+            ("occurred_at",),
+            # ``occurred_at`` is absent on every documents row, so a range compare on
+            # it is false for all — but the compiler DEFERS it, leaving the
+            # coordinator's post-filter to reject everything. Expect ZERO matches,
+            # asserted below as a deliberate exception to the narrowing precondition.
+            lambda _r: False,
+        ),
+        "or_wholly_deferred": (
+            {"$or": [{"occurred_at": {"$gte": "2020-01-01T00:00:00+00:00"}}, {"source_type": {"$eq": "report"}}]},
+            ("occurred_at", "source_type"),
+            lambda r: r["source_type"] == "report",
+        ),
+    }
+
+    @pytest.mark.parametrize(
+        ("wire", "expected", "matcher"), _PAGE_SPLIT_SHAPES.values(), ids=_PAGE_SPLIT_SHAPES.keys()
+    )
+    async def test_page_reports_its_residual_and_returns_exactly_the_matches(
+        self, seeded, wire, expected, matcher
+    ) -> None:
+        coordinator, namespace_id, rows = seeded
+        ast = to_filter_ast(wire)
+        expected_ids = [r["id"] for r in rows if matcher(r)]
+        assert len(expected_ids) < len(rows), "the shape must narrow, or completeness proves nothing"
+
+        page = await coordinator.scan_documents_page(namespace_id, filter_ast=ast, limit=100)
+
+        # 1. The reported residual, pinned and recomputed against the compiler.
+        assert page.post_filtered_keys == expected
+        compiler = CompilerRegistry.get("relational.postgresql", "documents")
+        consumed = compiler(ast, _documents_compile_context()).consumed_keys
+        assert page.post_filtered_keys == tuple(sorted(filter_leaf_keys(ast) - consumed))
+        # 2. COMPLETENESS — the assertion that can actually fail. Against the
+        #    hand-written matcher over the seed, never against another enumeration
+        #    call and never against ``compile_python`` (the coordinator's own).
+        assert_walk_matches_expected(page, expected_ids)
+        # 3. Order + the walk-control pair. Soundness rides along and is
+        #    tautological here by construction; see the helper's docstring.
+        assert_page_compliant(page, ast)
+
+    async def test_a_multi_page_walk_loses_no_match_across_cursor_boundaries(self, seeded) -> None:
+        """Completeness across a REAL walk, boundaries landing inside a tie block.
+
+        The single-page cases above cannot see a cursor bug: one page never resumes.
+        ``limit=2`` over a 5-row match set forces three pages whose boundaries fall
+        inside the seed's ``created_at`` tie block — where a cursor that mis-binds
+        its ``timestamptz`` or its ``uuid`` skips a tie-mate. That row simply never
+        appears, so no per-returned-row assertion can notice it; only the comparison
+        against the independently-known match set does.
+        """
+        coordinator, namespace_id, rows = seeded
+        ast = to_filter_ast({"created_at": {"$gte": WHOLE_SECOND.isoformat()}})
+        expected_ids = [r["id"] for r in rows if r["created_at"] >= WHOLE_SECOND]
+        assert len(expected_ids) == 5, "5 of 6 rows sit at or above the tie instant"
+
+        walked = []
+        after = None
+        while True:
+            page = await coordinator.scan_documents_page(namespace_id, filter_ast=ast, limit=2, after=after)
+            walked.append(page)
+            assert len(walked) < 10, "walk did not terminate"
+            if page.exhausted:
+                break
+            after = (page.next_after.created_at, page.next_after.id)
+
+        assert len(walked) >= 3, "limit=2 over 5 matches must span multiple pages"
+        assert_walk_compliant(walked, ast, expected_ids=expected_ids)
 
 
 @skip_no_pg

--- a/tests/integration/test_list_documents_enumeration_facade.py
+++ b/tests/integration/test_list_documents_enumeration_facade.py
@@ -31,7 +31,9 @@ except ImportError:
 
 from khora.core.models import Document
 from khora.core.models.document import DocumentPage, DocumentStatus
-from khora.filter import RecallFilterValidationError
+from khora.filter import RecallFilter, RecallFilterValidationError
+from khora.filter.ast import parse_to_ast
+from tests.test_helpers.document_page_oracle import assert_page_compliant, assert_walk_compliant
 
 pytestmark = [
     pytest.mark.integration,
@@ -39,6 +41,11 @@ pytestmark = [
 ]
 
 _BASE = datetime(2026, 1, 15, 9, 0, 0, tzinfo=UTC)
+
+
+def _ast(wire: dict):
+    """The canonical AST for a wire filter — what the oracle recompiles from."""
+    return parse_to_ast(RecallFilter.model_validate(wire))
 
 
 def _config(tmp_path: Path):
@@ -95,11 +102,13 @@ async def test_basic_walk_exactly_once_and_sequence_compat(tmp_path: Path) -> No
         expected = _expected_order(seeded)
 
         collected: list[UUID] = []
+        walked: list[DocumentPage] = []
         pages = 0
         after = None
         while True:
             page = await kb.list_documents(namespace=ns.namespace_id, limit=3, after=after)
             pages += 1
+            walked.append(page)
             assert isinstance(page, DocumentPage)
             assert len(page) <= 3
             collected.extend(d.id for d in page)  # Sequence iteration
@@ -113,6 +122,15 @@ async def test_basic_walk_exactly_once_and_sequence_compat(tmp_path: Path) -> No
         assert pages >= 3, "limit=3 over 7 rows must span multiple pages"
         assert collected == expected, "walk must be ordered and exactly-once"
         assert len(set(collected)) == len(collected), "no document returned twice"
+        # The reusable page-level oracle over the same walk: per-page total order,
+        # the next_after/exhausted pair, exactly-once, one descending run across the
+        # concatenation, and — via ``expected_ids`` — COMPLETENESS against the seed.
+        # That last one is the leg that matters: a dropped row never reaches the
+        # surface, so nothing else here (nor any per-returned-row predicate) can see
+        # it. The point of wiring it in is that the SAME helper is what the
+        # property-based walk fuzzer asserts with, so a divergence surfaces now.
+        flat = assert_walk_compliant(walked, expected_ids=expected)
+        assert [d.id for d in flat] == expected
 
 
 async def test_resume_from_returned_document(tmp_path: Path) -> None:
@@ -203,10 +221,15 @@ async def test_filter_narrows_and_occurred_at_rejected(tmp_path: Path) -> None:
         # Compare ordered lists, not sets: a post-filter ordering regression must fail.
         assert [d.id for d in page] == _expected_order([d for d in seeded if d.source_type == "report"])
         assert isinstance(page.post_filtered_keys, tuple)
+        # The oracle recompiles the filter and re-checks it against the RETURNED
+        # rows, so it fails on a returned row the filter excludes — independently of
+        # what ``post_filtered_keys`` claims about who enforced which leaf.
+        assert_page_compliant(page, _ast({"source_type": "report"}))
 
         # Metadata filter — exercises the in-memory post-filter path.
         gold = await kb.list_documents(namespace=ns.namespace_id, filter={"metadata.tier": "gold"}, limit=100)
         assert [d.id for d in gold] == _expected_order([d for d in seeded if d.metadata.get("tier") == "gold"])
+        assert_page_compliant(gold, _ast({"metadata.tier": "gold"}))
 
         # occurred_at is not enumerable on a document row.
         with pytest.raises(RecallFilterValidationError) as exc_info:
@@ -248,6 +271,7 @@ async def test_multistep_page_fill_and_short_page_not_exhausted(tmp_path: Path) 
         # the scan-bound-consumed short-page branch. Both complete exactly-once.
         for bound in (1000, 3):
             collected: list[UUID] = []
+            walked: list[DocumentPage] = []
             after = None
             exhausted = False
             steps = 0
@@ -257,6 +281,7 @@ async def test_multistep_page_fill_and_short_page_not_exhausted(tmp_path: Path) 
                 pg = await kb.storage.scan_documents_page(
                     row_ns, filter_ast=ast, limit=3, scan_bound=bound, after=after
                 )
+                walked.append(pg)
                 assert len(pg) <= 3
                 collected.extend(d.id for d in pg)
                 exhausted = pg.exhausted
@@ -265,6 +290,14 @@ async def test_multistep_page_fill_and_short_page_not_exhausted(tmp_path: Path) 
                     after = (pg.next_after.created_at, pg.next_after.id)
             assert collected == match_order, f"bound={bound}"
             assert len(set(collected)) == len(collected), f"bound={bound}"
+            # Same oracle, on the walk that actually exercises the residual: this
+            # filter is post-filtered rather than pushed, and the short-page branch
+            # (bound=3) is where the next_after/exhausted pair is easiest to get
+            # wrong. ``expected_ids`` is the load-bearing argument — it asserts the
+            # walk lost none of the 5 matches while re-stepping past rejected rows,
+            # which is precisely what a mis-sized intra-page step would break.
+            flat = assert_walk_compliant(walked, ast, expected_ids=match_order)
+            assert [d.id for d in flat] == match_order, f"bound={bound}"
 
         # scan_bound must be positive (guards the next_after/exhausted invariant).
         with pytest.raises(ValueError, match="scan_bound"):
@@ -287,18 +320,27 @@ async def test_walk_resumes_across_a_created_at_tie(tmp_path: Path) -> None:
         expected = _expected_order(seeded)
 
         collected: list[UUID] = []
+        walked: list[DocumentPage] = []
         after = None
         pages = 0
         while True:
             pages += 1
             assert pages < 20
             page = await kb.list_documents(namespace=ns.namespace_id, limit=2, after=after)  # boundary inside tie
+            walked.append(page)
             collected.extend(d.id for d in page)
             if page.exhausted:
                 break
             after = page.next_after
         assert collected == expected
         assert len(set(collected)) == len(collected)
+        # Both directions of the tie hazard, which is why this walk gets both legs:
+        # a boundary that RE-SERVED a tie-mate fails the strict total-order check and
+        # the exactly-once check, and one that SKIPPED a tie-mate fails only
+        # ``expected_ids`` — nothing about a page whose rows are all present and
+        # ordered reveals the row that is missing from it.
+        flat = assert_walk_compliant(walked, expected_ids=expected)
+        assert [d.id for d in flat] == expected
 
 
 async def test_empty_namespace_and_resume_past_end(tmp_path: Path) -> None:

--- a/tests/test_helpers/document_page_oracle.py
+++ b/tests/test_helpers/document_page_oracle.py
@@ -200,10 +200,17 @@ def assert_walk_compliant(
 ) -> list[Any]:
     """Assert a whole walk: every page compliant, exactly-once, one total order.
 
-    Checks each page individually, then the two properties that only exist across
-    pages — no document appears twice, and the concatenation is a single
-    descending run (a per-page order that resets at each boundary passes
-    :func:`assert_page_compliant` on every page and is still a broken walk).
+    Checks each page individually, then the properties that only exist across
+    pages: no document appears twice; the concatenation is a single descending run
+    (a per-page order that resets at each boundary passes
+    :func:`assert_page_compliant` on every page and is still a broken walk); and the
+    walk terminated correctly — nothing follows a page that reported
+    ``exhausted=True``, and (when any pages were supplied) the last page *is*
+    exhausted. That last rule is what makes the completeness leg meaningful: a walk
+    stopped early is a prefix of the match set, so judging it for completeness would
+    pass on rows that were simply never fetched. The per-page
+    ``next_after is None`` iff ``exhausted`` invariant is about a single page and
+    cannot see either termination property.
 
     ``expected_ids`` adds the completeness leg via
     :func:`assert_walk_matches_expected`. **Pass it whenever the test knows its
@@ -216,13 +223,23 @@ def assert_walk_compliant(
     """
     seen: set[UUID] = set()
     flat: list[Any] = []
+    saw_any = False
+    finished = False
     for page in pages:
+        assert not finished, "pages after exhaustion: a page followed one that already reported exhausted=True"
+        saw_any = True
         assert_page_compliant(page, filter_ast, backend_target=backend_target)
         for doc in page:
             doc_id = _as_uuid(doc.id)
             assert doc_id not in seen, f"exactly-once violated: {doc_id} repeated"
             seen.add(doc_id)
             flat.append(doc)
+        finished = page.exhausted
+    if saw_any:
+        assert finished, (
+            "walk did not finish: the last page reported exhausted=False — a truncated walk "
+            "proves nothing about completeness, since a missing match may simply be on a page never fetched"
+        )
     assert_total_order(flat)
     if expected_ids is not None:
         assert_walk_matches_expected(flat, expected_ids)

--- a/tests/test_helpers/document_page_oracle.py
+++ b/tests/test_helpers/document_page_oracle.py
@@ -1,0 +1,238 @@
+"""Page-level oracle for the document enumeration — the RESULT-SURFACE checks.
+
+The enumeration contract has four invariants a caller can actually be hurt by,
+and all four are properties of the documents a walk *returns*:
+
+* **INV-E, total order.** Every page, and the concatenation of every walk, is
+  strictly descending in ``(created_at, id)``. Strictly, not merely
+  non-ascending: a repeat is an exactly-once violation wearing an ordering
+  costume, so the same comparison catches both.
+* **Completeness.** The walk returns EVERY document the filter matches — see
+  :func:`assert_walk_matches_expected`, and read the warning on
+  :func:`assert_documents_satisfy` before relying on the soundness leg alone.
+* **Soundness: the full filter holds on every returned row.** Weaker than it
+  looks on the coordinator path; see below.
+* **``next_after is None`` iff ``exhausted``.** The pair a walking caller loops
+  on; either half alone is unactionable.
+
+**Soundness and completeness are not interchangeable, and only one of them is
+independent evidence here.** The coordinator applies
+``compile_python(filter_ast, build_compile_context("documents",
+on_unsupported="split")).predicate`` to every row before returning it
+(``storage/coordinator.py``, in ``scan_documents_page``). This module compiles the
+*same* predicate from the *same* AST, so on any page produced by the coordinator or
+the facade, :func:`assert_documents_satisfy` passes **by construction** — it is a
+cheap regression guard against the post-filter being removed or given the wrong
+context, not proof that the page is right. Worse, the failure it *cannot* see is
+the dangerous one: a silently DROPPED row never reaches the surface, so no
+per-returned-row predicate can notice it. That is what
+:func:`assert_walk_matches_expected` is for, and why a walk test that only asserts
+soundness is not testing the thing that hurts. (On a raw ``scan_documents`` step,
+where no post-filter has run, the soundness leg is genuinely independent — but a
+step's window is a deliberate superset of the matches, so the assertion that
+belongs there is the superset property, not this one.)
+
+**Why nothing here reads the report.** The tempting shortcut is to read
+``DocumentPage.post_filtered_keys`` and trust that the named leaves were enforced.
+That is exactly the mistake this tier guards against: ``post_filtered_keys`` is self-reported
+provenance, so a backend that lies about its split produces a *consistent* report
+over a *wrong* row set. The split's honesty is checked at the execution seam
+instead — :mod:`tests.test_helpers.document_scan_spy`.
+
+Engine- and backend-agnostic on purpose, mirroring
+:mod:`khora.filter.provenance`: it takes anything sequence-shaped carrying
+``Document``-shaped rows, compiles its own predicate, and knows nothing about
+which store produced the page. That is what lets the same four assertions serve
+the four per-backend scan modules, the facade walk, and the property-based walk fuzzer.
+
+``backend_target`` is a seam, not a knob: the default ``"documents"`` is the
+target every documents-tier compile context declares, and ``compile_python``
+reads ``field_mapping`` only for system keys (metadata always resolves through
+``record.metadata``), which every documents context identity-maps. So the
+identity context built here is compile-equivalent to any of the four backends'
+own ``_documents_compile_context()`` for this compiler — the parameter exists for
+a future non-``documents`` surface, not to be varied per store.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from khora.filter.compilers.python import compile_python
+from khora.filter.execute import build_compile_context
+from tests.test_helpers.document_scan import as_utc
+
+
+def _as_uuid(value: Any) -> UUID:
+    """Normalize a document id to :class:`~uuid.UUID` for comparison.
+
+    Both normalizations here exist because a mixed compare *raises* instead of
+    failing an assertion, which surfaces as an error in whatever test happens to
+    be running rather than as an ordering failure.
+
+    ``UUID`` passes through. A ``str`` is parsed — comparing as UUIDs rather than
+    as strings is the semantically correct choice, not a convenience: every store
+    orders on a uuid/record-id column, and the dashed string form sorts
+    differently from the 16-byte value (``-`` sorts below every hex digit, which is
+    the whole hazard the id-ladder seed in :mod:`tests.test_helpers.document_scan`
+    exists to expose). A SurrealDB ``RecordID`` carries the uuid on ``.id``, so it
+    recurses one level. Anything else fails loudly rather than being coerced.
+    """
+    if isinstance(value, UUID):
+        return value
+    if isinstance(value, str):
+        return UUID(value)
+    inner = getattr(value, "id", None)
+    if inner is not None and inner is not value:
+        return _as_uuid(inner)
+    raise AssertionError(
+        f"document id {value!r} ({type(value).__name__}) is not a UUID and cannot be normalized to one"
+    )
+
+
+def _order_key(doc: Any) -> tuple[datetime, UUID]:
+    """The enumeration sort key: ``(created_at, id)``, both operands normalized.
+
+    ``as_utc`` is load-bearing rather than tidy — PostgreSQL reads an aware
+    ``created_at`` off ``timestamptz`` while the embedded tiers read theirs back
+    naive. :func:`_as_uuid` does the same job for the id half. Normalizing keeps
+    one oracle usable on every store.
+    """
+    return (as_utc(doc.created_at), _as_uuid(doc.id))
+
+
+def assert_total_order(docs: Sequence[Any]) -> None:
+    """Assert ``docs`` strictly descends in ``(created_at, id)`` (INV-E).
+
+    STRICTLY descending, so this also catches a repeated document: a duplicate
+    compares equal on both key halves and fails here even before an exactly-once
+    check runs. Pass a single page's rows, or a whole walk's concatenation.
+    """
+    for a, b in zip(docs, docs[1:], strict=False):
+        assert _order_key(a) > _order_key(b), (
+            f"INV-E violated at {a.id} -> {b.id}: {_order_key(a)} does not sort strictly above {_order_key(b)}"
+        )
+
+
+def assert_documents_satisfy(docs: Iterable[Any], filter_ast: Any, *, backend_target: str = "documents") -> None:
+    """Assert every returned document satisfies the FULL filter AST (SOUNDNESS only).
+
+    **Not independent of the coordinator's post-filter, and it cannot catch a
+    dropped row.** ``scan_documents_page`` applies this exact predicate — same
+    compiler, same context — to every row before returning it, so on a coordinator
+    or facade page this passes by construction. Keep it as a cheap guard against the
+    post-filter being deleted or handed the wrong context; do NOT read a green run
+    as evidence the page is correct. Pair it with
+    :func:`assert_walk_matches_expected`, which checks the half that can actually
+    fail silently: a document the filter matches that the walk never returned.
+
+    Genuinely independent in one place only — a raw ``scan_documents`` step, which
+    has had no post-filter applied. Even there the assertion to prefer is the
+    superset property (the window must be a superset of the matches), since a
+    step's window is deliberately wider than the match set.
+    """
+    predicate = compile_python(filter_ast, build_compile_context(backend_target, on_unsupported="split")).predicate
+    for doc in docs:
+        assert predicate(doc), f"returned doc {doc.id} does not satisfy the full filter"
+
+
+def assert_walk_matches_expected(docs: Iterable[Any], expected_ids: Iterable[Any]) -> None:
+    """Assert a walk returned EXACTLY the expected document ids (COMPLETENESS).
+
+    The half of the contract no per-returned-row assertion can reach. A backend (or
+    a keyset cursor) that silently skips a matching row produces a page on which
+    every returned document satisfies the filter, is correctly ordered, and reports
+    a consistent split — and is missing data the caller will never learn about.
+    Only a comparison against an independently-known expectation catches it.
+
+    ``expected_ids`` must come from the test's own knowledge of its seed corpus —
+    hand-listed, or derived from the seeded ``Document`` objects — and **not** from
+    another enumeration call, which would compare the implementation against
+    itself. Ids are normalized through :func:`_as_uuid` on both sides, so a caller
+    may pass ``Document`` objects' ids in whatever shape its store hands back.
+
+    Set comparison, deliberately: ordering is :func:`assert_total_order`'s job and
+    exactly-once is :func:`assert_walk_compliant`'s, so a failure here reports the
+    missing and extra ids rather than a diff of two long lists.
+    """
+    got = {_as_uuid(doc.id) if hasattr(doc, "id") else _as_uuid(doc) for doc in docs}
+    want = {_as_uuid(doc.id) if hasattr(doc, "id") else _as_uuid(doc) for doc in expected_ids}
+    assert got == want, (
+        f"walk did not return exactly the matching set — "
+        f"MISSING (silently dropped): {sorted(want - got)}; UNEXPECTED (wrongly kept): {sorted(got - want)}"
+    )
+
+
+def assert_page_compliant(page: Any, filter_ast: Any = None, *, backend_target: str = "documents") -> None:
+    """Assert one ``DocumentPage`` is order-correct, sound and walk-actionable.
+
+    ``filter_ast`` is optional so the same helper serves an unfiltered walk; when
+    given, every row on the page must satisfy the whole AST — with the soundness
+    caveat on :func:`assert_documents_satisfy`, which applies in full here. This
+    helper deliberately does NOT check completeness: a single page is *expected* to
+    be a prefix of the match set (it is bounded by ``limit``), so the only place
+    completeness is well-defined is across a finished walk. Use
+    :func:`assert_walk_compliant` with ``expected_ids`` for that.
+
+    The final assertion is the walk-control invariant ``next_after is None``
+    **iff** ``exhausted`` — a page that reports neither a resume position nor
+    exhaustion is the one pair a walking caller cannot act on, and a page that
+    reports both is a walk that never terminates.
+    """
+    docs = list(page)
+    assert_total_order(docs)
+    if filter_ast is not None:
+        assert_documents_satisfy(docs, filter_ast, backend_target=backend_target)
+    assert (page.next_after is None) == page.exhausted, (
+        f"next_after/exhausted disagree: next_after={page.next_after!r}, exhausted={page.exhausted!r}"
+    )
+
+
+def assert_walk_compliant(
+    pages: Iterable[Any],
+    filter_ast: Any = None,
+    *,
+    backend_target: str = "documents",
+    expected_ids: Iterable[Any] | None = None,
+) -> list[Any]:
+    """Assert a whole walk: every page compliant, exactly-once, one total order.
+
+    Checks each page individually, then the two properties that only exist across
+    pages — no document appears twice, and the concatenation is a single
+    descending run (a per-page order that resets at each boundary passes
+    :func:`assert_page_compliant` on every page and is still a broken walk).
+
+    ``expected_ids`` adds the completeness leg via
+    :func:`assert_walk_matches_expected`. **Pass it whenever the test knows its
+    corpus** — without it this call proves only that what came back was ordered,
+    unique and (per the caveat on :func:`assert_documents_satisfy`) tautologically
+    filter-satisfying, none of which can fail when a matching row is dropped.
+
+    Returns the flattened documents in walk order, so a caller can go on to
+    compare the ordered list against its own corpus expectation.
+    """
+    seen: set[UUID] = set()
+    flat: list[Any] = []
+    for page in pages:
+        assert_page_compliant(page, filter_ast, backend_target=backend_target)
+        for doc in page:
+            doc_id = _as_uuid(doc.id)
+            assert doc_id not in seen, f"exactly-once violated: {doc_id} repeated"
+            seen.add(doc_id)
+            flat.append(doc)
+    assert_total_order(flat)
+    if expected_ids is not None:
+        assert_walk_matches_expected(flat, expected_ids)
+    return flat
+
+
+__all__ = [
+    "assert_documents_satisfy",
+    "assert_page_compliant",
+    "assert_total_order",
+    "assert_walk_compliant",
+    "assert_walk_matches_expected",
+]

--- a/tests/test_helpers/document_scan_spy.py
+++ b/tests/test_helpers/document_scan_spy.py
@@ -1,0 +1,277 @@
+"""Execution-seam spy for the document scans — is the reported split HONEST?
+
+``DocumentScanStep.consumed_keys`` is a self-report. Every existing scan test
+reads it, and none of them can tell the difference between the three things it
+might mean:
+
+* **honest** — the leaf really is in the statement the driver ran;
+* **a perf lie** — the compiler claims a leaf was pushed, SQL never saw it, and
+  the caller's post-filter silently covers for it. Correct rows, and the whole
+  point of pushdown (a narrowed window, fewer rows fetched) quietly gone. No
+  row-level assertion anywhere can see this.
+* **a correctness lie** — the compiler claims a leaf was pushed, and the caller
+  *believes* it: a caller that treated ``consumed_keys`` as permission to skip
+  those leaves would then enforce them nowhere at all. Today's coordinator always
+  re-checks the full AST, so this shows up as nothing at all on the result
+  surface — which is exactly why it needs a seam-level check rather than a
+  row-level one.
+
+So this module captures at the real driver boundary, per tier, and the tests
+assert against the values actually bound. Four stores, three seams:
+
+* **PostgreSQL** and **sqlite_lance** both hold a SQLAlchemy ``AsyncEngine`` at
+  ``store._engine`` — :func:`sqlalchemy_sql_log` attaches a
+  ``before_cursor_execute`` listener to its ``sync_engine`` (the same reason
+  ``sqlite_lance/relational.py``'s pragma listener attaches there) and detaches on
+  exit.
+* **raw SQLite** issues ``store._conn.execute(sql, params)`` on an aiosqlite
+  connection, and **SurrealDB** issues ``store._conn.query(sql, bindings)``:
+  :func:`method_sql_log` wraps either by name.
+
+**Why the assertion is value-based and not column-name-based.** Grepping the
+statement text for ``source_type`` proves nothing: ``created_at``, ``id``,
+``namespace_id`` and ``status`` appear in the ORDER BY, the keyset predicate and
+the namespace scope of *every* statement whether or not a filter leaf pushed, and
+a deferred leaf's column name can still show up in a ``SELECT *`` expansion or a
+comment. The bound *operand* is the discriminating evidence: a pushed leaf's
+literal reaches the driver, and a deferred one's cannot.
+
+Use a string-valued system key as the probe (``source_type`` is the natural one —
+every documents context declares it, and all four compilers push it) with a
+globally distinctive literal, :data:`PROBE_VALUE`, so a match cannot be some other
+column's coincidental value. Do **not** probe a date key by value: PostgreSQL
+binds a ``datetime`` object, the SQLite tiers bind their own string
+serializations, and SurrealDB binds a ``datetime`` again, so "is this value in the
+params" is a dialect quiz rather than a split check. Date-key pushdown is covered
+by the compile-split recompute instead (``step.consumed_keys`` against a fresh
+compile with the same compiler and context).
+
+Not to be confused with :mod:`tests.test_helpers.filter_spy`, which watches a
+different seam for a different question: it captures the ``filter_ast`` crossing an
+engine/compiler boundary and compares its ``canonical_hash``, proving the validated
+AST was *threaded* unchanged. This module sits one level lower — after compilation,
+at the driver — and asks whether the compiled predicate's operands were actually
+*bound*. A path can thread the AST faithfully and still push none of it.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from typing import Any
+
+from sqlalchemy import event
+
+# The probe literal. Deliberately unlike any real ``source_type`` and unlike any
+# other value the seed corpus writes, so finding it among the bound params can
+# only mean the probe leaf was pushed.
+PROBE_VALUE = "ZZZ_e3_marker"
+
+# One captured statement: the SQL text and whatever parameter container the seam
+# handed the driver (positional sequence, bind dict, or None).
+SqlLog = list[tuple[str, Any]]
+
+
+@contextmanager
+def sqlalchemy_sql_log(engine: Any) -> Iterator[SqlLog]:
+    """Record ``(statement, parameters)`` for every cursor execution on ``engine``.
+
+    ``before_cursor_execute`` fires after the dialect has compiled and bound the
+    statement, so the parameters recorded are the ones the DBAPI receives — not
+    the SQLAlchemy-level construct. The listener goes on ``engine.sync_engine``
+    because the async engine is a facade over it (same reason as the pragma
+    listener in ``sqlite_lance/relational.py``), and is removed on exit so a
+    fixture-scoped engine does not accumulate listeners across tests.
+    """
+    log: SqlLog = []
+
+    def _record(_conn, _cursor, statement, parameters, _context, _executemany) -> None:  # noqa: ANN001
+        log.append((statement, parameters))
+
+    event.listen(engine.sync_engine, "before_cursor_execute", _record)
+    try:
+        yield log
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _record)
+
+
+@contextmanager
+def method_sql_log(obj: Any, method_name: str) -> Iterator[SqlLog]:
+    """Record ``(sql, params)`` for every call to ``obj.method_name(sql, params)``.
+
+    The seam for the two stores that talk to their driver directly: aiosqlite's
+    ``execute(sql, params)`` and ``SurrealDBConnection.query(sql, bindings)``. The
+    second positional (or its keyword form) is the parameter container in both.
+
+    A resumed SurrealDB step issues up to TWO statements — the Q1 tie block and
+    the Q2 strictly-older range — and both land in the log; assertions here are
+    over the union of every statement in the step, which is the right granularity
+    (a leaf pushed into only one of the two legs is still pushed).
+    """
+    log: SqlLog = []
+    original: Callable[..., Any] = getattr(obj, method_name)
+    # Whether the name was the object's OWN attribute before we shadowed it. Both
+    # seams define theirs on the class, so the correct restore is to delete the
+    # instance attribute rather than leave a bound copy shadowing the class.
+    had_own_attr = method_name in vars(obj)
+
+    @functools.wraps(original)
+    async def _recording(sql: str, *args: Any, **kwargs: Any) -> Any:
+        params = args[0] if args else next((kwargs[k] for k in ("params", "bindings") if k in kwargs), None)
+        log.append((sql, params))
+        return await original(sql, *args, **kwargs)
+
+    setattr(obj, method_name, _recording)
+    try:
+        yield log
+    finally:
+        if had_own_attr:
+            setattr(obj, method_name, original)
+        else:
+            delattr(obj, method_name)
+
+
+def flatten_params(sql_log: SqlLog) -> set[str]:
+    """Every bound value in ``sql_log``, stringified, as one set.
+
+    Containers nest differently per seam — a positional tuple, a bind dict, a list
+    of tuples for an executemany — so this walks them all and stringifies the
+    leaves. Stringifying is what makes one assertion work across dialects that
+    bind the same logical operand as different Python types; it is sound for the
+    string-valued probe this module is for, and is the reason date keys are out of
+    scope (see the module docstring).
+    """
+    values: set[str] = set()
+
+    def _walk(value: Any) -> None:
+        if value is None:
+            return
+        if isinstance(value, Mapping):
+            for item in value.values():
+                _walk(item)
+            return
+        if isinstance(value, (str, bytes)):
+            values.add(str(value))
+            return
+        if isinstance(value, Sequence):
+            for item in value:
+                _walk(item)
+            return
+        values.add(str(value))
+
+    for _statement, parameters in sql_log:
+        _walk(parameters)
+    return values
+
+
+def _statement_text(sql_log: SqlLog) -> str:
+    """Every captured statement's SQL text, joined — searched alongside the params.
+
+    A pushed operand should arrive as a *bind*, and on all four seams today it does:
+    ``compile_lance`` never inlines a caller value (its ``?`` placeholders are
+    rewritten to ``:kf0``… and bound by ``_lance_fragment_to_text``), the postgres
+    compiler emits a SQLAlchemy expression, and the SurrealDB compiler emits
+    ``$f_0``-style bindings. So searching the text is a **tripwire, not a live
+    hazard** — but it is the direction that matters for the residual half: if a
+    compiler ever started inlining a literal, "the value is absent from the params"
+    would become a false pass while SQL enforced the leaf anyway. Including the text
+    costs nothing and closes that.
+    """
+    return "\n".join(statement for statement, _parameters in sql_log)
+
+
+def assert_split_honest(
+    sql_log: SqlLog,
+    *,
+    pushed_values: Sequence[Any] = (),
+    residual_values: Sequence[Any] = (),
+    must_touch: str = "document",
+) -> None:
+    """Assert the executed statements bound exactly the operands they claim to.
+
+    ``pushed_values`` must all appear in the executed statements (bound param or
+    SQL text) — a value missing is the perf lie: reported as pushed, absent from
+    the statement, the post-filter quietly covering. ``residual_values`` must all
+    be absent — a value present is the correctness lie's fingerprint: reported as
+    deferred, yet enforced in SQL, so the two halves of the split disagree about
+    who owns the leaf.
+
+    **Two vacuity guards, and they are the point of this function being a function.**
+    Every assertion here is over the statements that ran, so a spy attached to the
+    wrong seam captures nothing and satisfies the whole ``residual_values`` half
+    unconditionally — a green run that proves nothing and looks identical to a real
+    one. So: the log must be non-empty, AND at least one statement must mention
+    ``must_touch``. The default ``"document"`` is a substring of the ``documents``
+    table on three tiers and the exact ``document`` table on SurrealDB, so one
+    default covers all four; it rejects a log that captured only a namespace lookup,
+    a ``PRAGMA``, or a ``BEGIN``.
+    """
+    assert sql_log, "the spy captured no statements — it is attached to the wrong seam, or the scan never ran"
+    text = _statement_text(sql_log)
+    assert must_touch in text, (
+        f"no captured statement mentions {must_touch!r}, so the spy did not observe a documents scan — "
+        f"captured: {[statement[:120] for statement, _ in sql_log]}"
+    )
+    params = flatten_params(sql_log)
+
+    def _present(value: Any) -> bool:
+        # Exact match against a bound param (the expected route), OR a substring of
+        # the SQL text (the inlined-literal tripwire above).
+        needle = str(value)
+        return needle in params or needle in text
+
+    for value in pushed_values:
+        assert _present(value), (
+            f"{value!r} was reported as pushed down but appears in neither the bound params nor the SQL text — "
+            f"SQL never enforced it and the post-filter is silently covering for the report"
+        )
+    for value in residual_values:
+        assert not _present(value), (
+            f"{value!r} was reported as post-filtered (residual) but IS in the executed statement "
+            f"(params or SQL text) — the statement enforced a leaf the split says it deferred"
+        )
+
+
+def force_residual(monkeypatch: Any, backend_module: Any, drop_key: str = "source_type") -> None:
+    """Make ``drop_key`` unpushable on ``backend_module``, on every scan path.
+
+    The **uniform** forced-residual lever across all four stores, and it is not the
+    obvious one. A :class:`~khora.filter.context.SchemaCapabilities` override does
+    NOT work here: only ``compile_lance`` gates on a capability flag
+    (``sqlite_json1``), and the postgres / surrealdb documents compilers never read
+    ``schema_capabilities`` at all. What every one of them *does* read is the
+    ``field_mapping`` key set as the pushdown whitelist — so dropping a key from it
+    defers that leaf on all four under ``on_unsupported="split"``.
+
+    Patching is at the module level because all four stores call
+    ``_documents_compile_context()`` as a bare module-global name (``postgresql.py``,
+    ``sqlite_lance/relational.py``, ``sqlite.py``, and ``surrealdb/relational.py``
+    inside ``_documents_where``), so one ``setattr`` covers every scan path in that
+    store — including the second statement of a resumed SurrealDB step.
+    """
+    from dataclasses import replace
+
+    original = backend_module._documents_compile_context  # noqa: SLF001
+
+    def _patched() -> Any:
+        ctx = original()
+        mapping = dict(ctx.field_mapping or {})
+        assert drop_key in mapping, (
+            f"{drop_key!r} is not in this store's field_mapping, so dropping it forces nothing — "
+            f"the probe key must be one the store normally pushes"
+        )
+        del mapping[drop_key]
+        return replace(ctx, field_mapping=mapping)
+
+    monkeypatch.setattr(backend_module, "_documents_compile_context", _patched)
+
+
+__all__ = [
+    "PROBE_VALUE",
+    "assert_split_honest",
+    "flatten_params",
+    "force_residual",
+    "method_sql_log",
+    "sqlalchemy_sql_log",
+]

--- a/tests/unit/storage/backends/sqlite_lance/test_relational_scan_documents.py
+++ b/tests/unit/storage/backends/sqlite_lance/test_relational_scan_documents.py
@@ -35,6 +35,7 @@ import sqlalchemy.exc
 
 from khora.core.models import MemoryNamespace, TenancyMode
 from khora.core.models.document import DocumentStatus
+from khora.filter import CompilerRegistry
 from khora.filter.compilers.python import compile_python
 from tests.test_helpers.document_scan import (
     SUPERSET_SHAPES,
@@ -44,6 +45,12 @@ from tests.test_helpers.document_scan import (
     to_filter_ast,
     walk_scan,
     write_document,
+)
+from tests.test_helpers.document_scan_spy import (
+    PROBE_VALUE,
+    assert_split_honest,
+    force_residual,
+    sqlalchemy_sql_log,
 )
 
 # Lives in the unit lane next to the rest of this adapter's tests, and also
@@ -397,6 +404,167 @@ async def test_pushdown_never_rejects_a_row_the_full_filter_would_keep(adapter, 
     assert oracle, "the shape matches no row in this corpus — `oracle <= window` cannot fail"
 
     assert oracle <= {d.id for d in step.documents}
+
+
+# --------------------------------------------------------------------------- #
+# Is the reported split HONEST?
+#
+# Everything above reads ``consumed_keys`` and believes it. These three drive the
+# same scans and check the report against the statement the driver actually ran —
+# the spy attaches a ``before_cursor_execute`` listener to this store's
+# ``AsyncEngine``. See :mod:`tests.test_helpers.document_scan_spy` for why the
+# assertion is on bound VALUES rather than on column names.
+# --------------------------------------------------------------------------- #
+
+
+async def _seed_probe_corpus(adapter, namespace_id) -> int:
+    """Seed the varied corpus with the probe literal on half the rows.
+
+    Returns how many rows carry it, so a test can assert the pushed leaf really
+    narrowed rather than trusting the ``i % 2`` arithmetic.
+    """
+    seed = scan_seed(6)
+    for i, (doc_id, created_at) in enumerate(seed.writes):
+        await write_document(
+            adapter,
+            namespace_id,
+            doc_id,
+            created_at,
+            source_type=PROBE_VALUE if i % 2 == 0 else "library",
+        )
+    return sum(1 for i in range(len(seed.writes)) if i % 2 == 0)
+
+
+async def test_a_pushed_leaf_really_reaches_the_statement(adapter, namespace) -> None:
+    """The perf-lie catch: a leaf reported as pushed must be bound in the SQL.
+
+    ``consumed_keys == {"source_type"}`` is satisfied just as well by a compiler
+    that reported the leaf and emitted nothing for it — the caller's post-filter
+    would return the same rows, and the pushdown's entire purpose (a narrowed
+    window) would be silently gone. The probe literal appearing among the bound
+    params is what distinguishes the two.
+    """
+    matching = await _seed_probe_corpus(adapter, namespace.id)
+    ast = to_filter_ast({"source_type": {"$eq": PROBE_VALUE}})
+
+    with sqlalchemy_sql_log(adapter._engine) as sql_log:  # noqa: SLF001 — the driver seam has no public accessor
+        step = await adapter.scan_documents(namespace.id, filter_ast=ast, scan_limit=10)
+
+    assert step.consumed_keys == frozenset({"source_type"})
+    assert_split_honest(sql_log, pushed_values=[PROBE_VALUE])
+    # And the pushdown narrowed for real: the window is the matching subset, not
+    # the corpus with a post-filter's worth of work still owed.
+    assert len(step.documents) == matching
+    assert {d.source_type for d in step.documents} == {PROBE_VALUE}
+
+
+async def test_a_naturally_deferred_leaf_never_reaches_the_statement(adapter, namespace) -> None:
+    """The correctness-lie catch WITHOUT monkeypatching anything.
+
+    The stronger of the two residual tests, and the reason it exists separately: it
+    needs no ``force_residual``, so it tests the store as it actually ships. The
+    filter is an ``$or`` mixing this store's unpushable ``created_at`` with a
+    pushable ``source_type``, which ``compile_lance``'s all-or-nothing gate defers
+    **as a whole** rather than pushing half a disjunction. So ``source_type`` — a
+    key this store normally pushes eagerly — must NOT be bound here.
+
+    That gate is exactly what the ``scan_documents`` docstrings name as the reason
+    the pushdown is superset-safe: a match-all placeholder left inside a negation
+    inverts into a match-nothing and silently EXCLUDES rows. This asserts the gate
+    at the seam, where a regression is visible as a bound operand rather than as a
+    row count nobody cross-checks.
+    """
+    await _seed_probe_corpus(adapter, namespace.id)
+    ast = to_filter_ast(
+        {"$or": [{"created_at": {"$gte": "2026-01-01T00:00:00+00:00"}}, {"source_type": {"$eq": PROBE_VALUE}}]}
+    )
+
+    with sqlalchemy_sql_log(adapter._engine) as sql_log:  # noqa: SLF001
+        step = await adapter.scan_documents(namespace.id, filter_ast=ast, scan_limit=10)
+
+    assert step.consumed_keys == frozenset()
+    assert_split_honest(sql_log, residual_values=[PROBE_VALUE])
+    # The whole disjunction deferred, so SQL narrowed nothing: the raw window is
+    # the entire corpus and the post-filter owns every leaf.
+    assert len(step.documents) == 6
+
+
+async def test_a_residual_leaf_never_reaches_the_statement(adapter, namespace, monkeypatch) -> None:
+    """The correctness-lie catch, on the same filter with the leaf forced residual.
+
+    ``force_residual`` drops ``source_type`` from this store's ``field_mapping``,
+    which is the pushdown whitelist — so the identical AST now defers. Two things
+    must follow together, and asserting either alone is weak: the report must say
+    the leaf was NOT consumed, and the operand must be absent from the statement.
+    A report/statement disagreement in this direction means SQL enforced a leaf the
+    split told the caller it owned.
+    """
+    await _seed_probe_corpus(adapter, namespace.id)
+    from khora.storage.backends.sqlite_lance import relational as lance_module
+
+    force_residual(monkeypatch, lance_module)
+    ast = to_filter_ast({"source_type": {"$eq": PROBE_VALUE}})
+
+    with sqlalchemy_sql_log(adapter._engine) as sql_log:  # noqa: SLF001
+        step = await adapter.scan_documents(namespace.id, filter_ast=ast, scan_limit=10)
+
+    assert step.consumed_keys == frozenset()
+    assert_split_honest(sql_log, residual_values=[PROBE_VALUE])
+    # Deferred means "narrowed nothing here": the raw window is the whole corpus,
+    # which is the only correct compilation of a leaf this context cannot push.
+    assert len(step.documents) == 6
+
+
+# The split this store reports, per AST shape. The expected set is PINNED as well
+# as recomputed, because the recompute alone is satisfiable by two compilers that
+# agree on the wrong answer — including the degenerate "consumes nothing ever",
+# which would make every comparison ``frozenset() == frozenset()``. The spread is
+# what makes the parametrization non-vacuous: a full push, a partial push where
+# this store's unpushable date key is the residual, a fully-pushed disjunction, a
+# wholly-deferred one, and a pushed metadata path (this store has JSON1).
+_SPLIT_SHAPES: dict[str, tuple[dict[str, Any], frozenset[str]]] = {
+    "pushed_whole": ({"source_type": {"$eq": PROBE_VALUE}}, frozenset({"source_type"})),
+    "date_key_is_the_residual": (
+        {"source_type": {"$eq": PROBE_VALUE}, "created_at": {"$gte": "2026-01-01T00:00:00+00:00"}},
+        frozenset({"source_type"}),
+    ),
+    "or_wholly_pushable": (
+        {"$or": [{"source_type": {"$eq": PROBE_VALUE}}, {"title": {"$eq": "doc-1"}}]},
+        frozenset({"source_type", "title"}),
+    ),
+    "or_wholly_deferred": (
+        {"$or": [{"created_at": {"$gte": "2026-01-01T00:00:00+00:00"}}, {"source_type": {"$eq": PROBE_VALUE}}]},
+        frozenset(),
+    ),
+    "metadata_path": ({"metadata.tier": {"$eq": "gold"}}, frozenset({"metadata.tier"})),
+}
+
+
+@pytest.mark.parametrize(("wire", "expected"), _SPLIT_SHAPES.values(), ids=_SPLIT_SHAPES.keys())
+async def test_reported_split_equals_a_fresh_compile_of_the_same_ast(adapter, namespace, wire, expected) -> None:
+    """``consumed_keys`` is the compiler's answer, verbatim — no store-side edits.
+
+    The scan is free to compile once and report; what it must not do is add or
+    drop keys on the way out (a store that unioned in the keys it *hoped* were
+    pushed, or that stripped one it found inconvenient, would still look
+    plausible on every row assertion here, because the coordinator re-checks the
+    full AST regardless). Recomputed with the SAME compiler and the SAME context
+    the scan uses, so a difference can only be the store's own editing.
+
+    This is also how ``created_at`` pushdown is covered. The date key's *value* is
+    deliberately out of the spy's scope — dialects bind datetimes and strings
+    differently, so a value probe there is a dialect quiz — but its membership in
+    the split is exactly what these two shapes compare, and this store withholding
+    it is the difference from the PostgreSQL sibling.
+    """
+    await _seed_probe_corpus(adapter, namespace.id)
+    ast = to_filter_ast(wire)
+
+    step = await adapter.scan_documents(namespace.id, filter_ast=ast, scan_limit=10)
+
+    assert step.consumed_keys == expected
+    compiler = CompilerRegistry.get("relational.sqlite_lance", "documents")
+    assert step.consumed_keys == compiler(ast, _documents_compile_context()).consumed_keys
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_document_enumeration_helpers.py
+++ b/tests/unit/test_document_enumeration_helpers.py
@@ -255,6 +255,33 @@ class TestWalkCompliance:
         with pytest.raises(AssertionError, match="MISSING"):
             assert_walk_compliant([page], expected_ids=[page[0].id, _doc(0, "0002").id])
 
+    def test_a_walk_whose_last_page_is_not_exhausted_fails(self) -> None:
+        """A truncated walk proves nothing about completeness.
+
+        The final page is per-page compliant (a cursor is set, so
+        ``next_after is None`` matches ``exhausted=False``), yet the walk stopped
+        before the store signalled exhaustion — so any missing match could simply be
+        on a page the caller never fetched. Completeness is only well-defined once
+        ``exhausted`` is reached, so an unfinished walk must fail rather than pass on
+        whatever prefix it happened to collect.
+        """
+        cursor = DocumentCursor(created_at=_BASE, id=UUID(int=1))
+        unfinished = _page([_doc(1)], next_after=cursor, exhausted=False)
+        with pytest.raises(AssertionError, match="truncated walk"):
+            assert_walk_compliant([unfinished])
+
+    def test_a_page_after_an_exhausted_page_fails(self) -> None:
+        """``exhausted`` is the only termination signal, so nothing may follow it.
+
+        Both pages are per-page compliant; the violation is purely walk-level — a
+        page arrived after one that already reported ``exhausted=True``, which means
+        the caller kept fetching past the store's end-of-walk signal.
+        """
+        first = _page([_doc(1, "0001")])  # exhausted=True by default
+        second = _page([_doc(0, "0002")])
+        with pytest.raises(AssertionError, match="pages after exhaustion"):
+            assert_walk_compliant([first, second])
+
 
 class TestSplitHonestySpy:
     def test_flatten_walks_every_container_shape(self) -> None:

--- a/tests/unit/test_document_enumeration_helpers.py
+++ b/tests/unit/test_document_enumeration_helpers.py
@@ -1,0 +1,326 @@
+"""Self-tests for the two document-enumeration test helpers.
+
+Both helpers fail the same way when they are wrong — silently, by passing — and
+both are about to be depended on from four backend modules plus the property-based walk
+fuzzer, so each assertion they make gets a NEGATIVE case here proving it can
+actually fail. Precedent: ``tests/unit/test_diagnostics_helper.py``.
+
+Nothing here touches a store. These are pure-function tests over hand-built pages
+and hand-built parameter logs, which is the point: the per-backend modules prove
+the helpers say the right thing about a real scan, and this module proves they say
+*anything at all*.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import pytest
+
+from khora.core.models import Document
+from khora.core.models.document import DocumentCursor, DocumentPage
+from khora.filter import RecallFilter
+from khora.filter.ast import parse_to_ast
+from tests.test_helpers.document_page_oracle import (
+    assert_documents_satisfy,
+    assert_page_compliant,
+    assert_total_order,
+    assert_walk_compliant,
+    assert_walk_matches_expected,
+)
+from tests.test_helpers.document_scan_spy import (
+    PROBE_VALUE,
+    assert_split_honest,
+    flatten_params,
+)
+
+_BASE = datetime(2026, 1, 15, 9, 0, 0, tzinfo=UTC)
+
+
+def _ast(wire: dict):
+    return parse_to_ast(RecallFilter.model_validate(wire))
+
+
+def _doc(seconds: int, hex_tail: str = "0001", **fields) -> Document:
+    """A document at ``_BASE + seconds`` with a pinned id, so order is decidable."""
+    return Document(
+        id=UUID(f"00000000-0000-4000-8000-00000000{hex_tail}"),
+        content="x",
+        created_at=_BASE + timedelta(seconds=seconds),
+        **fields,
+    )
+
+
+def _page(docs: list[Document], *, next_after=None, exhausted=True) -> DocumentPage:
+    return DocumentPage(docs, next_after=next_after, exhausted=exhausted)
+
+
+class TestTotalOrder:
+    def test_descending_passes(self) -> None:
+        assert_total_order([_doc(2, "0001"), _doc(1, "0002"), _doc(0, "0003")])
+
+    def test_ascending_fails(self) -> None:
+        with pytest.raises(AssertionError, match="INV-E violated"):
+            assert_total_order([_doc(0), _doc(1, "0002")])
+
+    def test_a_repeat_fails_as_an_ordering_violation(self) -> None:
+        """STRICT descent is why the same comparison catches an exactly-once break."""
+        doc = _doc(1)
+        with pytest.raises(AssertionError, match="INV-E violated"):
+            assert_total_order([doc, doc])
+
+    def test_a_created_at_tie_is_decided_by_id(self) -> None:
+        """Equal timestamps must still descend — on ``id``, the keyset's second leg."""
+        assert_total_order([_doc(1, "0002"), _doc(1, "0001")])
+        with pytest.raises(AssertionError, match="INV-E violated"):
+            assert_total_order([_doc(1, "0001"), _doc(1, "0002")])
+
+    def test_naive_and_aware_timestamps_compare_without_raising(self) -> None:
+        """The reason ``as_utc`` is in the key: the embedded tiers read back naive.
+
+        Mixing the two shapes in one comparison raises ``TypeError`` rather than
+        failing an assertion, which would surface as an error in an unrelated test
+        rather than as an ordering failure here.
+        """
+        newer = _doc(1, "0001")
+        older = _doc(0, "0002")
+        older.created_at = older.created_at.replace(tzinfo=None)
+        assert_total_order([newer, older])
+
+    def test_a_string_id_compares_as_a_uuid_not_as_a_string(self) -> None:
+        """The id half of the same normalization, and it changes the ANSWER.
+
+        ``str(uuid)`` puts a dash at index 8, and ``-`` (0x2D) sorts below every hex
+        digit — so two ids that differ only after the dash order differently as
+        strings than as UUIDs. Comparing as UUIDs is what the stores do, so it is
+        the correct semantics, not a convenience; a mixed ``str``/``UUID`` pair would
+        also raise ``TypeError`` instead of failing an assertion.
+        """
+        newer, older = _doc(1, "0002"), _doc(1, "0001")
+        # Off-type on purpose: ``Document.id`` is declared ``UUID``, and planting the
+        # shape a store might actually hand back IS the subject. Same below. ``ty``
+        # runs on ``src/`` only (see the ``lint`` target), so these do not gate CI;
+        # were it ever pointed at ``tests/``, these three assignments are the
+        # intended warnings, not oversights.
+        older.id = str(older.id)
+        assert_total_order([newer, older])
+
+    def test_a_record_id_shaped_object_is_unwrapped(self) -> None:
+        """SurrealDB hands back a ``RecordID`` carrying the uuid on ``.id``."""
+
+        class _RecordID:
+            def __init__(self, value: UUID) -> None:
+                self.id = value
+
+        newer, older = _doc(1, "0002"), _doc(1, "0001")
+        newer.id = _RecordID(newer.id)
+        assert_total_order([newer, older])
+
+    def test_an_unnormalizable_id_fails_loudly_rather_than_being_coerced(self) -> None:
+        """An id shape the helper cannot map must raise, never be coerced — a silent
+        ``str(value)`` fallback would order rows by a rendering nothing stores."""
+        doc = _doc(1)
+        doc.id = 12345
+        with pytest.raises(AssertionError, match="cannot be normalized"):
+            assert_total_order([doc, _doc(0, "0002")])
+
+
+class TestCompleteness:
+    """The leg that catches a silently dropped row — the one no predicate can see."""
+
+    def test_exact_match_passes(self) -> None:
+        docs = [_doc(1, "0001"), _doc(0, "0002")]
+        assert_walk_matches_expected(docs, [d.id for d in docs])
+
+    def test_a_missing_document_fails_and_is_named(self) -> None:
+        """The dangerous failure: the returned rows are all correct, one is absent."""
+        returned = [_doc(1, "0001")]
+        dropped = _doc(0, "0002")
+        with pytest.raises(AssertionError, match="MISSING"):
+            assert_walk_matches_expected(returned, [returned[0].id, dropped.id])
+
+    def test_an_extra_document_fails_and_is_named(self) -> None:
+        kept = _doc(1, "0001")
+        extra = _doc(0, "0002")
+        with pytest.raises(AssertionError, match="UNEXPECTED"):
+            assert_walk_matches_expected([kept, extra], [kept.id])
+
+    def test_expected_may_be_ids_or_documents_in_either_id_shape(self) -> None:
+        docs = [_doc(1, "0001"), _doc(0, "0002")]
+        assert_walk_matches_expected(docs, docs)  # documents
+        assert_walk_matches_expected(docs, [str(d.id) for d in docs])  # dashed strings
+
+    def test_soundness_passing_does_not_imply_completeness(self) -> None:
+        """The two legs are independent, demonstrated rather than asserted in prose.
+
+        The returned page satisfies the filter on every row, is ordered, and is
+        missing a match. Soundness passes; completeness fails. This is exactly the
+        shape a keyset bug produces, and the reason
+        ``assert_documents_satisfy`` alone is not enough.
+        """
+        kept = _doc(1, "0001", source_type="report")
+        dropped = _doc(0, "0002", source_type="report")
+        ast = _ast({"source_type": "report"})
+
+        assert_documents_satisfy([kept], ast)  # sound
+        assert_total_order([kept])  # ordered
+        with pytest.raises(AssertionError, match="MISSING"):
+            assert_walk_matches_expected([kept], [kept.id, dropped.id])
+
+
+class TestDocumentsSatisfy:
+    def test_matching_rows_pass(self) -> None:
+        assert_documents_satisfy([_doc(0, source_type="report")], _ast({"source_type": "report"}))
+
+    def test_a_row_the_filter_excludes_fails(self) -> None:
+        with pytest.raises(AssertionError, match="does not satisfy the full filter"):
+            assert_documents_satisfy([_doc(0, source_type="library")], _ast({"source_type": "report"}))
+
+    def test_a_metadata_path_is_evaluated_on_the_document_blob(self) -> None:
+        """Metadata resolves through ``record.metadata`` regardless of field_mapping,
+        which is why the identity context here agrees with every backend's own."""
+        assert_documents_satisfy([_doc(0, metadata={"tier": "gold"})], _ast({"metadata.tier": "gold"}))
+        with pytest.raises(AssertionError, match="does not satisfy the full filter"):
+            assert_documents_satisfy([_doc(0, metadata={"tier": "silver"})], _ast({"metadata.tier": "gold"}))
+
+
+class TestPageCompliance:
+    def test_exhausted_page_without_a_cursor_passes(self) -> None:
+        assert_page_compliant(_page([_doc(1, "0001"), _doc(0, "0002")]))
+
+    def test_unexhausted_page_with_a_cursor_passes(self) -> None:
+        cursor = DocumentCursor(created_at=_BASE, id=UUID(int=1))
+        assert_page_compliant(_page([_doc(1)], next_after=cursor, exhausted=False))
+
+    @pytest.mark.parametrize(
+        ("next_after", "exhausted"),
+        [
+            (None, False),  # neither a resume position nor exhaustion — unactionable
+            (DocumentCursor(created_at=_BASE, id=UUID(int=1)), True),  # both — a walk that never ends
+        ],
+    )
+    def test_a_next_after_exhausted_mismatch_fails(self, next_after, exhausted) -> None:
+        with pytest.raises(AssertionError, match="next_after/exhausted disagree"):
+            assert_page_compliant(_page([_doc(1)], next_after=next_after, exhausted=exhausted))
+
+    def test_a_filter_violating_row_fails(self) -> None:
+        page = _page([_doc(0, source_type="library")])
+        with pytest.raises(AssertionError, match="does not satisfy the full filter"):
+            assert_page_compliant(page, _ast({"source_type": "report"}))
+
+    def test_no_filter_skips_the_predicate_entirely(self) -> None:
+        """``filter_ast=None`` must not silently compile a match-everything AST and
+        claim the filter was checked — an unfiltered walk has no filter to check."""
+        assert_page_compliant(_page([_doc(0, source_type="library")]))
+
+
+class TestWalkCompliance:
+    def test_a_clean_two_page_walk_returns_the_flat_rows_in_order(self) -> None:
+        cursor = DocumentCursor(created_at=_BASE, id=UUID(int=1))
+        first = _page([_doc(3, "0001"), _doc(2, "0002")], next_after=cursor, exhausted=False)
+        second = _page([_doc(1, "0003"), _doc(0, "0004")])
+
+        flat = assert_walk_compliant([first, second])
+
+        assert [d.created_at for d in flat] == [_BASE + timedelta(seconds=s) for s in (3, 2, 1, 0)]
+
+    def test_a_document_repeated_across_pages_fails(self) -> None:
+        cursor = DocumentCursor(created_at=_BASE, id=UUID(int=1))
+        repeated = _doc(2, "0002")
+        first = _page([_doc(3, "0001"), repeated], next_after=cursor, exhausted=False)
+        second = _page([repeated])
+
+        with pytest.raises(AssertionError, match="exactly-once violated"):
+            assert_walk_compliant([first, second])
+
+    def test_an_order_that_resets_at_a_page_boundary_fails(self) -> None:
+        """Each page descends on its own, and the walk still does not.
+
+        This is the failure a per-page assertion cannot see, and the reason
+        ``assert_walk_compliant`` re-checks the concatenation.
+        """
+        cursor = DocumentCursor(created_at=_BASE, id=UUID(int=1))
+        first = _page([_doc(1, "0001"), _doc(0, "0002")], next_after=cursor, exhausted=False)
+        second = _page([_doc(3, "0003"), _doc(2, "0004")])
+
+        assert_page_compliant(first)
+        assert_page_compliant(second)
+        with pytest.raises(AssertionError, match="INV-E violated"):
+            assert_walk_compliant([first, second])
+
+    def test_expected_ids_threads_through_to_the_completeness_check(self) -> None:
+        page = _page([_doc(1, "0001")])
+        assert_walk_compliant([page], expected_ids=[page[0].id])
+        with pytest.raises(AssertionError, match="MISSING"):
+            assert_walk_compliant([page], expected_ids=[page[0].id, _doc(0, "0002").id])
+
+
+class TestSplitHonestySpy:
+    def test_flatten_walks_every_container_shape(self) -> None:
+        """Positional tuples, bind dicts and executemany lists all reduce to values."""
+        log = [
+            ("SELECT 1", ("a", 2)),
+            ("SELECT 2", {"f_0": "b", "lim": 10}),
+            ("SELECT 3", [("c",), ("d",)]),
+            ("SELECT 4", None),
+        ]
+        assert flatten_params(log) == {"a", "2", "b", "10", "c", "d"}
+
+    def test_a_pushed_value_present_passes_and_absent_fails(self) -> None:
+        present = [("SELECT * FROM documents WHERE ...", (PROBE_VALUE, 10))]
+        assert_split_honest(present, pushed_values=[PROBE_VALUE])
+
+        absent = [("SELECT * FROM documents WHERE ...", ("library", 10))]
+        with pytest.raises(AssertionError, match="reported as pushed down"):
+            assert_split_honest(absent, pushed_values=[PROBE_VALUE])
+
+    def test_a_residual_value_absent_passes_and_present_fails(self) -> None:
+        absent = [("SELECT * FROM documents WHERE ...", ("library", 10))]
+        assert_split_honest(absent, residual_values=[PROBE_VALUE])
+
+        present = [("SELECT * FROM documents WHERE ...", {"f_0": PROBE_VALUE})]
+        with pytest.raises(AssertionError, match="reported as post-filtered"):
+            assert_split_honest(present, residual_values=[PROBE_VALUE])
+
+    def test_a_literal_inlined_into_the_sql_text_is_still_caught(self) -> None:
+        """The tripwire for a compiler that stopped binding and started inlining.
+
+        No compiler does this today (``_lance_fragment_to_text`` rewrites every
+        ``?`` to a named bind, and the other three emit binds natively), which is
+        exactly why it needs a test: were it to change, "the value is absent from
+        the params" would become a false pass while SQL enforced the leaf anyway.
+        """
+        # A fixture string, never handed to a driver; inlining the literal IS the
+        # condition under test, which is why S608 is suppressed rather than avoided.
+        inlined = [(f"SELECT * FROM documents WHERE source_type = '{PROBE_VALUE}'", None)]  # noqa: S608
+        assert_split_honest(inlined, pushed_values=[PROBE_VALUE])
+        with pytest.raises(AssertionError, match="reported as post-filtered"):
+            assert_split_honest(inlined, residual_values=[PROBE_VALUE])
+
+    def test_an_empty_log_fails_instead_of_passing_vacuously(self) -> None:
+        """The first failure the spy has to catch about ITSELF.
+
+        A spy attached to the wrong seam captures nothing, and every
+        ``residual_values`` assertion over an empty log is then trivially true — a
+        green run indistinguishable from a real one.
+        """
+        with pytest.raises(AssertionError, match="captured no statements"):
+            assert_split_honest([], residual_values=[PROBE_VALUE])
+
+    def test_a_log_that_never_touched_the_table_fails(self) -> None:
+        """The second, and the subtler one: a non-empty log of the WRONG statements.
+
+        An instrumented seam that ran only a namespace lookup, a ``PRAGMA`` or a
+        ``BEGIN`` clears the non-empty check while still having observed no scan, so
+        the residual half would again pass for free.
+        """
+        wrong = [("PRAGMA foreign_keys=ON", None), ("SELECT id FROM memory_namespaces WHERE ...", ("ns",))]
+        with pytest.raises(AssertionError, match="mentions 'document'"):
+            assert_split_honest(wrong, residual_values=[PROBE_VALUE])
+
+    def test_the_table_guard_accepts_both_table_names(self) -> None:
+        """One default covers all four tiers: ``documents`` on three, ``document`` on
+        SurrealDB — the latter being a substring of the former."""
+        assert_split_honest([("SELECT * FROM documents WHERE ...", None)], residual_values=[PROBE_VALUE])
+        assert_split_honest([("SELECT * FROM document WHERE ...", None)], residual_values=[PROBE_VALUE])

--- a/tests/unit/test_list_documents_enumeration.py
+++ b/tests/unit/test_list_documents_enumeration.py
@@ -2,24 +2,50 @@
 
 Covers the pieces that need no live backend: the ``DocumentPage`` sequence
 contract, the ``occurred_at`` enumeration key-scope rejection (structured error
-+ asserted copy), and the ``status`` enum validation. The multi-page cursor walk
-and facade/storage parity live in the integration lane (they need a seeded
-namespace on the sqlite_lance stack).
++ asserted copy), the ``status`` enum validation, and the coordinator's
+``post_filtered_keys`` derivation. The multi-page cursor walk and facade/storage
+parity live in the integration lane (they need a seeded namespace on the
+sqlite_lance stack).
+
+The ``post_filtered_keys`` class runs the real coordinator over a real store, and
+still needs no service: ``SQLiteRelationalBackend(":memory:")`` builds its own
+schema at ``connect()`` with no Alembic chain behind it. That is the cheapest
+store that can answer the question honestly — the derivation under test is a set
+difference over a compiler's answer, and a mock backend would let the test assert
+its own stub's arithmetic.
 """
 
 from __future__ import annotations
 
 from collections.abc import Sequence
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from typing import Any
 from uuid import uuid4
 
 import pytest
 
-from khora.core.models import Document
+from khora.core.models import Document, MemoryNamespace
 from khora.core.models.document import DocumentCursor, DocumentPage
-from khora.filter import RecallFilter, RecallFilterValidationError
+from khora.core.models.tenancy import TenancyMode
+from khora.filter import CompilerRegistry, RecallFilter, RecallFilterValidationError
 from khora.filter.ast import parse_to_ast
+from khora.filter.execute import filter_leaf_keys
 from khora.khora import _reject_non_enumerable_keys
+from khora.storage.backends import sqlite as sqlite_module
+from khora.storage.backends.sqlite import SQLiteRelationalBackend, _documents_compile_context
+from khora.storage.coordinator import StorageCoordinator
+from tests.test_helpers.document_page_oracle import (
+    assert_page_compliant,
+    assert_walk_compliant,
+    assert_walk_matches_expected,
+)
+from tests.test_helpers.document_scan import WHOLE_SECOND, scan_seed, to_filter_ast, write_document
+from tests.test_helpers.document_scan_spy import (
+    PROBE_VALUE,
+    assert_split_honest,
+    force_residual,
+    method_sql_log,
+)
 
 
 def _ast(wire: dict) -> object:
@@ -104,3 +130,220 @@ class TestOccurredAtRejection:
     def test_enumerable_keys_pass(self, wire: dict) -> None:
         # Does not raise.
         _reject_non_enumerable_keys(_ast(wire))
+
+
+# The shapes the page-level split is checked over. Each carries three things: the
+# wire filter, the residual the coordinator must REPORT, and an independent
+# plain-Python matcher over the seeded rows giving the id set the walk must RETURN.
+#
+# The matcher is hand-written arithmetic on purpose. Deriving the expectation with
+# ``compile_python`` would reproduce the very predicate the coordinator applies, so
+# the comparison could not fail — the tautology this triple exists to escape.
+#
+# The residual is pinned as well as recomputed against the compiler, because a
+# recompute alone is satisfied by two computations agreeing on the wrong answer,
+# including the degenerate all-empty case that makes every comparison ``() == ()``.
+#
+# The date bound is ``WHOLE_SECOND`` rather than some far-past date so it actually
+# BITES: the seed puts one row a second below the tie instant, so a ``$gte`` cutoff
+# there keeps 5 of 6. A bound every row satisfies would make the completeness check
+# "returns everything", which a dropped row would still fail but which cannot catch
+# an over-broad one.
+_CUTOFF = WHOLE_SECOND.isoformat()
+
+_PAGE_SPLIT_SHAPES: dict[str, tuple[dict[str, Any], tuple[str, ...], Any]] = {
+    "no_residual": (
+        {"source_type": {"$eq": PROBE_VALUE}},
+        (),
+        lambda r: r["source_type"] == PROBE_VALUE,
+    ),
+    "date_key_residual": (
+        {"created_at": {"$gte": _CUTOFF}},
+        ("created_at",),
+        lambda r: r["created_at"] >= WHOLE_SECOND,
+    ),
+    "mixed": (
+        {"source_type": {"$eq": PROBE_VALUE}, "created_at": {"$gte": _CUTOFF}},
+        ("created_at",),
+        lambda r: r["source_type"] == PROBE_VALUE and r["created_at"] >= WHOLE_SECOND,
+    ),
+    "or_wholly_deferred": (
+        {"$or": [{"created_at": {"$gte": _CUTOFF}}, {"source_type": {"$eq": PROBE_VALUE}}]},
+        ("created_at", "source_type"),
+        lambda r: r["created_at"] >= WHOLE_SECOND or r["source_type"] == PROBE_VALUE,
+    ),
+}
+
+
+class TestPagePostFilteredKeys:
+    """``DocumentPage.post_filtered_keys`` is the leaf keys the backend did NOT push.
+
+    The coordinator derives it as ``sorted(filter_leaf_keys(ast) - consumed_keys)``
+    unioned across the steps of a page. Two failures it has to be pinned against,
+    and neither shows up on the row set (the coordinator re-checks the full AST
+    either way, so the rows are right in both):
+
+    * **understating the residual** — a key the backend never pushed, omitted from
+      the report. A caller sizing its own over-fetch off this signal, or auditing
+      which leaves SQL enforced, is told SQL owns a predicate it does not.
+    * **overstating it** — a pushed key listed as residual, which makes the
+      pushdown look useless and invites a "fix" that removes it.
+
+    Recomputed with the same compiler and context the store scans with, so a
+    difference can only be the coordinator's own arithmetic.
+    """
+
+    @pytest.fixture
+    async def store(self):
+        backend = SQLiteRelationalBackend(":memory:")
+        await backend.connect()
+        try:
+            yield backend
+        finally:
+            await backend.disconnect()
+
+    @pytest.fixture
+    async def seeded(self, store):
+        """A coordinator over a varied six-row namespace.
+
+        Returns ``(coordinator, ns_id, rows)``. ``rows`` is the seed as plain dicts
+        — the INDEPENDENT record of what was written, which the completeness
+        matchers evaluate against. Nothing here reads it back out of the store.
+        """
+        nid = uuid4()
+        ns = await store.create_namespace(MemoryNamespace(id=nid, namespace_id=nid, tenancy_mode=TenancyMode.SHARED))
+        seed = scan_seed(6)
+        rows: list[dict[str, Any]] = []
+        for i, (doc_id, created_at) in enumerate(seed.writes):
+            fields = {"title": f"doc-{i}", "source_type": PROBE_VALUE if i % 2 == 0 else "library"}
+            await write_document(store, ns.id, doc_id, created_at, **fields)
+            rows.append({"id": doc_id, "created_at": created_at, **fields})
+        return StorageCoordinator(relational=store), ns.id, rows
+
+    @pytest.mark.parametrize(
+        ("wire", "expected", "matcher"), _PAGE_SPLIT_SHAPES.values(), ids=_PAGE_SPLIT_SHAPES.keys()
+    )
+    async def test_page_reports_its_residual_and_returns_exactly_the_matches(
+        self, seeded, wire, expected, matcher
+    ) -> None:
+        coordinator, namespace_id, rows = seeded
+        ast = to_filter_ast(wire)
+        expected_ids = [r["id"] for r in rows if matcher(r)]
+        assert 0 < len(expected_ids) < len(rows), "the shape must narrow, or completeness proves nothing"
+
+        page = await coordinator.scan_documents_page(namespace_id, filter_ast=ast, limit=100)
+
+        # 1. The reported residual, pinned and recomputed against the compiler.
+        assert page.post_filtered_keys == expected
+        compiler = CompilerRegistry.get("relational.sqlite", "documents")
+        consumed = compiler(ast, _documents_compile_context()).consumed_keys
+        assert page.post_filtered_keys == tuple(sorted(filter_leaf_keys(ast) - consumed))
+        # 2. COMPLETENESS — the assertion that can actually fail. Compared against
+        #    the hand-written matcher over the seed, never against another
+        #    enumeration call, and never against ``compile_python`` (which is the
+        #    predicate the coordinator itself applied).
+        assert_walk_matches_expected(page, expected_ids)
+        # 3. Order + the walk-control pair. Soundness rides along and is
+        #    tautological here by construction; see the helper's docstring.
+        assert_page_compliant(page, ast)
+
+    async def test_no_filter_reports_no_residual(self, seeded) -> None:
+        """Empty, and specifically not "every key, none of them pushed"."""
+        coordinator, namespace_id, rows = seeded
+
+        page = await coordinator.scan_documents_page(namespace_id, limit=100)
+
+        assert page.post_filtered_keys == ()
+        assert_walk_matches_expected(page, [r["id"] for r in rows])
+        assert_page_compliant(page)
+
+    async def test_a_residual_only_filter_still_narrows_the_page(self, seeded) -> None:
+        """The residual is enforced by the coordinator's post-filter, on rows.
+
+        ``created_at`` is unpushable on this store, so SQL narrows nothing and the
+        whole filter is the coordinator's to enforce. A page that reported the
+        residual honestly and then *skipped* it would return the full corpus, and
+        every reporting assertion above would still pass. Narrowed to a SINGLE row
+        so the completeness comparison is at its tightest.
+        """
+        coordinator, namespace_id, rows = seeded
+        # The seed puts exactly one row above its tie instant (see ``scan_seed``),
+        # so a cutoff one second past ``WHOLE_SECOND`` keeps that row and no other.
+        cutoff = WHOLE_SECOND + timedelta(seconds=1)
+        ast = to_filter_ast({"created_at": {"$gte": cutoff.isoformat()}})
+        expected_ids = [r["id"] for r in rows if r["created_at"] >= cutoff]
+        assert len(expected_ids) == 1, "the seed must put exactly one row above the cutoff"
+
+        page = await coordinator.scan_documents_page(namespace_id, filter_ast=ast, limit=100)
+
+        assert page.post_filtered_keys == ("created_at",)
+        assert_walk_matches_expected(page, expected_ids)
+        assert_page_compliant(page, ast)
+
+    async def test_a_multi_page_walk_loses_no_match_across_cursor_boundaries(self, seeded) -> None:
+        """Completeness across a REAL walk, with the page boundary inside a tie block.
+
+        The single-page tests above cannot see a cursor bug: one page never resumes.
+        Here ``limit=2`` over a 5-row match set forces three pages whose boundaries
+        land inside the seed's ``created_at`` tie block, which is where a cursor that
+        mis-serializes its timestamp or its id silently skips a tie-mate — the exact
+        failure no per-returned-row assertion can detect, because the skipped row
+        simply never appears.
+        """
+        coordinator, namespace_id, rows = seeded
+        cutoff = WHOLE_SECOND
+        ast = to_filter_ast({"created_at": {"$gte": cutoff.isoformat()}})
+        expected_ids = [r["id"] for r in rows if r["created_at"] >= cutoff]
+        assert len(expected_ids) == 5, "5 of 6 rows sit at or above the tie instant"
+
+        walked = []
+        after = None
+        while True:
+            page = await coordinator.scan_documents_page(namespace_id, filter_ast=ast, limit=2, after=after)
+            walked.append(page)
+            assert len(walked) < 10, "walk did not terminate"
+            if page.exhausted:
+                break
+            after = (page.next_after.created_at, page.next_after.id)
+
+        assert len(walked) >= 3, "limit=2 over 5 matches must span multiple pages"
+        assert_walk_compliant(walked, ast, expected_ids=expected_ids)
+
+    async def test_the_same_filter_both_ways_round_reaches_the_same_rows(self, seeded, store, monkeypatch) -> None:
+        """One AST, two splits, one answer — with the seam watched in both modes.
+
+        The end-to-end form of the split contract, and the only place both modes of
+        it are compared *for the same filter*. ``source_type`` normally pushes here,
+        so the natural mode reports no residual and the operand is bound in the SQL;
+        ``force_residual`` drops the key from this store's ``field_mapping`` (the
+        pushdown whitelist), and the SAME filter must then report the key as the
+        residual, bind nothing for it, and still return exactly the same three rows
+        because the coordinator's post-filter picked it up.
+
+        A page that reported the residual honestly and then failed to enforce it
+        would return all six rows here; one that enforced it in SQL while reporting
+        it deferred would bind the value and fail the seam check. The two modes
+        pin each other, which is what neither can do alone.
+        """
+        coordinator, namespace_id, rows = seeded
+        ast = to_filter_ast({"source_type": {"$eq": PROBE_VALUE}})
+        expected_ids = [r["id"] for r in rows if r["source_type"] == PROBE_VALUE]
+        assert len(expected_ids) == 3, "the filter must narrow, or neither mode proves anything"
+
+        with method_sql_log(store._conn, "execute") as pushed_log:  # noqa: SLF001 — no public driver seam
+            pushed_page = await coordinator.scan_documents_page(namespace_id, filter_ast=ast, limit=100)
+        assert pushed_page.post_filtered_keys == ()
+        assert_split_honest(pushed_log, pushed_values=[PROBE_VALUE])
+
+        force_residual(monkeypatch, sqlite_module)
+        with method_sql_log(store._conn, "execute") as residual_log:  # noqa: SLF001
+            residual_page = await coordinator.scan_documents_page(namespace_id, filter_ast=ast, limit=100)
+        assert residual_page.post_filtered_keys == ("source_type",)
+        assert_split_honest(residual_log, residual_values=[PROBE_VALUE])
+
+        # Both modes hit the independently-known match set, and each other.
+        assert_walk_matches_expected(pushed_page, expected_ids)
+        assert_walk_matches_expected(residual_page, expected_ids)
+        assert [d.id for d in residual_page] == [d.id for d in pushed_page]
+        assert_page_compliant(pushed_page, ast)
+        assert_page_compliant(residual_page, ast)

--- a/tests/unit/test_sqlite_scan_documents.py
+++ b/tests/unit/test_sqlite_scan_documents.py
@@ -104,6 +104,12 @@ from tests.test_helpers.document_scan import (
     walk_scan,
     write_document,
 )
+from tests.test_helpers.document_scan_spy import (
+    PROBE_VALUE,
+    assert_split_honest,
+    force_residual,
+    method_sql_log,
+)
 
 # This store needs no services and no Alembic chain — it builds its own schema in
 # ``:memory:`` — so the module carries no skip. The marker is declared anyway
@@ -651,6 +657,174 @@ async def test_pushdown_never_rejects_a_row_the_full_filter_would_keep(backend, 
         assert oracle, "the shape matches no row in this corpus — `oracle <= window` cannot fail"
 
     assert oracle <= {d.id for d in step.documents}
+
+
+# --------------------------------------------------------------------------- #
+# Is the reported split HONEST?
+#
+# Everything above reads ``consumed_keys`` and believes it. These three drive the
+# same scans and check the report against the statement the driver actually ran.
+# The seam here is the aiosqlite connection's own ``execute(sql, params)`` — this
+# store builds SQL text by hand, so there is no SQLAlchemy engine to listen on and
+# the spy wraps the method instead. See
+# :mod:`tests.test_helpers.document_scan_spy` for why the assertion is on bound
+# VALUES rather than on column names.
+# --------------------------------------------------------------------------- #
+
+
+async def _seed_probe_corpus(backend, namespace_id) -> int:
+    """Seed the corpus with the probe literal on half the rows.
+
+    Returns how many rows carry it, so a test can assert the pushed leaf really
+    narrowed rather than trusting the ``i % 2`` arithmetic.
+    """
+    seed = scan_seed(6)
+    for i, (doc_id, created_at) in enumerate(seed.writes):
+        await write_document(
+            backend,
+            namespace_id,
+            doc_id,
+            created_at,
+            source_type=PROBE_VALUE if i % 2 == 0 else "library",
+        )
+    return sum(1 for i in range(len(seed.writes)) if i % 2 == 0)
+
+
+async def test_a_pushed_leaf_really_reaches_the_statement(backend, namespace) -> None:
+    """The perf-lie catch: a leaf reported as pushed must be bound in the SQL.
+
+    ``consumed_keys == {"source_type"}`` is satisfied just as well by a compiler
+    that reported the leaf and emitted nothing for it — the caller's post-filter
+    would return the same rows, and the pushdown's entire purpose (a narrowed
+    window) would be silently gone. The probe literal appearing among the bound
+    params is what distinguishes the two.
+
+    On this store the params are POSITIONAL, so the spy's value set is the whole
+    ``params`` list in order: namespace, the fragment's args, the row bound. That
+    is the same list :func:`test_every_narrowing_leg_composes_in_one_statement`
+    reasons about from the outside, seen from the inside.
+    """
+    matching = await _seed_probe_corpus(backend, namespace.id)
+    ast = to_filter_ast({"source_type": {"$eq": PROBE_VALUE}})
+
+    with method_sql_log(backend._conn, "execute") as sql_log:  # noqa: SLF001 — the driver seam has no public accessor
+        step = await backend.scan_documents(namespace.id, filter_ast=ast, scan_limit=10)
+
+    assert step.consumed_keys == frozenset({"source_type"})
+    assert_split_honest(sql_log, pushed_values=[PROBE_VALUE])
+    # And the pushdown narrowed for real: the window is the matching subset, not
+    # the corpus with a post-filter's worth of work still owed.
+    assert len(step.documents) == matching
+    assert {d.source_type for d in step.documents} == {PROBE_VALUE}
+
+
+async def test_a_naturally_deferred_leaf_never_reaches_the_statement(backend, namespace) -> None:
+    """The correctness-lie catch WITHOUT monkeypatching anything.
+
+    The stronger of the two residual tests, and the reason it exists separately: it
+    needs no ``force_residual``, so it tests the store as it actually ships. The
+    filter is an ``$or`` mixing this store's unpushable ``created_at`` with a
+    pushable ``source_type``, which ``compile_lance``'s all-or-nothing gate defers
+    **as a whole** rather than pushing half a disjunction. So ``source_type`` — a
+    key this store normally pushes eagerly — must NOT be bound here.
+
+    That gate is what this store's ``scan_documents`` docstring names as the reason
+    resuming past pushdown-rejected rows skips nothing: a match-all placeholder left
+    inside a negation inverts into a match-nothing and silently EXCLUDES rows. This
+    asserts it at the seam, where a regression shows up as a bound operand rather
+    than as a row count nobody cross-checks.
+    """
+    await _seed_probe_corpus(backend, namespace.id)
+    ast = to_filter_ast(
+        {"$or": [{"created_at": {"$gte": "2026-01-01T00:00:00+00:00"}}, {"source_type": {"$eq": PROBE_VALUE}}]}
+    )
+
+    with method_sql_log(backend._conn, "execute") as sql_log:  # noqa: SLF001
+        step = await backend.scan_documents(namespace.id, filter_ast=ast, scan_limit=10)
+
+    assert step.consumed_keys == frozenset()
+    assert_split_honest(sql_log, residual_values=[PROBE_VALUE])
+    # The whole disjunction deferred, so SQL narrowed nothing: the raw window is
+    # the entire corpus and the post-filter owns every leaf.
+    assert len(step.documents) == 6
+
+
+async def test_a_residual_leaf_never_reaches_the_statement(backend, namespace, monkeypatch) -> None:
+    """The correctness-lie catch, on the same filter with the leaf forced residual.
+
+    ``force_residual`` drops ``source_type`` from this store's ``field_mapping``,
+    which ``compile_lance`` reads as the pushdown whitelist — so the identical AST
+    now defers. Two things must follow together, and asserting either alone is
+    weak: the report must say the leaf was NOT consumed, and the operand must be
+    absent from the statement. A disagreement in this direction means SQL enforced
+    a leaf the split told the caller it owned.
+    """
+    await _seed_probe_corpus(backend, namespace.id)
+    from khora.storage.backends import sqlite as sqlite_module
+
+    force_residual(monkeypatch, sqlite_module)
+    ast = to_filter_ast({"source_type": {"$eq": PROBE_VALUE}})
+
+    with method_sql_log(backend._conn, "execute") as sql_log:  # noqa: SLF001
+        step = await backend.scan_documents(namespace.id, filter_ast=ast, scan_limit=10)
+
+    assert step.consumed_keys == frozenset()
+    assert_split_honest(sql_log, residual_values=[PROBE_VALUE])
+    # Deferred means "narrowed nothing here": the raw window is the whole corpus,
+    # which is the only correct compilation of a leaf this context cannot push.
+    assert len(step.documents) == 6
+
+
+# The split this store reports, per AST shape. The expected set is PINNED as well
+# as recomputed, because the recompute alone is satisfiable by two compilers that
+# agree on the wrong answer — including the degenerate "consumes nothing ever",
+# which would make every comparison ``frozenset() == frozenset()``. The spread is
+# what makes the parametrization non-vacuous: a full push, a partial push where
+# this store's unpushable date key is the residual, a fully-pushed disjunction, a
+# wholly-deferred one, and a pushed metadata path (JSON1 is available here).
+_SPLIT_SHAPES: dict[str, tuple[dict[str, Any], frozenset[str]]] = {
+    "pushed_whole": ({"source_type": {"$eq": PROBE_VALUE}}, frozenset({"source_type"})),
+    "date_key_is_the_residual": (
+        {"source_type": {"$eq": PROBE_VALUE}, "created_at": {"$gte": "2026-01-01T00:00:00+00:00"}},
+        frozenset({"source_type"}),
+    ),
+    "or_wholly_pushable": (
+        {"$or": [{"source_type": {"$eq": PROBE_VALUE}}, {"title": {"$eq": "doc-1"}}]},
+        frozenset({"source_type", "title"}),
+    ),
+    "or_wholly_deferred": (
+        {"$or": [{"created_at": {"$gte": "2026-01-01T00:00:00+00:00"}}, {"source_type": {"$eq": PROBE_VALUE}}]},
+        frozenset(),
+    ),
+    "metadata_path": ({"metadata.tier": {"$eq": "gold"}}, frozenset({"metadata.tier"})),
+}
+
+
+@pytest.mark.parametrize(("wire", "expected"), _SPLIT_SHAPES.values(), ids=_SPLIT_SHAPES.keys())
+async def test_reported_split_equals_a_fresh_compile_of_the_same_ast(backend, namespace, wire, expected) -> None:
+    """``consumed_keys`` is the compiler's answer, verbatim — no store-side edits.
+
+    The scan is free to compile once and report; what it must not do is add or
+    drop keys on the way out (a store that unioned in the keys it *hoped* were
+    pushed, or that stripped one it found inconvenient, would still look
+    plausible on every row assertion here, because the caller re-checks the full
+    AST regardless). Recomputed with the SAME compiler and the SAME context the
+    scan uses, so a difference can only be the store's own editing.
+
+    This is also how ``created_at`` pushdown is covered. The date key's *value* is
+    deliberately out of the spy's scope — this store writes ``isoformat()`` while
+    PostgreSQL binds a ``datetime`` object, so a value probe there is a dialect
+    quiz — but its membership in the split is exactly what these two shapes
+    compare, and this store withholding it is the difference from the PostgreSQL
+    leg.
+    """
+    await _seed_probe_corpus(backend, namespace.id)
+    ast = to_filter_ast(wire)
+
+    step = await backend.scan_documents(namespace.id, filter_ast=ast, scan_limit=10)
+
+    assert step.consumed_keys == expected
+    assert step.consumed_keys == CompilerRegistry.get(*_COMPILER_KEY)(ast, _documents_compile_context()).consumed_keys
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

- Add a reusable, implementation-blind **page-level oracle helper** for the document-enumeration surface. It re-applies the Python filter predicate over every returned page and asserts full-predicate satisfaction, strict `(created_at DESC, id DESC)` total order, exactly-once enumeration across a cursor walk, and expected-id-set completeness — all computed from the result surface, never from self-reported provenance.
- Add a **scan-SQL seam spy** that captures the executed SQL and bound parameters at each relational backend's driver boundary (SQLAlchemy `before_cursor_execute` for the Postgres and embedded SQLite/LanceDB stores; direct connection wrapping for the raw-SQLite and SurrealDB stores). It asserts that pushed-down filter values reach the database and that residual (post-filtered) values do not — catching both the "claims pushdown, actually post-filters" and "claims post-filtered, actually dropped" failure modes — with empty-log and table-touch vacuity guards, and an inlined-literal tripwire.
- Add **per-backend split-honesty and split-equality tests** across all four relational backends (Postgres, raw SQLite, embedded SQLite/LanceDB, SurrealDB), each run in both natural-pushdown and forced-residual modes. The forced-residual path drops a key from the compile field mapping — the only lever that forces a residual uniformly across backends (a schema-capabilities override only affects the SQLite/LanceDB compiler).
- **Wire the page-level oracle into the facade enumeration walk suite** as a per-page assertion, and export the helper so the conformance, property-based, and end-to-end enumeration suites can reuse it.
- **Tests only** — no production/library code changes.

## Test plan

- [x] Unit tests pass (embedded SQLite + LanceDB legs + helper self-tests): 132 passed locally
- [x] Integration tests pass: SurrealDB (in-memory) 50 passed, Postgres (live) 27 passed, facade walk 7 passed
- [x] Lint / format / typecheck clean (`ruff check .`, `ruff format --check .`, `ty check src/`)
- [x] Repo-wide collection clean (no import breakage introduced)
- [ ] Full suite + coverage gate verified in CI

## Notes

- The forced-residual mode exercises the post-filter split path even on backends where residuals never occur naturally (Postgres, SurrealDB), so the honesty surface is verified on every backend rather than only where residuals arise.
- A companion property-based walk-fuzzer suite is landing separately; the exported oracle helper is designed for it to adopt as a per-page assertion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded document scan coverage across SQLite, PostgreSQL, and SurrealDB.
  * Verified accurate filter pushdown and residual handling, including deferred filters.
  * Added checks for cursor round-tripping, pagination, ordering, namespace isolation, and exact-once results.
  * Added reusable validation tools for complete page walks, filtering, SQL behavior, and page metadata.
  * Confirmed scans preserve all matching documents across cursor and page boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->