### PR TITLE
Index chunk titles in the lexical channel with a query-time title weight

### DIFF
--- a/docs/architecture/failure-observability-contract.md
+++ b/docs/architecture/failure-observability-contract.md
@@ -148,6 +148,7 @@ adding a new channel.
 | `khora.vectorcypher.cypher_expand.degraded_total`      | `RecallResult.engine_info`             |                                                 |
 | `khora.vectorcypher.entity_vector_search.degraded_total` | `RecallResult.engine_info`           |                                                 |
 | `khora.vectorcypher.bm25.degraded_total`               | `RecallResult.engine_info`             |                                                 |
+| `khora.vectorcypher.bm25_title_weight.degraded_total`  | `RecallResult.engine_info`             | Component `vectorcypher.bm25_title_weight`; reason `fts_missing_title_column`. A non-1.0 title weight requested against an FTS index with no `title` column (#1574) |
 | `khora.vectorcypher.community_projection.degraded_total` | `RecallResult.engine_info`           |                                                 |
 | `khora.vectorcypher.chunk_mirror.degraded_total`       | `RecallResult.engine_info`             |                                                 |
 | `khora.vectorcypher.temporal_semantic_fallback.degraded_total` | `RecallResult.engine_info`   |                                                 |

--- a/docs/telemetry-contract.json
+++ b/docs/telemetry-contract.json
@@ -1168,6 +1168,17 @@
       "description": "Issue #1158 (ADR-001). VectorCypher BM25 channel silent fallback - incremented when _bm25_search_chunks catches an exception (reason=channel_exception) or when a >=2-token keyword query returns 0 rows (reason=empty_multitoken_channel, #1330), dropping the independent lexical channel from RRF fusion, or when the KEYWORD-mode floor-gate search raises (reason=floor_gate_exception, #1425). The same event is also appended to RecallResult.engine_info['degradations']. NO namespace_id label - cardinality rule. See docs/architecture/failure-observability-contract.md."
     },
     {
+      "name": "khora.vectorcypher.bm25_title_weight.degraded_total",
+      "type": "counter",
+      "stability": "internal",
+      "unit": "1",
+      "owner": "vectorcypher",
+      "labels": [
+        {"name": "reason", "values": ["fts_missing_title_column"], "_comment": "Low-cardinality enum."}
+      ],
+      "description": "Incremented when title_weight != 1.0 but the FTS store lacks the title column, so the title weight cannot be applied. The same event is also appended to RecallResult.engine_info['degradations']. NO namespace_id label - cardinality rule. See docs/architecture/failure-observability-contract.md."
+    },
+    {
       "name": "khora.vectorcypher.recency_channel.degraded_total",
       "type": "counter",
       "stability": "public",

--- a/src/khora/config/schema.py
+++ b/src/khora/config/schema.py
@@ -1618,9 +1618,14 @@ class QuerySettings(BaseSettings):
         default=1.0,
         ge=0.0,
         le=10.0,
-        description="Query-time weight of chunk title vs content in the BM25 lexical channel "
-        "(1.0 = neutral). Values >1 rank title matches above body matches within the "
-        "lexical channel only; the channel's influence in fusion stays governed by keyword_weight.",
+        description="Query-time weight of chunk title vs content in the BM25 lexical channel. "
+        "1.0 leaves title and content weighted equally; values >1 rank title matches above body "
+        "matches within the lexical channel only, and the channel's influence in fusion stays "
+        "governed by keyword_weight. Note 1.0 does not mean 'no change': folding title into the "
+        "lexical index is a one-time schema change, so title-matching chunks become searchable "
+        "and can re-rank results at any value of this weight. Applied on the sqlite_lance and "
+        "pgvector temporal stores only - accepted but not applied on the surrealdb / turbopuffer / "
+        "weaviate stores and the Chronicle (legacy chunks) path (#1574 follow-up).",
     )
 
     # Lexical-channel selector (#1391). Picks which retriever fills the lexical

--- a/src/khora/config/schema.py
+++ b/src/khora/config/schema.py
@@ -1614,6 +1614,14 @@ class QuerySettings(BaseSettings):
     enable_bm25_channel: bool = Field(
         default=False, description="Enable the independent BM25 lexical channel in fusion"
     )
+    bm25_title_weight: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=10.0,
+        description="Query-time weight of chunk title vs content in the BM25 lexical channel "
+        "(1.0 = neutral). Values >1 rank title matches above body matches within the "
+        "lexical channel only; the channel's influence in fusion stays governed by keyword_weight.",
+    )
 
     # Lexical-channel selector (#1391). Picks which retriever fills the lexical
     # recall slot: "bm25" (default, current behavior, byte-identical) or

--- a/src/khora/db/migrations/versions/058_khora_chunks_title_fts.py
+++ b/src/khora/db/migrations/versions/058_khora_chunks_title_fts.py
@@ -1,0 +1,351 @@
+"""Fold ``khora_chunks.title`` into ``content_tsv`` and recompute every row.
+
+Revision ID: 058_khora_chunks_title_fts
+Revises: 057_drop_documents_created_at_index
+Create Date: 2026-08-12
+
+Migration 041 added the denormalized ``khora_chunks.title`` column and 044
+backfilled it from the parent ``documents`` row, but the lexical index never
+saw it: the ``khora_chunks_content_tsv_trigger()`` function has only ever
+computed ``to_tsvector('english', NEW.content)``. A chunk whose *title* is the
+only place a term appears is therefore invisible to the BM25 / ts_rank channel
+— the gap #1574 closes. This revision swaps the function to a weighted
+concatenation and recomputes the stored vectors::
+
+    setweight(to_tsvector('english', coalesce(NEW.title, '')), 'A')
+ || setweight(to_tsvector('english', NEW.content), 'B')
+
+``coalesce`` because ``title`` is nullable and ``to_tsvector(NULL)`` is NULL,
+which would annihilate the whole concatenation and blank the vector.
+
+Lockstep with the runtime store — this is a convergence contract
+-----------------------------------------------------------------
+``khora_chunks`` is **not** part of the Alembic-managed schema: it is created
+at runtime by ``PgVectorTemporalStore.connect()``, which issues its own
+``CREATE OR REPLACE FUNCTION`` / ``DROP TRIGGER`` / ``CREATE TRIGGER`` on every
+boot. So does this revision. Whichever runs last wins, and both must therefore
+install the *same* function — ``_TSV_FUNCTION_SQL`` below is byte-identical to
+the constant of the same name in ``khora/storage/temporal/pgvector.py``. Change
+both in the same commit. This mirrors the arrangement 044 already has with that
+store's filter-index DDL, and 055 has with ``storage/optimize.py``.
+
+The copy is duplicated rather than imported on purpose: a migration is a frozen
+snapshot of an intent at a point in the chain, and importing runtime code would
+let a future refactor retroactively change what this revision does.
+
+Mixed-version deployments have a write window that loses title tokens
+----------------------------------------------------------------------
+Because the runtime reinstalls the function at ``connect()``, an instance still
+on the **old** khora version that (re)connects after this migration runs will
+``CREATE OR REPLACE`` the content-only formula back over it. Rows it writes
+until a new-version instance next connects carry a vector with no title tokens.
+Nothing errors and nothing is corrupted — those rows are simply not
+title-searchable, and are repaired by any subsequent write to them (or by
+re-running this migration). Single-app-version deployments — the normal case —
+never enter this window. During a rolling deploy, keep it short by rolling
+forward promptly; it closes the moment the last old-version pod is gone and any
+new-version pod has connected.
+
+Step order is load-bearing
+--------------------------
+1. ``CREATE OR REPLACE FUNCTION`` with the new formula.
+2. ``DROP TRIGGER IF EXISTS`` + ``CREATE TRIGGER``.
+3. ``UPDATE khora_chunks SET content_tsv = NULL``.
+
+Step 3 does **not** inline the formula. ``khora_chunks_content_tsv_update`` is a
+``BEFORE INSERT OR UPDATE`` trigger, so it overwrites ``NEW.content_tsv`` on
+every row this UPDATE touches — an inlined expression would be computed and
+then immediately discarded, i.e. dead code that reads like the load-bearing
+part. Assigning NULL makes the trigger the single definition of the formula.
+
+That is also exactly why step 3 must run *after* steps 1-2 and never before.
+Before the swap it would recompute the old formula (pointless); and without
+step 2 it would blank ``content_tsv`` outright on any database where the
+trigger is missing or disabled, silently turning off full-text search for the
+whole table. Step 2 makes the revision self-contained rather than dependent on
+the runtime having booted first, and it repairs one real state: 044's documented
+crash caveat can leave the trigger ``DISABLE``d, and a disabled trigger would
+not fire on step 3's UPDATE. ``DROP``+``CREATE`` restores it enabled.
+
+Cost — this is a full-table rewrite; read before deploying at scale
+--------------------------------------------------------------------
+Step 3 updates every row in ``khora_chunks``:
+
+* Postgres writes a new heap tuple per row (an UPDATE is never a no-op even
+  when the recomputed value is unchanged), so expect table bloat on the order
+  of the table's own size until autovacuum catches up. 044 produced the same
+  shape of churn and documents it the same way.
+* ``content_tsv`` is GIN-indexed (``ix_khora_chunks_content_tsv``), so no update
+  can be HOT — every row costs index maintenance too. This dominates the
+  runtime.
+* The lock taken is ``ROW EXCLUSIVE``. **Concurrent reads are unaffected**;
+  concurrent writers to the *same rows* block until commit.
+* ``SET LOCAL lock_timeout = '5s'`` bounds how long the UPDATE waits to
+  *acquire* its lock. It does not bound how long the statement runs, nor how
+  long its locks are held once acquired.
+
+The compounding hazard is the advisory lock, not the table lock:
+``run_migrations()`` holds a session-scoped ``pg_advisory_lock`` for the entire
+run and a concurrent caller waits only 60s before raising ``TimeoutError``,
+which surfaces as ``RuntimeError: Database migration failed`` at startup. On a
+deployment with a large ``khora_chunks``, other services booting with
+``run_migrations=True`` will fail to start for as long as the rewrite takes.
+Run it out-of-band there rather than during a rolling deploy — the same
+guidance migrations 054 and 056 give for their own long statements.
+
+Re-running is safe but not cheap: the outcome is idempotent, the cost is not.
+There is no sentinel that distinguishes an already-recomputed row (both
+formulas leave ``content_tsv`` non-NULL), so a re-run rewrites the whole table
+again. This is deliberate — the alternatives (probing for weight labels in the
+stored vector) are fragile and no cheaper.
+
+Atomicity
+---------
+One transaction, no ``autocommit_block``, no ``CONCURRENTLY``. The function
+swap, the trigger recreate and the recompute commit together with the version
+stamp, so there is no partial state where the new function is installed but the
+existing rows were never recomputed. The trade is that the UPDATE's snapshot is
+open for the whole rewrite; that is the accepted cost of not shipping a
+half-applied formula.
+
+Ranking compatibility
+---------------------
+Labelling content ``'B'`` changes nothing about ranking on its own *because*
+``_bm25_search`` passes ``ts_rank_cd`` an explicit ``{D, C, B, A}`` weights
+vector rather than relying on the implicit default ``{0.1, 0.2, 0.4, 1.0}``.
+At the default ``title_weight=1.0`` it passes ``{0.1, 0.2, 0.1, 0.1}``, so a
+content hit scores exactly what it scored as an unlabelled (D) token before
+this revision. The match predicate ``content_tsv @@ tsquery`` is
+label-independent and is unchanged.
+
+Dialect and embedded posture
+----------------------------
+Postgres-only. Early-returns on other dialects (SQLite), so it is a clean no-op
+on the ``sqlite_lance`` test fixture.
+
+On Postgres it is additionally guarded by a two-part precondition — the
+``khora_chunks`` table must exist *and* must carry the denormalized ``title``
+column — and no-ops cleanly when either half is missing. Both halves are
+reachable, and neither is an error:
+
+* **No table.** ``khora_chunks`` is runtime-managed, so on a fresh deploy it
+  does not exist when migrations run. The store's ``connect()`` installs the
+  new function itself and there are no rows to recompute. Same gate 041 / 044
+  use.
+* **Table without ``title``.** A legacy or partially-migrated shape (anything
+  predating 041, or a minimal hand-built table) can exist without the
+  denormalized column. There is no title to fold in, so there is nothing to do.
+
+The second half is load-bearing, not defensive tidiness. plpgsql resolves
+``NEW.title`` **when the trigger fires**, not when the function is created, so
+against a title-less table the ``CREATE OR REPLACE FUNCTION`` and
+``CREATE TRIGGER`` both succeed and the recompute ``UPDATE`` is what raises
+``UndefinedColumnError: record "new" has no field "title"``. The blast radius
+would exceed this revision: the swapped function stays installed, so every
+later INSERT or UPDATE to ``khora_chunks`` would fail too — it is only the
+per-migration transaction rolling the whole revision back that contains it.
+The gate applies to ``_run``, so upgrade and downgrade skip the same databases.
+
+The embedded (``sqlite_lance``) stack gets its title FTS on the DDL side
+instead, in its own store. **Pre-existing embedded databases keep content-only
+FTS**: there is no migration chain over that store's hand-written schema, so
+enabling title search there means recreating the store and re-ingesting.
+
+Downgrade
+---------
+Fully symmetric and complete: it reinstalls the pre-#1574 content-only
+function, recreates the trigger, and recomputes every row back to a
+content-only vector. Unlike 055 / 056 nothing here is irreversible — the vector
+is derived data, reconstructible in either direction from ``title`` and
+``content``, which are untouched. The downgrade pays the same full-table
+rewrite cost as the upgrade.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from loguru import logger
+from sqlalchemy.exc import DBAPIError
+
+revision: str = "058_khora_chunks_title_fts"
+down_revision: str | Sequence[str] | None = "057_drop_documents_created_at_index"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# PostgreSQL SQLSTATE for "lock_not_available" — what `lock_timeout` raises
+# when an acquisition exceeds the configured timeout.
+_PG_LOCK_NOT_AVAILABLE = "55P03"
+
+_TSV_TRIGGER = "khora_chunks_content_tsv_update"
+
+# LOCKSTEP: byte-identical to ``_TSV_FUNCTION_SQL`` in
+# ``khora/storage/temporal/pgvector.py``, which issues the same statement at
+# every ``PgVectorTemporalStore.connect()``. Whichever runs last wins, so a
+# drift between the two makes the installed formula depend on boot order.
+# Change both in the same commit. See the module docstring.
+_TSV_FUNCTION_SQL = """CREATE OR REPLACE FUNCTION khora_chunks_content_tsv_trigger() RETURNS trigger AS $$
+BEGIN
+    NEW.content_tsv := setweight(to_tsvector('english', coalesce(NEW.title, '')), 'A')
+                    || setweight(to_tsvector('english', NEW.content), 'B');
+    RETURN NEW;
+END
+$$ LANGUAGE plpgsql"""
+
+# The pre-#1574 formula, restored by ``downgrade()``. Whitespace-normalized
+# relative to the string this revision replaces (that copy was indented inside
+# the store's ``connect()``); the statement itself is unchanged.
+_TSV_FUNCTION_SQL_CONTENT_ONLY = """CREATE OR REPLACE FUNCTION khora_chunks_content_tsv_trigger() RETURNS trigger AS $$
+BEGIN
+    NEW.content_tsv := to_tsvector('english', NEW.content);
+    RETURN NEW;
+END
+$$ LANGUAGE plpgsql"""
+
+_DROP_TRIGGER_SQL = f"DROP TRIGGER IF EXISTS {_TSV_TRIGGER} ON khora_chunks"
+
+_CREATE_TRIGGER_SQL = f"""CREATE TRIGGER {_TSV_TRIGGER}
+BEFORE INSERT OR UPDATE ON khora_chunks
+FOR EACH ROW EXECUTE FUNCTION khora_chunks_content_tsv_trigger()"""
+
+# Assigning NULL, not the formula: the BEFORE trigger overwrites
+# ``NEW.content_tsv`` on every touched row, so an inlined expression would be
+# dead code. See the module docstring.
+_RECOMPUTE_SQL = sa.text("UPDATE khora_chunks SET content_tsv = NULL")
+
+
+def _is_postgres() -> bool:
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def _has_khora_chunks() -> bool:
+    return sa.inspect(op.get_bind()).has_table("khora_chunks")
+
+
+def _has_title_column() -> bool:
+    """Is there a ``khora_chunks`` table that actually carries ``title``?
+
+    Both halves of the precondition, because both are reachable and neither is
+    an error. ``khora_chunks`` is runtime-managed, so on a fresh deploy it does
+    not exist yet; and a legacy or partially-migrated shape (anything predating
+    041, or a minimal hand-built table) can exist *without* the denormalized
+    ``title`` column. Either way there is no title to fold into the vector, so
+    the revision is a clean no-op rather than a failure.
+
+    The column half is not defensive tidiness — without it this revision breaks
+    such a database. plpgsql resolves ``NEW.title`` **when the trigger fires**,
+    not when the function is created, so ``CREATE OR REPLACE FUNCTION`` and
+    ``CREATE TRIGGER`` both succeed against a title-less table and the recompute
+    ``UPDATE`` is what raises ``UndefinedColumnError: record "new" has no field
+    "title"``. Worse, the failure is not confined to this revision: the swapped
+    function would remain installed, so every subsequent INSERT or UPDATE to
+    ``khora_chunks`` would fail too, had the per-migration transaction not
+    rolled it back.
+    """
+    if not _has_khora_chunks():
+        return False
+    columns = sa.inspect(op.get_bind()).get_columns("khora_chunks")
+    return any(c["name"] == "title" for c in columns)
+
+
+def _is_lock_timeout(exc: DBAPIError) -> bool:
+    """Distinguish a real lock_timeout trip from any other database error.
+
+    The caught class is ``DBAPIError``, not ``OperationalError``, and that is
+    load-bearing: on asyncpg a lock-timeout arrives as
+    ``LockNotAvailableError``, which the dialect maps to the *base* DBAPI
+    ``Error`` class, so SQLAlchemy wraps it in a plain ``DBAPIError`` and an
+    ``except OperationalError`` would never fire. Both attribute spellings are
+    read because asyncpg carries the code on ``sqlstate`` (leaving ``pgcode``
+    ``None``) while psycopg2/psycopg use ``pgcode``. Same reasoning as 056,
+    whose docstring records the verification.
+    """
+    orig = getattr(exc, "orig", None)
+    if orig is None:
+        return False
+    for attr in ("sqlstate", "pgcode"):
+        if getattr(orig, attr, None) == _PG_LOCK_NOT_AVAILABLE:
+            return True
+    return False
+
+
+def _swap_formula(function_sql: str) -> int:
+    """Install ``function_sql``, recreate the trigger, recompute every row.
+
+    Returns the number of rows recomputed. Shared by both directions — they
+    differ only in which function body is installed.
+    """
+    # Issued before any DML so it bounds lock *acquisition* for every statement
+    # in this revision: the DDL's ACCESS EXCLUSIVE on the trigger and the
+    # UPDATE's ROW EXCLUSIVE. LOCAL, so the 5s setting dies with this
+    # revision's transaction rather than leaking onto the next revision in the
+    # same ``alembic upgrade head`` run (055 / 056 / 057 do the same).
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    op.execute(function_sql)
+    op.execute(_DROP_TRIGGER_SQL)
+    op.execute(_CREATE_TRIGGER_SQL)
+
+    result = op.get_bind().execute(_RECOMPUTE_SQL)
+    # max(..., 0): the DBAPI contract lets rowcount be -1 when a driver cannot
+    # report a count, and a negative row count in a log field is noise (055 /
+    # 056 carry the same guard).
+    return max(int(result.rowcount or 0), 0)
+
+
+def _run(function_sql: str) -> None:
+    """Apply ``function_sql`` in either direction, with the structured log.
+
+    The precondition is checked here rather than in ``upgrade`` / ``downgrade``
+    so both directions no-op on exactly the same set of databases — a downgrade
+    that tried to recompute a table the upgrade had skipped would fail the same
+    way, for the same reason.
+    """
+    if not _is_postgres() or not _has_title_column():
+        return
+
+    start = time.monotonic()
+    # Initialized up-front so the error path emits the same field set as the
+    # success path. Only DBAPIError is caught; a non-database failure
+    # propagates without an event. Nothing is swallowed — the handler logs and
+    # re-raises — so no ADR-001 degradation record applies here.
+    rows_recomputed = 0
+    try:
+        rows_recomputed = _swap_formula(function_sql)
+    except DBAPIError as exc:
+        duration_ms = int((time.monotonic() - start) * 1000)
+        logger.bind(
+            migration_id=revision,
+            duration_ms=duration_ms,
+            lock_timeout_tripped=_is_lock_timeout(exc),
+            rows_recomputed=rows_recomputed,
+        ).error("khora.migration.applied")
+        # Bare ``raise`` preserves the traceback. The per-migration transaction
+        # rolls the function swap back along with the recompute.
+        raise
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+    logger.bind(
+        migration_id=revision,
+        duration_ms=duration_ms,
+        lock_timeout_tripped=False,
+        rows_recomputed=rows_recomputed,
+    ).info("khora.migration.applied")
+
+
+def upgrade() -> None:
+    _run(_TSV_FUNCTION_SQL)
+
+
+def downgrade() -> None:
+    """Restore the content-only formula and recompute every row.
+
+    Fully reversible: ``content_tsv`` is derived data and both ``title`` and
+    ``content`` are untouched, so the vector is reconstructible in either
+    direction. Pays the same full-table rewrite cost as the upgrade.
+    """
+    _run(_TSV_FUNCTION_SQL_CONTENT_ONLY)

--- a/src/khora/db/migrations/versions/058_khora_chunks_title_fts.py
+++ b/src/khora/db/migrations/versions/058_khora_chunks_title_fts.py
@@ -43,8 +43,18 @@ Nothing errors and nothing is corrupted — those rows are simply not
 title-searchable, and are repaired by any subsequent write to them (or by
 re-running this migration). Single-app-version deployments — the normal case —
 never enter this window. During a rolling deploy, keep it short by rolling
-forward promptly; it closes the moment the last old-version pod is gone and any
+forward promptly; it closes once the last old-version pod is gone and any
 new-version pod has connected.
+
+**It is not always a rolling-deploy artifact, though.** khora is a library, and
+it explicitly supports several downstream services on *different* khora
+versions sharing one database — that is what the skip-ahead logic in
+``run_migrations()`` exists for. A sibling service pinned to an old khora
+version reinstalls the content-only formula on **every** ``connect()``, so the
+two functions flap for as long as that pin stands and title tokens are lost
+intermittently rather than once. Rolling forward promptly does not help there;
+closing the window fully requires every service that connects to this database
+to be on the new khora version.
 
 Step order is load-bearing
 --------------------------
@@ -78,20 +88,33 @@ Step 3 updates every row in ``khora_chunks``:
 * ``content_tsv`` is GIN-indexed (``ix_khora_chunks_content_tsv``), so no update
   can be HOT — every row costs index maintenance too. This dominates the
   runtime.
-* The lock taken is ``ROW EXCLUSIVE``. **Concurrent reads are unaffected**;
-  concurrent writers to the *same rows* block until commit.
-* ``SET LOCAL lock_timeout = '5s'`` bounds how long the UPDATE waits to
-  *acquire* its lock. It does not bound how long the statement runs, nor how
-  long its locks are held once acquired.
+* **The transaction holds ``ACCESS EXCLUSIVE`` on ``khora_chunks`` for its
+  whole duration, and that blocks reads.** ``DROP TRIGGER`` (step 2) requires
+  that level — it was not part of PG 9.4's lock-level reduction — and Postgres
+  never releases a lock early, so it is taken *before* the long rewrite and
+  held to COMMIT. ``ACCESS EXCLUSIVE`` conflicts with the ``ACCESS SHARE``
+  every ``SELECT`` takes, so for the duration *no* query on ``khora_chunks``
+  proceeds — not merely writers to the same rows. Measured on PG: after
+  ``DROP TRIGGER`` the transaction holds ``AccessExclusiveLock``, and still
+  holds it while ``CREATE TRIGGER`` (``ShareRowExclusiveLock``) and the
+  ``UPDATE`` (``RowExclusiveLock``) stack their weaker levels on top.
+* ``SET LOCAL lock_timeout = '5s'`` bounds how long each statement waits to
+  *acquire* a lock. It does not bound how long a lock is held once acquired,
+  nor how long the rewrite runs.
 
-The compounding hazard is the advisory lock, not the table lock:
-``run_migrations()`` holds a session-scoped ``pg_advisory_lock`` for the entire
-run and a concurrent caller waits only 60s before raising ``TimeoutError``,
-which surfaces as ``RuntimeError: Database migration failed`` at startup. On a
-deployment with a large ``khora_chunks``, other services booting with
-``run_migrations=True`` will fail to start for as long as the rewrite takes.
-Run it out-of-band there rather than during a rolling deploy — the same
-guidance migrations 054 and 056 give for their own long statements.
+So there are two independent reasons to run this out-of-band rather than during
+a rolling deploy, not one:
+
+* The ``ACCESS EXCLUSIVE`` above makes ``khora_chunks`` unreadable for the
+  duration — recall stalls on every namespace, not just ingest.
+* ``run_migrations()`` holds a session-scoped ``pg_advisory_lock`` for the
+  entire run and a concurrent caller waits only 60s before raising
+  ``TimeoutError``, which surfaces as ``RuntimeError: Database migration
+  failed`` at startup. On a deployment with a large ``khora_chunks``, other
+  services booting with ``run_migrations=True`` will fail to start for as long
+  as the rewrite takes.
+
+Same guidance migrations 054 and 056 give for their own long statements.
 
 Re-running is safe but not cheap: the outcome is idempotent, the cost is not.
 There is no sentinel that distinguishes an already-recomputed row (both
@@ -108,15 +131,26 @@ existing rows were never recomputed. The trade is that the UPDATE's snapshot is
 open for the whole rewrite; that is the accepted cost of not shipping a
 half-applied formula.
 
-Ranking compatibility
----------------------
-Labelling content ``'B'`` changes nothing about ranking on its own *because*
+Ranking compatibility — per-token only, NOT the result set
+-----------------------------------------------------------
+The ``'B'`` relabel of content costs nothing on its own, because
 ``_bm25_search`` passes ``ts_rank_cd`` an explicit ``{D, C, B, A}`` weights
 vector rather than relying on the implicit default ``{0.1, 0.2, 0.4, 1.0}``.
 At the default ``title_weight=1.0`` it passes ``{0.1, 0.2, 0.1, 0.1}``, so a
 content hit scores exactly what it scored as an unlabelled (D) token before
 this revision. The match predicate ``content_tsv @@ tsquery`` is
 label-independent and is unchanged.
+
+Do not read that as "``title_weight=1.0`` preserves today's behaviour" — it
+preserves the *per-content-token score*, and nothing more. This revision folds
+``title`` into the vector **unconditionally**; ``title_weight`` only scales how
+much an ``'A'`` token contributes, it cannot switch one off. A chunk whose
+title matches the query therefore starts matching where it did not before, and
+enters and re-orders result sets at *every* ``title_weight``, including 1.0 and
+including 0.0 (a zero weight still yields a matching row, scored 0 from the
+title side). That is the point of the change, not a side effect — but it means
+the only way back to pre-#1574 retrieval is ``downgrade()``, not a config
+value.
 
 Dialect and embedded posture
 ----------------------------
@@ -157,8 +191,12 @@ Fully symmetric and complete: it reinstalls the pre-#1574 content-only
 function, recreates the trigger, and recomputes every row back to a
 content-only vector. Unlike 055 / 056 nothing here is irreversible — the vector
 is derived data, reconstructible in either direction from ``title`` and
-``content``, which are untouched. The downgrade pays the same full-table
-rewrite cost as the upgrade.
+``content``, which are untouched.
+
+It runs the identical three steps, so it carries the identical cost: a
+full-table rewrite under an ``ACCESS EXCLUSIVE`` lock held for the whole
+duration, blocking reads on ``khora_chunks`` throughout. Everything in the Cost
+section applies to this direction too — a downgrade is not the cheap way out.
 """
 
 from __future__ import annotations

--- a/src/khora/engines/chronicle/engine.py
+++ b/src/khora/engines/chronicle/engine.py
@@ -1791,6 +1791,11 @@ class ChronicleEngine:
             else DEFAULT_CHRONICLE_HALF_LIFE_HOURS
         )
         _enable_reinforcement = getattr(qs, "chronicle_enable_recall_reinforcement", False) if qs else False
+        # Issue #1574 - title-vs-content weight inside the lexical channel. Threaded
+        # through for uniformity; Chronicle's BM25 runs against the legacy
+        # relational ``chunks`` tier, which has no title column, so the value is
+        # accepted and not applied there.
+        _bm25_title_weight = getattr(qs, "bm25_title_weight", 1.0) if qs else 1.0
         overfetch_limit = limit * _overfetch
 
         # Resolve temporal references from query (fast dateparser, ~0.25ms)
@@ -1916,6 +1921,7 @@ class ChronicleEngine:
                     limit=overfetch_limit,
                     created_after=created_after,
                     created_before=created_before,
+                    title_weight=_bm25_title_weight,
                 )
             )
 

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -572,6 +572,12 @@ class VectorCypherConfig:
     def __post_init__(self) -> None:
         if self.max_chunks_in_flight is not None and self.max_chunks_in_flight < 1:
             raise ValueError(f"max_chunks_in_flight must be >= 1, got {self.max_chunks_in_flight}")
+        # Mirrors the [0, 10] contract Pydantic enforces on
+        # QuerySettings.bm25_title_weight. Direct construction of this dataclass
+        # bypasses that validation entirely, so without this the two entry
+        # points disagree on what a legal weight is (#1574).
+        if not 0.0 <= self.bm25_title_weight <= 10.0:
+            raise ValueError(f"bm25_title_weight must be between 0 and 10, got {self.bm25_title_weight}")
 
     # Streaming pipeline (A-1: batch entity storage across documents)
     streaming_pipeline: bool = True

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -595,9 +595,11 @@ class VectorCypherConfig:
     enable_bm25_channel: bool = False
     bm25_weight: float = 0.3
     bm25_top_k: int = 50
-    # Query-time weight of chunk title vs content INSIDE the lexical channel
-    # (1.0 = neutral, the pre-#1574 behavior). Distinct from bm25_weight,
-    # which governs the channel's influence in RRF fusion.
+    # Query-time weight of chunk title vs content INSIDE the lexical channel.
+    # 1.0 weighs the two equally, reproducing the pre-#1574 per-content-token
+    # ranking - NOT the pre-#1574 result set, which changes at every weight
+    # once title is folded into the index. Distinct from bm25_weight, which
+    # governs the channel's influence in RRF fusion.
     bm25_title_weight: float = 1.0
 
     # Session-aware parallel retrieval for cross-session temporal queries.

--- a/src/khora/engines/vectorcypher/engine.py
+++ b/src/khora/engines/vectorcypher/engine.py
@@ -595,6 +595,10 @@ class VectorCypherConfig:
     enable_bm25_channel: bool = False
     bm25_weight: float = 0.3
     bm25_top_k: int = 50
+    # Query-time weight of chunk title vs content INSIDE the lexical channel
+    # (1.0 = neutral, the pre-#1574 behavior). Distinct from bm25_weight,
+    # which governs the channel's influence in RRF fusion.
+    bm25_title_weight: float = 1.0
 
     # Session-aware parallel retrieval for cross-session temporal queries.
     # Only activates when: Neo4j is connected, query is temporal, and entry
@@ -750,6 +754,9 @@ class VectorCypherEngine:
                 ("recency_weight", "temporal_recency_weight"),
                 ("recency_decay_days", "temporal_recency_decay_days"),
                 ("keyword_weight", "bm25_weight"),
+                # Issue #1574 - query-time title-vs-content weight inside the
+                # lexical channel (KHORA_QUERY_BM25_TITLE_WEIGHT).
+                ("bm25_title_weight", "bm25_title_weight"),
             ):
                 _query_val = getattr(query_cfg, _query_field, None)
                 if _query_val is None:
@@ -1019,6 +1026,7 @@ class VectorCypherEngine:
             enable_bm25_channel=self._vc_config.enable_bm25_channel,
             bm25_weight=self._vc_config.bm25_weight,
             bm25_top_k=self._vc_config.bm25_top_k,
+            bm25_title_weight=self._vc_config.bm25_title_weight,
             # Issue #1391 — lexical-channel selector (keyword_ppr vs bm25).
             # Read straight from KhoraConfig.query (bypasses VectorCypherConfig,
             # mirroring the PPR flags above). Default "bm25" = unchanged.

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -228,10 +228,14 @@ _BM25_DEGRADED_COUNTER = metric_counter(
 
 # BM25 title-weight degradation counter (#1574, ADR-001). A non-neutral
 # ``bm25_title_weight`` is silently inert against a lexical store whose FTS
-# index has no ``title`` column (a store built before the #1574 migration, or
-# a backend that accepts the kwarg and ignores it). The lexical channel still
-# returns rows - only the requested title boost is missing - so this is a
-# degradation, not a failure. NO namespace_id label - cardinality rule.
+# index has no ``title`` column - i.e. a store built before the #1574 migration.
+# The lexical channel still returns rows - only the requested title boost is
+# missing - so this is a degradation, not a failure. Scope: only stores that
+# expose ``fts_has_title`` can trip this. The backends that accept the kwarg
+# and ignore it (surrealdb / turbopuffer / weaviate) do NOT expose the probe,
+# so the ``getattr(..., True)`` default assumes a capable index and this never
+# fires for them - their no-op status is documented on the config field and
+# tracked in the #1574 follow-up. NO namespace_id label - cardinality rule.
 _BM25_TITLE_WEIGHT_DEGRADED_COUNTER = metric_counter(
     "khora.vectorcypher.bm25_title_weight.degraded_total",
     unit="1",
@@ -2004,6 +2008,7 @@ class VectorCypherRetriever:
                     # identical WHERE, so one representative capture is honest.
                     filter_plan_out=vector_filter_plan_sink,
                     raw_cosine_out=raw_cosine_by_id,
+                    degradations=degradations,
                 )
             )
 
@@ -2202,6 +2207,7 @@ class VectorCypherRetriever:
                                 min_similarity=min_similarity,
                                 filter_ast=filter_ast,
                                 raw_cosine_out=raw_cosine_by_id,
+                                degradations=degradations,
                             )
                         )
                     )
@@ -2232,6 +2238,7 @@ class VectorCypherRetriever:
                             filter_ast=filter_ast,
                             filter_plan_out=vector_filter_plan_sink,
                             raw_cosine_out=raw_cosine_by_id,
+                            degradations=degradations,
                         )
                     )
                 )
@@ -2579,6 +2586,7 @@ class VectorCypherRetriever:
                 # drops the temporal filter, so there is no caller filter to
                 # thread here.
                 raw_cosine_out=raw_cosine_by_id,
+                degradations=degradations,
             )
 
         # Await BM25 results (also launched in parallel at the beginning)
@@ -2623,6 +2631,7 @@ class VectorCypherRetriever:
                         min_similarity=min_similarity,
                         filter_ast=filter_ast,
                         raw_cosine_out=sub_raw_cosine,
+                        degradations=degradations,
                     )
                     for _cid, _cos in sub_raw_cosine.items():
                         raw_cosine_by_id.setdefault(_cid, _cos)
@@ -3789,6 +3798,10 @@ class VectorCypherRetriever:
                     filter_plan_out=vector_filter_plan_sink,
                     title_weight=self._config.bm25_title_weight,
                 )
+                # ADR-001 (#1574): this store call carries a title_weight too,
+                # so the hybrid path must report an inapplicable one even when
+                # the dedicated lexical channel is off. Deduped per recall.
+                self._record_title_weight_degradation(degradations)
 
             chunk_results: list[tuple[Chunk, float]] = []
             _sorted_raw_cosines = sorted((r.similarity for r in results), reverse=True)
@@ -4952,6 +4965,7 @@ class VectorCypherRetriever:
         filter_ast: FilterNode | None = None,
         filter_plan_out: list[ChannelPlan] | None = None,
         raw_cosine_out: dict[UUID, float] | None = None,
+        degradations: list[Degradation] | None = None,
     ) -> list[tuple[UUID, float, Chunk]]:
         """Direct vector search on chunks via pgvector.
 
@@ -4980,6 +4994,11 @@ class VectorCypherRetriever:
                 store's hybrid blend); the sink carries the true cosine so the
                 exit-time display score and abstention metadata are cosine-scale,
                 never store-RRF (#1433).
+            degradations: Per-recall degradation sink (ADR-001). This channel
+                hands the store a ``title_weight``, so an inapplicable one is
+                recorded here as well as on the lexical channel; the record is
+                deduped to one per recall, hence the SHARED list rather than a
+                fresh one (#1574).
 
         Returns:
             List of (chunk_id, score, chunk) tuples
@@ -4998,6 +5017,9 @@ class VectorCypherRetriever:
                 filter_plan_out=filter_plan_out,
                 title_weight=self._config.bm25_title_weight,
             )
+            # ADR-001 (#1574): the hybrid blend consumes the title weight, so an
+            # inapplicable one degrades this channel too. Deduped per recall.
+            self._record_title_weight_degradation(degradations)
 
             span.set_attribute("chunk_count", len(results))
             if raw_cosine_out is not None:
@@ -5299,6 +5321,50 @@ class VectorCypherRetriever:
             span.set_attribute("chunk_count", len(results))
             return results
 
+    def _record_title_weight_degradation(self, degradations: list[Degradation] | None) -> None:
+        """Record the #1574 title-weight degradation, at most once per recall.
+
+        A non-neutral ``bm25_title_weight`` against a store whose FTS index has
+        no ``title`` column is silently inert: the channel returns rows, ranked
+        on content alone, and nothing raises. Only stores that can answer the
+        question expose ``fts_has_title``; absent the attribute (pgvector, the
+        accept-and-ignore backends, mocks) we assume a capable index and record
+        nothing.
+
+        Called from every channel that hands the store a ``title_weight`` - the
+        dedicated lexical channel and both hybrid vector paths. They all probe
+        the SAME store, so they would each observe the same missing column and
+        report it separately. The ``degradations`` list is the per-recall sink
+        that reaches ``RecallResult.engine_info["degradations"]``, so an
+        existing record in it means this recall already reported the fact:
+        that is the dedupe key, and the counter is bumped only on the append
+        so the metric counts recalls, not channels.
+
+        With no sink (``degradations is None``) the one-per-recall invariant
+        cannot be enforced, so nothing is recorded - the counter would
+        otherwise double-count across channels. Every path that reaches a
+        ``RecallResult`` supplies a list; ``None`` only happens on direct calls.
+        """
+        if self._config.bm25_title_weight == 1.0:
+            return
+        if getattr(self._vector_store, "fts_has_title", True) is not False:
+            return
+        if degradations is None:
+            return
+        if any(d.get("component") == "vectorcypher.bm25_title_weight" for d in degradations):
+            return
+        _BM25_TITLE_WEIGHT_DEGRADED_COUNTER.add(1, attributes={"reason": "fts_missing_title_column"})
+        degradations.append(
+            Degradation(
+                component="vectorcypher.bm25_title_weight",
+                reason="fts_missing_title_column",
+                detail=(
+                    f"bm25_title_weight={self._config.bm25_title_weight} requested but the "
+                    "FTS index has no title column; lexical ranking used content only"
+                ),
+            )
+        )
+
     async def _bm25_search_chunks(
         self,
         query: str,
@@ -5380,28 +5446,11 @@ class VectorCypherRetriever:
                         filter_plan_out=filter_plan_out,
                         title_weight=self._config.bm25_title_weight,
                     )
-                    # ADR-001 (#1574): a non-neutral title weight against a
-                    # store whose FTS index has no ``title`` column is silently
-                    # inert - the channel still returns rows, ranked on content
-                    # alone. Stores that can answer expose ``fts_has_title``;
-                    # absent the attribute (pgvector, mocks) we assume the
-                    # column is present and record nothing.
-                    if (
-                        self._config.bm25_title_weight != 1.0
-                        and getattr(self._vector_store, "fts_has_title", True) is False
-                    ):
-                        _BM25_TITLE_WEIGHT_DEGRADED_COUNTER.add(1, attributes={"reason": "fts_missing_title_column"})
-                        if degradations is not None:
-                            degradations.append(
-                                Degradation(
-                                    component="vectorcypher.bm25_title_weight",
-                                    reason="fts_missing_title_column",
-                                    detail=(
-                                        f"bm25_title_weight={self._config.bm25_title_weight} requested but the "
-                                        "FTS index has no title column; lexical ranking used content only"
-                                    ),
-                                )
-                            )
+                    # ADR-001 (#1574): a non-neutral title weight this store
+                    # cannot apply. Deduped to one record per recall by the
+                    # helper - the hybrid vector channel probes the same store
+                    # and would otherwise record the identical fact again.
+                    self._record_title_weight_degradation(degradations)
                     # Real backends return ``list[tuple[Chunk, float]]``; the
                     # ``isinstance`` check rejects the bare-AsyncMock case
                     # (and any other non-list return) so we fall through to

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -226,6 +226,25 @@ _BM25_DEGRADED_COUNTER = metric_counter(
     ),
 )
 
+# BM25 title-weight degradation counter (#1574, ADR-001). A non-neutral
+# ``bm25_title_weight`` is silently inert against a lexical store whose FTS
+# index has no ``title`` column (a store built before the #1574 migration, or
+# a backend that accepts the kwarg and ignores it). The lexical channel still
+# returns rows - only the requested title boost is missing - so this is a
+# degradation, not a failure. NO namespace_id label - cardinality rule.
+_BM25_TITLE_WEIGHT_DEGRADED_COUNTER = metric_counter(
+    "khora.vectorcypher.bm25_title_weight.degraded_total",
+    unit="1",
+    description=(
+        "Issue #1574 (ADR-001). Incremented when bm25_title_weight != 1.0 but the "
+        "FTS store lacks the title column, so the requested title weight cannot "
+        "be applied and the lexical channel ranks on content alone. The same "
+        "event is also appended to RecallResult.engine_info['degradations']. "
+        "Labels: reason (fts_missing_title_column). NO namespace_id label - "
+        "cardinality rule."
+    ),
+)
+
 # ADR-001. When the recency channel's ``search_recent_chunks`` raises an
 # operational fault (DB / network), the channel returns [] and its
 # pool-augmentation contribution drops out of RRF. The catch site records a
@@ -638,6 +657,13 @@ class RetrieverConfig:
     enable_bm25_channel: bool = False
     bm25_weight: float = 0.3
     bm25_top_k: int = 50  # How many BM25 results to fetch
+    # Issue #1574 - query-time weight of a chunk's title vs its content WITHIN
+    # the lexical channel (1.0 = neutral / pre-#1574 behavior). Distinct from
+    # bm25_weight, which is the channel's weight in RRF fusion. Part of the
+    # recall-cache fingerprint: the cache key is repr() of this dataclass, so
+    # declaring the field here is what keeps differently-weighted recalls from
+    # sharing a cache entry.
+    bm25_title_weight: float = 1.0
 
     # Lexical-channel selector (#1391). "bm25" (default) keeps BM25 in the
     # lexical slot; "keyword_ppr" swaps in the experimental keyword-chunk
@@ -3759,6 +3785,7 @@ class VectorCypherRetriever:
                     query_text=query,
                     filter_ast=filter_ast,
                     filter_plan_out=vector_filter_plan_sink,
+                    title_weight=self._config.bm25_title_weight,
                 )
 
             chunk_results: list[tuple[Chunk, float]] = []
@@ -4961,6 +4988,7 @@ class VectorCypherRetriever:
                 query_text=query_text,
                 filter_ast=filter_ast,
                 filter_plan_out=filter_plan_out,
+                title_weight=self._config.bm25_title_weight,
             )
 
             span.set_attribute("chunk_count", len(results))
@@ -5308,7 +5336,10 @@ class VectorCypherRetriever:
             degradations: When provided, a structured ``Degradation`` is appended
                 if the search raises so the silently-dropped lexical channel is
                 observable (ADR-001, issue #1158). Recall continues with the
-                BM25 contribution absent from RRF rather than crashing.
+                BM25 contribution absent from RRF rather than crashing. A second
+                record (``fts_missing_title_column``, #1574) is appended when
+                a non-neutral ``bm25_title_weight`` cannot be applied because the
+                store's FTS index has no ``title`` column.
 
         Returns:
             List of (chunk_id, score, chunk) tuples
@@ -5339,7 +5370,30 @@ class VectorCypherRetriever:
                         limit=limit,
                         filter_ast=filter_ast,
                         filter_plan_out=filter_plan_out,
+                        title_weight=self._config.bm25_title_weight,
                     )
+                    # ADR-001 (#1574): a non-neutral title weight against a
+                    # store whose FTS index has no ``title`` column is silently
+                    # inert - the channel still returns rows, ranked on content
+                    # alone. Stores that can answer expose ``fts_has_title``;
+                    # absent the attribute (pgvector, mocks) we assume the
+                    # column is present and record nothing.
+                    if (
+                        self._config.bm25_title_weight != 1.0
+                        and getattr(self._vector_store, "fts_has_title", True) is False
+                    ):
+                        _BM25_TITLE_WEIGHT_DEGRADED_COUNTER.add(1, attributes={"reason": "fts_missing_title_column"})
+                        if degradations is not None:
+                            degradations.append(
+                                Degradation(
+                                    component="vectorcypher.bm25_title_weight",
+                                    reason="fts_missing_title_column",
+                                    detail=(
+                                        f"bm25_title_weight={self._config.bm25_title_weight} requested but the "
+                                        "FTS index has no title column; lexical ranking used content only"
+                                    ),
+                                )
+                            )
                     # Real backends return ``list[tuple[Chunk, float]]``; the
                     # ``isinstance`` check rejects the bare-AsyncMock case
                     # (and any other non-list return) so we fall through to

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -658,7 +658,9 @@ class RetrieverConfig:
     bm25_weight: float = 0.3
     bm25_top_k: int = 50  # How many BM25 results to fetch
     # Issue #1574 - query-time weight of a chunk's title vs its content WITHIN
-    # the lexical channel (1.0 = neutral / pre-#1574 behavior). Distinct from
+    # the lexical channel. 1.0 weighs the two equally, reproducing the pre-#1574
+    # per-content-token score - not the pre-#1574 result set, which changes at
+    # every weight once title is folded into the index. Distinct from
     # bm25_weight, which is the channel's weight in RRF fusion. Part of the
     # recall-cache fingerprint: the cache key is repr() of this dataclass, so
     # declaring the field here is what keeps differently-weighted recalls from
@@ -3844,6 +3846,12 @@ class VectorCypherRetriever:
                     # leaks below-floor chunks).
                     if min_similarity > 0.0 and bm25_results:
                         try:
+                            # #1574: title_weight deliberately NOT threaded here,
+                            # unlike the hybrid/lexical sites. The gate runs pure
+                            # vector (hybrid_alpha=None) and only its id SET is
+                            # consumed - the returned order is discarded, hits stay
+                            # in BM25 order - so a lexical title weight cannot
+                            # change its outcome. Not an oversight; do not "fix".
                             gate_results = await self._vector_store.search(
                                 namespace_id=namespace_id,
                                 query_embedding=query_embedding,

--- a/src/khora/engines/vectorcypher/retriever.py
+++ b/src/khora/engines/vectorcypher/retriever.py
@@ -3801,7 +3801,11 @@ class VectorCypherRetriever:
                 # ADR-001 (#1574): this store call carries a title_weight too,
                 # so the hybrid path must report an inapplicable one even when
                 # the dedicated lexical channel is off. Deduped per recall.
-                self._record_title_weight_degradation(degradations)
+                # Gated on the blend: alpha None is SearchMode.VECTOR, where the
+                # store skips its internal BM25 entirely and never consumes the
+                # weight - reporting it unused there would be a false record.
+                if effective_alpha is not None:
+                    self._record_title_weight_degradation(degradations)
 
             chunk_results: list[tuple[Chunk, float]] = []
             _sorted_raw_cosines = sorted((r.similarity for r in results), reverse=True)
@@ -5019,6 +5023,13 @@ class VectorCypherRetriever:
             )
             # ADR-001 (#1574): the hybrid blend consumes the title weight, so an
             # inapplicable one degrades this channel too. Deduped per recall.
+            # Unconditional on purpose, unlike the ``_simple_retrieve`` site:
+            # ``effective_alpha`` is never None here (it falls back to the
+            # configured hybrid_alpha), so there is no pure-vector case to
+            # exclude. A caller passing ``hybrid_alpha_override=1.0`` does skip
+            # the blend, but that only happens when the lexical channel is
+            # active - which records the same fact genuinely - and the
+            # per-recall dedupe collapses the pair to one. Do not add a guard.
             self._record_title_weight_degradation(degradations)
 
             span.set_attribute("chunk_count", len(results))

--- a/src/khora/storage/coordinator.py
+++ b/src/khora/storage/coordinator.py
@@ -1840,6 +1840,7 @@ class StorageCoordinator:
         created_after: datetime | None = None,
         created_before: datetime | None = None,
         filter_ast: FilterNode | None = None,
+        title_weight: float = 1.0,
     ) -> list[tuple[Chunk, float]]:
         """Search chunks using PostgreSQL full-text search.
 
@@ -1849,9 +1850,15 @@ class StorageCoordinator:
         REFUSES to return rows under an active filter rather than risk
         smuggling unfiltered chunks. The filtered BM25 path is the
         ``khora_chunks`` temporal store (``TemporalVectorStore.search_fulltext``).
+
+        ``title_weight`` is accepted for signature uniformity with the temporal
+        store and is deliberately NOT forwarded — see below.
         """
         if not self._vector:
             raise RuntimeError("Vector backend not configured")
+        # ``title_weight`` intentionally not forwarded: this is the legacy
+        # relational ``chunks`` FTS tier, which is out of scope for #1574 - it
+        # has no title column.
         return await self._vector.search_fulltext(
             namespace_id,
             query_text,

--- a/src/khora/storage/temporal/__init__.py
+++ b/src/khora/storage/temporal/__init__.py
@@ -94,6 +94,7 @@ class TemporalVectorStore(Protocol):
         query_text: str | None = None,  # Required for hybrid search
         filter_ast: FilterNode | None = None,
         filter_plan_out: list[ChannelPlan] | None = None,
+        title_weight: float = 1.0,
     ) -> list[TemporalSearchResult]:
         """Search for similar chunks with temporal filtering.
 
@@ -116,6 +117,11 @@ class TemporalVectorStore(Protocol):
                 is race-free under concurrent recalls on a shared store — no mutable
                 instance state is involved. Backends that do not report pushdown
                 leave it untouched.
+            title_weight: Weight of a chunk's ``title`` relative to its
+                ``content`` in the lexical (BM25) half of a hybrid search
+                (#1574). ``1.0`` weighs the two equally and reproduces the
+                pre-#1574 ranking exactly. Backends without a title-aware
+                lexical index accept it and ignore it, as with ``filter_ast``.
 
         Returns:
             List of matching chunks with similarity scores
@@ -142,6 +148,7 @@ class TemporalVectorStore(Protocol):
         created_before: datetime | None = None,
         filter_ast: FilterNode | None = None,
         filter_plan_out: list[ChannelPlan] | None = None,
+        title_weight: float = 1.0,
     ) -> list[tuple[Chunk, float]]:
         """Full-text search over the temporal store's chunk table.
 
@@ -161,6 +168,12 @@ class TemporalVectorStore(Protocol):
         (sqlite_lance) reports the pushed/post-filtered partition its WHERE
         + in-memory re-check actually produced. The default (return ``[]``)
         leaves it untouched.
+
+        ``title_weight`` scales a chunk's ``title`` against its ``content`` in
+        the lexical ranking (#1574); ``1.0`` weighs the two equally and
+        reproduces the pre-#1574 ranking exactly. Backends whose fulltext index
+        does not cover ``title`` accept it and ignore it, as with
+        ``filter_ast``.
         """
         return []
 

--- a/src/khora/storage/temporal/__init__.py
+++ b/src/khora/storage/temporal/__init__.py
@@ -119,9 +119,13 @@ class TemporalVectorStore(Protocol):
                 leave it untouched.
             title_weight: Weight of a chunk's ``title`` relative to its
                 ``content`` in the lexical (BM25) half of a hybrid search
-                (#1574). ``1.0`` weighs the two equally and reproduces the
-                pre-#1574 ranking exactly. Backends without a title-aware
-                lexical index accept it and ignore it, as with ``filter_ast``.
+                (#1574). At ``1.0`` a content token scores exactly what it
+                scored pre-#1574, so per-content-token scoring is preserved;
+                this does NOT preserve the overall result set or ranking, since
+                folding ``title`` into the index means title-matching chunks
+                newly match and can re-rank at any ``title_weight``. Backends
+                without a title-aware lexical index accept it and ignore it, as
+                with ``filter_ast``.
 
         Returns:
             List of matching chunks with similarity scores
@@ -170,10 +174,12 @@ class TemporalVectorStore(Protocol):
         leaves it untouched.
 
         ``title_weight`` scales a chunk's ``title`` against its ``content`` in
-        the lexical ranking (#1574); ``1.0`` weighs the two equally and
-        reproduces the pre-#1574 ranking exactly. Backends whose fulltext index
-        does not cover ``title`` accept it and ignore it, as with
-        ``filter_ast``.
+        the lexical ranking (#1574). At ``1.0`` a content token scores exactly
+        what it scored pre-#1574, so per-content-token scoring is preserved;
+        this does NOT preserve the overall result set or ranking, since folding
+        ``title`` into the index means title-matching chunks newly match and
+        can re-rank at any ``title_weight``. Backends whose fulltext index does
+        not cover ``title`` accept it and ignore it, as with ``filter_ast``.
         """
         return []
 

--- a/src/khora/storage/temporal/pgvector.py
+++ b/src/khora/storage/temporal/pgvector.py
@@ -546,8 +546,12 @@ class PgVectorTemporalStore(TemporalVectorStore):
         coexist during the ``ChunkTemporalFilter`` deprecation window.
 
         ``title_weight`` scales the lexical rank contribution of a chunk's
-        ``title`` relative to its ``content`` (#1574); ``1.0`` weighs the two
-        equally and reproduces the pre-#1574 ranking exactly.
+        ``title`` relative to its ``content`` (#1574). At ``1.0`` a content
+        token scores exactly what it scored pre-#1574 (the D→B relabel is
+        pinned to 0.1), so per-content-token scoring is preserved. This does
+        NOT preserve the overall result set or ranking: migration 058 folds
+        ``title`` into the lexical index unconditionally, so title-matching
+        chunks newly match and can re-rank at any ``title_weight``.
         """
         with trace_span(
             "khora.temporal_store.search",
@@ -779,8 +783,12 @@ class PgVectorTemporalStore(TemporalVectorStore):
         filter and cannot return filter-violating chunks.
 
         ``title_weight`` scales the rank contribution of a chunk's ``title``
-        relative to its ``content`` (#1574); ``1.0`` weighs the two equally
-        and reproduces the pre-#1574 ranking exactly.
+        relative to its ``content`` (#1574). At ``1.0`` a content token scores
+        exactly what it scored pre-#1574 (the D→B relabel is pinned to 0.1),
+        so per-content-token scoring is preserved. This does NOT preserve the
+        overall result set or ranking: migration 058 folds ``title`` into the
+        lexical index unconditionally, so title-matching chunks newly match and
+        can re-rank at any ``title_weight``.
         """
         if not query_text or not query_text.strip():
             return []
@@ -901,9 +909,13 @@ class PgVectorTemporalStore(TemporalVectorStore):
         """Perform BM25-style full-text search using PostgreSQL ts_rank.
 
         ``title_weight`` scales the rank contribution of the ``'A'``-labelled
-        title tokens relative to the ``'B'``-labelled content tokens. ``1.0``
-        (the default) makes the two weigh the same, which reproduces the
-        pre-#1574 ranking exactly.
+        title tokens relative to the ``'B'``-labelled content tokens. At
+        ``1.0`` (the default) the two weigh the same and a content token
+        scores exactly what it scored pre-#1574 (the D→B relabel is pinned to
+        0.1), so per-content-token scoring is preserved. This does NOT preserve
+        the overall result set or ranking: migration 058 folds ``title`` into
+        the lexical index unconditionally, so title-matching chunks newly match
+        and can re-rank at any ``title_weight``.
         """
         # Create tsquery from query text
         # OR the query terms instead of plainto_tsquery's implicit AND: a full
@@ -918,8 +930,10 @@ class PgVectorTemporalStore(TemporalVectorStore):
         # (``{0.1, 0.2, 0.4, 1.0}``) would silently change ranking the moment
         # migration 058 relabels content from unlabelled (D, 0.1) to 'B' (0.4) —
         # a 4x jump on every content hit. Pinning D and B to the same 0.1 keeps
-        # a content match scoring exactly as it did before the relabel, so
-        # ``title_weight=1.0`` is numerically identical to today's ranking.
+        # a content match scoring exactly as it did before the relabel. That
+        # preserves per-content-token scoring only — NOT the result set: 058
+        # folds title into the index, so title-matching chunks newly match and
+        # can re-rank at any title_weight.
         # The literal is interpolated rather than bound because ``float`` under
         # ``:g`` can only render digits, ``.``, ``e`` and a sign — no injection
         # surface. The value originates from ``query.bm25_title_weight``, which

--- a/src/khora/storage/temporal/pgvector.py
+++ b/src/khora/storage/temporal/pgvector.py
@@ -121,6 +121,29 @@ khora_chunks_table = Table(
 )
 
 
+# Body of the ``khora_chunks.content_tsv`` trigger function (#1574). The
+# vector is weighted: ``title`` tokens carry label ``'A'`` and ``content``
+# tokens label ``'B'``, so ``ts_rank_cd`` can score a title hit above a body hit
+# via an explicit weights vector (see ``_bm25_search``). ``coalesce`` because
+# ``title`` is nullable; ``to_tsvector`` of NULL is NULL and would annihilate
+# the whole concatenation.
+#
+# LOCKSTEP: this string MUST stay byte-identical to ``_TSV_FUNCTION_SQL`` in
+# ``khora/db/migrations/versions/058_khora_chunks_title_fts.py``. Both sites
+# issue ``CREATE OR REPLACE`` against the same function, so whichever runs last
+# wins — a drift between them makes the installed formula depend on boot order
+# (migration vs. store ``connect()``). Change both in the same commit. Same
+# convergence contract migration 044 has with the filter-index DDL above, and
+# 055 has with ``storage/optimize.py``.
+_TSV_FUNCTION_SQL = """CREATE OR REPLACE FUNCTION khora_chunks_content_tsv_trigger() RETURNS trigger AS $$
+BEGIN
+    NEW.content_tsv := setweight(to_tsvector('english', coalesce(NEW.title, '')), 'A')
+                    || setweight(to_tsvector('english', NEW.content), 'B');
+    RETURN NEW;
+END
+$$ LANGUAGE plpgsql"""
+
+
 # Legacy ``ChunkTemporalFilter.additional`` range-op names → the canonical filter Op,
 # so the deterministic-filter compiler can build a type-gated metadata compare.
 _LEGACY_RANGE_OPS: dict[str, Op] = {
@@ -290,16 +313,9 @@ class PgVectorTemporalStore(TemporalVectorStore):
 
             # Create trigger for auto-updating content_tsv
             # Note: Each statement must be executed separately (asyncpg limitation)
-            await conn.execute(
-                text("""
-                CREATE OR REPLACE FUNCTION khora_chunks_content_tsv_trigger() RETURNS trigger AS $$
-                BEGIN
-                    NEW.content_tsv := to_tsvector('english', NEW.content);
-                    RETURN NEW;
-                END
-                $$ LANGUAGE plpgsql
-                """)
-            )
+            # The function body lives in the module-level ``_TSV_FUNCTION_SQL``
+            # so it can be kept byte-identical to migration 058's copy.
+            await conn.execute(text(_TSV_FUNCTION_SQL))
             await conn.execute(text("DROP TRIGGER IF EXISTS khora_chunks_content_tsv_update ON khora_chunks"))
             await conn.execute(
                 text("""
@@ -512,6 +528,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
         query_text: str | None = None,
         filter_ast: FilterNode | None = None,
         filter_plan_out: list[ChannelPlan] | None = None,
+        title_weight: float = 1.0,
     ) -> list[TemporalSearchResult]:
         """Search for similar chunks with temporal filtering.
 
@@ -527,6 +544,10 @@ class PgVectorTemporalStore(TemporalVectorStore):
         provided it is compiled to a single-table ``khora_chunks`` WHERE predicate
         and AND-ed alongside the legacy ``temporal_filter`` conditions. The two
         coexist during the ``ChunkTemporalFilter`` deprecation window.
+
+        ``title_weight`` scales the lexical rank contribution of a chunk's
+        ``title`` relative to its ``content`` (#1574); ``1.0`` weighs the two
+        equally and reproduces the pre-#1574 ranking exactly.
         """
         with trace_span(
             "khora.temporal_store.search",
@@ -544,6 +565,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
                 query_text=query_text,
                 filter_ast=filter_ast,
                 filter_plan_out=filter_plan_out,
+                title_weight=title_weight,
             )
             _search_span.set_attribute("result_count", len(results))
             return results
@@ -560,6 +582,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
         query_text: str | None = None,
         filter_ast: FilterNode | None = None,
         filter_plan_out: list[ChannelPlan] | None = None,
+        title_weight: float = 1.0,
     ) -> list[TemporalSearchResult]:
         async with self._get_session() as session:
             # Build base conditions
@@ -612,6 +635,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
                     query_text,
                     conditions,
                     limit * 2,
+                    title_weight=title_weight,
                 )
 
                 # Fuse results using RRF. An explicit min_similarity floor
@@ -643,6 +667,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
                         query_text,
                         conditions,
                         needed + len(existing_ids),  # Fetch extra to account for overlap
+                        title_weight=title_weight,
                     )
 
                     # Add BM25 results that aren't already in vector results
@@ -736,6 +761,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
         created_before: datetime | None = None,
         filter_ast: FilterNode | None = None,
         filter_plan_out: list[ChannelPlan] | None = None,
+        title_weight: float = 1.0,
     ) -> list[tuple[Chunk, float]]:
         """Public BM25 / ts_rank lookup over ``khora_chunks`` for the
         StorageCoordinator dispatch path.
@@ -751,6 +777,10 @@ class PgVectorTemporalStore(TemporalVectorStore):
         AND-ed into the conditions — the SAME compile context the vector path
         uses (``_search_inner``), so the BM25 channel honors the identical
         filter and cannot return filter-violating chunks.
+
+        ``title_weight`` scales the rank contribution of a chunk's ``title``
+        relative to its ``content`` (#1574); ``1.0`` weighs the two equally
+        and reproduces the pre-#1574 ranking exactly.
         """
         if not query_text or not query_text.strip():
             return []
@@ -790,7 +820,7 @@ class PgVectorTemporalStore(TemporalVectorStore):
         elif filter_plan_out is not None:
             filter_plan_out.append(ChannelPlan())
         async with self._get_session() as session:
-            results = await self._bm25_search(session, query_text, conditions, limit)
+            results = await self._bm25_search(session, query_text, conditions, limit, title_weight=title_weight)
         return [(temporal_chunk_to_chunk(r.chunk), float(r.bm25_score or 0.0)) for r in results]
 
     async def search_recent_chunks(
@@ -866,8 +896,15 @@ class PgVectorTemporalStore(TemporalVectorStore):
         query_text: str,
         conditions: list,
         limit: int,
+        title_weight: float = 1.0,
     ) -> list[TemporalSearchResult]:
-        """Perform BM25-style full-text search using PostgreSQL ts_rank."""
+        """Perform BM25-style full-text search using PostgreSQL ts_rank.
+
+        ``title_weight`` scales the rank contribution of the ``'A'``-labelled
+        title tokens relative to the ``'B'``-labelled content tokens. ``1.0``
+        (the default) makes the two weigh the same, which reproduces the
+        pre-#1574 ranking exactly.
+        """
         # Create tsquery from query text
         # OR the query terms instead of plainto_tsquery's implicit AND: a full
         # sentence rarely has every content word in one chunk, so AND matched
@@ -876,7 +913,19 @@ class PgVectorTemporalStore(TemporalVectorStore):
         if not terms:
             return []
         tsquery = func.to_tsquery("english", " | ".join(terms))
-        rank = func.ts_rank_cd(khora_chunks_table.c.content_tsv, tsquery).label("bm25_score")
+        # The weights vector is ALWAYS passed explicitly, in PostgreSQL's
+        # ``{D, C, B, A}`` order. Relying on ts_rank_cd's implicit default
+        # (``{0.1, 0.2, 0.4, 1.0}``) would silently change ranking the moment
+        # migration 058 relabels content from unlabelled (D, 0.1) to 'B' (0.4) —
+        # a 4x jump on every content hit. Pinning D and B to the same 0.1 keeps
+        # a content match scoring exactly as it did before the relabel, so
+        # ``title_weight=1.0`` is numerically identical to today's ranking.
+        # The literal is interpolated rather than bound because ``float`` under
+        # ``:g`` can only render digits, ``.``, ``e`` and a sign — no injection
+        # surface. The value originates from ``query.bm25_title_weight``, which
+        # Pydantic validates to [0.0, 10.0] at the config boundary.
+        weights = f"'{{0.1, 0.2, 0.1, {0.1 * title_weight:g}}}'::float4[]"
+        rank = func.ts_rank_cd(text(weights), khora_chunks_table.c.content_tsv, tsquery).label("bm25_score")
 
         _retrieval_cols_bm25 = [c for c in khora_chunks_table.c if c.name != "embedding"]
         stmt = (

--- a/src/khora/storage/temporal/sqlite_lance.py
+++ b/src/khora/storage/temporal/sqlite_lance.py
@@ -242,7 +242,20 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
             row = await cur.fetchone()
             self._fts_has_title = bool(row and row[0] and "title" in row[0].lower())
         except Exception:
+            # Distinct failure mode from the legacy 1-column shape: there the
+            # probe SUCCEEDS and simply reports no title column, which
+            # ``_bm25_expr`` handles with its own throttled warning. Here the
+            # probe itself raised, so the shape is UNKNOWN. We keep the same
+            # conservative False, but that is now an assumption rather than a
+            # reading — hence the WARNING with ``exc_info`` (ADR-001 convention).
             self._fts_has_title = False
+            logger.warning(
+                "SQLiteLanceTemporalStore: FTS5 shape probe failed — could not read "
+                "khora_chunks_fts from sqlite_master. This is NOT the legacy "
+                "1-column-table case; the table's shape is unknown. Assuming no title "
+                "column, so title weighting is inert for the life of this store.",
+                exc_info=True,
+            )
 
         # Create the LanceDB vector table for khora_chunks. exist_ok keeps
         # this idempotent across processes/test runs.

--- a/src/khora/storage/temporal/sqlite_lance.py
+++ b/src/khora/storage/temporal/sqlite_lance.py
@@ -12,7 +12,8 @@ Schema layout
   :meth:`connect` if absent (analogous to PgVectorTemporalStore which
   calls ``metadata.create_all`` in its connect()).
 * ``khora_chunks_fts`` (SQLite FTS5) — external-content virtual table
-  over ``khora_chunks.content``.  Triggers keep it in sync.
+  over ``khora_chunks.content`` (column 0) and ``khora_chunks.title``
+  (column 1).  Triggers keep it in sync.
 * ``khora_chunks_vec`` (LanceDB) — embeddings only.  Mirrors the
   ``chunks_vec`` Arrow schema used by the main vector adapter.
 
@@ -97,25 +98,27 @@ _KHORA_CHUNKS_SCHEMA: tuple[str, ...] = (
     "CREATE INDEX IF NOT EXISTS ix_khora_chunks_source ON khora_chunks(source_system)",
     """
     CREATE VIRTUAL TABLE IF NOT EXISTS khora_chunks_fts USING fts5(
-        content, content='khora_chunks', content_rowid='rowid', tokenize='porter'
+        content, title, content='khora_chunks', content_rowid='rowid', tokenize='porter'
     )
     """,
     """
     CREATE TRIGGER IF NOT EXISTS khora_chunks_ai AFTER INSERT ON khora_chunks BEGIN
-        INSERT INTO khora_chunks_fts(rowid, content) VALUES (new.rowid, new.content);
+        INSERT INTO khora_chunks_fts(rowid, content, title)
+        VALUES (new.rowid, new.content, new.title);
     END
     """,
     """
     CREATE TRIGGER IF NOT EXISTS khora_chunks_ad AFTER DELETE ON khora_chunks BEGIN
-        INSERT INTO khora_chunks_fts(khora_chunks_fts, rowid, content)
-        VALUES ('delete', old.rowid, old.content);
+        INSERT INTO khora_chunks_fts(khora_chunks_fts, rowid, content, title)
+        VALUES ('delete', old.rowid, old.content, old.title);
     END
     """,
     """
     CREATE TRIGGER IF NOT EXISTS khora_chunks_au AFTER UPDATE ON khora_chunks BEGIN
-        INSERT INTO khora_chunks_fts(khora_chunks_fts, rowid, content)
-        VALUES ('delete', old.rowid, old.content);
-        INSERT INTO khora_chunks_fts(rowid, content) VALUES (new.rowid, new.content);
+        INSERT INTO khora_chunks_fts(khora_chunks_fts, rowid, content, title)
+        VALUES ('delete', old.rowid, old.content, old.title);
+        INSERT INTO khora_chunks_fts(rowid, content, title)
+        VALUES (new.rowid, new.content, new.title);
     END
     """,
 )
@@ -184,6 +187,15 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         # compile_python post-filter. Tests may monkeypatch this to False to
         # exercise the fallback path.
         self._has_json1 = False
+        # Whether the live ``khora_chunks_fts`` table indexes ``title`` as a
+        # second column. Probed once in connect(); gates the weighted bm25()
+        # form. Defaults False so a pre-existing embedded DB built with the
+        # 1-column shape (the DDL is ``IF NOT EXISTS`` — never altered) is
+        # detected rather than scored with a weight that cannot apply.
+        self._fts_has_title = False
+        # One-shot latch for the title_weight-ignored degradation warning
+        # (ADR-001 throttle pattern, mirrors vectorcypher.version_filter).
+        self._title_weight_fallback_warned = False
         # LanceDB is a single-writer store — serialize add/delete on the
         # khora_chunks_vec table per-instance to mirror the main vector
         # adapter's policy.
@@ -218,6 +230,20 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         except Exception:
             self._has_json1 = False
 
+        # Probe the live FTS5 shape. The DDL above is ``IF NOT EXISTS``, so an
+        # embedded database created before ``title`` became a second FTS column
+        # keeps the 1-column table and its 1-column triggers (no ALTER, no
+        # backfill) — titles are simply not indexed there. SQLite does NOT
+        # reject the surplus weight argument on that shape (measured: 3.53.4
+        # silently ignores extra bm25() weights), so without this probe the
+        # no-op would be invisible. Hence: detect, degrade, and say so.
+        try:
+            cur = await sqlite.execute("SELECT sql FROM sqlite_master WHERE name = 'khora_chunks_fts'")
+            row = await cur.fetchone()
+            self._fts_has_title = bool(row and row[0] and "title" in row[0].lower())
+        except Exception:
+            self._fts_has_title = False
+
         # Create the LanceDB vector table for khora_chunks. exist_ok keeps
         # this idempotent across processes/test runs.
         lance = self._handle.lance
@@ -237,6 +263,15 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         self._chunks_vec = None
         self._connected = False
         logger.info("SQLiteLanceTemporalStore disconnected")
+
+    @property
+    def fts_has_title(self) -> bool:
+        """Whether the live FTS5 table indexes ``title`` (probed in connect()).
+
+        False before ``connect()`` and on pre-existing embedded databases built
+        with the 1-column shape — ``title_weight`` is inert on those.
+        """
+        return self._fts_has_title
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -435,6 +470,7 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         query_text: str | None = None,
         filter_ast: FilterNode | None = None,
         filter_plan_out: list[ChannelPlan] | None = None,
+        title_weight: float = 1.0,
     ) -> list[TemporalSearchResult]:
         # ``filter_ast`` is the deterministic recall-filter AST. compile_lance
         # pushes what JSON1 supports into the SQLite WHERE; a compile_python
@@ -455,6 +491,7 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
                 query_text=query_text,
                 filter_ast=filter_ast,
                 filter_plan_out=filter_plan_out,
+                title_weight=title_weight,
             )
             _span.set_attribute("result_count", len(results))
             return results
@@ -471,6 +508,7 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         query_text: str | None,
         filter_ast: FilterNode | None = None,
         filter_plan_out: list[ChannelPlan] | None = None,
+        title_weight: float = 1.0,
     ) -> list[TemporalSearchResult]:
         # Build the compile_python post-filter ONCE per recall (it is
         # alias-independent — it runs on decoded TemporalChunks). The compile_lance
@@ -528,6 +566,7 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
                 limit * 2,
                 filter_ast,
                 post_filter,
+                title_weight=title_weight,
             )
             # An explicit min_similarity floor applies to the BM25 side too:
             # BM25-only chunks never passed the vector floor (#1404).
@@ -555,6 +594,7 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
                 needed + len(existing_ids),
                 filter_ast,
                 post_filter,
+                title_weight=title_weight,
             )
             for bm25_result in bm25_results:
                 cid = str(bm25_result.chunk.id)
@@ -660,6 +700,7 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         created_before: datetime | None = None,
         filter_ast: FilterNode | None = None,
         filter_plan_out: list[ChannelPlan] | None = None,
+        title_weight: float = 1.0,
     ) -> list[tuple[Chunk, float]]:
         """Public BM25 (SQLite FTS5) lookup over ``khora_chunks`` for the
         StorageCoordinator dispatch path. See :func:`temporal_chunk_to_chunk`
@@ -705,8 +746,48 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
                 created_after=created_after,
                 created_before=created_before,
             )
-        results = await self._bm25_search(namespace_id, query_text, temporal_filter, limit, filter_ast=filter_ast)
+        results = await self._bm25_search(
+            namespace_id,
+            query_text,
+            temporal_filter,
+            limit,
+            filter_ast=filter_ast,
+            title_weight=title_weight,
+        )
         return [(temporal_chunk_to_chunk(r.chunk), float(r.bm25_score or 0.0)) for r in results]
+
+    def _bm25_expr(self, title_weight: float) -> str:
+        """Build the ``bm25()`` scoring call for the current FTS5 shape.
+
+        ``title_weight == 1.0`` (the default) yields the bare, shape-agnostic
+        call — byte-identical to the pre-title SQL, and equivalent to an
+        all-ones weight vector. A non-default weight yields the per-column form
+        ``bm25(khora_chunks_fts, 1.0, <w>)`` (content is column 0, title is
+        column 1), but only when the live table actually indexes ``title``;
+        on the legacy 1-column shape it degrades back to the bare call with a
+        throttled warning (ADR-001), never an exception. The degradation is
+        real even though SQLite tolerates the surplus argument: that table has
+        no title terms to weight.
+
+        The weight is inlined rather than bound: FTS5 auxiliary-function
+        arguments must be literals, and the value is a Pydantic-clamped float
+        from config ([0, 10]) — never user text.
+        """
+        if title_weight == 1.0:
+            return "bm25(khora_chunks_fts)"
+        if not self._fts_has_title:
+            msg = (
+                "SQLiteLanceTemporalStore: khora_chunks_fts lacks the 'title' column, "
+                f"so title_weight={title_weight:g} is ignored and BM25 scores content only. "
+                "Recreate the embedded database and re-ingest to enable title weighting."
+            )
+            if not self._title_weight_fallback_warned:
+                self._title_weight_fallback_warned = True
+                logger.warning(msg)
+            else:
+                logger.debug(msg)
+            return "bm25(khora_chunks_fts)"
+        return f"bm25(khora_chunks_fts, 1.0, {title_weight:g})"
 
     async def _bm25_search(
         self,
@@ -716,6 +797,7 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         limit: int,
         filter_ast: FilterNode | None = None,
         post_filter: Callable[[TemporalChunk], bool] | None = None,
+        title_weight: float = 1.0,
     ) -> list[TemporalSearchResult]:
         # FTS5 MATCH; SQLite's bm25() is lower-is-better — negate so the
         # semantics match the PG/SurrealDB siblings.
@@ -723,7 +805,10 @@ class SQLiteLanceTemporalStore(TemporalVectorStore):
         if not match_expr:
             return []
         sql_parts = [
-            "SELECT c.*, bm25(khora_chunks_fts) AS bm FROM khora_chunks_fts "
+            # noqa justification: the only interpolated value is _bm25_expr's
+            # own output — a fixed string, or a clamped config float rendered
+            # via {:g}. No caller input reaches the SQL text.
+            f"SELECT c.*, {self._bm25_expr(title_weight)} AS bm FROM khora_chunks_fts "  # noqa: S608
             "JOIN khora_chunks c ON c.rowid = khora_chunks_fts.rowid "
             "WHERE khora_chunks_fts MATCH ? AND c.namespace_id = ?"
         ]

--- a/src/khora/storage/temporal/surrealdb.py
+++ b/src/khora/storage/temporal/surrealdb.py
@@ -385,12 +385,16 @@ class SurrealDBTemporalStore(TemporalVectorStore):
         query_text: str | None = None,
         filter_ast: FilterNode | None = None,
         filter_plan_out: list[ChannelPlan] | None = None,
+        title_weight: float = 1.0,
     ) -> list[TemporalSearchResult]:
         """Search temporal chunks with optional hybrid (vector + BM25) ranking.
 
         ``filter_ast`` is the deterministic recall-filter AST. When provided it
         is compiled to a SurrealQL ``WHERE`` predicate and AND-ed alongside the
         legacy ``temporal_filter`` clauses.
+
+        ``title_weight`` is accepted for interface uniformity; not applied —
+        tracked in the #1574 follow-up issue.
         """
         with trace_span(
             "khora.temporal_store.search",
@@ -588,6 +592,7 @@ class SurrealDBTemporalStore(TemporalVectorStore):
         created_before: datetime | None = None,
         filter_ast: FilterNode | None = None,
         filter_plan_out: list[ChannelPlan] | None = None,
+        title_weight: float = 1.0,
     ) -> list[tuple[Chunk, float]]:
         """Public BM25 lookup over the SurrealDB temporal-chunk table.
 
@@ -598,6 +603,9 @@ class SurrealDBTemporalStore(TemporalVectorStore):
         ``filter_ast`` is the deterministic recall-filter AST. When provided it
         is compiled to a SurrealQL ``WHERE`` predicate and AND-ed into the BM25
         query alongside the namespace + temporal-bound clauses.
+
+        ``title_weight`` is accepted for interface uniformity; not applied —
+        tracked in the #1574 follow-up issue.
         """
         if not query_text or not query_text.strip():
             return []

--- a/src/khora/storage/temporal/turbopuffer.py
+++ b/src/khora/storage/temporal/turbopuffer.py
@@ -333,6 +333,7 @@ class TurbopufferTemporalStore(TemporalVectorStore):
         query_text: str | None = None,
         filter_ast: FilterNode | None = None,
         filter_plan_out: list[ChannelPlan] | None = None,
+        title_weight: float = 1.0,
     ) -> list[TemporalSearchResult]:
         """Vector or hybrid (vector + BM25) search.
 
@@ -352,6 +353,9 @@ class TurbopufferTemporalStore(TemporalVectorStore):
         normalizes to, i.e. an AND root with no children) is a no-op and passes
         through to the normal search path unchanged. ``filter_ast.children`` is
         the "has real constraints" check (the root is always an AND ``FilterNode``).
+
+        ``title_weight`` is accepted for interface uniformity; not applied —
+        tracked in the #1574 follow-up issue.
         """
         if filter_ast is not None and filter_ast.children:
             raise RecallFilterUnsupportedError(
@@ -448,6 +452,7 @@ class TurbopufferTemporalStore(TemporalVectorStore):
         created_before: datetime | None = None,
         filter_ast: FilterNode | None = None,
         filter_plan_out: list[ChannelPlan] | None = None,
+        title_weight: float = 1.0,
     ) -> list[tuple[Chunk, float]]:
         """BM25 keyword search over the turbopuffer namespace.
 
@@ -461,6 +466,9 @@ class TurbopufferTemporalStore(TemporalVectorStore):
 
         ``created_after`` / ``created_before`` translate to turbopuffer
         ``created_at`` range filters using the same grammar as ``search()``.
+
+        ``title_weight`` is accepted for interface uniformity; not applied —
+        tracked in the #1574 follow-up issue.
         """
         if filter_ast is not None and filter_ast.children:
             raise RecallFilterUnsupportedError(

--- a/src/khora/storage/temporal/weaviate.py
+++ b/src/khora/storage/temporal/weaviate.py
@@ -449,6 +449,7 @@ class WeaviateTemporalStore(TemporalVectorStore):
         query_text: str | None = None,
         filter_ast: FilterNode | None = None,
         filter_plan_out: list[ChannelPlan] | None = None,
+        title_weight: float = 1.0,
     ) -> list[TemporalSearchResult]:
         """Search for similar chunks with temporal filtering.
 
@@ -496,6 +497,9 @@ class WeaviateTemporalStore(TemporalVectorStore):
           (never a wrong row, only possibly fewer) and inherent to post-filtering;
           a caller needing exactly ``limit`` under heavy metadata selectivity must
           widen the candidate budget (raise ``limit`` upstream).
+
+        ``title_weight`` is accepted for interface uniformity; not applied —
+        tracked in the #1574 follow-up issue.
         """
         from weaviate.classes.query import HybridFusion, MetadataQuery
 
@@ -722,6 +726,7 @@ class WeaviateTemporalStore(TemporalVectorStore):
         created_before: datetime | None = None,
         filter_ast: FilterNode | None = None,
         filter_plan_out: list[ChannelPlan] | None = None,
+        title_weight: float = 1.0,
     ) -> list[tuple[Chunk, float]]:
         """BM25 keyword search over the Weaviate ``KhoraChunk`` collection.
 
@@ -731,6 +736,9 @@ class WeaviateTemporalStore(TemporalVectorStore):
 
         Returns ``(Chunk, score)`` tuples where ``score`` is the BM25
         relevance score from Weaviate's ``MetadataQuery(score=True)``.
+
+        ``title_weight`` is accepted for interface uniformity; not applied —
+        tracked in the #1574 follow-up issue.
         """
         from weaviate.classes.query import Filter, MetadataQuery
 

--- a/tests/integration/db/test_migration_044_chunks_backfill.py
+++ b/tests/integration/db/test_migration_044_chunks_backfill.py
@@ -95,6 +95,10 @@ _MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" /
 
 _PREV_REVISION = "043_khora_chunks_metadata_backfill"
 
+#: This module's revision under test. Only ``test_content_tsv_untouched_by_backfill``
+#: walks to it instead of ``head`` — see that test for why.
+_REVISION = "044_khora_chunks_backfill_denormalized"
+
 _TSV_TRIGGER = "khora_chunks_content_tsv_update"
 
 # The five filter indexes 044 builds CONCURRENTLY — names byte-identical to the
@@ -704,9 +708,20 @@ class TestMigration044OnPostgres:
         """The backfill UPDATE must not recompute ``content_tsv`` — proves the
         trigger was disabled across the backfill loop. We seed a row, capture
         its ``content_tsv``, run the backfill, and assert it is byte-identical
-        (the backfill never touches ``content``)."""
+        (the backfill never touches ``content``).
+
+        Targets 044 rather than ``head``, unlike its siblings in this class.
+        ``058_khora_chunks_title_fts`` sits later in the chain and *legitimately*
+        recomputes ``content_tsv`` into the title-weighted
+        ``setweight(title,'A') || setweight(content,'B')`` form, so walking to
+        head would break the byte-equality assertion for a reason that has
+        nothing to do with 044. The assertion is about 044's trigger handling, so
+        the walk is scoped to 044. (The siblings assert on the backfilled columns
+        and the trigger's enabled state, which 058 does not disturb — they stay
+        on ``head``.)
+        """
         cfg = _make_config(pg_url)
-        command.upgrade(cfg, "head")
+        command.upgrade(cfg, _REVISION)
 
         ns_id = uuid4()
         doc_id = uuid4()
@@ -750,23 +765,39 @@ class TestMigration044OnPostgres:
         # The seeded trigger populated content_tsv on INSERT.
         assert before, "seed precondition: content_tsv should be populated on INSERT"
 
-        command.upgrade(cfg, "head")  # backfill (trigger disabled across loop)
+        command.upgrade(cfg, _REVISION)  # backfill (trigger disabled across loop)
 
-        async def _capture_after() -> str:
+        async def _capture_after() -> tuple[str, str | None]:
             engine = create_async_engine(pg_url)
             try:
                 async with engine.connect() as conn:
-                    return (
+                    row = (
                         await conn.execute(
-                            sa.text("SELECT content_tsv::text FROM khora_chunks WHERE id = :id"),
+                            sa.text("SELECT content_tsv::text, source_type FROM khora_chunks WHERE id = :id"),
                             {"id": chunk_id},
                         )
-                    ).scalar()
+                    ).one()
+                    return row[0], row[1]
             finally:
                 await engine.dispose()
 
-        after = asyncio.run(_capture_after())
+        after, source_type = asyncio.run(_capture_after())
+        # The backfill must actually have run. Without this the assertion below
+        # is satisfied by 044 not executing at all — a live risk now that the
+        # walk stops at 044 instead of head. ``source_type`` was NULL on the
+        # seeded chunk and 'slack' on its parent document, so this is the
+        # cheapest available proof that the backfill loop touched the row.
+        assert source_type == "slack", f"044 did not run: source_type is {source_type!r}, expected 'slack'"
         assert after == before, "backfill recomputed content_tsv (trigger was not disabled)"
+
+        # Leave the shared database at head, like every sibling test in this
+        # class does (they end on their own ``upgrade(cfg, "head")``). Scoping
+        # the walk above to 044 is what makes this necessary: it stops the chain
+        # mid-way, and ``_step_version_back`` dropped ``chunks.occurred_at``,
+        # which only migration 046 puts back. The per-test ``pg_url`` fixture
+        # wipes and re-migrates anyway, so this is for whatever runs after the
+        # module, not for the next test.
+        command.upgrade(cfg, "head")
 
     def test_no_op_when_table_absent(self, pg_url: str) -> None:
         """Fresh DB with no ``khora_chunks``: the ``has_table`` guard

--- a/tests/integration/db/test_migration_058_khora_chunks_title_fts.py
+++ b/tests/integration/db/test_migration_058_khora_chunks_title_fts.py
@@ -1,0 +1,580 @@
+"""``058_khora_chunks_title_fts`` — PostgreSQL lane (#1574).
+
+Migration 041 added the denormalized ``khora_chunks.title`` column and 044
+backfilled it, but ``khora_chunks_content_tsv_trigger()`` only ever computed
+``to_tsvector('english', NEW.content)``. A chunk whose *title* was the only
+place a term appeared was invisible to the lexical channel. 058 swaps the
+function to a weighted concatenation (``title`` -> ``'A'``, ``content`` ->
+``'B'``) and recomputes every stored vector.
+
+Postgres-only by construction, and there is no SQLite twin: ``khora_chunks``
+does not exist on the embedded stack — that tier gets its title FTS from the
+sqlite_lance store's own DDL, covered by
+``tests/unit/storage/test_sqlite_lance_title_fts.py``. The one thing this
+revision shares with the runtime store — the trigger-function body, which both
+sites ``CREATE OR REPLACE`` — is pinned byte-for-byte in the unit lane by
+``tests/unit/db/test_migration_058_lockstep.py``, so that contract is checked on
+every PR even without a server.
+
+What is actually exercised here, none of which a string test can reach:
+
+1. The 0-hit repro, end to end through ``PgVectorTemporalStore.search_fulltext``
+   — before the migration a title-only query returns nothing, after it returns
+   the chunk. Seeded with the verbatim repro title
+   ``Floor Panels_Dimensioned_20260213``, which doubles as a tokenizer guard:
+   the ``english`` configuration must split it on the underscores.
+2. The stored vector carries the ``A`` / ``B`` weight labels.
+3. **Rank equality** — the assertion that makes "the default is not a behavior
+   change" a measured fact rather than an argument. Postgres' implicit
+   ``ts_rank_cd`` weights are ``{0.1, 0.2, 0.4, 1.0}``, so relabelling content
+   from unlabelled (``D`` = 0.1) to ``'B'`` (= 0.4) would quadruple every
+   content hit's score. The store therefore passes the vector explicitly, with
+   ``B`` pinned back to ``0.1``. This compares the post-migration score under
+   that vector against the pre-migration score under the *implicit* default on
+   the *unlabelled* vector, on the same row and the same query, and requires
+   them to be equal.
+4. ``downgrade()`` genuinely reverses: title tokens stop matching and the labels
+   are gone.
+
+Why the pre-migration state is set up by hand
+---------------------------------------------
+Building the schema at 057 is not enough to produce a "before". ``khora_chunks``
+is runtime-managed, and the runtime's ``connect()`` installs the *new* function
+unconditionally — so a store connected at 057 already indexes titles. The state
+058 exists to repair is "table created by an OLD khora runtime", which this
+module reproduces by installing the content-only body (imported from the
+revision's own ``downgrade`` constant, so it cannot drift from what a downgrade
+produces) over the function the store just created.
+
+Each class owns a throwaway database (``tests/test_helpers/pg_scratch_db.py``)
+rather than touching the shared dev one: these tests downgrade and re-upgrade,
+and CI runs the integration job with ``--timeout-method=thread``, which kills
+the process outright so ``finally`` blocks never run.
+
+Run explicitly::
+
+    KHORA_DATABASE_URL="postgresql://khora:khora@localhost:5434/khora" \\
+        UV_NO_SYNC=1 uv run pytest \\
+        tests/integration/db/test_migration_058_khora_chunks_title_fts.py \\
+        -o addopts="" --no-cov -q
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import re
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+from pydantic import SecretStr
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from khora.config.schema import KhoraConfig
+from khora.core.temporal import TemporalChunk
+from khora.storage.temporal.pgvector import PgVectorTemporalStore
+from tests.test_helpers.pg_scratch_db import pg_reachable, scratch_database
+
+pytestmark = [pytest.mark.integration]
+
+skip_no_pg = pytest.mark.skipif(
+    not pg_reachable(),
+    reason="PostgreSQL not reachable (run `make dev` first)",
+)
+
+MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "src" / "khora" / "db" / "migrations"
+
+REVISION = "058_khora_chunks_title_fts"
+PREV_REVISION = "057_drop_documents_created_at_index"
+
+#: The pre-#1574 function body, taken from the revision's own ``downgrade``
+#: constant. Imported rather than re-spelled so "the state before the upgrade"
+#: and "the state after a downgrade" are the same string by construction — a
+#: local copy could drift and quietly make the before/after comparison vacuous.
+_MIGRATION = importlib.import_module(f"khora.db.migrations.versions.{REVISION}")
+CONTENT_ONLY_FUNCTION_SQL: str = _MIGRATION._TSV_FUNCTION_SQL_CONTENT_ONLY
+
+#: Verbatim from the repro, and a tokenizer regression guard: the ``english``
+#: text-search configuration must split on ``_``, yielding ``floor`` / ``panel``
+#: / ``dimens`` / ``20260213``. A configuration that kept the underscores would
+#: index one unmatchable token and every title assertion below would fail.
+TITLE = "Floor Panels_Dimensioned_20260213"
+
+#: Shares no vocabulary with :data:`TITLE` — load-bearing, or a title hit and a
+#: content hit would be indistinguishable.
+BODY = "the assembly drawing revision notes for the north wing"
+
+#: A query whose terms live only in :data:`BODY`. The rank-equality comparison
+#: has to be a *content-only* match: it is asking whether an already-working
+#: content hit still scores what it scored before.
+CONTENT_QUERY = "assembly drawing"
+
+#: Queries whose terms live only in :data:`TITLE`.
+TITLE_QUERY = "floor panels dimensioned"
+TITLE_NUMERIC_QUERY = "20260213"
+
+#: The tsquery ``_bm25_search`` builds for :data:`CONTENT_QUERY` — same
+#: alnum-split + ``|`` join, so the rank numbers below come from the query the
+#: store actually issues rather than a lookalike.
+CONTENT_TSQUERY = "assembly | drawing"
+
+#: The vector the store passes at ``title_weight=1.0``, in Postgres'
+#: ``{D, C, B, A}`` order.
+NEUTRAL_WEIGHTS = "{0.1, 0.2, 0.1, 0.1}"
+
+
+def make_config(url: str) -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", str(MIGRATIONS_DIR))
+    # Alembic uses configparser.BasicInterpolation; escape any literal '%' so it
+    # is not read as an interpolation token.
+    cfg.set_main_option("sqlalchemy.url", url.replace("%", "%%"))
+    cfg.attributes["database_url"] = url
+    return cfg
+
+
+def _async_url(url: str) -> str:
+    if url.startswith("postgresql://"):
+        return url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    if url.startswith("postgres://"):
+        return url.replace("postgres://", "postgresql+asyncpg://", 1)
+    return url
+
+
+async def _scalar(url: str, statement: str, params: dict | None = None):
+    engine = create_async_engine(_async_url(url))
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(sa.text(statement), params or {})
+            return result.scalar()
+    finally:
+        await engine.dispose()
+
+
+async def _execute(url: str, statement: str) -> None:
+    engine = create_async_engine(_async_url(url))
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(sa.text(statement))
+    finally:
+        await engine.dispose()
+
+
+def _store_config(url: str) -> KhoraConfig:
+    config = KhoraConfig()
+    config.storage.postgresql_url = SecretStr(_async_url(url))
+    # Small vectors: the store builds an HNSW index at connect() and nothing
+    # here searches by vector. Keeps the fixture's setup cost near zero.
+    config.llm.embedding_dimension = 8
+    return config
+
+
+async def _connected_store(url: str) -> PgVectorTemporalStore:
+    store = PgVectorTemporalStore(_store_config(url))
+    await store.connect()
+    return store
+
+
+def _chunk(namespace_id: UUID, *, content: str, title: str | None) -> TemporalChunk:
+    return TemporalChunk(
+        id=uuid4(),
+        namespace_id=namespace_id,
+        document_id=uuid4(),
+        content=content,
+        embedding=[0.0] * 7 + [1.0],
+        occurred_at=datetime.now(UTC),
+        created_at=datetime.now(UTC),
+        title=title,
+    )
+
+
+class _Seeded:
+    """A scratch database sitting at 057 in the genuine pre-#1574 state."""
+
+    def __init__(self, url: str, namespace_id: UUID, chunk_id: UUID) -> None:
+        self.url = url
+        self.namespace_id = namespace_id
+        self.chunk_id = chunk_id
+        self.config = make_config(url)
+
+
+async def _search(url: str, seeded: _Seeded, query: str, **kwargs) -> list[UUID]:
+    """Chunk ids the lexical channel returns, best-ranked first.
+
+    Goes through the real store rather than raw SQL so the assertions cover the
+    query the product issues — the ``|``-joined tsquery, the explicit weights
+    vector, and the ``@@`` predicate — not a hand-written approximation.
+
+    Note what connecting a store costs: ``connect()`` reinstalls the *new*
+    trigger function every time, so after the first call here the content-only
+    body is gone. That does not weaken anything below, because the trigger only
+    fires on INSERT/UPDATE and every assertion in this module reads *stored*
+    vectors — which only the migration's recompute rewrites. It does mean the
+    downgrade test proves the downgrade's **recompute**, not that its function
+    swap survives a subsequent runtime boot; that it cannot survive one is the
+    documented mixed-version window, and the function bodies themselves are
+    pinned in the unit lane. Do not "fix" this by moving the reinstall.
+    """
+    store = await _connected_store(url)
+    try:
+        rows = await store.search_fulltext(seeded.namespace_id, query, limit=10, **kwargs)
+        return [chunk.id for chunk, _score in rows]
+    finally:
+        await store.disconnect()
+
+
+# A ``khora_chunks`` predating migration 041 — the identity/content/tsv columns
+# and NOTHING else. Hand-written rather than produced by the store, because the
+# store's ``connect()`` builds the current (title-bearing) shape and there is no
+# chain over this runtime-managed table to walk backwards. The trigger installed
+# alongside it is the content-only formula, which is what such a database has.
+_TITLE_LESS_KHORA_CHUNKS_DDL = (
+    """
+    CREATE TABLE khora_chunks (
+        id UUID PRIMARY KEY,
+        namespace_id UUID NOT NULL,
+        document_id UUID NOT NULL,
+        content TEXT NOT NULL,
+        created_at TIMESTAMPTZ,
+        content_tsv TSVECTOR
+    )
+    """,
+    CONTENT_ONLY_FUNCTION_SQL,
+    """
+    CREATE TRIGGER khora_chunks_content_tsv_update
+    BEFORE INSERT OR UPDATE ON khora_chunks
+    FOR EACH ROW EXECUTE FUNCTION khora_chunks_content_tsv_trigger()
+    """,
+    """
+    INSERT INTO khora_chunks (id, namespace_id, document_id, content, created_at)
+    VALUES (gen_random_uuid(), gen_random_uuid(), gen_random_uuid(), 'legacy chunk body', NOW())
+    """,
+)
+
+#: A write issued *after* the migration ran. If 058 had swapped the function in,
+#: this INSERT would raise ``UndefinedColumnError: record "new" has no field
+#: "title"`` — the failure that outlives the revision.
+_TITLE_LESS_SECOND_INSERT_SQL = """
+INSERT INTO khora_chunks (id, namespace_id, document_id, content, created_at)
+VALUES (gen_random_uuid(), gen_random_uuid(), gen_random_uuid(), 'written after the migration', NOW())
+"""
+
+
+async def _install_title_less_khora_chunks(url: str) -> None:
+    for statement in _TITLE_LESS_KHORA_CHUNKS_DDL:
+        await _execute(url, statement)
+
+
+async def _seed_rows(url: str) -> tuple[UUID, UUID]:
+    """Create the runtime table, revert its function, and insert one chunk.
+
+    ``connect()`` creates the runtime table, its indexes and its trigger; the
+    content-only function is then installed over the new one so the trigger that
+    fires on the seed INSERT computes the pre-#1574 vector. That is what an
+    old khora instance would have left behind, and it is the only starting state
+    from which "before the migration" means anything.
+    """
+    store = await _connected_store(url)
+    try:
+        namespace_id = uuid4()
+        await _execute(url, CONTENT_ONLY_FUNCTION_SQL)
+        chunk = _chunk(namespace_id, content=BODY, title=TITLE)
+        await store.create_chunk(chunk)
+    finally:
+        await store.disconnect()
+    return namespace_id, chunk.id
+
+
+@pytest.fixture
+def seeded() -> Iterator[_Seeded]:
+    """A throwaway database at 057, seeded, in the pre-migration state.
+
+    Function-scoped: every test here moves the schema, and the setup is a few
+    seconds against an empty database — cheaper than the coupling a shared,
+    rewound fixture would introduce.
+
+    ``command.upgrade`` runs OUTSIDE the ``asyncio.run`` below on purpose:
+    Alembic's async ``env.py`` opens its own event loop, so calling it from
+    inside a coroutine raises ``asyncio.run() cannot be called from a running
+    event loop``. Every test in this module keeps the same split.
+    """
+    with scratch_database("mig058") as url:
+        command.upgrade(make_config(url), PREV_REVISION)
+        namespace_id, chunk_id = asyncio.run(_seed_rows(url))
+        yield _Seeded(url, namespace_id, chunk_id)
+
+
+@skip_no_pg
+class TestMigration058TitleFts:
+    def test_title_is_not_searchable_before_the_upgrade(self, seeded: _Seeded) -> None:
+        """The bug, reproduced. Body words find the chunk; title words do not.
+
+        The body query is the control: it proves the seed is searchable at all,
+        so the two empty results below are the missing title tokens and not an
+        empty table or a mis-scoped namespace.
+        """
+        assert asyncio.run(_search(seeded.url, seeded, CONTENT_QUERY)) == [seeded.chunk_id]
+        assert asyncio.run(_search(seeded.url, seeded, TITLE_QUERY)) == []
+        assert asyncio.run(_search(seeded.url, seeded, TITLE_NUMERIC_QUERY)) == []
+
+    def test_upgrade_makes_title_searchable(self, seeded: _Seeded) -> None:
+        """After 058 the SAME rows answer a title-only query.
+
+        No re-ingest: the revision recomputes ``content_tsv`` in place, so this
+        also proves the backfill ran rather than only the function swap.
+        """
+        command.upgrade(seeded.config, REVISION)
+
+        assert asyncio.run(_search(seeded.url, seeded, TITLE_QUERY)) == [seeded.chunk_id]
+        # The bare numeric token separately: it is the half a tokenizer that
+        # swallowed the surrounding underscores would lose.
+        assert asyncio.run(_search(seeded.url, seeded, TITLE_NUMERIC_QUERY)) == [seeded.chunk_id]
+        # And content is still searchable — the concatenation added a label to
+        # the content tokens, it did not replace them.
+        assert asyncio.run(_search(seeded.url, seeded, CONTENT_QUERY)) == [seeded.chunk_id]
+
+    def test_upgrade_labels_the_stored_vector(self, seeded: _Seeded) -> None:
+        """``title`` tokens carry ``A``, ``content`` tokens carry ``B``.
+
+        Read off ``content_tsv::text`` because the labels are what the weights
+        vector addresses; a title-token search passing tells you the terms are
+        present, not that they are separable from the body.
+        """
+        before = asyncio.run(_scalar(seeded.url, "SELECT content_tsv::text FROM khora_chunks"))
+        assert not re.search(r":\d+[A-C]", before), f"pre-migration vector should be unlabelled: {before}"
+
+        command.upgrade(seeded.config, REVISION)
+
+        after = asyncio.run(_scalar(seeded.url, "SELECT content_tsv::text FROM khora_chunks"))
+        assert re.search(r"'dimens':\d+A", after), f"title tokens must be weighted 'A': {after}"
+        assert re.search(r"'assembl':\d+B", after), f"content tokens must be weighted 'B': {after}"
+
+    def test_default_weights_reproduce_the_pre_migration_rank_exactly(self, seeded: _Seeded) -> None:
+        """The compatibility claim, measured on one row across the upgrade.
+
+        Before: the unlabelled vector under ``ts_rank_cd``'s implicit default.
+        After: the relabelled vector under the ``{0.1, 0.2, 0.1, 0.1}`` the
+        store passes at ``title_weight=1.0``.
+
+        Equality is the whole point of pinning ``B`` back to ``0.1``: Postgres'
+        implicit default weights ``B`` at 0.4, so an implementation that simply
+        relabelled and kept relying on the default would have multiplied every
+        content hit's score by four — a silent, global ranking change shipped
+        under a feature that is supposed to be off by default. The control below
+        makes that concrete rather than hypothetical.
+        """
+        rank_sql = "SELECT ts_rank_cd({0}content_tsv, to_tsquery('english', :q)) FROM khora_chunks"
+        params = {"q": CONTENT_TSQUERY}
+
+        before = asyncio.run(_scalar(seeded.url, rank_sql.format(""), params))
+        assert before > 0, "the pre-migration content match must score something to compare against"
+
+        command.upgrade(seeded.config, REVISION)
+
+        after = asyncio.run(_scalar(seeded.url, rank_sql.format(f"'{NEUTRAL_WEIGHTS}'::float4[], "), params))
+        assert after == pytest.approx(before, rel=1e-9), (
+            f"title_weight=1.0 must reproduce the pre-058 ranking exactly: {before} -> {after}"
+        )
+
+        # Control: the same relabelled vector under the IMPLICIT default is a
+        # different number. Without this, an implementation that dropped the
+        # explicit vector entirely would still pass the equality above if the
+        # two happened to coincide.
+        implicit = asyncio.run(_scalar(seeded.url, rank_sql.format(""), params))
+        assert implicit != pytest.approx(before, rel=1e-9), (
+            "relabelling content to 'B' must change the IMPLICIT-default score — "
+            "otherwise this test is not measuring what it claims"
+        )
+
+    def test_raised_title_weight_lifts_only_the_title_match(self, seeded: _Seeded) -> None:
+        """The knob does something once the labels exist — and only to titles.
+
+        Two chunks matching the same query, one through its title and one
+        through its body. Raising ``title_weight`` moves the ``A`` slot of the
+        weights vector and leaves ``B`` alone, so the exact expected effect is:
+        the title match's score rises, the body match's score does not move at
+        all, and the order flips. Asserting the scores rather than only the
+        order is what makes this non-vacuous — an order assertion alone would
+        pass if the titled chunk happened to lead at the neutral weight too.
+
+        Seeded after the upgrade so both rows go through the new trigger.
+        """
+        command.upgrade(seeded.config, REVISION)
+
+        async def _run() -> tuple[dict[UUID, float], dict[UUID, float], UUID, UUID]:
+            store = await _connected_store(seeded.url)
+            try:
+                ns = uuid4()
+                titled = _chunk(ns, content="unrelated filler prose", title="Gasket Torque Specification")
+                bodied = _chunk(ns, content="gasket torque specification and nothing else", title=None)
+                await store.create_chunks_batch([titled, bodied])
+                query = "gasket torque"
+                neutral = {c.id: s for c, s in await store.search_fulltext(ns, query, limit=10)}
+                weighted = {c.id: s for c, s in await store.search_fulltext(ns, query, limit=10, title_weight=8.0)}
+                return neutral, weighted, titled.id, bodied.id
+            finally:
+                await store.disconnect()
+
+        neutral, weighted, titled_id, bodied_id = asyncio.run(_run())
+
+        assert set(neutral) == {titled_id, bodied_id}, "both chunks must match; the weight orders, it does not filter"
+        assert set(weighted) == set(neutral)
+        assert weighted[titled_id] > neutral[titled_id], "the title match must score higher at a raised weight"
+        assert weighted[bodied_id] == pytest.approx(neutral[bodied_id]), (
+            "title_weight moves only the 'A' slot — a body-only match must be untouched"
+        )
+        assert max(weighted, key=weighted.__getitem__) == titled_id
+
+    def test_downgrade_restores_content_only_matching(self, seeded: _Seeded) -> None:
+        """058 is fully reversible — the vector is derived data.
+
+        Both halves are asserted: title tokens stop matching (the terms were
+        really removed, not merely relabelled) and the labels are gone from the
+        stored vector, while the content match survives untouched.
+        """
+        command.upgrade(seeded.config, REVISION)
+        assert asyncio.run(_search(seeded.url, seeded, TITLE_QUERY)) == [seeded.chunk_id]
+
+        command.downgrade(seeded.config, PREV_REVISION)
+
+        assert asyncio.run(_search(seeded.url, seeded, TITLE_QUERY)) == []
+        assert asyncio.run(_search(seeded.url, seeded, TITLE_NUMERIC_QUERY)) == []
+        assert asyncio.run(_search(seeded.url, seeded, CONTENT_QUERY)) == [seeded.chunk_id]
+
+        vector = asyncio.run(_scalar(seeded.url, "SELECT content_tsv::text FROM khora_chunks"))
+        assert not re.search(r":\d+[A-C]", vector), f"downgrade must leave an unlabelled vector: {vector}"
+
+    def test_re_running_the_upgrade_is_idempotent(self, seeded: _Seeded) -> None:
+        """Down-and-up returns the same vector, byte for byte.
+
+        The revision has no sentinel distinguishing an already-recomputed row,
+        so a re-run rewrites the whole table — deliberately. What must hold is
+        that the *outcome* is stable; the cost is documented, not asserted.
+        """
+        command.upgrade(seeded.config, REVISION)
+        first = asyncio.run(_scalar(seeded.url, "SELECT content_tsv::text FROM khora_chunks"))
+
+        command.downgrade(seeded.config, PREV_REVISION)
+        command.upgrade(seeded.config, REVISION)
+        second = asyncio.run(_scalar(seeded.url, "SELECT content_tsv::text FROM khora_chunks"))
+
+        assert second == first
+
+    def test_null_title_does_not_blank_the_vector(self, seeded: _Seeded) -> None:
+        """The ``coalesce`` guard: ``to_tsvector(NULL)`` is NULL, and NULL
+        concatenated with anything is NULL — which would erase the content
+        tokens of every untitled chunk. ``title`` is nullable and 044's backfill
+        leaves it NULL wherever the parent document had none, so this is a real
+        row shape, not a contrived one."""
+        command.upgrade(seeded.config, REVISION)
+
+        async def _run() -> list[UUID]:
+            store = await _connected_store(seeded.url)
+            try:
+                ns = uuid4()
+                untitled = _chunk(ns, content=BODY, title=None)
+                await store.create_chunk(untitled)
+                rows = await store.search_fulltext(ns, CONTENT_QUERY, limit=10)
+                return [c.id for c, _ in rows]
+            finally:
+                await store.disconnect()
+
+        assert asyncio.run(_run()), "an untitled chunk must still be content-searchable"
+
+
+@skip_no_pg
+class TestMigration058NoOpPaths:
+    def test_upgrade_is_a_no_op_without_khora_chunks(self) -> None:
+        """A fresh Postgres deploy reaches 058 before any store has connected.
+
+        ``khora_chunks`` is runtime-managed, so on a database that has never run
+        the app the table does not exist and the revision must pass through
+        cleanly — the store's own ``connect()`` installs the new function
+        moments later and there are no rows to recompute.
+        """
+        with scratch_database("mig058_fresh") as url:
+            cfg = make_config(url)
+            command.upgrade(cfg, PREV_REVISION)
+            assert asyncio.run(_scalar(url, "SELECT to_regclass('public.khora_chunks')")) is None
+
+            command.upgrade(cfg, REVISION)
+
+            assert asyncio.run(_scalar(url, "SELECT version_num FROM khora_alembic_version")) == REVISION
+            assert asyncio.run(_scalar(url, "SELECT to_regclass('public.khora_chunks')")) is None
+
+    def test_downgrade_is_a_no_op_without_khora_chunks(self) -> None:
+        """Same guard on the way back down, so a rewind cannot fail on a
+        database that never ran the app."""
+        with scratch_database("mig058_fresh_down") as url:
+            cfg = make_config(url)
+            command.upgrade(cfg, REVISION)
+
+            command.downgrade(cfg, PREV_REVISION)
+
+            assert asyncio.run(_scalar(url, "SELECT version_num FROM khora_alembic_version")) == PREV_REVISION
+
+    def test_upgrade_is_a_no_op_when_the_table_has_no_title_column(self) -> None:
+        """A ``khora_chunks`` that predates 041 must be skipped, not broken.
+
+        The second half of the precondition, and the one with teeth. plpgsql
+        resolves ``NEW.title`` when the trigger *fires*, not when the function is
+        created — so against a title-less table the ``CREATE OR REPLACE
+        FUNCTION`` and ``CREATE TRIGGER`` both succeed and the recompute
+        ``UPDATE`` is what raises ``UndefinedColumnError: record "new" has no
+        field "title"``. Without the gate the damage would also outlive the
+        statement: the swapped function stays installed, so every later INSERT
+        or UPDATE to ``khora_chunks`` fails too.
+
+        Three assertions, in increasing order of what they would have caught:
+        the upgrade completes and stamps 058; the seeded row's vector is
+        byte-unchanged (nothing was recomputed); and — the one that matters — a
+        row written *after* the migration still gets a content-only vector,
+        proving the weighted function was never installed. Only the third
+        distinguishes "gated" from "swapped the function but happened not to
+        rewrite any rows".
+        """
+        with scratch_database("mig058_no_title_col") as url:
+            cfg = make_config(url)
+            command.upgrade(cfg, PREV_REVISION)
+            asyncio.run(_install_title_less_khora_chunks(url))
+
+            before = asyncio.run(_scalar(url, "SELECT content_tsv::text FROM khora_chunks"))
+            assert before, "precondition: the seeded trigger must populate content_tsv on INSERT"
+            assert not re.search(r":\d+[A-C]", before), f"precondition: seed must be unlabelled: {before}"
+
+            command.upgrade(cfg, REVISION)
+
+            assert asyncio.run(_scalar(url, "SELECT version_num FROM khora_alembic_version")) == REVISION
+            after = asyncio.run(_scalar(url, "SELECT content_tsv::text FROM khora_chunks"))
+            assert after == before, "the gate must skip the recompute on a title-less table"
+
+            asyncio.run(_execute(url, _TITLE_LESS_SECOND_INSERT_SQL))
+            written_after = asyncio.run(
+                _scalar(url, "SELECT content_tsv::text FROM khora_chunks WHERE content = 'written after the migration'")
+            )
+            assert written_after, "the post-migration INSERT must succeed and populate content_tsv"
+            assert not re.search(r":\d+[A-C]", written_after), (
+                f"the weighted function was installed on a title-less table: {written_after}"
+            )
+
+    def test_downgrade_is_a_no_op_when_the_table_has_no_title_column(self) -> None:
+        """The gate lives in the shared ``_run``, so both directions skip the
+        same databases. A downgrade that tried to recompute a table the upgrade
+        had skipped would fail identically, and for the same reason."""
+        with scratch_database("mig058_no_title_col_down") as url:
+            cfg = make_config(url)
+            command.upgrade(cfg, PREV_REVISION)
+            asyncio.run(_install_title_less_khora_chunks(url))
+            command.upgrade(cfg, REVISION)
+            before = asyncio.run(_scalar(url, "SELECT content_tsv::text FROM khora_chunks"))
+
+            command.downgrade(cfg, PREV_REVISION)
+
+            assert asyncio.run(_scalar(url, "SELECT version_num FROM khora_alembic_version")) == PREV_REVISION
+            assert asyncio.run(_scalar(url, "SELECT content_tsv::text FROM khora_chunks")) == before

--- a/tests/unit/db/test_migration_058_lockstep.py
+++ b/tests/unit/db/test_migration_058_lockstep.py
@@ -1,0 +1,99 @@
+"""#1574 — migration 058 and the pgvector store must install the SAME function.
+
+``khora_chunks`` is not part of the Alembic-managed schema: it is created at
+runtime by ``PgVectorTemporalStore.connect()``, which issues its own
+``CREATE OR REPLACE FUNCTION khora_chunks_content_tsv_trigger()`` on every boot.
+Migration ``058_khora_chunks_title_fts`` issues one too. Both target the same
+function, so **whichever runs last wins** — and if the two bodies ever drift, the
+formula a deployment ends up with depends on boot order (migration first, or a
+store ``connect()`` first). That is not a difference a test elsewhere would
+catch: both statements succeed either way, and the only symptom is a lexical
+index that is weighted on some deployments and not others.
+
+The duplication itself is deliberate — a migration is a frozen snapshot, so it
+must not ``import`` the runtime constant. This module is the seam that keeps the
+two copies honest without coupling them, and it is the reason the runtime SQL
+was lifted out of ``connect()`` into a module-level constant in the first place.
+
+No database: this is a string comparison. It belongs in the unit lane so it runs
+on every PR, including for contributors without Docker.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from khora.storage.temporal.pgvector import _TSV_FUNCTION_SQL as RUNTIME_TSV_FUNCTION_SQL
+
+pytestmark = pytest.mark.unit
+
+_REVISION = "058_khora_chunks_title_fts"
+_MIGRATION = importlib.import_module(f"khora.db.migrations.versions.{_REVISION}")
+
+MIGRATION_TSV_FUNCTION_SQL: str = _MIGRATION._TSV_FUNCTION_SQL
+MIGRATION_TSV_FUNCTION_SQL_CONTENT_ONLY: str = _MIGRATION._TSV_FUNCTION_SQL_CONTENT_ONLY
+
+
+def test_upgrade_function_body_is_byte_identical_to_the_runtime_copy() -> None:
+    """The convergence contract, asserted the only way that is meaningful.
+
+    Byte-for-byte rather than normalized: whitespace inside a ``plpgsql`` body
+    is cosmetic to Postgres but a normalized comparison would let the two copies
+    diverge in the parts that ARE cosmetic, and nobody would then notice the
+    edit that changed one of them substantively.
+    """
+    assert MIGRATION_TSV_FUNCTION_SQL == RUNTIME_TSV_FUNCTION_SQL, (
+        "migration 058 and khora/storage/temporal/pgvector.py install different "
+        "khora_chunks_content_tsv_trigger() bodies; whichever runs last wins, so "
+        "the installed formula would depend on boot order. Change both together."
+    )
+
+
+def test_both_copies_weight_title_above_content() -> None:
+    """The shared body is the #1574 formula, not merely a matching pair.
+
+    Equality alone would still pass if both copies were reverted together. These
+    are the three fragments the feature actually needs: the ``'A'`` label on
+    ``title``, the ``'B'`` label on ``content``, and the ``coalesce`` that stops
+    a NULL title annihilating the whole concatenation.
+    """
+    for name, sql in (
+        ("runtime", RUNTIME_TSV_FUNCTION_SQL),
+        ("migration", MIGRATION_TSV_FUNCTION_SQL),
+    ):
+        assert "setweight(to_tsvector('english', coalesce(NEW.title, '')), 'A')" in sql, name
+        assert "setweight(to_tsvector('english', NEW.content), 'B')" in sql, name
+
+
+def test_downgrade_restores_the_unweighted_content_only_formula() -> None:
+    """058's ``downgrade()`` must reinstall the pre-#1574 body, not a variant.
+
+    A downgrade that left ``setweight`` in place would keep the labels while
+    claiming to have removed them — and the ranking vector the store passes is
+    chosen on the assumption that a downgraded database has unlabelled (``D``)
+    content tokens.
+    """
+    assert "NEW.content_tsv := to_tsvector('english', NEW.content);" in MIGRATION_TSV_FUNCTION_SQL_CONTENT_ONLY
+    assert "setweight" not in MIGRATION_TSV_FUNCTION_SQL_CONTENT_ONLY
+    assert "NEW.title" not in MIGRATION_TSV_FUNCTION_SQL_CONTENT_ONLY
+
+
+def test_both_directions_replace_the_same_function() -> None:
+    """Upgrade and downgrade must name one function, or a downgrade orphans one."""
+    signature = "CREATE OR REPLACE FUNCTION khora_chunks_content_tsv_trigger() RETURNS trigger"
+    assert MIGRATION_TSV_FUNCTION_SQL.startswith(signature)
+    assert MIGRATION_TSV_FUNCTION_SQL_CONTENT_ONLY.startswith(signature)
+    assert RUNTIME_TSV_FUNCTION_SQL.startswith(signature)
+
+
+def test_revision_pins_the_expected_predecessor() -> None:
+    """Cheap chain guard: 058 sits directly on top of 057.
+
+    The PG lane builds the schema at ``down_revision`` and then upgrades one
+    step, so a silently re-pointed ``down_revision`` would make that test
+    exercise a different chain position while still passing.
+    """
+    assert _MIGRATION.revision == _REVISION
+    assert _MIGRATION.down_revision == "057_drop_documents_created_at_index"

--- a/tests/unit/db/test_migration_chain_populated_sqlite.py
+++ b/tests/unit/db/test_migration_chain_populated_sqlite.py
@@ -63,6 +63,7 @@ from typing import Any
 import pytest
 import sqlalchemy as sa
 
+from tests.test_helpers.alembic_head import current_head
 from tests.test_helpers.schema_drift import upgrade
 
 pytestmark = pytest.mark.unit
@@ -82,7 +83,15 @@ _START_REVISIONS = [
     "054_documents_namespace_created_at_id",
 ]
 
-_HEAD_REVISION = "057_drop_documents_created_at_index"
+#: Read from the bundled chain rather than spelled out. This is a *head*
+#: reference — the test walks to ``head`` and asserts it arrived — so pinning a
+#: literal only means every new migration breaks this file for a reason that has
+#: nothing to do with what it guards. (It did: migration 058 landed and all six
+#: parameterisations failed on the constant alone.) The start revisions above
+#: stay literals, because those name specific chain positions and must not drift
+#: forward. See ``tests/test_helpers/alembic_head.py``, which draws exactly this
+#: distinction; ``current_head()`` is called inside the test body per its
+#: contract, never at module scope.
 
 #: Dropped by ``010_flatten_namespace_hierarchy``. The only tables the chain
 #: removes on the walk from any revision above.
@@ -323,7 +332,7 @@ def test_populated_database_survives_the_upgrade_to_head(tmp_path: Path, start_r
     # which is what it is.
     upgrade(url, "head")
 
-    assert _head_revision(url) == _HEAD_REVISION, "the chain did not reach head"
+    assert _head_revision(url) == current_head(), "the chain did not reach head"
 
     after = _row_counts(url)
     disappeared = set(before) - set(after)

--- a/tests/unit/engines/skeleton/backends/test_pgvector_coverage.py
+++ b/tests/unit/engines/skeleton/backends/test_pgvector_coverage.py
@@ -540,4 +540,8 @@ class TestSearchTelemetryWrapper:
             query_text="x",
             filter_ast=None,
             filter_plan_out=None,
+            # #1574: forwarded on every call, default included — the telemetry
+            # wrapper must not drop it, or the lexical half of a hybrid search
+            # would silently score on content alone.
+            title_weight=1.0,
         )

--- a/tests/unit/engines/test_vectorcypher_filter_report.py
+++ b/tests/unit/engines/test_vectorcypher_filter_report.py
@@ -231,6 +231,11 @@ def _make_retriever(
         limit: int,
         filter_ast: FilterNode | None = None,
         filter_plan_out: list[ChannelPlan] | None = None,
+        # #1574: the retriever passes ``title_weight`` on EVERY call, default
+        # included. Spelled out rather than absorbed by a ``**kwargs`` so this
+        # double keeps mirroring the real ``search_fulltext`` signature — the
+        # point of it being an explicit callable rather than an AsyncMock.
+        title_weight: float = 1.0,
     ) -> list[Any]:
         if filter_ast is not None and filter_plan_out is not None:
             filter_plan_out.append(ChannelPlan(pushed_keys=filter_leaf_keys(filter_ast)))
@@ -1051,6 +1056,9 @@ def _simple_retriever(ns_id: UUID, *, enable_bm25: bool) -> VectorCypherRetrieve
         limit: int,
         filter_ast: FilterNode | None = None,
         filter_plan_out: list[ChannelPlan] | None = None,
+        # #1574: passed on every call, default included. See the sibling
+        # double above for why it is spelled out rather than swallowed.
+        title_weight: float = 1.0,
     ) -> list[Any]:
         # The temporal-store fulltext path records the bm25 plan from its compile.
         if filter_ast is not None and filter_plan_out is not None:

--- a/tests/unit/engines/vectorcypher/test_channel_degradation_1158.py
+++ b/tests/unit/engines/vectorcypher/test_channel_degradation_1158.py
@@ -344,3 +344,135 @@ async def test_retrieve_surfaces_bm25_channel_degradation() -> None:
     assert "vectorcypher.bm25" in components, f"degradations: {degradations!r}"
     bm25_deg = next(d for d in degradations if d.get("component") == "vectorcypher.bm25")
     assert bm25_deg["reason"] == "channel_exception"
+
+
+# ---------------------------------------------------------------------------
+# #1574 — an inapplicable ``bm25_title_weight``.
+#
+# This one degrades without anything going wrong: the lexical channel runs,
+# returns rows, and raises nothing. What is missing is only the requested title
+# boost, because the store's FTS index has no ``title`` column (an embedded
+# database built before #1574 — its DDL is ``IF NOT EXISTS``, so nothing ever
+# migrates it to the 2-column shape).
+#
+# It is worth a record precisely because it is invisible otherwise. SQLite does
+# not reject the surplus weight argument (measured on 3.53.4: extra bm25()
+# weights are silently ignored), so the operator who set the knob gets ranking
+# identical to not having set it, with nothing anywhere to say so.
+# ---------------------------------------------------------------------------
+
+
+class _FulltextStore:
+    """A minimal lexical store: only what the channel actually reaches for.
+
+    A ``MagicMock`` cannot express the third case below — the ``getattr`` probe
+    would auto-create a truthy ``fts_has_title`` — so the shape is spelled out.
+    ``fts_has_title`` is set as an *instance* attribute only when a case wants
+    one, leaving it genuinely absent otherwise.
+    """
+
+    def __init__(self, *, fts_has_title: bool | None = None) -> None:
+        self.calls: list[dict] = []
+        if fts_has_title is not None:
+            self.fts_has_title = fts_has_title
+
+    async def search_fulltext(self, namespace_id, query, **kwargs):
+        self.calls.append(kwargs)
+        chunk = MagicMock()
+        chunk.id = uuid4()
+        return [(chunk, 0.9)]
+
+
+def _title_weight_retriever(store: _FulltextStore, weight: float) -> VectorCypherRetriever:
+    return VectorCypherRetriever(
+        vector_store=store,
+        neo4j_driver=None,
+        embedder=AsyncMock(),
+        config=RetrieverConfig(bm25_title_weight=weight),
+        storage=MagicMock(),
+    )
+
+
+async def _degradations_for(store: _FulltextStore, weight: float) -> list[Degradation]:
+    retriever = _title_weight_retriever(store, weight)
+    degradations: list[Degradation] = []
+    results = await retriever._bm25_search_chunks(
+        query="floor panels dimensioned",
+        namespace_id=uuid4(),
+        limit=10,
+        degradations=degradations,
+    )
+    # Always: the channel is NOT broken. Rows still come back — that is what
+    # makes this a degradation rather than a failure, and asserting it here
+    # keeps every case below honest about the distinction.
+    assert len(results) == 1, f"the lexical channel must still return rows, got {results!r}"
+    return degradations
+
+
+async def test_title_weight_records_degradation_on_a_store_without_the_column() -> None:
+    """The #1574 record: weight requested, store cannot apply it."""
+    degradations = await _degradations_for(_FulltextStore(fts_has_title=False), 2.0)
+
+    assert len(degradations) == 1, f"expected one degradation, got {degradations!r}"
+    deg = degradations[0]
+    assert deg["component"] == "vectorcypher.bm25_title_weight"
+    assert deg["reason"] == "fts_missing_title_column"
+    # The detail has to name the value that was ignored — an operator reading
+    # this in a log needs to know which knob did nothing.
+    assert "2.0" in (deg.get("detail") or "")
+
+
+async def test_neutral_weight_on_the_same_store_does_not_degrade() -> None:
+    """1.0 asks for nothing, so nothing is being dropped.
+
+    Without this gate every recall on every un-upgraded embedded deployment
+    would emit a degradation and bump a public counter, for a default none of
+    them chose. That noise would make the signal above worthless.
+    """
+    assert await _degradations_for(_FulltextStore(fts_has_title=False), 1.0) == []
+
+
+async def test_capable_store_does_not_degrade_at_a_raised_weight() -> None:
+    """The weight applies, so there is nothing to report."""
+    assert await _degradations_for(_FulltextStore(fts_has_title=True), 2.0) == []
+
+
+async def test_store_without_the_probe_attribute_is_assumed_capable() -> None:
+    """No ``fts_has_title`` -> no claim either way -> no record.
+
+    Every non-embedded store is in this position: pgvector gets its title
+    coverage from migration 058 and exposes no probe, and neither do the
+    accept-and-ignore backends or a test double. Defaulting to "degraded" would
+    fire the counter on the *normal* Postgres path, where the weight works.
+    """
+    store = _FulltextStore()
+    assert not hasattr(store, "fts_has_title"), "the fixture must leave the attribute genuinely absent"
+
+    assert await _degradations_for(store, 2.0) == []
+
+
+async def test_title_weight_is_forwarded_to_the_store_on_every_call() -> None:
+    """The kwarg is passed unconditionally, including at the default.
+
+    Unconditional forwarding is what lets each backend decide for itself
+    (apply / ignore / probe-and-warn) instead of the retriever guessing — and it
+    is also the change that can break a hand-rolled test double with a strict
+    signature, so it is pinned rather than assumed.
+    """
+    store = _FulltextStore(fts_has_title=True)
+    await _degradations_for(store, 1.0)
+    await _degradations_for(store, 3.0)
+
+    assert [call.get("title_weight") for call in store.calls] == [1.0, 3.0]
+
+
+async def test_no_degradation_sink_still_degrades_cleanly() -> None:
+    """``degradations=None`` is the default; the guard must short-circuit."""
+    retriever = _title_weight_retriever(_FulltextStore(fts_has_title=False), 2.0)
+
+    results = await retriever._bm25_search_chunks(
+        query="floor panels dimensioned",
+        namespace_id=uuid4(),
+        limit=10,
+    )
+    assert len(results) == 1

--- a/tests/unit/engines/vectorcypher/test_channel_degradation_1158.py
+++ b/tests/unit/engines/vectorcypher/test_channel_degradation_1158.py
@@ -22,6 +22,7 @@ These are pure-unit tests with a mocked storage coordinator / vector store
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -35,6 +36,7 @@ from khora.engines.vectorcypher.retriever import (
     VectorCypherRetriever,
 )
 from khora.engines.vectorcypher.router import QueryComplexity, RoutingDecision
+from khora.query import SearchMode
 
 pytestmark = pytest.mark.unit
 
@@ -564,6 +566,99 @@ async def test_the_record_is_deduped_to_one_per_recall() -> None:
     assert degradations[0]["component"] == "vectorcypher.bm25_title_weight"
     # The dedupe must not swallow OTHER components' records on the same list.
     assert [d["component"] for d in degradations] == ["vectorcypher.bm25_title_weight"]
+
+
+def _simple_routing() -> RoutingDecision:
+    return RoutingDecision(
+        complexity=QueryComplexity.SIMPLE,
+        use_graph=False,
+        graph_depth=0,
+        confidence=0.9,
+        reasoning="simple query",
+    )
+
+
+async def _simple_retrieve_degradations(
+    monkeypatch: pytest.MonkeyPatch, mode: SearchMode
+) -> tuple[list[Degradation], list[dict], _FulltextStore]:
+    """Run ``_simple_retrieve`` in ``mode``; return (degradations, bumps, store).
+
+    The store comes back so each case can prove the search actually ran — a
+    "no degradation" assertion is worthless if the path never reached the store.
+
+    The counter is a no-op object without logfire, so it cannot be read back.
+    Swapping the module-level counter for a recorder is what makes "the counter
+    did not move" an assertion rather than an inference from the record count —
+    the two are separate statements, and the guard has to satisfy both.
+    """
+    import khora.engines.vectorcypher.retriever as retriever_module
+
+    bumps: list[dict] = []
+    monkeypatch.setattr(
+        retriever_module,
+        "_BM25_TITLE_WEIGHT_DEGRADED_COUNTER",
+        SimpleNamespace(add=lambda amount, attributes=None: bumps.append(attributes or {})),
+    )
+
+    store = _FulltextStore(fts_has_title=False)
+    retriever = _title_weight_retriever(store, 2.0)
+    retriever._storage = None  # no coordinator fallback; keep the path to the store
+    degradations: list[Degradation] = []
+
+    await retriever._simple_retrieve(
+        query="floor panels dimensioned",
+        query_embedding=[0.1, 0.2, 0.3, 0.4],
+        namespace_id=uuid4(),
+        temporal_filter=None,
+        limit=10,
+        routing=_simple_routing(),
+        mode=mode,
+        degradations=degradations,
+    )
+    return degradations, bumps, store
+
+
+async def test_pure_vector_mode_does_not_record_an_unused_title_weight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SearchMode.VECTOR sets hybrid_alpha=None: the weight is never consumed.
+
+    The store skips its internal BM25 entirely on that call, so the missing
+    title column costs the query nothing. Recording it would put a degradation
+    on a recall that was not degraded — and on the deployment where someone set
+    the knob globally, EVERY pure-vector recall would carry one.
+    """
+    degradations, bumps, store = await _simple_retrieve_degradations(monkeypatch, SearchMode.VECTOR)
+
+    # Anti-vacuity: the search must have RUN and been handed the weight. Without
+    # this the test would also pass if the path short-circuited before the store.
+    assert len(store.search_calls) == 1, f"the vector search must still run, got {store.search_calls!r}"
+    assert store.search_calls[0].get("title_weight") == 2.0
+    assert store.search_calls[0].get("hybrid_alpha") is None, "VECTOR mode must ask for a pure-vector search"
+
+    title_records = [d for d in degradations if d["component"] == "vectorcypher.bm25_title_weight"]
+    assert title_records == [], f"pure vector must not report an unused weight, got {title_records!r}"
+    assert bumps == [], f"the counter must not move either, got {bumps!r}"
+
+
+async def test_hybrid_mode_on_the_same_setup_does_record(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The contrast half: identical store and weight, blend on -> one record.
+
+    Paired with the VECTOR case above deliberately. Alone, either test passes
+    for the wrong reason — a guard that never fires and a guard that always
+    fires each satisfy one of them. Only the pair pins the behavior to the
+    blend actually being in play.
+    """
+    degradations, bumps, store = await _simple_retrieve_degradations(monkeypatch, SearchMode.HYBRID)
+
+    assert store.search_calls[0].get("hybrid_alpha") is not None, "HYBRID must ask for a blend"
+
+    title_records = [d for d in degradations if d["component"] == "vectorcypher.bm25_title_weight"]
+    assert len(title_records) == 1, f"expected exactly one record, got {title_records!r}"
+    assert title_records[0]["reason"] == "fts_missing_title_column"
+    assert bumps == [{"reason": "fts_missing_title_column"}], f"expected one counter bump, got {bumps!r}"
 
 
 async def test_a_separate_recall_records_again() -> None:

--- a/tests/unit/engines/vectorcypher/test_channel_degradation_1158.py
+++ b/tests/unit/engines/vectorcypher/test_channel_degradation_1158.py
@@ -21,12 +21,14 @@ These are pure-unit tests with a mocked storage coordinator / vector store
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
 
 from khora.core.diagnostics import Degradation
+from khora.core.temporal import TemporalChunk, TemporalSearchResult
 from khora.engines.vectorcypher.retriever import (
     RetrieverConfig,
     VectorCypherResult,
@@ -373,6 +375,7 @@ class _FulltextStore:
 
     def __init__(self, *, fts_has_title: bool | None = None) -> None:
         self.calls: list[dict] = []
+        self.search_calls: list[dict] = []
         if fts_has_title is not None:
             self.fts_has_title = fts_has_title
 
@@ -381,6 +384,28 @@ class _FulltextStore:
         chunk = MagicMock()
         chunk.id = uuid4()
         return [(chunk, 0.9)]
+
+    async def search(self, **kwargs):
+        """The hybrid channel's entry point — same store, same missing column.
+
+        Returns a real ``TemporalSearchResult`` rather than a mock because
+        ``_vector_search_chunks`` reads nine chunk attributes off it and builds
+        a domain ``Chunk``; a MagicMock would pass attribute access and fail
+        construction, hiding the assertion behind an unrelated error.
+        """
+        self.search_calls.append(kwargs)
+        return [
+            TemporalSearchResult(
+                chunk=TemporalChunk(
+                    id=uuid4(),
+                    namespace_id=uuid4(),
+                    document_id=uuid4(),
+                    content="floor panels dimensioned to the bay spacing",
+                    created_at=datetime(2026, 1, 1, tzinfo=UTC),
+                ),
+                similarity=0.9,
+            )
+        ]
 
 
 def _title_weight_retriever(store: _FulltextStore, weight: float) -> VectorCypherRetriever:
@@ -476,3 +501,85 @@ async def test_no_degradation_sink_still_degrades_cleanly() -> None:
         limit=10,
     )
     assert len(results) == 1
+
+
+async def _hybrid_search(retriever: VectorCypherRetriever, degradations: list[Degradation]) -> list:
+    """One hybrid vector-channel call, sharing the caller's per-recall sink."""
+    return await retriever._vector_search_chunks(
+        query_embedding=[0.1, 0.2, 0.3, 0.4],
+        namespace_id=uuid4(),
+        temporal_filter=None,
+        query_text="floor panels dimensioned",
+        limit=10,
+        degradations=degradations,
+    )
+
+
+async def test_hybrid_path_records_the_title_weight_degradation() -> None:
+    """The hybrid vector channel hands the store a title_weight too.
+
+    Recording only on the dedicated lexical channel would leave the common
+    configuration — BM25 channel off, hybrid blend on — silently unweighted:
+    the store is asked for a title boost it cannot give, and nothing says so.
+    """
+    store = _FulltextStore(fts_has_title=False)
+    retriever = _title_weight_retriever(store, 2.0)
+    degradations: list[Degradation] = []
+
+    chunks = await _hybrid_search(retriever, degradations)
+
+    # Same distinction the lexical cases assert: rows still come back.
+    assert len(chunks) == 1, f"the hybrid channel must still return rows, got {chunks!r}"
+    assert store.search_calls[0].get("title_weight") == 2.0
+    assert len(degradations) == 1, f"expected one degradation, got {degradations!r}"
+    assert degradations[0]["component"] == "vectorcypher.bm25_title_weight"
+    assert degradations[0]["reason"] == "fts_missing_title_column"
+
+
+async def test_the_record_is_deduped_to_one_per_recall() -> None:
+    """One recall, many channels, one record — and one counter increment.
+
+    A recall runs the lexical channel and the hybrid channel against the SAME
+    store, and the session fan-out calls the hybrid channel repeatedly (once
+    per session, plus an unscoped fallback). Each observes the identical
+    missing column. Without the dedupe an operator would read a counter that
+    tracks channel invocations — so a fan-out over 8 sessions reports 9 —
+    and could not tell one broken deployment from nine. The counter is bumped
+    only on the append, so pinning the record count pins the metric too.
+    """
+    store = _FulltextStore(fts_has_title=False)
+    retriever = _title_weight_retriever(store, 2.0)
+    degradations: list[Degradation] = []
+
+    await retriever._bm25_search_chunks(
+        query="floor panels dimensioned",
+        namespace_id=uuid4(),
+        limit=10,
+        degradations=degradations,
+    )
+    await _hybrid_search(retriever, degradations)
+    await _hybrid_search(retriever, degradations)
+
+    assert len(degradations) == 1, f"one record per recall, not per channel; got {degradations!r}"
+    assert degradations[0]["component"] == "vectorcypher.bm25_title_weight"
+    # The dedupe must not swallow OTHER components' records on the same list.
+    assert [d["component"] for d in degradations] == ["vectorcypher.bm25_title_weight"]
+
+
+async def test_a_separate_recall_records_again() -> None:
+    """Dedupe is per-sink, not per-process.
+
+    The guard keys off the in-scope ``degradations`` list, so a fresh recall
+    starts clean. If it were memoized on the retriever instead, a long-lived
+    engine would report the fault once and then go quiet forever.
+    """
+    store = _FulltextStore(fts_has_title=False)
+    retriever = _title_weight_retriever(store, 2.0)
+
+    first: list[Degradation] = []
+    second: list[Degradation] = []
+    await _hybrid_search(retriever, first)
+    await _hybrid_search(retriever, second)
+
+    assert len(first) == 1
+    assert len(second) == 1

--- a/tests/unit/engines/vectorcypher/test_recall_query_settings_1018.py
+++ b/tests/unit/engines/vectorcypher/test_recall_query_settings_1018.py
@@ -129,6 +129,29 @@ def test_bm25_title_weight_is_clamped_at_the_config_boundary() -> None:
             QuerySettings(bm25_title_weight=out_of_range)
 
 
+def test_bm25_title_weight_is_validated_on_direct_dataclass_construction() -> None:
+    """The bounds must hold on the path Pydantic never sees.
+
+    ``VectorCypherConfig`` is a plain dataclass, so a caller that constructs it
+    directly — a supported entry point, it is a public kwarg on the engine —
+    skips the ``QuerySettings`` validation asserted above. Without the
+    ``__post_init__`` check the two doors into the same knob disagree: -1 is
+    rejected through config and accepted through the dataclass, and the store
+    inlines the value into FTS5 SQL (it cannot be a bind parameter), which is
+    exactly the argument the config-side bounds exist to support.
+    """
+    from khora.engines.vectorcypher.engine import VectorCypherConfig
+
+    for out_of_range in (-1, 100):
+        with pytest.raises(ValueError, match="bm25_title_weight must be between 0 and 10"):
+            VectorCypherConfig(bm25_title_weight=out_of_range)
+
+    # Boundaries are legal on both sides — an exclusive check here would reject
+    # values QuerySettings accepts, which is the same divergence in reverse.
+    assert VectorCypherConfig(bm25_title_weight=0.0).bm25_title_weight == 0.0
+    assert VectorCypherConfig(bm25_title_weight=10.0).bm25_title_weight == 10.0
+
+
 def test_bm25_title_weight_changes_the_recall_cache_key() -> None:
     """Two weights must not share a cached result.
 

--- a/tests/unit/engines/vectorcypher/test_recall_query_settings_1018.py
+++ b/tests/unit/engines/vectorcypher/test_recall_query_settings_1018.py
@@ -82,6 +82,90 @@ def test_query_settings_defaults_match_retriever_defaults() -> None:
 
 
 # --------------------------------------------------------------------------- #
+# #1574 — bm25_title_weight: config -> engine -> retriever, and the cache key.
+# --------------------------------------------------------------------------- #
+
+
+def test_bm25_title_weight_defaults_to_neutral() -> None:
+    """1.0 is the "behave exactly as before" value, on BOTH sides of the wiring.
+
+    Asserted on the config and the retriever separately: the engine copies the
+    field across, so a default that drifted on one side only would silently
+    change ranking for every deployment that never sets the knob.
+    """
+    cfg = _config()
+    assert cfg.query.bm25_title_weight == 1.0
+    assert _build_retriever_config(cfg).bm25_title_weight == 1.0
+
+
+def test_bm25_title_weight_flows_to_retriever_config() -> None:
+    """KHORA_QUERY_BM25_TITLE_WEIGHT reaches the retriever (the #1018 hazard).
+
+    ``recall()`` bypasses ``QueryEngine`` entirely, so a QuerySettings field
+    that is not explicitly copied in ``_assemble_retriever_config`` is inert —
+    settable, documented, and doing nothing. That is the failure this file
+    exists for.
+    """
+    rc = _build_retriever_config(_config(bm25_title_weight=2.5))
+    assert rc.bm25_title_weight == 2.5
+
+
+def test_bm25_title_weight_is_clamped_at_the_config_boundary() -> None:
+    """Pydantic bounds are what let the store inline the value into SQL.
+
+    The weight cannot be a bind parameter — FTS5 auxiliary-function arguments
+    must be literals — so "this float came from a validated [0, 10] field" is
+    the whole safety argument for the interpolation. Pinning the bounds here
+    keeps that argument true.
+    """
+    from pydantic import ValidationError
+
+    from khora.config.schema import QuerySettings
+
+    assert QuerySettings(bm25_title_weight=0.0).bm25_title_weight == 0.0
+    assert QuerySettings(bm25_title_weight=10.0).bm25_title_weight == 10.0
+    for out_of_range in (-0.1, 10.1):
+        with pytest.raises(ValidationError):
+            QuerySettings(bm25_title_weight=out_of_range)
+
+
+def test_bm25_title_weight_changes_the_recall_cache_key() -> None:
+    """Two weights must not share a cached result.
+
+    The recall cache folds the retriever config in as ``repr()`` of the
+    dataclass, so a new field is captured only because it is *declared on the
+    dataclass*. A weight threaded through as a loose kwarg instead would have
+    served a 1.0-ranked result to a 2.0 query for the rest of the epoch — a
+    wrong answer with no error anywhere. Both links in that chain are asserted:
+    the repr differs, and the digest built from it differs.
+    """
+    from uuid import uuid4
+
+    from khora.engines.vectorcypher.recall_cache import RecallResultCache
+
+    neutral = RetrieverConfig(bm25_title_weight=1.0)
+    weighted = RetrieverConfig(bm25_title_weight=2.0)
+    assert repr(neutral) != repr(weighted), "the field must be declared on RetrieverConfig to be fingerprinted"
+
+    common = dict(
+        query="floor panels",
+        namespace_id=uuid4(),
+        epoch=0,
+        mode="hybrid",
+        limit=10,
+        min_similarity=0.0,
+        graph_depth=None,
+        hybrid_alpha=None,
+        recency_bias=None,
+        temporal_filter=None,
+        filter_ast=None,
+    )
+    assert RecallResultCache._digest(**common, config_fingerprint=repr(neutral)) != RecallResultCache._digest(
+        **common, config_fingerprint=repr(weighted)
+    )
+
+
+# --------------------------------------------------------------------------- #
 # #1018 — behavioral: HyDE / diversity / stage1 actually change retrieval.
 # --------------------------------------------------------------------------- #
 
@@ -399,3 +483,78 @@ async def test_hyde_always_fires_through_recall_stack(monkeypatch) -> None:
     never_calls = await _recall_completion_count("never")
     always_calls = await _recall_completion_count("always")
     assert always_calls > never_calls
+
+
+# --------------------------------------------------------------------------- #
+# #1574 — embedded end-to-end: a title-only query reaches the chunk through
+# the lexical channel.
+# --------------------------------------------------------------------------- #
+
+#: Verbatim from the #1574 repro. Doubles as a tokenizer guard: unicode61
+#: (wrapped by the ``porter`` tokenizer) splits on ``_``, so this must index as
+#: ``floor`` / ``panel`` / ``dimens`` / ``20260213``.
+_REPRO_TITLE = "Floor Panels_Dimensioned_20260213"
+#: Shares no vocabulary with the title — otherwise a content hit would be
+#: indistinguishable from a title hit and the test would prove nothing.
+_REPRO_BODY = "the assembly drawing revision notes for the north wing"
+
+#: A second document, to prove the title match is targeted rather than "the
+#: lexical channel returns whatever it has". Its title and body vocabularies are
+#: disjoint from each other AND from the first document's.
+_DECOY_TITLE = "Procurement Ledger"
+_DECOY_BODY = "quarterly stationery orders for the southern depot"
+
+
+@pytest.mark.embedded
+async def test_title_only_query_recalls_the_chunk_via_the_lexical_channel(monkeypatch) -> None:
+    """The #1574 repro, through the full ``Khora.recall()`` stack on sqlite_lance.
+
+    ``mode=KEYWORD`` is what makes this an honest test of the *lexical* channel:
+    per #833 it skips the vector store search entirely, so every returned chunk
+    came from BM25. Under HYBRID the hash-derived mock embeddings would surface
+    the only chunk in the namespace regardless, and the test would pass with the
+    title still unindexed.
+
+    Four queries against two documents:
+      * title-only words -> the titled chunk (the bug: this returned nothing);
+      * the bare numeric token -> same chunk (the half a tokenizer change would
+        lose to the surrounding underscores);
+      * the other document's title -> only that one (targeted, not indiscriminate);
+      * a word in neither -> nothing (the channel is not matching everything).
+    """
+    try:
+        import aiosqlite  # noqa: F401, PLC0415
+        import lancedb  # noqa: F401, PLC0415
+    except ImportError:
+        pytest.skip("sqlite_lance optional deps not installed")
+
+    from khora.search_mode import SearchMode  # noqa: PLC0415
+
+    embedded_khora, install_mock_llm = _import_embedded_helpers()
+
+    monkeypatch.setenv("KHORA_QUERY_ENABLE_BM25_CHANNEL", "true")
+    monkeypatch.setenv("KHORA_QUERY_ENABLE_RERANKING", "false")
+    install_mock_llm(dim=64)
+
+    async with embedded_khora(embedding_dimension=64) as kb:
+        ns = await kb.create_namespace()
+        for body, title in ((_REPRO_BODY, _REPRO_TITLE), (_DECOY_BODY, _DECOY_TITLE)):
+            await kb.remember(
+                body,
+                namespace=ns.namespace_id,
+                title=title,
+                entity_types=["PERSON"],
+                relationship_types=["MET"],
+            )
+
+        async def _keyword_recall(query: str) -> list[str]:
+            result = await kb.recall(query, namespace=ns.namespace_id, mode=SearchMode.KEYWORD)
+            # Happy path (title_weight=1.0, a store WITH the title column): the
+            # #1574 wiring must not manufacture a degradation (ADR-001).
+            assert_no_silent_degradation(result)
+            return [chunk.content for chunk in result.chunks]
+
+        assert await _keyword_recall("floor panels dimensioned") == [_REPRO_BODY]
+        assert await _keyword_recall("20260213") == [_REPRO_BODY]
+        assert await _keyword_recall("procurement ledger") == [_DECOY_BODY]
+        assert await _keyword_recall("bathymetry") == []

--- a/tests/unit/storage/test_sqlite_lance_title_fts.py
+++ b/tests/unit/storage/test_sqlite_lance_title_fts.py
@@ -1,0 +1,509 @@
+"""#1574 — chunk ``title`` folded into the embedded (sqlite_lance) FTS index.
+
+``khora_chunks.title`` has been a denormalized column since migration 041, but
+``khora_chunks_fts`` only ever indexed ``content``.  A chunk whose *title* was
+the only place a term appeared was invisible to the lexical channel — the
+"0-hit repro" this module pins first.
+
+Four groups, in the order the change has to hold up:
+
+1. :class:`TestTitleIsIndexed` — the repro probe.  Body tokens AND title tokens
+   both find the chunk.
+2. :class:`TestTriggerSync` — the FTS mirror tracks ``title`` through UPDATE and
+   DELETE.  The delete leg is the one worth having: FTS5 external-content
+   ``'delete'`` rows must carry the SAME column list the index was built with,
+   or terms are left behind and the index silently rots.  Asserted twice — no
+   match, and a clean ``'integrity-check'``.
+3. :class:`TestTitleWeight` — ``title_weight`` actually reorders results, and
+   ``1.0`` emits the bare, byte-identical-to-before ``bm25()`` call.
+4. :class:`TestLegacyOneColumnShape` — a database built before this change keeps
+   its 1-column FTS table (the DDL is ``IF NOT EXISTS``; nothing alters it), so
+   ``title_weight`` is inert there.  Verified on SQLite 3.53.4: a weighted
+   ``bm25(fts, 1.0, w)`` against that shape does **not** raise — SQLite ignores
+   the surplus weight argument.  The store therefore cannot rely on an
+   exception; it probes the shape and warns.  These tests pin the probe, the
+   no-crash return, and the warning, and deliberately assert NO exception.
+
+Embedded only: aiosqlite + LanceDB in ``tmp_path``.  No Docker, no LLM.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+try:
+    import aiosqlite  # noqa: F401
+    import lancedb  # noqa: F401
+
+    _HAS_EMBEDDED = True
+except ImportError:  # pragma: no cover - optional extra
+    _HAS_EMBEDDED = False
+
+from loguru import logger
+
+from khora.core.temporal import TemporalChunk
+from khora.storage.backends.sqlite_lance.connection import (
+    EmbeddedStorageHandle,
+    EmbeddedStorageHandleConfig,
+)
+from khora.storage.temporal.sqlite_lance import SQLiteLanceTemporalStore
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.skipif(not _HAS_EMBEDDED, reason="aiosqlite/lancedb not installed"),
+]
+
+EMBED_DIM = 8
+
+#: The field name from the #1574 repro.  Kept verbatim because it is a
+#: tokenizer regression guard as much as a fixture: unicode61 (which ``porter``
+#: wraps) treats ``_`` as a separator, so this must index as four tokens —
+#: ``floor``, ``panel`` (stemmed), ``dimens`` (stemmed), ``20260213``.  A
+#: tokenizer change that swallowed the underscores would make the whole title
+#: one unmatchable token and every assertion below would fail loudly.
+TITLE = "Floor Panels_Dimensioned_20260213"
+
+#: Body text sharing NO vocabulary with :data:`TITLE`.  Load-bearing: if the
+#: body contained title words, a title hit and a content hit would be
+#: indistinguishable and the repro probe would pass without the change.
+BODY = "the assembly drawing revision notes for the north wing"
+
+#: A replacement title with disjoint vocabulary, for the UPDATE-trigger leg.
+NEW_TITLE = "Ceiling Tiles_Revised_20260314"
+
+
+def _chunk(namespace_id: UUID, *, content: str, title: str | None) -> TemporalChunk:
+    return TemporalChunk(
+        id=uuid4(),
+        namespace_id=namespace_id,
+        document_id=uuid4(),
+        content=content,
+        embedding=[0.0] * (EMBED_DIM - 1) + [1.0],
+        occurred_at=datetime.now(UTC),
+        created_at=datetime.now(UTC),
+        title=title,
+    )
+
+
+async def _make_handle(tmp_path: Path) -> EmbeddedStorageHandle:
+    handle = EmbeddedStorageHandle(
+        EmbeddedStorageHandleConfig(
+            db_path=str(tmp_path / "khora.db"),
+            lance_path=str(tmp_path / "khora.lance"),
+            embedding_dimension=EMBED_DIM,
+        )
+    )
+    await handle.connect()
+    return handle
+
+
+@pytest.fixture
+async def store(tmp_path: Path) -> AsyncIterator[SQLiteLanceTemporalStore]:
+    """A connected temporal store on a throwaway embedded database.
+
+    ``khora_chunks`` is runtime-managed (the store's own ``connect()`` issues
+    its DDL), so no Alembic run is needed here.
+    """
+    handle = await _make_handle(tmp_path)
+    temporal = SQLiteLanceTemporalStore(handle)
+    await temporal.connect()
+    try:
+        yield temporal
+    finally:
+        with contextlib.suppress(Exception):
+            await temporal.disconnect()
+        with contextlib.suppress(Exception):
+            await handle.disconnect()
+
+
+async def _contents(store: SQLiteLanceTemporalStore, ns: UUID, query: str, **kwargs) -> list[str]:
+    """Chunk contents returned by the lexical channel, best-ranked first."""
+    return [chunk.content for chunk, _score in await store.search_fulltext(ns, query, limit=10, **kwargs)]
+
+
+# ---------------------------------------------------------------------------
+# 1. Repro probe — the 0-hit bug
+# ---------------------------------------------------------------------------
+
+
+class TestTitleIsIndexed:
+    async def test_body_and_title_tokens_both_match(self, store: SQLiteLanceTemporalStore) -> None:
+        """The #1574 repro: title vocabulary finds the chunk.
+
+        Three queries against ONE chunk. The body query is the control — it
+        passed before the change and must still pass. The two title queries are
+        the bug: each returned zero rows because ``khora_chunks_fts`` indexed
+        only ``content``.
+        """
+        ns = uuid4()
+        await store.create_chunk(_chunk(ns, content=BODY, title=TITLE))
+
+        # Control: content is still indexed (no regression on the old path).
+        assert await _contents(store, ns, "assembly drawing") == [BODY]
+
+        # The repro. Words that exist ONLY in the title.
+        assert await _contents(store, ns, "floor panels dimensioned") == [BODY], (
+            "title words must reach the FTS index (#1574 0-hit repro)"
+        )
+        # The bare numeric token, separately: it is the half a naive tokenizer
+        # would lose to the underscores around it.
+        assert await _contents(store, ns, "20260213") == [BODY]
+
+    async def test_title_only_chunk_is_reachable(self, store: SQLiteLanceTemporalStore) -> None:
+        """A title query must not just match *something* — it must match the
+        chunk that carries the title, and not its title-less neighbour."""
+        ns = uuid4()
+        titled = _chunk(ns, content=BODY, title=TITLE)
+        untitled = _chunk(ns, content="wholly unrelated procurement paperwork", title=None)
+        await store.create_chunks_batch([titled, untitled])
+
+        assert await _contents(store, ns, "floor panels") == [BODY]
+
+    async def test_title_search_is_namespace_scoped(self, store: SQLiteLanceTemporalStore) -> None:
+        """Indexing the title must not leak it across namespaces."""
+        mine, theirs = uuid4(), uuid4()
+        await store.create_chunk(_chunk(theirs, content=BODY, title=TITLE))
+
+        assert await _contents(store, mine, "floor panels dimensioned") == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Trigger sync — UPDATE and DELETE keep the 2-column mirror honest
+# ---------------------------------------------------------------------------
+
+
+async def _fts_integrity_ok(store: SQLiteLanceTemporalStore) -> bool:
+    """True when the FTS index agrees with the ``khora_chunks`` rows it mirrors.
+
+    ``rank = 1`` is load-bearing and not decoration. The bare
+    ``VALUES('integrity-check')`` form checks only that the index is internally
+    well-formed, and an asymmetric ``'delete'`` leaves a *well-formed* index
+    that merely disagrees with the content table — verified: against a 2-column
+    index with a 1-column delete trigger, the bare form returns OK while the
+    ``rank = 1`` form raises ``database disk image is malformed``. Only the
+    latter re-derives terms from ``khora_chunks`` and compares.
+
+    Kept alongside the behavioural "no longer matches" assertions rather than
+    instead of them: those catch residue on the deleted row, this catches
+    residue anywhere in the table.
+    """
+    try:
+        await store._sqlite.execute("INSERT INTO khora_chunks_fts(khora_chunks_fts, rank) VALUES('integrity-check', 1)")
+    except Exception:
+        return False
+    return True
+
+
+class TestTriggerSync:
+    async def test_update_swaps_the_indexed_title(self, store: SQLiteLanceTemporalStore) -> None:
+        """AFTER UPDATE deletes the OLD title terms and inserts the new ones.
+
+        Written as a raw ``UPDATE`` because that is what the trigger is for —
+        the store has no update-chunk method, and any future one would go
+        through the same statement.
+        """
+        ns = uuid4()
+        chunk = _chunk(ns, content=BODY, title=TITLE)
+        await store.create_chunk(chunk)
+        assert await _contents(store, ns, "floor panels") == [BODY]
+
+        await store._sqlite.execute(
+            "UPDATE khora_chunks SET title = ? WHERE id = ?",
+            (NEW_TITLE, chunk.id.hex),
+        )
+        await store._sqlite.commit()
+
+        # Old title terms are gone ...
+        assert await _contents(store, ns, "floor panels") == []
+        assert await _contents(store, ns, "20260213") == []
+        # ... the new ones are present ...
+        assert await _contents(store, ns, "ceiling tiles") == [BODY]
+        assert await _contents(store, ns, "20260314") == [BODY]
+        # ... and content is untouched by the title swap.
+        assert await _contents(store, ns, "assembly drawing") == [BODY]
+        assert await _fts_integrity_ok(store)
+
+    async def test_delete_removes_both_columns_symmetrically(self, store: SQLiteLanceTemporalStore) -> None:
+        """AFTER DELETE must pass the same ``(content, title)`` pair the insert did.
+
+        An external-content FTS5 table stores no copy of the row; the ``'delete'``
+        command re-tokenizes the values it is handed to work out which terms to
+        remove. Hand it fewer columns than the index has and the title terms are
+        never removed.
+        """
+        ns = uuid4()
+        chunk = _chunk(ns, content=BODY, title=TITLE)
+        await store.create_chunk(chunk)
+
+        assert await store.delete_chunk(chunk.id, ns) is True
+
+        assert await _contents(store, ns, "floor panels dimensioned") == []
+        assert await _contents(store, ns, "assembly drawing") == []
+        assert await _fts_integrity_ok(store), (
+            "the AFTER DELETE trigger left title terms in khora_chunks_fts — "
+            "its column list must match the CREATE VIRTUAL TABLE column list"
+        )
+
+    async def test_delete_leaves_sibling_rows_searchable(self, store: SQLiteLanceTemporalStore) -> None:
+        """Deleting one chunk must not disturb another's title terms."""
+        ns = uuid4()
+        doomed = _chunk(ns, content=BODY, title=TITLE)
+        keeper = _chunk(ns, content="separate body prose entirely", title=NEW_TITLE)
+        await store.create_chunks_batch([doomed, keeper])
+
+        await store.delete_chunk(doomed.id, ns)
+
+        assert await _contents(store, ns, "floor panels") == []
+        assert await _contents(store, ns, "ceiling tiles") == ["separate body prose entirely"]
+        assert await _fts_integrity_ok(store)
+
+
+# ---------------------------------------------------------------------------
+# 3. title_weight — reordering, and the untouched default
+# ---------------------------------------------------------------------------
+
+#: Filler that shares no vocabulary with the query. The two fixture chunks below
+#: differ in length on purpose: at the neutral weight the SHORTER body-only
+#: chunk must win on BM25's length normalization, so a weight that flips the
+#: order is doing real work rather than confirming a pre-existing tie.
+_FILLER = " ".join(f"pad{i}" for i in range(40))
+_EXTRA_FILLER = " ".join(f"extra{i}" for i in range(20))
+
+#: Query terms live ONLY in this chunk's title; its body is the longer one.
+_TITLED_BODY = f"{_FILLER} {_EXTRA_FILLER}"
+#: Query terms live ONLY in this chunk's body, which is shorter.
+_BODY_ONLY = f"floor panels {_FILLER}"
+
+
+class TestTitleWeight:
+    async def _seed_pair(self, store: SQLiteLanceTemporalStore) -> UUID:
+        ns = uuid4()
+        await store.create_chunks_batch(
+            [
+                _chunk(ns, content=_TITLED_BODY, title="Floor Panels"),
+                _chunk(ns, content=_BODY_ONLY, title=None),
+            ]
+        )
+        return ns
+
+    async def test_neutral_weight_ranks_the_body_match_first(self, store: SQLiteLanceTemporalStore) -> None:
+        """The baseline the reordering test below is measured against.
+
+        With every column weighted 1.0 the shorter body-only chunk outscores the
+        longer title-only one on BM25's length normalization. This is not the
+        pre-change behavior — before the change the titled chunk would not have
+        matched at all — it is the fixture's neutral-weight order. If it ever
+        stops holding, the flip asserted next proves nothing, so it is pinned
+        rather than assumed.
+        """
+        ns = await self._seed_pair(store)
+        assert await _contents(store, ns, "floor panels") == [_BODY_ONLY, _TITLED_BODY]
+
+    async def test_raised_weight_floats_the_titled_chunk(self, store: SQLiteLanceTemporalStore) -> None:
+        """``title_weight > 1`` reorders the SAME two chunks, title first."""
+        ns = await self._seed_pair(store)
+        assert await _contents(store, ns, "floor panels", title_weight=4.0) == [_TITLED_BODY, _BODY_ONLY]
+
+    async def test_weight_is_the_only_difference(self, store: SQLiteLanceTemporalStore) -> None:
+        """Both weights return the same result SET — only the order differs.
+
+        Guards against a weighted call accidentally becoming a filter.
+        """
+        ns = await self._seed_pair(store)
+        neutral = await _contents(store, ns, "floor panels")
+        weighted = await _contents(store, ns, "floor panels", title_weight=4.0)
+        assert sorted(neutral) == sorted(weighted)
+        assert neutral != weighted
+
+    def test_default_weight_emits_the_bare_bm25_call(self, store: SQLiteLanceTemporalStore) -> None:
+        """``title_weight=1.0`` must produce the pre-#1574 SQL verbatim.
+
+        The default path is the one every existing deployment takes, so the
+        scoring expression has to be byte-identical rather than merely
+        equivalent — an all-ones weight vector would compute the same numbers
+        but is a different string, and this is the cheapest place to pin it.
+        """
+        assert store._bm25_expr(1.0) == "bm25(khora_chunks_fts)"
+
+    def test_non_default_weight_emits_the_per_column_call(self, store: SQLiteLanceTemporalStore) -> None:
+        """Content is column 0 (weight pinned at 1.0), title is column 1."""
+        assert store.fts_has_title is True
+        assert store._bm25_expr(2.0) == "bm25(khora_chunks_fts, 1.0, 2)"
+        assert store._bm25_expr(0.5) == "bm25(khora_chunks_fts, 1.0, 0.5)"
+
+    def test_rendered_weight_carries_no_injection_surface(self, store: SQLiteLanceTemporalStore) -> None:
+        """The weight is inlined, not bound — so its rendering IS the argument.
+
+        FTS5 auxiliary-function arguments must be literals, which rules out a
+        bind parameter. What makes that safe is that the value is a
+        Pydantic-clamped ``float`` rendered through ``{:g}``, which can only
+        emit digits, ``.``, ``e`` and a sign. Checked across the config range's
+        ends and a fractional value rather than argued in a comment.
+        """
+        allowed = set("0123456789.e+-")
+        for weight in (0.0, 0.25, 3.0, 10.0):
+            expr = store._bm25_expr(weight)
+            rendered = expr.removeprefix("bm25(khora_chunks_fts, 1.0, ").removesuffix(")")
+            assert set(rendered) <= allowed, expr
+
+    async def test_zero_weight_mutes_the_title_channel(self, store: SQLiteLanceTemporalStore) -> None:
+        """``title_weight=0.0`` is a legal config value (Pydantic's floor).
+
+        A title-only match still MATCHes — the predicate is weight-independent —
+        but contributes nothing to the score. Worth pinning because "0 disables
+        the column" and "0 hides the row" are easy to confuse, and the recall
+        semantics differ sharply.
+        """
+        ns = uuid4()
+        await store.create_chunk(_chunk(ns, content=_TITLED_BODY, title="Floor Panels"))
+
+        results = await store.search_fulltext(ns, "floor panels", limit=10, title_weight=0.0)
+        assert [c.content for c, _ in results] == [_TITLED_BODY]
+        assert results[0][1] == pytest.approx(0.0, abs=1e-12), "a zeroed column contributes nothing to bm25"
+
+
+# ---------------------------------------------------------------------------
+# 4. Legacy 1-column FTS shape — degrade, do not crash
+# ---------------------------------------------------------------------------
+
+#: The pre-#1574 embedded schema, replayed verbatim. Recreating it by hand is
+#: the only way to get one: the live DDL is ``CREATE ... IF NOT EXISTS``, so a
+#: database built before the change is never migrated to the 2-column shape.
+_LEGACY_FTS_DDL = (
+    "DROP TRIGGER IF EXISTS khora_chunks_ai",
+    "DROP TRIGGER IF EXISTS khora_chunks_ad",
+    "DROP TRIGGER IF EXISTS khora_chunks_au",
+    "DROP TABLE IF EXISTS khora_chunks_fts",
+    """
+    CREATE VIRTUAL TABLE khora_chunks_fts USING fts5(
+        content, content='khora_chunks', content_rowid='rowid', tokenize='porter'
+    )
+    """,
+    """
+    CREATE TRIGGER khora_chunks_ai AFTER INSERT ON khora_chunks BEGIN
+        INSERT INTO khora_chunks_fts(rowid, content) VALUES (new.rowid, new.content);
+    END
+    """,
+    """
+    CREATE TRIGGER khora_chunks_ad AFTER DELETE ON khora_chunks BEGIN
+        INSERT INTO khora_chunks_fts(khora_chunks_fts, rowid, content)
+        VALUES ('delete', old.rowid, old.content);
+    END
+    """,
+    """
+    CREATE TRIGGER khora_chunks_au AFTER UPDATE ON khora_chunks BEGIN
+        INSERT INTO khora_chunks_fts(khora_chunks_fts, rowid, content)
+        VALUES ('delete', old.rowid, old.content);
+        INSERT INTO khora_chunks_fts(rowid, content) VALUES (new.rowid, new.content);
+    END
+    """,
+)
+
+
+async def _downgrade_fts_to_legacy(handle: EmbeddedStorageHandle) -> None:
+    for statement in _LEGACY_FTS_DDL:
+        await handle.sqlite.execute(statement)
+    await handle.sqlite.commit()
+
+
+@pytest.fixture
+async def legacy_store(tmp_path: Path) -> AsyncIterator[SQLiteLanceTemporalStore]:
+    """A store whose live FTS table has the old 1-column shape.
+
+    Built the way a real one is: the current DDL runs first (creating
+    ``khora_chunks``), the FTS table and its triggers are swapped back to the
+    legacy shape, and then a FRESH store connects — so its probe sees exactly
+    what a pre-change database presents. The second ``connect()`` re-runs the
+    ``IF NOT EXISTS`` DDL and, correctly, changes nothing.
+    """
+    handle = await _make_handle(tmp_path)
+    bootstrap = SQLiteLanceTemporalStore(handle)
+    await bootstrap.connect()
+    await _downgrade_fts_to_legacy(handle)
+
+    temporal = SQLiteLanceTemporalStore(handle)
+    await temporal.connect()
+    try:
+        yield temporal
+    finally:
+        with contextlib.suppress(Exception):
+            await temporal.disconnect()
+        with contextlib.suppress(Exception):
+            await handle.disconnect()
+
+
+class TestLegacyOneColumnShape:
+    async def test_probe_reports_no_title_column(self, legacy_store: SQLiteLanceTemporalStore) -> None:
+        assert legacy_store.fts_has_title is False
+
+    async def test_title_is_genuinely_not_indexed(self, legacy_store: SQLiteLanceTemporalStore) -> None:
+        """The degradation is real, not cosmetic: there is nothing to weight.
+
+        This is why the store cannot treat SQLite's tolerance of the surplus
+        weight argument as "it worked".
+        """
+        ns = uuid4()
+        await legacy_store.create_chunk(_chunk(ns, content=BODY, title=TITLE))
+
+        assert await _contents(legacy_store, ns, "assembly drawing") == [BODY]
+        assert await _contents(legacy_store, ns, "floor panels dimensioned") == []
+
+    async def test_weighted_search_returns_rows_without_raising(self, legacy_store: SQLiteLanceTemporalStore) -> None:
+        """A non-neutral weight on the legacy shape degrades to content-only.
+
+        Deliberately NOT a ``pytest.raises``: measured on SQLite 3.53.4, a
+        weighted ``bm25(fts, 1.0, w)`` against a 1-column table silently ignores
+        the extra argument. The guard exists to make the no-op *visible*, not to
+        prevent a crash — so the contract under test is "results, no exception".
+        """
+        ns = uuid4()
+        await legacy_store.create_chunk(_chunk(ns, content=BODY, title=TITLE))
+
+        results = await legacy_store.search_fulltext(ns, "assembly drawing", limit=10, title_weight=2.0)
+
+        assert [chunk.content for chunk, _ in results] == [BODY]
+
+    async def test_fallback_expression_is_the_bare_call(self, legacy_store: SQLiteLanceTemporalStore) -> None:
+        """Even asked for a weight, the legacy shape gets the shape-agnostic SQL."""
+        assert legacy_store._bm25_expr(2.0) == "bm25(khora_chunks_fts)"
+
+    async def test_fallback_warns_once_then_throttles(self, legacy_store: SQLiteLanceTemporalStore) -> None:
+        """ADR-001 throttle: WARNING on the first ignored weight, DEBUG after.
+
+        Both halves matter. Without the warning the no-op is invisible; without
+        the throttle a per-query warning would flood the log of any deployment
+        that sets the knob and never upgraded its database.
+        """
+        captured: list[str] = []
+        sink = logger.add(lambda message: captured.append(str(message)), level="WARNING")
+        try:
+            legacy_store._bm25_expr(2.0)
+            legacy_store._bm25_expr(2.0)
+            legacy_store._bm25_expr(3.0)
+        finally:
+            logger.remove(sink)
+
+        assert len(captured) == 1, f"expected exactly one WARNING, got {captured!r}"
+        assert "title_weight=2" in captured[0]
+        assert "khora_chunks_fts lacks the 'title' column" in captured[0]
+
+    async def test_neutral_weight_never_warns(self, legacy_store: SQLiteLanceTemporalStore) -> None:
+        """The default asks for nothing, so nothing is being ignored.
+
+        A warning here would fire on every recall of every un-upgraded embedded
+        deployment, none of which requested title weighting.
+        """
+        captured: list[str] = []
+        sink = logger.add(lambda message: captured.append(str(message)), level="WARNING")
+        try:
+            assert legacy_store._bm25_expr(1.0) == "bm25(khora_chunks_fts)"
+        finally:
+            logger.remove(sink)
+
+        assert captured == []


### PR DESCRIPTION
## Summary

Chunk `title` is stored on `khora_chunks` and already prepended to content for **embeddings**, but the lexical channel (SQLite FTS5 + PostgreSQL `tsvector`) indexed `content` only — so quoted-title / exact-token title queries (file names, sheet codes, dates) returned 0 rows from the BM25/FTS channel. This folds `title` into the lexical indexes for the two temporal stores behind `enable_bm25_channel` (`sqlite_lance`, `pgvector`).

- **New query-time setting** `query.bm25_title_weight` (env `KHORA_QUERY_BM25_TITLE_WEIGHT`, default `1.0`, clamped `[0, 10]`) tunes title-vs-body emphasis **within** the lexical channel. The channel's weight in fusion stays governed by `keyword_weight` (RRF is rank-only, so the title weight never leaks into fused scores directly).
- **Default `1.0` preserves content-hit ranking exactly** — PostgreSQL relabels content lexemes to `B` and scores them with an explicit `{0.1, 0.2, 0.1, 0.1}` vector (the same `0.1` the old unlabeled lexemes received), and SQLite emits the bare `bm25()` call. This is *not* "no behavior change": with `title` now indexed, title-only-matching chunks become lexically searchable at the default and title matches contribute to rank. That gap-closing is the point of the change; the weight only tunes emphasis on top of it.
- **PostgreSQL:** migration `058` (PG-only, reversible) swaps the `content_tsv` trigger function to `setweight(title,'A') || setweight(content,'B')` and recomputes existing rows via a `SET content_tsv = NULL` backfill that fires the `BEFORE` trigger. The trigger-function SQL is kept **byte-identical** between the migration and the store's connect-time DDL (a lockstep unit test guards this).
- **Embedded (`sqlite_lance`):** connect-time DDL adds `title` as the second FTS5 column and carries it through all three sync triggers (external-content delete symmetry preserved). Fresh embedded DBs get the new shape; pre-existing embedded DBs keep content-only FTS and require recreate + re-ingest (no SQLite migration, by design — "Postgres must work with migrations; SQLite may require a new database"). A connect-time shape probe (`fts_has_title`) gates the weighted scoring.
- **Failure observability (ADR-001):** when a non-neutral weight is requested against a legacy 1-column FTS shape, scoring falls back to the bare call (never errors), the store logs a throttled warning, and the engine records a `Degradation` on `RecallResult.engine_info["degradations"]` plus a new internal counter `khora.vectorcypher.bm25_title_weight.degraded_total` (telemetry contract updated in the same change; no `namespace_id` label).
- **Out of scope (follow-up):** SurrealDB temporal, the `backend: sqlite` / main-`chunks` tier, turbopuffer, weaviate — these accept-and-ignore the new kwarg only. A follow-up issue tracks title lexical matching for those surfaces.

Fixes #1574

## Test plan

- [x] Unit — embedded FTS5 title indexing (repro probe, trigger sync incl. delete symmetry, weight paths, legacy-shape degrade-without-crash), config validation + env override, recall-cache fingerprint captures the new weight, engine degradation-record cases + `assert_no_silent_degradation` on the happy path
- [x] Integration — migration `058` against PostgreSQL: title tokens match only after upgrade, `content_tsv::text` shows `A`/`B` labels, content-hit rank-equality at the default, reversible downgrade
- [x] Lockstep byte-identity test: store connect-time DDL function body == migration function body
- [x] `make lint` (ruff + `ty`) and `make format` clean
- [ ] Full CI matrix (Neo4j / SurrealDB / e2e lanes) — verified in CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable BM25 title weighting from 0–10, enabling search results to prioritize titles relative to content.
  * PostgreSQL and SQLite full-text search now support title-aware indexing and ranking.
  * Title weighting is propagated through hybrid and full-text search.

* **Bug Fixes**
  * Unsupported or legacy stores safely fall back to content-only ranking with degradation diagnostics.
  * Database upgrades preserve existing search behavior by default.
  * Added safeguards for nullable titles and legacy full-text schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->